### PR TITLE
[DNM] common/msg: sockaddr on FreeBSD differs from Linux, has sa_len

### DIFF
--- a/cmake/modules/CephChecks.cmake
+++ b/cmake/modules/CephChecks.cmake
@@ -91,6 +91,8 @@ CHECK_STRUCT_HAS_MEMBER("struct stat" st_mtim.tv_nsec sys/stat.h
   HAVE_STAT_ST_MTIM_TV_NSEC LANGUAGE C)
 CHECK_STRUCT_HAS_MEMBER("struct stat" st_mtimespec.tv_nsec sys/stat.h
   HAVE_STAT_ST_MTIMESPEC_TV_NSEC LANGUAGE C)
+CHECK_STRUCT_HAS_MEMBER("struct sockaddr" sa_len sys/socket.h
+  HAVE_STRUCT_SOCKADDR_SA_LEN LANGUAGE C)
 
 if(NOT CMAKE_CROSSCOMPILING)
   include(CheckCXXSourceRuns)

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -286,6 +286,9 @@
 /* Define if you have struct stat.st_mtim.tv_nsec */
 #cmakedefine HAVE_STAT_ST_MTIM_TV_NSEC
 
+/* Define if the sockaddr struct has a sa_len part */
+#cmakedefine HAVE_STRUCT_SOCKADDR_SA_LEN
+
 /* Define if compiler supports static_cast<> */
 #cmakedefine HAVE_STATIC_CAST
 

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -130,10 +130,10 @@ bool entity_addr_t::parse(const char *s, const char **end, int default_type)
   struct in6_addr a6;
   if (inet_pton(AF_INET, buf4, &a4)) {
     u.sin.sin_addr.s_addr = a4.s_addr;
-    u.sa.sa_family = AF_INET;
+    u.set_family(AF_INET);
     p = start + strlen(buf4);
   } else if (inet_pton(AF_INET6, buf6, &a6)) {
-    u.sa.sa_family = AF_INET6;
+    u.set_family(AF_INET6);
     memcpy(&u.sin6.sin6_addr, &a6, sizeof(a6));
     p = start + strlen(buf6);
   } else {
@@ -297,6 +297,7 @@ void entity_addrvec_t::decode(ceph::buffer::list::const_iterator& bl)
     // legacy!
     entity_addr_t addr;
     addr.decode_legacy_addr_after_marker(bl);
+    addr.ntohs_family_sa_len();
     v.clear();
     v.push_back(addr);
     return;
@@ -310,6 +311,7 @@ void entity_addrvec_t::decode(ceph::buffer::list::const_iterator& bl)
     decode(elen, bl);
     if (elen) {
       bl.copy(elen, (char*)addr.get_sockaddr());
+      addr.ntohs_family_sa_len();
     }
     DECODE_FINISH(bl);
     v.clear();

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -152,6 +152,36 @@ namespace std {
   };
 } // namespace std
 
+/*
+ * Return the expected socket length as indicated by the
+ * family.
+ */
+static inline size_t get_family_len(int family) {
+    switch (family) {
+    case AF_INET:
+      return sizeof(struct sockaddr_in);
+    case AF_INET6:
+      return sizeof(struct sockaddr_in6);
+    }
+    return 0;
+}
+
+/*
+ * Return the size of the socket, or the max size of what it
+ * could be in the family is unknown.
+ */
+r
+static inline size_t get_sockaddr_size(int family) {
+    switch (family) {
+    case AF_INET:
+      return sizeof(struct sockaddr_in);
+    case AF_INET6:
+      return sizeof(struct sockaddr_in6);
+    }
+    return sizeof(struct ceph_sockaddr_storage);
+}
+
+
 // define a wire format for sockaddr that matches Linux's.
 struct ceph_sockaddr_storage {
   ceph_le16 ss_family;
@@ -171,34 +201,6 @@ struct ceph_sockaddr_storage {
   }
 } __attribute__ ((__packed__));
 WRITE_CLASS_ENCODER(ceph_sockaddr_storage)
-
-/*
- * Return the expected socket length as indicated by the
- * family.
- */
-static inline size_t get_family_len(int family) {
-    switch (family) {
-    case AF_INET:
-      return sizeof(struct sockaddr_in);
-    case AF_INET6:
-      return sizeof(struct sockaddr_in6);
-    }
-    return 0;
-}
-
-/*
- * Return the size of the socket, or the max size of what it
- * could be in the family is unknown.
- */
-static inline size_t get_sockaddr_size(int family) {
-    switch (family) {
-    case AF_INET:
-      return sizeof(struct sockaddr_in);
-    case AF_INET6:
-      return sizeof(struct sockaddr_in6);
-    }
-    return sizeof(struct ceph_sockaddr_storage);
-}
 
 /*
  * encode sockaddr.ss_family as network byte order


### PR DESCRIPTION
On Linux the definition of a sockaddr is:
```
struct sockaddr {
        sa_family_t sa_family;
        char        sa_data[14];
}
typedef unsigned short __kernel_sa_family_t;
```
Short is atleast 16 bits.

And on FreeBSD ik looks like:
```
struct sockaddr {
	unsigned char	sa_len;		/* total length */
	sa_family_t	sa_family;	/* address family */
	char		sa_data[14];	/* actually longer; address value */
};
typedef       __sa_family_t   sa_family_t;
:typedef       __uint8_t       __sa_family_t;
```
So the `sa_data[]` array always starts after 2 bytes. 
But depending on architecture lands the LSB of a short in the first of the second byte of the structure.
On i386/amd64 it lands in the first byte where FreeBSD would expect sa_len.

We need to do:
 - maintain the sa_len value for FreeBSD, otherwise memcmp() calls
   can return unequal, where the only difference would be `sa_len`.
   sa_len is set on returns from the FreeBSD syscalls.
 - add getter and setter functions for sa_len and sa_family.
 - Look into comparing structures whch have sockaddr as members.

Testing with `ceph_test_msgr` will show all poll tests failing.
Most of the time the script wil just loop endlessly.

Future work could be to actually rework the comparission routines in
msg_types.h to make full use of the structure. But for now it looks
like it not needed.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
Backport: Mimic, Luminous

Tracker: http://tracker.ceph.com/issues/38457

- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug