### PR TITLE
mgr/dashboard: iSCSI - Infrastructure for multiple backstores (backend)

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -396,7 +396,8 @@ class IscsiTarget(RESTController):
                 image = disk['image']
                 image_id = '{}.{}'.format(pool, image)
                 if image_id not in config['disks']:
-                    IscsiClient.instance(gateway_name=gateway_name).create_disk(image_id)
+                    backstore = disk['backstore']
+                    IscsiClient.instance(gateway_name=gateway_name).create_disk(image_id, backstore)
                 if not target_config or image_id not in target_config['disks']:
                     IscsiClient.instance(gateway_name=gateway_name).create_target_lun(target_iqn,
                                                                                       image_id)
@@ -469,6 +470,7 @@ class IscsiTarget(RESTController):
                 'pool': disk_config['pool'],
                 'image': disk_config['image'],
                 'controls': disk_config['controls'],
+                'backstore': disk_config['backstore']
             }
             disks.append(disk)
         disks = IscsiTarget._sorted_disks(disks)

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -91,10 +91,11 @@ class IscsiClient(RestClient):
         })
 
     @RestClient.api_put('/api/disk/{image_id}')
-    def create_disk(self, image_id, request=None):
+    def create_disk(self, image_id, backstore, request=None):
         logger.debug("iSCSI: Creating disk: %s", image_id)
         return request({
-            'mode': 'create'
+            'mode': 'create',
+            'backstore': backstore
         })
 
     @RestClient.api_delete('/api/disk/{image_id}')

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -162,7 +162,8 @@ class IscsiTest(ControllerTestCase):
             {
                 "image": "lun3",
                 "pool": "rbd",
-                "controls": {}
+                "controls": {},
+                "backstore": "user:rbd"
             })
         update_request['clients'][0]['luns'].append({"image": "lun3", "pool": "rbd"})
         response = copy.deepcopy(iscsi_target_response)
@@ -171,7 +172,8 @@ class IscsiTest(ControllerTestCase):
             {
                 "image": "lun3",
                 "pool": "rbd",
-                "controls": {}
+                "controls": {},
+                "backstore": "user:rbd"
             })
         response['clients'][0]['luns'].append({"image": "lun3", "pool": "rbd"})
         self._update_iscsi_target(create_request, update_request, response)
@@ -306,8 +308,10 @@ iscsi_target_request = {
         {"ip": "192.168.100.203", "host": "node3"}
     ],
     "disks": [
-        {"image": "lun1", "pool": "rbd", "controls": {"max_data_area_mb": 128}},
-        {"image": "lun2", "pool": "rbd", "controls": {"max_data_area_mb": 128}}
+        {"image": "lun1", "pool": "rbd", "backstore": "user:rbd",
+         "controls": {"max_data_area_mb": 128}},
+        {"image": "lun2", "pool": "rbd", "backstore": "user:rbd",
+         "controls": {"max_data_area_mb": 128}}
     ],
     "clients": [
         {
@@ -348,8 +352,10 @@ iscsi_target_response = {
         {'host': 'node3', 'ip': '192.168.100.203'}
     ],
     'disks': [
-        {'pool': 'rbd', 'image': 'lun1', 'controls': {'max_data_area_mb': 128}},
-        {'pool': 'rbd', 'image': 'lun2', 'controls': {'max_data_area_mb': 128}}
+        {'pool': 'rbd', 'image': 'lun1', 'backstore': 'user:rbd',
+         'controls': {'max_data_area_mb': 128}},
+        {'pool': 'rbd', 'image': 'lun2', 'backstore': 'user:rbd',
+         'controls': {'max_data_area_mb': 128}}
     ],
     'clients': [
         {
@@ -417,14 +423,20 @@ class IscsiClientMock(object):
 
     def get_settings(self):
         return {
+            "backstores": [
+                "user:rbd"
+            ],
             "config": {
                 "minimum_gateways": 2
             },
+            "default_backstore": "user:rbd",
             "disk_default_controls": {
-                "hw_max_sectors": 1024,
-                "max_data_area_mb": 8,
-                "osd_op_timeout": 30,
-                "qfull_timeout": 5
+                "user:rbd": {
+                    "hw_max_sectors": 1024,
+                    "max_data_area_mb": 8,
+                    "osd_op_timeout": 30,
+                    "qfull_timeout": 5
+                }
             },
             "target_default_controls": {
                 "cmdsn_depth": 128,
@@ -463,11 +475,12 @@ class IscsiClientMock(object):
             "portal_ip_address": ip_address[0]
         }
 
-    def create_disk(self, image_id):
+    def create_disk(self, image_id, backstore):
         pool, image = image_id.split('.')
         self.config['disks'][image_id] = {
             "pool": pool,
             "image": image,
+            "backstore": backstore,
             "controls": {}
         }
 


### PR DESCRIPTION
This PR adapts the Ceph Manager Dashboard according to https://github.com/ceph/ceph-iscsi/pull/23

Fixes: https://tracker.ceph.com/issues/38090

Signed-off-by: Ricardo Marques <rimarques@suse.com>

