### PR TITLE
mgr/orchestrator/rook: allow the creation of OSDs in directories

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -566,9 +566,9 @@ class DriveGroupSpec(object):
     understands.
     """
     def __init__(self, host_pattern, data_devices, db_devices=None, wal_devices=None, journal_devices=None,
-                 osds_per_device=None, objectstore='bluestore', encrypted=False, db_slots=None,
-                 wal_slots=None):
-        # type: (str, DeviceSelection, Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], int, str, bool, int, int) -> ()
+                 data_directories=None, osds_per_device=None, objectstore='bluestore', encrypted=False,
+                 db_slots=None, wal_slots=None):
+        # type: (str, DeviceSelection, Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], Optional[List[str]], int, str, bool, int, int) -> ()
 
         # concept of applying a drive group to a (set) of hosts is tightly
         # linked to the drive group itself
@@ -591,6 +591,9 @@ class DriveGroupSpec(object):
         #: Number of osd daemons per "DATA" device.
         #: To fully utilize nvme devices multiple osds are required.
         self.osds_per_device = osds_per_device
+
+        #: A list of strings, containing paths which should back OSDs
+        self.data_directories = data_directories
 
         #: ``filestore`` or ``bluestore``
         self.objectstore = objectstore

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -565,10 +565,10 @@ class DriveGroupSpec(object):
     Describe a drive group in the same form that ceph-volume
     understands.
     """
-    def __init__(self, host_pattern, data_devices, db_devices=None, wal_devices=None, journal_devices=None,
+    def __init__(self, host_pattern, data_devices=None, db_devices=None, wal_devices=None, journal_devices=None,
                  data_directories=None, osds_per_device=None, objectstore='bluestore', encrypted=False,
                  db_slots=None, wal_slots=None):
-        # type: (str, DeviceSelection, Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], Optional[List[str]], int, str, bool, int, int) -> ()
+        # type: (str, Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], Optional[DeviceSelection], Optional[List[str]], int, str, bool, int, int) -> ()
 
         # concept of applying a drive group to a (set) of hosts is tightly
         # linked to the drive group itself

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -404,6 +404,12 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         # type: (orchestrator.DriveGroupSpec, List[str]) -> RookWriteCompletion
 
         assert len(drive_group.hosts(all_hosts)) == 1
+        targets = []
+        if drive_group.data_devices:
+            targets += drive_group.data_devices.paths
+        if drive_group.data_directories:
+            targets += drive_group.data_directories
+
         if not self.rook_cluster.node_exists(drive_group.hosts(all_hosts)[0]):
             raise RuntimeError("Node '{0}' is not in the Kubernetes "
                                "cluster".format(drive_group.hosts(all_hosts)))
@@ -438,7 +444,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                     continue
 
                 metadata = self.get_metadata('osd', "%s" % osd_id)
-                if metadata and metadata['devices'] in drive_group.data_devices.paths:
+                if metadata and metadata['devices'] in targets:
                     found.append(osd_id)
                 else:
                     self.log.info("ignoring osd {0} {1}".format(
@@ -449,6 +455,5 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         return RookWriteCompletion(execute, is_complete,
                                    "Creating OSD on {0}:{1}".format(
-                                       drive_group.hosts(all_hosts)[0],
-                                       drive_group.data_devices.paths
+                                       drive_group.hosts(all_hosts)[0], targets
                                    ))


### PR DESCRIPTION
The original idea here was to allow filestore OSDs to be created in directories, but we don't really want that after all -- filestore is on the way to being deprecated. Thus, this PR has morphed into one that allows the creation of OSDs in directories, still defaulting to bluestore.