### PR TITLE
ceph.spec.in: python-kubernetes broken on rhel

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -488,7 +488,6 @@ BuildArch:	noarch
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
-Requires:       python-kubernetes
 %description mgr-rook
 ceph-mgr-rook is a ceph-mgr plugin for orchestration functions using
 a Rook backend.


### PR DESCRIPTION
Error: Package: python2-kubernetes-8.0.0-6.el7.noarch (epel)
           Requires: python-adal

Signed-off-by: Sage Weil <sage@redhat.com>