### PR TITLE
rpm: tweak lttng builds for SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -51,7 +51,7 @@
 %else
 %bcond_with libradosstriper
 %endif
-%ifarch x86_64 aarch64
+%ifarch x86_64 aarch64 ppc64le
 %bcond_without lttng
 %else
 %bcond_with lttng

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -47,15 +47,14 @@
 %global _fillupdir /var/adm/fillup-templates
 %endif
 %if 0%{?is_opensuse}
-%bcond_without lttng
 %bcond_without libradosstriper
 %else
 %bcond_with libradosstriper
+%endif
 %ifarch x86_64 aarch64
 %bcond_without lttng
 %else
 %bcond_with lttng
-%endif
 %endif
 %endif
 %bcond_with seastar


### PR DESCRIPTION
SUSE-specific spec-file changes to reflect that:

* s390x build is now possible in OBS
* lttng build is now possible on ppc64le (but still not on s390x)