### PR TITLE
mimic: build/ops: Destruction of basic_string _GLIBCXX_USE_CXX11_ABI=0 and C++17 mode results in invalid delete

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -131,7 +131,7 @@ BuildRequires:	fuse-devel
 %if 0%{?rhel} == 7
 # devtoolset offers newer make and valgrind-devel, but the old ones are good
 # enough.
-BuildRequires:	devtoolset-7-gcc-c++ >= 7.3.1
+BuildRequires:	devtoolset-7-gcc-c++ >= 7.3.1-5.13
 %else
 BuildRequires:	gcc-c++
 %endif

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -131,7 +131,7 @@ BuildRequires:	fuse-devel
 %if 0%{?rhel} == 7
 # devtoolset offers newer make and valgrind-devel, but the old ones are good
 # enough.
-BuildRequires:	devtoolset-7-gcc-c++
+BuildRequires:	devtoolset-7-gcc-c++ >= 7.3.1
 %else
 BuildRequires:	gcc-c++
 %endif


### PR DESCRIPTION
http://tracker.ceph.com/issues/38451