### PR TITLE
luminous: qa/standalone/osd/osd-markdown: disable CLI command dups

### DIFF
--- a/qa/standalone/osd/osd-markdown.sh
+++ b/qa/standalone/osd/osd-markdown.sh
@@ -45,7 +45,10 @@ function markdown_N_impl() {
     ceph osd tree
     ceph osd tree | grep osd.0 |grep up || return 1
     # mark the OSD down.
-    ceph osd down 0
+    # override any dup setting in the environment to ensure we do this
+    # exactly once (modulo messenger failures, at least; we can't *actually*
+    # provide exactly-once semantics for mon commands).
+    CEPH_CLI_TEST_DUP_COMMAND=0 ceph osd down 0
     sleep $sleeptime
   done
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/38442