### PR TITLE
rpm,deb: remove python-jinja2 dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -432,7 +432,6 @@ Requires:       python%{_python_buildid}-six
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       python%{_python_buildid}-cherrypy
 Requires:       python%{_python_buildid}-jwt
-Requires:       python%{_python_buildid}-jinja2
 Requires:       python%{_python_buildid}-routes
 Requires:       python%{_python_buildid}-werkzeug
 Requires:       pyOpenSSL%{_python_buildid}
@@ -442,7 +441,6 @@ Requires:	python%{_python_buildid}-bcrypt
 Requires:       python%{_python_buildid}-CherryPy
 Requires:       python%{_python_buildid}-PyJWT
 Requires:       python%{_python_buildid}-Routes
-Requires:       python%{_python_buildid}-Jinja2
 Requires:       python%{_python_buildid}-Werkzeug
 Requires:       python%{_python_buildid}-pyOpenSSL
 Requires:       python%{_python_buildid}-bcrypt

--- a/debian/control
+++ b/debian/control
@@ -180,7 +180,6 @@ Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
          python-cherrypy3,
          python-jwt,
-         python-jinja2,
          python-openssl,
          python-pecan,
          python-bcrypt,


### PR DESCRIPTION
python-jinja2 dependency was added for the dashboard v1 in 87399bea. but
dashboard v2, which is now known as "dashboard" has taken the place of
the old dashboard. and dashboard now does not use jinja2, so we should
drop this dependency.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

