### PR TITLE
common: compile-time option to use OpenSSL's async interface for hashing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,12 @@ set(USE_NSS 1)
 set(USE_OPENSSL 1)
 set(CRYPTO_LIBS ${NSS_LIBRARIES} ${NSPR_LIBRARIES} OpenSSL::Crypto)
 
+option(WITH_OPENSSL_ASYNC "Enable Asynchronous OpenSSL operations" OFF)
+if(WITH_OPENSSL_ASYNC)
+  set(USE_OPENSSL_ASYNC 1)
+  find_package(OpenSSL 1.1 REQUIRED)
+endif()
+
 option(WITH_XIO "Enable XIO messaging" OFF)
 if(WITH_XIO)
   find_package(xio REQUIRED)

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -26,7 +26,34 @@
 
 #ifdef USE_OPENSSL
 #include <openssl/evp.h>
+
+#ifdef USE_OPENSSL_ASYNC
+#include <forward_list>
+#include <functional>
+#include <openssl/async.h>
+#include "common/Thread.h"
+#endif /* USE_OPENSSL_ASYNC */
 #endif /*USE_OPENSSL*/
+
+void ceph::crypto::init(CephContext *cct)
+{
+#ifdef USE_OPENSSL
+  ceph::crypto::ssl::init(cct);
+#endif
+#ifdef USE_NSS
+  ceph::crypto::nss::init(cct);
+#endif
+}
+
+void ceph::crypto::shutdown(bool shared)
+{
+#ifdef USE_NSS
+  ceph::crypto::nss::shutdown(shared);
+#endif
+#ifdef USE_OPENSSL
+  ceph::crypto::ssl::shutdown(shared);
+#endif
+}
 
 #ifdef USE_NSS
 
@@ -35,7 +62,7 @@ static uint32_t crypto_refs = 0;
 static NSSInitContext *crypto_context = NULL;
 static pid_t crypto_init_pid = 0;
 
-void ceph::crypto::init(CephContext *cct)
+void ceph::crypto::nss::init(CephContext *cct)
 {
   pid_t pid = getpid();
   pthread_mutex_lock(&crypto_init_mutex);
@@ -62,7 +89,7 @@ void ceph::crypto::init(CephContext *cct)
   ceph_assert_always(crypto_context != NULL);
 }
 
