### PR TITLE
build: further removal of `subman` configuration

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1079,9 +1079,6 @@ ${CMAKE} .. \
     -DWITH_PYTHON2=OFF \
     -DMGR_PYTHON_VERSION=3 \
 %endif
-%if 0%{?rhel} && ! 0%{?centos}
-    -DWITH_SUBMAN=ON \
-%endif
 %if 0%{without ceph_test_package}
     -DWITH_TESTS=OFF \
 %endif
@@ -1738,9 +1735,6 @@ fi
 %{_mandir}/man8/ceph-bluestore-tool.8*
 %{_mandir}/man8/ceph-volume.8*
 %{_mandir}/man8/ceph-volume-systemd.8*
-%if 0%{?rhel} && ! 0%{?centos}
-%attr(0755,-,-) %{_sysconfdir}/cron.hourly/subman
-%endif
 %{_unitdir}/ceph-osd@.service
 %{_unitdir}/ceph-osd.target
 %{_unitdir}/ceph-volume@.service

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -1,11 +1,3 @@
-option(WITH_SUBMAN "install subscription manager cron job" OFF)
-
-if(WITH_SUBMAN)
-  install(PROGRAMS
-    ${CMAKE_CURRENT_SOURCE_DIR}/subman
-    DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/cron.hourly)
-endif()
-
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"


### PR DESCRIPTION
Since it has been removed for a while (See http://github.com/ceph/ceph/commit/1bcc870305dbbe9b3b04278b545cce60aeb4d869 ) it not only doesn't make sense to keep these around, but it causes issues for some packaging systems.

Fixes: http://tracker.ceph.com/issues/38261