### PR TITLE
mgr/dashboard: special casing for minikube in run-backend-rook-api-request.sh

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-rook-api-request.sh
+++ b/src/pybind/mgr/dashboard/run-backend-rook-api-request.sh
@@ -8,6 +8,9 @@ CURR_DIR=`pwd`
 K8S_NAMESPACE='rook-ceph'
 
 HOST=$(kubectl get pods -n $K8S_NAMESPACE -l "app=rook-ceph-mgr" -o json | jq .items[0].spec.nodeName | sed s/\"//g)
+if [ "$HOST" = "minikube" ]; then
+	HOST=$(minikube ip)
+fi
 PORT=$(kubectl get service -n $K8S_NAMESPACE rook-ceph-mgr-dashboard -o yaml | grep nodePort: | awk '{print $2}')
 API_URL="https://${HOST}:${PORT}"
 


### PR DESCRIPTION
For people running minikube for testing, the hostname "minikube" is
often not resolvable. If that's what the hostname is, then get
the address from "minikube ip" instead.

Signed-off-by: Jeff Layton <jlayton@redhat.com>