### PR TITLE
mgr/dashboard: Add NFS status endpoint 

### DIFF
--- a/qa/tasks/mgr/dashboard/test_ganesha.py
+++ b/qa/tasks/mgr/dashboard/test_ganesha.py
@@ -147,3 +147,23 @@ class GaneshaTest(DashboardTestCase):
 
         export2 = self._get("/api/nfs-ganesha/export/cluster2/2")
         self.assertDictEqual(export2, data2)
+
+    def test_invalid_status(self):
+        self._ceph_cmd(['dashboard', 'set-ganesha-clusters-rados-pool-namespace', ''])
+
+        data = self._get('/api/nfs-ganesha/status')
+        self.assertStatus(200)
+        self.assertIn('available', data)
+        self.assertIn('message', data)
+        self.assertFalse(data['available'])
+        self.assertIn('Ganesha config location is not configured. Please set the GANESHA_RADOS_POOL_NAMESPACE setting.',
+                      data['message'])
+
+        self._ceph_cmd(['dashboard', 'set-ganesha-clusters-rados-pool-namespace', 'cluster1:ganesha/ganesha1,cluster2:ganesha/ganesha2'])
+
+    def test_valid_status(self):
+        data = self._get('/api/nfs-ganesha/status')
+        self.assertStatus(200)
+        self.assertIn('available', data)
+        self.assertIn('message', data)
+        self.assertTrue(data['available'])

--- a/src/pybind/mgr/dashboard/controllers/nfsganesha.py
+++ b/src/pybind/mgr/dashboard/controllers/nfsganesha.py
@@ -7,7 +7,7 @@ import cherrypy
 import cephfs
 
 from . import ApiController, RESTController, UiApiController, BaseController, \
-              Endpoint, Task
+              Endpoint, Task, ReadPermission
 from .. import logger
 from ..security import Scope
 from ..services.cephfs import CephFS
@@ -24,6 +24,22 @@ def NfsTask(name, metadata, wait_for):
                     partial(serialize_dashboard_exception,
                             include_http_status=True))(func)
     return composed_decorator
+
+
+@ApiController('/nfs-ganesha', Scope.NFS_GANESHA)
+class NFSGanesha(RESTController):
+
+    @Endpoint()
+    @ReadPermission
+    def status(self):
+        status = {'available': True, 'message': None}
+        try:
+            Ganesha.get_ganesha_clusters()
+        except NFSException as e:
+            status['message'] = str(e)
+            status['available'] = False
+
+        return status
 
 
 @ApiController('/nfs-ganesha/export', Scope.NFS_GANESHA)

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -17,6 +17,7 @@ import { MonitorComponent } from './ceph/cluster/monitor/monitor.component';
 import { OsdListComponent } from './ceph/cluster/osd/osd-list/osd-list.component';
 import { PrometheusListComponent } from './ceph/cluster/prometheus/prometheus-list/prometheus-list.component';
 import { DashboardComponent } from './ceph/dashboard/dashboard/dashboard.component';
+import { Nfs501Component } from './ceph/nfs/nfs-501/nfs-501.component';
 import { NfsFormComponent } from './ceph/nfs/nfs-form/nfs-form.component';
 import { NfsListComponent } from './ceph/nfs/nfs-list/nfs-list.component';
 import { PerformanceCounterComponent } from './ceph/performance-counter/performance-counter/performance-counter.component';
@@ -309,10 +310,22 @@ const routes: Routes = [
   },
   // NFS
   {
+    path: 'nfs/501/:message',
+    component: Nfs501Component,
+    canActivate: [AuthGuardService],
+    data: { breadcrumbs: 'NFS' }
+  },
+  {
     path: 'nfs',
     canActivate: [AuthGuardService],
-    canActivateChild: [AuthGuardService],
-    data: { breadcrumbs: 'NFS' },
+    canActivateChild: [AuthGuardService, ModuleStatusGuardService],
+    data: {
+      moduleStatusGuardConfig: {
+        apiPath: 'nfs-ganesha',
+        redirectTo: 'nfs/501'
+      },
+      breadcrumbs: 'NFS'
+    },
     children: [
       { path: '', component: NfsListComponent },
       { path: 'add', component: NfsFormComponent, data: { breadcrumbs: 'Add' } },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-501/nfs-501.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-501/nfs-501.component.html
@@ -1,0 +1,5 @@
+<cd-info-panel>
+  {{ message }}<br>
+  <ng-container i18n>Please consult the <a href="{{docsUrl}}" target="_blank">documentation</a>
+  on how to configure and enable the NFS Ganesha management functionality.</ng-container>
+</cd-info-panel>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-501/nfs-501.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-501/nfs-501.component.spec.ts
@@ -1,0 +1,28 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { SharedModule } from '../../../shared/shared.module';
+import { Nfs501Component } from './nfs-501.component';
+
+describe('Nfs501Component', () => {
+  let component: Nfs501Component;
+  let fixture: ComponentFixture<Nfs501Component>;
+
+  configureTestBed({
+    declarations: [Nfs501Component],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    providers: i18nProviders
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(Nfs501Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-501/nfs-501.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-501/nfs-501.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { I18n } from '@ngx-translate/i18n-polyfill';
+
+import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
+import { SummaryService } from '../../../shared/services/summary.service';
+
+@Component({
+  selector: 'cd-nfs-501',
+  templateUrl: './nfs-501.component.html',
+  styleUrls: ['./nfs-501.component.scss']
+})
+export class Nfs501Component implements OnInit, OnDestroy {
+  docsUrl: string;
+  message = this.i18n('The NFS Ganesha service is not configured.');
+  routeParamsSubscribe: any;
+
+  constructor(
+    private route: ActivatedRoute,
+    private summaryService: SummaryService,
+    private cephReleaseNamePipe: CephReleaseNamePipe,
+    private i18n: I18n
+  ) {}
+
+  ngOnInit() {
+    const subs = this.summaryService.subscribe((summary: any) => {
+      if (!summary) {
+        return;
+      }
+
+      const releaseName = this.cephReleaseNamePipe.transform(summary.version);
+      this.docsUrl =
+        `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/` +
+        `#configuring-nfs-ganesha-in-the-dashboard`;
+
+      setTimeout(() => {
+        subs.unsubscribe();
+      }, 0);
+    });
+
+    this.routeParamsSubscribe = this.route.params.subscribe((params: { message: string }) => {
+      this.message = params.message;
+    });
+  }
+
+  ngOnDestroy() {
+    this.routeParamsSubscribe.unsubscribe();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.html
@@ -1,8 +1,3 @@
-<cd-info-panel *ngIf="true"
-               title="Orchestrator not available"
-               i18n-title
-               i18n>To apply any changes you have to restart the Ganisha services.</cd-info-panel>
-
 <cd-table #table
           [data]="exports"
           columnMode="flex"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
@@ -7,6 +7,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 
 import { SharedModule } from '../../shared/shared.module';
+import { Nfs501Component } from './nfs-501/nfs-501.component';
 import { NfsDetailsComponent } from './nfs-details/nfs-details.component';
 import { NfsFormClientComponent } from './nfs-form-client/nfs-form-client.component';
 import { NfsFormComponent } from './nfs-form/nfs-form.component';
@@ -21,6 +22,13 @@ import { NfsListComponent } from './nfs-list/nfs-list.component';
     CommonModule,
     TypeaheadModule.forRoot()
   ],
-  declarations: [NfsListComponent, NfsDetailsComponent, NfsFormComponent, NfsFormClientComponent]
+  declarations: [
+    NfsListComponent,
+    NfsDetailsComponent,
+    NfsFormComponent,
+    NfsFormClientComponent,
+    Nfs501Component
+  ],
+  exports: [Nfs501Component]
 })
 export class NfsModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -178,7 +178,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/nfs/nfs-list/nfs-list.component.html</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit><trans-unit id="9e24f9e2d42104ffc01599db4d566d1cc518f9e6" datatype="html">
         <source>Daemons</source>
@@ -1673,6 +1673,13 @@
           <context context-type="sourcefile">app/ceph/dashboard/dashboard/dashboard.component.html</context>
           <context context-type="linenumber">8</context>
         </context-group>
+      </trans-unit><trans-unit id="f8f74e5f683012b9c0702b1446011c6b9158bc67" datatype="html">
+        <source>Please consult the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+  on how to configure and enable the NFS Ganesha management functionality.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-501/nfs-501.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
       </trans-unit><trans-unit id="7ffe39df9d88c972792bd8688b215392deb8313d" datatype="html">
         <source>Clients</source>
         <context-group purpose="location">
@@ -2030,23 +2037,11 @@
           <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
           <context context-type="linenumber">493</context>
         </context-group>
-      </trans-unit><trans-unit id="3bd5ad3144184479c23ec67ceda089f9883840aa" datatype="html">
-        <source>To apply any changes you have to restart the Ganisha services.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-list/nfs-list.component.html</context>
-          <context context-type="linenumber">4</context>
-        </context-group>
-      </trans-unit><trans-unit id="5a9de53b931d4b73b84f3fd729abfbbb20a9619e" datatype="html">
-        <source>Orchestrator not available</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-list/nfs-list.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
       </trans-unit><trans-unit id="734c9905951a774870497c5aaae8e3ee833b6196" datatype="html">
         <source>CephFS</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/nfs/nfs-list/nfs-list.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit><trans-unit id="594cd9429597cf6bede5560b3d8fe578821213de" datatype="html">
         <source>Add erasure code profile</source>
@@ -5454,6 +5449,13 @@
         <source>quorum</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/dashboard/mon-summary.pipe.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2fa50bc07995c6ea660412294298ded39fcb08d9" datatype="html">
+        <source>The NFS Ganesha service is not configured.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/nfs/nfs-501/nfs-501.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>


### PR DESCRIPTION
Currently each time NFS page is opened and NFS Ganesha is not configured
an error notification is thrown and no extra information is given.
Now the user will be redirected to an information page.

Removed the orchestrator information since it no longer applies.

Fixes: http://tracker.ceph.com/issues/38399

Signed-off-by: Tiago Melo <tmelo@suse.com>