### PR TITLE
qa/suite, doc: mon kv backend and fast_read cleanup

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -988,6 +988,14 @@ Monitors can also disallow removal of pools if configured that way.
 :Type: Boolean
 :Default: ``false``
 
+``osd pool default ec fast read``
+
+:Description: Whether to turn on fast read on the pool or not. It will be used as
+              the default setting of newly created erasure coded pools if ``fast_read``
+              is not specified at create time.
+:Type: Boolean
+:Default: ``false``
+
 ``osd pool default flag hashpspool``
 
 :Description: Set the hashpspool flag on new pools
@@ -1097,15 +1105,6 @@ Miscellaneous
 ``mon osd allow primary affinity``
 
 :Description: allow ``primary_affinity`` to be set in the osdmap.
-:Type: Boolean
-:Default: False
-
-
-``mon osd pool ec fast read``
-
-:Description: Whether turn on fast read on the pool or not. It will be used as
-              the default setting of newly created erasure pools if ``fast_read``
-              is not specified at create time.
 :Type: Boolean
 :Default: False
 

--- a/qa/mon_kv_backend/leveldb.yaml
+++ b/qa/mon_kv_backend/leveldb.yaml
@@ -1,5 +1,0 @@
-overrides:
-  ceph:
-    conf:
-      mon:
-        mon keyvaluedb: leveldb

--- a/qa/mon_kv_backend/rocksdb.yaml
+++ b/qa/mon_kv_backend/rocksdb.yaml
@@ -1,7 +1,0 @@
-overrides:
-  ceph:
-    conf:
-      global:
-        enable experimental unrecoverable data corrupting features: '*'
-      mon:
-        mon keyvaluedb: rocksdb

--- a/qa/suites/rados/basic/mon_kv_backend
+++ b/qa/suites/rados/basic/mon_kv_backend
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend

--- a/qa/suites/rados/monthrash/mon_kv_backend
+++ b/qa/suites/rados/monthrash/mon_kv_backend
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend

--- a/qa/suites/rados/multimon/mon_kv_backend
+++ b/qa/suites/rados/multimon/mon_kv_backend
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend

--- a/qa/suites/rados/thrash-erasure-code-big/leveldb.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/leveldb.yaml
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend/leveldb.yaml

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
@@ -5,7 +5,7 @@ overrides:
     - objects unfound and apparently lost
     conf:
       mon:
-        mon osd pool ec fast read: 1
+        osd pool default ec fast read: true
       osd:
         osd debug reject backfill probability: .1
         osd scrub min interval: 60

--- a/qa/suites/rados/thrash-erasure-code-isa/leveldb.yaml
+++ b/qa/suites/rados/thrash-erasure-code-isa/leveldb.yaml
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend/leveldb.yaml

--- a/qa/suites/rados/thrash-erasure-code-overwrites/leveldb.yaml
+++ b/qa/suites/rados/thrash-erasure-code-overwrites/leveldb.yaml
@@ -1,1 +1,0 @@
-../thrash-erasure-code/leveldb.yaml

--- a/qa/suites/rados/thrash-erasure-code-shec/leveldb.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/leveldb.yaml
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend/leveldb.yaml

--- a/qa/suites/rados/thrash-erasure-code/fast/fast.yaml
+++ b/qa/suites/rados/thrash-erasure-code/fast/fast.yaml
@@ -2,4 +2,4 @@ overrides:
   ceph:
     conf:
       global:
-        mon osd pool ec fast read: true
+        osd pool default ec fast read: true

--- a/qa/suites/rados/thrash-erasure-code/leveldb.yaml
+++ b/qa/suites/rados/thrash-erasure-code/leveldb.yaml
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend/leveldb.yaml

--- a/qa/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
@@ -5,7 +5,7 @@ overrides:
     - objects unfound and apparently lost
     conf:
       mon:
-        mon osd pool ec fast read: 1
+        osd pool default ec fast read: true
       osd:
         osd debug reject backfill probability: .1
         osd scrub min interval: 60

--- a/qa/suites/rados/thrash-old-clients/rocksdb.yaml
+++ b/qa/suites/rados/thrash-old-clients/rocksdb.yaml
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend/rocksdb.yaml

--- a/qa/suites/rados/thrash/rocksdb.yaml
+++ b/qa/suites/rados/thrash/rocksdb.yaml
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend/rocksdb.yaml

--- a/qa/suites/rados/verify/mon_kv_backend
+++ b/qa/suites/rados/verify/mon_kv_backend
@@ -1,1 +1,0 @@
-.qa/mon_kv_backend


### PR DESCRIPTION
Correct a renamed option and remove no-longer-useful leveldb testing.