### PR TITLE
mgr: Selftest fails, dashboard/server_port not string

### DIFF
--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -317,10 +317,10 @@ class Module(MgrModule):
         assert self.get_module_option_ex("dashboard", "password", "foobar") == "foobar"
 
         # Option type is not defined => return as string.
-        self.set_module_option_ex("dashboard", "server_port", 8080)
-        value = self.get_module_option_ex("dashboard", "server_port")
+        self.set_module_option_ex("selftest", "rwoption1", 1234)
+        value = self.get_module_option_ex("selftest", "rwoption1")
         assert isinstance(value, str)
-        assert value == "8080"
+        assert value == "1234"
 
         # Option type is defined => return as integer.
         self.set_module_option_ex("telemetry", "interval", 60)


### PR DESCRIPTION
Replace ``dashboard/server_port`` with ``selftest/rwoption1`` because the server_port option has been modified by PR #26386 and is now defined as 'int' type.

Fixes: http://tracker.ceph.com/issues/38380

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

