### PR TITLE
qa: change mon_bind_msgr2 to ms_bind_msgr2

### DIFF
--- a/qa/msgr/async-v1only.yaml
+++ b/qa/msgr/async-v1only.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     conf:
       global:
         ms type: async

--- a/qa/msgr/random.yaml
+++ b/qa/msgr/random.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     conf:
       global:
         ms type: random

--- a/qa/msgr/simple.yaml
+++ b/qa/msgr/simple.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     conf:
       global:
         ms type: simple

--- a/qa/suites/fs/basic_functional/tasks/volume-client/task/test/test.yaml
+++ b/qa/suites/fs/basic_functional/tasks/volume-client/task/test/test.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     conf:
       global:
         ms type: simple

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-luminous.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-luminous.yaml
@@ -13,7 +13,7 @@ tasks:
 - print: "**** done installing luminous"
 - ceph:
     mon_bind_addrvec: false
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     log-whitelist:
       - overall HEALTH_
       - \(FS_

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-luminous.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-luminous.yaml
@@ -13,7 +13,7 @@ tasks:
 - print: "**** done installing luminous"
 - ceph:
     mon_bind_addrvec: false
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     log-whitelist:
       - overall HEALTH_
       - \(FS_

--- a/qa/suites/fs/upgrade/snaps/tasks/0-luminous.yaml
+++ b/qa/suites/fs/upgrade/snaps/tasks/0-luminous.yaml
@@ -13,7 +13,7 @@ tasks:
 - print: "**** done installing luminous"
 - ceph:
     mon_bind_addrvec: false
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     log-whitelist:
       - overall HEALTH_
       - \(FS_

--- a/qa/suites/rados/thrash-old-clients/ceph.yaml
+++ b/qa/suites/rados/thrash-old-clients/ceph.yaml
@@ -1,7 +1,7 @@
 tasks:
 - ceph:
     mon_bind_addrvec: false
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     conf:
       global:
         ms bind msgr2: false

--- a/qa/suites/rados/upgrade/luminous-x-singleton/0-cluster/start.yaml
+++ b/qa/suites/rados/upgrade/luminous-x-singleton/0-cluster/start.yaml
@@ -6,7 +6,7 @@ meta:
 overrides:
   ceph:
     mon_bind_addrvec: false
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     fs: xfs
     conf:
       global:

--- a/qa/suites/upgrade/luminous-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/luminous-x/parallel/0-cluster/start.yaml
@@ -20,7 +20,7 @@ roles:
   - client.3
 overrides:
   ceph:
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     mon_bind_addrvec: false
     log-whitelist:
     - scrub mismatch

--- a/qa/suites/upgrade/luminous-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/0-cluster/start.yaml
@@ -5,7 +5,7 @@ meta:
    Use xfs beneath the osds.
 overrides:
   ceph:
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     mon_bind_addrvec: false
     fs: xfs
     log-whitelist:

--- a/qa/suites/upgrade/mimic-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/0-cluster/start.yaml
@@ -23,7 +23,7 @@ roles:
   - client.3
 overrides:
   ceph:
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     mon_bind_addrvec: false
     log-whitelist:
     - scrub mismatch

--- a/qa/suites/upgrade/mimic-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/0-cluster/start.yaml
@@ -8,7 +8,7 @@ meta:
    # skip_tags: entitlements,packages,repos
 overrides:
   ceph:
-    mon_bind_msgr2: false
+    ms_bind_msgr2: false
     mon_bind_addrvec: false
     fs: xfs
     log-whitelist:

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -420,7 +420,7 @@ def cephfs_setup(ctx, config):
 
 
 def get_mons(roles, ips, cluster_name,
-             mon_bind_msgr2=False,
+             ms_bind_msgr2=False,
              mon_bind_addrvec=False):
     """
     Get monitors and their associated addresses
@@ -438,7 +438,7 @@ def get_mons(roles, ips, cluster_name,
                 v1_ports[ips[idx]] = 6789
             else:
                 v1_ports[ips[idx]] += 1
-            if mon_bind_msgr2:
+            if ms_bind_msgr2:
                 if ips[idx] not in v2_ports:
                     v2_ports[ips[idx]] = 3300
                     addr = '{ip}'.format(ip=ips[idx])
@@ -653,7 +653,7 @@ def cluster(ctx, config):
            (remote.ssh.get_transport().getpeername() for (remote, role_list) in remotes_and_roles)]
     mons = get_mons(
         roles, ips, cluster_name,
-        mon_bind_msgr2=config.get('mon_bind_msgr2'),
+        ms_bind_msgr2=config.get('ms_bind_msgr2'),
         mon_bind_addrvec=config.get('mon_bind_addrvec'),
         )
     conf = skeleton_config(
@@ -1902,7 +1902,7 @@ def task(ctx, config):
             log_whitelist=config.get('log-whitelist', []),
             cpu_profile=set(config.get('cpu_profile', []),),
             cluster=config['cluster'],
-            mon_bind_msgr2=config.get('mon_bind_msgr2', True),
+            ms_bind_msgr2=config.get('ms_bind_msgr2', True),
             mon_bind_addrvec=config.get('mon_bind_addrvec', True),
         )),
         lambda: run_daemon(ctx=ctx, config=config, type_='mon'),


### PR DESCRIPTION
This brings the ceph task into line with the state of the ceph.conf option
("ms bind msgr2" instead of "mon bind msgr2")

Fixes: https://tracker.ceph.com/issues/38216

Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

