### PR TITLE
osd/PG.cc: remove incorrect assert

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1768,7 +1768,7 @@ bool PG::choose_acting(pg_shard_t &auth_log_shard_id,
   dout(10) << "acting_recovery_backfill is " << acting_recovery_backfill << dendl;
   ceph_assert(backfill_targets.empty());
   if (backfill_targets.empty()) {
-    // Caller is GetInfo
+    // Caller is GetLog
     backfill_targets = want_backfill;
   }
   // Adding !needs_recovery() to let the async_recovery_targets reset after recovery is complete

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1766,7 +1766,7 @@ bool PG::choose_acting(pg_shard_t &auth_log_shard_id,
   want_acting.clear();
   acting_recovery_backfill = want_acting_backfill;
   dout(10) << "acting_recovery_backfill is " << acting_recovery_backfill << dendl;
-  ceph_assert(backfill_targets.empty() || backfill_targets == want_backfill);
+  ceph_assert(backfill_targets.empty());
   if (backfill_targets.empty()) {
     // Caller is GetInfo
     backfill_targets = want_backfill;


### PR DESCRIPTION
choose_acting() has only two callers:
(1) PG::RecoveryState::GetLog::GetLog()
This caller always call choose_acting() with an empty backfill_targets, because it is cleared
in start_peering_interval() before.
(2) PG::RecoveryState::Recovered::Recovered()
This function is entered only when receiving AllReplicasRecovered/Backfilled event,
in either case, the backfill process must have completed. Then when Recovered() calls
choose_acting(), the calc_replicated_acting() in choose_acting() will get an empty want_backfill
since backfill completed, but backfill_targets may not be empty, they are not equal which will
lead to assert fail. Practically, if backfill_targets not empty, which means a temporary PG is
acting, implies "want" not equal to "acting" after calc_replicated_acting(), then choose_acting()
returns without reaching the assert
