### PR TITLE
ceph-deploy would not support --cluster option anymore

### DIFF
--- a/doc/rados/deployment/ceph-deploy-new.rst
+++ b/doc/rados/deployment/ceph-deploy-new.rst
@@ -41,26 +41,6 @@ to the Ceph configuration file. For additional details, execute::
 	ceph-deploy new -h
 
 
-Naming a Cluster
-----------------
-
-By default, Ceph clusters have a cluster name of ``ceph``. You can specify
-a cluster name if you want to run multiple clusters on the same hardware. For
-example, if you want to optimize a cluster for use with block devices, and
-another for use with the gateway, you can run two different clusters on the same
-hardware if they have a different ``fsid`` and cluster name. ::
-
-	ceph-deploy --cluster {cluster-name} new {host [host], ...}
-
-For example::
-
-	ceph-deploy --cluster rbdcluster new ceph-mon1
-	ceph-deploy --cluster rbdcluster new ceph-mon{1,2,3}
-
-.. note:: If you run multiple clusters, ensure you adjust the default
-   port settings and open ports for your additional cluster(s) so that
-   the networks of the two different clusters don't conflict with each other.
-
 
 .. _Monitor Configuration Reference: ../../configuration/mon-config-ref
 .. _Cephx Guide: ../../../dev/mon-bootstrap#secret-keys


### PR DESCRIPTION
Since ceph-deploy would not support --cluster option anymore, section in this doc could be removed
Signed-off-by: Tatsuya Naganawa <tatsuyan201101@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

