### PR TITLE
mgr/dashboard: Make preventDefault work with 400 errors

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
@@ -182,6 +182,16 @@ describe('ApiInterceptorService', () => {
       expect(notificationService.save).not.toHaveBeenCalled();
     }));
 
+    it('should be able to use preventDefault with 400 errors', fakeAsync(() => {
+      httpError(
+        { task: { name: 'someName', metadata: { component: 'someComponent' } } },
+        { status: 400 },
+        (resp) => resp.preventDefault()
+      );
+      tick(10);
+      expect(notificationService.save).not.toHaveBeenCalled();
+    }));
+
     it('should prevent the default behaviour by status code', fakeAsync(() => {
       httpError(undefined, { status: 500 }, (resp) => resp.ignoreStatusCode(500));
       tick(10);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
@@ -33,7 +33,7 @@ export class ApiInterceptorService implements HttpInterceptor {
     return next.handle(request).pipe(
       catchError((resp) => {
         if (resp instanceof HttpErrorResponse) {
-          let showNotification = true;
+          let timeoutId: number;
           switch (resp.status) {
             case 400:
               const finishedTask = new FinishedTask();
@@ -50,20 +50,18 @@ export class ApiInterceptorService implements HttpInterceptor {
 
               finishedTask.success = false;
               finishedTask.exception = resp.error;
-              this.notificationService.notifyTask(finishedTask);
-              showNotification = false;
+              timeoutId = this.notificationService.notifyTask(finishedTask);
               break;
             case 401:
               this.authStorageService.remove();
               this.router.navigate(['/login']);
-              showNotification = false;
               break;
             case 403:
               this.router.navigate(['/403']);
               break;
+            default:
+              timeoutId = this.prepareNotification(resp);
           }
-
-          const timeoutId = showNotification ? this.prepareNotification(resp) : undefined;
 
           /**
            * Decorated preventDefault method (in case error previously had

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -107,6 +107,16 @@ describe('NotificationService', () => {
     expect(notification.message).toBe(undefined);
   }));
 
+  it('should be able to stop notifyTask from notifying', fakeAsync(() => {
+    const task = _.assign(new FinishedTask(), {
+      success: true
+    });
+    const timeoutId = service.notifyTask(task, true);
+    service.cancel(timeoutId);
+    tick(100);
+    expect(service['dataSource'].getValue().length).toBe(0);
+  }));
+
   it('should show a error task notification', fakeAsync(() => {
     const task = _.assign(
       new FinishedTask('rbd/create', {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -150,7 +150,7 @@ export class NotificationService {
     }"></i>`;
   }
 
-  notifyTask(finishedTask: FinishedTask, success: boolean = true) {
+  notifyTask(finishedTask: FinishedTask, success: boolean = true): number {
     let notification: CdNotificationConfig;
     if (finishedTask.success && success) {
       notification = new CdNotificationConfig(
@@ -164,7 +164,7 @@ export class NotificationService {
         this.taskMessageService.getErrorMessage(finishedTask)
       );
     }
-    this.show(notification);
+    return this.show(notification);
   }
 
   /**


### PR DESCRIPTION
The problem was that, if a error with the status code 400 was
received by the error interceptor the "timeoutId" was not tracked,
therefor "preventDefault" didn't prevent anything as "timeoutId"
was undefined.

Signed-off-by: Stephan Müller <smueller@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

