### PR TITLE
os/bluestore: Only use F_SET_FILE_RW_HINT when available

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -92,6 +92,7 @@ int KernelDevice::open(const string& p)
     goto out_fail;
   }
 
+#if defined(F_SET_FILE_RW_HINT)
   for (i = WRITE_LIFE_NONE; i < WRITE_LIFE_MAX; i++) {
     if (fcntl(fd_directs[i], F_SET_FILE_RW_HINT, &i) < 0) {
       r = -errno;
@@ -106,6 +107,7 @@ int KernelDevice::open(const string& p)
     enable_wrt = false;
     dout(0) << "ioctl(F_SET_FILE_RW_HINT) on " << path << " failed: " << cpp_strerror(r) << dendl;
   }
+#endif
 
   dio = true;
   aio = cct->_conf->bdev_aio;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug