### PR TITLE
debian/control: change Architecture python plugins to "all"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -201,7 +201,7 @@ Description: manager for the ceph distributed storage system
  level management and monitoring functionality.
 
 Package: ceph-mgr-diskprediction-local
-Architecture: any
+Architecture: all
 Depends: ceph-mgr (= ${binary:Version}),
          python-numpy,
          python-scipy,
@@ -218,7 +218,7 @@ Description: diskprediction-local plugin for ceph-mgr
  daemon, which helps predict disk failures.
 
 Package: ceph-mgr-diskprediction-cloud
-Architecture: any
+Architecture: all
 Depends: ceph-mgr (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
@@ -232,9 +232,9 @@ Description: diskprediction-cloud plugin for ceph-mgr
  daemon, which helps predict disk failures.
 
 Package: ceph-mgr-rook
-Architecture: any
+Architecture: all
 Depends: ceph-mgr (= ${binary:Version}),
-	 python-six,
+         python-six,
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},


### PR DESCRIPTION
change following plugins' Architecture to "all", as they are pure python
plugins and are architecture-independent packages.

- ceph-mgr-diskprediction-cloud
- ceph-mgr-diskprediction-local
- ceph-mgr-rook

this also matches their couterparts in ceph.spec.in, where we have
```
BuildArch:  noarch
```

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

