### PR TITLE
ceph.in: ability to change file ownership

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1451,6 +1451,16 @@ Options
    reply to outfile.  Only specific monitor commands (e.g. osd getmap)
    return a payload.
 
+.. option:: --setuser user
+
+   will apply the appropriate user ownership to the file specified by
+   the option '-o'.
+
+.. option:: --setgroup group
+
+   will apply the appropriate group ownership to the file specified by
+   the option '-o'.
+
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use ceph.conf configuration file instead of the default

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -22,7 +22,9 @@ Foundation.  See file COPYING.
 from __future__ import print_function
 from time import sleep
 import codecs
+import grp
 import os
+import pwd
 import sys
 import time
 import platform
@@ -289,7 +291,10 @@ def parse_cmdargs(args=None, target=''):
                         help='input file, or "-" for stdin')
     parser.add_argument('-o', '--out-file', dest='output_file',
                         help='output file, or "-" for stdout')
-
+    parser.add_argument('--setuser', dest='setuser',
+                        help='set user file permission')
+    parser.add_argument('--setgroup', dest='setgroup',
+                        help='set group file permission')
     parser.add_argument('--id', '--user', dest='client_id',
                         help='client id for authentication')
     parser.add_argument('--name', '-n', dest='client_name',
@@ -615,9 +620,9 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
             ret, outbuf, outs = do_command(parsed_args, target, cmdargs, sigdict, inbuf, verbose)
         else:
             # Interactive mode (ceph cli)
-            if sys.stdin.isatty():  
-                # do the command-interpreter looping    
-                # for input to do readline cmd editing    
+            if sys.stdin.isatty():
+                # do the command-interpreter looping
+                # for input to do readline cmd editing
                 import readline  # noqa
 
             while True:
@@ -1107,6 +1112,20 @@ def main():
         except Exception as e:
             print('Can\'t open output file {0}: {1}'.format(parsed_args.output_file, e), file=sys.stderr)
             return 1
+        if parsed_args.setuser:
+            try:
+                ownerid = pwd.getpwnam(parsed_args.setuser).pw_uid
+                os.fchown(outf.fileno(), ownerid, -1)
+            except OSError as e:
+                print('Failed to change user ownership of {0} to {1}: {2}'.format(outf, parsed_args.setuser, e))
+                return 1
+        if parsed_args.setgroup:
+            try:
+                groupid = grp.getgrnam(parsed_args.setgroup).gr_gid
+                os.fchown(outf.fileno(), -1, groupid)
+            except OSError as e:
+                print('Failed to change group ownership of {0} to {1}: {2}'.format(outf, parsed_args.setgroup, e))
+                return 1
 
     # -s behaves like a command (ceph status).
     if parsed_args.status:


### PR DESCRIPTION
When creating/fetching key it's nice to have the ability to change the
ownership of the created file.

This commit adds the '--setuser' and 'setgroup' which respectively apply
the desired owner and group to a file user when '--output' is passed.

Closes: https://tracker.ceph.com/issues/38370
Signed-off-by: Sébastien Han <seb@redhat.com>

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

