### PR TITLE
osd: after IPv6 address matches, continue on

### DIFF
--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -352,6 +352,10 @@ int pick_addresses(
 	  (ipv & CEPH_PICK_ADDRESS_IPV6)) {
 	r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV6, networks,
 				interfaces, addrs, preferred_numa_node);
+
+        if (r >= 0) {
+            break;
+        }
       }
       if (r >= 0 &&
 	  (ipv & CEPH_PICK_ADDRESS_IPV4) &&


### PR DESCRIPTION
Fix for bug "ceph-osd fails to bind to IPv6 interface for public_network"

http://tracker.ceph.com/issues/38307

Instead of trying to keep matching, once we have attached to IPv6,
continue the program.

Signed-off-by: Jesse Williamson <jwilliamson@suse.de>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

