### PR TITLE
mimic: qa/tasks/radosbench: default to 64k writes

### DIFF
--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -76,12 +76,12 @@ def task(ctx, config):
             else:
                 pool = manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
 
-        osize = config.get('objectsize', 0)
+        osize = config.get('objectsize', 65536)
         if osize is 0:
             objectsize = []
         else:
             objectsize = ['-o', str(osize)]
-        size = ['-b', str(config.get('size', 4<<20))]
+        size = ['-b', str(config.get('size', 65536))]
         # If doing a reading run then populate data
         if runtype != "write":
             proc = remote.run(


### PR DESCRIPTION
http://tracker.ceph.com/issues/38239