### PR TITLE
qa/workunits/rest: Better detection of rest url

### DIFF
--- a/qa/workunits/rest/test-restful.sh
+++ b/qa/workunits/rest/test-restful.sh
@@ -3,14 +3,8 @@
 mydir=`dirname $0`
 
 secret=`ceph config-key get mgr/restful/keys/admin`
-active=`ceph mgr dump | jq -r .active_name`
-echo "active $active  admin secret $secret"
-
-prefix="mgr/restful/$active"
-addr=`ceph config-key get $prefix/server_addr || echo 127.0.0.1`
-port=`ceph config-key get $prefix/server_port || echo 8003`
-url="https://$addr:$port"
-echo "prefix $prefix url $url"
+url=$(ceph mgr dump|jq -r .services.restful|sed -e 's/\/$//')
+echo "url $url secret $secret"
 $mydir/test_mgr_rest_api.py $url $secret
 
 echo $0 OK


### PR DESCRIPTION
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

