### PR TITLE
common/ceph_timer: stop timer's thread when it is suspended

### DIFF
--- a/src/common/ceph_timer.h
+++ b/src/common/ceph_timer.h
@@ -138,6 +138,8 @@ namespace ceph {
 	    } // Otherwise the event requeued itself
 	  }
 
+          if (suspended)
+            break;
 	  if (schedule.empty())
 	    cond.wait(l);
 	  else


### PR DESCRIPTION
otherwise the client could hang when shutting down

Fixes: https://tracker.ceph.com/issues/37766
Signed-off-by: Peng Wang <wp389@126.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

