### PR TITLE
rgw: orphan fixes 

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -355,6 +355,7 @@ void usage()
   cout << "   --orphan-stale-secs       num of seconds to wait before declaring an object to be an orphan (default: 86400)\n";
   cout << "   --job-id                  set the job id (for orphans find)\n";
   cout << "   --max-concurrent-ios      maximum concurrent ios for orphans find (default: 32)\n";
+  cout << "   --detail                  detailed mode, log and stat head objects as well\n";
   cout << "\nOrphans list-jobs options:\n";
   cout << "   --extra-info              provide extra info in job list\n";
   cout << "\nRole options:\n";
@@ -2830,6 +2831,7 @@ int main(int argc, const char **argv)
   bool num_shards_specified = false;
   int max_concurrent_ios = 32;
   uint64_t orphan_stale_secs = (24 * 3600);
+  int detail = false;
 
   std::string val;
   std::ostringstream errs;
@@ -3204,6 +3206,8 @@ int main(int argc, const char **argv)
       event_id = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--event-type", "--event-types", (char*)NULL)) {
       get_str_set(val, ",", event_types);
+    } else if (ceph_argparse_binary_flag(args, i, &detail, NULL, "--detail", (char*)NULL)) {
+      // do nothing
     } else if (strncmp(*i, "-", 1) == 0) {
       cerr << "ERROR: invalid flag " << *i << std::endl;
       return EINVAL;
@@ -6600,7 +6604,7 @@ next:
     info.job_name = job_id;
     info.num_shards = num_shards;
 
-    int ret = search.init(job_id, &info);
+    int ret = search.init(job_id, &info, detail);
     if (ret < 0) {
       cerr << "could not init search, ret=" << ret << std::endl;
       return -ret;

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -191,6 +191,10 @@ int RGWOrphanSearch::init(const string& job_name, RGWOrphanSearchInfo *info) {
     return r;
   }
 
+  constexpr auto MAX_LIST_OBJS_ENTRIES = 100;
+  max_list_bucket_entries = std::max(store->ctx()->_conf->rgw_list_bucket_min_readahead,
+                                     MAX_LIST_OBJS_ENTRIES)
+
   RGWOrphanSearchState state;
   r = orphan_store.read_job(job_name, state);
   if (r < 0 && r != -ENOENT) {
@@ -503,8 +507,8 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
   do {
     vector<rgw_bucket_dir_entry> result;
 
-#define MAX_LIST_OBJS_ENTRIES 100
-    ret = list_op.list_objects(MAX_LIST_OBJS_ENTRIES, &result, NULL, &truncated);
+    ret = list_op.list_objects(max_list_bucket_entries,
+                               &result, nullptr, &truncated);
     if (ret < 0) {
       cerr << "ERROR: store->list_objects(): " << cpp_strerror(-ret) << std::endl;
       return -ret;

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -186,7 +186,7 @@ int RGWOrphanStore::read_entries(const string& oid, const string& marker, map<st
   return 0;
 }
 
-int RGWOrphanSearch::init(const string& job_name, RGWOrphanSearchInfo *info, bool detailed_mode)
+int RGWOrphanSearch::init(const string& job_name, RGWOrphanSearchInfo *info, bool _detailed_mode)
 {
   int r = orphan_store.init();
   if (r < 0) {
@@ -198,7 +198,7 @@ int RGWOrphanSearch::init(const string& job_name, RGWOrphanSearchInfo *info, boo
   max_list_bucket_entries = std::max(store->ctx()->_conf->rgw_list_bucket_min_readahead,
                                      MAX_LIST_OBJS_ENTRIES);
 
-  detailed_mode = detailed_mode;
+  detailed_mode = _detailed_mode;
   RGWOrphanSearchState state;
   r = orphan_store.read_job(job_name, state);
   if (r < 0 && r != -ENOENT) {

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -163,7 +163,9 @@ class RGWOrphanSearch {
 
   uint16_t max_concurrent_ios;
   uint64_t stale_secs;
-  uint64_t max_list_obj_entries;
+  int64_t max_list_bucket_entries;
+
+  bool detailed_mode;
 
   struct log_iter_info {
     string oid;
@@ -193,7 +195,7 @@ public:
     return orphan_store.write_job(search_info.job_name, state);
   }
 
-  int init(const string& job_name, RGWOrphanSearchInfo *info);
+  int init(const string& job_name, RGWOrphanSearchInfo *info, bool detailed_mode=false);
 
   int create(const string& job_name, int num_shards);
 

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -163,6 +163,7 @@ class RGWOrphanSearch {
 
   uint16_t max_concurrent_ios;
   uint64_t stale_secs;
+  uint64_t max_list_obj_entries;
 
   struct log_iter_info {
     string oid;

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -195,7 +195,7 @@ public:
     return orphan_store.write_job(search_info.job_name, state);
   }
 
-  int init(const string& job_name, RGWOrphanSearchInfo *info, bool detailed_mode=false);
+  int init(const string& job_name, RGWOrphanSearchInfo *info, bool _detailed_mode=false);
 
   int create(const string& job_name, int num_shards);
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -279,6 +279,7 @@
      --orphan-stale-secs       num of seconds to wait before declaring an object to be an orphan (default: 86400)
      --job-id                  set the job id (for orphans find)
      --max-concurrent-ios      maximum concurrent ios for orphans find (default: 32)
+     --detail                  detailed mode, log and stat head objects as well
   
   Orphans list-jobs options:
      --extra-info              provide extra info in job list


### PR DESCRIPTION
I saw an issue in luminous where orphans find was running really slowly. Reproducing on my vstart cluster, with a single bucket having 2 million+ entries, I was able to see orphans find taking upwards of 24 hours in a vstart cluster on SSDs. The search was continually in the third bucket index stage. Stopping the IO resulted in orphans find still taking around 6.5 hours to complete.

Upon analyzing further I saw that we ignore head objects in the initial rados listing, however we do account for, stat and store the entry in the linked entry. I  added a check after the rados stat stage where we check the size of OLH and compare against the size of the object. If the object size fits within the manifest then we can safely avoid logging this object as it would have been skipped anyway.  I further assume clusters from luminous with object sizes < 4MiB would not have a shadow object and we could reduce a rados stat as well as an omap entry which we would ignore in the end as head objects are dropped in the initial rados list. For older clusters from pre Jewel era, the old behaviour can be turned back on by adding a `--detail` flag to orphans search

I also saw that we request a max_entries of 100 keys for bucket listing, however the underlying bucket still requests `rgw_list_bucket_min_readahead` entries anyway in the cls which lead to wasteful object listing as we were requesting 100 entries though the underlying layer anyway requested a 1000 entries and threw away the rest. Also workloads which continously append objects in an increasing alphabetic order would mean this stage would almost never complete as at the pace of 100 objects we may not be able to catch up with the bucket which might be able to add more in that time frame. Keeping listing in sync with the underlying cls layer helped massively speed up to less than an hours time.

I further noticed that we process all bucket instances, which meant in a bucket with million objects we would have processed every stale instance left behind as well (unless the cluster is 12.2.11+ which has all the resharding fixes). This made the cluster actually list and process the bucket many many times, so avoiding this and only comparing the actual bucket id greatly reduced the IO and I was able to bring down the total processing time to a couple of minutes. 

Another improvement which I feel could be done which is still to be implemented would be to ask for an unordered listing for buckets as we hash the object names and store them on the linked shard, and assuming ultimately that omap write actually orders the keys, then there isn't a need to request ordered listing from the bucket. 

*edit*- dropped TODO