### PR TITLE
mgr/orchestrator: fix device pretty print with None attributes

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -788,9 +788,10 @@ class InventoryDevice(object):
             return row_format.format("Device Path", "Type", "Size", "Rotates",
                                      "Available", "Model")
         else:
-            return row_format.format(self.id, self.type, format_bytes(self.size, 5, colored=False),
+            return row_format.format(self.id, self.type if self.type is not None else "",
+                                     format_bytes(self.size, 5, colored=False),
                                      str(self.rotates), str(self.available),
-                                     self.dev_id)
+                                     self.dev_id if self.dev_id is not None else "")
 
 
 class InventoryNode(object):

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -788,8 +788,9 @@ class InventoryDevice(object):
             return row_format.format("Device Path", "Type", "Size", "Rotates",
                                      "Available", "Model")
         else:
-            return row_format.format(self.id, self.type if self.type is not None else "",
-                                     format_bytes(self.size, 5, colored=False),
+            return row_format.format(str(self.id), self.type if self.type is not None else "",
+                                     format_bytes(self.size if self.size is not None else 0, 5,
+                                                  colored=False),
                                      str(self.rotates), str(self.available),
                                      self.dev_id if self.dev_id is not None else "")
 

--- a/src/pybind/mgr/orchestrator_cli/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator_cli/test_orchestrator.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import pytest
 
 
-from orchestrator import DriveGroupSpec, DeviceSelection, DriveGroupValidationError
+from orchestrator import DriveGroupSpec, DeviceSelection, DriveGroupValidationError, InventoryDevice
 
 
 def test_DriveGroup():
@@ -34,3 +34,7 @@ def test_drive_selection():
     with pytest.raises(DriveGroupValidationError, match='exclusive'):
         DeviceSelection(paths=['/dev/sda'], rotates=False)
 
+def test_inventory_device():
+    i_d = InventoryDevice()
+    s = i_d.pretty_print()
+    assert len(s)


### PR DESCRIPTION
Fixes the pretty print of disk devices function when some of the disk attributes have the `None` value.

Before this fix we were getting the following stack trace:
```
Error EINVAL: Traceback (most recent call last):
  File "/home/rdias/Work/ceph/src/pybind/mgr/mgr_module.py", line 838, in _handle_command
    return CLICommand.COMMANDS[cmd['prefix']].call(self, cmd, inbuf)
  File "/home/rdias/Work/ceph/src/pybind/mgr/mgr_module.py", line 337, in call
    return self.func(mgr, **kwargs)
  File "/home/rdias/Work/ceph/src/pybind/mgr/orchestrator_cli/module.py", line 27, in inner
    return func(*args, **kwargs)
  File "/home/rdias/Work/ceph/src/pybind/mgr/orchestrator_cli/module.py", line 107, in _list_devices
    result += d.pretty_print()
  File "/home/rdias/Work/ceph/src/pybind/mgr/orchestrator.py", line 790, in pretty_print
    self.dev_id)
TypeError: unsupported format string passed to NoneType.__format__
```


Signed-off-by: Ricardo Dias <rdias@suse.com>

