### PR TITLE
osd: clean up oncommit contexts in _process shutdown

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10694,6 +10694,10 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
   if (sdata->pqueue->empty()) {
     if (osd->is_stopping()) {
       sdata->shard_lock.unlock();
+      for (auto c : oncommits) {
+	dout(10) << __func__ << " discarding in-flight oncommit " << c << dendl;
+	delete c;
+      }
       return;    // OSD shutdown, discard.
     }
     sdata->shard_lock.unlock();
@@ -10704,6 +10708,10 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
   OpQueueItem item = sdata->pqueue->dequeue();
   if (osd->is_stopping()) {
     sdata->shard_lock.unlock();
+    for (auto c : oncommits) {
+      dout(10) << __func__ << " discarding in-flight oncommit " << c << dendl;
+      delete c;
+    }
     return;    // OSD shutdown, discard.
   }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -153,7 +153,8 @@ void PGStateHistory::dump(Formatter* f) const {
 void PG::get(const char* tag)
 {
   int after = ++ref;
-  lgeneric_subdout(cct, refs, 1) << "PG::get " << this << " "
+  lgeneric_subdout(cct, refs, 5) << "PG::get " << this << " "
+				 << "tag " << (tag ? tag : "(none") << " "
 				 << (after - 1) << " -> " << after << dendl;
 #ifdef PG_DEBUG_REFS
   std::lock_guard l(_ref_id_lock);
@@ -175,7 +176,8 @@ void PG::put(const char* tag)
   }
 #endif
   int after = --ref;
-  lgeneric_subdout(cct, refs, 1) << "PG::put " << this << " "
+  lgeneric_subdout(cct, refs, 5) << "PG::put " << this << " "
+				 << "tag " << (tag ? tag : "(none") << " "
 				 << (after + 1) << " -> " << after << dendl;
   if (after == 0)
     delete this;


### PR DESCRIPTION
If we have queued PG completions in the workqueue and have to shut down,
delete them, so that the PG refs get cleaned up.

Fixes: http://tracker.ceph.com/issues/38431
Signed-off-by: Sage Weil <sage@redhat.com>