### PR TITLE
rpm,cmake: additional fixes to make amqp support optional

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -187,7 +187,9 @@ BuildRequires:	xfsprogs
 BuildRequires:	xfsprogs-devel
 BuildRequires:	xmlstarlet
 BuildRequires:	yasm
+%if 0%{with amqp_endpoint}
 BuildRequires:  librabbitmq-devel
+%endif
 %if 0%{with make_check}
 BuildRequires:  jq
 BuildRequires:	python%{_python_buildid}-bcrypt

--- a/src/tools/ceph-dencoder/CMakeLists.txt
+++ b/src/tools/ceph-dencoder/CMakeLists.txt
@@ -22,6 +22,10 @@ if(WITH_RADOSGW)
   list(APPEND DENCODER_EXTRALIBS
     rgw_a
     cls_rgw_client)
+  if(WITH_RADOSGW_AMQP_ENDPOINT)
+    list(APPEND DENCODER_EXTRALIBS
+      rabbitmq)
+  endif()
 endif()
 
 if(WITH_RBD)
@@ -56,6 +60,5 @@ target_link_libraries(ceph-dencoder
   cls_journal_client
   cls_timeindex_client
   ${EXTRALIBS}
-  ${CMAKE_DL_LIBS}
-  rabbitmq)
+  ${CMAKE_DL_LIBS})
 install(TARGETS ceph-dencoder DESTINATION bin)


### PR DESCRIPTION
I found a couple of extra tweaks necessary when building master on SLES since https://github.com/ceph/ceph/pull/26555 was merged. Please note that this change makes the build succeed on SLES when AMQP is _disabled_, but I don't have a suitable environment here to test if the build works correctly with AMQP enabled. That said, it _should_ do the right thing...