### PR TITLE
mgr/dashboard: typescript cleanup

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/tsconfig.e2e.json
+++ b/src/pybind/mgr/dashboard/frontend/e2e/tsconfig.e2e.json
@@ -9,6 +9,7 @@
       "jasmine",
       "jasminewd2",
       "node"
-    ]
+    ],
+    "noEmit": true
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -8,14 +8,16 @@
     "build": "npm run env_build && ng build",
     "env_build": "cp src/environments/environment.tpl.ts src/environments/environment.prod.ts && cp src/environments/environment.tpl.ts src/environments/environment.ts  && node ./environment.build.js",
     "i18n": "ng xi18n --i18n-format xlf --i18n-locale en-US --output-path locale --progress=false && ngx-extractor -i 'src/**/*.ts' -f xlf -o src/locale/messages.xlf -l en-US",
-    "test": "jest --watch",
-    "test:ci": "JEST_SILENT_REPORTER_DOTS=true jest --coverage --reporters jest-silent-reporter",
+    "test": "npm run test:config && jest --watch",
+    "test:ci": "npm run test:config && JEST_SILENT_REPORTER_DOTS=true jest --coverage --reporters jest-silent-reporter",
+    "test:config": "if [ ! -e 'src/unit-test-configuration.ts' ]; then cp 'src/unit-test-configuration.ts.sample' 'src/unit-test-configuration.ts'; fi",
     "e2e": "npm run env_build && ng e2e",
     "e2e:dev": "npm run env_build && ng e2e --dev-server-target",
     "lint:tslint": "ng lint",
     "lint:prettier": "prettier --list-different \"{src,e2e}/**/*.{ts,scss}\"",
     "lint:html": "html-linter --config html-linter.config.json",
-    "lint": "npm run lint:tslint && npm run lint:prettier && npm run lint:html",
+    "lint:tsc": "npm run test:config && tsc -p src/tsconfig.app.json --noEmit --noUnusedLocals --noUnusedParameters && tsc -p src/tsconfig.spec.json --noEmit --noUnusedLocals --noUnusedParameters && tsc -p e2e/tsconfig.e2e.json --noEmit --noUnusedLocals --noUnusedParameters",
+    "lint": "npm run lint:tsc && npm run lint:tslint && npm run lint:prettier && npm run lint:html",
     "fix:prettier": "prettier --write \"{src,e2e}/**/*.{ts,scss}\"",
     "fix:tslint": "npm run lint:tslint -- --fix",
     "fixmod": "prettier --write $(git rev-parse --show-toplevel)/$(git status --porcelain | grep -E '^(\\sM|\\?\\?|A)' | sed -e 's/^...//' | grep -E '^(src|e2e).*\\.(ts|scss)$') 1>/dev/null 2>&1 && echo 'done' || echo 'no changes found'",
@@ -43,6 +45,9 @@
     ],
     "modulePathIgnorePatterns": [
       "<rootDir>/coverage/"
+    ],
+    "testMatch": [
+      "**/*.spec.ts"
     ],
     "testURL": "http://localhost/"
   },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
@@ -27,7 +27,7 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
     const currentSettings = this.imagesSettings[this.image];
     this.helpText = this.iscsiService.imageAdvancedSettings;
 
