### PR TITLE
doc: Updated Ceph Dashboard documentation

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -126,10 +126,13 @@ reflect either technical terms or legacy ways of referring to Ceph systems.
 
 	Ceph Manager Dashboard
 	Ceph Dashboard
+	Dashboard Module
 	Dashboard Plugin
 	Dashboard
-                A built-in web based monitoring and administration application to
-                Ceph Manager. Refer :ref:`mgr-dashboard` for more details.
+		A built-in web-based Ceph management and monitoring application to
+		administer various aspects and objects of the cluster. The dashboard is
+		implemented as a Ceph Manager module. See :ref:`mgr-dashboard` for more
+		details.
 
 	Ceph Metadata Server
 	MDS

--- a/doc/mgr/dashboard_plugins/feature_toggles.inc.rst
+++ b/doc/mgr/dashboard_plugins/feature_toggles.inc.rst
@@ -3,7 +3,7 @@
 Feature Toggles
 ^^^^^^^^^^^^^^^
 
-This plug-in allows to enable or disable some features from the Ceph-Dashboard
+This plug-in allows to enable or disable some features from the Ceph Dashboard
 on-demand. When a feature becomes disabled:
 
 - Its front-end elements (web pages, menu entries, charts, etc.) will become hidden.

--- a/doc/mgr/index.rst
+++ b/doc/mgr/index.rst
@@ -1,4 +1,4 @@
-
+.. _ceph-manager-daemon:
 
 ===================
 Ceph Manager Daemon

--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -1,3 +1,5 @@
+.. _mgr-prometheus:
+
 =================
 Prometheus Module
 =================

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -1,5 +1,5 @@
-Dashboard Developer Documentation
-====================================
+Ceph Dashboard Developer Documentation
+======================================
 
 .. contents:: Table of Contents
 
@@ -1030,7 +1030,7 @@ The value of the class attribute is a pair composed by the default value for tha
 setting, and the python type of the value.
 
 By declaring the ``ADMIN_EMAIL_ADDRESS`` class attribute, when you restart the
-dashboard plugin, you will automatically gain two additional CLI commands to
+dashboard module, you will automatically gain two additional CLI commands to
 get and set that setting::
 
   $ ceph dashboard get-admin-email-address
@@ -1585,12 +1585,12 @@ Plug-ins
 
 New functionality can be provided by means of a plug-in architecture. Among the
 benefits this approach brings in, loosely coupled development is one of the most
-notable. As the Ceph-Dashboard grows in feature richness, its code-base becomes
+notable. As the Ceph Dashboard grows in feature richness, its code-base becomes
 more and more complex. The hook-based nature of a plug-in architecture allows to
 extend functionality in a controlled manner, and isolate the scope of the
 changes.
 
-Ceph-Dashboard relies on `Pluggy <https://pluggy.readthedocs.io>`_ to provide
+Ceph Dashboard relies on `Pluggy <https://pluggy.readthedocs.io>`_ to provide
 for plug-ing support. On top of pluggy, an interface-based approach has been
 implemented, with some safety checks (method override and abstract method
 checks).
@@ -1601,13 +1601,13 @@ In order to create a new plugin, the following steps are required:
 #. Import the ``PLUGIN_MANAGER`` instance and the ``Interfaces``.
 #. Create a class extending the desired interfaces. The plug-in library will check if all the methods of the interfaces have been properly overridden.
 #. Register the plugin in the ``PLUGIN_MANAGER`` instance.
-#. Import the plug-in from within the Ceph-Dashboard ``module.py`` (currently no dynamic loading is implemented).
+#. Import the plug-in from within the Ceph Dashboard ``module.py`` (currently no dynamic loading is implemented).
 
 The available interfaces are the following:
 
 - ``CanMgr``: provides the plug-in with access to the ``mgr`` instance under ``self.mgr``.
