### PR TITLE
src/tools: only build dedup tool if WITH_TESTS is set

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -100,10 +100,12 @@ add_executable(ceph-authtool ${ceph_authtool_srcs})
 target_link_libraries(ceph-authtool global ${EXTRALIBS} ${CRYPTO_LIBS})
 install(TARGETS ceph-authtool DESTINATION bin)
 
+if(WITH_TESTS)
 set(cephdeduptool_srcs ceph_dedup_tool.cc)
 add_executable(cephdeduptool ${cephdeduptool_srcs})
 target_link_libraries(cephdeduptool librados-cxx global cls_cas_client)
 install(TARGETS cephdeduptool DESTINATION bin)
+endif(WITH_TESTS)
 
 if(WITH_CEPHFS)
   add_subdirectory(cephfs)


### PR DESCRIPTION
We need to only build the dedup tool if WITH_TESTS is set.
Otherwise, when building an RPM *without* tests enabled, the build
will fail with "error: Installed (but unpackaged) file(s) found:
/usr/bin/cephdeduptool".

Signed-off-by: Tim Serong <tserong@suse.com>