### PR TITLE
mon: mons also connect to mgrs

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -5875,7 +5875,8 @@ int Monitor::get_auth_request(
   bufferlist *out)
 {
   std::scoped_lock l(auth_lock);
-  if (con->get_peer_type() != CEPH_ENTITY_TYPE_MON) {
+  if (con->get_peer_type() != CEPH_ENTITY_TYPE_MON &&
+      con->get_peer_type() != CEPH_ENTITY_TYPE_MGR) {
     return -EACCES;
   }
   AuthAuthorizer *auth;
@@ -5883,7 +5884,7 @@ int Monitor::get_auth_request(
     return -EACCES;
   }
   auth_meta->authorizer.reset(auth);
-  auth_registry.get_supported_modes(CEPH_ENTITY_TYPE_MON,
+  auth_registry.get_supported_modes(con->get_peer_type(),
 				    auth->protocol,
 				    preferred_modes);
   *method = auth->protocol;


### PR DESCRIPTION
Some dashboard teuthology jobs were getting stuck because the mon was not able to authenticate with a mgr daemon.

```
2019-02-12 07:45:07.067 7fa3fd4f5700  1 --2-  >> [v2:172.21.15.198:6800/33044,v1:172.21.15.198:6801/33044] conn(0x5608e6d5d800 0x5608e6b84400 :-1 s=NONE pgs=0 cs=0 l=0).connect
2019-02-12 07:45:07.067 7fa3facf0700  1 --2-  >> [v2:172.21.15.198:6800/33044,v1:172.21.15.198:6801/33044] conn(0x5608e6d5d800 0x5608e6b84400 :-1 s=CONNECTING pgs=0 cs=0 l=0)._handle_peer_banner_payload supported=0 required=0
2019-02-12 07:45:07.067 7fa3facf0700  0 --2-  >> [v2:172.21.15.198:6800/33044,v1:172.21.15.198:6801/33044] conn(0x5608e6d5d800 0x5608e6b84400 :-1 s=CONNECTING pgs=0 cs=0 l=0).send_auth_request get_initial_auth_request returned -13
2019-02-12 07:45:07.067 7fa3facf0700  1 --2-  >> [v2:172.21.15.198:6800/33044,v1:172.21.15.198:6801/33044] conn(0x5608e6d5d800 0x5608e6b84400 :-1 s=CONNECTING pgs=0 cs=0 l=0).stop

```

Signed-off-by: Ricardo Dias <rdias@suse.com>
