### PR TITLE
mgr/dashboard: unify button/URL actions naming

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -236,6 +236,25 @@ Example:
       Some <strong>helper</strong> html text
     </cd-helper>
 
+Terminology and wording
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of using the Ceph component names, the approach
+suggested is to use the logical/generic names (Block over RBD, Filesystem over
+CephFS, Object over RGW). Nevertheless, as Ceph-Dashboard cannot completely hide
+the Ceph internals, some Ceph-specific names might remain visible.
+
+Regarding the wording for action labels and other textual elements (form titles,
+buttons, etc.), the chosen approach is to follow `these guidelines
+<https://www.patternfly.org/styles/terminology-and-wording/#terminology-and-wording-for-action-labels>`_.
+As a rule of thumb, 'Create' and 'Delete' are the proper wording for most forms,
+instead of 'Add' and 'Remove', unless some already created item is either added
+or removed to/from a set of items (e.g.: 'Add permission' to a user vs. 'Create
+(new) permission').
+
+In order to enforce the use of this wording, a service ``ActionLabelsI18n`` has
+been created, which provides translated labels for use in UI elements.
+    
 Frontend branding
 ~~~~~~~~~~~~~~~~~
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -1,14 +1,8 @@
 import { NgModule } from '@angular/core';
-import { ActivatedRouteSnapshot, RouterModule, Routes } from '@angular/router';
+import { ActivatedRouteSnapshot, PreloadAllModules, RouterModule, Routes } from '@angular/router';
 
 import * as _ from 'lodash';
 
-import { IscsiTargetFormComponent } from './ceph/block/iscsi-target-form/iscsi-target-form.component';
-import { IscsiTargetListComponent } from './ceph/block/iscsi-target-list/iscsi-target-list.component';
-import { IscsiComponent } from './ceph/block/iscsi/iscsi.component';
-import { OverviewComponent as RbdMirroringComponent } from './ceph/block/mirroring/overview/overview.component';
-import { RbdFormComponent } from './ceph/block/rbd-form/rbd-form.component';
-import { RbdImagesComponent } from './ceph/block/rbd-images/rbd-images.component';
 import { CephfsListComponent } from './ceph/cephfs/cephfs-list/cephfs-list.component';
 import { ConfigurationFormComponent } from './ceph/cluster/configuration/configuration-form/configuration-form.component';
 import { ConfigurationComponent } from './ceph/cluster/configuration/configuration.component';
@@ -25,20 +19,8 @@ import { Nfs501Component } from './ceph/nfs/nfs-501/nfs-501.component';
 import { NfsFormComponent } from './ceph/nfs/nfs-form/nfs-form.component';
 import { NfsListComponent } from './ceph/nfs/nfs-list/nfs-list.component';
 import { PerformanceCounterComponent } from './ceph/performance-counter/performance-counter/performance-counter.component';
-import { PoolFormComponent } from './ceph/pool/pool-form/pool-form.component';
-import { PoolListComponent } from './ceph/pool/pool-list/pool-list.component';
-import { Rgw501Component } from './ceph/rgw/rgw-501/rgw-501.component';
-import { RgwBucketFormComponent } from './ceph/rgw/rgw-bucket-form/rgw-bucket-form.component';
-import { RgwBucketListComponent } from './ceph/rgw/rgw-bucket-list/rgw-bucket-list.component';
-import { RgwDaemonListComponent } from './ceph/rgw/rgw-daemon-list/rgw-daemon-list.component';
-import { RgwUserFormComponent } from './ceph/rgw/rgw-user-form/rgw-user-form.component';
-import { RgwUserListComponent } from './ceph/rgw/rgw-user-list/rgw-user-list.component';
 import { LoginComponent } from './core/auth/login/login.component';
-import { RoleFormComponent } from './core/auth/role-form/role-form.component';
-import { RoleListComponent } from './core/auth/role-list/role-list.component';
 import { SsoNotFoundComponent } from './core/auth/sso/sso-not-found/sso-not-found.component';
-import { UserFormComponent } from './core/auth/user-form/user-form.component';
-import { UserListComponent } from './core/auth/user-list/user-list.component';
 import { ForbiddenComponent } from './core/forbidden/forbidden.component';
 import { NotFoundComponent } from './core/not-found/not-found.component';
 import { BreadcrumbsResolver, IBreadcrumb } from './shared/models/breadcrumbs';
@@ -98,12 +80,7 @@ const routes: Routes = [
     canActivate: [AuthGuardService],
     canActivateChild: [AuthGuardService],
     data: { breadcrumbs: 'Cluster/OSDs' },
-    children: [
-      {
-        path: '',
-        component: OsdListComponent
-      }
-    ]
+    children: [{ path: '', component: OsdListComponent }]
   },
   {
     path: 'configuration',
@@ -169,11 +146,7 @@ const routes: Routes = [
     canActivate: [AuthGuardService],
     canActivateChild: [AuthGuardService],
     data: { breadcrumbs: 'Pools' },
-    children: [
-      { path: '', component: PoolListComponent },
-      { path: 'add', component: PoolFormComponent, data: { breadcrumbs: 'Add' } },
-      { path: 'edit/:name', component: PoolFormComponent, data: { breadcrumbs: 'Edit' } }
-    ]
+    loadChildren: './ceph/pool/pool.module#RoutedPoolModule'
   },
   // Block
   {
@@ -181,71 +154,7 @@ const routes: Routes = [
     canActivateChild: [AuthGuardService],
     canActivate: [AuthGuardService],
     data: { breadcrumbs: true, text: 'Block', path: null },
-    children: [
-      {
-        path: '',
-        redirectTo: 'rbd',
-        pathMatch: 'full'
-      },
-      {
-        path: 'rbd',
-        canActivate: [FeatureTogglesGuardService],
-        data: { breadcrumbs: 'Images' },
-        children: [
-          { path: '', component: RbdImagesComponent },
-          { path: 'add', component: RbdFormComponent, data: { breadcrumbs: 'Add' } },
-          { path: 'edit/:pool/:name', component: RbdFormComponent, data: { breadcrumbs: 'Edit' } },
-          {
-            path: 'clone/:pool/:name/:snap',
-            component: RbdFormComponent,
-            data: { breadcrumbs: 'Clone' }
-          },
-          { path: 'copy/:pool/:name', component: RbdFormComponent, data: { breadcrumbs: 'Copy' } },
-          {
-            path: 'copy/:pool/:name/:snap',
-            component: RbdFormComponent,
-            data: { breadcrumbs: 'Copy' }
-          }
-        ]
-      },
-      {
-        path: 'mirroring',
-        component: RbdMirroringComponent,
-        canActivate: [FeatureTogglesGuardService],
-        data: { breadcrumbs: 'Mirroring' }
-      },
-      // iSCSI
-      {
-        path: 'iscsi',
-        canActivate: [FeatureTogglesGuardService],
-        data: { breadcrumbs: 'iSCSI' },
-        children: [
-          {
-            path: '',
-            redirectTo: 'overview',
-            pathMatch: 'full'
-          },
-          {
-            path: 'overview',
-            data: { breadcrumbs: 'Overview' },
-            children: [{ path: '', component: IscsiComponent }]
-          },
-          {
-            path: 'targets',
-            data: { breadcrumbs: 'Targets' },
-            children: [
-              { path: '', component: IscsiTargetListComponent },
-              { path: 'add', component: IscsiTargetFormComponent, data: { breadcrumbs: 'Add' } },
-              {
-                path: 'edit/:target_iqn',
-                component: IscsiTargetFormComponent,
-                data: { breadcrumbs: 'Edit' }
-              }
-            ]
-          }
-        ]
-      }
-    ]
+    loadChildren: './ceph/block/block.module#RoutedBlockModule'
   },
   // Filesystems
   {
@@ -255,12 +164,6 @@ const routes: Routes = [
     data: { breadcrumbs: 'Filesystems' }
   },
   // Object Gateway
-  {
-    path: 'rgw/501/:message',
-    component: Rgw501Component,
-    canActivate: [AuthGuardService],
-    data: { breadcrumbs: 'Object Gateway' }
-  },
   {
     path: 'rgw',
     canActivateChild: [FeatureTogglesGuardService, ModuleStatusGuardService, AuthGuardService],
@@ -273,27 +176,7 @@ const routes: Routes = [
       text: 'Object Gateway',
       path: null
     },
-    children: [
-      { path: 'daemon', component: RgwDaemonListComponent, data: { breadcrumbs: 'Daemons' } },
-      {
-        path: 'user',
-        data: { breadcrumbs: 'Users' },
-        children: [
-          { path: '', component: RgwUserListComponent },
-          { path: 'add', component: RgwUserFormComponent, data: { breadcrumbs: 'Add' } },
-          { path: 'edit/:uid', component: RgwUserFormComponent, data: { breadcrumbs: 'Edit' } }
-        ]
-      },
-      {
-        path: 'bucket',
-        data: { breadcrumbs: 'Buckets' },
-        children: [
-          { path: '', component: RgwBucketListComponent },
-          { path: 'add', component: RgwBucketFormComponent, data: { breadcrumbs: 'Add' } },
-          { path: 'edit/:bid', component: RgwBucketFormComponent, data: { breadcrumbs: 'Edit' } }
-        ]
-      }
-    ]
+    loadChildren: './ceph/rgw/rgw.module#RoutedRgwModule'
   },
   // Dashboard Settings
   {
@@ -301,31 +184,7 @@ const routes: Routes = [
     canActivate: [AuthGuardService],
     canActivateChild: [AuthGuardService],
     data: { breadcrumbs: 'User management', path: null },
-    children: [
-      {
-        path: '',
-        redirectTo: 'users',
-        pathMatch: 'full'
-      },
-      {
-        path: 'users',
-        data: { breadcrumbs: 'Users' },
-        children: [
-          { path: '', component: UserListComponent },
-          { path: 'add', component: UserFormComponent, data: { breadcrumbs: 'Add' } },
-          { path: 'edit/:username', component: UserFormComponent, data: { breadcrumbs: 'Edit' } }
-        ]
-      },
-      {
-        path: 'roles',
-        data: { breadcrumbs: 'Roles' },
-        children: [
-          { path: '', component: RoleListComponent },
-          { path: 'add', component: RoleFormComponent, data: { breadcrumbs: 'Add' } },
-          { path: 'edit/:name', component: RoleFormComponent, data: { breadcrumbs: 'Edit' } }
-        ]
-      }
-    ]
+    loadChildren: './core/auth/auth.module#RoutedAuthModule'
   },
   // NFS
   {
@@ -366,7 +225,12 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, { useHash: true })],
+  imports: [
+    RouterModule.forRoot(routes, {
+      useHash: true,
+      preloadingStrategy: PreloadAllModules
+    })
+  ],
   exports: [RouterModule],
   providers: [StartCaseBreadcrumbsResolver, PerformanceCounterBreadcrumbsResolver]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -7,8 +7,8 @@
         *ngIf="targetForm">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"
-            i18n>{isEdit, select, 1 {Edit} other {Add}} target</h3>
+        <h3 i18n="form title|Example: Create Pool@@formTitle"
+            class="panel-title">{{ action | titlecase }} {{ resource | upperFirst }}</h3>
       </div>
 
       <div class="panel-body">
@@ -556,10 +556,11 @@
       </div>
       <div class="panel-footer">
         <div class="button-group text-right">
-          <cd-submit-button [form]="formDir"
-                            type="button"
-                            (submitAction)="submit()"
-                            i18n>Submit</cd-submit-button>
+          <cd-submit-button
+            [form]="formDir"
+            (submitAction)="submit()"
+            i18n="form action button|Example: Create Pool@@formActionButton"
+            type="button">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
           <cd-back-button></cd-back-button>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -11,6 +11,7 @@ import { IscsiService } from '../../../shared/api/iscsi.service';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { SelectMessages } from '../../../shared/components/select/select-messages.model';
 import { SelectOption } from '../../../shared/components/select/select-option.model';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { FinishedTask } from '../../../shared/models/finished-task';
@@ -76,6 +77,8 @@ export class IscsiTargetFormComponent implements OnInit {
   IQN_REGEX = /^iqn\.(19|20)\d\d-(0[1-9]|1[0-2])\.\D{2,3}(\.[A-Za-z0-9-]+)+(:[A-Za-z0-9-\.]+)*$/;
   USER_REGEX = /[\w\.:@_-]{8,64}/;
   PASSWORD_REGEX = /[\w@\-_\/]{12,16}/;
+  action: string;
+  resource: string;
 
   constructor(
     private iscsiService: IscsiService,
@@ -84,8 +87,11 @@ export class IscsiTargetFormComponent implements OnInit {
     private router: Router,
     private route: ActivatedRoute,
     private i18n: I18n,
-    private taskWrapper: TaskWrapperService
-  ) {}
+    private taskWrapper: TaskWrapperService,
+    public actionLabels: ActionLabelsI18n
+  ) {
+    this.resource = this.i18n('target');
+  }
 
   ngOnInit() {
     const promises: any[] = [
@@ -102,6 +108,7 @@ export class IscsiTargetFormComponent implements OnInit {
         promises.push(this.iscsiService.getTarget(this.target_iqn));
       });
     }
+    this.action = this.isEdit ? this.actionLabels.EDIT : this.actionLabels.CREATE;
 
     forkJoin(promises).subscribe((data: any[]) => {
       // iscsiService.listTargets

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -6,11 +6,8 @@
         novalidate>
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">
-          <span
-            i18n>{mode, select, editing {Edit} cloning {Clone} copying {Copy} other {Add}}</span>
-          RBD
-        </h3>
+        <h3 i18n="form title|Example: Create Pool@@formTitle"
+            class="panel-title">{{ action | titlecase }} {{ resource | upperFirst }}</h3>
       </div>
       <div class="panel-body">
 
@@ -19,7 +16,7 @@
              *ngIf="rbdForm.getValue('parent')">
           <label i18n
                  class="control-label col-sm-3"
-                 for="name">{mode, select, cloning {Clone from} copying {Copy from} other {Parent}}</label>
+                 for="name">{{ action | titlecase }} from</label>
           <div class="col-sm-9">
             <input class="form-control"
                    type="text"
@@ -307,11 +304,11 @@
       </div>
       <div class="panel-footer">
         <div class="button-group text-right">
-          <cd-submit-button [form]="formDir"
-                            type="button"
-                            (submitAction)="submit()">
-            <span i18n>{mode, select, editing {Update} cloning {Clone} copying {Copy} other {Create}} RBD</span>
-          </cd-submit-button>
+          <cd-submit-button
+            [form]="formDir"
+            (submitAction)="submit()"
+            i18n="form action button|Example: Create Pool@@formActionButton"
+            type="button">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
           <cd-back-button></cd-back-button>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -8,6 +8,7 @@ import { Observable } from 'rxjs';
 
 import { PoolService } from '../../../shared/api/pool.service';
 import { RbdService } from '../../../shared/api/rbd.service';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import {
   RbdConfigurationEntry,
@@ -85,6 +86,8 @@ export class RbdFormComponent implements OnInit {
     '16 MiB',
     '32 MiB'
   ];
+  action: string;
+  resource: string;
 
   constructor(
     private authStorageService: AuthStorageService,
@@ -95,9 +98,11 @@ export class RbdFormComponent implements OnInit {
     private formatter: FormatterService,
     private taskWrapper: TaskWrapperService,
     private dimlessBinaryPipe: DimlessBinaryPipe,
-    private i18n: I18n
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
   ) {
     this.poolPermission = this.authStorageService.getPermissions().pool;
+    this.resource = this.i18n('RBD');
     this.features = {
       'deep-flatten': {
         desc: this.i18n('Deep flatten'),
@@ -207,13 +212,18 @@ export class RbdFormComponent implements OnInit {
   ngOnInit() {
     if (this.router.url.startsWith('/block/rbd/edit')) {
       this.mode = this.rbdFormMode.editing;
+      this.action = this.actionLabels.EDIT;
       this.disableForEdit();
     } else if (this.router.url.startsWith('/block/rbd/clone')) {
       this.mode = this.rbdFormMode.cloning;
       this.disableForClone();
+      this.action = this.actionLabels.CLONE;
     } else if (this.router.url.startsWith('/block/rbd/copy')) {
       this.mode = this.rbdFormMode.copying;
+      this.action = this.actionLabels.COPY;
       this.disableForCopy();
+    } else {
+      this.action = this.actionLabels.CREATE;
     }
     if (
       this.mode === this.rbdFormMode.editing ||

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -17,6 +17,7 @@ import {
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
 import { RbdService } from '../../../shared/api/rbd.service';
+import { ActionLabels } from '../../../shared/constants/app.constants';
 import { TableActionsComponent } from '../../../shared/datatable/table-actions/table-actions.component';
 import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
 import { ExecutingTask } from '../../../shared/models/executing-task';
@@ -212,8 +213,8 @@ describe('RbdListComponent', () => {
       );
       scenario = {
         fn: () => tableActions.getCurrentButton().name,
-        single: 'Edit',
-        empty: 'Add'
+        single: ActionLabels.EDIT,
+        empty: ActionLabels.CREATE
       };
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -7,6 +7,7 @@ import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { ConfirmationModalComponent } from '../../../shared/components/confirmation-modal/confirmation-modal.component';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { CellTemplate } from '../../../shared/enum/cell-template.enum';
 import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
@@ -20,15 +21,21 @@ import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { TaskListService } from '../../../shared/services/task-list.service';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
+import { URLBuilderService } from '../../../shared/services/url-builder.service';
 import { RbdParentModel } from '../rbd-form/rbd-parent.model';
 import { RbdTrashMoveModalComponent } from '../rbd-trash-move-modal/rbd-trash-move-modal.component';
 import { RbdModel } from './rbd-model';
+
+const BASE_URL = 'block/rbd';
 
 @Component({
   selector: 'cd-rbd-list',
   templateUrl: './rbd-list.component.html',
   styleUrls: ['./rbd-list.component.scss'],
-  providers: [TaskListService]
+  providers: [
+    TaskListService,
+    { provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }
+  ]
 })
 export class RbdListComponent implements OnInit {
   @ViewChild(TableComponent)
@@ -77,7 +84,9 @@ export class RbdListComponent implements OnInit {
     private modalService: BsModalService,
     private taskWrapper: TaskWrapperService,
     private taskListService: TaskListService,
-    private i18n: I18n
+    private i18n: I18n,
+    private urlBuilder: URLBuilderService,
+    public actionLabels: ActionLabelsI18n
   ) {
     this.permission = this.authStorageService.getPermissions().rbdImage;
     const getImageUri = () =>
@@ -88,21 +97,21 @@ export class RbdListComponent implements OnInit {
     const addAction: CdTableAction = {
       permission: 'create',
       icon: 'fa-plus',
-      routerLink: () => '/block/rbd/add',
+      routerLink: () => this.urlBuilder.getCreate(),
       canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection,
-      name: this.i18n('Add')
+      name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
       icon: 'fa-pencil',
-      routerLink: () => `/block/rbd/edit/${getImageUri()}`,
-      name: this.i18n('Edit')
+      routerLink: () => this.urlBuilder.getEdit(getImageUri()),
+      name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
       icon: 'fa-times',
       click: () => this.deleteRbdModal(),
-      name: this.i18n('Delete')
+      name: this.actionLabels.DELETE
     };
     const copyAction: CdTableAction = {
       permission: 'create',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/ceph.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/ceph.module.ts
@@ -2,24 +2,18 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { SharedModule } from '../shared/shared.module';
-import { BlockModule } from './block/block.module';
 import { CephfsModule } from './cephfs/cephfs.module';
 import { ClusterModule } from './cluster/cluster.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { NfsModule } from './nfs/nfs.module';
 import { PerformanceCounterModule } from './performance-counter/performance-counter.module';
-import { PoolModule } from './pool/pool.module';
-import { RgwModule } from './rgw/rgw.module';
 
 @NgModule({
   imports: [
     CommonModule,
     ClusterModule,
     DashboardModule,
-    RgwModule,
     PerformanceCounterModule,
-    BlockModule,
-    PoolModule,
     CephfsModule,
     NfsModule,
     SharedModule

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
-  <h4 class="modal-title pull-left"
-      i18n>Add erasure code profile</h4>
+  <h4 i18n="form title|Example: Create Pool@@formTitle"
+      class="modal-title pull-left">{{ action | titlecase }} {{ resource | upperFirst }}</h4>
   <button type="button"
           class="close pull-right"
           aria-label="Close"
@@ -321,12 +321,10 @@
   </div>
 
   <div class="modal-footer">
-    <cd-submit-button (submitAction)="onSubmit()"
-                      [form]="frm"
-                      i18n>Add</cd-submit-button>
-    <cd-back-button [back]="bsModalRef.hide"
-                    name="Close"
-                    i18n-name>
-    </cd-back-button>
+    <cd-submit-button
+      (submitAction)="onSubmit()"
+      i18n="form action button|Example: Create Pool@@formActionButton"
+      [form]="frm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
+    <cd-back-button [back]="bsModalRef.hide"></cd-back-button>
   </div>
 </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.ts
@@ -1,9 +1,11 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { Validators } from '@angular/forms';
 
+import { I18n } from '@ngx-translate/i18n-polyfill';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { ErasureCodeProfileService } from '../../../shared/api/erasure-code-profile.service';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
@@ -36,13 +38,19 @@ export class ErasureCodeProfileFormComponent implements OnInit {
     ISA: 'isa' // Intel Storage Acceleration
   };
   plugin = this.PLUGIN.JERASURE;
+  action: string;
+  resource: string;
 
   constructor(
     private formBuilder: CdFormBuilder,
     public bsModalRef: BsModalRef,
     private taskWrapper: TaskWrapperService,
-    private ecpService: ErasureCodeProfileService
+    private ecpService: ErasureCodeProfileService,
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
   ) {
+    this.action = this.actionLabels.CREATE;
+    this.resource = this.i18n('EC Profile');
     this.createForm();
     this.setJerasureDefaults();
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
@@ -6,6 +6,7 @@ import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-h
 import { AppModule } from '../../../app.module';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permissions } from '../../../shared/models/permissions';
+import { RbdConfigurationListComponent } from '../../block/rbd-configuration-list/rbd-configuration-list.component';
 import { PoolDetailsComponent } from './pool-details.component';
 
 describe('PoolDetailsComponent', () => {
@@ -14,7 +15,7 @@ describe('PoolDetailsComponent', () => {
 
   configureTestBed({
     imports: [TabsModule.forRoot(), AppModule],
-    decalarations: [PoolDetailsComponent],
+    declarations: [PoolDetailsComponent, RbdConfigurationListComponent],
     providers: [i18nProviders]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -12,9 +12,8 @@
         novalidate>
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">
-          <span i18n>{editing, select, 1 {Edit} other {Add}} pool</span>
-        </h3>
+        <h3 i18n="form title|Example: Create Pool@@formTitle"
+            class="panel-title">{{ action | titlecase }} {{ resource | upperFirst }}</h3>
       </div>
 
       <div class="panel-body">
@@ -449,11 +448,11 @@
       </div>
       <div class="panel-footer">
         <div class="button-group text-right">
-          <cd-submit-button [form]="formDir"
-                            type="button"
-                            (submitAction)="submit()">
-            <span i18n>{editing, select, 1 {Edit} other {Create}} pool</span>
-          </cd-submit-button>
+          <cd-submit-button
+            [form]="formDir"
+            type="button"
+            i18n="form action button|Example: Create Pool@@formActionButton"
+            (submitAction)="submit()">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
           <cd-back-button></cd-back-button>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -10,6 +10,7 @@ import { forkJoin, Subscription } from 'rxjs';
 import { ErasureCodeProfileService } from '../../../shared/api/erasure-code-profile.service';
 import { PoolService } from '../../../shared/api/pool.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { ActionLabelsI18n, URLVerbs } from '../../../shared/constants/app.constants';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import {
@@ -62,6 +63,8 @@ export class PoolFormComponent implements OnInit {
     sourceType: RbdConfigurationSourceField;
   }>();
   currentConfigurationValues: { [configKey: string]: any } = {};
+  action: string;
+  resource: string;
 
   constructor(
     private dimlessBinaryPipe: DimlessBinaryPipe,
@@ -74,9 +77,12 @@ export class PoolFormComponent implements OnInit {
     private bsModalService: BsModalService,
     private taskWrapper: TaskWrapperService,
     private ecpService: ErasureCodeProfileService,
-    private i18n: I18n
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
   ) {
-    this.editing = this.router.url.startsWith('/pool/edit');
+    this.editing = this.router.url.startsWith(`/pool/${URLVerbs.EDIT}`);
+    this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
+    this.resource = this.i18n('pool');
     this.authenticate();
     this.createForm();
   }
@@ -649,10 +655,10 @@ export class PoolFormComponent implements OnInit {
   private triggerApiTask(pool) {
     this.taskWrapper
       .wrapTaskAroundCall({
-        task: new FinishedTask('pool/' + (this.editing ? 'edit' : 'create'), {
+        task: new FinishedTask('pool/' + (this.editing ? URLVerbs.EDIT : URLVerbs.CREATE), {
           pool_name: pool.hasOwnProperty('srcpool') ? pool.srcpool : pool.pool
         }),
-        call: this.poolService[this.editing ? 'update' : 'create'](pool)
+        call: this.poolService[this.editing ? URLVerbs.UPDATE : URLVerbs.CREATE](pool)
       })
       .subscribe(
         undefined,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
@@ -1,13 +1,14 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { PopoverModule } from 'ngx-bootstrap/popover';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
+import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
 import { ServicesModule } from '../../shared/services/services.module';
 import { SharedModule } from '../../shared/shared.module';
 import { BlockModule } from '../block/block.module';
@@ -41,3 +42,22 @@ import { PoolListComponent } from './pool-list/pool-list.component';
   entryComponents: [ErasureCodeProfileFormComponent]
 })
 export class PoolModule {}
+
+const routes: Routes = [
+  { path: '', component: PoolListComponent },
+  {
+    path: URLVerbs.CREATE,
+    component: PoolFormComponent,
+    data: { breadcrumbs: ActionLabels.CREATE }
+  },
+  {
+    path: `${URLVerbs.EDIT}/:name`,
+    component: PoolFormComponent,
+    data: { breadcrumbs: ActionLabels.EDIT }
+  }
+];
+
+@NgModule({
+  imports: [PoolModule, RouterModule.forChild(routes)]
+})
+export class RoutedPoolModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -13,8 +13,8 @@
         novalidate>
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"
-            i18n>{editing, select, 1 {Edit} other {Add}} bucket</h3>
+        <h3 i18n="form title|Example: Create Pool@@formTitle"
+            class="panel-title">{{ action | titlecase }} {{ resource | upperFirst }}</h3>
       </div>
       <div class="panel-body">
 
@@ -96,11 +96,10 @@
       </div>
       <div class="panel-footer">
         <div class="button-group text-right">
-          <cd-submit-button type="button"
-                            (submitAction)="submit()"
-                            [form]="bucketForm">
-            <ng-container i18n>{editing, select, 1 {Update} other {Add}}</ng-container>
-          </cd-submit-button>
+          <cd-submit-button
+            (submitAction)="submit()" [form]="bucketForm"
+            i18n="form action button|Example: Create Pool@@formActionButton"
+            type="button">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
           <cd-back-button></cd-back-button>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -7,6 +7,7 @@ import * as _ from 'lodash';
 
 import { RgwBucketService } from '../../../shared/api/rgw-bucket.service';
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
+import { ActionLabelsI18n, URLVerbs } from '../../../shared/constants/app.constants';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
@@ -23,6 +24,8 @@ export class RgwBucketFormComponent implements OnInit {
   error = false;
   loading = false;
   owners = null;
+  action: string;
+  resource: string;
 
   constructor(
     private route: ActivatedRoute,
@@ -31,8 +34,12 @@ export class RgwBucketFormComponent implements OnInit {
     private rgwBucketService: RgwBucketService,
     private rgwUserService: RgwUserService,
     private notificationService: NotificationService,
-    private i18n: I18n
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
   ) {
+    this.editing = this.router.url.startsWith(`/rgw/bucket/${URLVerbs.EDIT}`);
+    this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
+    this.resource = this.i18n('bucket');
     this.createForm();
   }
 
@@ -58,8 +65,7 @@ export class RgwBucketFormComponent implements OnInit {
         }
         const bid = decodeURIComponent(params.bid);
         this.loading = true;
-        // Load the bucket data in 'edit' mode.
-        this.editing = true;
+
         this.rgwBucketService.get(bid).subscribe((resp: object) => {
           this.loading = false;
           // Get the default values.

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
@@ -11,6 +11,7 @@ import {
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
+import { ActionLabels } from '../../../shared/constants/app.constants';
 import { TableActionsComponent } from '../../../shared/datatable/table-actions/table-actions.component';
 import { SharedModule } from '../../../shared/shared.module';
 import { RgwBucketDetailsComponent } from '../rgw-bucket-details/rgw-bucket-details.component';
@@ -58,8 +59,8 @@ describe('RgwBucketListComponent', () => {
       );
       scenario = {
         fn: () => tableActions.getCurrentButton().name,
-        single: 'Edit',
-        empty: 'Add'
+        single: ActionLabels.EDIT,
+        empty: ActionLabels.CREATE
       };
     });
 
@@ -117,7 +118,7 @@ describe('RgwBucketListComponent', () => {
       });
 
       it(`shows always 'Edit' as main action`, () => {
-        scenario.empty = 'Edit';
+        scenario.empty = ActionLabels.EDIT;
         permissionHelper.testScenarios(scenario);
       });
 
@@ -136,7 +137,7 @@ describe('RgwBucketListComponent', () => {
       });
 
       it(`shows always 'Add' as main action`, () => {
-        scenario.single = 'Add';
+        scenario.single = ActionLabels.CREATE;
         permissionHelper.testScenarios(scenario);
       });
 
@@ -152,7 +153,7 @@ describe('RgwBucketListComponent', () => {
       });
 
       it(`shows always 'Edit' as main action`, () => {
-        scenario.empty = 'Edit';
+        scenario.empty = ActionLabels.EDIT;
         permissionHelper.testScenarios(scenario);
       });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
@@ -6,6 +6,7 @@ import { forkJoin as observableForkJoin, Observable, Subscriber } from 'rxjs';
 
 import { RgwBucketService } from '../../../shared/api/rgw-bucket.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { CdTableAction } from '../../../shared/models/cd-table-action';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
@@ -13,11 +14,15 @@ import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-d
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permission } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
+import { URLBuilderService } from '../../../shared/services/url-builder.service';
+
+const BASE_URL = 'rgw/bucket';
 
 @Component({
   selector: 'cd-rgw-bucket-list',
   templateUrl: './rgw-bucket-list.component.html',
-  styleUrls: ['./rgw-bucket-list.component.scss']
+  styleUrls: ['./rgw-bucket-list.component.scss'],
+  providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }]
 })
 export class RgwBucketListComponent {
   @ViewChild(TableComponent)
@@ -33,7 +38,9 @@ export class RgwBucketListComponent {
     private authStorageService: AuthStorageService,
     private rgwBucketService: RgwBucketService,
     private bsModalService: BsModalService,
-    private i18n: I18n
+    private i18n: I18n,
+    private urlBuilder: URLBuilderService,
+    public actionLabels: ActionLabelsI18n
   ) {
     this.permission = this.authStorageService.getPermissions().rgw;
     this.columns = [
@@ -53,20 +60,20 @@ export class RgwBucketListComponent {
     const addAction: CdTableAction = {
       permission: 'create',
       icon: 'fa-plus',
-      routerLink: () => '/rgw/bucket/add',
-      name: this.i18n('Add')
+      routerLink: () => this.urlBuilder.getCreate(),
+      name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
       icon: 'fa-pencil',
-      routerLink: () => `/rgw/bucket/edit/${getBucketUri()}`,
-      name: this.i18n('Edit')
+      routerLink: () => this.urlBuilder.getEdit(getBucketUri()),
+      name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
       icon: 'fa-times',
       click: () => this.deleteAction(),
-      name: this.i18n('Delete')
+      name: this.actionLabels.DELETE
     };
     this.tableActions = [addAction, editAction, deleteAction];
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
-  <h4 class="modal-title pull-left"
-      i18n>Capability</h4>
+  <h4 i18n="form title|Example: Create Pool@@formTitle"
+      class="modal-title pull-left">{{ action | titlecase }} {{ resource | upperFirst }}</h4>
   <button type="button"
           class="close pull-right"
           aria-label="Close"
@@ -75,13 +75,10 @@
 
   </div>
   <div class="modal-footer">
-    <cd-submit-button (submitAction)="onSubmit()"
-                      [form]="formGroup">
-      <ng-container i18n>{editing, select, 1 {Update} other {Add}}</ng-container>
-    </cd-submit-button>
-    <cd-back-button [back]="bsModalRef.hide"
-                    name="Close"
-                    i18n-name>
-    </cd-back-button>
+    <cd-submit-button
+      (submitAction)="onSubmit()"
+      i18n="form action button|Example: Create Pool@@formActionButton"
+      [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
+    <cd-back-button [back]="bsModalRef.hide"></cd-back-button>
   </div>
 </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.ts
@@ -4,6 +4,8 @@ import { Validators } from '@angular/forms';
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { I18n } from '@ngx-translate/i18n-polyfill';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { RgwUserCapability } from '../models/rgw-user-capability';
@@ -24,8 +26,16 @@ export class RgwUserCapabilityModalComponent {
   formGroup: CdFormGroup;
   editing = true;
   types: string[] = [];
+  resource: string;
+  action: string;
 
-  constructor(private formBuilder: CdFormBuilder, public bsModalRef: BsModalRef) {
+  constructor(
+    private formBuilder: CdFormBuilder,
+    public bsModalRef: BsModalRef,
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
+  ) {
+    this.resource = this.i18n('capability');
     this.createForm();
   }
 
@@ -44,6 +54,7 @@ export class RgwUserCapabilityModalComponent {
    */
   setEditing(editing: boolean = true) {
     this.editing = editing;
+    this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.ADD;
   }
 
   /**

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -12,7 +12,8 @@
         novalidate>
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">{editing, select, 1 {Edit} other {Add}} user</h3>
+        <h3 i18n="form title|Example: Create Pool@@formTitle"
+            class="panel-title">{{ action | titlecase }} {{ resource | upperFirst }}</h3>
       </div>
       <div class="panel-body">
 
@@ -253,7 +254,7 @@
                       class="btn btn-sm btn-default btn-label pull-right tc_addSubuserButton"
                       (click)="showSubuserModal()">
                 <i class="fa fa-fw fa-plus"></i>
-                <ng-container i18n>Add subuser</ng-container>
+                <ng-container i18n>{{ actionLabels.CREATE | titlecase }} {{ subuserLabel | upperFirst }}</ng-container>
               </button>
             </span>
           </div>
@@ -307,7 +308,7 @@
                       class="btn btn-sm btn-default btn-label pull-right tc_addS3KeyButton"
                       (click)="showS3KeyModal()">
                 <i class="fa fa-fw fa-plus"></i>
-                <ng-container i18n>Add S3 key</ng-container>
+                <ng-container i18n>{{ actionLabels.CREATE | titlecase }} {{ s3keyLabel | upperFirst }}</ng-container>
               </button>
             </span>
             <hr>
@@ -392,7 +393,7 @@
                       class="btn btn-sm btn-default btn-label pull-right tc_addCapButton"
                       (click)="showCapabilityModal()">
                 <i class="fa fa-fw fa-plus"></i>
-                <ng-container i18n>Add capability</ng-container>
+                <ng-container i18n>{{ actionLabels.ADD | titlecase }} {{ capabilityLabel | upperFirst }}</ng-container>
               </button>
             </span>
           </div>
@@ -587,11 +588,11 @@
 
       <div class="panel-footer">
         <div class="button-group text-right">
-          <cd-submit-button type="button"
-                            (submitAction)="onSubmit()"
-                            [form]="userForm">
-            <ng-container i18n>{editing, select, 1 {Update} other {Add}}</ng-container>
-          </cd-submit-button>
+          <cd-submit-button
+            (submitAction)="onSubmit()"
+            [form]="userForm"
+            i18n="form action button|Example: Create Pool@@formActionButton"
+            type="button">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
           <cd-back-button></cd-back-button>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -8,6 +8,7 @@ import { BsModalService } from 'ngx-bootstrap/modal';
 import { forkJoin as observableForkJoin, Observable } from 'rxjs';
 
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
+import { ActionLabelsI18n, URLVerbs } from '../../../shared/constants/app.constants';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
@@ -40,6 +41,12 @@ export class RgwUserFormComponent implements OnInit {
   swiftKeys: RgwUserSwiftKey[] = [];
   capabilities: RgwUserCapability[] = [];
 
+  action: string;
+  resource: string;
+  subuserLabel: string;
+  s3keyLabel: string;
+  capabilityLabel: string;
+
   constructor(
     private formBuilder: CdFormBuilder,
     private route: ActivatedRoute,
@@ -47,8 +54,13 @@ export class RgwUserFormComponent implements OnInit {
     private rgwUserService: RgwUserService,
     private bsModalService: BsModalService,
     private notificationService: NotificationService,
-    private i18n: I18n
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
   ) {
+    this.resource = this.i18n('user');
+    this.subuserLabel = this.i18n('subuser');
+    this.s3keyLabel = this.i18n('S3 Key');
+    this.capabilityLabel = this.i18n('capability');
     this.createForm();
     this.listenToChanges();
   }
@@ -158,6 +170,8 @@ export class RgwUserFormComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.editing = this.router.url.startsWith(`/rgw/user/${URLVerbs.EDIT}`);
+    this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
     // Process route parameters.
     this.route.params.subscribe((params: { uid: string }) => {
       if (!params.hasOwnProperty('uid')) {
@@ -165,8 +179,6 @@ export class RgwUserFormComponent implements OnInit {
       }
       const uid = decodeURIComponent(params.uid);
       this.loading = true;
-      // Load the user data in 'edit' mode.
-      this.editing = true;
       // Load the user and quota information.
       const observables = [];
       observables.push(this.rgwUserService.get(uid));

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.spec.ts
@@ -11,6 +11,7 @@ import {
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
+import { ActionLabels } from '../../../shared/constants/app.constants';
 import { TableActionsComponent } from '../../../shared/datatable/table-actions/table-actions.component';
 import { SharedModule } from '../../../shared/shared.module';
 import { RgwUserListComponent } from './rgw-user-list.component';
@@ -52,8 +53,8 @@ describe('RgwUserListComponent', () => {
       );
       scenario = {
         fn: () => tableActions.getCurrentButton().name,
-        single: 'Edit',
-        empty: 'Add'
+        single: ActionLabels.EDIT,
+        empty: ActionLabels.CREATE
       };
     });
 
@@ -111,7 +112,7 @@ describe('RgwUserListComponent', () => {
       });
 
       it(`shows always 'Edit' as main action`, () => {
-        scenario.empty = 'Edit';
+        scenario.empty = ActionLabels.EDIT;
         permissionHelper.testScenarios(scenario);
       });
 
@@ -130,7 +131,7 @@ describe('RgwUserListComponent', () => {
       });
 
       it(`shows always 'Add' as main action`, () => {
-        scenario.single = 'Add';
+        scenario.single = ActionLabels.CREATE;
         permissionHelper.testScenarios(scenario);
       });
 
@@ -146,7 +147,7 @@ describe('RgwUserListComponent', () => {
       });
 
       it(`shows always 'Edit' as main action`, () => {
-        scenario.empty = 'Edit';
+        scenario.empty = ActionLabels.EDIT;
         permissionHelper.testScenarios(scenario);
       });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
@@ -6,6 +6,7 @@ import { forkJoin as observableForkJoin, Observable, Subscriber } from 'rxjs';
 
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { CellTemplate } from '../../../shared/enum/cell-template.enum';
 import { CdTableAction } from '../../../shared/models/cd-table-action';
@@ -14,11 +15,15 @@ import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-d
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permission } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
+import { URLBuilderService } from '../../../shared/services/url-builder.service';
+
+const BASE_URL = 'rgw/user';
 
 @Component({
   selector: 'cd-rgw-user-list',
   templateUrl: './rgw-user-list.component.html',
-  styleUrls: ['./rgw-user-list.component.scss']
+  styleUrls: ['./rgw-user-list.component.scss'],
+  providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }]
 })
 export class RgwUserListComponent {
   @ViewChild(TableComponent)
@@ -34,7 +39,9 @@ export class RgwUserListComponent {
     private authStorageService: AuthStorageService,
     private rgwUserService: RgwUserService,
     private bsModalService: BsModalService,
-    private i18n: I18n
+    private i18n: I18n,
+    private urlBuilder: URLBuilderService,
+    public actionLabels: ActionLabelsI18n
   ) {
     this.permission = this.authStorageService.getPermissions().rgw;
     this.columns = [
@@ -71,20 +78,20 @@ export class RgwUserListComponent {
     const addAction: CdTableAction = {
       permission: 'create',
       icon: 'fa-plus',
-      routerLink: () => '/rgw/user/add',
-      name: this.i18n('Add')
+      routerLink: () => this.urlBuilder.getCreate(),
+      name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
       icon: 'fa-pencil',
-      routerLink: () => `/rgw/user/edit/${getUserUri()}`,
-      name: this.i18n('Edit')
+      routerLink: () => this.urlBuilder.getEdit(getUserUri()),
+      name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
       icon: 'fa-times',
       click: () => this.deleteAction(),
-      name: this.i18n('Delete')
+      name: this.actionLabels.DELETE
     };
     this.tableActions = [addAction, editAction, deleteAction];
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
-  <h4 class="modal-title pull-left"
-      i18n>S3 key</h4>
+  <h4 i18n="form title|Example: Create Pool@@formTitle"
+      class="modal-title pull-left">{{ action | titlecase }} {{ resource | upperFirst }}</h4>
   <button type="button"
           class="close pull-right"
           aria-label="Close"
@@ -134,13 +134,11 @@
 
   </div>
   <div class="modal-footer">
-    <cd-submit-button *ngIf="!viewing"
-                      (submitAction)="onSubmit()"
-                      [form]="formGroup"
-                      i18n>Add</cd-submit-button>
-    <cd-back-button [back]="bsModalRef.hide"
-                    name="Close"
-                    i18n-name>
-    </cd-back-button>
+    <cd-submit-button
+      *ngIf="!viewing"
+      (submitAction)="onSubmit()"
+      i18n="form action button|Example: Create Pool@@formActionButton"
+      [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
+    <cd-back-button [back]="bsModalRef.hide"></cd-back-button>
   </div>
 </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.ts
@@ -1,9 +1,11 @@
 import { Component, EventEmitter, Output } from '@angular/core';
 import { Validators } from '@angular/forms';
 
+import { I18n } from '@ngx-translate/i18n-polyfill';
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
@@ -24,8 +26,16 @@ export class RgwUserS3KeyModalComponent {
   formGroup: CdFormGroup;
   viewing = true;
   userCandidates: string[] = [];
+  resource: string;
+  action: string;
 
-  constructor(private formBuilder: CdFormBuilder, public bsModalRef: BsModalRef) {
+  constructor(
+    private formBuilder: CdFormBuilder,
+    public bsModalRef: BsModalRef,
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
+  ) {
+    this.resource = this.i18n('S3 Key');
     this.createForm();
     this.listenToChanges();
   }
@@ -57,6 +67,7 @@ export class RgwUserS3KeyModalComponent {
    * @param {boolean} viewing
    */
   setViewing(viewing: boolean = true) {
+    this.action = this.actionLabels.SHOW;
     this.viewing = viewing;
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
-  <h4 class="modal-title pull-left"
-      i18n>Subuser</h4>
+  <h4 i18n="form title|Example: Create Pool@@formTitle"
+      class="modal-title pull-left">{{ action | titlecase }} {{ resource | upperFirst }}</h4>
   <button type="button"
           class="close pull-right"
           aria-label="Close"
@@ -137,13 +137,10 @@
 
   </div>
   <div class="modal-footer">
-    <cd-submit-button (submitAction)="onSubmit()"
-                      [form]="formGroup">
-      <ng-container i18n>{editing, select, 1 {Update} other {Add}}</ng-container>
-    </cd-submit-button>
-    <cd-back-button [back]="bsModalRef.hide"
-                    name="Close"
-                    i18n-name>
-    </cd-back-button>
+    <cd-submit-button
+      (submitAction)="onSubmit()"
+      i18n="form action button|Example: Create Pool@@formActionButton"
+      [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
+    <cd-back-button [back]="bsModalRef.hide"></cd-back-button>
   </div>
 </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.ts
@@ -4,6 +4,8 @@ import { AbstractControl, ValidationErrors, ValidatorFn, Validators } from '@ang
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { I18n } from '@ngx-translate/i18n-polyfill';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators, isEmptyInputValue } from '../../../shared/forms/cd-validators';
@@ -25,8 +27,16 @@ export class RgwUserSubuserModalComponent {
   formGroup: CdFormGroup;
   editing = true;
   subusers: RgwUserSubuser[] = [];
+  resource: string;
+  action: string;
 
-  constructor(private formBuilder: CdFormBuilder, public bsModalRef: BsModalRef) {
+  constructor(
+    private formBuilder: CdFormBuilder,
+    public bsModalRef: BsModalRef,
+    private i18n: I18n,
+    private actionLabels: ActionLabelsI18n
+  ) {
+    this.resource = this.i18n('Subuser');
     this.createForm();
     this.listenToChanges();
   }
@@ -96,6 +106,7 @@ export class RgwUserSubuserModalComponent {
    */
   setEditing(editing: boolean = true) {
     this.editing = editing;
+    this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
   }
 
   /**

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
-  <h4 class="modal-title pull-left"
-      i18n>Swift key</h4>
+  <h4 i18n="form title|Example: Create Pool@@formTitle"
+      class="modal-title pull-left">{{ action | titlecase }} {{ resource | upperFirst }}</h4>
   <button type="button"
           class="close pull-right"
           aria-label="Close"
@@ -57,8 +57,5 @@
   </form>
 </div>
 <div class="modal-footer">
-  <button class="btn btn-sm btn-default"
-          type="button"
-          (click)="bsModalRef.hide()"
-          i18n>Close</button>
+  <cd-back-button [back]="bsModalRef.hide"></cd-back-button>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.spec.ts
@@ -1,9 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
 
+import { ToastModule } from 'ng2-toastr';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
-import { configureTestBed } from '../../../../testing/unit-test-helper';
+import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { SharedModule } from '../../../shared/shared.module';
 import { RgwUserSwiftKeyModalComponent } from './rgw-user-swift-key-modal.component';
 
 describe('RgwUserSwiftKeyModalComponent', () => {
@@ -12,8 +15,8 @@ describe('RgwUserSwiftKeyModalComponent', () => {
 
   configureTestBed({
     declarations: [RgwUserSwiftKeyModalComponent],
-    imports: [FormsModule],
-    providers: [BsModalRef]
+    imports: [ToastModule.forRoot(), FormsModule, SharedModule, RouterTestingModule],
+    providers: [BsModalRef, i18nProviders]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 
+import { I18n } from '@ngx-translate/i18n-polyfill';
 import { BsModalRef } from 'ngx-bootstrap/modal';
+
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 
 @Component({
   selector: 'cd-rgw-user-swift-key-modal',
@@ -10,8 +13,17 @@ import { BsModalRef } from 'ngx-bootstrap/modal';
 export class RgwUserSwiftKeyModalComponent {
   user: string;
   secret_key: string;
+  resource: string;
+  action: string;
 
-  constructor(public bsModalRef: BsModalRef) {}
+  constructor(
+    public bsModalRef: BsModalRef,
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
+  ) {
+    this.resource = this.i18n('Swift Key');
+    this.action = this.actionLabels.SHOW;
+  }
 
   /**
    * Set the values displayed in the dialog.

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
 
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -8,7 +9,8 @@ import { ModalModule } from 'ngx-bootstrap/modal';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
-import { AppRoutingModule } from '../../app-routing.module';
+import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
+import { AuthGuardService } from '../../shared/services/auth-guard.service';
 import { SharedModule } from '../../shared/shared.module';
 import { PerformanceCounterModule } from '../performance-counter/performance-counter.module';
 import { Rgw501Component } from './rgw-501/rgw-501.component';
@@ -38,7 +40,6 @@ import { RgwUserSwiftKeyModalComponent } from './rgw-user-swift-key-modal/rgw-us
   imports: [
     CommonModule,
     SharedModule,
-    AppRoutingModule,
     FormsModule,
     ReactiveFormsModule,
     PerformanceCounterModule,
@@ -46,7 +47,8 @@ import { RgwUserSwiftKeyModalComponent } from './rgw-user-swift-key-modal/rgw-us
     BsDropdownModule.forRoot(),
     TabsModule.forRoot(),
     TooltipModule.forRoot(),
-    ModalModule.forRoot()
+    ModalModule.forRoot(),
+    RouterModule
   ],
   exports: [
     Rgw501Component,
@@ -76,3 +78,57 @@ import { RgwUserSwiftKeyModalComponent } from './rgw-user-swift-key-modal/rgw-us
   ]
 })
 export class RgwModule {}
+
+const routes: Routes = [
+  {
+    path: '',
+    redirectTo: 'daemon',
+    pathMatch: 'full'
+  },
+  { path: 'daemon', component: RgwDaemonListComponent, data: { breadcrumbs: 'Daemons' } },
+  {
+    path: 'user',
+    data: { breadcrumbs: 'Users' },
+    children: [
+      { path: '', component: RgwUserListComponent },
+      {
+        path: URLVerbs.CREATE,
+        component: RgwUserFormComponent,
+        data: { breadcrumbs: ActionLabels.CREATE }
+      },
+      {
+        path: `${URLVerbs.EDIT}/:uid`,
+        component: RgwUserFormComponent,
+        data: { breadcrumbs: ActionLabels.EDIT }
+      }
+    ]
+  },
+  {
+    path: 'bucket',
+    data: { breadcrumbs: 'Buckets' },
+    children: [
+      { path: '', component: RgwBucketListComponent },
+      {
+        path: URLVerbs.CREATE,
+        component: RgwBucketFormComponent,
+        data: { breadcrumbs: ActionLabels.CREATE }
+      },
+      {
+        path: `${URLVerbs.EDIT}/:bid`,
+        component: RgwBucketFormComponent,
+        data: { breadcrumbs: ActionLabels.EDIT }
+      }
+    ]
+  },
+  {
+    path: '501/:message',
+    component: Rgw501Component,
+    canActivate: [AuthGuardService],
+    data: { breadcrumbs: 'Object Gateway' }
+  }
+];
+
+@NgModule({
+  imports: [RgwModule, RouterModule.forChild(routes)]
+})
+export class RoutedRgwModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { PopoverModule } from 'ngx-bootstrap/popover';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
+import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
 import { SharedModule } from '../../shared/shared.module';
 import { LoginComponent } from './login/login.component';
 import { RoleDetailsComponent } from './role-details/role-details.component';
@@ -40,3 +41,46 @@ import { UserTabsComponent } from './user-tabs/user-tabs.component';
   ]
 })
 export class AuthModule {}
+
+const routes: Routes = [
+  { path: '', redirectTo: 'users', pathMatch: 'full' },
+  {
+    path: 'users',
+    data: { breadcrumbs: 'Users' },
+    children: [
+      { path: '', component: UserListComponent },
+      {
+        path: URLVerbs.CREATE,
+        component: UserFormComponent,
+        data: { breadcrumbs: ActionLabels.CREATE }
+      },
+      {
+        path: `${URLVerbs.EDIT}/:username`,
+        component: UserFormComponent,
+        data: { breadcrumbs: ActionLabels.EDIT }
+      }
+    ]
+  },
+  {
+    path: 'roles',
+    data: { breadcrumbs: 'Roles' },
+    children: [
+      { path: '', component: RoleListComponent },
+      {
+        path: URLVerbs.CREATE,
+        component: RoleFormComponent,
+        data: { breadcrumbs: ActionLabels.CREATE }
+      },
+      {
+        path: `${URLVerbs.EDIT}/:name`,
+        component: RoleFormComponent,
+        data: { breadcrumbs: ActionLabels.EDIT }
+      }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [AuthModule, RouterModule.forChild(routes)]
+})
+export class RoutedAuthModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
@@ -6,8 +6,8 @@
         novalidate>
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"
-            i18n>{mode, select, editing {Edit} other {Add}} Role</h3>
+        <h3 i18n="form title|Example: Create Pool@@formTitle"
+            class="panel-title">{{ action | titlecase }} {{ resource | upperFirst }}</h3>
       </div>
       <div class="panel-body">
 
@@ -75,10 +75,10 @@
       </div>
       <div class="panel-footer">
         <div class="button-group text-right">
-          <cd-submit-button [form]="formDir"
-                            type="button"
-                            (submitAction)="submit()"
-                            i18n>{mode, select, editing {Update} other {Create}} Role</cd-submit-button>
+          <cd-submit-button
+            [form]="formDir" (submitAction)="submit()"
+            i18n="form action button|Example: Create Pool@@formActionButton"
+            type="button">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
           <cd-back-button></cd-back-button>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.ts
@@ -9,6 +9,7 @@ import { forkJoin as observableForkJoin } from 'rxjs';
 
 import { RoleService } from '../../../shared/api/role.service';
 import { ScopeService } from '../../../shared/api/scope.service';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
@@ -42,14 +43,19 @@ export class RoleFormComponent implements OnInit {
   roleFormMode = RoleFormMode;
   mode: RoleFormMode;
 
+  action: string;
+  resource: string;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private roleService: RoleService,
     private scopeService: ScopeService,
     private notificationService: NotificationService,
-    private i18n: I18n
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
   ) {
+    this.resource = this.i18n('role');
     this.createForm();
     this.listenToChanges();
   }
@@ -109,6 +115,9 @@ export class RoleFormComponent implements OnInit {
     ];
     if (this.router.url.startsWith('/user-management/roles/edit')) {
       this.mode = this.roleFormMode.editing;
+      this.action = this.actionLabels.EDIT;
+    } else {
+      this.action = this.actionLabels.CREATE;
     }
     if (this.mode === this.roleFormMode.editing) {
       this.initEdit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.spec.ts
@@ -11,6 +11,7 @@ import {
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
+import { ActionLabels } from '../../../shared/constants/app.constants';
 import { TableActionsComponent } from '../../../shared/datatable/table-actions/table-actions.component';
 import { SharedModule } from '../../../shared/shared.module';
 import { RoleDetailsComponent } from '../role-details/role-details.component';
@@ -59,8 +60,8 @@ describe('RoleListComponent', () => {
       );
       scenario = {
         fn: () => tableActions.getCurrentButton().name,
-        single: 'Edit',
-        empty: 'Add'
+        single: ActionLabels.EDIT,
+        empty: ActionLabels.CREATE
       };
     });
 
@@ -118,7 +119,7 @@ describe('RoleListComponent', () => {
       });
 
       it(`shows always 'Edit' as main action`, () => {
-        scenario.empty = 'Edit';
+        scenario.empty = ActionLabels.EDIT;
         permissionHelper.testScenarios(scenario);
       });
 
@@ -137,7 +138,7 @@ describe('RoleListComponent', () => {
       });
 
       it(`shows always 'Add' as main action`, () => {
-        scenario.single = 'Add';
+        scenario.single = ActionLabels.CREATE;
         permissionHelper.testScenarios(scenario);
       });
 
@@ -153,7 +154,7 @@ describe('RoleListComponent', () => {
       });
 
       it(`shows always 'Edit' as main action`, () => {
-        scenario.empty = 'Edit';
+        scenario.empty = ActionLabels.EDIT;
         permissionHelper.testScenarios(scenario);
       });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.ts
@@ -7,6 +7,7 @@ import { forkJoin } from 'rxjs';
 import { RoleService } from '../../../shared/api/role.service';
 import { ScopeService } from '../../../shared/api/scope.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CellTemplate } from '../../../shared/enum/cell-template.enum';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { CdTableAction } from '../../../shared/models/cd-table-action';
@@ -16,11 +17,15 @@ import { Permission } from '../../../shared/models/permissions';
 import { EmptyPipe } from '../../../shared/pipes/empty.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
+import { URLBuilderService } from '../../../shared/services/url-builder.service';
+
+const BASE_URL = 'user-management/roles';
 
 @Component({
   selector: 'cd-role-list',
   templateUrl: './role-list.component.html',
-  styleUrls: ['./role-list.component.scss']
+  styleUrls: ['./role-list.component.scss'],
+  providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }]
 })
 export class RoleListComponent implements OnInit {
   permission: Permission;
@@ -39,29 +44,31 @@ export class RoleListComponent implements OnInit {
     private authStorageService: AuthStorageService,
     private modalService: BsModalService,
     private notificationService: NotificationService,
-    private i18n: I18n
+    private i18n: I18n,
+    private urlBuilder: URLBuilderService,
+    public actionLabels: ActionLabelsI18n
   ) {
     this.permission = this.authStorageService.getPermissions().user;
     const addAction: CdTableAction = {
       permission: 'create',
       icon: 'fa-plus',
-      routerLink: () => '/user-management/roles/add',
-      name: this.i18n('Add')
+      routerLink: () => this.urlBuilder.getCreate(),
+      name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
       icon: 'fa-pencil',
       disable: () => !this.selection.hasSingleSelection || this.selection.first().system,
       routerLink: () =>
-        this.selection.first() && `/user-management/roles/edit/${this.selection.first().name}`,
-      name: this.i18n('Edit')
+        this.selection.first() && this.urlBuilder.getEdit(this.selection.first().name),
+      name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
       icon: 'fa-times',
       disable: () => !this.selection.hasSingleSelection || this.selection.first().system,
       click: () => this.deleteRoleModal(),
-      name: this.i18n('Delete')
+      name: this.actionLabels.DELETE
     };
     this.tableActions = [addAction, editAction, deleteAction];
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -6,8 +6,8 @@
         novalidate>
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"
-            i18n>{mode, select, editing {Edit} other {Add}} User</h3>
+        <h3 i18n="form title|Example: Create Pool@@formTitle"
+            class="panel-title">{{ action | titlecase }} {{ resource | upperFirst }}</h3>
       </div>
       <div class="panel-body">
 
@@ -47,6 +47,7 @@
                      placeholder="Password..."
                      id="password"
                      name="password"
+                     autocomplete="new-password"
                      formControlName="password">
               <span class="input-group-btn">
                 <button type="button"
@@ -141,10 +142,11 @@
       </div>
       <div class="panel-footer">
         <div class="button-group text-right">
-          <cd-submit-button [form]="formDir"
-                            type="button"
-                            (submitAction)="submit()"
-                            i18n>{mode, select, editing {Update} other {Create}} User</cd-submit-button>
+          <cd-submit-button
+            [form]="formDir"
+            (submitAction)="submit()"
+            i18n="form action button|Example: Create Pool@@formActionButton"
+            type="button">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
           <cd-back-button></cd-back-button>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -11,6 +11,7 @@ import { RoleService } from '../../../shared/api/role.service';
 import { UserService } from '../../../shared/api/user.service';
 import { ConfirmationModalComponent } from '../../../shared/components/confirmation-modal/confirmation-modal.component';
 import { SelectMessages } from '../../../shared/components/select/select-messages.model';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
@@ -38,6 +39,8 @@ export class UserFormComponent implements OnInit {
   mode: UserFormMode;
   allRoles: Array<UserFormRoleModel>;
   messages = new SelectMessages({ empty: 'There are no roles.' }, this.i18n);
+  action: string;
+  resource: string;
 
   constructor(
     private authService: AuthService,
@@ -48,8 +51,10 @@ export class UserFormComponent implements OnInit {
     private roleService: RoleService,
     private userService: UserService,
     private notificationService: NotificationService,
-    private i18n: I18n
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
   ) {
+    this.resource = this.i18n('user');
     this.createForm();
     this.messages = new SelectMessages({ empty: 'There are no roles.' }, this.i18n);
   }
@@ -82,7 +87,11 @@ export class UserFormComponent implements OnInit {
   ngOnInit() {
     if (this.router.url.startsWith('/user-management/users/edit')) {
       this.mode = this.userFormMode.editing;
+      this.action = this.actionLabels.EDIT;
+    } else {
+      this.action = this.actionLabels.CREATE;
     }
+
     this.roleService.list().subscribe((roles: Array<UserFormRoleModel>) => {
       this.allRoles = roles;
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.spec.ts
@@ -11,6 +11,7 @@ import {
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
+import { ActionLabels } from '../../../shared/constants/app.constants';
 import { TableActionsComponent } from '../../../shared/datatable/table-actions/table-actions.component';
 import { SharedModule } from '../../../shared/shared.module';
 import { UserTabsComponent } from '../user-tabs/user-tabs.component';
@@ -58,8 +59,8 @@ describe('UserListComponent', () => {
       );
       scenario = {
         fn: () => tableActions.getCurrentButton().name,
-        single: 'Edit',
-        empty: 'Add'
+        single: ActionLabels.EDIT,
+        empty: ActionLabels.CREATE
       };
     });
 
@@ -117,7 +118,7 @@ describe('UserListComponent', () => {
       });
 
       it(`shows always 'Edit' as main action`, () => {
-        scenario.empty = 'Edit';
+        scenario.empty = ActionLabels.EDIT;
         permissionHelper.testScenarios(scenario);
       });
 
@@ -136,7 +137,7 @@ describe('UserListComponent', () => {
       });
 
       it(`shows always 'Add' as main action`, () => {
-        scenario.single = 'Add';
+        scenario.single = ActionLabels.CREATE;
         permissionHelper.testScenarios(scenario);
       });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -5,6 +5,7 @@ import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 
 import { UserService } from '../../../shared/api/user.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { CdTableAction } from '../../../shared/models/cd-table-action';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
@@ -13,11 +14,15 @@ import { Permission } from '../../../shared/models/permissions';
 import { EmptyPipe } from '../../../shared/pipes/empty.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
+import { URLBuilderService } from '../../../shared/services/url-builder.service';
+
+const BASE_URL = 'user-management/users';
 
 @Component({
   selector: 'cd-user-list',
   templateUrl: './user-list.component.html',
-  styleUrls: ['./user-list.component.scss']
+  styleUrls: ['./user-list.component.scss'],
+  providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }]
 })
 export class UserListComponent implements OnInit {
   @ViewChild('userRolesTpl')
@@ -37,27 +42,29 @@ export class UserListComponent implements OnInit {
     private modalService: BsModalService,
     private notificationService: NotificationService,
     private authStorageService: AuthStorageService,
-    private i18n: I18n
+    private i18n: I18n,
+    private urlBuilder: URLBuilderService,
+    public actionLabels: ActionLabelsI18n
   ) {
     this.permission = this.authStorageService.getPermissions().user;
     const addAction: CdTableAction = {
       permission: 'create',
       icon: 'fa-plus',
-      routerLink: () => '/user-management/users/add',
-      name: this.i18n('Add')
+      routerLink: () => this.urlBuilder.getCreate(),
+      name: this.actionLabels.CREATE
     };
     const editAction: CdTableAction = {
       permission: 'update',
       icon: 'fa-pencil',
       routerLink: () =>
-        this.selection.first() && `/user-management/users/edit/${this.selection.first().username}`,
-      name: this.i18n('Edit')
+        this.selection.first() && this.urlBuilder.getEdit(this.selection.first().username),
+      name: this.actionLabels.EDIT
     };
     const deleteAction: CdTableAction = {
       permission: 'delete',
       icon: 'fa-times',
       click: () => this.deleteUserModal(),
-      name: this.i18n('Delete')
+      name: this.actionLabels.DELETE
     };
     this.tableActions = [addAction, editAction, deleteAction];
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/core.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/core.module.ts
@@ -1,13 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { AuthModule } from './auth/auth.module';
 import { ForbiddenComponent } from './forbidden/forbidden.component';
 import { NavigationModule } from './navigation/navigation.module';
 import { NotFoundComponent } from './not-found/not-found.component';
 
 @NgModule({
-  imports: [CommonModule, NavigationModule, AuthModule],
+  imports: [CommonModule, NavigationModule],
   exports: [NavigationModule],
   declarations: [NotFoundComponent, ForbiddenComponent]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/back-button/back-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/back-button/back-button.component.ts
@@ -1,7 +1,7 @@
 import { Location } from '@angular/common';
 import { Component, Input } from '@angular/core';
 
-import { I18n } from '@ngx-translate/i18n-polyfill';
+import { ActionLabelsI18n } from '../../constants/app.constants';
 
 @Component({
   selector: 'cd-back-button',
@@ -9,8 +9,8 @@ import { I18n } from '@ngx-translate/i18n-polyfill';
   styleUrls: ['./back-button.component.scss']
 })
 export class BackButtonComponent {
-  constructor(private location: Location, private i18n: I18n) {}
+  constructor(private location: Location, private actionLabels: ActionLabelsI18n) {}
 
-  @Input() name: string = this.i18n('Back');
+  @Input() name: string = this.actionLabels.CANCEL;
   @Input() back: Function = () => this.location.back();
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -1,5 +1,102 @@
+import { Injectable } from '@angular/core';
+
+import { I18n } from '@ngx-translate/i18n-polyfill';
+
 export class AppConstants {
   public static readonly organization = 'ceph';
   public static readonly projectName = 'Ceph Manager Dashboard';
   public static readonly license = 'Free software (LGPL 2.1).';
+}
+
+export enum URLVerbs {
+  /* Create a new item */
+  CREATE = 'create',
+
+  /* Make changes to an existing item */
+  EDIT = 'edit',
+
+  /* Make changes to an existing item */
+  UPDATE = 'update',
+
+  /* Remove an item from a container WITHOUT deleting it */
+  REMOVE = 'remove',
+
+  /* Destroy an existing item */
+  DELETE = 'delete',
+
+  /* Add an existing item to a container */
+  ADD = 'add',
+
+  /* Non-standard verbs */
+  COPY = 'copy',
+  CLONE = 'clone'
+}
+
+export enum ActionLabels {
+  /* Create a new item */
+  CREATE = 'Create',
+
+  /* Destroy an existing item */
+  DELETE = 'Delete',
+
+  /* Add an existing item to a container */
+  ADD = 'Add',
+
+  /* Remove an item from a container WITHOUT deleting it */
+  REMOVE = 'Remove',
+
+  /* Make changes to an existing item */
+  EDIT = 'Edit',
+
+  /* */
+  CANCEL = 'Cancel',
+
+  /* Non-standard actions */
+  COPY = 'Copy',
+  CLONE = 'Clone',
+
+  /* Read-only */
+  SHOW = 'Show'
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ActionLabelsI18n {
+  /* This service is required as the i18n polyfill does not provide static
+  translation
+  */
+  CREATE: string;
+  DELETE: string;
+  ADD: string;
+  REMOVE: string;
+  EDIT: string;
+  CANCEL: string;
+  COPY: string;
+  CLONE: string;
+  SHOW: string;
+
+  constructor(private i18n: I18n) {
+    /* Create a new item */
+    this.CREATE = this.i18n('Create');
+
+    /* Destroy an existing item */
+    this.DELETE = this.i18n('Delete');
+
+    /* Add an existing item to a container */
+    this.ADD = this.i18n('Add');
+
+    /* Remove an item from a container WITHOUT deleting it */
+    this.REMOVE = this.i18n('Remove');
+
+    /* Make changes to an existing item */
+    this.EDIT = this.i18n('Edit');
+    this.CANCEL = this.i18n('Cancel');
+
+    /* Non-standard actions */
+    this.COPY = this.i18n('Copy');
+    this.CLONE = this.i18n('Clone');
+
+    this.SHOW = this.i18n('Show');
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/url-builder.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/url-builder.service.spec.ts
@@ -1,0 +1,32 @@
+import { URLVerbs } from '../constants/app.constants';
+import { URLBuilderService } from './url-builder.service';
+
+describe('URLBuilderService', () => {
+  const BASE = 'pool';
+  const urlBuilder = new URLBuilderService(BASE);
+
+  it('get base', () => {
+    expect(urlBuilder.base).toBe(BASE);
+  });
+
+  it('build absolute URL', () => {
+    expect(URLBuilderService.buildURL(true, urlBuilder.base, URLVerbs.CREATE)).toBe(
+      `/${urlBuilder.base}/${URLVerbs.CREATE}`
+    );
+  });
+
+  it('build relative URL', () => {
+    expect(URLBuilderService.buildURL(false, urlBuilder.base, URLVerbs.CREATE)).toBe(
+      `${urlBuilder.base}/${URLVerbs.CREATE}`
+    );
+  });
+
+  it('get Create URL', () => {
+    expect(urlBuilder.getCreate()).toBe(`/${urlBuilder.base}/${URLVerbs.CREATE}`);
+  });
+
+  it('get Edit URL with item', () => {
+    const item = 'test_pool';
+    expect(urlBuilder.getEdit(item)).toBe(`/${urlBuilder.base}/${URLVerbs.EDIT}/${item}`);
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/url-builder.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/url-builder.service.ts
@@ -1,0 +1,40 @@
+import { Location } from '@angular/common';
+
+import { URLVerbs } from '../constants/app.constants';
+
+export class URLBuilderService {
+  constructor(readonly base: string) {}
+
+  private static concatURLSegments(segments: string[]): string {
+    return segments.reduce(Location.joinWithSlash);
+  }
+
+  static buildURL(absolute: boolean, ...segments: string[]): string {
+    return URLBuilderService.concatURLSegments([...(absolute ? ['/'] : []), ...segments]);
+  }
+
+  private getURL(verb: URLVerbs, absolute = true, ...segments: string[]): string {
+    return URLBuilderService.buildURL(absolute, this.base, verb, ...segments);
+  }
+
+  getCreate(absolute = true): string {
+    return this.getURL(URLVerbs.CREATE, absolute);
+  }
+  getDelete(absolute = true): string {
+    return this.getURL(URLVerbs.DELETE, absolute);
+  }
+
+  getEdit(item: string, absolute = true): string {
+    return this.getURL(URLVerbs.EDIT, absolute, item);
+  }
+  getUpdate(item: string, absolute = true): string {
+    return this.getURL(URLVerbs.UPDATE, absolute, item);
+  }
+
+  getAdd(absolute = true): string {
+    return this.getURL(URLVerbs.ADD, absolute);
+  }
+  getRemove(absolute = true): string {
+    return this.getURL(URLVerbs.REMOVE, absolute);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -99,16 +99,16 @@
           <context context-type="linenumber">115</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/overview/overview.component.html</context>
-          <context context-type="linenumber">12</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/dashboard/health/health.component.html</context>
           <context context-type="linenumber">190</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
           <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/overview/overview.component.html</context>
+          <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit><trans-unit id="7f5d0c10614e8a34f0e2dad33a0568277c50cf69" datatype="html">
         <source>Block</source>
@@ -123,6 +123,18 @@
           <context context-type="linenumber">138</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/overview/overview.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi/iscsi.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-images/rbd-images.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
           <context context-type="linenumber">120</context>
         </context-group>
@@ -133,18 +145,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
           <context context-type="linenumber">502</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi/iscsi.component.html</context>
-          <context context-type="linenumber">9</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/overview/overview.component.html</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-images/rbd-images.component.html</context>
-          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit><trans-unit id="3c2562ba992127203dcfd014010b03cb7b8113c6" datatype="html">
         <source>Mirroring</source>
@@ -187,16 +187,16 @@
           <context context-type="linenumber">196</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi/iscsi.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">53</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/mirroring/overview/overview.component.html</context>
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="sourcefile">app/ceph/block/iscsi/iscsi.component.html</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit><trans-unit id="4d13a9cd5ed3dcee0eab22cb25198d43886942be" datatype="html">
         <source>Users</source>
@@ -319,560 +319,29 @@
           <context context-type="linenumber">118</context>
         </context-group>
         <note priority="1" from="description">X total</note>
-      </trans-unit><trans-unit id="121cc5391cd2a5115bc2b3160379ee5b36cd7716" datatype="html">
-        <source>Settings</source>
+      </trans-unit><trans-unit id="28f86ffd419b869711aa13f5e5ff54be6d70731c" datatype="html">
+        <source>Edit</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-      </trans-unit><trans-unit id="9e515f954730279c31d5301f02479666d6264e8b" datatype="html">
-        <source>Changing these parameters from their default values is usually not necessary.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
+          <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-form/configuration-form.component.html</context>
           <context context-type="linenumber">10</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html</context>
-          <context context-type="linenumber">13</context>
-        </context-group>
-      </trans-unit><trans-unit id="69a47cbabcc51ca942606e1d8da0ec11f98a2690" datatype="html">
-        <source>Backstore</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
-          <context context-type="linenumber">17</context>
-        </context-group>
-      </trans-unit><trans-unit id="68e710782ccb5398b3acb8844caf0b199da2c3da" datatype="html">
-        <source>Confirm</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
-          <context context-type="linenumber">50</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html</context>
-          <context context-type="linenumber">53</context>
-        </context-group>
-      </trans-unit><trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
-        <source>Cancel</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
-          <context context-type="linenumber">52</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html</context>
-          <context context-type="linenumber">55</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">135</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/components/confirmation-modal/confirmation-modal.component.html</context>
-          <context context-type="linenumber">19</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html</context>
-          <context context-type="linenumber">36</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html</context>
-          <context context-type="linenumber">89</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.html</context>
-          <context context-type="linenumber">32</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.html</context>
-          <context context-type="linenumber">42</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.html</context>
-          <context context-type="linenumber">42</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
-          <context context-type="linenumber">108</context>
-        </context-group>
-      </trans-unit><trans-unit id="339878da255ab55447c43afef8d9b2f9753bf5f6" datatype="html">
-        <source>Advanced Settings</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-      </trans-unit><trans-unit id="602ace8a29cf86e2e7db2f6b0cdb896ddf760e0d" datatype="html">
-        <source><x id="ICU" equiv-text="{isEdit, select, 1 {...} other {...}}"/> target</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">11</context>
-        </context-group>
-      </trans-unit><trans-unit id="457db3d876e89cae583be9845912213ae73dc398" datatype="html">
-        <source>{VAR_SELECT, select, 1 {Edit} other {Add} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">11</context>
-        </context-group>
-      </trans-unit><trans-unit id="1406c2fb12a20c1528b19bcc5e24a6a2386167f3" datatype="html">
-        <source>Target IQN</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-      </trans-unit><trans-unit id="7cbdabcece469fab89cfa687ab152bca18b97498" datatype="html">
-        <source>This field is required.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">231</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">253</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">288</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">313</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">348</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">60</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">84</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">119</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">97</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">157</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">181</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html</context>
-          <context context-type="linenumber">79</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html</context>
-          <context context-type="linenumber">100</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html</context>
-          <context context-type="linenumber">31</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.html</context>
-          <context context-type="linenumber">18</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">58</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">92</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">72</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">131</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">236</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">38</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">62</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">101</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">166</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">198</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">449</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">486</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">542</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">579</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">33</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">60</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">87</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html</context>
-          <context context-type="linenumber">36</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.html</context>
-          <context context-type="linenumber">32</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
-          <context context-type="linenumber">36</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
-          <context context-type="linenumber">58</context>
-        </context-group>
-      </trans-unit><trans-unit id="5fe42339be910372fa689f559155631862d218e8" datatype="html">
-        <source>IQN has wrong pattern.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">235</context>
-        </context-group>
-      </trans-unit><trans-unit id="47d1bfe4f5b3f292e1202dfe691195b10cb99500" datatype="html">
-        <source>An IQN has the following notation &apos;iqn.$year-$month.$reversedAddress:$definedName&apos;</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-      </trans-unit><trans-unit id="c8ada4b53396d8366db00a435acc61d53d857047" datatype="html">
-        <source>For example: iqn.2016-06.org.dashboard:storage:disk.sn-a8675309</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">53</context>
-        </context-group>
-      </trans-unit><trans-unit id="e60c11e1b1dfbbeda577364b8de39ded2d796c5e" datatype="html">
-        <source>More information</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">57</context>
-        </context-group>
-      </trans-unit><trans-unit id="9b1aa85dfc6849196e64060db02c5410de69b7a1" datatype="html">
-        <source>This target has modified advanced settings.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">62</context>
-        </context-group>
-      </trans-unit><trans-unit id="6990ad8d6182662e864495ac31c3758cda1c7a28" datatype="html">
-        <source>Portals</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">72</context>
-        </context-group>
-      </trans-unit><trans-unit id="c3638c01b6c34066438909713ec96087c813fc7e" datatype="html">
-        <source>At least <x id="INTERPOLATION" equiv-text="{{ minimum_gateways }}"/> gateways are required.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-      </trans-unit><trans-unit id="6a3ac2b4137d723fd9878cd357c2012ff6c07973" datatype="html">
-        <source>Add portal</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">106</context>
-        </context-group>
-      </trans-unit><trans-unit id="6c1c7f516d021abaf155aab1e9c2fe96e2c4ff40" datatype="html">
-        <source>Backstore: <x id="INTERPOLATION" equiv-text="{{ imagesSettings[image].backstore }}"/>. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">147</context>
-        </context-group>
-      </trans-unit><trans-unit id="e3484cae8b118c576ca2815bf9c9406c2eb2cae3" datatype="html">
-        <source>This image has modified settings.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">150</context>
-        </context-group>
-      </trans-unit><trans-unit id="107c84e820909b44fe258673938a68ced1bbff72" datatype="html">
-        <source>At least 1 image is required.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">156</context>
-        </context-group>
-      </trans-unit><trans-unit id="808038f912fdc7f0e03f82d4afd3bf9178527fc8" datatype="html">
-        <source>Add image</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">166</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">393</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">529</context>
-        </context-group>
-      </trans-unit><trans-unit id="66c5fb27f52e75b70ca4b670b9b15a2a51cf9543" datatype="html">
-        <source>ACL authentication</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">184</context>
-        </context-group>
-      </trans-unit><trans-unit id="f494bd31f095f6dcc656ce87ec2dcf07a2e9b30c" datatype="html">
-        <source>Initiators</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">196</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">460</context>
-        </context-group>
-      </trans-unit><trans-unit id="e98239d8a6be1100119ff4b5630c822b82786740" datatype="html">
-        <source>Initiator</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">203</context>
-        </context-group>
-      </trans-unit><trans-unit id="f2c5059d8cda15d8d03e2cce30f2d139623d9a91" datatype="html">
-        <source>Client IQN</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">216</context>
-        </context-group>
-      </trans-unit><trans-unit id="107d5aabce23d900f0a80e6ddc1c10e29aa0bed8" datatype="html">
-        <source>Initiator IQN needs to be unique.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">227</context>
-        </context-group>
-      </trans-unit><trans-unit id="e08a77594f3d89311cdf6da5090044270909c194" datatype="html">
-        <source>User</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">245</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">17</context>
-        </context-group>
-      </trans-unit><trans-unit id="bbf0b34a3fcc80800fcb44b9e1e86931a530dfe3" datatype="html">
-        <source>Usernames must have a length of 8 to 64 characters and
-                        can only contain letters, &apos;.&apos;, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;:&apos;.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">257</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">317</context>
-        </context-group>
-      </trans-unit><trans-unit id="c32ef07f8803a223a83ed17024b38e8d82292407" datatype="html">
-        <source>Password</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">267</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">42</context>
-        </context-group>
-      </trans-unit><trans-unit id="fdfee5d7a27e1bdd97a176097277bee078de6aaf" datatype="html">
-        <source>Passwords must have a length of 12 to 16 characters
-                        and can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">292</context>
-        </context-group>
-      </trans-unit><trans-unit id="ff40391de7a1944ea95091e4045cc34c4979b736" datatype="html">
-        <source>Mutual User</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">303</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">74</context>
-        </context-group>
-      </trans-unit><trans-unit id="0cf73dbebe99b737c4d288788182fc356e3c93d3" datatype="html">
-        <source>Mutual Password</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">327</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">98</context>
-        </context-group>
-      </trans-unit><trans-unit id="8406eb7415ee40e54d9ecb209abb056f06e3d666" datatype="html">
-        <source>Passwords must have a length of 12 to 16 characters and
-                        can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">352</context>
-        </context-group>
-      </trans-unit><trans-unit id="5d1878d5fc761cbe9614bfd87047a740c82a6951" datatype="html">
-        <source>Initiator belongs to a group. Images will be configure in the group.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">383</context>
-        </context-group>
-      </trans-unit><trans-unit id="c0de67b9d97fafbf200f9451e8388ee8128a56ac" datatype="html">
-        <source>No items added.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">406</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">544</context>
-        </context-group>
-      </trans-unit><trans-unit id="d565e47726158e428ecdc952fc9233b9b7d7f049" datatype="html">
-        <source>Add initiator</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">411</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">488</context>
-        </context-group>
-      </trans-unit><trans-unit id="c22ba03540aa3217da059f45e7eab138b51a96e2" datatype="html">
-        <source>Groups</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">426</context>
-        </context-group>
-      </trans-unit><trans-unit id="4c90059afafb7e160384d9f512797c95bb95c6dc" datatype="html">
-        <source>Group</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">433</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit><trans-unit id="cff1428d10d59d14e45edec3c735a27b5482db59" datatype="html">
         <source>Name</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">445</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">38</context>
-        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-form/configuration-form.component.html</context>
           <context context-type="linenumber">18</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">26</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">42</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
           <context context-type="linenumber">19</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">8</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-details/configuration-details.component.html</context>
@@ -883,392 +352,32 @@
           <context context-type="linenumber">13</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-      </trans-unit><trans-unit id="3084948274cff4f56d0f431af47240e9cf02fcc7" datatype="html">
-        <source>Add group</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">549</context>
-        </context-group>
-      </trans-unit><trans-unit id="71c77bb8cecdf11ec3eead24dd1ba506573fa9cd" datatype="html">
-        <source>Submit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
-          <context context-type="linenumber">562</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">133</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html</context>
-          <context context-type="linenumber">87</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">515</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
-          <context context-type="linenumber">106</context>
-        </context-group>
-      </trans-unit><trans-unit id="54839ebc827b73c9dc4e1df731c6d36a85036af7" datatype="html">
-        <source>Are you sure that you want to <x id="INTERPOLATION" equiv-text="{{ actionDescription | lowercase }}"/> the selected <x id="INTERPOLATION_1" equiv-text="{{ itemDescription }}"/>?</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html</context>
-          <context context-type="linenumber">15</context>
-        </context-group>
-      </trans-unit><trans-unit id="2be8b7f04f0104d3fad90d079d8202b74f758b9a" datatype="html">
-        <source>Yes, I am sure.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-      </trans-unit><trans-unit id="6803e31b7395d94934e091a49a9524026b59b018" datatype="html">
-        <source>Discovery Authentication</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-      </trans-unit><trans-unit id="0214f773f8e394f50f953f39962e352d7863e959" datatype="html">
-        <source>Usernames must have a length of 8 to 64 characters and
-              can only contain letters, &apos;.&apos;, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;:&apos;.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">29</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">88</context>
-        </context-group>
-      </trans-unit><trans-unit id="6682d1c00263bee204583a5d589b308b6be88b0f" datatype="html">
-        <source>Passwords must have a length of 12 to 16 characters
-              and can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">64</context>
-        </context-group>
-      </trans-unit><trans-unit id="8800276925157c666b103c36ff7fe8ffe11980b4" datatype="html">
-        <source>Passwords must have a length of 12 to 16 characters and
-              can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
-          <context context-type="linenumber">123</context>
-        </context-group>
-      </trans-unit><trans-unit id="53a583cd5f15059cc958b7d547f72cc78f68e123" datatype="html">
-        <source>Please consult the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
-    on how to configure and enable the iSCSI Targets management functionality.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-list/iscsi-target-list.component.html</context>
-          <context context-type="linenumber">6</context>
-        </context-group>
-      </trans-unit><trans-unit id="3b301d0044f62c92af0da53d7aaca52a436a547d" datatype="html">
-        <source>Available information:</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-list/iscsi-target-list.component.html</context>
-          <context context-type="linenumber">12</context>
-        </context-group>
-      </trans-unit><trans-unit id="332227f088a4877b3c11f5fb3ae8bc812c470fae" datatype="html">
-        <source>iSCSI Targets not available</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-list/iscsi-target-list.component.html</context>
-          <context context-type="linenumber">4</context>
-        </context-group>
-      </trans-unit><trans-unit id="8f4c079a38df7c3b64a4dfe8daa4d02aeffefbfa" datatype="html">
-        <source>Set discovery authentication</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/iscsi-target-list/iscsi-target-list.component.html</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-      </trans-unit><trans-unit id="beb1391a148bd032914f49a2665dcc414a5d56d0" datatype="html">
-        <source>{VAR_SELECT, select, editing {Edit} cloning {Clone} copying {Copy} other {Add} }</source>
-        <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">11</context>
-        </context-group>
-      </trans-unit><trans-unit id="52dd89f49fc440660cbbb3665b88d80f5baa7437" datatype="html">
-        <source>{VAR_SELECT, select, cloning {Clone from} copying {Copy from} other {Parent} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">22</context>
-        </context-group>
-      </trans-unit><trans-unit id="0e9ecf29a4fa5b057bd8052e0d801b3fde6a30bf" datatype="html">
-        <source>&apos;/&apos; and &apos;@&apos; are not allowed.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">55</context>
-        </context-group>
-      </trans-unit><trans-unit id="94516fa213706c67ce5a5b5765681d7fb032033a" datatype="html">
-        <source>Loading...</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">85</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">145</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">32</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">106</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">139</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">171</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">204</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">418</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">453</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">59</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">186</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">210</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">5</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">219</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">342</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-      </trans-unit><trans-unit id="b99417c4dd46286ffd37c8d2e987c8b512ec7052" datatype="html">
-        <source>-- No rbd pools available --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">88</context>
-        </context-group>
-      </trans-unit><trans-unit id="ef83ec9c304a89d45650e580dcdc2978c37b3a83" datatype="html">
-        <source>-- Select a pool --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">91</context>
-        </context-group>
-      </trans-unit><trans-unit id="49449943d8cbf59d8c401c8bd2e76f92e207cc5f" datatype="html">
-        <source>Use a dedicated data pool</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">111</context>
-        </context-group>
-      </trans-unit><trans-unit id="870aee0dd31a9643bf62007beb8f1ae1deb34d42" datatype="html">
-        <source>Data pool</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">122</context>
-        </context-group>
-      </trans-unit><trans-unit id="3792ca829d9b9f687e1f5d7733d30e9bb0bfec47" datatype="html">
-        <source>Dedicated pool that stores the object-data of the RBD.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">126</context>
-        </context-group>
-      </trans-unit><trans-unit id="151c80ea931037cd92e854442927f8a0f6ae7795" datatype="html">
-        <source>-- No data pools available --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">148</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
-          <context context-type="linenumber">109</context>
-        </context-group>
-      </trans-unit><trans-unit id="7faaaa08f56427999f3be41df1093ce4089bbd75" datatype="html">
-        <source>Size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">166</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-details/rbd-details.component.html</context>
-          <context context-type="linenumber">33</context>
-        </context-group>
-      </trans-unit><trans-unit id="f0016bd458baa88284a658ce9eeda42d8ad88d2c" datatype="html">
-        <source>e.g., 10GiB</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">176</context>
-        </context-group>
-      </trans-unit><trans-unit id="0a88bbee20570aaf9615332fb27020627044874d" datatype="html">
-        <source>You have to increase the size.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">184</context>
-        </context-group>
-      </trans-unit><trans-unit id="6cdb1fea93d77c07950c0c76c6e0ad79ebbef084" datatype="html">
-        <source>Features</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">194</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-details/rbd-details.component.html</context>
-          <context context-type="linenumber">48</context>
-        </context-group>
-      </trans-unit><trans-unit id="1cfe07dac5b4ee1c464eb24225ddeb4f1d24076a" datatype="html">
-        <source>Advanced...</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">216</context>
-        </context-group>
-      </trans-unit><trans-unit id="bc2e854e111ecf2bd7db170da5e3c2ed08181d88" datatype="html">
-        <source>Advanced</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">222</context>
-        </context-group>
-      </trans-unit><trans-unit id="3562a3778695a5f9c0445660e35301f0a39aaf73" datatype="html">
-        <source>Striping</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">225</context>
-        </context-group>
-      </trans-unit><trans-unit id="ceac8e132384322ec778ba760875a6c6897d3e42" datatype="html">
-        <source>Object size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">232</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-details/rbd-details.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-      </trans-unit><trans-unit id="ef3c3f3b5f562a5cdbe0ee2874287db1534b5958" datatype="html">
-        <source>Stripe unit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">249</context>
-        </context-group>
-      </trans-unit><trans-unit id="84471be1049006edecbcaef1a32ae0893c229c50" datatype="html">
-        <source>-- Select stripe unit --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">260</context>
-        </context-group>
-      </trans-unit><trans-unit id="8d32c5c54c8581c774a7f467fbd4e329b15a74fa" datatype="html">
-        <source>This field is required because stripe count is defined!</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">266</context>
-        </context-group>
-      </trans-unit><trans-unit id="6bbf9040be7c5491d4a03f2185708f43a6582a3b" datatype="html">
-        <source>Stripe unit is greater than object size.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">269</context>
-        </context-group>
-      </trans-unit><trans-unit id="a682f49f9b761591661276d7c6f550e641a130a4" datatype="html">
-        <source>Stripe count</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">278</context>
-        </context-group>
-      </trans-unit><trans-unit id="baa74031990c5370008ba622d0a250f0929097f4" datatype="html">
-        <source>This field is required because stripe unit is defined!</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">291</context>
-        </context-group>
-      </trans-unit><trans-unit id="cd2ada6d5ecbd5cbf89eae0a1f5326efedac0dbc" datatype="html">
-        <source>Stripe count must be greater than 0.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">294</context>
-        </context-group>
-      </trans-unit><trans-unit id="21afa21d069c7fdfc742e6fbbe7e6c0f6ff4e580" datatype="html">
-        <source><x id="ICU" equiv-text="{mode, select, editing {...} cloning {...} copying {...} other {...}}"/> RBD</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">313</context>
-        </context-group>
-      </trans-unit><trans-unit id="96d97d99d8c30942ace7d29cad9dcfb5d32315a1" datatype="html">
-        <source>{VAR_SELECT, select, editing {Update} cloning {Clone} copying {Copy} other {Create} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
-          <context context-type="linenumber">313</context>
-        </context-group>
-      </trans-unit><trans-unit id="aba82bfd8e177d35b76cad7cd43941f8e5e5acac" datatype="html">
-        <source>Trash</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-images/rbd-images.component.html</context>
-          <context context-type="linenumber">8</context>
-        </context-group>
-      </trans-unit><trans-unit id="5e7f4b1ca49e8d217bd0e12c6f7d6b6a2ade2c18" datatype="html">
-        <source>Overall Performance</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-images/rbd-images.component.html</context>
-          <context context-type="linenumber">12</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/hosts/hosts.component.html</context>
-          <context context-type="linenumber">29</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-list/osd-list.component.html</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-list/pool-list.component.html</context>
           <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html</context>
-          <context context-type="linenumber">16</context>
-        </context-group>
-      </trans-unit><trans-unit id="28f86ffd419b869711aa13f5e5ff54be6d70731c" datatype="html">
-        <source>Edit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-form/configuration-form.component.html</context>
-          <context context-type="linenumber">10</context>
+          <context context-type="sourcefile">app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html</context>
+          <context context-type="linenumber">23</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">235</context>
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">445</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">374</context>
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit><trans-unit id="eec715de352a6b114713b30b640d319fa78207a0" datatype="html">
         <source>Description</source>
@@ -1360,6 +469,28 @@
           <context context-type="sourcefile">app/ceph/cluster/hosts/hosts.component.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
+      </trans-unit><trans-unit id="5e7f4b1ca49e8d217bd0e12c6f7d6b6a2ade2c18" datatype="html">
+        <source>Overall Performance</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/hosts/hosts.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-list/osd-list.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-images/rbd-images.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-list/pool-list.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
       </trans-unit><trans-unit id="e6d57f36aa2bad303c8a8ee944b9bd7fae3c8c26" datatype="html">
         <source>No entries found</source>
         <context-group purpose="location">
@@ -1441,6 +572,188 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html</context>
           <context context-type="linenumber">65</context>
+        </context-group>
+      </trans-unit><trans-unit id="7cbdabcece469fab89cfa687ab152bca18b97498" datatype="html">
+        <source>This field is required.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">154</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">231</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">253</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">288</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">313</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">348</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">131</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">132</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">167</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">199</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">450</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">487</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">543</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit><trans-unit id="f19106149f4b07a0d721f9d317afed393cb7bd93" datatype="html">
         <source>The entered value is too high! It must be lower or equal to <x id="INTERPOLATION" equiv-text="{{ moduleOption.value.max }}"/>.</source>
@@ -1540,11 +853,107 @@
           <context context-type="sourcefile">app/ceph/cluster/monitor/monitor.component.html</context>
           <context context-type="linenumber">54</context>
         </context-group>
+      </trans-unit><trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/components/confirmation-modal/confirmation-modal.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html</context>
+          <context context-type="linenumber">89</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">135</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
+          <context context-type="linenumber">108</context>
+        </context-group>
+      </trans-unit><trans-unit id="54839ebc827b73c9dc4e1df731c6d36a85036af7" datatype="html">
+        <source>Are you sure that you want to <x id="INTERPOLATION" equiv-text="{{ actionDescription | lowercase }}"/> the selected <x id="INTERPOLATION_1" equiv-text="{{ itemDescription }}"/>?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit><trans-unit id="2be8b7f04f0104d3fad90d079d8202b74f758b9a" datatype="html">
+        <source>Yes, I am sure.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
       </trans-unit><trans-unit id="5ef50ba2514414f799d4c8fc36067a251904ba81" datatype="html">
         <source>Cluster-wide OSD Flags</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html</context>
           <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit><trans-unit id="71c77bb8cecdf11ec3eead24dd1ba506573fa9cd" datatype="html">
+        <source>Submit</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">515</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">133</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit><trans-unit id="c35f9c5f268a514b970cc55e9a5dc4bed0988e7f" datatype="html">
         <source>OSD Recovery Priority</source>
@@ -1592,15 +1001,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">40</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">94</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit><trans-unit id="b699e94bf376491bd50b70a98531071c737eaf40" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ attr.value.patternHelpText }}"/></source>
@@ -1712,23 +1121,19 @@
           <context context-type="linenumber">2</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-        <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-details/configuration-details.component.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/mgr-modules/mgr-module-details/mgr-module-details.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-details/nfs-details.component.html</context>
           <context context-type="linenumber">2</context>
         </context-group>
         <context-group purpose="location">
@@ -1740,12 +1145,16 @@
           <context context-type="linenumber">5</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/nfs/nfs-details/nfs-details.component.html</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
           <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit><trans-unit id="d2bcd3296d2850de762fb943060b7e086a893181" datatype="html">
         <source>Health</source>
@@ -1886,6 +1295,72 @@
           <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
           <context context-type="linenumber">10</context>
         </context-group>
+      </trans-unit><trans-unit id="94516fa213706c67ce5a5b5765681d7fb032033a" datatype="html">
+        <source>Loading...</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">139</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">171</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">204</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">418</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">453</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">142</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">186</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">210</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">218</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">341</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
       </trans-unit><trans-unit id="135b91a2d908d5814b782695470a6a786c99d9d2" datatype="html">
         <source>-- No cluster available --</source>
         <context-group purpose="location">
@@ -1909,6 +1384,16 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
           <context context-type="linenumber">95</context>
+        </context-group>
+      </trans-unit><trans-unit id="151c80ea931037cd92e854442927f8a0f6ae7795" datatype="html">
+        <source>-- No data pools available --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/nfs/nfs-form/nfs-form.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">145</context>
         </context-group>
       </trans-unit><trans-unit id="b6fee356d1db954255a56d8169405a89595246b9" datatype="html">
         <source>-- Select the storage backend --</source>
@@ -2133,1017 +1618,6 @@
           <context context-type="sourcefile">app/ceph/nfs/nfs-list/nfs-list.component.html</context>
           <context context-type="linenumber">25</context>
         </context-group>
-      </trans-unit><trans-unit id="594cd9429597cf6bede5560b3d8fe578821213de" datatype="html">
-        <source>Add erasure code profile</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-      </trans-unit><trans-unit id="490e15ecc922965b6d8194754c87c5583aa071f3" datatype="html">
-        <source>The name can only consist of alphanumeric characters, dashes and underscores.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-      </trans-unit><trans-unit id="9edc2b494e660618af3e5225f68d40b7ca67629c" datatype="html">
-        <source>The chosen erasure code profile name is already in use.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-      </trans-unit><trans-unit id="ef9ff0e6227947b48dfab4ac39ade04af758913b" datatype="html">
-        <source>Plugin</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit><trans-unit id="dd69b31bce8f630eac1d4762b0bbcf72ce19d193" datatype="html">
-        <source>Data chunks (k)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">75</context>
-        </context-group>
-      </trans-unit><trans-unit id="b0d26a6172d32cb81218fe2103c54a818cbc1189" datatype="html">
-        <source>Must be equal to or greater than 2.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">94</context>
-        </context-group>
-      </trans-unit><trans-unit id="dab3a299ead121169b8e08ed618c3b6a2f66691b" datatype="html">
-        <source>Coding chunks (m)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-      </trans-unit><trans-unit id="1e2773e5bd4948193f18f2361d663ecc3988c656" datatype="html">
-        <source>Must be equal to or greater than 1.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">120</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">142</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">168</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">261</context>
-        </context-group>
-      </trans-unit><trans-unit id="6cde4c945a49a260c0a47bcc7cd956846930a5f7" datatype="html">
-        <source>Durability estimator (c)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">129</context>
-        </context-group>
-      </trans-unit><trans-unit id="af668c2a095a979ea2b4e43cd82c2120ab56c21c" datatype="html">
-        <source>Locality (l)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">151</context>
-        </context-group>
-      </trans-unit><trans-unit id="d455a110bf6d2235e314e295ce1dfeee93d3dff2" datatype="html">
-        <source>Crush failure domain</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">175</context>
-        </context-group>
-      </trans-unit><trans-unit id="b74a495f041f7dd102eee5c0bbc9e03083b538ae" datatype="html">
-        <source>Crush Locality</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">199</context>
-        </context-group>
-      </trans-unit><trans-unit id="a2f14a73f7a6e94479f67423cc51102da8d6f524" datatype="html">
-        <source>None</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">213</context>
-        </context-group>
-      </trans-unit><trans-unit id="2981733b912b693a9dd9d915d6d34f4692cc874a" datatype="html">
-        <source>Technique</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">226</context>
-        </context-group>
-      </trans-unit><trans-unit id="e0098b6e47b04ec817361f384ce81d454ba5c0bb" datatype="html">
-        <source>Packetsize</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">248</context>
-        </context-group>
-      </trans-unit><trans-unit id="c0252cd81ca54d0a2f69ec9ccf4248e73df5aa4a" datatype="html">
-        <source>Crush root</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">269</context>
-        </context-group>
-      </trans-unit><trans-unit id="1548d5c76f0406ddd1ba3c557e1e6db22e95b340" datatype="html">
-        <source>Crush device class</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">286</context>
-        </context-group>
-      </trans-unit><trans-unit id="5e85feb6f9f0334366e46ee09ca6b8df52397432" datatype="html">
-        <source>any</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">296</context>
-        </context-group>
-      </trans-unit><trans-unit id="03d84645f6e019c5a43909bbf2ea1696ee88332c" datatype="html">
-        <source>Directory</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">308</context>
-        </context-group>
-      </trans-unit><trans-unit id="f6755cff4957d5c3c89bafce5651f1b6fa2b1fd9" datatype="html">
-        <source>Add</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">326</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">140</context>
-        </context-group>
-      </trans-unit><trans-unit id="f4e529ae5ffd73001d1ff4bbdeeb0a72e342e5c8" datatype="html">
-        <source>Close</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
-          <context context-type="linenumber">328</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">142</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">145</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html</context>
-          <context context-type="linenumber">48</context>
-        </context-group>
-      </trans-unit><trans-unit id="feb7520a18f7cda6389712427d0a6e4c38b76000" datatype="html">
-        <source><x id="ICU" equiv-text="{editing, select, 1 {...} other {...}}"/> pool</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">16</context>
-        </context-group>
-      </trans-unit><trans-unit id="ecef2f4d8d12929542a3b16f268dac8156f2ee14" datatype="html">
-        <source>{VAR_SELECT, select, 1 {Edit} other {Add} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">16</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">17</context>
-        </context-group>
-      </trans-unit><trans-unit id="2fecea01ce1d44114ee45144eff6d47a5016a74f" datatype="html">
-        <source>Name...</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">52</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">27</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
-          <context context-type="linenumber">28</context>
-        </context-group>
-      </trans-unit><trans-unit id="16e113230b6b0d3165e076300880542bac7c8138" datatype="html">
-        <source>The chosen Ceph pool name is already in use.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-      </trans-unit><trans-unit id="b85c657469e5ec8231c3de99b22f437bc01ffde5" datatype="html">
-        <source>Pool type</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">52</context>
-        </context-group>
-      </trans-unit><trans-unit id="526c5443254c3b126eedb264840ffe827727bfd3" datatype="html">
-        <source>-- Select a pool type --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">61</context>
-        </context-group>
-      </trans-unit><trans-unit id="0aa21053410a94aa61d16985a4e95fd65523430d" datatype="html">
-        <source>Placement groups</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">79</context>
-        </context-group>
-      </trans-unit><trans-unit id="6301f1391d726f8f450bb358058534db19541ca9" datatype="html">
-        <source>At least one placement group is needed!</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">97</context>
-        </context-group>
-      </trans-unit><trans-unit id="ba9469a1ce6ed36e039c1f67247c8c81a5c71449" datatype="html">
-        <source>Your cluster can&apos;t handle this many PGs. Please recalculate the PG amount needed.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">100</context>
-        </context-group>
-      </trans-unit><trans-unit id="62148abc31999dcfa38220cb09c33c8148b4b53a" datatype="html">
-        <source>You can only increase the number of PGs of an existing pool.
-                Currently your pool has <x id="INTERPOLATION" equiv-text="{{ data.pool.pg_num }}"/> PGs.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">103</context>
-        </context-group>
-      </trans-unit><trans-unit id="80ac68cd883369dac20688bc32b4cb33291b5e50" datatype="html">
-        <source>Calculation help</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">108</context>
-        </context-group>
-      </trans-unit><trans-unit id="37dd747f97e873d4280500da71b0076805f530a1" datatype="html">
-        <source>The current PGs settings were calculated for you, you
-                    should make sure the values suit your needs before submit.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">112</context>
-        </context-group>
-      </trans-unit><trans-unit id="33150f22ce5348aa6c499bd092c3f4f3695d62cc" datatype="html">
-        <source>Crush ruleset</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">123</context>
-        </context-group>
-      </trans-unit><trans-unit id="73a6b31116b3cc322af951daa0bafdc169e6c42e" datatype="html">
-        <source>-- Select a crush rule --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">131</context>
-        </context-group>
-      </trans-unit><trans-unit id="92da80699921e89fb19372e25b8d0f3b9fa427fc" datatype="html">
-        <source>Crush rule</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">152</context>
-        </context-group>
-      </trans-unit><trans-unit id="5489e9f96835f469f6f728a00d8efa88ea5bc940" datatype="html">
-        <source>Crush steps</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">158</context>
-        </context-group>
-      </trans-unit><trans-unit id="54a53b1b402aafff5b992ee9b64e409fbfe9074f" datatype="html">
-        <source>The rule can&apos;t be used in the current cluster as it has
-                to few OSDs to meet the minimum required OSD by this rule.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">169</context>
-        </context-group>
-      </trans-unit><trans-unit id="a43b2695131b48b76cebba676aba98a2bee17515" datatype="html">
-        <source>Replicated size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">180</context>
-        </context-group>
-      </trans-unit><trans-unit id="7bff144a4c4dc63b0e18fff2617d61a7ebdf2b6c" datatype="html">
-        <source>Minimum: <x id="INTERPOLATION" equiv-text="{{ getMinSize() }}"/></source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">194</context>
-        </context-group>
-      </trans-unit><trans-unit id="1a9c54b41f6d58a74e5d0aa3429ed0c87a482551" datatype="html">
-        <source>Maximum: <x id="INTERPOLATION" equiv-text="{{ getMaxSize() }}"/></source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">195</context>
-        </context-group>
-      </trans-unit><trans-unit id="43c6dd9233d6a8242cec2b025d25c273244d8d61" datatype="html">
-        <source>The size specified is out of range. A value from
-                    <x id="INTERPOLATION" equiv-text="{{ getMinSize() }}"/> to <x id="INTERPOLATION_1" equiv-text="{{ getMaxSize() }}"/> is valid.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">200</context>
-        </context-group>
-      </trans-unit><trans-unit id="9de7dde00e2139cc4bd03b1837afbe72ad15a1ff" datatype="html">
-        <source>Erasure code profile</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">210</context>
-        </context-group>
-      </trans-unit><trans-unit id="39b4620e6bd444e0a57a0a5c03fa8c96d7fe5235" datatype="html">
-        <source>-- No erasure code profile available --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">222</context>
-        </context-group>
-      </trans-unit><trans-unit id="498561757390d5528b263ce450d5f38efb00266d" datatype="html">
-        <source>-- Select an erasure code profile --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">225</context>
-        </context-group>
-      </trans-unit><trans-unit id="920617c6a1a4805e53bcb5af6a9c76f8387e89c6" datatype="html">
-        <source>Flags</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">271</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-details/configuration-details.component.html</context>
-          <context context-type="linenumber">57</context>
-        </context-group>
-      </trans-unit><trans-unit id="1c870fb00256b8a5b9cb9cd1a124e6390b9bc639" datatype="html">
-        <source>EC Overwrites</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">279</context>
-        </context-group>
-      </trans-unit><trans-unit id="f1abafaeb40ce52355ddcc24686e3cd17b64e08a" datatype="html">
-        <source>Applications</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">290</context>
-        </context-group>
-      </trans-unit><trans-unit id="2208d63d5940ce656006a220102b1eb2b5e553da" datatype="html">
-        <source>Compression</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">309</context>
-        </context-group>
-      </trans-unit><trans-unit id="37e10df2d9c0c25ef04ac112c9c9a7723e8efae0" datatype="html">
-        <source>Mode</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">315</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html</context>
-          <context context-type="linenumber">22</context>
-        </context-group>
-      </trans-unit><trans-unit id="6c6f25c47da62ec597c6057a36ddfc3209811ec5" datatype="html">
-        <source>Algorithm</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">334</context>
-        </context-group>
-      </trans-unit><trans-unit id="4903231d42089325a28892c0fde1aed46b733ae6" datatype="html">
-        <source>-- No erasure compression algorithm available --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">345</context>
-        </context-group>
-      </trans-unit><trans-unit id="5d68ddb254275f8f44221e9ad6d8ceeb59ca46a6" datatype="html">
-        <source>Minimum blob size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">359</context>
-        </context-group>
-      </trans-unit><trans-unit id="fb2f176df80647137cbb02bbeb29e5dec707a400" datatype="html">
-        <source>e.g., 128KiB</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">368</context>
-        </context-group>
-      </trans-unit><trans-unit id="1b7f6e53a4521c6eb3ced4c007fdd4cf80bb7707" datatype="html">
-        <source>Value should be greater than 0</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">373</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">398</context>
-        </context-group>
-      </trans-unit><trans-unit id="54be22af9625a595ee5d70917ee1fb116be7c4be" datatype="html">
-        <source>Value should be greater than the maximum blob size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">376</context>
-        </context-group>
-      </trans-unit><trans-unit id="151efb127a9a4dd25259a0b2055442318a141f5b" datatype="html">
-        <source>Maximum blob size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">385</context>
-        </context-group>
-      </trans-unit><trans-unit id="0c656f0e346bbadf46eb1a5d20d0307a3bd20ba8" datatype="html">
-        <source>e.g., 512KiB</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">393</context>
-        </context-group>
-      </trans-unit><trans-unit id="0a65a24eee8a026f3b1113fe9e157e9a0dd69486" datatype="html">
-        <source>Value should be greater than the minimum blob size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">401</context>
-        </context-group>
-      </trans-unit><trans-unit id="261ba09c4a59de83f48f52a23fd328da37e61ff4" datatype="html">
-        <source>Ratio</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">410</context>
-        </context-group>
-      </trans-unit><trans-unit id="c1430457a9c3c66366e51d76bf10396014c576be" datatype="html">
-        <source>Compression ratio</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">421</context>
-        </context-group>
-      </trans-unit><trans-unit id="ae5ce6de352cde949998fb10754459c3a4eb183b" datatype="html">
-        <source>Value should be between 0.0 and 1.0</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">424</context>
-        </context-group>
-      </trans-unit><trans-unit id="4b673e771a3f6b056837b22ef19a825386046095" datatype="html">
-        <source>It&apos;s not possible to create an RBD pool with &apos;/&apos; in the name.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">444</context>
-        </context-group>
-      </trans-unit><trans-unit id="a9c02674c6e4936562d1146e1ecf0c4240dfcf96" datatype="html">
-        <source>Please change the name or remove &apos;rbd&apos; from the applications list.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">446</context>
-        </context-group>
-      </trans-unit><trans-unit id="c6d3131ce5386154504dc91b5ad08855d85881d3" datatype="html">
-        <source><x id="ICU" equiv-text="{editing, select, 1 {...} other {...}}"/> pool</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">455</context>
-        </context-group>
-      </trans-unit><trans-unit id="e2b15aacc2f17a9c3276895eeeaadd342ab26555" datatype="html">
-        <source>{VAR_SELECT, select, 1 {Edit} other {Create} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
-          <context context-type="linenumber">455</context>
-        </context-group>
-      </trans-unit><trans-unit id="1d8a7c8aea58294a3c57c23af0468ddf0ba0c9c7" datatype="html">
-        <source>Pools List</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-list/pool-list.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-      </trans-unit><trans-unit id="9424badb7e0c6ac792d020d7830645b529a80aad" datatype="html">
-        <source>Please consult the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
-  on how to configure and enable the Object Gateway management functionality.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-501/rgw-501.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-      </trans-unit><trans-unit id="5f67f2247b9c6bbaf24a0f2d37f4ac0537c6fa53" datatype="html">
-        <source>Loading bucket data...</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-      </trans-unit><trans-unit id="8508c0ab851ad91fd0410da1266c02b0ef9d3ff9" datatype="html">
-        <source>The bucket data could not be loaded.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">5</context>
-        </context-group>
-      </trans-unit><trans-unit id="838abd335419fb1a7a6f14398ef17eee3e3fdeb6" datatype="html">
-        <source><x id="ICU" equiv-text="{editing, select, 1 {...} other {...}}"/> bucket</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">17</context>
-        </context-group>
-      </trans-unit><trans-unit id="2798cc1e152b1ec07fd8daf94a2a073d1ba1ebcc" datatype="html">
-        <source>Id</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">26</context>
-        </context-group>
-      </trans-unit><trans-unit id="db4e1a734518691b128ef40b939cc673f01d03a6" datatype="html">
-        <source>The value is not valid.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">61</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">452</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">545</context>
-        </context-group>
-      </trans-unit><trans-unit id="eabb4db920d9f9b2480cf438468b86e1bea02a9b" datatype="html">
-        <source>The chosen name is already in use.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">64</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-      </trans-unit><trans-unit id="0ee5132a8da30e0b7f9f5c70dbc91928d17dd909" datatype="html">
-        <source>Owner</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">73</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">18</context>
-        </context-group>
-      </trans-unit><trans-unit id="8e4c918357c7445fbf19a203e5f0f0ece1960b3b" datatype="html">
-        <source>-- Select a user --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">86</context>
-        </context-group>
-      </trans-unit><trans-unit id="315bfc460250cbfcf9b90beff732cf0770912990" datatype="html">
-        <source>{VAR_SELECT, select, 1 {Update} other {Add} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">80</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">142</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">593</context>
-        </context-group>
-      </trans-unit><trans-unit id="479488ab6e91ecb375484edc78bee3d13467f33f" datatype="html">
-        <source>Daemons List</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-      </trans-unit><trans-unit id="6bcc896f4c3dbf91cc00d8506409e6e22bccaacd" datatype="html">
-        <source>Capability</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-      </trans-unit><trans-unit id="f61c6867295f3b53d23557021f2f4e0aa1d0b8fc" datatype="html">
-        <source>Type</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">22</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-details/configuration-details.component.html</context>
-          <context context-type="linenumber">42</context>
-        </context-group>
-      </trans-unit><trans-unit id="1221ca97d19eaa9a7bc0c5243d5fc5befe1d2314" datatype="html">
-        <source>-- Select a type --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit><trans-unit id="d1b8990332af18f1c5159a6061ca889bcbb28432" datatype="html">
-        <source>Permission</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">56</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-      </trans-unit><trans-unit id="a08c589f82f69d892307288da14190ae1dd583d5" datatype="html">
-        <source>-- Select a permission --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
-          <context context-type="linenumber">64</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit><trans-unit id="583a219c524155c2314eb06ee29162bb315272a3" datatype="html">
-        <source>S3 key</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">123</context>
-        </context-group>
-      </trans-unit><trans-unit id="08c74dc9762957593b91f6eb5d65efdfc975bf48" datatype="html">
-        <source>Username</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">22</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">22</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html</context>
-          <context context-type="linenumber">19</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">24</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">19</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">9</context>
-        </context-group>
-      </trans-unit><trans-unit id="49c614babd1950adb2be75df4e2c9747286d6adc" datatype="html">
-        <source>-- Select a username --</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit><trans-unit id="c217ee914725a37e9dd2336c721c8e63e9666bdc" datatype="html">
-        <source>Auto-generate key</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">60</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">133</context>
-        </context-group>
-      </trans-unit><trans-unit id="2f1c1c0f2bce4c9f92d1a2061e8161cb0006c31a" datatype="html">
-        <source>Access key</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">144</context>
-        </context-group>
-      </trans-unit><trans-unit id="b864acb67296a9819c1db0069c4c47d8b5ce8f44" datatype="html">
-        <source>Secret key</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
-          <context context-type="linenumber">106</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">110</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">176</context>
-        </context-group>
-      </trans-unit><trans-unit id="b2841767821d6b66238c34d07e413b0af67aee92" datatype="html">
-        <source>Subuser</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-      </trans-unit><trans-unit id="bd59fc25a7bd98cff3e75117c09697c8a007a514" datatype="html">
-        <source>The chosen subuser ID is already in use.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">54</context>
-        </context-group>
-      </trans-unit><trans-unit id="3d386c357ebcbc04ed05c4babd5a03626f9b1674" datatype="html">
-        <source>read, write</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">77</context>
-        </context-group>
-      </trans-unit><trans-unit id="84e3e3f9a4f31a039b648c97debf95fcb20f4c4a" datatype="html">
-        <source>full</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">79</context>
-        </context-group>
-      </trans-unit><trans-unit id="b6bf81d032a2316464f9df2f0d2f3d753f89f0d3" datatype="html">
-        <source>Swift key</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">89</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html</context>
-          <context context-type="linenumber">3</context>
-        </context-group>
-      </trans-unit><trans-unit id="1e0c12685d50d47448ceed9423977ef39775c037" datatype="html">
-        <source>Auto-generate secret</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
-          <context context-type="linenumber">99</context>
-        </context-group>
-      </trans-unit><trans-unit id="3d1c7a6004bd5d86a7fa096ae24209e8aa7a53e3" datatype="html">
-        <source>Loading user data...</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-      </trans-unit><trans-unit id="faa5d834ab28571423d794d32b57998920efb65f" datatype="html">
-        <source>The user data could not be loaded.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">5</context>
-        </context-group>
-      </trans-unit><trans-unit id="6aaf5d2a304167272ac73e3b1d1c162e16c77858" datatype="html">
-        <source>The chosen user ID is already in use.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit><trans-unit id="b760f123248930122fc7e7b6b6bf94e376e959c8" datatype="html">
-        <source>Full name</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">50</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">98</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">14</context>
-        </context-group>
-      </trans-unit><trans-unit id="69b6ac577a19acc39fc0c22342092f327fff2529" datatype="html">
-        <source>Email address</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">19</context>
-        </context-group>
-      </trans-unit><trans-unit id="df441e80db2157f9d272b75de724ba4a82b96b57" datatype="html">
-        <source>This is not a valid email address.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">79</context>
-        </context-group>
-      </trans-unit><trans-unit id="ca271adf154956b8fcb28f4f50a37acb3057ff7c" datatype="html">
-        <source>The chosen email address is already in use.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">82</context>
-        </context-group>
-      </trans-unit><trans-unit id="030197cebe938edf35422e92fe14183d06eb670b" datatype="html">
-        <source>Max. buckets</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">91</context>
-        </context-group>
-      </trans-unit><trans-unit id="623ac50f37a26caec6fd7cd519b653e3315cba25" datatype="html">
-        <source>The entered value must be &gt;= 0.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">104</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">489</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">582</context>
-        </context-group>
-      </trans-unit><trans-unit id="92f3f203270a29b3001871153f02c063484a1574" datatype="html">
-        <source>Suspended</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">116</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">24</context>
-        </context-group>
-      </trans-unit><trans-unit id="2c4c62e8ba24601be5cfe7dc5d32c24bbbd4b53c" datatype="html">
-        <source>Subusers</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">205</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">39</context>
-        </context-group>
-      </trans-unit><trans-unit id="128d6efb51d9ddc7c0cc695a2deeca5b9523f6e4" datatype="html">
-        <source>There are no subusers.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">211</context>
-        </context-group>
-      </trans-unit><trans-unit id="826b25211922a1b46436589233cb6f1a163d89b7" datatype="html">
-        <source>Delete</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">242</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">296</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">381</context>
-        </context-group>
-      </trans-unit><trans-unit id="1c9f46392d9b25bfb9afe74c87ddfe94f44c0b60" datatype="html">
-        <source>Add subuser</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">256</context>
-        </context-group>
-      </trans-unit><trans-unit id="0bcd5ef19af0f1b814141ca8c57df623d8270088" datatype="html">
-        <source>Keys</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">264</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">133</context>
-        </context-group>
-      </trans-unit><trans-unit id="67c746c1ba9dab4351fedc4c7cba4e6d6b0dbc47" datatype="html">
-        <source>S3</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">268</context>
-        </context-group>
-      </trans-unit><trans-unit id="d6819038d608623503918fb2553f53d68231ec3a" datatype="html">
-        <source>There are no keys.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">273</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">323</context>
-        </context-group>
-      </trans-unit><trans-unit id="2aba1e87039819aca3b70faa9aa848c12bf139ca" datatype="html">
-        <source>Show</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">289</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">339</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">148</context>
-        </context-group>
-      </trans-unit><trans-unit id="a5193a8d59cd045c18ef9521f486a091dad1f513" datatype="html">
-        <source>Add S3 key</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">310</context>
-        </context-group>
-      </trans-unit><trans-unit id="6ddb5e991a3ecd2659fb520bc5acc81b67e08ddd" datatype="html">
-        <source>Swift</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">318</context>
-        </context-group>
-      </trans-unit><trans-unit id="17bb3082e6fe5003203ef992a3714172334631a1" datatype="html">
-        <source>Capabilities</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">352</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">48</context>
-        </context-group>
-      </trans-unit><trans-unit id="1d01eccdda47fc907c5be35bcb16d2dcd02b0270" datatype="html">
-        <source>There are no capabilities.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">358</context>
-        </context-group>
-      </trans-unit><trans-unit id="60a495bec6eae04c9b7570956a6673069e8e47d6" datatype="html">
-        <source>Add capability</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">395</context>
-        </context-group>
-      </trans-unit><trans-unit id="36ad38f9c1a1485e09b67778a28af84553290ffb" datatype="html">
-        <source>User quota</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">403</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">60</context>
-        </context-group>
-      </trans-unit><trans-unit id="f50a33d3c339f8f4a465141f8caa5d2d8c005251" datatype="html">
-        <source>Enabled</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">413</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">506</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">65</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">101</context>
-        </context-group>
-      </trans-unit><trans-unit id="6146e13ceca5fa5cc17b771b282fe5955f3d19fa" datatype="html">
-        <source>Unlimited size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">427</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">520</context>
-        </context-group>
-      </trans-unit><trans-unit id="f6db8aa7c99fdce18edb33dde57729acede2b308" datatype="html">
-        <source>Max. size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">438</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">531</context>
-        </context-group>
-      </trans-unit><trans-unit id="fc630b2093e880fffa19df99d5cd8b87605037f8" datatype="html">
-        <source>Unlimited objects</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">465</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">558</context>
-        </context-group>
-      </trans-unit><trans-unit id="6cda5a993d06f0bb10048be9d3aba6555aa9f356" datatype="html">
-        <source>Max. objects</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">476</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">569</context>
-        </context-group>
-      </trans-unit><trans-unit id="649a410bd0ace333d067d8fa22f12bdbdb43533b" datatype="html">
-        <source>Bucket quota</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
-          <context context-type="linenumber">496</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">66</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
       </trans-unit><trans-unit id="449dca3d3a93ead418b0541ea81b0dda7e6483c2" datatype="html">
         <source>Welcome to Ceph!</source>
         <context-group purpose="location">
@@ -3169,50 +1643,6 @@
           <context context-type="sourcefile">app/core/auth/login/login.component.html</context>
           <context context-type="linenumber">64</context>
         </context-group>
-      </trans-unit><trans-unit id="d96493d07439fc50485a66b7469451d30fc8ad25" datatype="html">
-        <source><x id="ICU" equiv-text="{mode, select, editing {...} other {...}}"/> Role</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">10</context>
-        </context-group>
-      </trans-unit><trans-unit id="72d6ccefaf8e300c9bc29d5e9757aaf79cd3f7eb" datatype="html">
-        <source>{VAR_SELECT, select, editing {Edit} other {Add} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">10</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">10</context>
-        </context-group>
-      </trans-unit><trans-unit id="1ea5c4d8942c00752dcc72e72949c5d9832f6399" datatype="html">
-        <source>Description...</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-      </trans-unit><trans-unit id="70f45880fce6ac5d8e468e25e82aefbba8098cfe" datatype="html">
-        <source>Permissions</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">61</context>
-        </context-group>
-      </trans-unit><trans-unit id="95af469f00ed2c20403755ad45e9f00439027617" datatype="html">
-        <source><x id="ICU" equiv-text="{mode, select, editing {...} other {...}}"/> Role</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">81</context>
-        </context-group>
-      </trans-unit><trans-unit id="b46ed6a153fed3fcba2f1296155fc4bfb1b3b166" datatype="html">
-        <source>{VAR_SELECT, select, editing {Update} other {Create} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
-          <context context-type="linenumber">81</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">147</context>
-        </context-group>
       </trans-unit><trans-unit id="58fc1b5c79a75370eb52644fd83fb2e7096b6649" datatype="html">
         <source>Sorry, the user does not exist in Ceph.</source>
         <context-group purpose="location">
@@ -3224,70 +1654,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/core/auth/sso/sso-not-found/sso-not-found.component.html</context>
           <context context-type="linenumber">4</context>
-        </context-group>
-      </trans-unit><trans-unit id="e83cda1d2f391695610a1c572332e5f81499dd83" datatype="html">
-        <source><x id="ICU" equiv-text="{mode, select, editing {...} other {...}}"/> User</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">10</context>
-        </context-group>
-      </trans-unit><trans-unit id="7f3bdcce4b2e8c37cd7f0f6c92ef8cff34b039b8" datatype="html">
-        <source>Confirm password</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">69</context>
-        </context-group>
-      </trans-unit><trans-unit id="cbb979e63ba50e0ca3adfa09cbdcaefd0853fca1" datatype="html">
-        <source>Password confirmation doesn&apos;t match the password.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">90</context>
-        </context-group>
-      </trans-unit><trans-unit id="244aae9346da82b0922506c2d2581373a15641cc" datatype="html">
-        <source>Email</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">114</context>
-        </context-group>
-      </trans-unit><trans-unit id="d0ec081dd61eb4f43aea269077bbe38eae87b7f9" datatype="html">
-        <source>Invalid email.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">125</context>
-        </context-group>
-      </trans-unit><trans-unit id="9610487cbeb5796d34d8601b5ac0c0a65f9e1d19" datatype="html">
-        <source>Roles</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">131</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-tabs/user-tabs.component.html</context>
-          <context context-type="linenumber">7</context>
-        </context-group>
-      </trans-unit><trans-unit id="9c4773dff91deccdacd78a4cd578f8f5f7fa229b" datatype="html">
-        <source><x id="ICU" equiv-text="{mode, select, editing {...} other {...}}"/> User</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">147</context>
-        </context-group>
-      </trans-unit><trans-unit id="0051a3479d3ba79135c16dc8cc017950a2cce821" datatype="html">
-        <source>You are about to remove &quot;user read / update&quot; permissions from your own user.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">156</context>
-        </context-group>
-      </trans-unit><trans-unit id="af4bf9fcb256853f14cf947eb1deb8d7f176d3f9" datatype="html">
-        <source>If you continue, you will no longer be able to add or remove roles from any user.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">158</context>
-        </context-group>
-      </trans-unit><trans-unit id="7d1dcf2a9146caac0581329acf94806ec69a89a5" datatype="html">
-        <source>Are you sure you want to continue?</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
-          <context context-type="linenumber">160</context>
         </context-group>
       </trans-unit><trans-unit id="471e78026c258073ba687478dc54c35d9041ea42" datatype="html">
         <source>Forbidden</source>
@@ -3406,191 +1772,257 @@
           <context context-type="sourcefile">app/core/navigation/identity/identity.component.html</context>
           <context context-type="linenumber">27</context>
         </context-group>
-      </trans-unit><trans-unit id="eeba399c4dae8d4890c27b7a2cd2dc28fcf8b5f9" datatype="html">
-        <source>Performance Counters</source>
+      </trans-unit><trans-unit id="formTitle" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ action | titlecase }}"/> <x id="INTERPOLATION_1" equiv-text="{{ resource | upperFirst }}"/></source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html</context>
-          <context context-type="linenumber">9</context>
-        </context-group>
-      </trans-unit><trans-unit id="fbbaf5cb02ed419e79a27072478f716a4666a99d" datatype="html">
-        <source>Performance Details</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
+          <context context-type="linenumber">10</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/osd/osd-details/osd-details.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">10</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cluster/hosts/host-details/host-details.component.html</context>
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/pool/pool-details/pool-details.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">16</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">17</context>
         </context-group>
-      </trans-unit><trans-unit id="45cc8ca94b5a50842a9a8ef804a5ab089a38ae5c" datatype="html">
-        <source>ID</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">3</context>
         </context-group>
-      </trans-unit><trans-unit id="e5c51963a9c553b29427ef783bbb69fa6634fa8c" datatype="html">
-        <source>Index type</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html</context>
+          <context context-type="linenumber">3</context>
         </context-group>
-      </trans-unit><trans-unit id="8e6f950a32eaea32ec7e192f9ca3d3dfe469d4ba" datatype="html">
-        <source>Placement rule</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Example: Create Pool</note>
+        <note priority="1" from="meaning">form title</note>
+      </trans-unit><trans-unit id="2fecea01ce1d44114ee45144eff6d47a5016a74f" datatype="html">
+        <source>Name...</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
           <context context-type="linenumber">28</context>
         </context-group>
-      </trans-unit><trans-unit id="6972d213e31c4ea4f887e60db99d9881bc8fcd3e" datatype="html">
-        <source>Marker</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
           <context context-type="linenumber">33</context>
         </context-group>
-      </trans-unit><trans-unit id="47b02acd2d3254d1ace1926f840523f154ebef71" datatype="html">
-        <source>Maximum marker</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">52</context>
         </context-group>
-      </trans-unit><trans-unit id="8fe73a4787b8068b2ba61f54ab7e0f9af2ea1fc9" datatype="html">
-        <source>Version</source>
+      </trans-unit><trans-unit id="eabb4db920d9f9b2480cf438468b86e1bea02a9b" datatype="html">
+        <source>The chosen name is already in use.</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-      </trans-unit><trans-unit id="092fa3a7df9168b14d3f83a77a4035e92b92ce15" datatype="html">
-        <source>Master version</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">48</context>
-        </context-group>
-      </trans-unit><trans-unit id="97434cc5001d407f90c7447a12d9e8e6848a2aa3" datatype="html">
-        <source>Modification time</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">53</context>
-        </context-group>
-      </trans-unit><trans-unit id="90fe2e41e7fde38453ce4e619efeea9bc6adea9c" datatype="html">
-        <source>Zonegroup</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">58</context>
-        </context-group>
-      </trans-unit><trans-unit id="cef1595d040e77cbb4466e60382028d4c2040cac" datatype="html">
-        <source>Maximum size</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">70</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">64</context>
         </context-group>
+      </trans-unit><trans-unit id="1ea5c4d8942c00752dcc72e72949c5d9832f6399" datatype="html">
+        <source>Description...</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
-      </trans-unit><trans-unit id="aa6fb95c355f172bda303de1ce2f38c251a149cf" datatype="html">
-        <source>Unlimited</source>
+      </trans-unit><trans-unit id="70f45880fce6ac5d8e468e25e82aefbba8098cfe" datatype="html">
+        <source>Permissions</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
+          <context context-type="linenumber">61</context>
         </context-group>
+      </trans-unit><trans-unit id="formActionButton" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ action | titlecase }}"/> <x id="INTERPOLATION_1" equiv-text="{{ resource | upperFirst }}"/></source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">90</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">73</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">84</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">109</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">120</context>
-        </context-group>
-      </trans-unit><trans-unit id="ee862a800364b4d11f9b8cb9955a28a60f840a45" datatype="html">
-        <source>Maximum objects</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
-          <context context-type="linenumber">87</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="sourcefile">app/core/auth/role-form/role-form.component.html</context>
           <context context-type="linenumber">81</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">117</context>
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">149</context>
         </context-group>
-      </trans-unit><trans-unit id="8011e20c5bbe51602d459a860fbf29b599b55edd" datatype="html">
-        <source>System</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">311</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">563</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">327</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">455</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">143</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">595</context>
+        </context-group>
+        <note priority="1" from="description">Example: Create Pool</note>
+        <note priority="1" from="meaning">form action button</note>
+      </trans-unit><trans-unit id="9610487cbeb5796d34d8601b5ac0c0a65f9e1d19" datatype="html">
+        <source>Roles</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-tabs/user-tabs.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">132</context>
+        </context-group>
+      </trans-unit><trans-unit id="08c74dc9762957593b91f6eb5d65efdfc975bf48" datatype="html">
+        <source>Username</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">9</context>
         </context-group>
-      </trans-unit><trans-unit id="db18a2772988415466a7f75dc42663ce78c9c1d3" datatype="html">
-        <source>Maximum buckets</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit><trans-unit id="c32ef07f8803a223a83ed17024b38e8d82292407" datatype="html">
+        <source>Password</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">267</context>
+        </context-group>
+      </trans-unit><trans-unit id="7f3bdcce4b2e8c37cd7f0f6c92ef8cff34b039b8" datatype="html">
+        <source>Confirm password</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit><trans-unit id="cbb979e63ba50e0ca3adfa09cbdcaefd0853fca1" datatype="html">
+        <source>Password confirmation doesn&apos;t match the password.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+      </trans-unit><trans-unit id="b760f123248930122fc7e7b6b6bf94e376e959c8" datatype="html">
+        <source>Full name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+      </trans-unit><trans-unit id="244aae9346da82b0922506c2d2581373a15641cc" datatype="html">
+        <source>Email</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+      </trans-unit><trans-unit id="d0ec081dd61eb4f43aea269077bbe38eae87b7f9" datatype="html">
+        <source>Invalid email.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">126</context>
+        </context-group>
+      </trans-unit><trans-unit id="0051a3479d3ba79135c16dc8cc017950a2cce821" datatype="html">
+        <source>You are about to remove &quot;user read / update&quot; permissions from your own user.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">158</context>
+        </context-group>
+      </trans-unit><trans-unit id="af4bf9fcb256853f14cf947eb1deb8d7f176d3f9" datatype="html">
+        <source>If you continue, you will no longer be able to add or remove roles from any user.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">160</context>
+        </context-group>
+      </trans-unit><trans-unit id="7d1dcf2a9146caac0581329acf94806ec69a89a5" datatype="html">
+        <source>Are you sure you want to continue?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
+          <context context-type="linenumber">162</context>
         </context-group>
       </trans-unit><trans-unit id="ca53d681a9892d6fdbb57ee9676582186515e961" datatype="html">
         <source>Performance counters not available</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html</context>
           <context context-type="linenumber">12</context>
-        </context-group>
-      </trans-unit><trans-unit id="a949d7e577902d0e5dc5d0971bb0170a21be7728" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ value | titlecase }}"/></source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.html</context>
-          <context context-type="linenumber">13</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.html</context>
-          <context context-type="linenumber">14</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.html</context>
-          <context context-type="linenumber">15</context>
-        </context-group>
-      </trans-unit><trans-unit id="ff92fbdec9fdd5054493eeda0d7ee8b450f83e72" datatype="html">
-        <source>RBD Configuration</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.html</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-      </trans-unit><trans-unit id="b62d9efc8eb3b589904f6cb96a0406bbda55673a" datatype="html">
-        <source>Remove the local configuration value. The parent configuration value will be inherited and used instead.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.html</context>
-          <context context-type="linenumber">60</context>
-        </context-group>
-      </trans-unit><trans-unit id="963488a1010d46067b238c4ae917fab3907c0a3a" datatype="html">
-        <source>The mininum value is 0</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.html</context>
-          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit><trans-unit id="91853167141c37b58868f3b0421383dd72fa8a01" datatype="html">
         <source>Attributes (OSD map)</source>
@@ -3640,11 +2072,43 @@
           <context context-type="sourcefile">app/ceph/cluster/osd/osd-details/osd-details.component.html</context>
           <context context-type="linenumber">25</context>
         </context-group>
+      </trans-unit><trans-unit id="fbbaf5cb02ed419e79a27072478f716a4666a99d" datatype="html">
+        <source>Performance Details</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/osd/osd-details/osd-details.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/hosts/host-details/host-details.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-details/pool-details.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
       </trans-unit><trans-unit id="26fb5f81b3581f06b9210defb0e71dc69a67e819" datatype="html">
         <source>Current values</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-details/configuration-details.component.html</context>
           <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit><trans-unit id="f61c6867295f3b53d23557021f2f4e0aa1d0b8fc" datatype="html">
+        <source>Type</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-details/configuration-details.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
+          <context context-type="linenumber">22</context>
         </context-group>
       </trans-unit><trans-unit id="9abcd7c82643d60c22733470463f74e4a54bc069" datatype="html">
         <source>Min</source>
@@ -3657,6 +2121,16 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-details/configuration-details.component.html</context>
           <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit><trans-unit id="920617c6a1a4805e53bcb5af6a9c76f8387e89c6" datatype="html">
+        <source>Flags</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cluster/configuration/configuration-details/configuration-details.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">270</context>
         </context-group>
       </trans-unit><trans-unit id="6834fa6b43d1ecbdf147c48dd9c4d72f1484571d" datatype="html">
         <source>Source</source>
@@ -3800,6 +2274,18 @@
           <context context-type="sourcefile">app/ceph/dashboard/health/health.component.html</context>
           <context context-type="linenumber">265</context>
         </context-group>
+      </trans-unit><trans-unit id="0c1e17956453ad772dbe82d6946f62748c692f3e" datatype="html">
+        <source>Ranks</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit><trans-unit id="95c96d55690c0c685deebe52a1da94dc36f5e99d" datatype="html">
+        <source>Clients: <x id="INTERPOLATION" equiv-text="{{ clientCount }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
       </trans-unit><trans-unit id="f0b5d789d42c0e69348e5fe0037fcbf5b5fbbdcc" datatype="html">
         <source>Move an image to trash</source>
         <context-group purpose="location">
@@ -3855,6 +2341,92 @@
           <context context-type="sourcefile">app/ceph/block/iscsi-tabs/iscsi-tabs.component.html</context>
           <context context-type="linenumber">7</context>
         </context-group>
+      </trans-unit><trans-unit id="6803e31b7395d94934e091a49a9524026b59b018" datatype="html">
+        <source>Discovery Authentication</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit><trans-unit id="e08a77594f3d89311cdf6da5090044270909c194" datatype="html">
+        <source>User</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">245</context>
+        </context-group>
+      </trans-unit><trans-unit id="0214f773f8e394f50f953f39962e352d7863e959" datatype="html">
+        <source>Usernames must have a length of 8 to 64 characters and
+              can only contain letters, &apos;.&apos;, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;:&apos;.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+      </trans-unit><trans-unit id="6682d1c00263bee204583a5d589b308b6be88b0f" datatype="html">
+        <source>Passwords must have a length of 12 to 16 characters
+              and can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit><trans-unit id="ff40391de7a1944ea95091e4045cc34c4979b736" datatype="html">
+        <source>Mutual User</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">303</context>
+        </context-group>
+      </trans-unit><trans-unit id="0cf73dbebe99b737c4d288788182fc356e3c93d3" datatype="html">
+        <source>Mutual Password</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">327</context>
+        </context-group>
+      </trans-unit><trans-unit id="8800276925157c666b103c36ff7fe8ffe11980b4" datatype="html">
+        <source>Passwords must have a length of 12 to 16 characters and
+              can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
+          <context context-type="linenumber">123</context>
+        </context-group>
+      </trans-unit><trans-unit id="53a583cd5f15059cc958b7d547f72cc78f68e123" datatype="html">
+        <source>Please consult the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+    on how to configure and enable the iSCSI Targets management functionality.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-list/iscsi-target-list.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit><trans-unit id="3b301d0044f62c92af0da53d7aaca52a436a547d" datatype="html">
+        <source>Available information:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-list/iscsi-target-list.component.html</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit><trans-unit id="332227f088a4877b3c11f5fb3ae8bc812c470fae" datatype="html">
+        <source>iSCSI Targets not available</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-list/iscsi-target-list.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit><trans-unit id="8f4c079a38df7c3b64a4dfe8daa4d02aeffefbfa" datatype="html">
+        <source>Set discovery authentication</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-list/iscsi-target-list.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
       </trans-unit><trans-unit id="0f6e8f6094b180eaf1f11bc0ffe383f1cdcd059e" datatype="html">
         <source>Only available for RBD images with <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>fast-diff<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> enabled</source>
         <context-group purpose="location">
@@ -3878,6 +2450,36 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/rbd-details/rbd-details.component.html</context>
           <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit><trans-unit id="7faaaa08f56427999f3be41df1093ce4089bbd75" datatype="html">
+        <source>Size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-details/rbd-details.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">163</context>
+        </context-group>
+      </trans-unit><trans-unit id="ceac8e132384322ec778ba760875a6c6897d3e42" datatype="html">
+        <source>Object size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-details/rbd-details.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">229</context>
+        </context-group>
+      </trans-unit><trans-unit id="6cdb1fea93d77c07950c0c76c6e0ad79ebbef084" datatype="html">
+        <source>Features</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-details/rbd-details.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit><trans-unit id="0a65771c9a73b9aa609d592fc96a64801a8f40bd" datatype="html">
         <source>Provisioned</source>
@@ -3961,6 +2563,120 @@
           <context context-type="sourcefile">app/ceph/block/rbd-details/rbd-details.component.html</context>
           <context context-type="linenumber">137</context>
         </context-group>
+      </trans-unit><trans-unit id="6547c9c4d5f62942ac4b1fe459cf9a03d4dbf5a0" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ action | titlecase }}"/> from</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit><trans-unit id="0e9ecf29a4fa5b057bd8052e0d801b3fde6a30bf" datatype="html">
+        <source>&apos;/&apos; and &apos;@&apos; are not allowed.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit><trans-unit id="b99417c4dd46286ffd37c8d2e987c8b512ec7052" datatype="html">
+        <source>-- No rbd pools available --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
+      </trans-unit><trans-unit id="ef83ec9c304a89d45650e580dcdc2978c37b3a83" datatype="html">
+        <source>-- Select a pool --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+      </trans-unit><trans-unit id="49449943d8cbf59d8c401c8bd2e76f92e207cc5f" datatype="html">
+        <source>Use a dedicated data pool</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">108</context>
+        </context-group>
+      </trans-unit><trans-unit id="870aee0dd31a9643bf62007beb8f1ae1deb34d42" datatype="html">
+        <source>Data pool</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+      </trans-unit><trans-unit id="3792ca829d9b9f687e1f5d7733d30e9bb0bfec47" datatype="html">
+        <source>Dedicated pool that stores the object-data of the RBD.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">123</context>
+        </context-group>
+      </trans-unit><trans-unit id="f0016bd458baa88284a658ce9eeda42d8ad88d2c" datatype="html">
+        <source>e.g., 10GiB</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">173</context>
+        </context-group>
+      </trans-unit><trans-unit id="0a88bbee20570aaf9615332fb27020627044874d" datatype="html">
+        <source>You have to increase the size.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">181</context>
+        </context-group>
+      </trans-unit><trans-unit id="1cfe07dac5b4ee1c464eb24225ddeb4f1d24076a" datatype="html">
+        <source>Advanced...</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">213</context>
+        </context-group>
+      </trans-unit><trans-unit id="bc2e854e111ecf2bd7db170da5e3c2ed08181d88" datatype="html">
+        <source>Advanced</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">219</context>
+        </context-group>
+      </trans-unit><trans-unit id="3562a3778695a5f9c0445660e35301f0a39aaf73" datatype="html">
+        <source>Striping</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">222</context>
+        </context-group>
+      </trans-unit><trans-unit id="ef3c3f3b5f562a5cdbe0ee2874287db1534b5958" datatype="html">
+        <source>Stripe unit</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">246</context>
+        </context-group>
+      </trans-unit><trans-unit id="84471be1049006edecbcaef1a32ae0893c229c50" datatype="html">
+        <source>-- Select stripe unit --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">257</context>
+        </context-group>
+      </trans-unit><trans-unit id="8d32c5c54c8581c774a7f467fbd4e329b15a74fa" datatype="html">
+        <source>This field is required because stripe count is defined!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">263</context>
+        </context-group>
+      </trans-unit><trans-unit id="6bbf9040be7c5491d4a03f2185708f43a6582a3b" datatype="html">
+        <source>Stripe unit is greater than object size.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">266</context>
+        </context-group>
+      </trans-unit><trans-unit id="a682f49f9b761591661276d7c6f550e641a130a4" datatype="html">
+        <source>Stripe count</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">275</context>
+        </context-group>
+      </trans-unit><trans-unit id="baa74031990c5370008ba622d0a250f0929097f4" datatype="html">
+        <source>This field is required because stripe unit is defined!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">288</context>
+        </context-group>
+      </trans-unit><trans-unit id="cd2ada6d5ecbd5cbf89eae0a1f5326efedac0dbc" datatype="html">
+        <source>Stripe count must be greater than 0.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-form/rbd-form.component.html</context>
+          <context context-type="linenumber">291</context>
+        </context-group>
       </trans-unit><trans-unit id="3f67f30568e9ae47507d46e28e1e82a7dca772e2" datatype="html">
         <source><x id="ICU" equiv-text="{ editing, select, true {...} other {...}}"/> RBD Snapshot</source>
         <context-group purpose="location">
@@ -3982,6 +2698,12 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html</context>
           <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit><trans-unit id="f4e529ae5ffd73001d1ff4bbdeeb0a72e342e5c8" datatype="html">
+        <source>Close</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html</context>
+          <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit><trans-unit id="cb60c1cd3655234756b5b92d4d597d92d520ee30" datatype="html">
         <source>PROTECTED</source>
@@ -4093,11 +2815,280 @@
           <context context-type="sourcefile">app/ceph/block/rbd-trash-list/rbd-trash-list.component.html</context>
           <context context-type="linenumber">47</context>
         </context-group>
+      </trans-unit><trans-unit id="aba82bfd8e177d35b76cad7cd43941f8e5e5acac" datatype="html">
+        <source>Trash</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-images/rbd-images.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
       </trans-unit><trans-unit id="a674ab267d1934bf395f87ca1503fd474296893f" datatype="html">
         <source>iSCSI Topology</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/iscsi-target-details/iscsi-target-details.component.html</context>
           <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit><trans-unit id="121cc5391cd2a5115bc2b3160379ee5b36cd7716" datatype="html">
+        <source>Settings</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit><trans-unit id="9e515f954730279c31d5301f02479666d6264e8b" datatype="html">
+        <source>Changing these parameters from their default values is usually not necessary.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit><trans-unit id="69a47cbabcc51ca942606e1d8da0ec11f98a2690" datatype="html">
+        <source>Backstore</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit><trans-unit id="68e710782ccb5398b3acb8844caf0b199da2c3da" datatype="html">
+        <source>Confirm</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit><trans-unit id="339878da255ab55447c43afef8d9b2f9753bf5f6" datatype="html">
+        <source>Advanced Settings</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit><trans-unit id="1406c2fb12a20c1528b19bcc5e24a6a2386167f3" datatype="html">
+        <source>Target IQN</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit><trans-unit id="5fe42339be910372fa689f559155631862d218e8" datatype="html">
+        <source>IQN has wrong pattern.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">235</context>
+        </context-group>
+      </trans-unit><trans-unit id="47d1bfe4f5b3f292e1202dfe691195b10cb99500" datatype="html">
+        <source>An IQN has the following notation &apos;iqn.$year-$month.$reversedAddress:$definedName&apos;</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+      </trans-unit><trans-unit id="c8ada4b53396d8366db00a435acc61d53d857047" datatype="html">
+        <source>For example: iqn.2016-06.org.dashboard:storage:disk.sn-a8675309</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit><trans-unit id="e60c11e1b1dfbbeda577364b8de39ded2d796c5e" datatype="html">
+        <source>More information</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit><trans-unit id="9b1aa85dfc6849196e64060db02c5410de69b7a1" datatype="html">
+        <source>This target has modified advanced settings.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit><trans-unit id="6990ad8d6182662e864495ac31c3758cda1c7a28" datatype="html">
+        <source>Portals</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+      </trans-unit><trans-unit id="c3638c01b6c34066438909713ec96087c813fc7e" datatype="html">
+        <source>At least <x id="INTERPOLATION" equiv-text="{{ minimum_gateways }}"/> gateways are required.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+      </trans-unit><trans-unit id="6a3ac2b4137d723fd9878cd357c2012ff6c07973" datatype="html">
+        <source>Add portal</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit><trans-unit id="6c1c7f516d021abaf155aab1e9c2fe96e2c4ff40" datatype="html">
+        <source>Backstore: <x id="INTERPOLATION" equiv-text="{{ imagesSettings[image].backstore }}"/>. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">147</context>
+        </context-group>
+      </trans-unit><trans-unit id="e3484cae8b118c576ca2815bf9c9406c2eb2cae3" datatype="html">
+        <source>This image has modified settings.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+      </trans-unit><trans-unit id="107c84e820909b44fe258673938a68ced1bbff72" datatype="html">
+        <source>At least 1 image is required.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">156</context>
+        </context-group>
+      </trans-unit><trans-unit id="808038f912fdc7f0e03f82d4afd3bf9178527fc8" datatype="html">
+        <source>Add image</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">393</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">529</context>
+        </context-group>
+      </trans-unit><trans-unit id="66c5fb27f52e75b70ca4b670b9b15a2a51cf9543" datatype="html">
+        <source>ACL authentication</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">184</context>
+        </context-group>
+      </trans-unit><trans-unit id="f494bd31f095f6dcc656ce87ec2dcf07a2e9b30c" datatype="html">
+        <source>Initiators</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">196</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">460</context>
+        </context-group>
+      </trans-unit><trans-unit id="e98239d8a6be1100119ff4b5630c822b82786740" datatype="html">
+        <source>Initiator</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">203</context>
+        </context-group>
+      </trans-unit><trans-unit id="f2c5059d8cda15d8d03e2cce30f2d139623d9a91" datatype="html">
+        <source>Client IQN</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">216</context>
+        </context-group>
+      </trans-unit><trans-unit id="107d5aabce23d900f0a80e6ddc1c10e29aa0bed8" datatype="html">
+        <source>Initiator IQN needs to be unique.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">227</context>
+        </context-group>
+      </trans-unit><trans-unit id="bbf0b34a3fcc80800fcb44b9e1e86931a530dfe3" datatype="html">
+        <source>Usernames must have a length of 8 to 64 characters and
+                        can only contain letters, &apos;.&apos;, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;:&apos;.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">257</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">317</context>
+        </context-group>
+      </trans-unit><trans-unit id="fdfee5d7a27e1bdd97a176097277bee078de6aaf" datatype="html">
+        <source>Passwords must have a length of 12 to 16 characters
+                        and can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">292</context>
+        </context-group>
+      </trans-unit><trans-unit id="8406eb7415ee40e54d9ecb209abb056f06e3d666" datatype="html">
+        <source>Passwords must have a length of 12 to 16 characters and
+                        can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">352</context>
+        </context-group>
+      </trans-unit><trans-unit id="5d1878d5fc761cbe9614bfd87047a740c82a6951" datatype="html">
+        <source>Initiator belongs to a group. Images will be configure in the group.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">383</context>
+        </context-group>
+      </trans-unit><trans-unit id="c0de67b9d97fafbf200f9451e8388ee8128a56ac" datatype="html">
+        <source>No items added.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">406</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">544</context>
+        </context-group>
+      </trans-unit><trans-unit id="d565e47726158e428ecdc952fc9233b9b7d7f049" datatype="html">
+        <source>Add initiator</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">411</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">488</context>
+        </context-group>
+      </trans-unit><trans-unit id="c22ba03540aa3217da059f45e7eab138b51a96e2" datatype="html">
+        <source>Groups</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">426</context>
+        </context-group>
+      </trans-unit><trans-unit id="4c90059afafb7e160384d9f512797c95bb95c6dc" datatype="html">
+        <source>Group</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">433</context>
+        </context-group>
+      </trans-unit><trans-unit id="3084948274cff4f56d0f431af47240e9cf02fcc7" datatype="html">
+        <source>Add group</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
+          <context context-type="linenumber">549</context>
+        </context-group>
+      </trans-unit><trans-unit id="a949d7e577902d0e5dc5d0971bb0170a21be7728" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ value | titlecase }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.html</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit><trans-unit id="ff92fbdec9fdd5054493eeda0d7ee8b450f83e72" datatype="html">
+        <source>RBD Configuration</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit><trans-unit id="b62d9efc8eb3b589904f6cb96a0406bbda55673a" datatype="html">
+        <source>Remove the local configuration value. The parent configuration value will be inherited and used instead.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+      </trans-unit><trans-unit id="963488a1010d46067b238c4ae917fab3907c0a3a" datatype="html">
+        <source>The mininum value is 0</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.html</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit><trans-unit id="66db799d67958d4b0765181d072df62e2d1c16f5" datatype="html">
         <source>Issues</source>
@@ -4134,6 +3125,16 @@
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html</context>
           <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit><trans-unit id="37e10df2d9c0c25ef04ac112c9c9a7723e8efae0" datatype="html">
+        <source>Mode</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">314</context>
         </context-group>
       </trans-unit><trans-unit id="32ca348ef926b0a6a7a780b8b64c3a8239895cec" datatype="html">
         <source>Peer clusters must be removed prior to disabling mirror.</source>
@@ -4232,23 +3233,938 @@
           <context context-type="sourcefile">app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html</context>
           <context context-type="linenumber">97</context>
         </context-group>
+      </trans-unit><trans-unit id="1d8a7c8aea58294a3c57c23af0468ddf0ba0c9c7" datatype="html">
+        <source>Pools List</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-list/pool-list.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit><trans-unit id="490e15ecc922965b6d8194754c87c5583aa071f3" datatype="html">
+        <source>The name can only consist of alphanumeric characters, dashes and underscores.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit><trans-unit id="9edc2b494e660618af3e5225f68d40b7ca67629c" datatype="html">
+        <source>The chosen erasure code profile name is already in use.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+      </trans-unit><trans-unit id="ef9ff0e6227947b48dfab4ac39ade04af758913b" datatype="html">
+        <source>Plugin</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+      </trans-unit><trans-unit id="dd69b31bce8f630eac1d4762b0bbcf72ce19d193" datatype="html">
+        <source>Data chunks (k)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit><trans-unit id="b0d26a6172d32cb81218fe2103c54a818cbc1189" datatype="html">
+        <source>Must be equal to or greater than 2.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit><trans-unit id="dab3a299ead121169b8e08ed618c3b6a2f66691b" datatype="html">
+        <source>Coding chunks (m)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+      </trans-unit><trans-unit id="1e2773e5bd4948193f18f2361d663ecc3988c656" datatype="html">
+        <source>Must be equal to or greater than 1.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">142</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">168</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">261</context>
+        </context-group>
+      </trans-unit><trans-unit id="6cde4c945a49a260c0a47bcc7cd956846930a5f7" datatype="html">
+        <source>Durability estimator (c)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">129</context>
+        </context-group>
+      </trans-unit><trans-unit id="af668c2a095a979ea2b4e43cd82c2120ab56c21c" datatype="html">
+        <source>Locality (l)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">151</context>
+        </context-group>
+      </trans-unit><trans-unit id="d455a110bf6d2235e314e295ce1dfeee93d3dff2" datatype="html">
+        <source>Crush failure domain</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">175</context>
+        </context-group>
+      </trans-unit><trans-unit id="b74a495f041f7dd102eee5c0bbc9e03083b538ae" datatype="html">
+        <source>Crush Locality</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">199</context>
+        </context-group>
+      </trans-unit><trans-unit id="a2f14a73f7a6e94479f67423cc51102da8d6f524" datatype="html">
+        <source>None</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">213</context>
+        </context-group>
+      </trans-unit><trans-unit id="2981733b912b693a9dd9d915d6d34f4692cc874a" datatype="html">
+        <source>Technique</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">226</context>
+        </context-group>
+      </trans-unit><trans-unit id="e0098b6e47b04ec817361f384ce81d454ba5c0bb" datatype="html">
+        <source>Packetsize</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">248</context>
+        </context-group>
+      </trans-unit><trans-unit id="c0252cd81ca54d0a2f69ec9ccf4248e73df5aa4a" datatype="html">
+        <source>Crush root</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">269</context>
+        </context-group>
+      </trans-unit><trans-unit id="1548d5c76f0406ddd1ba3c557e1e6db22e95b340" datatype="html">
+        <source>Crush device class</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">286</context>
+        </context-group>
+      </trans-unit><trans-unit id="5e85feb6f9f0334366e46ee09ca6b8df52397432" datatype="html">
+        <source>any</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">296</context>
+        </context-group>
+      </trans-unit><trans-unit id="03d84645f6e019c5a43909bbf2ea1696ee88332c" datatype="html">
+        <source>Directory</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.html</context>
+          <context context-type="linenumber">308</context>
+        </context-group>
+      </trans-unit><trans-unit id="16e113230b6b0d3165e076300880542bac7c8138" datatype="html">
+        <source>The chosen Ceph pool name is already in use.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit><trans-unit id="b85c657469e5ec8231c3de99b22f437bc01ffde5" datatype="html">
+        <source>Pool type</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+      </trans-unit><trans-unit id="526c5443254c3b126eedb264840ffe827727bfd3" datatype="html">
+        <source>-- Select a pool type --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+      </trans-unit><trans-unit id="0aa21053410a94aa61d16985a4e95fd65523430d" datatype="html">
+        <source>Placement groups</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+      </trans-unit><trans-unit id="6301f1391d726f8f450bb358058534db19541ca9" datatype="html">
+        <source>At least one placement group is needed!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+      </trans-unit><trans-unit id="ba9469a1ce6ed36e039c1f67247c8c81a5c71449" datatype="html">
+        <source>Your cluster can&apos;t handle this many PGs. Please recalculate the PG amount needed.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit><trans-unit id="62148abc31999dcfa38220cb09c33c8148b4b53a" datatype="html">
+        <source>You can only increase the number of PGs of an existing pool.
+                Currently your pool has <x id="INTERPOLATION" equiv-text="{{ data.pool.pg_num }}"/> PGs.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+      </trans-unit><trans-unit id="80ac68cd883369dac20688bc32b4cb33291b5e50" datatype="html">
+        <source>Calculation help</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">107</context>
+        </context-group>
+      </trans-unit><trans-unit id="37dd747f97e873d4280500da71b0076805f530a1" datatype="html">
+        <source>The current PGs settings were calculated for you, you
+                    should make sure the values suit your needs before submit.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+      </trans-unit><trans-unit id="33150f22ce5348aa6c499bd092c3f4f3695d62cc" datatype="html">
+        <source>Crush ruleset</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">122</context>
+        </context-group>
+      </trans-unit><trans-unit id="73a6b31116b3cc322af951daa0bafdc169e6c42e" datatype="html">
+        <source>-- Select a crush rule --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">130</context>
+        </context-group>
+      </trans-unit><trans-unit id="92da80699921e89fb19372e25b8d0f3b9fa427fc" datatype="html">
+        <source>Crush rule</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">151</context>
+        </context-group>
+      </trans-unit><trans-unit id="5489e9f96835f469f6f728a00d8efa88ea5bc940" datatype="html">
+        <source>Crush steps</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit><trans-unit id="54a53b1b402aafff5b992ee9b64e409fbfe9074f" datatype="html">
+        <source>The rule can&apos;t be used in the current cluster as it has
+                to few OSDs to meet the minimum required OSD by this rule.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">168</context>
+        </context-group>
+      </trans-unit><trans-unit id="a43b2695131b48b76cebba676aba98a2bee17515" datatype="html">
+        <source>Replicated size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">179</context>
+        </context-group>
+      </trans-unit><trans-unit id="7bff144a4c4dc63b0e18fff2617d61a7ebdf2b6c" datatype="html">
+        <source>Minimum: <x id="INTERPOLATION" equiv-text="{{ getMinSize() }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">193</context>
+        </context-group>
+      </trans-unit><trans-unit id="1a9c54b41f6d58a74e5d0aa3429ed0c87a482551" datatype="html">
+        <source>Maximum: <x id="INTERPOLATION" equiv-text="{{ getMaxSize() }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">194</context>
+        </context-group>
+      </trans-unit><trans-unit id="43c6dd9233d6a8242cec2b025d25c273244d8d61" datatype="html">
+        <source>The size specified is out of range. A value from
+                    <x id="INTERPOLATION" equiv-text="{{ getMinSize() }}"/> to <x id="INTERPOLATION_1" equiv-text="{{ getMaxSize() }}"/> is valid.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">199</context>
+        </context-group>
+      </trans-unit><trans-unit id="9de7dde00e2139cc4bd03b1837afbe72ad15a1ff" datatype="html">
+        <source>Erasure code profile</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+      </trans-unit><trans-unit id="39b4620e6bd444e0a57a0a5c03fa8c96d7fe5235" datatype="html">
+        <source>-- No erasure code profile available --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">221</context>
+        </context-group>
+      </trans-unit><trans-unit id="498561757390d5528b263ce450d5f38efb00266d" datatype="html">
+        <source>-- Select an erasure code profile --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">224</context>
+        </context-group>
+      </trans-unit><trans-unit id="1c870fb00256b8a5b9cb9cd1a124e6390b9bc639" datatype="html">
+        <source>EC Overwrites</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">278</context>
+        </context-group>
+      </trans-unit><trans-unit id="f1abafaeb40ce52355ddcc24686e3cd17b64e08a" datatype="html">
+        <source>Applications</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">289</context>
+        </context-group>
+      </trans-unit><trans-unit id="2208d63d5940ce656006a220102b1eb2b5e553da" datatype="html">
+        <source>Compression</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">308</context>
+        </context-group>
+      </trans-unit><trans-unit id="6c6f25c47da62ec597c6057a36ddfc3209811ec5" datatype="html">
+        <source>Algorithm</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">333</context>
+        </context-group>
+      </trans-unit><trans-unit id="4903231d42089325a28892c0fde1aed46b733ae6" datatype="html">
+        <source>-- No erasure compression algorithm available --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">344</context>
+        </context-group>
+      </trans-unit><trans-unit id="5d68ddb254275f8f44221e9ad6d8ceeb59ca46a6" datatype="html">
+        <source>Minimum blob size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">358</context>
+        </context-group>
+      </trans-unit><trans-unit id="fb2f176df80647137cbb02bbeb29e5dec707a400" datatype="html">
+        <source>e.g., 128KiB</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">367</context>
+        </context-group>
+      </trans-unit><trans-unit id="1b7f6e53a4521c6eb3ced4c007fdd4cf80bb7707" datatype="html">
+        <source>Value should be greater than 0</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">372</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">397</context>
+        </context-group>
+      </trans-unit><trans-unit id="54be22af9625a595ee5d70917ee1fb116be7c4be" datatype="html">
+        <source>Value should be greater than the maximum blob size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">375</context>
+        </context-group>
+      </trans-unit><trans-unit id="151efb127a9a4dd25259a0b2055442318a141f5b" datatype="html">
+        <source>Maximum blob size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">384</context>
+        </context-group>
+      </trans-unit><trans-unit id="0c656f0e346bbadf46eb1a5d20d0307a3bd20ba8" datatype="html">
+        <source>e.g., 512KiB</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">392</context>
+        </context-group>
+      </trans-unit><trans-unit id="0a65a24eee8a026f3b1113fe9e157e9a0dd69486" datatype="html">
+        <source>Value should be greater than the minimum blob size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">400</context>
+        </context-group>
+      </trans-unit><trans-unit id="261ba09c4a59de83f48f52a23fd328da37e61ff4" datatype="html">
+        <source>Ratio</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">409</context>
+        </context-group>
+      </trans-unit><trans-unit id="c1430457a9c3c66366e51d76bf10396014c576be" datatype="html">
+        <source>Compression ratio</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">420</context>
+        </context-group>
+      </trans-unit><trans-unit id="ae5ce6de352cde949998fb10754459c3a4eb183b" datatype="html">
+        <source>Value should be between 0.0 and 1.0</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">423</context>
+        </context-group>
+      </trans-unit><trans-unit id="4b673e771a3f6b056837b22ef19a825386046095" datatype="html">
+        <source>It&apos;s not possible to create an RBD pool with &apos;/&apos; in the name.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">443</context>
+        </context-group>
+      </trans-unit><trans-unit id="a9c02674c6e4936562d1146e1ecf0c4240dfcf96" datatype="html">
+        <source>Please change the name or remove &apos;rbd&apos; from the applications list.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
+          <context context-type="linenumber">445</context>
+        </context-group>
       </trans-unit><trans-unit id="3938a411d76796f8ae73b72ea4c77661207453bd" datatype="html">
         <source>Cache Tiers Details</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/pool/pool-details/pool-details.component.html</context>
           <context context-type="linenumber">27</context>
         </context-group>
-      </trans-unit><trans-unit id="0c1e17956453ad772dbe82d6946f62748c692f3e" datatype="html">
-        <source>Ranks</source>
+      </trans-unit><trans-unit id="9424badb7e0c6ac792d020d7830645b529a80aad" datatype="html">
+        <source>Please consult the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+  on how to configure and enable the Object Gateway management functionality.</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
-          <context context-type="linenumber">6</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-501/rgw-501.component.html</context>
+          <context context-type="linenumber">3</context>
         </context-group>
-      </trans-unit><trans-unit id="95c96d55690c0c685deebe52a1da94dc36f5e99d" datatype="html">
-        <source>Clients: <x id="INTERPOLATION" equiv-text="{{ clientCount }}"/></source>
+      </trans-unit><trans-unit id="479488ab6e91ecb375484edc78bee3d13467f33f" datatype="html">
+        <source>Daemons List</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit><trans-unit id="eeba399c4dae8d4890c27b7a2cd2dc28fcf8b5f9" datatype="html">
+        <source>Performance Counters</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+      </trans-unit><trans-unit id="5f67f2247b9c6bbaf24a0f2d37f4ac0537c6fa53" datatype="html">
+        <source>Loading bucket data...</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit><trans-unit id="8508c0ab851ad91fd0410da1266c02b0ef9d3ff9" datatype="html">
+        <source>The bucket data could not be loaded.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit><trans-unit id="2798cc1e152b1ec07fd8daf94a2a073d1ba1ebcc" datatype="html">
+        <source>Id</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit><trans-unit id="db4e1a734518691b128ef40b939cc673f01d03a6" datatype="html">
+        <source>The value is not valid.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">453</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">546</context>
+        </context-group>
+      </trans-unit><trans-unit id="0ee5132a8da30e0b7f9f5c70dbc91928d17dd909" datatype="html">
+        <source>Owner</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit><trans-unit id="8e4c918357c7445fbf19a203e5f0f0ece1960b3b" datatype="html">
+        <source>-- Select a user --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+      </trans-unit><trans-unit id="45cc8ca94b5a50842a9a8ef804a5ab089a38ae5c" datatype="html">
+        <source>ID</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit><trans-unit id="e5c51963a9c553b29427ef783bbb69fa6634fa8c" datatype="html">
+        <source>Index type</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit><trans-unit id="8e6f950a32eaea32ec7e192f9ca3d3dfe469d4ba" datatype="html">
+        <source>Placement rule</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit><trans-unit id="6972d213e31c4ea4f887e60db99d9881bc8fcd3e" datatype="html">
+        <source>Marker</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit><trans-unit id="47b02acd2d3254d1ace1926f840523f154ebef71" datatype="html">
+        <source>Maximum marker</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit><trans-unit id="8fe73a4787b8068b2ba61f54ab7e0f9af2ea1fc9" datatype="html">
+        <source>Version</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit><trans-unit id="092fa3a7df9168b14d3f83a77a4035e92b92ce15" datatype="html">
+        <source>Master version</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit><trans-unit id="97434cc5001d407f90c7447a12d9e8e6848a2aa3" datatype="html">
+        <source>Modification time</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit><trans-unit id="90fe2e41e7fde38453ce4e619efeea9bc6adea9c" datatype="html">
+        <source>Zonegroup</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+      </trans-unit><trans-unit id="649a410bd0ace333d067d8fa22f12bdbdb43533b" datatype="html">
+        <source>Bucket quota</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">497</context>
+        </context-group>
+      </trans-unit><trans-unit id="f50a33d3c339f8f4a465141f8caa5d2d8c005251" datatype="html">
+        <source>Enabled</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">414</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">507</context>
+        </context-group>
+      </trans-unit><trans-unit id="cef1595d040e77cbb4466e60382028d4c2040cac" datatype="html">
+        <source>Maximum size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit><trans-unit id="aa6fb95c355f172bda303de1ce2f38c251a149cf" datatype="html">
+        <source>Unlimited</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">120</context>
+        </context-group>
+      </trans-unit><trans-unit id="ee862a800364b4d11f9b8cb9955a28a60f840a45" datatype="html">
+        <source>Maximum objects</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+      </trans-unit><trans-unit id="49c614babd1950adb2be75df4e2c9747286d6adc" datatype="html">
+        <source>-- Select a username --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit><trans-unit id="c217ee914725a37e9dd2336c721c8e63e9666bdc" datatype="html">
+        <source>Auto-generate key</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">134</context>
+        </context-group>
+      </trans-unit><trans-unit id="2f1c1c0f2bce4c9f92d1a2061e8161cb0006c31a" datatype="html">
+        <source>Access key</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">145</context>
+        </context-group>
+      </trans-unit><trans-unit id="b864acb67296a9819c1db0069c4c47d8b5ce8f44" datatype="html">
+        <source>Secret key</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">110</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">177</context>
+        </context-group>
+      </trans-unit><trans-unit id="69b6ac577a19acc39fc0c22342092f327fff2529" datatype="html">
+        <source>Email address</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+      </trans-unit><trans-unit id="92f3f203270a29b3001871153f02c063484a1574" datatype="html">
+        <source>Suspended</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+      </trans-unit><trans-unit id="8011e20c5bbe51602d459a860fbf29b599b55edd" datatype="html">
+        <source>System</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+      </trans-unit><trans-unit id="db18a2772988415466a7f75dc42663ce78c9c1d3" datatype="html">
+        <source>Maximum buckets</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit><trans-unit id="2c4c62e8ba24601be5cfe7dc5d32c24bbbd4b53c" datatype="html">
+        <source>Subusers</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">206</context>
+        </context-group>
+      </trans-unit><trans-unit id="17bb3082e6fe5003203ef992a3714172334631a1" datatype="html">
+        <source>Capabilities</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">353</context>
+        </context-group>
+      </trans-unit><trans-unit id="36ad38f9c1a1485e09b67778a28af84553290ffb" datatype="html">
+        <source>User quota</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">404</context>
+        </context-group>
+      </trans-unit><trans-unit id="2aba1e87039819aca3b70faa9aa848c12bf139ca" datatype="html">
+        <source>Show</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">148</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">290</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">340</context>
+        </context-group>
+      </trans-unit><trans-unit id="0bcd5ef19af0f1b814141ca8c57df623d8270088" datatype="html">
+        <source>Keys</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-details/rgw-user-details.component.html</context>
+          <context context-type="linenumber">133</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">265</context>
+        </context-group>
+      </trans-unit><trans-unit id="1221ca97d19eaa9a7bc0c5243d5fc5befe1d2314" datatype="html">
+        <source>-- Select a type --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit><trans-unit id="d1b8990332af18f1c5159a6061ca889bcbb28432" datatype="html">
+        <source>Permission</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit><trans-unit id="a08c589f82f69d892307288da14190ae1dd583d5" datatype="html">
+        <source>-- Select a permission --</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+      </trans-unit><trans-unit id="b2841767821d6b66238c34d07e413b0af67aee92" datatype="html">
+        <source>Subuser</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit><trans-unit id="bd59fc25a7bd98cff3e75117c09697c8a007a514" datatype="html">
+        <source>The chosen subuser ID is already in use.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+      </trans-unit><trans-unit id="3d386c357ebcbc04ed05c4babd5a03626f9b1674" datatype="html">
+        <source>read, write</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+      </trans-unit><trans-unit id="84e3e3f9a4f31a039b648c97debf95fcb20f4c4a" datatype="html">
+        <source>full</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+      </trans-unit><trans-unit id="b6bf81d032a2316464f9df2f0d2f3d753f89f0d3" datatype="html">
+        <source>Swift key</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">89</context>
+        </context-group>
+      </trans-unit><trans-unit id="1e0c12685d50d47448ceed9423977ef39775c037" datatype="html">
+        <source>Auto-generate secret</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit><trans-unit id="3d1c7a6004bd5d86a7fa096ae24209e8aa7a53e3" datatype="html">
+        <source>Loading user data...</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit><trans-unit id="faa5d834ab28571423d794d32b57998920efb65f" datatype="html">
+        <source>The user data could not be loaded.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit><trans-unit id="6aaf5d2a304167272ac73e3b1d1c162e16c77858" datatype="html">
+        <source>The chosen user ID is already in use.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit><trans-unit id="df441e80db2157f9d272b75de724ba4a82b96b57" datatype="html">
+        <source>This is not a valid email address.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+      </trans-unit><trans-unit id="ca271adf154956b8fcb28f4f50a37acb3057ff7c" datatype="html">
+        <source>The chosen email address is already in use.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit><trans-unit id="030197cebe938edf35422e92fe14183d06eb670b" datatype="html">
+        <source>Max. buckets</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+      </trans-unit><trans-unit id="623ac50f37a26caec6fd7cd519b653e3315cba25" datatype="html">
+        <source>The entered value must be &gt;= 0.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">490</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">583</context>
+        </context-group>
+      </trans-unit><trans-unit id="583a219c524155c2314eb06ee29162bb315272a3" datatype="html">
+        <source>S3 key</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">124</context>
+        </context-group>
+      </trans-unit><trans-unit id="128d6efb51d9ddc7c0cc695a2deeca5b9523f6e4" datatype="html">
+        <source>There are no subusers.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">212</context>
+        </context-group>
+      </trans-unit><trans-unit id="826b25211922a1b46436589233cb6f1a163d89b7" datatype="html">
+        <source>Delete</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">243</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">297</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">382</context>
+        </context-group>
+      </trans-unit><trans-unit id="8c49635e3672c82d9cf3b416a0d1a03460191699" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ actionLabels.CREATE | titlecase }}"/> <x id="INTERPOLATION_1" equiv-text="{{ subuserLabel | upperFirst }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">257</context>
+        </context-group>
+      </trans-unit><trans-unit id="67c746c1ba9dab4351fedc4c7cba4e6d6b0dbc47" datatype="html">
+        <source>S3</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">269</context>
+        </context-group>
+      </trans-unit><trans-unit id="d6819038d608623503918fb2553f53d68231ec3a" datatype="html">
+        <source>There are no keys.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">274</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">324</context>
+        </context-group>
+      </trans-unit><trans-unit id="8b1d0beb2246fd01d9b25400bf9c67cbd532baee" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ actionLabels.CREATE | titlecase }}"/> <x id="INTERPOLATION_1" equiv-text="{{ s3keyLabel | upperFirst }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">311</context>
+        </context-group>
+      </trans-unit><trans-unit id="6ddb5e991a3ecd2659fb520bc5acc81b67e08ddd" datatype="html">
+        <source>Swift</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">319</context>
+        </context-group>
+      </trans-unit><trans-unit id="1d01eccdda47fc907c5be35bcb16d2dcd02b0270" datatype="html">
+        <source>There are no capabilities.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">359</context>
+        </context-group>
+      </trans-unit><trans-unit id="af26a69a40b3a5477a7d062756a44c8d91f988a4" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ actionLabels.ADD | titlecase }}"/> <x id="INTERPOLATION_1" equiv-text="{{ capabilityLabel | upperFirst }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">396</context>
+        </context-group>
+      </trans-unit><trans-unit id="6146e13ceca5fa5cc17b771b282fe5955f3d19fa" datatype="html">
+        <source>Unlimited size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">428</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">521</context>
+        </context-group>
+      </trans-unit><trans-unit id="f6db8aa7c99fdce18edb33dde57729acede2b308" datatype="html">
+        <source>Max. size</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">439</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">532</context>
+        </context-group>
+      </trans-unit><trans-unit id="fc630b2093e880fffa19df99d5cd8b87605037f8" datatype="html">
+        <source>Unlimited objects</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">466</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">559</context>
+        </context-group>
+      </trans-unit><trans-unit id="6cda5a993d06f0bb10048be9d3aba6555aa9f356" datatype="html">
+        <source>Max. objects</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">477</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/ceph/rgw/rgw-user-form/rgw-user-form.component.html</context>
+          <context context-type="linenumber">570</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bd5a3b1c5a3c185c7bbb0e09a061d4cdc88ce5ad" datatype="html">
@@ -4290,6 +4206,28 @@
         <source>There are no initiators available. Please make sure you add an initiator to the target.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="cea3c6fe490385eef1584cbc4983fda7ece24bb6" datatype="html">
+        <source>target</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f6755cff4957d5c3c89bafce5651f1b6fa2b1fd9" datatype="html">
+        <source>Add</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/nfs/nfs-list/nfs-list.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/constants/app.constants.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
@@ -4511,6 +4449,13 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="e9cac80fb5d9de66f0006d0bec530fd1fc69a674" datatype="html">
+        <source>RBD</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/block/rbd-form/rbd-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="4130b1a836f2000cfe9a11fb62493dc42d444de7" datatype="html">
         <source>Deep flatten</source>
         <context-group purpose="location">
@@ -4563,6 +4508,10 @@
           <context context-type="sourcefile">src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/constants/app.constants.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="3747fff7faf52b436ecff5fb8555091736d92c70" datatype="html">
         <source>Flatten</source>
@@ -4592,6 +4541,10 @@
           <context context-type="sourcefile">src/app/core/auth/role-form/role-form.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/constants/app.constants.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="e26f9cf3666aace4e524b1505c9795d76d87738d" datatype="html">
         <source>Rename</source>
@@ -4618,6 +4571,10 @@
         <source>Clone</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/constants/app.constants.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
@@ -5523,6 +5480,13 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="ae128527ec18892f812a62a1fd15dc50a38060c0" datatype="html">
+        <source>EC Profile</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="60fb10c145f9c7ede2b9ddf9b2b0b0f6191d0ebd" datatype="html">
         <source>Cache Mode</source>
         <context-group purpose="location">
@@ -5607,6 +5571,13 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="db8c42f077700d8a94619fad9f4c94b7361d5f1d" datatype="html">
+        <source>pool</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/pool/pool-form/pool-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="65bb2be83261bc4798853bbccdedc110c43feea7" datatype="html">
         <source>erasure code profile</source>
         <context-group purpose="location">
@@ -5649,6 +5620,17 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="44939fd05cedfd077db886528b755e77d5fa3885" datatype="html">
+        <source>bucket</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="364cc3f92837b6000e686aab6d03bd2ad8007b50" datatype="html">
         <source>Updated Object Gateway bucket &quot;<x id="INTERPOLATION" equiv-text="{{bid}}"/>&quot;</source>
         <context-group purpose="location">
@@ -5663,17 +5645,54 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="44939fd05cedfd077db886528b755e77d5fa3885" datatype="html">
-        <source>bucket</source>
+      <trans-unit id="ec40d74ecfb1d6d60455af6805c9a714a3f5750a" datatype="html">
+        <source>buckets</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="ec40d74ecfb1d6d60455af6805c9a714a3f5750a" datatype="html">
-        <source>buckets</source>
+      <trans-unit id="764585d5595bac113582ee14a6fd07006770ceb1" datatype="html">
+        <source>capability</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts</context>
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="0914cbe18bae204217e1851be6d2d24d86e74605" datatype="html">
+        <source>user</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/auth/user-form/user-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d8c86dc5e48a63590d9c94e19f90b5f8325cbd49" datatype="html">
+        <source>subuser</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f45a3de8a8b40d161cc36a55d77548a27107ca04" datatype="html">
+        <source>S3 Key</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
@@ -5691,17 +5710,17 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0914cbe18bae204217e1851be6d2d24d86e74605" datatype="html">
-        <source>user</source>
+      <trans-unit id="7c7f4be7b726e61c577e63842a58d9e435f7c597" datatype="html">
+        <source>users</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7c7f4be7b726e61c577e63842a58d9e435f7c597" datatype="html">
-        <source>users</source>
+      <trans-unit id="9f7760223efd77806f1bbaf963e6993bb4bc6a0a" datatype="html">
+        <source>Swift Key</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts</context>
+          <context context-type="sourcefile">src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
@@ -5718,6 +5737,13 @@
           <context context-type="sourcefile">src/app/core/auth/role-details/role-details.component.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/auth/role-form/role-form.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="dc4fba275819619ee78e8eae14d357ea69ba7477" datatype="html">
+        <source>role</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/auth/role-form/role-form.component.ts</context>
           <context context-type="linenumber">1</context>
@@ -6259,6 +6285,13 @@
         <source>There are no items available.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/select/select-messages.model.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="019d4bd6a5690f0cfa0ecf346a4e6bf7f0d8debb" datatype="html">
+        <source>Remove</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/constants/app.constants.ts</context>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>


### PR DESCRIPTION
The screenshots below show an example of the changes performed. They've been applied to the top 8 components (Pools, RBD images, iSCSI, mirroring, RGW users, RGW buckets, Users and Roles).

Before:
![before](https://user-images.githubusercontent.com/37327689/55000423-c2b6d800-4fd2-11e9-98b8-543986c69b55.png)

After:
![after](https://user-images.githubusercontent.com/37327689/55000485-ea0da500-4fd2-11e9-8ba3-f412ceb28c5b.png)


Detailed changes:
- Mappings (actually an Enum) created for actions (buttons and other UI elements) and URLs: `ActionLabels` and `URLVerbs`.
  - Probably a generic store for translatable strings would be better.
  - An alternative would be to fix/improve the current i18n-polyfill, which only works with literal strings (not even with 'const enums' which become literals after Typescript transpiling).
  - Additionally having a predefined file with some strings to translate (actions, verbs, etc) could improve on the 1st of the 2-stage i18n process (as extraction tool has a lot of limitations).
- A corresponding `ActionLabelsI18n` service with translated labels (it's a service as I haven't found the way to either translate no-const strings (ngx-translate/AST parser failure) or get a static translator).
  - This services could/should be extended to cover all strings that are defined in static/globally scoped objects before any I18n provider has been initialized.
- Breadcrumbs are not translated (neither were they before this change). This part remains untackled: using 'proxy' static objects and performing live translation could deal with the issue.
- New `URLBuilder` service created (following a established pattern in the Java/.NET world) . This should avoid the need of messing with literal URLs and string composition/parsing, and while the front-end is not meant to be consumed by anyone, Angular does not provide any other way for the app to navigate between components, so the URLs are a de-facto interface contract. Unlike this approach is not flawless, it's easier to enforce, while issues coming from free-from strings are really hard to catch.
  - This could be further improved by using a router registry/dynamic routing. Most of the routes are trivial.
- This PR initially included some code to remove leading/trailing whitespace/newlines from i18n elements in XLIFF file, but it turned out it didn't work correctly as long as the extractor tool will still calculate different IDs for equal strings with varying whitespacing.
- As a side effect of these changes, routing module has been refactored and some routes moved to their specific modules (pool, rbd, rgw), via `loadChildren` and `routes.forChild()` magic. Now the above mentioned components are lazy-loaded/pre-loaded (it means right after the main code is loaded). This should also decrease the loading time (though probably this is not biggest time eater here).
  - As now modules can be loaded multiple times, not only from App module by means of lazy loading, but also from other ones (as PoolModule loads BlockModule to get QoS widgets in Pool windows), now lazy loaded modules include 2 `NgModules` (one with `imports: RouterModule.forChild(routes)`, meant for lazy-loading, and another without routes).
- Some parts might not be (fully) translated (NFS, iSCSI, mirroring), as there's been ongoing work on them and it's hard to keep up with the new code.
- These changes will be a waste of time if the new code does not take benefit from/adheres to it, so I'm still figuring out how to spread this (nothing really fancy to demo). Maybe adding some checks/harnessing to enforce the new naming convention (ideas greatly welcome here).

Fixes: http://tracker.ceph.com/issues/37337
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug