### PR TITLE
doc: mgr/orch: Fix remote_host doc reference

### DIFF
--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -164,7 +164,7 @@ Host management
 ---------------
 
 .. automethod:: Orchestrator.add_host
-.. automethod:: Orchestrator.remote_host
+.. automethod:: Orchestrator.remove_host
 .. automethod:: Orchestrator.get_hosts
 
 Inventory and status


### PR DESCRIPTION
The typo fix in the remote_host to remove_host has caused a Ceph docs
build failure.

Introduced-By: 05cfa6fd6b205de3ef6b3d093576b3c86d31f160 (#26314)
Fixes: http://tracker.ceph.com/issues/38254
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