-void ceph::crypto::shutdown(bool shared)
+void ceph::crypto::nss::shutdown(bool shared)
 {
   pthread_mutex_lock(&crypto_init_mutex);
   ceph_assert_always(crypto_refs > 0);
@@ -90,6 +117,279 @@ ceph::crypto::HMAC::~HMAC()
 
 #ifdef USE_OPENSSL
 
+#ifdef USE_OPENSSL_ASYNC
+class OpenSSLAsyncEngine {
+ public:
+  int init() {return 0;}
+
+  int run()
+  {
+    mStop = false;
+    mThread = make_named_thread("openssl_async",
+				&OpenSSLAsyncEngine::entry,
+				this);
+    return 0;
+  }
+
+  void stop()
+  {
+    {
+      std::lock_guard<std::mutex> lock(mMutex);
+
+      mStop = true;
+    }
+
+    mCond.notify_one();
+  }
+
+  void join()
+  {
+    if (mThread.joinable())
+      mThread.join();
+  }
+
+  bool stopped()
+  {
+    return mStop;
+  }
+
+ private:
+  static void entry(OpenSSLAsyncEngine *that)
+  {
+    that->main();
+  }
+
+  void main()
+  {
+    /* Initialise OpenSSL things that will be needed */
+    ASYNC_init_thread(0, 10);
+    ASYNC_WAIT_CTX *ctx  = ASYNC_WAIT_CTX_new();
+
+    while (true) {
+      jobs_type::iterator it;
+      {
+	std::unique_lock<std::mutex> lock(mMutex);
+
+	if (mStop)
+	  break;
+
+	while (mJobs.empty()) {
+	  mCond.wait(lock);
+	  if (mStop)
+	    break;
+	}
+
+	it = mJobs.begin();
+      }
+
+      jobs_type::iterator prev = mJobs.end();
+      int ret;
+      while (it != mJobs.end()) {
+	if (mStop)
+	  break;
+
+	if (ASYNC_start_job(&(*it)->job,
+			    ctx,
+			    &ret,
+			    &OpenSSLAsyncEngine::job_entry,
+			    &(*it),
+			    sizeof(JobData *)) == ASYNC_PAUSE) {
+	  /* The job has been paused, safe to move on to the next job */
+	  prev = it++;
+	  continue;
+	}
+
+	/* Assuming job has completed notify waiting thread*/
+	(*it)->failure_code = ret;
+	{
+	  std::lock_guard<std::mutex> lock((*it)->mutex);
+
+	  (*it)->done = true;
+	}
+	(*it)->cond.notify_one();
+
+	{
+	  std::lock_guard<std::mutex> lock(mMutex);
+	  if (prev == mJobs.end()) {
+	    mJobs.pop_front();
+	    it = mJobs.begin();
+	  } else {
+	    it = mJobs.erase_after(prev);
+	  }
+	}
+      }
+
+      if (mStop)
+	break;
+    }
+
+    /* We have exited the loop, cleanup the thread */
+    ASYNC_cleanup_thread();
+  }
+
+  static int job_entry(void *arg)
+  {
+    auto job = *reinterpret_cast<JobData **>(arg);
+
+
+    int rval = 0;
+    try {
+      rval = job->f();
+    } catch (...) {
+      return -1;
+    }
+
+    return rval;
+  }
+
+ public:
+  static OpenSSLAsyncEngine &instance()
+  {
+    /* In C++11 this is thread safe. */
+    static OpenSSLAsyncEngine inst;
+    return inst;
+  }
+
+  int submit_job_and_wait(const std::string &name, std::function<int ()> f)
+  {
+    JobData job(name, f);
+
+    /* Submit job to be handled by the worker thread */
+    {
+      std::lock_guard<std::mutex> lock(mMutex);
+
+      mJobs.push_front(&job);
+
+      if (mStop) {
+	/* The worker thread is not running, it needs to be restarted */
+	run();
+      }
+    }
+
+    /* If the worker thread is paused waiting for there to be jobs this will wake it up */
+    mCond.notify_one();
+
+    /* Wait until the job has completed */
+    {
+      std::unique_lock<std::mutex> lock(job.mutex);
+
+      auto done = &job.done;
+      job.cond.wait(lock, [done]{ return *done; });
+    }
+
+
+    return job.failure_code;
+  }
+
+  OpenSSLAsyncEngine(const OpenSSLAsyncEngine&) = delete;
+  void operator=(OpenSSLAsyncEngine const&)  = delete;
+
+ private:
+  OpenSSLAsyncEngine()
+    : mThread()
+    , mMutex()
+    , mCond()
+    , mStop(false)
+    , mJobs() {}
+
+  ~OpenSSLAsyncEngine()
+  {
+    stop();
+    join();
+  }
+
+ private:
+  std::thread mThread;
+  std::mutex mMutex;
+  std::condition_variable mCond;
+
+  bool mStop;
+
+  struct JobData {
+    std::string name;
+    ASYNC_JOB *job;
+    std::function<int ()> f;
+    bool done;
+    std::mutex mutex;
+    std::condition_variable cond;
+    int failure_code;
+
+    JobData(const std::string &name, std::function<int ()> f)
+      : name(name)
+      , job(NULL)
+      , f(std::move(f))
+      , done(false)
+      , mutex()
+      , cond()
+      , failure_code(0) {}
+  };
+
+  typedef std::forward_list<JobData *> jobs_type;
+  jobs_type mJobs;
+};
+
+void ceph::crypto::ssl::init(CephContext *cct)
+{
+  OpenSSLAsyncEngine &async = OpenSSLAsyncEngine::instance();
+
+  async.init();
+  async.run();
+}
+
+void ceph::crypto::ssl::shutdown(bool shared)
+{
+  OpenSSLAsyncEngine &async = OpenSSLAsyncEngine::instance();
+
+  async.stop();
+  async.join();
+}
+
+ceph::crypto::ssl::OpenSSLDigest::OpenSSLDigest(const EVP_MD * _type)
+  : mpContext(EVP_MD_CTX_create())
+  , mpType(_type) {
+  this->Restart();
+}
+
+ceph::crypto::ssl::OpenSSLDigest::~OpenSSLDigest() {
+  EVP_MD_CTX_destroy(mpContext);
+}
+
+void ceph::crypto::ssl::OpenSSLDigest::Restart() {
+  OpenSSLAsyncEngine &async = OpenSSLAsyncEngine::instance();
+
+  std::function<int ()> func = std::bind(EVP_DigestInit_ex, mpContext, mpType, reinterpret_cast<ENGINE *>(NULL));
+  async.submit_job_and_wait("EVP_DigestInit_ex", func);
+}
+
+void ceph::crypto::ssl::OpenSSLDigest::Update(const unsigned char *input, size_t length) {
+  if (length) {
+    OpenSSLAsyncEngine &async = OpenSSLAsyncEngine::instance();
+
+    auto func = std::bind(EVP_DigestUpdate,
+			  mpContext,
+			  const_cast<void *>(reinterpret_cast<const void *>(input)),
+			  length);
+    async.submit_job_and_wait("EVP_DigestUpdate", func);
+  }
+}
+
+void ceph::crypto::ssl::OpenSSLDigest::Final(unsigned char *digest) {
+  OpenSSLAsyncEngine &async = OpenSSLAsyncEngine::instance();
+  unsigned int s;
+  auto func = std::bind(EVP_DigestFinal_ex, mpContext, digest, &s);
+  async.submit_job_and_wait("EVP_DigestFinal_ex", func);
+}
+
+#else
+
+void ceph::crypto::ssl::init(CephContext *cct)
+{
+}
+
+void ceph::crypto::ssl::shutdown(bool shared)
+{
+}
+
 ceph::crypto::ssl::OpenSSLDigest::OpenSSLDigest(const EVP_MD * _type)
   : mpContext(EVP_MD_CTX_create())
   , mpType(_type) {
@@ -114,4 +414,6 @@ void ceph::crypto::ssl::OpenSSLDigest::Final(unsigned char *digest) {
   unsigned int s;
   EVP_DigestFinal_ex(mpContext, digest, &s);
 }
+
+#endif /* USE_OPENSSL_ASYNC */
 #endif /*USE_OPENSSL*/

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -35,7 +35,6 @@ extern "C" {
 
 namespace ceph {
   namespace crypto {
-    void assert_init();
     void init(CephContext *cct);
     void shutdown(bool shared=true);
   }
@@ -45,6 +44,9 @@ namespace ceph {
 namespace ceph {
   namespace crypto {
     namespace nss {
+      void init(CephContext *cct);
+      void shutdown(bool shared=true);
+
       class NSSDigest {
       private:
         PK11Context *ctx;
@@ -104,6 +106,9 @@ namespace ceph {
 namespace ceph {
   namespace crypto {
     namespace ssl {
+      void init(CephContext *cct);
+      void shutdown(bool shared=true);
+
       class OpenSSLDigest {
       private:
 	EVP_MD_CTX *mpContext;


### PR DESCRIPTION
This option is not a good idea to turn on in general. If using the standard software-based openssl hashing implementations this will significantly reduce the performance of programs such as radosgw that make heavy use of hashing. This is because all communication with openssl is serialised through a single thread, which is a significant bottleneck.

However in the case where a hardware offload engine for OpenSSL which supports hashing operations in asynchronous mode is installed then this code could dramatically reduce cpu usage during these operations by allowing the hardware offload engine to pause jobs whilst waiting for responses from the hardware engine. Paused jobs will still be polled by the worker thread that communicates with openssl, but all other threads waiting on the result will wait on condition_variables.

Signed-off-by: James Weaver <james.barrett@bbc.co.uk>