### PR TITLE
Revert "Merge pull request #25077 from rzarzynski/wip-bl-kill_append_buffer"

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -734,8 +734,14 @@ static ceph::spinlock debug_lock;
     //     << " (p_off " << p_off << " in " << p->length() << ")"
     //     << std::endl;
 
-    p_off +=o;
-    while (p != ls->end()) {
+    p_off += o;
+
+    if (!o) {
+      return;
+    }
+    while (p_off > 0) {
+      if (p == ls->end())
+        throw end_of_buffer();
       if (p_off >= p->length()) {
         // skip this buffer
         p_off -= p->length();
@@ -744,9 +750,6 @@ static ceph::spinlock debug_lock;
         // somewhere in this buffer!
         break;
       }
-    }
-    if (p == ls->end() && p_off) {
-      throw end_of_buffer();
     }
     off += o;
   }
@@ -803,6 +806,7 @@ static ceph::spinlock debug_lock;
     while (len > 0) {
       if (p == ls->end())
 	throw end_of_buffer();
+      ceph_assert(p->length() > 0);
 
       unsigned howmuch = p->length() - p_off;
       if (len < howmuch) howmuch = len;
@@ -828,6 +832,7 @@ static ceph::spinlock debug_lock;
     }
     if (p == ls->end())
       throw end_of_buffer();
+    ceph_assert(p->length() > 0);
     dest = create(len);
     copy(len, dest.c_str());
   }
@@ -840,6 +845,7 @@ static ceph::spinlock debug_lock;
     }
     if (p == ls->end())
       throw end_of_buffer();
+    ceph_assert(p->length() > 0);
     unsigned howmuch = p->length() - p_off;
     if (howmuch < len) {
       dest = create(len);
@@ -897,6 +903,7 @@ static ceph::spinlock debug_lock;
     while (1) {
       if (p == ls->end())
 	return;
+      ceph_assert(p->length() > 0);
 
       unsigned howmuch = p->length() - p_off;
       const char *c_str = p->c_str();
@@ -996,10 +1003,10 @@ static ceph::spinlock debug_lock;
 
   buffer::list::list(list&& other) noexcept
     : _buffers(std::move(other._buffers)),
-      _carriage(&always_empty_bptr),
       _len(other._len),
       _memcopy_count(other._memcopy_count),
       last_p(this) {
+    append_buffer.swap(other.append_buffer);
     other.clear();
   }
 
@@ -1007,8 +1014,8 @@ static ceph::spinlock debug_lock;
   {
     std::swap(_len, other._len);
     std::swap(_memcopy_count, other._memcopy_count);
-    std::swap(_carriage, other._carriage);
     _buffers.swap(other._buffers);
+    append_buffer.swap(other.append_buffer);
     //last_p.swap(other.last_p);
     last_p = begin();
     other.last_p = other.begin();
@@ -1041,6 +1048,7 @@ static ceph::spinlock debug_lock;
 	  ++b;
 	}
       }
+      ceph_assert(b == std::cend(other._buffers));
       return true;
     }
 
