### PR TITLE
rgw: lifecycle: alternate solution to prefix_map conflict

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -172,32 +172,10 @@ bool RGWLifecycleConfiguration::has_same_action(const lc_op& first, const lc_op&
   return false;
 }
 
-//Rules are conflicted: if one rule's prefix starts with other rule's prefix, and these two rules
-//define same action. 
+/* Formerly, this method checked for duplicate rules using an invalid
+ * method (prefix uniqueness). */
 bool RGWLifecycleConfiguration::valid() 
 {
-  if (prefix_map.size() < 2) {
-    return true;
-  }
-  auto cur_iter = prefix_map.begin();
-  while (cur_iter != prefix_map.end()) {
-    auto next_iter = cur_iter;
-    ++next_iter;
-    while (next_iter != prefix_map.end()) {
-      string c_pre = cur_iter->first;
-      string n_pre = next_iter->first;
-      if (n_pre.compare(0, c_pre.length(), c_pre) == 0) {
-        if (has_same_action(cur_iter->second, next_iter->second)) {
-          return false;
-        } else {
-          ++next_iter;
-        }
-      } else {
-        break;
-      }
-    }
-    ++cur_iter;
-  }
   return true;
 }
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -372,8 +372,10 @@ struct transition_action
   transition_action() : days(0) {}
 };
 
+/* XXX why not LCRule? */
 struct lc_op
 {
+  string id;
   bool status{false};
   bool dm_expiration{false};
   int expiration{0};
@@ -383,7 +385,13 @@ struct lc_op
   boost::optional<RGWObjTags> obj_tags;
   map<string, transition_action> transitions;
   map<string, transition_action> noncur_transitions;
-  
+
+  /* ctors are nice */
+  lc_op() = delete;
+
+  lc_op(const std::string id) : id(id)
+    {}
+
   void dump(Formatter *f) const;
 };
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -391,7 +391,7 @@ class RGWLifecycleConfiguration
 {
 protected:
   CephContext *cct;
-  map<string, lc_op> prefix_map;
+  multimap<string, lc_op> prefix_map;
   multimap<string, LCRule> rule_map;
   bool _add_rule(const LCRule& rule);
   bool has_same_action(const lc_op& first, const lc_op& second);
@@ -432,7 +432,7 @@ public:
   bool valid();
 
   multimap<string, LCRule>& get_rule_map() { return rule_map; }
-  map<string, lc_op>& get_prefix_map() { return prefix_map; }
+  multimap<string, lc_op>& get_prefix_map() { return prefix_map; }
 /*
   void create_default(string id, string name) {
     ACLGrant grant;
@@ -499,7 +499,8 @@ class RGWLC : public DoutPrefixProvider {
 
   private:
 
-  int handle_multipart_expiration(RGWRados::Bucket *target, const map<string, lc_op>& prefix_map);
+  int handle_multipart_expiration(RGWRados::Bucket *target,
+				  const multimap<string, lc_op>& prefix_map);
 };
 
 namespace rgw::lc {


### PR DESCRIPTION
A rule containing a tag filter but no constraining prefix is
legal, as is a sequence of >1 such rules.

As currently designed, enforcement requires rules to be
installed in prefix_map as well as rule_map, though only the
latter is encoded.

Fixes: http://tracker.ceph.com/issues/37879

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

