### PR TITLE
mimic: rgw: when exclusive lock fails due existing lock, log add'l info

### DIFF
--- a/src/test/cls_lock/test_cls_lock.cc
+++ b/src/test/cls_lock/test_cls_lock.cc
@@ -85,6 +85,9 @@ TEST(ClsLock, TestMultiLocking) {
   ASSERT_EQ(0, ioctx.write(oid, bl, bl.length(), 0));
 
   Lock l(lock_name);
+  // we set the duration, so the log output contains a locker with a
+  // non-zero expiration time
+  l.set_duration(utime_t(120, 0));
 
   /* test lock object */
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38396