### PR TITLE
journal: fix potential race when closing object recorder

### DIFF
--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -303,10 +303,12 @@ void ObjectRecorder::handle_append_flushed(uint64_t tid, int r) {
       // all remaining unsent appends should be redirected to new object
       m_append_buffers.splice(m_append_buffers.begin(), m_pending_buffers);
       notify_handler_unlock();
-    } else {
+    } else if (!m_pending_buffers.empty()) {
       m_aio_scheduled = true;
       m_lock->Unlock();
       send_appends_aio();
+    } else {
+      m_lock->Unlock();
     }
   } else {
     m_lock->Unlock();


### PR DESCRIPTION
Calls `send_appends_aio` only if m_pending_buffers is not
empty. It was supposed it was ok to call it even for empty
buffers, because `send_appends_aio` just returned in this
case. But the problem is caused by m_aio_scheduled flag, which is
set before releasing the lock and cleared in `send_appends_aio`,
after reacquiring the lock. If during this time window `close` is
called it will return false due to m_aio_scheduled flag set, and
the caller will expect "closed" notification, which is never
fired in this case.

Fixes: https://tracker.ceph.com/issues/38315
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

