### PR TITLE
mimic: rgw: lifcycle: don't reject compound rules with empty prefix

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -80,8 +80,14 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
   if (rule->get_filter().has_tags()){
     op.obj_tags = rule->get_filter().get_tags();
   }
-  auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
-  return ret.second;
+
+  /* prefix is optional, update prefix map only if prefix...exists */
+  if (!prefix.empty()) {
+    auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
+    return ret.second;
+  }
+
+  return true;
 }
 
 int RGWLifecycleConfiguration::check_and_add_rule(LCRule *rule)


### PR DESCRIPTION
https://tracker.ceph.com/issues/38369