### PR TITLE
mgr/dashboard: iSCSI - Adds support for pool/image names with dots

### DIFF
--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -90,24 +90,24 @@ class IscsiClient(RestClient):
             'skipchecks': 'true'
         })
 
-    @RestClient.api_put('/api/disk/{image_id}')
-    def create_disk(self, image_id, backstore, request=None):
-        logger.debug("iSCSI: Creating disk: %s", image_id)
+    @RestClient.api_put('/api/disk/{pool}/{image}')
+    def create_disk(self, pool, image, backstore, request=None):
+        logger.debug("iSCSI: Creating disk: %s/%s", pool, image)
         return request({
             'mode': 'create',
             'backstore': backstore
         })
 
-    @RestClient.api_delete('/api/disk/{image_id}')
-    def delete_disk(self, image_id, request=None):
-        logger.debug("iSCSI: Deleting disk: %s", image_id)
+    @RestClient.api_delete('/api/disk/{pool}/{image}')
+    def delete_disk(self, pool, image, request=None):
+        logger.debug("iSCSI: Deleting disk: %s/%s", pool, image)
         return request({
             'preserve_image': 'true'
         })
 
-    @RestClient.api_put('/api/disk/{image_id}')
-    def reconfigure_disk(self, image_id, controls, request=None):
-        logger.debug("iSCSI: Reconfiguring disk: %s", image_id)
+    @RestClient.api_put('/api/disk/{pool}/{image}')
+    def reconfigure_disk(self, pool, image, controls, request=None):
+        logger.debug("iSCSI: Reconfiguring disk: %s/%s", pool, image)
         return request({
             'controls': json.dumps(controls),
             'mode': 'reconfigure'

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -480,8 +480,8 @@ class IscsiClientMock(object):
             "portal_ip_address": ip_address[0]
         }
 
-    def create_disk(self, image_id, backstore):
-        pool, image = image_id.split('.')
+    def create_disk(self, pool, image, backstore):
+        image_id = '{}/{}'.format(pool, image)
         self.config['disks'][image_id] = {
             "pool": pool,
             "image": image,
@@ -494,7 +494,8 @@ class IscsiClientMock(object):
         target_config['disks'].append(image_id)
         self.config['disks'][image_id]['owner'] = list(target_config['portals'].keys())[0]
 
-    def reconfigure_disk(self, image_id, controls):
+    def reconfigure_disk(self, pool, image, controls):
+        image_id = '{}/{}'.format(pool, image)
         self.config['disks'][image_id]['controls'] = controls
 
     def create_client(self, target_iqn, client_iqn):
@@ -540,7 +541,8 @@ class IscsiClientMock(object):
         target_config['disks'].remove(image_id)
         del self.config['disks'][image_id]['owner']
 
-    def delete_disk(self, image_id):
+    def delete_disk(self, pool, image):
+        image_id = '{}/{}'.format(pool, image)
         del self.config['disks'][image_id]
 
     def delete_target(self, target_iqn):


### PR DESCRIPTION
This PR adapts ceph manager dashboard according to https://github.com/ceph/ceph-iscsi/pull/29

Signed-off-by: Ricardo Marques <rimarques@suse.com>

