### PR TITLE
mimic: rgw: check for non-existent bucket in RGWGetACLs

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4766,6 +4766,9 @@ int RGWGetACLs::verify_permission()
 
     perm = verify_object_permission(s, iam_action);
   } else {
+    if (!s->bucket_exists) {
+      return -ERR_NO_SUCH_BUCKET;
+    }
     perm = verify_bucket_permission(s, rgw::IAM::s3GetBucketAcl);
   }
   if (!perm)


### PR DESCRIPTION
http://tracker.ceph.com/issues/38353