### PR TITLE
mimic: qa: don't use notcmalloc flavor unless we need it

### DIFF
--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -1,6 +1,5 @@
 tasks:
 - install:
-    flavor: notcmalloc
 - ceph:
 - tox: [ client.0 ]
 - keystone:

--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -333,7 +333,6 @@ def task(ctx, config):
     Example of configuration:
 
       - install:
-          flavor: notcmalloc
       - ceph:
       - tox: [ client.0 ]
       - keystone:


### PR DESCRIPTION
Mimic backport of https://github.com/ceph/ceph/pull/26336

No luminous backport necessary