### PR TITLE
msg/async, v2: fix unused variable warning in ::discard_out_queue().

### DIFF
--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -607,6 +607,7 @@ void ProtocolV2::discard_out_queue() {
   }
   sent.clear();
   for (auto& [ prio, entries ] : out_queue) {
+    static_cast<void>(prio);
     for (auto& entry : entries) {
       ldout(cct, 20) << __func__ << " discard " << *entry.m << dendl;
       entry.m->put();


### PR DESCRIPTION
Related-To: https://github.com/ceph/ceph/pull/26466.