### PR TITLE
luminous: rgw: when exclusive lock fails due existing lock, log add'l info

### DIFF
--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -10,6 +10,7 @@
 
 #include <errno.h>
 #include <map>
+#include <sstream>
 
 #include "include/types.h"
 #include "include/utime.h"
@@ -197,7 +198,27 @@ static int lock_obj(cls_method_context_t hctx,
 
   if (!lockers.empty()) {
     if (exclusive) {
-      CLS_LOG(20, "could not exclusive-lock object, already locked");
+      std::stringstream locker_list;
+      bool first = true;
+      // there could be multiple lockers if they are all shared
+      for (const auto& l : lockers) {
+	if (first) {
+	  first = false;
+	} else {
+	  locker_list << ", ";
+	}
+	locker_list << "{name:" << l.first.locker <<
+	  ", addr:" << l.second.addr <<
+	  ", exp:";
+	const auto& exp = l.second.expiration;
+	if (exp.is_zero()) {
+	  locker_list << "never}";
+	} else {
+	  locker_list << exp.to_real_time() << "}";
+	}
+      }
+      CLS_LOG(20, "could not exclusive-lock object, already locked by [%s]",
+	      locker_list.str().c_str());
       return -EBUSY;
     }
 

--- a/src/test/cls_lock/test_cls_lock.cc
+++ b/src/test/cls_lock/test_cls_lock.cc
@@ -85,6 +85,9 @@ TEST(ClsLock, TestMultiLocking) {
   ASSERT_EQ(0, ioctx.write(oid, bl, bl.length(), 0));
 
   Lock l(lock_name);
+  // we set the duration, so the log output contains a locker with a
+  // non-zero expiration time
+  l.set_duration(utime_t(120, 0));
 
   /* test lock object */
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38397