### PR TITLE
Allow rook to scale the mon count

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -347,24 +347,6 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def add_mon(self, node_name):
-        # type: (str) -> WriteCompletion
-        """
-        We operate on a node rather than a particular device: it is
-        assumed/expected that proper SSD storage is already available
-        and accessible in /var.
-
-        :param node_name:
-        """
-        raise NotImplementedError()
-
-    def remove_mon(self, node_name):
-        # type: (str) -> WriteCompletion
-        """
-        :param node_name: Remove MON from that host.
-        """
-        raise NotImplementedError()
-
     def upgrade_start(self, upgrade_spec):
         # type: (UpgradeSpec) -> WriteCompletion
         raise NotImplementedError()

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -392,6 +392,14 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             lambda: self.rook_cluster.rm_service(service_type, service_id), None,
             "Removing {0} services for {1}".format(service_type, service_id))
 
+    def update_mons(self, num, hosts):
+        if hosts:
+            raise RuntimeError("Host list is not supported by rook.")
+
+        return RookWriteCompletion(
+            lambda: self.rook_cluster.update_mon_count(num), None,
+            "Updating mon count to {0}".format(num))
+
     def create_osds(self, drive_group, all_hosts):
         # type: (orchestrator.DriveGroupSpec, List[str]) -> RookWriteCompletion
 

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -337,6 +337,20 @@ class RookCluster(object):
         else:
             return True
 
+    def update_mon_count(self, newcount):
+        patch = [{"op": "replace", "path": "/spec/mon/count", "value": newcount}]
+
+        try:
+            self.rook_api_patch(
+                "cephclusters/{0}".format(self.cluster_name),
+                body=patch)
+        except ApiException as e:
+            log.exception("API exception: {0}".format(e))
+            raise ApplyException(
+                "Failed to update mon count in Cluster CRD: {0}".format(e))
+
+        return "Updated mon count to {0}".format(newcount)
+
     def add_osds(self, drive_group, all_hosts):
         # type: (orchestrator.DriveGroupSpec, List[str]) -> None
         """


### PR DESCRIPTION
Just a small patch to the rook orchestrator backend that allows it to scale the mon count up and down via `ceph orchestrator mon update <count>`. It raises an exception if you try to use the hosts field -- hopefully that's ok.

I also went ahead and removed the add_mon and remove_mon methods since nothing implements or calls them. Let's just use update_mons going forward.