### PR TITLE
osd/PrimaryLogPG: handle object !exists in handle_watch_timeout

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10911,6 +10911,10 @@ void PrimaryLogPG::handle_watch_timeout(WatchRef watch)
     dout(10) << "handle_watch_timeout not active, no-op" << dendl;
     return;
   }
+  if (!obc->obs.exists) {
+    dout(10) << __func__ << " object " << obc->obs.oi.soid << " dne" << dendl;
+    return;
+  }
   if (is_degraded_or_backfilling_object(obc->obs.oi.soid)) {
     callbacks_for_degraded_object[obc->obs.oi.soid].push_back(
       watch->get_delayed_cb()


### PR DESCRIPTION
- watch on object
- watch timeout queued
- rados op deletes object
- handle_watch_timeout tries to delete it again

Fixes: http://tracker.ceph.com/issues/38432
Signed-off-by: Sage Weil <sage@redhat.com>