### PR TITLE
mon,osd: limit MOSDMap messages by size as well as map count

### DIFF
--- a/src/common/config_values.h
+++ b/src/common/config_values.h
@@ -49,6 +49,7 @@ public:
 #define OPTION_OPT_U32(name) uint64_t name;
 #define OPTION_OPT_U64(name) uint64_t name;
 #define OPTION_OPT_UUID(name) uuid_d name;
+#define OPTION_OPT_SIZE(name) size_t name;
 #define OPTION(name, ty)       \
   public:                      \
     OPTION_##ty(name)          

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -599,6 +599,7 @@ OPTION(osd_objecter_finishers, OPT_INT)
 OPTION(osd_map_dedup, OPT_BOOL)
 OPTION(osd_map_cache_size, OPT_INT)
 OPTION(osd_map_message_max, OPT_INT)  // max maps per MOSDMap message
+OPTION(osd_map_message_max_bytes, OPT_SIZE)  // max maps per MOSDMap message
 OPTION(osd_map_share_max_epochs, OPT_INT)  // cap on # of inc maps we send to peers, clients
 OPTION(osd_inject_bad_map_crc_probability, OPT_FLOAT)
 OPTION(osd_inject_failure_on_pg_removal, OPT_BOOL)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2578,7 +2578,11 @@ std::vector<Option> get_global_options() {
 
     Option("osd_map_message_max", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(40)
-    .set_description(""),
+    .set_description("maximum number of OSDMaps to include in a single message"),
+
+    Option("osd_map_message_max_bytes", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .set_default(10_M)
+    .set_description("maximum number of bytes worth of OSDMaps to include in a single message"),
 
     Option("osd_map_share_max_epochs", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(40)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2234,17 +2234,22 @@ bool OSDMonitor::preprocess_get_osdmap(MonOpRequestRef op)
   epoch_t first = get_first_committed();
   epoch_t last = osdmap.get_epoch();
   int max = g_conf()->osd_map_message_max;
+  ssize_t max_bytes = g_conf()->osd_map_message_max_bytes;
   for (epoch_t e = std::max(first, m->get_full_first());
-       e <= std::min(last, m->get_full_last()) && max > 0;
+       e <= std::min(last, m->get_full_last()) && max > 0 && max_bytes > 0;
        ++e, --max) {
-    int r = get_version_full(e, features, reply->maps[e]);
+    bufferlist& bl = reply->maps[e];
+    int r = get_version_full(e, features, bl);
     ceph_assert(r >= 0);
+    max_bytes -= bl.length();
   }
   for (epoch_t e = std::max(first, m->get_inc_first());
-       e <= std::min(last, m->get_inc_last()) && max > 0;
+       e <= std::min(last, m->get_inc_last()) && max > 0 && max_bytes > 0;
        ++e, --max) {
-    int r = get_version(e, features, reply->incremental_maps[e]);
+    bufferlist& bl = reply->incremental_maps[e];
+    int r = get_version(e, features, bl);
     ceph_assert(r >= 0);
+    max_bytes -= bl.length();
   }
   reply->oldest_map = first;
   reply->newest_map = last;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1469,22 +1469,52 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
   m->oldest_map = max_oldest_map;
   m->newest_map = sblock.newest_map;
 
-  for (epoch_t e = to; e > since; e--) {
+  int max = cct->_conf->osd_map_message_max;
+  ssize_t max_bytes = cct->_conf->osd_map_message_max_bytes;
+
+  if (since > m->oldest_map) {
+    // we don't have the next map the target wants, so start with a
+    // full map.
     bufferlist bl;
-    if (e > m->oldest_map && get_inc_map_bl(e, bl)) {
-      m->incremental_maps[e].claim(bl);
-    } else if (get_map_bl(e, bl)) {
-      m->maps[e].claim(bl);
-      break;
-    } else {
-      derr << "since " << since << " to " << to
-	   << " oldest " << m->oldest_map << " newest " << m->newest_map
-	   << dendl;
-      m->put();
-      m = NULL;
+    dout(10) << __func__ << " oldest map " << max_oldest_map << " < since "
+	     << since << ", starting with full map" << dendl;
+    since = m->oldest_map;
+    if (!get_map_bl(since, bl)) {
+      derr << __func__ << " missing full map " << since << dendl;
+      goto panic;
+    }
+    max--;
+    max_bytes -= bl.length();
+    m->maps[since].claim(bl);
+  }
+  for (epoch_t e = since + 1; e <= to; ++e) {
+    bufferlist bl;
+    if (!get_inc_map_bl(e, bl)) {
+      derr << __func__ << " missing incremental map " << e << dendl;
+      goto panic;
+    }
+    max--;
+    max_bytes -= bl.length();
+    m->incremental_maps[e].claim(bl);
+    if (max <= 0 || max_bytes <= 0) {
       break;
     }
   }
+  return m;
+
+ panic:
+  if (!m->maps.empty() ||
+      !m->incremental_maps.empty()) {
+    // send what we have so far
+    return m;
+  }
+  // send something
+  bufferlist bl;
+  if (!get_inc_map_bl(m->newest_map, bl)) {
+    derr << __func__ << " unable to load latest map " << m->newest_map << dendl;
+    ceph_abort();
+  }
+  m->incremental_maps[m->newest_map].claim(bl);
   return m;
 }
 
@@ -1520,8 +1550,6 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
       since = to - cct->_conf->osd_map_share_max_epochs;
     }
 
-    if (to - since > (epoch_t)cct->_conf->osd_map_message_max)
-      to = since + cct->_conf->osd_map_message_max;
     m = build_incremental_map_msg(since, to, sblock);
   }
   send_map(m, con);


### PR DESCRIPTION
Start with 10 MB per message.

Fixes: http://tracker.ceph.com/issues/38040