-    _.forIn(this.disk_default_controls, (value, key) => {
+    _.forIn(this.disk_default_controls, (_value, key) => {
       fg[key] = new FormControl(currentSettings[key]);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
@@ -25,7 +25,7 @@ export class IscsiTargetIqnSettingsModalComponent implements OnInit {
     const fg = {};
     this.helpText = this.iscsiService.targetAdvancedSettings;
 
-    _.forIn(this.target_default_controls, (value, key) => {
+    _.forIn(this.target_default_controls, (_value, key) => {
       fg[key] = new FormControl(this.target_controls.value[key]);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
@@ -20,7 +20,7 @@ describe('IscsiComponent', () => {
 
   const fakeService = {
     tcmuiscsi: () => {
-      return new Promise(function(resolve, reject) {
+      return new Promise(function() {
         return;
       });
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirror-health-color.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirror-health-color.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'mirrorHealthColor'
 })
 export class MirrorHealthColorPipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (value === 'warning') {
       return 'label label-warning';
     } else if (value === 'error') {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-response.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-response.model.ts
@@ -3,4 +3,5 @@ export class PoolEditPeerResponseModel {
   client_id: string;
   mon_host: string;
   key: string;
+  uuid: string;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.ts
@@ -57,9 +57,8 @@ export class PoolListComponent implements OnInit, OnDestroy {
       icon: 'fa-plus',
       name: this.i18n('Add Peer'),
       click: () => this.editPeersModal('add'),
-      disable: (selection: CdTableSelection) =>
-        !this.selection.first() || this.selection.first().mirror_mode === 'disabled',
-      visible: (selection: CdTableSelection) => !this.getPeerUUID(),
+      disable: () => !this.selection.first() || this.selection.first().mirror_mode === 'disabled',
+      visible: () => !this.getPeerUUID(),
       canBePrimary: () => false
     };
     const editPeerAction: CdTableAction = {
@@ -67,14 +66,14 @@ export class PoolListComponent implements OnInit, OnDestroy {
       icon: 'fa-exchange',
       name: this.i18n('Edit Peer'),
       click: () => this.editPeersModal('edit'),
-      visible: (selection: CdTableSelection) => !!this.getPeerUUID()
+      visible: () => !!this.getPeerUUID()
     };
     const deletePeerAction: CdTableAction = {
       permission: 'delete',
       icon: 'fa-times',
       name: this.i18n('Delete Peer'),
       click: () => this.deletePeersModal(),
-      visible: (selection: CdTableSelection) => !!this.getPeerUUID()
+      visible: () => !!this.getPeerUUID()
     };
     this.tableActions = [editModeAction, addPeerAction, editPeerAction, deletePeerAction];
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.spec.ts
@@ -1,4 +1,3 @@
-import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -59,7 +58,7 @@ describe('RbdConfigurationListComponent', () => {
     } as RbdConfigurationEntry;
 
     component.data = [fakeOption, realOption];
-    component.ngOnChanges({ name: new SimpleChange(null, null, null) });
+    component.ngOnChanges();
 
     expect(component.data.length).toBe(1);
     expect(component.data.pop()).toBe(realOption);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges,
-  TemplateRef,
-  ViewChild
-} from '@angular/core';
+import { Component, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
@@ -51,7 +43,7 @@ export class RbdConfigurationListComponent implements OnInit, OnChanges {
     ];
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(): void {
     if (!this.data) {
       return;
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
@@ -73,7 +73,7 @@ export class RbdSnapshotFormComponent implements OnInit {
     this.rbdService
       .renameSnapshot(this.poolName, this.imageName, this.snapName, snapshotName)
       .toPromise()
-      .then((resp) => {
+      .then(() => {
         this.taskManagerService.subscribe(
           finishedTask.name,
           finishedTask.metadata,
@@ -84,7 +84,7 @@ export class RbdSnapshotFormComponent implements OnInit {
         this.modalRef.hide();
         this.onSubmit.next(this.snapName);
       })
-      .catch((resp) => {
+      .catch(() => {
         this.snapshotForm.setErrors({ cdSubmitButton: true });
       });
   }
@@ -101,7 +101,7 @@ export class RbdSnapshotFormComponent implements OnInit {
     this.rbdService
       .createSnapshot(this.poolName, this.imageName, snapshotName)
       .toPromise()
-      .then((resp) => {
+      .then(() => {
         this.taskManagerService.subscribe(
           finishedTask.name,
           finishedTask.metadata,
@@ -112,7 +112,7 @@ export class RbdSnapshotFormComponent implements OnInit {
         this.modalRef.hide();
         this.onSubmit.next(snapshotName);
       })
-      .catch((resp) => {
+      .catch(() => {
         this.snapshotForm.setErrors({ cdSubmitButton: true });
       });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -83,8 +83,8 @@ describe('RbdSnapshotListComponent', () => {
       fixture.detectChanges();
       const i18n = TestBed.get(I18n);
       called = false;
-      rbdService = new RbdService(null);
-      notificationService = new NotificationService(null, null);
+      rbdService = new RbdService(null, null);
+      notificationService = new NotificationService(null, null, null);
       authStorageService = new AuthStorageService();
       authStorageService.set('user', '', { 'rbd-image': ['create', 'read', 'update', 'delete'] });
       component = new RbdSnapshotListComponent(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -206,7 +206,7 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
     this.rbdService
       .protectSnapshot(this.poolName, this.rbdName, snapshotName, !isProtected)
       .toPromise()
-      .then((resp) => {
+      .then(() => {
         const executingTask = new ExecutingTask();
         executingTask.name = finishedTask.name;
         executingTask.metadata = finishedTask.metadata;
@@ -247,7 +247,7 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
           }
         );
       })
-      .catch((resp) => {
+      .catch(() => {
         this.modalRef.content.stopLoadingSpinner();
       });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
@@ -86,7 +86,7 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
         {
           name: this.i18n('Usage'),
           cellTemplate: this.poolUsageTpl,
-          comparator: (valueA, valueB, rowA, rowB, sortDirection) => {
+          comparator: (_valueA, _valueB, rowA, rowB) => {
             const valA = rowA.used / rowA.avail;
             const valB = rowB.used / rowB.avail;
 
@@ -124,7 +124,7 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
     });
 
     this.cephfsService.getMdsCounters(this.id).subscribe((data) => {
-      _.each(this.mdsCounters, (value, key) => {
+      _.each(this.mdsCounters, (_value, key) => {
         if (data[key] === undefined) {
           delete this.mdsCounters[key];
         }
@@ -137,7 +137,7 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
     });
   }
 
-  trackByFn(index, item) {
+  trackByFn(_index, item) {
     return item.name;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -160,7 +160,8 @@ describe('OsdListComponent', () => {
     const expectOpensModal = (actionName: string, modalClass): void => {
       openActionModal(actionName);
 
-      expect(modalServiceShowSpy.calls.any()).toBe(true, 'modalService.show called');
+      // @TODO: check why tsc is complaining when passing 'expectationFailOutput' param.
+      expect(modalServiceShowSpy.calls.any()).toBeTruthy();
       expect(modalServiceShowSpy.calls.first().args[0]).toBe(modalClass);
 
       modalServiceShowSpy.calls.reset();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.spec.ts
@@ -15,19 +15,13 @@ describe('OsdScrubModalComponent', () => {
 
   const fakeService = {
     list: () => {
-      return new Promise(function(resolve, reject) {
-        return {};
-      });
+      return new Promise(() => {});
     },
-    scrub: (data: any) => {
-      return new Promise(function(resolve, reject) {
-        return {};
-      });
+    scrub: () => {
+      return new Promise(() => {});
     },
-    scrub_many: (data: any) => {
-      return new Promise(function(resolve, reject) {
-        return {};
-      });
+    scrub_many: () => {
+      return new Promise(() => {});
     }
   };
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.ts
@@ -33,7 +33,7 @@ export class OsdScrubModalComponent implements OnInit {
     const id = this.selected[0].id;
 
     this.osdService.scrub(id, this.deep).subscribe(
-      (res) => {
+      () => {
         const operation = this.deep ? 'Deep scrub' : 'Scrub';
 
         this.notificationService.show(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.ts
@@ -183,7 +183,7 @@ export class HealthPieComponent implements OnChanges, OnInit {
   }
 
   private hideSlices() {
-    _.forEach(this.chartConfig.dataset[0].data, (slice, sliceIndex) => {
+    _.forEach(this.chartConfig.dataset[0].data, (_slice, sliceIndex) => {
       if (this.hiddenSlices[sliceIndex]) {
         this.chartConfig.dataset[0].data[sliceIndex] = undefined;
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -52,7 +52,7 @@ export class HealthComponent implements OnInit, OnDestroy {
     });
   }
 
-  prepareReadWriteRatio(chart, data) {
+  prepareReadWriteRatio(chart) {
     const ratioLabels = [];
     const ratioData = [];
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mds-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mds-summary.pipe.ts
@@ -9,7 +9,7 @@ import * as _ from 'lodash';
 export class MdsSummaryPipe implements PipeTransform {
   constructor(private i18n: I18n) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (!value) {
       return '';
     }
@@ -19,7 +19,7 @@ export class MdsSummaryPipe implements PipeTransform {
     let standbys = 0;
     let active = 0;
     let standbyReplay = 0;
-    _.each(value.standbys, (s, i) => {
+    _.each(value.standbys, () => {
       standbys += 1;
     });
 
@@ -29,8 +29,8 @@ export class MdsSummaryPipe implements PipeTransform {
     } else if (value.filesystems.length === 0) {
       contentLine1 = this.i18n('no filesystems');
     } else {
-      _.each(value.filesystems, (fs, i) => {
-        _.each(fs.mdsmap.info, (mds, j) => {
+      _.each(value.filesystems, (fs) => {
+        _.each(fs.mdsmap.info, (mds) => {
           if (mds.state === 'up:standby-replay') {
             standbyReplay += 1;
           } else {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mgr-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mgr-summary.pipe.ts
@@ -9,7 +9,7 @@ import * as _ from 'lodash';
 export class MgrSummaryPipe implements PipeTransform {
   constructor(private i18n: I18n) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (!value) {
       return '';
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mon-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mon-summary.pipe.ts
@@ -8,7 +8,7 @@ import { I18n } from '@ngx-translate/i18n-polyfill';
 export class MonSummaryPipe implements PipeTransform {
   constructor(private i18n: I18n) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (!value) {
       return '';
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.ts
@@ -9,7 +9,7 @@ import * as _ from 'lodash';
 export class OsdSummaryPipe implements PipeTransform {
   constructor(private i18n: I18n) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (!value) {
       return '';
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -109,20 +109,15 @@ export class NfsFormComponent implements OnInit {
   }
 
   getData(promises) {
-    forkJoin(promises).subscribe(
-      (data: any[]) => {
-        this.resolveDaemons(data[0]);
-        this.resolvefsals(data[1]);
-        this.resolveClients(data[2]);
-        this.resolveFilesystems(data[3]);
-        if (data[4]) {
-          this.resolveModel(data[4]);
-        }
-      },
-      (error) => {
-        // this.error = error;
+    forkJoin(promises).subscribe((data: any[]) => {
+      this.resolveDaemons(data[0]);
+      this.resolvefsals(data[1]);
+      this.resolveClients(data[2]);
+      this.resolveFilesystems(data[3]);
+      if (data[4]) {
+        this.resolveModel(data[4]);
       }
-    );
+    });
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -149,7 +149,7 @@ export class NfsListComponent implements OnInit, OnDestroy {
           this.builders
         );
       },
-      (error) => {
+      () => {
         this.onFetchError();
       }
     );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.ts
@@ -239,7 +239,7 @@ export class ErasureCodeProfileFormComponent implements OnInit {
       })
       .subscribe(
         undefined,
-        (resp) => {
+        () => {
           this.form.setErrors({ cdSubmitButton: true });
         },
         () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -177,7 +177,7 @@ describe('PoolListComponent', () => {
 
   describe('getPgStatusCellClass', () => {
     const testMethod = (value, expected) =>
-      expect(component.getPgStatusCellClass({ row: '', column: '', value: value })).toEqual({
+      expect(component.getPgStatusCellClass('', '', value)).toEqual({
         'text-right': true,
         [expected]: true
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -103,7 +103,7 @@ export class PoolListComponent implements OnInit {
         name: this.i18n('PG Status'),
         flexGrow: 3,
         cellClass: ({ row, column, value }): any => {
-          return this.getPgStatusCellClass({ row, column, value });
+          return this.getPgStatusCellClass(row, column, value);
         }
       },
       {
@@ -190,7 +190,7 @@ export class PoolListComponent implements OnInit {
     });
   }
 
-  getPgStatusCellClass({ row, column, value }): object {
+  getPgStatusCellClass(_row, _column, value): object {
     return {
       'text-right': true,
       [`pg-${this.pgCategoryService.getTypeByStates(value)}`]: true

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
@@ -25,8 +25,8 @@ describe('LoginComponent', () => {
   });
 
   it('should ensure no modal dialogs are opened', () => {
-    component.bsModalService.modalsCount = 2;
+    component['bsModalService']['modalsCount'] = 2;
     component.ngOnInit();
-    expect(component.bsModalService.getModalsCount()).toBe(0);
+    expect(component['bsModalService'].getModalsCount()).toBe(0);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.spec.ts
@@ -123,7 +123,9 @@ describe('RoleFormComponent', () => {
         cephfs: ['read', 'delete'],
         grafana: ['update']
       });
-      component.onClickHeaderCheckbox('scope', { target: { checked: false } });
+      component.onClickHeaderCheckbox('scope', ({
+        target: { checked: false }
+      } as unknown) as Event);
       const scopes_permissions = form.getValue('scopes_permissions');
       expect(scopes_permissions).toEqual({});
     });
@@ -134,7 +136,7 @@ describe('RoleFormComponent', () => {
         cephfs: ['create', 'update'],
         grafana: ['delete']
       });
-      component.onClickHeaderCheckbox('scope', { target: { checked: true } });
+      component.onClickHeaderCheckbox('scope', ({ target: { checked: true } } as unknown) as Event);
       const scopes_permissions = form.getValue('scopes_permissions');
       const keys = Object.keys(scopes_permissions);
       expect(keys).toEqual(['cephfs', 'grafana']);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -193,7 +193,7 @@ describe('UserFormComponent', () => {
     it('should alert if user is removing needed role permission', () => {
       spyOn(TestBed.get(AuthStorageService), 'getUsername').and.callFake(() => user.username);
       let modalBodyTpl = null;
-      spyOn(modalService, 'show').and.callFake((content, config) => {
+      spyOn(modalService, 'show').and.callFake((_content, config) => {
         modalBodyTpl = config.initialState.bodyTpl;
       });
       formHelper.setValue('roles', ['read-only']);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
@@ -16,7 +16,8 @@ describe('RbdMirroringService', () => {
       image_error: [],
       image_syncing: [],
       image_ready: []
-    }
+    },
+    executing_tasks: [{}]
   };
 
   configureTestBed(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.spec.ts
@@ -104,7 +104,7 @@ describe('CriticalConfirmationModalComponent', () => {
     mockFixture = TestBed.createComponent(MockComponent);
     mockComponent = mockFixture.componentInstance;
     // Mocking the modals as a lot would be left over
-    spyOn(mockComponent.modalService, 'show').and.callFake((modalComp, config) => {
+    spyOn(mockComponent.modalService, 'show').and.callFake((_modalComp, config) => {
       const ref = new BsModalRef();
       fixture = TestBed.createComponent(CriticalConfirmationModalComponent);
       component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -216,7 +216,7 @@ export class GrafanaComponent implements OnInit, OnChanges {
     this.grafanaSrc = this.sanitizer.bypassSecurityTrustResourceUrl(this.url);
   }
 
-  onTimepickerChange(event) {
+  onTimepickerChange() {
     if (this.grafanaExist) {
       this.getFrame();
     }
@@ -229,7 +229,7 @@ export class GrafanaComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(changes) {
+  ngOnChanges() {
     if (this.grafanaExist) {
       this.getFrame();
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sparkline/sparkline.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sparkline/sparkline.component.ts
@@ -90,7 +90,7 @@ export class SparklineComponent implements OnInit, OnChanges {
   constructor(private dimlessBinaryPipe: DimlessBinaryPipe) {}
 
   ngOnInit() {
-    const getStyleTop = (tooltip, positionY) => {
+    const getStyleTop = (tooltip) => {
       return tooltip.caretY - tooltip.height - tooltip.yPadding - 5 + 'px';
     };
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.ts
@@ -91,7 +91,7 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
     this.useData();
   }
 
-  ngOnChanges(changes) {
+  ngOnChanges() {
     this.useData();
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -125,7 +125,7 @@ describe('TableComponent', () => {
 
       it('should test search manipulation', () => {
         let searchTerms = [];
-        spyOn(component, 'subSearch').and.callFake((d, search) => {
+        spyOn(component, 'subSearch').and.callFake((_d, search) => {
           expect(search).toEqual(searchTerms);
         });
         const searchTest = (s: string, st: string[]) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -333,7 +333,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     return _.isEmpty(css) ? undefined : css;
   }
 
-  ngOnChanges(changes) {
+  ngOnChanges() {
     this.useData();
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/empty.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/empty.pipe.ts
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
   name: 'empty'
 })
 export class EmptyPipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     return _.isUndefined(value) || _.isNull(value) ? '-' : value;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/cd-date.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/cd-date.pipe.ts
@@ -7,7 +7,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class CdDatePipe implements PipeTransform {
   constructor(private datePipe: DatePipe) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (value === null || value === '') {
       return '';
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'cephReleaseName'
 })
 export class CephReleaseNamePipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     // Expect "ceph version 13.1.0-419-g251e2515b5
     //         (251e2515b563856349498c6caf34e7a282f62937) nautilus (dev)"
     const result = /ceph version\s+[^ ]+\s+\(.+\)\s+(.+)\s+\((.+)\)/.exec(value);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-short-version.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-short-version.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'cephShortVersion'
 })
 export class CephShortVersionPipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     // Expect "ceph version 1.2.3-g9asdasd (as98d7a0s8d7)"
     const result = /ceph version\s+([^ ]+)\s+\(.+\)/.exec(value);
     if (result) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless-binary-per-second.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless-binary-per-second.pipe.ts
@@ -7,7 +7,7 @@ import { FormatterService } from '../services/formatter.service';
 export class DimlessBinaryPerSecondPipe implements PipeTransform {
   constructor(private formatter: FormatterService) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     return this.formatter.format_number(value, 1024, [
       'B/s',
       'kB/s',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless-binary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless-binary.pipe.ts
@@ -7,7 +7,7 @@ import { FormatterService } from '../services/formatter.service';
 export class DimlessBinaryPipe implements PipeTransform {
   constructor(private formatter: FormatterService) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     return this.formatter.format_number(value, 1024, [
       'B',
       'KiB',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless.pipe.ts
@@ -7,7 +7,7 @@ import { FormatterService } from '../services/formatter.service';
 export class DimlessPipe implements PipeTransform {
   constructor(private formatter: FormatterService) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     return this.formatter.format_number(value, 1000, ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/filter.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/filter.pipe.spec.ts
@@ -44,7 +44,7 @@ describe('FilterPipe', () => {
     const filters = [
       {
         value: '',
-        applyFilter: (row, val) => {
+        applyFilter: () => {
           return false;
         }
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/health-color.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/health-color.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'healthColor'
 })
 export class HealthColorPipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (value === 'HEALTH_OK') {
       return { color: '#00bb00' };
     } else if (value === 'HEALTH_WARN') {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/iops.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/iops.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'iops'
 })
 export class IopsPipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     return `${value} IOPS`;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/list.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/list.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'list'
 })
 export class ListPipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     return value.join(', ');
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/log-priority.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/log-priority.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'logPriority'
 })
 export class LogPriorityPipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (value === '[INF]') {
       return 'info';
     } else if (value === '[WRN]') {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/milliseconds.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/milliseconds.pipe.ts
@@ -4,7 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'milliseconds'
 })
 export class MillisecondsPipe implements PipeTransform {
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     return `${value} ms`;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/relative-date.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/relative-date.pipe.ts
@@ -8,7 +8,7 @@ import * as moment from 'moment';
 export class RelativeDatePipe implements PipeTransform {
   constructor() {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any): any {
     if (!value) {
       return 'unknown';
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
@@ -18,7 +18,7 @@ describe('ApiInterceptorService', () => {
   let router: Router;
   const url = 'api/xyz';
 
-  const httpError = (error, errorOpts, done = (resp) => {}) => {
+  const httpError = (error, errorOpts, done = (_resp) => {}) => {
     httpClient.get(url).subscribe(
       () => {},
       (resp) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
@@ -35,13 +35,13 @@ describe('AuthGuardService', () => {
 
   it('should allow the user if loggedIn', () => {
     spyOn(authStorageService, 'isLoggedIn').and.returnValue(true);
-    expect(service.canActivate(null, null)).toBe(true);
+    expect(service.canActivate()).toBe(true);
   });
 
   it('should prevent user if not loggedIn and redirect to login page', fakeAsync(() => {
     const router = TestBed.get(Router);
     ngZone.run(() => {
-      expect(service.canActivate(null, null)).toBe(false);
+      expect(service.canActivate()).toBe(false);
     });
     tick();
     expect(router.url).toBe('/login');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
@@ -1,11 +1,5 @@
 import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  CanActivateChild,
-  Router,
-  RouterStateSnapshot
-} from '@angular/router';
+import { CanActivate, CanActivateChild, Router } from '@angular/router';
 
 import { AuthStorageService } from './auth-storage.service';
 import { ServicesModule } from './services.module';
@@ -16,7 +10,7 @@ import { ServicesModule } from './services.module';
 export class AuthGuardService implements CanActivate, CanActivateChild {
   constructor(private router: Router, private authStorageService: AuthStorageService) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+  canActivate() {
     if (this.authStorageService.isLoggedIn()) {
       return true;
     }
@@ -24,7 +18,7 @@ export class AuthGuardService implements CanActivate, CanActivateChild {
     return false;
   }
 
-  canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    return this.canActivate(route, state);
+  canActivateChild(): boolean {
+    return this.canActivate();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.spec.ts
@@ -13,18 +13,18 @@ describe('AuthStorageService', () => {
   });
 
   it('should store username', () => {
-    service.set(username);
+    service.set(username, '');
     expect(localStorage.getItem('dashboard_username')).toBe(username);
   });
 
   it('should remove username', () => {
-    service.set(username);
+    service.set(username, '');
     service.remove();
     expect(localStorage.getItem('dashboard_username')).toBe(null);
   });
 
   it('should be loggedIn', () => {
-    service.set(username);
+    service.set(username, '');
     expect(service.isLoggedIn()).toBe(true);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles-guard.service.spec.ts
@@ -52,7 +52,7 @@ describe('FeatureTogglesGuardService', () => {
 
     ngZone.run(() => {
       service
-        .canActivate(<ActivatedRouteSnapshot>{ routeConfig: { path: path } }, null)
+        .canActivate(<ActivatedRouteSnapshot>{ routeConfig: { path: path } })
         .subscribe((val) => (result = val));
     });
     tick();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles-guard.service.ts
@@ -1,11 +1,5 @@
 import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  CanActivateChild,
-  Router,
-  RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router } from '@angular/router';
 
 import { map } from 'rxjs/operators';
 
@@ -18,7 +12,7 @@ import { ServicesModule } from './services.module';
 export class FeatureTogglesGuardService implements CanActivate, CanActivateChild {
   constructor(private router: Router, private featureToggles: FeatureTogglesService) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+  canActivate(route: ActivatedRouteSnapshot) {
     return this.featureToggles.get().pipe(
       map((enabledFeatures: FeatureTogglesMap) => {
         if (enabledFeatures[route.routeConfig.path] === false) {
@@ -30,7 +24,7 @@ export class FeatureTogglesGuardService implements CanActivate, CanActivateChild
     );
   }
 
-  canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    return this.canActivate(route.parent, state);
+  canActivateChild(route: ActivatedRouteSnapshot) {
+    return this.canActivate(route.parent);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
@@ -63,7 +63,7 @@ describe('FormatterService', () => {
       expect(service.toBytes('1.1  kib')).toBeNull();
       expect(service.toBytes('1.kib')).toBeNull();
       expect(service.toBytes('1 ki')).toBeNull();
-      expect(service.toBytes()).toBeNull();
+      expect(service.toBytes(undefined)).toBeNull();
       expect(service.toBytes('')).toBeNull();
       expect(service.toBytes('-')).toBeNull();
       expect(service.toBytes(null)).toBeNull();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -29,7 +29,7 @@ describe('ModuleStatusGuardService', () => {
     let result: boolean;
     spyOn(httpClient, 'get').and.returnValue(observableOf(getResult));
     ngZone.run(() => {
-      service.canActivateChild(route, null).subscribe((resp) => {
+      service.canActivateChild(route).subscribe((resp) => {
         result = resp;
       });
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
@@ -1,12 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  CanActivateChild,
-  Router,
-  RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router } from '@angular/router';
 
 import { of as observableOf } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -44,11 +38,11 @@ import { ServicesModule } from './services.module';
 export class ModuleStatusGuardService implements CanActivate, CanActivateChild {
   constructor(private http: HttpClient, private router: Router) {}
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+  canActivate(route: ActivatedRouteSnapshot) {
     return this.doCheck(route);
   }
 
-  canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+  canActivateChild(childRoute: ActivatedRouteSnapshot) {
     return this.doCheck(childRoute);
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -36,7 +36,7 @@ export class NotificationService {
     let notifications: CdNotification[] = [];
 
     if (_.isString(stringNotifications)) {
-      notifications = JSON.parse(stringNotifications, (key, value) => {
+      notifications = JSON.parse(stringNotifications, (_key, value) => {
         if (_.isPlainObject(value)) {
           return _.assign(new CdNotification(), value);
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
@@ -42,7 +42,7 @@ describe('PrometheusAlertService', () => {
     const resp = { status: 500, error: {} };
     service = new PrometheusAlertService(null, <PrometheusService>{
       ifAlertmanagerConfigured: (fn) => fn(),
-      list: () => ({ subscribe: (fn, err) => err(resp) })
+      list: () => ({ subscribe: (_fn, err) => err(resp) })
     });
 
     expect(service['connected']).toBe(true);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -293,24 +293,24 @@ export class TaskMessageService {
     'rbd/mirroring/pool/edit': this.newTaskMessage(
       this.commonOperations.update,
       this.rbd_mirroring.pool,
-      (metadata) => ({
+      () => ({
         16: this.i18n('Cannot disable mirroring because it contains a peer.')
       })
     ),
     'rbd/mirroring/peer/add': this.newTaskMessage(
       this.commonOperations.create,
       this.rbd_mirroring.pool_peer,
-      (metadata) => ({})
+      () => ({})
     ),
     'rbd/mirroring/peer/edit': this.newTaskMessage(
       this.commonOperations.update,
       this.rbd_mirroring.pool_peer,
-      (metadata) => ({})
+      () => ({})
     ),
     'rbd/mirroring/peer/delete': this.newTaskMessage(
       this.commonOperations.delete,
       this.rbd_mirroring.pool_peer,
-      (metadata) => ({})
+      () => ({})
     ),
     // iSCSI target tasks
     'iscsi/target/create': this.newTaskMessage(this.commonOperations.create, (metadata) =>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
@@ -76,7 +76,7 @@ describe('TaskWrapperService', () => {
 
     it('should call notifyTask if asynchronous task would have been finished', () => {
       const taskManager = TestBed.get(TaskManagerService);
-      spyOn(taskManager, 'subscribe').and.callFake((name, metadata, onTaskFinished) => {
+      spyOn(taskManager, 'subscribe').and.callFake((_name, _metadata, onTaskFinished) => {
         onTaskFinished();
       });
       callWrapTaskAroundCall(202, 'async').subscribe(null, null, () => (passed = true));

--- a/src/pybind/mgr/dashboard/frontend/src/jestGlobalMocks.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/jestGlobalMocks.ts
@@ -12,7 +12,7 @@ Object.defineProperty(window, 'localStorage', { value: mock() });
 Object.defineProperty(window, 'sessionStorage', { value: mock() });
 Object.defineProperty(window, 'getComputedStyle', {
   value: () => ({
-    getPropertyValue: (prop) => {
+    getPropertyValue: () => {
       return '';
     }
   })

--- a/src/pybind/mgr/dashboard/frontend/src/tsconfig.app.json
+++ b/src/pybind/mgr/dashboard/frontend/src/tsconfig.app.json
@@ -8,7 +8,6 @@
   },
   "exclude": [
     "**/*.spec.ts",
-    "test.ts",
     "testing/*.ts"
   ]
 }

--- a/src/pybind/mgr/dashboard/frontend/src/tsconfig.spec.json
+++ b/src/pybind/mgr/dashboard/frontend/src/tsconfig.spec.json
@@ -6,12 +6,12 @@
     "module": "commonjs",
     "target": "es5",
     "types": [
-      "jasmine",
+      "jest",
       "node"
-    ]
+    ],
+    "noEmit": true
   },
   "files": [
-    "test.ts",
     "polyfills.ts"
   ],
   "include": [

--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -40,7 +40,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
@@ -61,7 +60,7 @@
       }
     ],
     "unified-signatures": true,
-    "variable-name": [true, "check-format", "allow-snake-case"],
+    "variable-name": [true, "check-format", "allow-snake-case", "allow-leading-underscore"],
     "whitespace": [
       true,
       "check-branch",


### PR DESCRIPTION
* Added npm script 'lint:tsc' to check for unused local variables & parameters.
Notice that vars/params beginning with '_' are ignored by compiler.

* tslint: removed 'no-unused-variable' controversial rule in favor of compiler checks.

* Added npm script 'test:config' to address 'lint:tsc' complaining about
  not finding module 'unit-test-configuration.ts'.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

