### PR TITLE
osd: fix typo in numa node check; lower debug level

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2402,8 +2402,8 @@ int OSD::set_numa_affinity()
 	  numa_node = front_node;
 	}
       } else {
-	derr << __func__ << " objectstore and network numa nodes to not match"
-	     << dendl;
+	dout(1) << __func__ << " objectstore and network numa nodes do not match"
+		<< dendl;
       }
     }
   } else {


### PR DESCRIPTION
- s/to/do/
- no need for this on stderr, since they don't match on *most* systems
  it seems.

Signed-off-by: Sage Weil <sage@redhat.com>