### PR TITLE
doc: Add select and vertical color line to choose and distinguish the release 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ alpine/APKBUILD
 
 # specific local dir files
 /build-doc
+/build-full-doc
 
 # where is this from?
 web/*.html

--- a/admin/apply-to-all-docs
+++ b/admin/apply-to-all-docs
@@ -53,7 +53,8 @@ do
     CHERRY_PICK_RESULT=$?
 
     if [ "${CHERRY_PICK_RESULT}" -ne 0 ]; then
-        read -p "ERROR: cherry-pick has failed (Press ^C to exit and resolve manually, ENTER - continue)"
+        git status
+        read -p "ERROR: cherry-pick on $i has failed (Press ^C to exit and resolve manually, ENTER - continue)"
     fi
     set -e
 

--- a/admin/apply-to-all-docs
+++ b/admin/apply-to-all-docs
@@ -22,8 +22,9 @@ fi
 
 COMMIT=$1
 
-
-# Uncomment for debug
+# Don't enable -e until after running all the potentially-erroring checks
+# for availability of commands
+set -e
 set -x
 
 ##### Idea:
@@ -47,6 +48,9 @@ do
 
     git checkout "$i"
     git checkout -b "${TGT_BRANCH}"
+
+    # Here error are expected due merge-conflicts
+    set +e
     git cherry-pick $COMMIT
     CHERRY_PICK_RESULT=$?
 
@@ -54,10 +58,11 @@ do
         read -p "WARNING: cherry-pick has failed (Continue?)\n"\
                 "(Press ^C to exit and resolve manually)"
     fi
+    set -e
 
     # NOTE: here you can write the auto-resolving actions if it is possible
-    git checkout master -- doc/releases/releases.yml
-    git cherry-pick --continue
+    # echo "please shell, resolve all automatically"
+    # git cherry-pick --continue
 done
 
 for i in "${CEPH_RELEASES[@]}"
@@ -69,4 +74,5 @@ do
     git branch -d "${TGT_BRANCH}"
 done
 
+git checkout master
 echo "All cherry-picks have been sucessfully resolved"

--- a/admin/apply-to-all-docs
+++ b/admin/apply-to-all-docs
@@ -1,17 +1,15 @@
 #!/bin/sh
 
-# copy-paste from doc/releases/releases.yml:releases
-# FIXME: do it automatically
-CEPH_RELEASES[0]=dumpling
-CEPH_RELEASES[1]=emperor
-CEPH_RELEASES[2]=firefly
-CEPH_RELEASES[3]=giant
-CEPH_RELEASES[4]=hammer
-CEPH_RELEASES[5]=infernalis
-CEPH_RELEASES[6]=jewel
-CEPH_RELEASES[8]=kraken
-CEPH_RELEASES[9]=luminous
-CEPH_RELEASES[10]=mimic
+if [ ! -d admin ]; then
+    echo "ERROR: run script from ceph-root directory"
+    exit -1
+fi
+
+source admin/releases
+
+# FIXME: see admin/releases
+# I could not build docs in all versions, nevertheless I try to apply COMMIT to all of them
+CEPH_RELEASES+=("dumpling" "infernalis" "jewel" "kraken")
 
 if [ "$#" -ne 1 ]; then
     echo "$0: make cherry-pick to all release branches to update the docs globally"
@@ -55,8 +53,7 @@ do
     CHERRY_PICK_RESULT=$?
 
     if [ "${CHERRY_PICK_RESULT}" -ne 0 ]; then
-        read -p "WARNING: cherry-pick has failed (Continue?)\n"\
-                "(Press ^C to exit and resolve manually)"
+        read -p "ERROR: cherry-pick has failed (Press ^C to exit and resolve manually, ENTER - continue)"
     fi
     set -e
 

--- a/admin/apply-to-all-docs
+++ b/admin/apply-to-all-docs
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# copy-paste from doc/releases/releases.yml:releases
+# FIXME: do it automatically
+CEPH_RELEASES[0]=dumpling
+CEPH_RELEASES[1]=emperor
+CEPH_RELEASES[2]=firefly
+CEPH_RELEASES[3]=giant
+CEPH_RELEASES[4]=hammer
+CEPH_RELEASES[5]=infernalis
+CEPH_RELEASES[6]=jewel
+CEPH_RELEASES[8]=kraken
+CEPH_RELEASES[9]=luminous
+CEPH_RELEASES[10]=mimic
+
+if [ "$#" -ne 1 ]; then
+    echo "$0: make cherry-pick to all release branches to update the docs globally"
+    echo "WARNING: DO NOT use this scritp if you do not understand what it does"
+    echo "USAGE: admin/admin/apply-to-all-docs '<commit>'"
+    exit -1
+fi
+
+COMMIT=$1
+
+
+# Uncomment for debug
+set -x
+
+##### Idea:
+# After cherry-pick there can be merge-conflicts, which developer should resolve
+# Script create branch TGT_BRANCH=<CEPH_RELEASE>-<COMMIT> from <CEPH_RELEASE> branch,
+# and try apply cherry pick on TGT_BRANCH
+#
+# if TGT_BRANCH exists the script considers the conflict as resolved
+#
+# After all TGT_BRANCH have been resolved, script merges from TGT_BRANCH
+# and remove it
+#####
+
+for i in "${CEPH_RELEASES[@]}"
+do
+    TGT_BRANCH="$i-$COMMIT"
+
+    if [ `git branch | grep -E "^[[:space:]]+${TGT_BRANCH}$"` ]; then
+        continue;
+    fi
+
+    git checkout "$i"
+    git checkout -b "${TGT_BRANCH}"
+    git cherry-pick $COMMIT
+    CHERRY_PICK_RESULT=$?
+
+    if [ "${CHERRY_PICK_RESULT}" -ne 0 ]; then
+        read -p "WARNING: cherry-pick has failed (Continue?)\n"\
+                "(Press ^C to exit and resolve manually)"
+    fi
+
+    # NOTE: here you can write the auto-resolving actions if it is possible
+    git checkout master -- doc/releases/releases.yml
+    git cherry-pick --continue
+done
+
+for i in "${CEPH_RELEASES[@]}"
+do
+    TGT_BRANCH="$i-$COMMIT"
+
+    git checkout "$i"
+    git merge "${TGT_BRANCH}"
+    git branch -d "${TGT_BRANCH}"
+done
+
+echo "All cherry-picks have been sucessfully resolved"

--- a/admin/apply-to-all-docs
+++ b/admin/apply-to-all-docs
@@ -34,17 +34,19 @@ set -x
 #
 # After all TGT_BRANCH have been resolved, script merges from TGT_BRANCH
 # and remove it
+#
+# After it you can push all release branches
 #####
 
-for i in "${CEPH_RELEASES[@]}"
+for release in "${CEPH_RELEASES[@]}"
 do
-    TGT_BRANCH="$i-$COMMIT"
+    TGT_BRANCH="$release-$COMMIT"
 
     if [ `git branch | grep -E "^[[:space:]]+${TGT_BRANCH}$"` ]; then
         continue;
     fi
 
-    git checkout "$i"
+    git checkout "$release"
     git checkout -b "${TGT_BRANCH}"
 
     # Here error are expected due merge-conflicts
@@ -54,7 +56,7 @@ do
 
     if [ "${CHERRY_PICK_RESULT}" -ne 0 ]; then
         git status
-        read -p "ERROR: cherry-pick on $i has failed (Press ^C to exit and resolve manually, ENTER - continue)"
+        read -p "ERROR: cherry-pick on $release has failed (Press ^C to exit and resolve manually, ENTER - continue)"
     fi
     set -e
 
@@ -63,14 +65,24 @@ do
     # git cherry-pick --continue
 done
 
-for i in "${CEPH_RELEASES[@]}"
+for release in "${CEPH_RELEASES[@]}"
 do
-    TGT_BRANCH="$i-$COMMIT"
+    TGT_BRANCH="$release-$COMMIT"
 
-    git checkout "$i"
+    git checkout "$release"
     git merge "${TGT_BRANCH}"
     git branch -d "${TGT_BRANCH}"
 done
 
 git checkout master
 echo "All cherry-picks have been sucessfully resolved"
+
+read -p "Do you want to push the releases to origin? (Press ^C to cancel, ENTER to push)"
+for release in "${CEPH_RELEASES[@]}"
+do
+    git checkout "$release"
+    git push
+done
+
+git checkout master
+echo "All commits in the releases have been sucessfully pushed"

--- a/admin/build-full-doc
+++ b/admin/build-full-doc
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+if [ ! -d admin ]; then
+    echo "ERROR: run script from ceph-root directory"
+    exit -1
+fi
+
+source admin/releases
+CEPH_RELEASES+=("master")
+
+# Don't enable -e until after running all the potentially-erroring checks
+# for availability of commands
+set -e
+set -x
+
+mkdir -p build-full-doc
+
+read -p "WARNING: 'git clean -xfd' may remove all your uncommited data (Press ^C to cancel, ENTER to continue)"
+
+git clean -xfd --exclude="build-full-doc"
+
+for i in "${CEPH_RELEASES[@]}"
+do
+    git checkout "$i"
+
+    # reset the files to get clean document build
+    git clean -xfd --exclude="build-full-doc"
+
+    # FIXME: I do not know how to make it in one git clean
+    # git clean are skipping repos from virtual env, we have to remove them manually
+    rm -rf build-doc/virtualenv
+
+    admin/build-doc
+    mv build-doc/output "build-full-doc/$i"
+done
+
+git checkout master

--- a/admin/build-full-doc
+++ b/admin/build-full-doc
@@ -19,9 +19,9 @@ read -p "WARNING: 'git clean -xfd' may remove all your uncommited data (Press ^C
 
 git clean -xfd --exclude="build-full-doc"
 
-for i in "${CEPH_RELEASES[@]}"
+for release in "${CEPH_RELEASES[@]}"
 do
-    git checkout "$i"
+    git checkout "$release"
 
     # reset the files to get clean document build
     git clean -xfd --exclude="build-full-doc"
@@ -31,7 +31,11 @@ do
     rm -rf build-doc/virtualenv
 
     admin/build-doc
-    mv build-doc/output "build-full-doc/$i"
+
+    if [ -d "build-full-doc/$release" ]; then
+        rm -r "build-full-doc/$release"
+    fi
+    mv build-doc/output "build-full-doc/$release"
 done
 
 git checkout master

--- a/admin/releases
+++ b/admin/releases
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# copy-paste from doc/releases/releases.yml:releases
+# FIXME: do it automatically
+
+# CEPH_RELEASES[0]=dumpling # FIXME: admin/build-doc looks broken: http://docs.ceph.com/docs/dumpling/
+# Running Sphinx v1.8.4
+# Extension error:
+# Could not import extension sphinx_ditaa (exception: cannot import name Directive)
+
+CEPH_RELEASES[1]=emperor
+CEPH_RELEASES[2]=firefly
+CEPH_RELEASES[3]=giant
+CEPH_RELEASES[4]=hammer
+
+# CEPH_RELEASES[5]=infernalis # FIXME: inconsistent build-doc dependencies:
+#breathe 4.11.1 has requirement Sphinx>=1.8, but you'll have sphinx 1.1.3 which is incompatible.
+
+# CEPH_RELEASES[6]=jewel # FIXME: could not build, error in Sphinx
+# Running Sphinx v1.6.3
+# Exception occurred:
+#   File "/home/suhoy/src/github/suhoy95/ceph/build-doc/virtualenv/src/breathe/breathe/renderer/sphinxrenderer.py", line 80, in DomainDirectiveFactory
+#     'union': (cpp.CPPUnionObject, 'union'),
+# AttributeError: 'module' object has no attribute 'CPPUnionObject'
+
+# CEPH_RELEASES[8]=kraken # FIXME: could not build, error in Sphinx
+# Running Sphinx v1.1.3
+# Exception occurred:
+#   File "/home/suhoy/src/github/suhoy95/ceph/build-doc/virtualenv/src/breathe/breathe/renderer/sphinxrenderer.py", line 77, in DomainDirectiveFactory
+#     'enum': (cpp.CPPEnumObject, 'enum'),
+# AttributeError: 'module' object has no attribute 'CPPEnumObject'
+
+CEPH_RELEASES[9]=luminous
+CEPH_RELEASES[10]=mimic
+
+export CEPH_RELEASES

--- a/doc/_static/js/ceph.js
+++ b/doc/_static/js/ceph.js
@@ -7,14 +7,14 @@ $(function() {
       if (eol) {
         $("#eol-warning").show();
       }
-      return !eol;
+      return eol;
     }
     return false;
   }
 
   function get_branch() {
     var path = window.location.pathname;
-    var res = path.match(/\/docs\/([a-z]+)\/?/i)
+    var res = path.match(/^\/docs\/([a-z]+)\/?/i)
     if (res) {
       return res[1]
     }
@@ -23,12 +23,32 @@ $(function() {
 
   function show_releases_select(branch, data) {
 
+    // Sort the releases according the last release
+    var releases = [];
+
+    for(var release in data.releases) {
+      // try to avoid modern JS: https://stackoverflow.com/a/36411645
+      if(data.releases.hasOwnProperty(release)) {
+        releases.push({
+          release_name: release,
+          released: data.releases[release].releases[0].released,
+        });
+      }
+    }
+
+    releases.sort(function (a, b) {
+      return a.released < b.released;
+    });
+
     var select = $("#ceph-release-select");
-    for (var release in data.releases) {
+
+    select.append('<option value="master">master</option>');
+    for (var i = 0; i < releases.length; i++) {
+      var release = releases[i].release_name;
       var option = '<option value="' + release + '">' + release + '</option>';
       select.append(option);
     }
-    select.append('<option value="master">master</option>');
+    // choose the current release
     select.val(branch);
 
     select.change(function (){
@@ -83,7 +103,7 @@ $(function() {
     show_releases_select(branch, data);
     draw_release_line(branch);
 
-    if (is_eol(branch, data)) {
+    if (!is_eol(branch, data)) {
       // patch the edit-on-github URL for correct branch
       var url = $("#edit-on-github").attr("href");
       url = url.replace("master", branch);

--- a/doc/_static/js/ceph.js
+++ b/doc/_static/js/ceph.js
@@ -43,6 +43,31 @@ $(function() {
     $("#ceph-releases").show()
   }
 
+  // show horizontal color line to easy distinguish the releases
+  // even in the middle of the page
+  function draw_release_line(branch) {
+    var color_map = {
+      // colors are got from https://github.com/d3/d3-scale-chromatic#schemeSet3
+      "dumpling": "#8dd3c7",
+      "emperor": "#ffffb3",
+      "firefly": "#bebada",
+      "giant": "#fb8072",
+      "hammer": "#80b1d3",
+      "infernalis": "#fdb462",
+      "jewel": "#b3de69",
+      "kraken": "#fccde5",
+      "luminous": "#d9d9d9",
+      "mimic": "#bc80bd",
+      // free colors:
+      // "": "#ccebc5",
+      // "": "#ffed6f",
+      // development documentation is always red to attract attention
+      "master": "#FF0000",
+    };
+    var color = (branch in color_map) ? color_map[branch] : "#000";
+    $(".body").css("border-left", "5px solid " + color);
+  }
+
   $.getJSON(releases_url, function(data) {
     var branch = get_branch();
 
@@ -54,8 +79,9 @@ $(function() {
       $("#dev-warning").show();
     }
 
-    // show select regardless of eol release
+    // show select and color line regardless of eol release
     show_releases_select(branch, data);
+    draw_release_line(branch);
 
     if (is_eol(branch, data)) {
       // patch the edit-on-github URL for correct branch

--- a/doc/_static/js/ceph.js
+++ b/doc/_static/js/ceph.js
@@ -1,41 +1,70 @@
 $(function() {
-  var releases_url = "http://docs.ceph.com/docs/master/releases.json";
+  var releases_url = "/docs/master/releases.json";
 
-  function show_edit(branch, data) {
-    if (branch) {
-      if (branch === "master") {
-        $("#dev-warning").show();
-        return true;
+  function is_eol(branch, data) {
+    if (data && data.releases && branch in data.releases) {
+      var eol = ("actual_eol" in data.releases[branch]);
+      if (eol) {
+        $("#eol-warning").show();
       }
-      if (data && data.releases && branch in data.releases) {
-        var eol = ("actual_eol" in data.releases[branch]);
-        if (eol) {
-          $("#eol-warning").show();
-        }
-        return !eol;
-      }
+      return !eol;
     }
-    $("#dev-warning").show();
     return false;
   }
 
   function get_branch() {
-    var url = window.location.href;
-    var res = url.match(/docs.ceph.com\/docs\/([a-z]+)\/?/i)
+    var path = window.location.pathname;
+    var res = path.match(/\/docs\/([a-z]+)\/?/i)
     if (res) {
       return res[1]
     }
     return null;
   }
 
+  function show_releases_select(branch, data) {
+
+    var select = $("#ceph-release-select");
+    for (var release in data.releases) {
+      var option = '<option value="' + release + '">' + release + '</option>';
+      select.append(option);
+    }
+    select.append('<option value="master">master</option>');
+    select.val(branch);
+
+    select.change(function (){
+      var tgt_branch = select.val();
+      var pathname = window.location.pathname;
+
+      var tgt_path = pathname.replace(/^\/docs\/([a-z]+)\/?/i, '/docs/' + tgt_branch + '/');
+
+      window.location.pathname = tgt_path;
+    });
+
+    $("#ceph-releases").show()
+  }
+
   $.getJSON(releases_url, function(data) {
     var branch = get_branch();
-    if (show_edit(branch, data)) {
+
+    if (branch === null) {
+      $("#dev-warning").show();
+      return;
+    }
+    if (branch === "master") {
+      $("#dev-warning").show();
+    }
+
+    // show select regardless of eol release
+    show_releases_select(branch, data);
+
+    if (is_eol(branch, data)) {
       // patch the edit-on-github URL for correct branch
       var url = $("#edit-on-github").attr("href");
       url = url.replace("master", branch);
       $("#edit-on-github").attr("href", url);
+
       $("#docubetter").show();
     }
+
   });
 });

--- a/doc/_static/js/ceph.js
+++ b/doc/_static/js/ceph.js
@@ -36,8 +36,15 @@ $(function() {
       }
     }
 
+    // RTFM: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
     releases.sort(function (a, b) {
-      return a.released < b.released;
+      if (a.released > b.released) { // newer release come first
+        return -1;
+      }
+      if (a.released < b.released) {
+        return 1;
+      }
+      return 0;
     });
 
     var select = $("#ceph-release-select");

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,5 +1,0 @@
-{% extends "!layout.html" %}
-
-{%- block extrahead %}
-    <script type="text/javascript" src="http://ayni.ceph.com/public/js/ceph.js"></script>
-{% endblock %}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,6 +1,20 @@
 {% extends "!page.html" %}
 {% block body %}
 
+<div id="ceph-releases" style="float: left; display:none; padding: 15px;">
+  <label>
+      Release: <select id="ceph-release-select"></select>
+  </label>
+</div>
+
+{%- if edit_on_github_url %}
+  <div id="docubetter" align="right" style="float: right; display:none; padding: 15px; font-weight: bold;">
+    <a id="edit-on-github" href="{{ edit_on_github_url }}" rel="nofollow">{{ _('Edit on GitHub')}}</a> | <a href="https://github.com/ceph/ceph/projects/4">Report a Documentation Bug</a>
+  </div>
+{%- endif %}
+
+<div style="clear: both"></div>
+
 <div id="dev-warning" class="admonition note" style="display:none;">
   <p class="first admonition-title">Notice</p>
   <p class="last">This document is for a development version of Ceph.</p>
@@ -10,18 +24,6 @@
   <p class="first admonition-title">Warning</p>
   <p class="last">This document is for an unsupported version of Ceph.</p>
 </div>
-
-{%- if edit_on_github_url %}
-  <div id="docubetter" align="right" style="display:none; padding: 15px; font-weight: bold;">
-    <a id="edit-on-github" href="{{ edit_on_github_url }}" rel="nofollow">{{ _('Edit on GitHub')}}</a> | <a href="https://github.com/ceph/ceph/projects/4">Report a Documentation Bug</a>
-  </div>
-{%- endif %}
-
-  <div id="ceph-releases">
-    <label>
-        Release: <select id="ceph-release-select"></select>
-    </label>
-  </div>
 
   {{ super() }}
 {% endblock %}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -24,6 +24,4 @@
   </div>
 
   {{ super() }}
-
-  <script type="text/javascript" src="/docs/master/_static/js/ceph.js"></script>
 {% endblock %}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -17,5 +17,13 @@
   </div>
 {%- endif %}
 
+  <div id="ceph-releases">
+    <label>
+        Release: <select id="ceph-release-select"></select>
+    </label>
+  </div>
+
   {{ super() }}
+
+  <script type="text/javascript" src="/docs/master/_static/js/ceph.js"></script>
 {% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,10 +79,6 @@ breathe_domain_by_extension = {'py': 'py', 'c': 'c', 'h': 'c', 'cc': 'cxx', 'hpp
 edit_on_github_project = 'ceph/ceph'
 edit_on_github_branch = 'master'
 
-# handles edit-on-github and old version warning display
-def setup(app):
-    app.add_javascript('js/ceph.js')
-
 # mocking ceph_module offered by ceph-mgr. `ceph_module` is required by
 # mgr.mgr_module
 class Dummy(object):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,6 +79,11 @@ breathe_domain_by_extension = {'py': 'py', 'c': 'c', 'h': 'c', 'cc': 'cxx', 'hpp
 edit_on_github_project = 'ceph/ceph'
 edit_on_github_branch = 'master'
 
+# handles edit-on-github, old version warning display, releases-select and
+# releases color vertical-line
+def setup(app):
+    app.add_javascript('js/ceph.js')
+
 # mocking ceph_module offered by ceph-mgr. `ceph_module` is required by
 # mgr.mgr_module
 class Dummy(object):

--- a/doc/releases/releases.yml
+++ b/doc/releases/releases.yml
@@ -11,7 +11,7 @@
 #
 # If a version might represent an actual number (e.g. 0.80) quote it.
 #
-# NOTE: When updating check the CEPH_RELEASES in the admin/apply-to-all-docs
+# NOTE: check the CEPH_RELEASES in the admin/releases on UPDATE
 releases:
   mimic:
     releases:

--- a/doc/releases/releases.yml
+++ b/doc/releases/releases.yml
@@ -11,6 +11,7 @@
 #
 # If a version might represent an actual number (e.g. 0.80) quote it.
 #
+# NOTE: When updating check the CEPH_RELEASES in the admin/apply-to-all-docs
 releases:
   mimic:
     releases:
@@ -24,7 +25,7 @@ releases:
         released: 2018-07-01
       - version: 13.2.0
         released: 2018-06-01
-  
+
   luminous:
     releases:
       - version: 12.2.10
@@ -49,7 +50,7 @@ releases:
         released: 2017-09-01
       - version: 12.2.0
         released: 2017-08-01
-  
+
   kraken:
     target_eol: 2017-08-01
     actual_eol: 2017-08-01

--- a/doc/releases/releases.yml
+++ b/doc/releases/releases.yml
@@ -11,7 +11,9 @@
 #
 # If a version might represent an actual number (e.g. 0.80) quote it.
 #
-# NOTE: check the CEPH_RELEASES in the admin/releases on UPDATE
+# NOTE: on UPDATE check
+# - the CEPH_RELEASES in the admin/releases
+# - the draw_release_line() in the doc/_static/js/ceph.js
 releases:
   mimic:
     releases:


### PR DESCRIPTION
doc: Add select and vertical color line to choose and distinguish the release 

Getting to the documentation from Google, it is very easy to get lost in releases. 
To facilitate it I've added select and horizontal color line ([result: ceph-docs.std12.os3.su:56765](http://ceph-docs.std12.os3.su:56765/docs/master/) [It's my workstation and site may not work, just tell me about that]). 


**Note:** Ceph doc has warnings about  unsupported Ceph release, but it is not back-ported and could be confused (e.i. [Ceph hammer doc](http://docs.ceph.com/docs/hammer/)). This PR also resolves this issue.

There are two scripts to change documentation in releases:

- `admin/apply-to-all-docs` - cherry-pick the commit to all release branches
- `admin/build-full-doc` - build full documentation as `http://docs.ceph.com/docs/{release}` into `build-full-doc/{release}`

I could not build the documentation in the branches `dumpling`, `infernalis`, `jewel`, `kraken`. 

This PR **must**  be considered together with pull-requests:

- [Suhoy95:ceph/dumpling](https://github.com/ceph/ceph/pull/26839) 
- [Suhoy95:ceph/emperor](https://github.com/ceph/ceph/pull/26840) 
- [Suhoy95:ceph/firefly](https://github.com/ceph/ceph/pull/26841) 
- [Suhoy95:ceph/giant](https://github.com/ceph/ceph/pull/26842) 
- [Suhoy95:ceph/hammer](https://github.com/ceph/ceph/pull/26843)
- [Suhoy95:ceph/infernalis](https://github.com/ceph/ceph/pull/26844)
- [Suhoy95:ceph/jewel](https://github.com/ceph/ceph/pull/26845) 
- [Suhoy95:ceph/kraken](https://github.com/ceph/ceph/pull/26846) 
- [Suhoy95:ceph/luminous](https://github.com/ceph/ceph/pull/26847) 
- [Suhoy95:ceph/mimic](https://github.com/ceph/ceph/pull/26848) 

I'm looking forward to comments, and I will open the remain PRs when receiving the approval.

Signed-off-by: Ilya Sukhoplyuev <i.sukhoplyuev@innopolis.ru>
(Innopolis University,  SNE master student)