### PR TITLE
mgr/dashboard: Fix iSCSI + Rook issues

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -51,10 +51,14 @@ class IscsiUi(BaseController):
             status['available'] = True
         except RequestException as e:
             if e.content:
-                content = json.loads(e.content)
-                content_message = content.get('message')
+                try:
+                    content = json.loads(e.content)
+                    content_message = content.get('message')
+                except ValueError:
+                    content_message = e.content
                 if content_message:
                     status['message'] = content_message
+
         return status
 
     @Endpoint()

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -36,7 +36,7 @@ class IscsiUi(BaseController):
             status['message'] = 'There are no gateways defined'
             return status
         try:
-            for gateway in gateways.keys():
+            for gateway in gateways:
                 try:
                     IscsiClient.instance(gateway_name=gateway).ping()
                 except RequestException:
@@ -67,7 +67,7 @@ class IscsiUi(BaseController):
     def portals(self):
         portals = []
         gateways_config = IscsiGatewaysConfig.get_gateways_config()
-        for name in gateways_config['gateways'].keys():
+        for name in gateways_config['gateways']:
             ip_addresses = IscsiClient.instance(gateway_name=name).get_ip_addresses()
             portals.append({'name': name, 'ip_addresses': ip_addresses['data']})
         return sorted(portals, key=lambda p: '{}.{}'.format(p['name'], p['ip_addresses']))

--- a/src/pybind/mgr/dashboard/services/iscsi_config.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_config.py
@@ -3,11 +3,14 @@ from __future__ import absolute_import
 
 import json
 
+from orchestrator import OrchestratorError
+
 try:
     from urlparse import urlparse
 except ImportError:
     from urllib.parse import urlparse
 
+from mgr_util import merge_dicts
 from .orchestrator import OrchClient
 from .. import mgr
 
@@ -48,12 +51,23 @@ _ISCSI_STORE_KEY = "_iscsi_config"
 
 class IscsiGatewaysConfig(object):
     @classmethod
-    def _load_config(cls):
-        if OrchClient().available():
-            raise ManagedByOrchestratorException()
+    def _load_config_from_store(cls):
         json_db = mgr.get_store(_ISCSI_STORE_KEY,
                                 '{"gateways": {}}')
         return json.loads(json_db)
+
+    @staticmethod
+    def _load_config_from_orchestrator():
+        config = {'gateways': {}}
+        try:
+            instances = OrchClient().list_service_info("iscsi")
+            for instance in instances:
+                config['gateways'][instance.nodename] = {
+                    'service_url': instance.service_url
+                }
+        except (RuntimeError, OrchestratorError, ImportError):
+            pass
+        return config
 
     @classmethod
     def _save_config(cls, config):
@@ -67,7 +81,7 @@ class IscsiGatewaysConfig(object):
 
     @classmethod
     def add_gateway(cls, name, service_url):
-        config = cls._load_config()
+        config = cls.get_gateways_config()
         if name in config:
             raise IscsiGatewayAlreadyExists(name)
         IscsiGatewaysConfig.validate_service_url(service_url)
@@ -76,7 +90,10 @@ class IscsiGatewaysConfig(object):
 
     @classmethod
     def remove_gateway(cls, name):
-        config = cls._load_config()
+        if name in cls._load_config_from_orchestrator()['gateways']:
+            raise ManagedByOrchestratorException()
+
+        config = cls._load_config_from_store()
         if name not in config['gateways']:
             raise IscsiGatewayDoesNotExist(name)
 
@@ -85,16 +102,10 @@ class IscsiGatewaysConfig(object):
 
     @classmethod
     def get_gateways_config(cls):
-        try:
-            config = cls._load_config()
-        except ManagedByOrchestratorException:
-            config = {'gateways': {}}
-            instances = OrchClient().list_service_info("iscsi")
-            for instance in instances:
-                config['gateways'][instance.nodename] = {
-                    'service_url': instance.service_url
-                }
-        return config
+        orch_config = cls._load_config_from_orchestrator()
+        local_config = cls._load_config_from_store()
+
+        return {'gateways': merge_dicts(orch_config['gateways'], local_config['gateways'])}
 
     @classmethod
     def get_gateway_config(cls, name):

--- a/src/pybind/mgr/dashboard/services/iscsi_config.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_config.py
@@ -49,7 +49,7 @@ _ISCSI_STORE_KEY = "_iscsi_config"
 class IscsiGatewaysConfig(object):
     @classmethod
     def _load_config(cls):
-        if OrchClient.instance().available():
+        if OrchClient().available():
             raise ManagedByOrchestratorException()
         json_db = mgr.get_store(_ISCSI_STORE_KEY,
                                 '{"gateways": {}}')
@@ -89,7 +89,7 @@ class IscsiGatewaysConfig(object):
             config = cls._load_config()
         except ManagedByOrchestratorException:
             config = {'gateways': {}}
