### PR TITLE
mimic: qa/workunits/cephtool/test_kvstore_tool.sh: run test in ., not /tmp

### DIFF
--- a/qa/workunits/cephtool/test_kvstore_tool.sh
+++ b/qa/workunits/cephtool/test_kvstore_tool.sh
@@ -18,8 +18,7 @@ expect_false()
     if "$@"; then return 1; else return 0; fi
 }
 
-TMPDIR=${TMPDIR:-${TESTDIR}}
-TEMP_DIR=$(mktemp -d ${TMPDIR:-/tmp}/cephtool.XXX)
+TEMP_DIR=$(mktemp -d ./cephtool.XXX)
 trap "rm -fr $TEMP_DIR" 0
 
 TEMP_FILE=$(mktemp $TEMP_DIR/test_invalid.XXX)


### PR DESCRIPTION




This is a backport of https://github.com/ceph/ceph/pull/24143

Fixes: https://tracker.ceph.com/issues/38083


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

