### PR TITLE
Revert: pybind: set language_level for cythonize explicitly

### DIFF
--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -205,7 +205,6 @@ setup(
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
         ],
-        compiler_directives={'language_level': sys.version_info.major},
         build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         include_path=[
             os.path.join(os.path.dirname(__file__), "..", "rados")

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -1,4 +1,4 @@
-# cython: embedsignature=True, c_string_type=str, c_string_encoding=ascii
+# cython: embedsignature=True
 """
 This module is a thin wrapper around librados.
 

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -199,9 +199,7 @@ setup(
                 libraries=["rados"] + flags['ldflags']['l'],
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
-        ],
-        compiler_directives={'language_level': sys.version_info.major},
-        build_dir=os.environ.get("CYTHON_BUILD_DIR", None)
+        ], build_dir=os.environ.get("CYTHON_BUILD_DIR", None)
     ),
     classifiers=[
         'Intended Audience :: Developers',

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -1,4 +1,4 @@
-# cython: embedsignature=True, c_string_type=str, c_string_encoding=ascii
+# cython: embedsignature=True
 """
 This module is a thin wrapper around librbd.
 

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -204,7 +204,6 @@ setup(
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
         ],
-        compiler_directives={'language_level': sys.version_info.major},
         build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         include_path=[
             os.path.join(os.path.dirname(__file__), "..", "rados")

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -205,7 +205,6 @@ setup(
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
         ],
-        compiler_directives={'language_level': sys.version_info.major},
         build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         include_path=[
             os.path.join(os.path.dirname(__file__), "..", "rados")


### PR DESCRIPTION
This reverts https://github.com/ceph/ceph/pull/26476.

Signed-off-by: Neha Ojha <nojha@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