-            instances = OrchClient.instance().list_service_info("iscsi")
+            instances = OrchClient().list_service_info("iscsi")
             for instance in instances:
                 config['gateways'][instance.nodename] = {
                     'service_url': instance.service_url

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -1,55 +1,38 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import time
-
+from orchestrator import OrchestratorClientMixin, raise_if_exception, OrchestratorError
 from .. import mgr, logger
 
 
-class NoOrchestratorConfiguredException(Exception):
-    pass
-
-
-class OrchClient(object):
-    _instance = None
-
-    @classmethod
-    def instance(cls):
-        if cls._instance is None:
-            cls._instance = OrchClient()
-        return cls._instance
-
-    def _call(self, method, *args, **kwargs):
-        _backend = mgr.get_module_option_ex("orchestrator_cli", "orchestrator")
-        if not _backend:
-            raise NoOrchestratorConfiguredException()
-        return mgr.remote(_backend, method, *args, **kwargs)
-
-    def _wait(self, completions):
-        while not self._call("wait", completions):
-            if any(c.should_wait for c in completions):
-                time.sleep(5)
-            else:
-                break
+# pylint: disable=abstract-method
+class OrchClient(OrchestratorClientMixin):
+    def __init__(self):
+        super(OrchClient, self).__init__()
+        self.set_mgr(mgr)
 
     def list_service_info(self, service_type):
-        completion = self._call("describe_service", service_type, None, None)
-        self._wait([completion])
+        # type: (str) -> list
+        completion = self.describe_service(service_type, None, None)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
         return completion.result
 
     def available(self):
-        _backend = mgr.get_module_option_ex("orchestrator_cli", "orchestrator")
-        if not _backend:
+        try:
+            status, desc = super(OrchClient, self).available()
+            logger.info("[ORCH] is orchestrator available: %s, %s", status, desc)
+            return status
+        except (RuntimeError, OrchestratorError, ImportError):
             return False
-        status, desc = self._call("available")
-        logger.info("[ORCH] is orchestrator available: %s, %s", status, desc)
-        return status
 
     def reload_service(self, service_type, service_ids):
         if not isinstance(service_ids, list):
             service_ids = [service_ids]
 
-        completion_list = [self._call("service_action", 'reload', service_type,
-                                      service_name, service_id)
+        completion_list = [self.service_action('reload', service_type,
+                                               service_name, service_id)
                            for service_name, service_id in service_ids]
-        self._wait(completion_list)
+        self._orchestrator_wait(completion_list)
+        for c in completion_list:
+            raise_if_exception(c)

--- a/src/pybind/mgr/dashboard/tests/test_ganesha.py
+++ b/src/pybind/mgr/dashboard/tests/test_ganesha.py
@@ -5,6 +5,7 @@ import unittest
 
 from mock import MagicMock, Mock
 
+import orchestrator
 from . import KVStoreMockMixin
 from .. import mgr
 from ..settings import Settings
@@ -127,7 +128,9 @@ EXPORT
 
         mgr.rados = MagicMock()
         mgr.rados.open_ioctx.return_value = ioctx_mock
-        mgr.remote.return_value = False, None
+
+        # pylint: disable=protected-access
+        mgr._select_orchestrator.side_effect = orchestrator.NoOrchestrator()
 
         ganesha.CephX = MagicMock()
         ganesha.CephX.list_clients.return_value = ['ganesha']

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -17,7 +17,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
 
     @classmethod
     def setup_server(cls):
-        OrchClient.instance().available = lambda: False
+        OrchClient().available = lambda: False
         mgr.rados.side_effect = None
         # pylint: disable=protected-access
         Iscsi._cp_config['tools.authenticate.on'] = False

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -670,7 +670,12 @@ def build_url(host, scheme=None, port=None):
     :rtype: str
     """
     try:
-        ipaddress.IPv6Address(six.u(host))
+        try:
+            u_host = six.u(host)
+        except TypeError:
+            u_host = host
+
+        ipaddress.IPv6Address(u_host)
         netloc = '[{}]'.format(host)
     except ValueError:
         netloc = host

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -71,3 +71,17 @@ def format_dimless(n, width, colored=True):
 
 def format_bytes(n, width, colored=True):
     return format_units(n, width, colored, decimal=False)
+
+
+def merge_dicts(*args):
+    # type: (dict) -> dict
+    """
+    >>> assert merge_dicts({1:2}, {3:4}) == {1:2, 3:4}
+        You can also overwrite keys:
+    >>> assert merge_dicts({1:2}, {1:4}) == {1:4}
+    :rtype: dict[str, Any]
+    """
+    ret = {}
+    for arg in args:
+        ret.update(arg)
+    return ret

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -11,6 +11,7 @@ import uuid
 
 import six
 
+from mgr_module import MgrModule
 from mgr_util import format_bytes
 
 try:
@@ -230,7 +231,7 @@ class Orchestrator(object):
         return True
 
     def available(self):
-        # type: () -> Tuple[Optional[bool], Optional[str]]
+        # type: () -> Tuple[bool, str]
         """
         Report whether we can talk to the orchestrator.  This is the
         place to give the user a meaningful message if the orchestrator
@@ -242,13 +243,16 @@ class Orchestrator(object):
         (e.g. based on a periodic background ping of the orchestrator)
         if that's necessary to make this method fast.
 
-        Do not override this method if you don't have a meaningful
-        status to return: the default None, None return value is used
-        to indicate that a module is unable to indicate its availability.
+        ..note:: `True` doesn't mean that the desired functionality
+            is actually available in the orchestrator. I.e. this
+            won't work as expected::
+
+                >>> if OrchestratorClientMixin().available()[0]:  # wrong.
+                ...     OrchestratorClientMixin().get_hosts()
 
         :return: two-tuple of boolean, string
         """
-        return None, None
+        raise NotImplementedError()
 
     def wait(self, completions):
         """
@@ -305,7 +309,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def describe_service(self, service_type=None, service_id=None, node_name=None):
-        # type: (str, str, str) -> ReadCompletion[List[ServiceDescription]]
+        # type: (Optional[str], Optional[str], Optional[str]) -> ReadCompletion[List[ServiceDescription]]
         """
         Describe a service (of any kind) that is already configured in
         the orchestrator.  For example, when viewing an OSD in the dashboard
@@ -611,7 +615,7 @@ class DriveGroupSpec(object):
     def __init__(self, host_pattern, data_devices=None, db_devices=None, wal_devices=None, journal_devices=None,
                  data_directories=None, osds_per_device=None, objectstore='bluestore', encrypted=False,
                  db_slots=None, wal_slots=None):
-        # type: (str, Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], Optional[List[str]], int, str, bool, int, int) -> ()
+        # type: (str, Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], Optional[List[str]], int, str, bool, int, int) -> None
 
         # concept of applying a drive group to a (set) of hosts is tightly
         # linked to the drive group itself
@@ -873,24 +877,37 @@ class OrchestratorClientMixin(Orchestrator):
     ...        self.log.debug(completion.result)
 
     """
+
+    def set_mgr(self, mgr):
+        # type: (MgrModule) -> None
+        """
+        Useable in the Dashbord that uses a global ``mgr``
+        """
+
+        self.__mgr = mgr  # Make sure we're not overwriting any other `mgr` properties
+
     def _oremote(self, meth, args, kwargs):
         """
         Helper for invoking `remote` on whichever orchestrator is enabled
 
         :raises RuntimeError: If the remote method failed.
-        :raises NoOrchestrator:
+        :raises OrchestratorError: orchestrator failed to perform
         :raises ImportError: no `orchestrator_cli` module or backend not found.
         """
         try:
-            o = self._select_orchestrator()
+            mgr = self.__mgr
         except AttributeError:
-            o = self.remote('orchestrator_cli', '_select_orchestrator')
+            mgr = self
+        try:
+            o = mgr._select_orchestrator()
+        except AttributeError:
+            o = mgr.remote('orchestrator_cli', '_select_orchestrator')
 
         if o is None:
             raise NoOrchestrator()
 
-        self.log.debug("_oremote {} -> {}.{}(*{}, **{})".format(self.module_name, o, meth, args, kwargs))
-        return self.remote(o, meth, *args, **kwargs)
+        mgr.log.debug("_oremote {} -> {}.{}(*{}, **{})".format(mgr.module_name, o, meth, args, kwargs))
+        return mgr.remote(o, meth, *args, **kwargs)
 
     def _update_completion_progress(self, completion, force_progress=None):
         # type: (WriteCompletion, Optional[float]) -> None

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -182,10 +182,11 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             try:
                 c.execute()
             except Exception as e:
-                self.log.exception("Completion {0} threw an exception:".format(
-                    c.message
-                ))
-                c.error = e
+                if not isinstance(e, orchestrator.OrchestratorError):
+                    self.log.exception("Completion {0} threw an exception:".format(
+                        c.message
+                    ))
+                c.exception = e
                 c._complete = True
 
             if not c.is_complete:
@@ -331,7 +332,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @deferred_read
     def describe_service(self, service_type=None, service_id=None, node_name=None):
 
-        assert service_type in ("mds", "osd", "mgr", "mon", "nfs", None), service_type + " unsupported"
+        if service_type not in ("mds", "osd", "mgr", "mon", "nfs", None):
+            raise orchestrator.OrchestratorValidationError(service_type + " unsupported")
 
         pods = self.rook_cluster.describe_pods(service_type, service_id, node_name)
 


### PR DESCRIPTION
This contains three interdependent fixes: 

1. mgr/rook: Raise proper exception in `describe_service`
  `describe_service` is called often and raising
  assertions will pollute the log file with tracebacks.
2. mgr/dashboard: Load iSCSI config from local store and orchestrator
  As iSCSI is not supported by Rook, users need a way to manage
  ceph-iscsi without Rook knowledge.
  I.e. Using the Rook orchestrator would render the iSCSI page unusable.
3. mgr/dashboard: Merge OrchClient with OrchestratorClientMixin
  Fixed missing error propagation from
  the orchestrator to the dashboard

Fixes https://github.com/rook/rook/issues/3106
Fixes http://tracker.ceph.com/issues/39586

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

