### PR TITLE
rbd: fix segmentation fault when rbd_group_image_list() getting -ENOENT

### DIFF
--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -5878,6 +5878,7 @@ extern "C" int rbd_group_image_list(rados_ioctx_t group_p,
 
   if (r == -ENOENT) {
     tracepoint(librbd, group_image_list_exit, 0);
+    *image_size = 0;
     return 0;
   }
 

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -2531,6 +2531,12 @@ cdef class Group(object):
         self._ioctx = convert_ioctx(ioctx)
         self._name = name
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        return False
+
     def add_image(self, image_ioctx, image_name):
         """
         Add an image to a group.

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -2024,6 +2024,16 @@ class TestGroups(object):
         self.group.add_image(ioctx, image_name)
         eq([image_name], [img['name'] for img in self.group.list_images()])
 
+    def test_group_image_list_move_to_trash(self):
+        eq([], list(self.group.list_images()))
+        with Image(ioctx, image_name) as image:
+            image_id = image.id()
+        self.group.add_image(ioctx, image_name)
+        eq([image_name], [img['name'] for img in self.group.list_images()])
+        RBD().trash_move(ioctx, image_name, 0)
+        eq([], list(self.group.list_images()))
+        RBD().trash_restore(ioctx, image_id, image_name)
+
     def test_group_image_many_images(self):
         eq([], list(self.group.list_images()))
         self.group.add_image(ioctx, image_name)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Fixes: http://tracker.ceph.com/issues/38468