### PR TITLE
mgr/dashboard: iSCSI - Add support for disabling ACL authentication (backend)

### DIFF
--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -179,3 +179,10 @@ class IscsiClient(RestClient):
             'chap': chap,
             'chap_mutual': chap_mutual
         })
+
+    @RestClient.api_put('/api/targetauth/{target_iqn}')
+    def update_targetauth(self, target_iqn, action, request=None):
+        logger.debug("iSCSI: Updating targetauth: %s/%s", target_iqn, action)
+        return request({
+            'action': action
+        })

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-public-methods
+
 import copy
 import mock
 
@@ -330,6 +332,7 @@ iscsi_target_request = {
             }
         }
     ],
+    "acl_enabled": True,
     "target_controls": {},
     "groups": [
         {
@@ -373,6 +376,7 @@ iscsi_target_response = {
             }
         }
     ],
+    "acl_enabled": True,
     'groups': [
         {
             'group_id': 'mygroup',
@@ -401,7 +405,7 @@ class IscsiClientMock(object):
             "gateways": {},
             "targets": {},
             "updated": "",
-            "version": 4
+            "version": 5
         }
 
     @classmethod
@@ -447,6 +451,7 @@ class IscsiClientMock(object):
     def create_target(self, target_iqn, target_controls):
         self.config['targets'][target_iqn] = {
             "clients": {},
+            "acl_enabled": True,
             "controls": target_controls,
             "created": "2019/01/17 09:22:34",
             "disks": [],
@@ -547,3 +552,6 @@ class IscsiClientMock(object):
             'chap': chap,
             'chap_mutual': chap_mutual
         }
+
+    def update_targetauth(self, target_iqn, action):
+        self.config['targets'][target_iqn]['acl_enabled'] = (action == 'enable_acl')


### PR DESCRIPTION
This PR adds the support for disabling ACL authentication using the iSCSI REST API.

Fixes: https://tracker.ceph.com/issues/38016

Signed-off-by: Ricardo Marques <rimarques@suse.com>
