### PR TITLE
mgr/dashboard: disallow editing read-only config options (part 2)

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -181,6 +181,54 @@ class ClusterConfigurationTest(DashboardTestCase):
             self._clear_all_values_for_config_option(config_name)
             self._reset_original_values(config_name, orig_values[config_name])
 
+    def test_bulk_set_cant_update_at_runtime(self):
+        config_options = {
+            'clog_to_syslog': {'section': 'global', 'value': 'true'},  # not updatable
+            'clog_to_graylog': {'section': 'global', 'value': 'true'}  # not updatable
+        }
+        orig_values = dict()
+
+        for config_name in config_options:
+            orig_values[config_name] = self._get_config_by_name(config_name)
+
+        # try to set config options and see if it fails
+        self._put('/api/cluster_conf', {'options': config_options})
+        self.assertStatus(400)
+        self.assertError(code='config_option_not_updatable_at_runtime',
+                         component='cluster_configuration',
+                         detail='Config option {} is/are not updatable at runtime'.format(
+                             ', '.join(config_options.keys())))
+
+        # check if config option values are still the original ones
+        for config_name, value in orig_values.items():
+            result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                        value)
+            self.assertEqual(result, value)
+
+    def test_bulk_set_cant_update_at_runtime_partial(self):
+        config_options = {
+            'clog_to_syslog': {'section': 'global', 'value': 'true'},  # not updatable
+            'log_to_stderr': {'section': 'global', 'value': 'true'}  # updatable
+        }
+        orig_values = dict()
+
+        for config_name in config_options:
+            orig_values[config_name] = self._get_config_by_name(config_name)
+
+        # try to set config options and see if it fails
+        self._put('/api/cluster_conf', {'options': config_options})
+        self.assertStatus(400)
+        self.assertError(code='config_option_not_updatable_at_runtime',
+                         component='cluster_configuration',
+                         detail='Config option {} is/are not updatable at runtime'.format(
+                             'clog_to_syslog'))
+
+        # check if config option values are still the original ones
+        for config_name, value in orig_values.items():
+            result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                        value)
+            self.assertEqual(result, value)
+
     def _validate_single(self, data):
         self.assertIn('name', data)
         self.assertIn('daemon_default', data)

--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -65,6 +65,27 @@ class ClusterConfigurationTest(DashboardTestCase):
         self._clear_all_values_for_config_option(config_name)
         self._reset_original_values(config_name, orig_value)
 
+    def test_create_cant_update_at_runtime(self):
+        config_name = 'clog_to_syslog'  # not updatable
+        config_value = [{'section': 'global', 'value': 'true'}]
+        orig_value = self._get_config_by_name(config_name)
+
+        # try to set config option and check if it fails
+        self._post('/api/cluster_conf', {
+            'name': config_name,
+            'value': config_value
+        })
+        self.assertStatus(400)
+        self.assertError(code='config_option_not_updatable_at_runtime',
+                         component='cluster_configuration',
+                         detail='Config option {} is/are not updatable at runtime'.format(
+                             config_name))
+
+        # check if config option value is still the original one
+        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                    orig_value)
+        self.assertEqual(result, orig_value)
+
     def test_create_two_values(self):
         config_name = 'debug_ms'
         orig_value = self._get_config_by_name(config_name)


### PR DESCRIPTION
This is a follow-up PR for https://github.com/ceph/ceph/pull/26297 as two parts were missing:

- add missing test case for 60bda9a
- check config option updatability also for bulk create

Fixes https://tracker.ceph.com/issues/34528

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

