### PR TITLE
client: parameter "cap" is not used

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3947,7 +3947,7 @@ void Client::_flushed(Inode *in)
 
 
 // checks common to add_update_cap, handle_cap_grant
-void Client::check_cap_issue(Inode *in, Cap *cap, unsigned issued)
+void Client::check_cap_issue(Inode *in, unsigned issued)
 {
   unsigned had = in->caps_issued();
 
@@ -4011,7 +4011,7 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
     }
   }
 
-  check_cap_issue(in, &cap, issued);
+  check_cap_issue(in, issued);
 
   if (flags & CEPH_CAP_FLAG_AUTH) {
     if (in->auth_cap != &cap &&
@@ -5143,7 +5143,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
   cap->seq = m->get_seq();
   cap->gen = session->cap_gen;
 
-  check_cap_issue(in, cap, new_caps);
+  check_cap_issue(in, new_caps);
 
   // update inode
   int issued;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -642,7 +642,7 @@ public:
   int uninline_data(Inode *in, Context *onfinish);
 
   // file caps
-  void check_cap_issue(Inode *in, Cap *cap, unsigned issued);
+  void check_cap_issue(Inode *in, unsigned issued);
   void add_update_cap(Inode *in, MetaSession *session, uint64_t cap_id,
 		      unsigned issued, unsigned wanted, unsigned seq, unsigned mseq,
 		      inodeno_t realm, int flags, const UserPerm& perms);


### PR DESCRIPTION
client: parameter "cap" is not used

Fixes: http://tracker.ceph.com/issues/38376
Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

