### PR TITLE
mimic: Revert "msg/async: bump global_seq when retrying connection"

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2127,7 +2127,6 @@ void AsyncConnection::fault()
     } else {
       ldout(async_msgr->cct, 0) << __func__ << " initiating reconnect" << dendl;
       connect_seq++;
-      global_seq = async_msgr->get_global_seq();
       state = STATE_CONNECTING;
     }
     backoff = utime_t();
@@ -2143,7 +2142,6 @@ void AsyncConnection::fault()
         backoff.set_from_double(async_msgr->cct->_conf->ms_max_backoff);
     }
 
-    global_seq = async_msgr->get_global_seq();
     state = STATE_CONNECTING;
     ldout(async_msgr->cct, 10) << __func__ << " waiting " << backoff << dendl;
     // woke up again;


### PR DESCRIPTION
This reverts commit ed65a7a53aedfd56343fdaefdeb59c22256f01b7.

See: https://github.com/ceph/ceph/pull/25956

Seems we don't want [39e8de2](https://github.com/ceph/ceph/commit/39e8de2d72e2541323f8ed9d8b68075fcbd02701)
to be backported.
It turns out the old async-connection implementation will
automatically bump the global_seq each time it switches to
the STATE_CONNECTING state and restarts the connecting process.

The same applies to mimic.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

