### PR TITLE
mimic: doc: Fix default value of 'mon_osd_max_split_count' 

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -1193,7 +1193,7 @@ Miscellaneous
               will be splitted on all OSDs serving that pool. We want to avoid
               extreme multipliers on PG splits.
 :Type: Integer
-:Default: 300
+:Default: 32
 
 
 ``mon session timeout``


### PR DESCRIPTION
Fixed default value of ''mon_osd_max_split_count' in "/doc/rados/configuration/mon-config-ref.rst"

Fixes: https://tracker.ceph.com/issues/38429

Signed-off-by: Kai Wagner [kwagner@suse.com](mailto:kwagner@suse.com)