### PR TITLE
osd: fix build_incremental_map_msg

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1472,11 +1472,11 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
   int max = cct->_conf->osd_map_message_max;
   ssize_t max_bytes = cct->_conf->osd_map_message_max_bytes;
 
-  if (since > m->oldest_map) {
+  if (since < m->oldest_map) {
     // we don't have the next map the target wants, so start with a
     // full map.
     bufferlist bl;
-    dout(10) << __func__ << " oldest map " << max_oldest_map << " < since "
+    dout(10) << __func__ << " oldest map " << max_oldest_map << " > since "
 	     << since << ", starting with full map" << dendl;
     since = m->oldest_map;
     if (!get_map_bl(since, bl)) {


### PR DESCRIPTION
We need to fall back to an old map if since (the peer's epoch) is *older*
than our oldest.  If it's newer, we have it, and can just send
incrementals.

Fixes: http://tracker.ceph.com/issues/38282
Signed-off-by: Sage Weil <sage@redhat.com>