### PR TITLE
msg/async: add retry for RDMAStack when poll is interrupted by signal

### DIFF
--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -283,9 +283,14 @@ void RDMADispatcher::polling()
         channel_poll[1].revents = 0;
         r = 0;
         perf_logger->set(l_msgr_rdma_polling, 0);
-        while (!done && r == 0) {
+        while (!done) {
           r = poll(channel_poll, 2, 100);
-          if (r < 0) {
+          if (r > 0) {
+            break;
+          } else if (r < 0) {
+            if (errno == EINTR) {
+              continue;
+            }
             r = -errno;
             lderr(cct) << __func__ << " poll failed " << r << dendl;
             ceph_abort();


### PR DESCRIPTION
msg/async: add retry for RDMAStack when poll is interrupted by signal

the poll needs to retry when it is interrupted by sgnal

Fixes: https://tracker.ceph.com/issues/38392
Signed-off-by: Peng Liu <liupeng37@baidu.com>