### PR TITLE
pybind: move FLAGS into Flag class

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -138,11 +138,10 @@ import signal
 import string
 import subprocess
 
-import ceph_argparse
 from ceph_argparse import \
     concise_sig, descsort_key, parse_json_funcsigs, \
     validate_command, find_cmd_target, \
-    json_command, run_in_thread
+    json_command, run_in_thread, Flag
 
 from ceph_daemon import admin_socket, DaemonWatcher, Termsize
 
@@ -472,7 +471,7 @@ def format_help(cmddict, partial=None):
         if not cmd['help']:
             continue
         flags = cmd.get('flags', 0)
-        if flags & (ceph_argparse.FLAG_OBSOLETE | ceph_argparse.FLAG_DEPRECATED | ceph_argparse.FLAG_HIDDEN):
+        if flags & (Flag.OBSOLETE | Flag.DEPRECATED | Flag.HIDDEN):
             continue
         concise = concise_sig(cmd['sig'])
         if partial and not concise.startswith(partial):

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -24,12 +24,13 @@ import threading
 import uuid
 
 # Flags are from MonCommand.h
-FLAG_NOFORWARD = (1 << 0)
-FLAG_OBSOLETE = (1 << 1)
-FLAG_DEPRECATED = (1 << 2)
-FLAG_MGR = (1<<3)
-FLAG_POLL = (1 << 4)
-FLAG_HIDDEN = (1 << 5)
+class Flag:
+    NOFORWARD = (1 << 0)
+    OBSOLETE = (1 << 1)
+    DEPRECATED = (1 << 2)
+    MGR = (1<<3)
+    POLL = (1 << 4)
+    HIDDEN = (1 << 5)
 
 KWARG_EQUALS = "--([^=]+)=(.+)"
 KWARG_SPACE = "--([^=]+)"
@@ -1095,10 +1096,10 @@ def validate(args, signature, flags=0, partial=False):
             print(save_exception[0], 'not valid: ', save_exception[1], file=sys.stderr)
         raise ArgumentError("unused arguments: " + str(myargs))
 
-    if flags & FLAG_MGR:
+    if flags & Flag.MGR:
         d['target'] = ('mgr','')
 
-    if flags & FLAG_POLL:
+    if flags & Flag.POLL:
         d['poll'] = True
 
     # Finally, success
@@ -1133,7 +1134,7 @@ def validate_command(sigdict, args, verbose=False):
     bestcmds = []
     for cmd in sigdict.values():
         flags = cmd.get('flags', 0)
-        if flags & FLAG_OBSOLETE:
+        if flags & Flag.OBSOLETE:
             continue
         sig = cmd['sig']
         matched = matchnum(args, sig, partial=True)
@@ -1199,7 +1200,8 @@ def validate_command(sigdict, args, verbose=False):
             print("Invalid command:", ex, file=sys.stderr)
             print(concise_sig(sig), ': ', cmd['help'], file=sys.stderr)
     else:
-        bestcmds = [c for c in bestcmds if not c.get('flags', 0) & (FLAG_DEPRECATED | FLAG_HIDDEN)]
+        bestcmds = [c for c in bestcmds
+                    if not c.get('flags', 0) & (Flag.DEPRECATED | Flag.HIDDEN)]
         bestcmds = bestcmds[:10] # top 10
         print('no valid command found; {0} closest matches:'.format(len(bestcmds)), file=sys.stderr)
         for cmd in bestcmds:


### PR DESCRIPTION
so we ~~have shorter names, and~~ don't need to import ceph_argparse
only for accessing the flags

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

