### PR TITLE
mgr/dashboard: Add implicit wait in e2e tests

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/protractor.conf.js
+++ b/src/pybind/mgr/dashboard/frontend/protractor.conf.js
@@ -29,6 +29,8 @@ exports.config = {
     }
   },
   onPrepare() {
+    browser.manage().timeouts().implicitlyWait(360000);
+
     require('ts-node').register({
       project: 'e2e/tsconfig.e2e.json'
     });


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/38269

`Signed-off-by: Tiago Melo <tmelo@suse.com>`

- [x] Passed 9 dashboard tests