-- ``CanLog``: provides the plug-in with access to the Ceph-Dashboard logger under ``self.log``.
-- ``Setupable``: requires overriding ``setup()`` hook. This method is run in the Ceph-Dashboard ``serve()`` method, right after CherryPy has been configured, but before it is started. It's a placeholder for the plug-in initialization logic.
+- ``CanLog``: provides the plug-in with access to the Ceph Dashboard logger under ``self.log``.
+- ``Setupable``: requires overriding ``setup()`` hook. This method is run in the Ceph Dashboard ``serve()`` method, right after CherryPy has been configured, but before it is started. It's a placeholder for the plug-in initialization logic.
 - ``HasOptions``: requires overriding ``get_options()`` hook by returning a list of ``Options()``. The options returned here are added to the ``MODULE_OPTIONS``.
 - ``HasCommands``: requires overriding ``register_commands()`` hook by defining the commands the plug-in can handle and decorating them with ``@CLICommand`. The commands can be optionally returned, so that they can be invoked externally (which makes unit testing easier).
 - ``HasControllers``: requires overriding ``get_controllers()`` hook by defining and returning the controllers as usual.

--- a/src/pybind/mgr/dashboard/README.rst
+++ b/src/pybind/mgr/dashboard/README.rst
@@ -1,41 +1,15 @@
-Dashboard and Administration Module for Ceph Manager
-====================================================
+Ceph Dashboard
+==============
 
 Overview
 --------
 
-The original Ceph manager dashboard that was shipped with Ceph "Luminous"
-started out as a simple read-only view into various run-time information and
-performance data of a Ceph cluster. It used a very simple architecture to
-achieve the original goal.
-
-However, there was a growing demand for adding more web-based management
-capabilities, to make it easier to administer Ceph for users that prefer a WebUI
-over using the command line.
-
-This new dashboard module is a replacement of the previous one and an
-ongoing project to add a native web based monitoring and administration
-application to Ceph Manager.
-
-The architecture and functionality of this module are derived from and inspired
-by the `openATTIC Ceph management and monitoring tool
-<https://openattic.org/>`_. The development is actively driven by the team
-behind openATTIC at SUSE.
-
-The intention is to reuse as much of the existing openATTIC functionality as
-possible, while adapting it to the different environment. The Dashboard module's
-backend code uses the CherryPy framework and a custom REST API implementation
-instead of Django and the Django REST Framework.
-
-The WebUI implementation is based on Angular/TypeScript, merging both
-functionality from the original dashboard as well as adding new functionality
-originally developed for the standalone version of openATTIC.
+The Ceph Dashboard is a built-in web-based Ceph management and monitoring
+application to administer various aspects and objects of the cluster. It is
+implemented as a Ceph Manager module.
 
 Enabling and Starting the Dashboard
 -----------------------------------
-
-If you have installed Ceph from distribution packages, the package management
-system should have taken care of installing all the required dependencies.
 
 If you want to start the dashboard from within a development environment, you
 need to have built Ceph (see the toplevel ``README.md`` file and the `developer
@@ -50,30 +24,14 @@ If you use the ``vstart.sh`` script to start up your development cluster, it
 will configure and enable the dashboard automatically. The URL and login
 credentials are displayed when the script finishes.
 
-See the `Ceph Dashboard plugin documentation
+Please see the `Ceph Dashboard documentation
 <http://docs.ceph.com/docs/master/mgr/dashboard/>`_ for details on how to enable
 and configure the dashboard manually and how to configure other settings, e.g.
 access to the Ceph object gateway.
-
-Supported browsers
-------------------
-
-The Ceph Manager Dashboard is tested and developed on the following browsers:
-
-+----------------------------------------------+----------+
-|                    Browser                   | Versions |
-+==============================================+==========+
-| `Chrome <https://www.google.com/chrome/>`_   | 68+      |
-+----------------------------------------------+----------+
-| `Firefox <http://www.mozilla.org/firefox/>`_ | 61+      |
-+----------------------------------------------+----------+
-
-While Ceph Manager Dashboard might work in older browsers, we cannot guarantee
-it and recommend you update your browser to the latest version.
 
 Working on the Dashboard Code
 -----------------------------
 
 If you're interested in helping with the development of the dashboard, please
 see the file ``HACKING.rst`` for details on how to set up a development
-environment and some other development-related topics.
+environment and other development-related topics.


### PR DESCRIPTION
* Updated the Ceph Dashboard chapter: replaced "Manager Dashboard" with "Dashboard", replaced "plugin" with "module".
* Overhauled dashboard the feature list, added more references to configuration instructions.
* Removed duplicate content from the dashboard `README.rst`, moved some parts (supported browser list) into the documentation instead.


Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>