### PR TITLE
restful: Fix regression when traversing leaf nodes

### DIFF
--- a/src/pybind/mgr/restful/common.py
+++ b/src/pybind/mgr/restful/common.py
@@ -142,7 +142,7 @@ def crush_rule_osds(node_buckets, rule):
                 if node_id >= 0:
                     osds.add(node_id)
                 else:
-                    for desc_node in nodes_by_id[node_id]:
+                    for desc_node in nodes_by_id[node_id]['items']:
                         # Short circuit another iteration to find the emit
                         # and assume anything we've done a chooseleaf on
                         # is going to be part of the selected set of osds


### PR DESCRIPTION
The commit 23b6c90 introduced a regression when traversing leaf nodes.
The issue is that it traverses the keys of a `dict` returned by
`nodes_by_id`, not the actual `items` of the node. That resulted in an
500 error because it tried to treat `str` as a `dict` and failed.

Signed-off-by: Boris Ranto <branto@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

