### PR TITLE
luminous: doc: move keyring caps RN to correct point release

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,12 @@
->= 12.2.11
-----------
+12.2.12
+-------
+* In 12.2.9 and earlier releases, keyring caps were not checked for validity,
+  so the caps string could be anything. As of 12.2.10, caps strings are
+  validated and providing a keyring with an invalid caps string to, e.g.,
+  "ceph auth add" will result in an error.
+
+12.2.11
+-------
 * `cephfs-journal-tool` makes rank argument (--rank) mandatory. Rank is
   of format `filesystem:rank`, where `filesystem` is the cephfs filesystem
   and `rank` is the MDS rank on which the operation is to be executed. To
@@ -7,10 +14,6 @@
   operations that dump journal information to file will now dump to per-rank
   suffixed dump files. Importing journal information from dump files is
   disallowed if operation is targetted for all ranks.
-* In 12.2.9 and earlier releases, keyring caps were not checked for validity,
-  so the caps string could be anything. As of 12.2.10, caps strings are
-  validated and providing a keyring with an invalid caps string to, e.g.,
-  "ceph auth add" will result in an error.
 
 >= 12.1.2
 ---------


### PR DESCRIPTION
This is still technically correct (thanks to the `>=`), but move the release note under an explicit
12.2.12 heading since 12.2.11 is already out and the PR introducing the release note (#24906)
has been merged and will be included in 12.2.12.

This commit cannot be cherry-picked from master because PendingReleaseNotes has
completely different content in master.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

See also:

* https://github.com/ceph/ceph/pull/24906
* https://github.com/ceph/ceph/pull/26596