### PR TITLE
Revert "ceph.spec.in: python-kubernetes broken on rhel"

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -505,6 +505,7 @@ Summary:        ceph-mgr rook plugin
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
+Requires:       python%{_python_buildid}-kubernetes
 %description mgr-rook
 ceph-mgr-rook is a ceph-mgr plugin for orchestration functions using
 a Rook backend.


### PR DESCRIPTION
This reverts commit c32c4874e139d0e97116d6f3d368ac9c3e393c9f.

An updated python2-kubernetes package that does not depend on
python-adal has made it into the epel7 repos. With that change,
we can now revert this patch.

Signed-off-by: Jeff Layton <jlayton@redhat.com>