@@ -1170,6 +1178,9 @@ static ceph::spinlock debug_lock;
 
   void buffer::list::reassign_to_mempool(int pool)
   {
+    if (append_buffer.get_raw()) {
+      append_buffer.get_raw()->reassign_to_mempool(pool);
+    }
     for (auto& p : _buffers) {
       p.get_raw()->reassign_to_mempool(pool);
     }
@@ -1177,6 +1188,9 @@ static ceph::spinlock debug_lock;
 
   void buffer::list::try_assign_to_mempool(int pool)
   {
+    if (append_buffer.get_raw()) {
+      append_buffer.get_raw()->try_assign_to_mempool(pool);
+    }
     for (auto& p : _buffers) {
       p.get_raw()->try_assign_to_mempool(pool);
     }
@@ -1211,7 +1225,6 @@ static ceph::spinlock debug_lock;
   void buffer::list::rebuild()
   {
     if (_len == 0) {
-      _carriage = &always_empty_bptr;
       _buffers.clear_and_dispose();
       return;
     }
@@ -1230,10 +1243,8 @@ static ceph::spinlock debug_lock;
       pos += node.length();
     }
     _memcopy_count += pos;
-    _carriage = &always_empty_bptr;
     _buffers.clear_and_dispose();
     if (likely(nb->length())) {
-      _carriage = nb.get();
       _buffers.push_back(*nb.release());
     }
     invalidate_crc();
@@ -1310,11 +1321,9 @@ static ceph::spinlock debug_lock;
 
   void buffer::list::reserve(size_t prealloc)
   {
-    if (get_append_buffer_unused_tail_length() < prealloc) {
-      auto ptr = ptr_node::create(buffer::create_page_aligned(prealloc));
-      ptr->set_length(0);   // unused, so far.
-      _carriage = ptr.get();
-      _buffers.push_back(*ptr.release());
+    if (append_buffer.unused_tail_length() < prealloc) {
+      append_buffer = buffer::create_page_aligned(prealloc);
+      append_buffer.set_length(0);   // unused, so far.
     }
   }
 
@@ -1333,8 +1342,6 @@ static ceph::spinlock debug_lock;
     if (!(flags & CLAIM_ALLOW_NONSHAREABLE))
       bl.make_shareable();
     _buffers.splice_back(bl._buffers);
-    bl._carriage = &always_empty_bptr;
-    bl._buffers.clear_and_dispose();
     bl._len = 0;
     bl.last_p = bl.begin();
   }
@@ -1393,91 +1400,39 @@ static ceph::spinlock debug_lock;
   void buffer::list::append(char c)
   {
     // put what we can into the existing append_buffer.
-    unsigned gap = get_append_buffer_unused_tail_length();
+    unsigned gap = append_buffer.unused_tail_length();
     if (!gap) {
-      // make a new buffer!
-      auto buf = ptr_node::create(
-	raw_combined::create(CEPH_BUFFER_APPEND_SIZE, 0, get_mempool()));
-      buf->set_length(0);   // unused, so far.
-      _carriage = buf.get();
-      _buffers.push_back(*buf.release());
-    } else if (unlikely(_carriage != &_buffers.back())) {
-      auto bptr = ptr_node::create(*_carriage, _carriage->length(), 0);
-      _carriage = bptr.get();
-      _buffers.push_back(*bptr.release());
+      // make a new append_buffer!
+      append_buffer = raw_combined::create(CEPH_BUFFER_APPEND_SIZE, 0,
+					   get_mempool());
+      append_buffer.set_length(0);   // unused, so far.
     }
-    _carriage->append(c);
-    _len++;
-  }
-
-  buffer::ptr buffer::list::always_empty_bptr;
-
-  buffer::ptr_node& buffer::list::refill_append_space(const unsigned len)
-  {
-    // make a new buffer.  fill out a complete page, factoring in the
-    // raw_combined overhead.
-    size_t need = round_up_to(len, sizeof(size_t)) + sizeof(raw_combined);
-    size_t alen = round_up_to(need, CEPH_BUFFER_ALLOC_UNIT) -
-      sizeof(raw_combined);
-    auto new_back = \
-      ptr_node::create(raw_combined::create(alen, 0, get_mempool()));
-    new_back->set_length(0);   // unused, so far.
-    _carriage = new_back.get();
-    _buffers.push_back(*new_back.release());
-    return _buffers.back();
+    append(append_buffer, append_buffer.append(c) - 1, 1);	// add segment to the list
   }
 
   void buffer::list::append(const char *data, unsigned len)
   {
-    _len += len;
-
-    const unsigned free_in_last = get_append_buffer_unused_tail_length();
-    const unsigned first_round = std::min(len, free_in_last);
-    if (first_round) {
-      // _buffers and carriage can desynchronize when 1) a new ptr
-      // we don't own has been added into the _buffers 2) _buffers
-      // has been emptied as as a result of std::move or stolen by
-      // claim_append.
-      if (unlikely(_carriage != &_buffers.back())) {
-        auto bptr = ptr_node::create(*_carriage, _carriage->length(), 0);
-	_carriage = bptr.get();
-	_buffers.push_back(*bptr.release());
+    while (len > 0) {
+      // put what we can into the existing append_buffer.
+      unsigned gap = append_buffer.unused_tail_length();
+      if (gap > 0) {
+        if (gap > len) gap = len;
+    //cout << "append first char is " << data[0] << ", last char is " << data[len-1] << std::endl;
+        append_buffer.append(data, gap);
+        append(append_buffer, append_buffer.length() - gap, gap);	// add segment to the list
+        len -= gap;
+        data += gap;
       }
-      _carriage->append(data, first_round);
-    }
-
-    const unsigned second_round = len - first_round;
-    if (second_round) {
-      auto& new_back = refill_append_space(second_round);
-      new_back.append(data + first_round, second_round);
-    }
-  }
-
-  buffer::list::reserve_t buffer::list::obtain_contiguous_space(
-    const unsigned len)
-  {
-    // note: if len < the normal append_buffer size it *might*
-    // be better to allocate a normal-sized append_buffer and
-    // use part of it.  however, that optimizes for the case of
-    // old-style types including new-style types.  and in most
-    // such cases, this won't be the very first thing encoded to
-    // the list, so append_buffer will already be allocated.
-    // OTOH if everything is new-style, we *should* allocate
-    // only what we need and conserve memory.
-    if (unlikely(get_append_buffer_unused_tail_length() < len)) {
-      auto new_back = \
-	buffer::ptr_node::create(buffer::create(len)).release();
-      new_back->set_length(0);   // unused, so far.
-      _buffers.push_back(*new_back);
-      _carriage = new_back;
-      return { new_back->c_str(), &new_back->_len, &_len };
-    } else {
-      if (unlikely(_carriage != &_buffers.back())) {
-        auto bptr = ptr_node::create(*_carriage, _carriage->length(), 0);
-	_carriage = bptr.get();
-	_buffers.push_back(*bptr.release());
-      }
-      return { _carriage->end_c_str(), &_carriage->_len, &_len };
+      if (len == 0)
+        break;  // done!
+      
+      // make a new append_buffer.  fill out a complete page, factoring in the
+      // raw_combined overhead.
+      size_t need = round_up_to(len, sizeof(size_t)) + sizeof(raw_combined);
+      size_t alen = round_up_to(need, CEPH_BUFFER_ALLOC_UNIT) -
+	sizeof(raw_combined);
+      append_buffer = raw_combined::create(alen, 0, get_mempool());
+      append_buffer.set_length(0);   // unused, so far.
     }
   }
 
@@ -1505,8 +1460,7 @@ static ceph::spinlock debug_lock;
       }
     }
     // add new item to list
-    _buffers.push_back(*ptr_node::create(bp, off, len).release());
-    _len += len;
+    push_back(ptr_node::create(bp, off, len));
   }
 
   void buffer::list::append(const list& bl)
@@ -1530,21 +1484,21 @@ static ceph::spinlock debug_lock;
 
   buffer::list::contiguous_filler buffer::list::append_hole(const unsigned len)
   {
-    _len += len;
-
-    if (unlikely(get_append_buffer_unused_tail_length() < len)) {
+    if (unlikely(append_buffer.unused_tail_length() < len)) {
       // make a new append_buffer.  fill out a complete page, factoring in
       // the raw_combined overhead.
-      auto& new_back = refill_append_space(len);
-      new_back.set_length(len);
-      return { new_back.c_str() };
-    } else if (unlikely(_carriage != &_buffers.back())) {
-      auto bptr = ptr_node::create(*_carriage, _carriage->length(), 0);
-      _carriage = bptr.get();
-      _buffers.push_back(*bptr.release());
+      const size_t need = \
+	round_up_to(len, sizeof(size_t)) + sizeof(raw_combined);
+      const size_t alen = \
+	round_up_to(need, CEPH_BUFFER_ALLOC_UNIT) - sizeof(raw_combined);
+      append_buffer = raw_combined::create(alen, 0, get_mempool());
+      append_buffer.set_length(0);
     }
-    _carriage->set_length(_carriage->length() + len);
-    return { _carriage->end_c_str() - len };
+
+    append_buffer.set_length(append_buffer.length() + len);
+    append(append_buffer, append_buffer.length() - len, len);
+
+    return { _buffers.back().end_c_str() - len };
   }
 
   void buffer::list::prepend_zero(unsigned len)
@@ -1557,24 +1511,16 @@ static ceph::spinlock debug_lock;
   
   void buffer::list::append_zero(unsigned len)
   {
-    _len += len;
-
-    const unsigned free_in_last = get_append_buffer_unused_tail_length();
-    const unsigned first_round = std::min(len, free_in_last);
-    if (first_round) {
-      if (unlikely(_carriage != &_buffers.back())) {
-        auto bptr = ptr_node::create(*_carriage, _carriage->length(), 0);
-	_carriage = bptr.get();
-	_buffers.push_back(*bptr.release());
-      }
-      _carriage->append_zeros(first_round);
+    unsigned need = std::min(append_buffer.unused_tail_length(), len);
+    if (need) {
+      append_buffer.append_zeros(need);
+      append(append_buffer, append_buffer.length() - need, need);
+      len -= need;
     }
-
-    const unsigned second_round = len - first_round;
-    if (second_round) {
-      auto& new_back = refill_append_space(second_round);
-      new_back.set_length(second_round);
-      new_back.zero(false);
+    if (len) {
+      auto bp = ptr_node::create(buffer::create_page_aligned(len));
+      bp->zero(false);
+      push_back(std::move(bp));
     }
   }
 
@@ -1701,8 +1647,6 @@ static ceph::spinlock debug_lock;
       ++curbuf_prev;
     }
     
-    _carriage = &always_empty_bptr;
-
     while (len > 0) {
       // partial?
       if (off + len < (*curbuf).length()) {

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -178,9 +178,7 @@ namespace buffer CEPH_BUFFER_API {
    */
   class CEPH_BUFFER_API ptr {
     raw *_raw;
-  public: // dirty hack for testing; if it works, this will be abstracted
     unsigned _off, _len;
-  private:
 
     void release();
 
@@ -655,13 +653,9 @@ namespace buffer CEPH_BUFFER_API {
   private:
     // my private bits
     buffers_t _buffers;
-
-    // track bufferptr we can modify (especially ::append() to). Not all bptrs
-    // bufferlist holds have this trait -- if somebody ::push_back(const ptr&),
-    // he expects it won't change.
-    ptr* _carriage;
     unsigned _len;
     unsigned _memcopy_count; //the total of memcopy using rebuild().
+    ptr append_buffer;  // where i put small appends.
 
     template <bool is_const>
     class CEPH_BUFFER_API iterator_impl {
@@ -762,46 +756,75 @@ namespace buffer CEPH_BUFFER_API {
       void copy_in(unsigned len, const list& otherl);
     };
 
-    struct reserve_t {
-      char* bp_data;
-      unsigned* bp_len;
-      unsigned* bl_len;
-    };
-
     class contiguous_appender {
-      ceph::bufferlist& bl;
-      ceph::bufferlist::reserve_t space;
-      char* pos;
+      bufferlist *pbl;
+      char *pos;
+      ptr bp;
       bool deep;
 
       /// running count of bytes appended that are not reflected by @pos
       size_t out_of_band_offset = 0;
 
-      contiguous_appender(bufferlist& bl, size_t len, bool d)
-	: bl(bl),
-	  space(bl.obtain_contiguous_space(len)),
-	  pos(space.bp_data),
+      contiguous_appender(bufferlist *l, size_t len, bool d)
+	: pbl(l),
 	  deep(d) {
+	size_t unused = pbl->append_buffer.unused_tail_length();
+	if (len > unused) {
+	  // note: if len < the normal append_buffer size it *might*
+	  // be better to allocate a normal-sized append_buffer and
+	  // use part of it.  however, that optimizes for the case of
+	  // old-style types including new-style types.  and in most
+	  // such cases, this won't be the very first thing encoded to
+	  // the list, so append_buffer will already be allocated.
+	  // OTOH if everything is new-style, we *should* allocate
+	  // only what we need and conserve memory.
+	  bp = buffer::create(len);
+	  pos = bp.c_str();
+	} else {
+	  pos = pbl->append_buffer.end_c_str();
+	}
       }
 
       void flush_and_continue() {
-	const size_t l = pos - space.bp_data;
-	*space.bp_len += l;
-	*space.bl_len += l;
-	space.bp_data = pos;
+	if (bp.have_raw()) {
+	  // we allocated a new buffer
+	  size_t l = pos - bp.c_str();
+	  pbl->append(bufferptr(bp, 0, l));
+	  bp.set_length(bp.length() - l);
+	  bp.set_offset(bp.offset() + l);
+	} else {
+	  // we are using pbl's append_buffer
+	  size_t l = pos - pbl->append_buffer.end_c_str();
+	  if (l) {
+	    pbl->append_buffer.set_length(pbl->append_buffer.length() + l);
+	    pbl->append(pbl->append_buffer, pbl->append_buffer.end() - l, l);
+	    pos = pbl->append_buffer.end_c_str();
+	  }
+	}
       }
 
       friend class list;
 
     public:
       ~contiguous_appender() {
-	flush_and_continue();
+	if (bp.have_raw()) {
+	  // we allocated a new buffer
+	  bp.set_length(pos - bp.c_str());
+	  pbl->append(std::move(bp));
+	} else {
+	  // we are using pbl's append_buffer
+	  size_t l = pos - pbl->append_buffer.end_c_str();
+	  if (l) {
+	    pbl->append_buffer.set_length(pbl->append_buffer.length() + l);
+	    pbl->append(pbl->append_buffer, pbl->append_buffer.end() - l, l);
+	  }
+	}
       }
 
       size_t get_out_of_band_offset() const {
 	return out_of_band_offset;
       }
-      void append(const char* __restrict__ p, size_t l) {
+      void append(const char *p, size_t l) {
 	maybe_inline_memcpy(pos, p, l, 16);
 	pos += l;
       }
@@ -815,39 +838,43 @@ namespace buffer CEPH_BUFFER_API {
       }
 
       void append(const bufferptr& p) {
-	const auto plen = p.length();
-	if (!plen) {
+	if (!p.length()) {
 	  return;
 	}
 	if (deep) {
-	  append(p.c_str(), plen);
+	  append(p.c_str(), p.length());
 	} else {
 	  flush_and_continue();
-	  bl.append(p);
-	  space = bl.obtain_contiguous_space(0);
-	  out_of_band_offset += plen;
+	  pbl->append(p);
+	  out_of_band_offset += p.length();
 	}
       }
       void append(const bufferlist& l) {
+	if (!l.length()) {
+	  return;
+	}
 	if (deep) {
 	  for (const auto &p : l._buffers) {
 	    append(p.c_str(), p.length());
 	  }
 	} else {
 	  flush_and_continue();
-	  bl.append(l);
-	  space = bl.obtain_contiguous_space(0);
+	  pbl->append(l);
 	  out_of_band_offset += l.length();
 	}
       }
 
       size_t get_logical_offset() {
-	return out_of_band_offset + (pos - space.bp_data);
+	if (bp.have_raw()) {
+	  return out_of_band_offset + (pos - bp.c_str());
+	} else {
+	  return out_of_band_offset + (pos - pbl->append_buffer.end_c_str());
+	}
       }
     };
 
     contiguous_appender get_contiguous_appender(size_t len, bool deep=false) {
-      return contiguous_appender(*this, len, deep);
+      return contiguous_appender(this, len, deep);
     }
 
     class contiguous_filler {
@@ -931,35 +958,16 @@ namespace buffer CEPH_BUFFER_API {
   private:
     mutable iterator last_p;
 
-    // always_empty_bptr has no underlying raw but its _len is always 0.
-    // This is useful for e.g. get_append_buffer_unused_tail_length() as
-    // it allows to avoid conditionals on hot paths.
-    static ptr always_empty_bptr;
-    ptr_node& refill_append_space(const unsigned len);
-
   public:
     // cons/des
-    list()
-      : _carriage(&always_empty_bptr),
-        _len(0),
-        _memcopy_count(0),
-        last_p(this) {
-    }
+    list() : _len(0), _memcopy_count(0), last_p(this) {}
     // cppcheck-suppress noExplicitConstructor
-    // cppcheck-suppress noExplicitConstructor
-    list(unsigned prealloc)
-      : _carriage(&always_empty_bptr),
-        _len(0),
-        _memcopy_count(0),
-	last_p(this) {
+    list(unsigned prealloc) : _len(0), _memcopy_count(0), last_p(this) {
       reserve(prealloc);
     }
 
-    list(const list& other)
-      : _carriage(&always_empty_bptr),
-        _len(other._len),
-        _memcopy_count(other._memcopy_count),
-        last_p(this) {
+    list(const list& other) : _len(other._len),
+			      _memcopy_count(other._memcopy_count), last_p(this) {
       _buffers.clone_from(other._buffers);
       make_shareable();
     }
@@ -971,7 +979,6 @@ namespace buffer CEPH_BUFFER_API {
 
     list& operator= (const list& other) {
       if (this != &other) {
-        _carriage = &always_empty_bptr;
         _buffers.clone_from(other._buffers);
         _len = other._len;
 	make_shareable();
@@ -980,10 +987,10 @@ namespace buffer CEPH_BUFFER_API {
     }
     list& operator= (list&& other) noexcept {
       _buffers = std::move(other._buffers);
-      _carriage = other._carriage;
       _len = other._len;
       _memcopy_count = other._memcopy_count;
       last_p = begin();
+      append_buffer.swap(other.append_buffer);
       other.clear();
       return *this;
     }
@@ -998,7 +1005,7 @@ namespace buffer CEPH_BUFFER_API {
     void try_assign_to_mempool(int pool);
 
     size_t get_append_buffer_unused_tail_length() const {
-      return _carriage->unused_tail_length();
+      return append_buffer.unused_tail_length();
     }
 
     unsigned get_memcopy_count() const {return _memcopy_count; }
@@ -1036,11 +1043,11 @@ namespace buffer CEPH_BUFFER_API {
 
     // modifiers
     void clear() noexcept {
-      _carriage = &always_empty_bptr;
       _buffers.clear_and_dispose();
       _len = 0;
       _memcopy_count = 0;
       last_p = begin();
+      append_buffer = ptr();
     }
     void push_back(const ptr& bp) {
       if (bp.length() == 0)
@@ -1053,7 +1060,6 @@ namespace buffer CEPH_BUFFER_API {
 	return;
       _len += bp.length();
       _buffers.push_back(*ptr_node::create(std::move(bp)).release());
-      _carriage = &always_empty_bptr;
     }
     void push_back(const ptr_node&) = delete;
     void push_back(ptr_node&) = delete;
@@ -1061,13 +1067,11 @@ namespace buffer CEPH_BUFFER_API {
     void push_back(std::unique_ptr<ptr_node, ptr_node::disposer> bp) {
       if (bp->length() == 0)
 	return;
-      _carriage = bp.get();
       _len += bp->length();
       _buffers.push_back(*bp.release());
     }
     void push_back(raw* const r) {
       _buffers.push_back(*ptr_node::create(r).release());
-      _carriage = &_buffers.back();
       _len += _buffers.back().length();
     }
 
@@ -1098,8 +1102,9 @@ namespace buffer CEPH_BUFFER_API {
 
     // clone non-shareable buffers (make shareable)
     void make_shareable() {
-      for (auto& bp : _buffers) {
-        bp.make_shareable();
+      decltype(_buffers)::iterator pb;
+      for (pb = _buffers.begin(); pb != _buffers.end(); ++pb) {
+        (void) pb->make_shareable();
       }
     }
 
@@ -1108,10 +1113,9 @@ namespace buffer CEPH_BUFFER_API {
     {
       if (this != &bl) {
         clear();
-	for (const auto& bp : bl._buffers) {
-          _buffers.push_back(*ptr_node::create(bp).release());
+	for (const auto& pb : bl._buffers) {
+          push_back(static_cast<const ptr&>(pb));
         }
-        _len = bl._len;
       }
     }
 
@@ -1172,8 +1176,6 @@ namespace buffer CEPH_BUFFER_API {
     contiguous_filler append_hole(unsigned len);
     void append_zero(unsigned len);
     void prepend_zero(unsigned len);
-
-    reserve_t obtain_contiguous_space(unsigned len);
 
     /*
      * get a char

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -828,53 +828,6 @@ TEST(BufferListIterator, advance) {
   }
 }
 
-TEST(BufferListIterator, iterate_with_empties) {
-  ceph::bufferlist bl;
-  EXPECT_EQ(bl.get_num_buffers(), 0u);
-
-  bl.push_back(ceph::buffer::create(0));
-  EXPECT_EQ(bl.length(), 0u);
-  EXPECT_EQ(bl.get_num_buffers(), 1u);
-
-  encode(42l, bl);
-  EXPECT_EQ(bl.get_num_buffers(), 2u);
-
-  bl.push_back(ceph::buffer::create(0));
-  EXPECT_EQ(bl.get_num_buffers(), 3u);
-
-  // append bufferlist with single, 0-sized ptr inside
-  {
-    ceph::bufferlist bl_with_empty_ptr;
-    bl_with_empty_ptr.push_back(ceph::buffer::create(0));
-    EXPECT_EQ(bl_with_empty_ptr.length(), 0u);
-    EXPECT_EQ(bl_with_empty_ptr.get_num_buffers(), 1u);
-
-    bl.append(bl_with_empty_ptr);
-  }
-
-  encode(24l, bl);
-  EXPECT_EQ(bl.get_num_buffers(), 5u);
-
-  auto i = bl.cbegin();
-  long val;
-  decode(val, i);
-  EXPECT_EQ(val, 42l);
-
-  decode(val, i);
-  EXPECT_EQ(val, 24l);
-
-  val = 0;
-  i.seek(sizeof(long));
-  decode(val, i);
-  EXPECT_EQ(val, 24l);
-  EXPECT_TRUE(i == bl.end());
-
-  i.seek(0);
-  decode(val, i);
-  EXPECT_EQ(val, 42);
-  EXPECT_FALSE(i == bl.end());
-}
-
 TEST(BufferListIterator, get_ptr_and_advance)
 {
   bufferptr a("one", 3);
@@ -2658,59 +2611,6 @@ TEST(BufferList, EmptyAppend) {
   bufferptr ptr;
   bl.push_back(ptr);
   ASSERT_EQ(bl.begin().end(), 1);
-}
-
-TEST(BufferList, InternalCarriage) {
-  ceph::bufferlist bl;
-  EXPECT_EQ(bl.get_num_buffers(), 0u);
-
-  encode(42l, bl);
-  EXPECT_EQ(bl.get_num_buffers(), 1u);
-
-  {
-    ceph::bufferlist bl_with_foo;
-    bl_with_foo.append("foo", 3);
-    EXPECT_EQ(bl_with_foo.length(), 3u);
-    EXPECT_EQ(bl_with_foo.get_num_buffers(), 1u);
-
-    bl.append(bl_with_foo);
-    EXPECT_EQ(bl.get_num_buffers(), 2u);
-  }
-
-  encode(24l, bl);
-  EXPECT_EQ(bl.get_num_buffers(), 3u);
-}
-
-TEST(BufferList, ContiguousAppender) {
-  ceph::bufferlist bl;
-  EXPECT_EQ(bl.get_num_buffers(), 0u);
-
-  // we expect a flush in ~contiguous_appender
-  {
-    auto ap = bl.get_contiguous_appender(100);
-
-    denc(42l, ap);
-    EXPECT_EQ(bl.get_num_buffers(), 1u);
-
-    // append bufferlist with single ptr inside. This should
-    // commit changes to bl::_len and the underlying bp::len.
-    {
-      ceph::bufferlist bl_with_foo;
-      bl_with_foo.append("foo", 3);
-      EXPECT_EQ(bl_with_foo.length(), 3u);
-      EXPECT_EQ(bl_with_foo.get_num_buffers(), 1u);
-
-      ap.append(bl_with_foo);
-      // 3 as the ap::append(const bl&) splits the bp with free
-      // space.
-      EXPECT_EQ(bl.get_num_buffers(), 3u);
-    }
-
-    denc(24l, ap);
-    EXPECT_EQ(bl.get_num_buffers(), 3u);
-    EXPECT_EQ(bl.length(), sizeof(long) + 3u);
-  }
-  EXPECT_EQ(bl.length(), 2u * sizeof(long) + 3u);
 }
 
 TEST(BufferList, TestPtrAppend) {


### PR DESCRIPTION
This reverts commit be56801eb86db61e4aa3bbdeb584571b644eaf92, reversing
changes made to 8805a28b0f934e17ad953c9281e92f3a50a34e80.

See various seg faults in the OSD, e.g.,

http://tracker.ceph.com/issues/38024
http://tracker.ceph.com/issues/38230

Signed-off-by: Sage Weil <sage@redhat.com>