### PR TITLE
mgr/orch: refresh option for inventory query

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -39,6 +39,10 @@ class TestOrchestratorCli(MgrTestCase):
         ret = self._orch_cmd("device", "ls")
         self.assertIn("localhost:", ret)
 
+    def test_device_ls_refresh(self):
+        ret = self._orch_cmd("device", "ls", "--refresh")
+        self.assertIn("localhost:", ret)
+
     def test_device_ls_hoshs(self):
         ret = self._orch_cmd("device", "ls", "localhost", "host1")
         self.assertIn("localhost:", ret)

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -267,10 +267,11 @@ class Module(MgrModule, orchestrator.Orchestrator):
         self.log.info('Stopping Ansible orchestrator module')
         self.run = False
 
-    def get_inventory(self, node_filter=None):
+    def get_inventory(self, node_filter=None, refresh=False):
         """
 
         :param   :	node_filter instance
+        :param   :      refresh any cached state
         :Return  :	A AnsibleReadOperation instance (Completion Object)
         """
 

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -120,7 +120,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
         return True, ""
 
 
-    def get_inventory(self, node_filter=None):
+    def get_inventory(self, node_filter=None, refresh=False):
         """
         Note that this will raise an exception (e.g. if the salt-api is down,
         or the username/password is incorret).  Same for other methods.

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -216,8 +216,8 @@ class Orchestrator(object):
         """
         return self.get_inventory()
 
-    def get_inventory(self, node_filter=None):
-        # type: (InventoryFilter) -> ReadCompletion[List[InventoryNode]]
+    def get_inventory(self, node_filter=None, refresh=False):
+        # type: (InventoryFilter, bool) -> ReadCompletion[List[InventoryNode]]
         """
         Returns something that was created by `ceph-volume inventory`.
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -44,11 +44,12 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @CLIReadCommand('orchestrator device ls',
                     "name=host,type=CephString,n=N,req=false "
-                    "name=format,type=CephChoices,strings=json|plain,req=false",
+                    "name=format,type=CephChoices,strings=json|plain,req=false "
+                    "name=refresh,type=CephBool,req=false",
                     'List devices on a node')
     @handle_exceptions
-    def _list_devices(self, host=None, format='plain'):
-        # type: (List[str], str) -> HandleCommandResult
+    def _list_devices(self, host=None, format='plain', refresh=False):
+        # type: (List[str], str, bool) -> HandleCommandResult
         """
         Provide information about storage devices present in cluster hosts
 
@@ -58,7 +59,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         nf = orchestrator.InventoryFilter(nodes=host) if host else None
 
-        completion = self.get_inventory(node_filter=nf)
+        completion = self.get_inventory(node_filter=nf, refresh=refresh)
 
         self._orchestrator_wait([completion])
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -294,7 +294,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         # things look a bit out of sync?
 
     @deferred_read
-    def get_inventory(self, node_filter=None):
+    def get_inventory(self, node_filter=None, refresh=False):
         node_list = None
         if node_filter and node_filter.nodes:
             # Explicit node list

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -203,7 +203,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             self._shutdown.wait(5)
 
     @deferred_read
-    def get_inventory(self, node_filter=None):
+    def get_inventory(self, node_filter=None, refresh=False):
         """
         There is no guarantee which devices are returned by get_inventory.
         """


### PR DESCRIPTION
Adds a `refresh` option to `get inventory` interface meant to indicate that a backend should return non-cached inventory. defaults to `False`, and backends should indicate their exact semantics in their documentation.

Note that this PR doesn't touch the docs as `--refresh` is already described there.

