### PR TITLE
luminous: ceph_detect_init: Add support for ALT Linux

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -14,6 +14,7 @@
 # GNU Library Public License for more details.
 #
 from ceph_detect_init import alpine
+from ceph_detect_init import alt
 from ceph_detect_init import arch
 from ceph_detect_init import centos
 from ceph_detect_init import debian
@@ -60,6 +61,7 @@ def _get_distro(distro, use_rhceph=False):
     distro = _normalized_distro_name(distro)
     distributions = {
         'alpine': alpine,
+        'alt': alt,
         'arch': arch,
         'debian': debian,
         'ubuntu': debian,
@@ -103,6 +105,8 @@ def _normalized_distro_name(distro):
         return 'gentoo'
     elif distro.startswith('virtuozzo'):
         return 'virtuozzo'
+    elif distro.startswith(('alt', 'altlinux', 'basealt', 'alt linux')):
+        return 'alt'
     return distro
 
 

--- a/src/ceph-detect-init/ceph_detect_init/alt/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/alt/__init__.py
@@ -1,0 +1,18 @@
+import os
+
+distro = None
+release = None
+codename = None
+
+
+def choose_init():
+    """Select a init system
+
+    Returns the name of a init system (upstart, sysvinit ...).
+    """
+    # yes, this is heuristics
+    if os.path.isdir('/run/systemd/system'):
+        return 'systemd'
+
+    if os.path.isfile('/sbin/init') and not os.path.islink('/sbin/init'):
+        return 'sysvinit'

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -24,6 +24,7 @@ import testtools
 
 import ceph_detect_init
 from ceph_detect_init import alpine
+from ceph_detect_init import alt
 from ceph_detect_init import arch
 from ceph_detect_init import centos
 from ceph_detect_init import debian
@@ -45,6 +46,19 @@ class TestCephDetectInit(testtools.TestCase):
 
     def test_alpine(self):
         self.assertEqual('openrc', alpine.choose_init())
+
+    def test_alt(self):
+        with mock.patch.multiple('os.path',
+                                 isdir=lambda x: x == '/run/systemd/system'):
+            self.assertEqual('systemd', alt.choose_init())
+
+        with mock.patch.multiple('os.path',
+                                 isdir=lambda x: False,
+                                 isfile=lambda x: x == '/sbin/init',
+                                 islink=lambda x: x != '/sbin/init'):
+            with mock.patch.multiple('subprocess',
+                                     call=lambda *args, **kwargs: 1):
+                self.assertEqual('sysvinit', alt.choose_init())
 
     def test_arch(self):
         self.assertEqual('systemd', arch.choose_init())
@@ -221,6 +235,7 @@ class TestCephDetectInit(testtools.TestCase):
         self.assertEqual(rhel, g('redhat', use_rhceph=True))
         self.assertEqual(gentoo, g('gentoo'))
         self.assertEqual(centos, g('virtuozzo'))
+        self.assertEqual(alt, g('alt'))
 
     def test_normalized_distro_name(self):
         n = ceph_detect_init._normalized_distro_name
@@ -251,6 +266,10 @@ class TestCephDetectInit(testtools.TestCase):
         self.assertEqual('gentoo', n('Exherbo'))
         self.assertEqual('gentoo', n('exherbo'))
         self.assertEqual('virtuozzo', n('Virtuozzo Linux'))
+        self.assertEqual('alt', n('ALTLinux'))
+        self.assertEqual('alt', n('ALT'))
+        self.assertEqual('alt', n('BaseALT'))
+        self.assertEqual('alt', n('ALT Linux'))
 
     @mock.patch('platform.system', lambda: 'Linux')
     def test_platform_information_linux(self):


### PR DESCRIPTION
Support Alt Linux distribution added.

Signed-off-by: Andrey Bychkov <mrdrew@altlinux.org>