### PR TITLE
run-standalone.sh: Need double-quotes to handle | in core_pattern on all distributions

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -38,7 +38,7 @@ fi
 
 function cleanup() {
     if [ -n "$precore" ]; then
-        sudo sysctl -w ${KERNCORE}=${precore}
+        sudo sysctl -w "${KERNCORE}=${precore}"
     fi
 }
 
@@ -81,7 +81,7 @@ precore="$(sysctl -n $KERNCORE)"
 if [ "$precore" = "$COREPATTERN" ]; then
     precore=""
 else
-    sudo sysctl -w ${KERNCORE}=${COREPATTERN}
+    sudo sysctl -w "${KERNCORE}=${COREPATTERN}"
 fi
 # Clean out any cores in core target directory (currently .)
 if ls $(dirname $(sysctl -n $KERNCORE)) | grep -q '^core\|core$' ; then

--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -77,11 +77,6 @@ count=0
 errors=0
 userargs=""
 precore="$(sysctl -n $KERNCORE)"
-
-if [[ "${precore:0:1}" = "|" ]]; then
-  precore="${precore:1}"
-fi
-
 # If corepattern already set, avoid having to use sudo
 if [ "$precore" = "$COREPATTERN" ]; then
     precore=""


### PR DESCRIPTION


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket


