### PR TITLE
osd/ReplicatedPG: do not whiteout non-existent obj when reading it

### DIFF
--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -90,6 +90,7 @@ public:
     vector<snapid_t> snaps;  ///< src's snaps (if clone)
     snapid_t snap_seq;       ///< src's snap_seq (if head)
     librados::snap_set_t snapset; ///< src snapset (if head)
+    int list_snaps_ret = 0; ///< return value of list_snaps (if head)
     bool mirror_snapset;
     bool has_omap;
     uint32_t flags;    // object_copy_data_t::FLAG_*
@@ -1322,7 +1323,8 @@ protected:
   }
   void _copy_some(ObjectContextRef obc, CopyOpRef cop);
   void finish_copyfrom(CopyFromCallback *cb);
-  void finish_promote(int r, CopyResults *results, ObjectContextRef obc);
+  void finish_promote(int r, CopyResults *results, bool maybe_write,
+		      ObjectContextRef obc);
   void cancel_copy(CopyOpRef cop, bool requeue, vector<ceph_tid_t> *tids);
   void cancel_copy_ops(bool requeue, vector<ceph_tid_t> *tids);
 


### PR DESCRIPTION
When doing list_snaps on an non-existent object in base pool, a whiteouted
object is created in the writeback cache tier, and an empty snapset is
attached to it. Then the list_snaps op succeeds and gets the empty snapset,
which makes librbd::DiffIterate work improperly.

This patch add return value of list_snaps to ReplicatedPG::CopyResults, and
also pass op->may_write() to ReplicatedPG::finishi_promote. A whiteouted
object is only created when the head object is not exist and if list_snaps
doesn't fail or the original op is write.

Fixes: http://tracker.ceph.com/issues/16890
Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

