### PR TITLE
ceph.spec.in: Don't use noarch for mgr module subpackages, fix /usr/lib64/ceph/mgr dir ownership

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1437,6 +1437,7 @@ fi
 
 %files mgr
 %{_bindir}/ceph-mgr
+%dir %{_libdir}/ceph/mgr
 %{_libdir}/ceph/mgr/ansible
 %{_libdir}/ceph/mgr/balancer
 %{_libdir}/ceph/mgr/crash

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -457,7 +457,6 @@ exposes all these to the python modules.
 
 %package mgr-diskprediction-local
 Summary:        ceph-mgr diskprediction_local plugin
-BuildArch:	noarch
 %if 0%{?suse_version}
 Group:          System/Filesystems
 %endif
@@ -470,7 +469,6 @@ disk failures using local algorithms and machine-learning databases.
 
 %package mgr-diskprediction-cloud
 Summary:        ceph-mgr diskprediction_cloud plugin
-BuildArch:	noarch
 %if 0%{?suse_version}
 Group:          System/Filesystems
 %endif
@@ -481,7 +479,6 @@ disk failures using services in the Google cloud.
 
 %package mgr-rook
 Summary:        ceph-mgr rook plugin
-BuildArch:	noarch
 %if 0%{?suse_version}
 Group:          System/Filesystems
 %endif


### PR DESCRIPTION
A couple of small kinks resulting from #25977:

1) Even though ceph-mgr modules are notionally non-architecture-specific, the files themselves are installed to an architecture-specific path (/usr/lib64/ceph/mgr/....), which causes the build to fail on SUSE distros with a huge long list of errors like:
    
ceph-mgr-diskprediction-cloud.noarch: E: suse-filelist-forbidden-noarch (Badness: 10000) /usr/lib64/ceph/mgr/diskprediction_cloud is not allowed in a noarch package
[...]
(none): E: badness 1120287 exceeds threshold 1000, aborting.

2) The /usr/lib64/ceph/mgr directory isn't owned by any package, which fails the build with "directories not owned by a package" errors for ceph-mgr, ceph-mgr-diskprediction-local, ceph-mgr-diskprediction-cloud and ceph-mgr-rook.
