### PR TITLE
mgr/PyModule: put mgr_module_path first in sys.path

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -337,8 +337,8 @@ int PyModule::load(PyThreadState *pMainThreadState)
       PySys_SetArgv(1, (char**)argv);
 #endif
       // Configure sys.path to include mgr_module_path
-      string paths = (":" + get_site_packages() +
-		      ":" + g_conf().get_val<std::string>("mgr_module_path"));
+      string paths = (":" + g_conf().get_val<std::string>("mgr_module_path") +
+		      ":" + get_site_packages());
 #if PY_MAJOR_VERSION >= 3
       wstring sys_path(Py_GetPath() + wstring(begin(paths), end(paths)));
       PySys_SetPath(const_cast<wchar_t*>(sys_path.c_str()));


### PR DESCRIPTION
If the various python site packages appear first in sys.path, and there
happens to be a package whose name is the same as an mgr module, mgr will
try to load that thing instead of the expected mgr module.  This results
in a very terse couple of errors:

  mgr[py] Class not found in module 'deepsea'
  mgr[py] Error loading module 'deepsea': (22) Invalid argument

Before this commit, sys.path on my SLE 11 SP1 dev system is:

  /usr/lib/python36.zip
  /usr/lib64/python3.6
  /usr/lib64/python3.6
  /usr/lib64/python3.6/lib-dynload
  /usr/lib64/python3.6/site-packages
  /usr/lib/python3.6/site-packages
  /usr/local/lib64/python3.6/site-packages
  /usr/local/lib/python3.6/site-packages
  /usr/lib64/ceph/mgr

After this commit, /usr/share/ceph/mgr comes before python's site-packages,
and everything works properly:

  /usr/lib/python36.zip
  /usr/lib64/python3.6
  /usr/lib64/python3.6
  /usr/lib64/python3.6/lib-dynload
  /usr/share/ceph/mgr
  /usr/lib64/python3.6/site-packages
  /usr/lib/python3.6/site-packages
  /usr/local/lib64/python3.6/site-packages
  /usr/local/lib/python3.6/site-packages

(If you're interested in seeing what's in sys.path, turn "debug mgr" up
to at least 10, then grep the logs for "Computed sys.path")

Fixes: https://tracker.ceph.com/issues/38469
Signed-off-by: Tim Serong <tserong@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

