### PR TITLE
mimic: client: session flush does not cause cap release message flush

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2119,6 +2119,10 @@ void Client::handle_client_session(MClientSession *m)
     break;
 
   case CEPH_SESSION_FLUSHMSG:
+    /* flush cap release */
+    if (auto& m = session->release; m) {
+      session->con->send_message(m.detach());
+    }
     session->con->send_message(new MClientSession(CEPH_SESSION_FLUSHMSG_ACK, m->get_seq()));
     break;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38103