### PR TITLE
ceph-volume: implement __format__ in Size to format sizes in py3

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -601,6 +601,9 @@ class Size(object):
     def __str__(self):
         return "%s" % self._get_best_format()
 
+    def __format__(self, spec):
+        return str(self._get_best_format()).__format__(spec)
+
     def __lt__(self, other):
         return self._b < other._b
 


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Fixes: http://tracker.ceph.com/issues/38291