### PR TITLE
mgr/dashboard: fix: tox not detecting deps changes

### DIFF
--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -5,10 +5,6 @@ toxworkdir = {env:CEPH_BUILD_DIR}/dashboard
 minversion = 2.8.1
 
 [testenv]
-deps =
-    -r{toxinidir}/requirements.txt
-    py27: -r{toxinidir}/requirements-py27.txt
-    py3: -r{toxinidir}/requirements-py3.txt
 setenv=
     CFLAGS = -DXMLSEC_NO_SIZE_T
     UNITTEST = true
@@ -20,6 +16,9 @@ setenv=
     cov:  UNITTEST = true
     cov:  COVERAGE_FILE = .coverage.{envname}
 commands=
+    pip install -r {toxinidir}/requirements.txt
+    py27: pip install -r {toxinidir}/requirements-py27.txt
+    py3: pip install -r {toxinidir}/requirements-py3.txt
     cov: coverage erase
     cov: {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml --doctest-modules controllers/rbd.py services/ tests/ tools.py
     cov: coverage combine {toxinidir}/{env:COVERAGE_FILE}


### PR DESCRIPTION
* tox.ini: replaced 'deps' setting by appropriate commands
  due to this bug:
  https://github.com/tox-dev/tox/issues/149
  tox is not detecting changes in requirements.txt when using
  'deps' setting in 'tox.ini'.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

