### PR TITLE
ceph-volume: make Device hashable to allow set of Device list in py3

### DIFF
--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -106,6 +106,9 @@ class Device(object):
     def __eq__(self, other):
         return self.path == other.path
 
+    def __hash__(self):
+        return hash(self.path)
+
     def _parse(self):
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Fixes: http://tracker.ceph.com/issues/38290
