### PR TITLE
mimic: cephfs: MDCache::finish_snaprealm_reconnect() create and drop MClientSnap message

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2975,7 +2975,6 @@ void Locker::handle_client_caps(MClientCaps *m)
 
       if (cap->get_last_seq() == 0 &&
 	  (cap->pending() & (CEPH_CAP_FILE_WR|CEPH_CAP_FILE_BUFFER))) {
-	cap->issue_norevoke(cap->issued());
 	share_inode_max_size(in, cap);
       }
     }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6094,6 +6094,7 @@ void MDCache::finish_snaprealm_reconnect(client_t client, SnapRealm *realm, snap
     snap->bl = realm->get_snap_trace();
     for (const auto& child : realm->open_children)
       snap->split_realms.push_back(child->inode->ino());
+    updates.emplace(std::piecewise_construct, std::forward_as_tuple(client), std::forward_as_tuple(snap));
   } else {
     dout(10) << "finish_snaprealm_reconnect client." << client << " up to date"
 	     << " on " << *realm << dendl;


### PR DESCRIPTION
http://tracker.ceph.com/issues/38334