### PR TITLE
luminous: doc: Fix default value of 'mon_osd_max_split_count'

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -1193,7 +1193,7 @@ Miscellaneous
               will be splitted on all OSDs serving that pool. We want to avoid
               extreme multipliers on PG splits.
 :Type: Integer
-:Default: 300
+:Default: 32
 
 
 ``mon session timeout``


### PR DESCRIPTION
This commit is not cherry-picked from master because the config
parameter mon_osd_max_split_count has been dropped in master

Signed-off-by: Kai Wagner <kwagner@suse.com>
(cherry picked from commit 17d503f5adfbfd96502877bcb55c42ba1eb34a5c)

(Note: backport of #26585)