### PR TITLE
msg/async/rdma: set/get silence warning

### DIFF
--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -363,8 +363,8 @@ class Infiniband {
   Device *device = NULL;
   ProtectionDomain *pd = NULL;
   DeviceList *device_list = nullptr;
-  void wire_gid_to_gid(const char *wgid, union ibv_gid *gid);
-  void gid_to_wire_gid(const union ibv_gid *gid, char wgid[]);
+  void wire_gid_to_gid(const char *wgid, IBSYNMsg* im);
+  void gid_to_wire_gid(const IBSYNMsg& im, char wgid[]);
   CephContext *cct;
   Mutex lock;
   bool initialized = false;


### PR DESCRIPTION
functions like gid_to_wire_gid() is not aware of the alignment of the
IBSYNMsg, so we should pass the enclosing structure to it.

to silence warnings like:

ceph/src/msg/async/rdma/Infiniband.cc: In member function ‘int
Infiniband::send_msg(CephContext*, int, IBSYNMsg&)’:
ssd/ceph/src/msg/async/rdma/Infiniband.cc:1123:19: warning: taking
address of packed member of ‘IBSYNMsg’ may result in an unaligned
pointer value [-Waddress-of-packed-
member]
 1123 |   gid_to_wire_gid(&(im.gid), gid);
      |                   ^~~~~~~~~

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

