### PR TITLE
osd: fix pg split/merge prime during startup

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3101,12 +3101,17 @@ int OSD::init()
   service.max_oldest_map = superblock.oldest_map;
 
   for (auto& shard : shards) {
+    // put PGs in a temporary set because we may modify pg_slots
+    // unordered_map below.
+    set<PGRef> pgs;
     for (auto& i : shard->pg_slots) {
       PGRef pg = i.second->pg;
       if (!pg) {
 	continue;
       }
-
+      pgs.insert(pg);
+    }
+    for (auto pg : pgs) {
       pg->lock();
       set<pair<spg_t,epoch_t>> new_children;
       set<pair<spg_t,epoch_t>> merge_pgs;


### PR DESCRIPTION
The priming of split/merge targets may modify pg_slots, an unordered_map,
which means our iterator may become invalid.  Put PGs in a temporary set
and use that instead.

Fixes: http://tracker.ceph.com/issues/36304
Signed-off-by: Sage Weil <sage@redhat.com>