### PR TITLE
Revert "rgw: lifcycle: don't reject compound rules with empty prefix"

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -126,14 +126,8 @@ bool RGWLifecycleConfiguration::_add_rule(const LCRule& rule)
   if (rule.get_filter().has_tags()){
     op.obj_tags = rule.get_filter().get_tags();
   }
-
-  /* prefix is optional, update prefix map only if prefix...exists */
-  if (!prefix.empty()) {
-    auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
-    return ret.second;
-  }
-
-  return true;
+  auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
+  return ret.second;
 }
 
 int RGWLifecycleConfiguration::check_and_add_rule(const LCRule& rule)


### PR DESCRIPTION
Reverts ceph/ceph#25926
This is needed temporarily to resolve need  for prefix_map entry in bucket_lc_process