### PR TITLE
rgw: LC: handle resharded buckets

### DIFF
--- a/doc/radosgw/dynamicresharding.rst
+++ b/doc/radosgw/dynamicresharding.rst
@@ -95,3 +95,45 @@ Manual bucket resharding
 ::
 
    # radosgw-admin bucket reshard --bucket <bucket_name> --num-shards <new number of shards>
+
+
+Troubleshooting
+===============
+
+Clusters prior to Luminous 12.2.11 and Mimic 13.2.5 left behind stale bucket
+instance entries that weren't automatically cleaned up. The issue also affected
+LifeCycle policies which weren't applied to resharded buckets anymore. Both of
+these issues can be worked around using a couple of radosgw-admin commands.
+
+Stale Instance Management
+-------------------------
+
+::
+
+   # radosgw-admin reshard stale-instances list
+
+This lists the stale instances in a cluster that are ready to be cleaned up.
+Please note that the cleanup of these instances should be done only on a single
+site cluster. The cleanup can be done by the following command:
+
+::
+
+   # radosgw-admin reshard stale-instances rm
+
+
+Lifecycle fixes
+---------------
+
+For clusters which had resharded instances, it is highly likely that the old
+lifecycle processes would've flagged and deleted lifecycle processing as the
+bucket instance changed during a reshard. While this is fixed for newer clusters
+(from 13.2.6 and 12.2.12), older buckets which had lifecycle policies and
+would've undergone reshard will have to be manually fixed by issuing the following command
+
+::
+
+   # radosgw-admin lc reshard fix --bucket {bucketname}
+
+
+As a convenience wrapper, if the ``--bucket`` argument is dropped then this
+command will try and fix LC policies for all the buckets in the cluster.

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -757,7 +757,7 @@ static void log_entry(const char *func, const char *str, rgw_bucket_olh_entry *e
 
 template <class T>
 static int read_omap_entry(cls_method_context_t hctx, const std::string& name,
-                           T *entry)
+                           T* entry)
 {
   bufferlist current_entry;
   int rc = cls_cxx_map_get_val(hctx, name, &current_entry);
@@ -776,7 +776,7 @@ static int read_omap_entry(cls_method_context_t hctx, const std::string& name,
 }
 
 template <class T>
-static int read_index_entry(cls_method_context_t hctx, string& name, T *entry)
+static int read_index_entry(cls_method_context_t hctx, string& name, T* entry)
 {
   int ret = read_omap_entry(hctx, name, entry);
   if (ret < 0) {
@@ -3179,7 +3179,7 @@ static int gc_omap_get(cls_method_context_t hctx, int type, const string& key, c
   string index;
   prepend_index_prefix(key, type, &index);
 
-  int ret = read_omap_entry(hctx, key, info);
+  int ret = read_omap_entry(hctx, index, info);
   if (ret < 0)
     return ret;
 

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -816,6 +816,29 @@ int cls_rgw_lc_set_entry(IoCtx& io_ctx, const string& oid, const pair<string, in
   return r;
 }
 
+int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid, const std::string& marker, rgw_lc_entry_t& entry)
+{
+  bufferlist in, out;
+  cls_rgw_lc_get_entry_op call{marker};;
+  encode(call, in);
+  int r = io_ctx.exec(oid, RGW_CLASS, RGW_LC_GET_ENTRY, in, out);
+
+  if (r < 0) {
+    return r;
+  }
+
+  cls_rgw_lc_get_entry_ret ret;
+  try {
+    auto iter = out.cbegin();
+    decode(ret, iter);
+  } catch (buffer::error& err) {
+    return -EIO;
+  }
+
+  entry = std::move(ret.entry);
+  return r;
+}
+
 int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
                     const string& marker,
                     uint32_t max_entries,

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -553,6 +553,7 @@ int cls_rgw_lc_put_head(librados::IoCtx& io_ctx, const string& oid, cls_rgw_lc_o
 int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, const string& oid, string& marker, pair<string, int>& entry);
 int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, const string& oid, const pair<string, int>& entry);
 int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, const string& oid, const pair<string, int>& entry);
+int cls_rgw_lc_get_entry(librados::IoCtx& io_ctx, const string& oid, const std::string& marker, rgw_lc_entry_t& entry);
 int cls_rgw_lc_list(librados::IoCtx& io_ctx, const string& oid,
                     const string& marker,
                     uint32_t max_entries,

--- a/src/cls/rgw/cls_rgw_const.h
+++ b/src/cls/rgw/cls_rgw_const.h
@@ -52,6 +52,7 @@
 #define RGW_GC_REMOVE "gc_remove"
 
 /* lifecycle bucket list */
+#define RGW_LC_GET_ENTRY "lc_get_entry"
 #define RGW_LC_SET_ENTRY "lc_set_entry"
 #define RGW_LC_RM_ENTRY "lc_rm_entry"
 #define RGW_LC_GET_NEXT_ENTRY "lc_get_next_entry"

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1010,9 +1010,10 @@ struct cls_rgw_lc_get_next_entry_op {
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_next_entry_op)
 
-struct cls_rgw_lc_get_next_entry_ret {
-  pair<string, int> entry;
+using rgw_lc_entry_t = std::pair<std::string, int>;
 
+struct cls_rgw_lc_get_next_entry_ret {
+  rgw_lc_entry_t entry;
   cls_rgw_lc_get_next_entry_ret() {}
 
   void encode(bufferlist& bl) const {
@@ -1031,7 +1032,7 @@ struct cls_rgw_lc_get_next_entry_ret {
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_next_entry_ret)
 
 struct cls_rgw_lc_rm_entry_op {
-  pair<string, int> entry;
+  rgw_lc_entry_t entry;
   cls_rgw_lc_rm_entry_op() {}
 
   void encode(bufferlist& bl) const {
@@ -1049,7 +1050,7 @@ struct cls_rgw_lc_rm_entry_op {
 WRITE_CLASS_ENCODER(cls_rgw_lc_rm_entry_op)
 
 struct cls_rgw_lc_set_entry_op {
-  pair<string, int> entry;
+  rgw_lc_entry_t entry;
   cls_rgw_lc_set_entry_op() {}
 
   void encode(bufferlist& bl) const {

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1031,6 +1031,46 @@ struct cls_rgw_lc_get_next_entry_ret {
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_next_entry_ret)
 
+struct cls_rgw_lc_get_entry_op {
+  string marker;
+  cls_rgw_lc_get_entry_op() {}
+  cls_rgw_lc_get_entry_op(const std::string& _marker) : marker(_marker) {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(marker, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(marker, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_rgw_lc_get_entry_op)
+
+struct cls_rgw_lc_get_entry_ret {
+  rgw_lc_entry_t entry;
+  cls_rgw_lc_get_entry_ret() {}
+  cls_rgw_lc_get_entry_ret(rgw_lc_entry_t&& _entry) : entry(std::move(_entry)) {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(entry, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(entry, bl);
+    DECODE_FINISH(bl);
+  }
+
+};
+WRITE_CLASS_ENCODER(cls_rgw_lc_get_entry_ret)
+
+
 struct cls_rgw_lc_rm_entry_op {
   rgw_lc_entry_t entry;
   cls_rgw_lc_rm_entry_op() {}

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -193,6 +193,7 @@ void usage()
   cout << "  lc list                    list all bucket lifecycle progress\n";
   cout << "  lc get                     get a lifecycle bucket configuration\n";
   cout << "  lc process                 manually process lifecycle\n";
+  cout << "  lc fix                     fix LC for a resharded bucket\n";
   cout << "  metadata get               get metadata info\n";
   cout << "  metadata put               put metadata info\n";
   cout << "  metadata rm                remove metadata info\n";
@@ -435,6 +436,7 @@ enum {
   OPT_LC_LIST,
   OPT_LC_GET,
   OPT_LC_PROCESS,
+  OPT_LC_FIX,
   OPT_ORPHANS_FIND,
   OPT_ORPHANS_FINISH,
   OPT_ORPHANS_LIST_JOBS,
@@ -888,6 +890,8 @@ static int get_cmd(const char *cmd, const char *prev_cmd, const char *prev_prev_
       return OPT_LC_GET;
     if (strcmp(cmd, "process") == 0)
       return OPT_LC_PROCESS;
+    if (strcmp(cmd, "fix") == 0)
+      return OPT_LC_FIX;
   } else if (strcmp(prev_cmd, "orphans") == 0) {
     if (strcmp(cmd, "find") == 0)
       return OPT_ORPHANS_FIND;
@@ -6575,6 +6579,23 @@ next:
     if (ret < 0) {
       cerr << "ERROR: lc processing returned error: " << cpp_strerror(-ret) << std::endl;
       return 1;
+    }
+  }
+
+
+  if (opt_cmd == OPT_LC_FIX) {
+    rgw_bucket bucket;
+    RGWBucketInfo bucket_info;
+    map<string, bufferlist> attrs;
+    ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket, &attrs);
+    if (ret < 0) {
+      cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
+      return -ret;
+    }
+
+    ret = rgw::lc::fix_lc_shard_entry(store, bucket_info, attrs);
+    if (ret < 0) {
+      cerr << "ERROR: fixing lc shard entry failed with" << cpp_strerror(-ret) << std::endl;
     }
   }
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -31,6 +31,7 @@
 // until everything is moved from rgw_common
 #include "rgw_common.h"
 #include "rgw_reshard.h"
+#include "rgw_lc.h"
 #include "cls/user/cls_user_types.h"
 
 #define dout_context g_ceph_context
@@ -1875,6 +1876,87 @@ int RGWBucketAdminOp::clear_stale_instances(RGWRados *store,
                    };
 
   return process_stale_instances(store, op_state, flusher, process_f);
+}
+
+static int fix_single_bucket_lc(RGWRados *store,
+                                const std::string& tenant_name,
+                                const std::string& bucket_name)
+{
+  auto obj_ctx = store->svc.sysobj->init_obj_ctx();
+  RGWBucketInfo bucket_info;
+  map <std::string, bufferlist> bucket_attrs;
+  int ret = store->get_bucket_info(obj_ctx, tenant_name, bucket_name,
+                                   bucket_info, nullptr, &bucket_attrs);
+  if (ret < 0) {
+    // TODO: Should we handle the case where the bucket could've been removed between
+    // listing and fetching?
+    return ret;
+  }
+
+  return rgw::lc::fix_lc_shard_entry(store, bucket_info, bucket_attrs);
+}
+
+static void format_lc_status(Formatter* formatter,
+                             const std::string& tenant_name,
+                             const std::string& bucket_name,
+                             int status)
+{
+  formatter->open_object_section("bucket_entry");
+  std::string entry = tenant_name.empty() ? bucket_name : tenant_name + "/" + bucket_name;
+  formatter->dump_string("bucket", entry);
+  formatter->dump_int("status", status);
+  formatter->close_section(); // bucket_entry
+}
+
+static void process_single_lc_entry(RGWRados *store, Formatter *formatter,
+                                    const std::string& tenant_name,
+                                    const std::string& bucket_name)
+{
+  int ret = fix_single_bucket_lc(store, tenant_name, bucket_name);
+  format_lc_status(formatter, tenant_name, bucket_name, -ret);
+}
+
+int RGWBucketAdminOp::fix_lc_shards(RGWRados *store,
+                                    RGWBucketAdminOpState& op_state,
+                                    RGWFormatterFlusher& flusher)
+{
+  std::string marker;
+  void *handle;
+  Formatter *formatter = flusher.get_formatter();
+  static constexpr auto default_max_keys = 1000;
+
+  int ret = store->meta_mgr->list_keys_init("bucket", marker, &handle);
+  if (ret < 0) {
+    std::cerr << "ERROR: can't get key: " << cpp_strerror(-ret) << std::endl;
+    return ret;
+  }
+
+  bool truncated;
+  if (const std::string& bucket_name = op_state.get_bucket_name();
+      ! bucket_name.empty()) {
+    const rgw_user user_id = op_state.get_user_id();
+    process_single_lc_entry(store, formatter, user_id.tenant, bucket_name);
+  } else {
+    formatter->open_array_section("lc_fix_status");
+    do {
+      list<std::string> keys;
+      ret = store->meta_mgr->list_keys_next(handle, default_max_keys, keys, &truncated);
+      if (ret < 0 && ret != -ENOENT) {
+        std::cerr << "ERROR: lists_keys_next(): " << cpp_strerror(-ret) << std::endl;
+        return ret;
+      } if (ret != -ENOENT) {
+        for (const auto &key:keys) {
+          auto [tenant_name, bucket_name] = split_tenant(key);
+          process_single_lc_entry(store, formatter, tenant_name, bucket_name);
+        }
+      }
+      formatter->flush(cout); // regularly flush every 1k entries
+    } while (truncated);
+    formatter->close_section(); // lc_fix_status
+  }
+  formatter->flush(cout);
+  return 0;
+
 }
 
 void rgw_data_change::dump(Formatter *f) const

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -365,6 +365,8 @@ public:
 
   static int clear_stale_instances(RGWRados *store, RGWBucketAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher);
+  static int fix_lc_shards(RGWRados *store, RGWBucketAdminOpState& op_state,
+                           RGWFormatterFlusher& flusher);
 };
 
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1305,7 +1305,7 @@ template<typename F>
 static int guard_lc_modify(RGWRados* store, const rgw_bucket& bucket, const string& cookie, const F& f) {
   CephContext *cct = store->ctx();
 
-  string shard_id = bucket.tenant + ':' + bucket.name + ':' + bucket.bucket_id;  
+  string shard_id = bucket.tenant + ':' + bucket.name + ':' + bucket.marker;
 
   string oid; 
   get_lc_oid(cct, shard_id, &oid);

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -952,16 +952,17 @@ int RGWLC::bucket_lc_process(string& shard_id)
   boost::split(result, shard_id, boost::is_any_of(":"));
   string bucket_tenant = result[0];
   string bucket_name = result[1];
-  string bucket_id = result[2];
+  string bucket_marker = result[2];
   int ret = store->get_bucket_info(obj_ctx, bucket_tenant, bucket_name, bucket_info, NULL, &bucket_attrs);
   if (ret < 0) {
     ldpp_dout(this, 0) << "LC:get_bucket_info for " << bucket_name << " failed" << dendl;
     return ret;
   }
 
-  ret = bucket_info.bucket.bucket_id.compare(bucket_id) ;
-  if (ret != 0) {
-    ldpp_dout(this, 0) << "LC:old bucket id found. " << bucket_name << " should be deleted" << dendl;
+  if (bucket_info.bucket.marker != bucket_marker) {
+    ldpp_dout(this, 1) << "LC: deleting stale entry found for bucket=" << bucket_tenant
+                       << ":" << bucket_name << " cur_marker=" << bucket_info.bucket.marker
+                       << " orig_marker=" << bucket_marker << dendl;
     return -ENOENT;
   }
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -502,6 +502,11 @@ class RGWLC : public DoutPrefixProvider {
   int handle_multipart_expiration(RGWRados::Bucket *target, const map<string, lc_op>& prefix_map);
 };
 
+namespace rgw::lc {
 
+int fix_lc_shard_entry(RGWRados *store, const RGWBucketInfo& bucket_info,
+		       const map<std::string,bufferlist>& battrs);
+
+} // namespace rgw::lc
 
 #endif

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -115,6 +115,7 @@
     lc list                    list all bucket lifecycle progress
     lc get                     get a lifecycle bucket configuration
     lc process                 manually process lifecycle
+    lc fix                     fix LC for a resharded bucket
     metadata get               get metadata info
     metadata put               put metadata info
     metadata rm                remove metadata info

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -115,7 +115,7 @@
     lc list                    list all bucket lifecycle progress
     lc get                     get a lifecycle bucket configuration
     lc process                 manually process lifecycle
-    lc fix                     fix LC for a resharded bucket
+    lc reshard fix             fix LC for a resharded bucket
     metadata get               get metadata info
     metadata put               put metadata info
     metadata rm                remove metadata info


### PR DESCRIPTION
Currently if a reshard happens, we'd be left with an old bucket id, however the
cur_bucket_info is still readable. Recreate this entry with the new bucket id
before deleting the entry. In case an LC processing has already taken place
after a reshard, this changeset will not help as the entry would have been
dropped already. So while newer reshards will be handled correctly, an admin
tooling might be required to re-add LC processing of resharded buckets

Fixes: https://tracker.ceph.com/issues/36512


- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

