### PR TITLE
mgr/orchestrator: Allow the orchestrator to scale the NFS server count

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -126,3 +126,6 @@ class TestOrchestratorCli(MgrTestCase):
 
     def test_mgr_update(self):
         self._orch_cmd("mgr", "update", "3")
+
+    def test_nfs_update(self):
+        self._orch_cmd("nfs", "update", "service_name", "2")

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -332,8 +332,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def update_stateless_service(self, service_type, id_, spec):
-        # type: (str, str, StatelessServiceSpec) -> WriteCompletion
+    def update_stateless_service(self, service_type, spec):
+        # type: (str, StatelessServiceSpec) -> WriteCompletion
         """
         This is about changing / redeploying existing services. Like for
         example changing the number of service instances.

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -658,9 +658,8 @@ class StatelessServiceSpec(object):
         # within one ceph cluster.
         self.name = ""
 
-        # Minimum and maximum number of service instances
-        self.min_size = 1
-        self.max_size = 1
+        # Count of service instances
+        self.count = 1
 
         # Arbitrary JSON-serializable object.
         # Maybe you're using e.g. kubenetes and you want to pass through

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -268,6 +268,19 @@ Usage:
     def _nfs_rm(self, svc_id):
         return self._rm_stateless_svc("nfs", svc_id)
 
+    @CLIWriteCommand('orchestrator nfs update',
+                     "name=svc_id,type=CephString "
+                     "name=num,type=CephInt",
+                     'Scale an NFS service')
+    @handle_exceptions
+    def _nfs_update(self, svc_id, num):
+        spec = orchestrator.StatelessServiceSpec()
+        spec.name = svc_id
+        spec.count = num
+        completion = self.update_stateless_service("nfs", spec)
+        self._orchestrator_wait([completion])
+        return HandleCommandResult()
+
     @CLIWriteCommand('orchestrator service',
                      "name=action,type=CephChoices,strings=start|stop|reload "
                      "name=svc_type,type=CephString "

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -400,6 +400,16 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             lambda: self.rook_cluster.update_mon_count(num), None,
             "Updating mon count to {0}".format(num))
 
+    def update_stateless_service(self, svc_type, spec):
+        # only nfs is currently supported
+        if svc_type != "nfs":
+            raise NotImplementedError(svc_type)
+
+        num = spec.count
+        return RookWriteCompletion(
+            lambda: self.rook_cluster.update_nfs_count(spec.name, num), None,
+                "Updating NFS server count in {0} to {1}".format(spec.name, num))
+
     def create_osds(self, drive_group, all_hosts):
         # type: (orchestrator.DriveGroupSpec, List[str]) -> RookWriteCompletion
 

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -348,6 +348,19 @@ class RookCluster(object):
 
         return "Updated mon count to {0}".format(newcount)
 
+    def update_nfs_count(self, svc_id, newcount):
+        patch = [{"op": "replace", "path": "/spec/server/active", "value": newcount}]
+
+        try:
+            self.rook_api_patch(
+                "cephnfses/{0}".format(svc_id),
+                body=patch)
+        except ApiException as e:
+            log.exception("API exception: {0}".format(e))
+            raise ApplyException(
+                "Failed to update NFS server count for {0}: {1}".format(svc_id, e))
+        return "Updated NFS server count for {0} to {1}".format(svc_id, newcount)
+
     def add_osds(self, drive_group, all_hosts):
         # type: (orchestrator.DriveGroupSpec, List[str]) -> None
         """

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -209,7 +209,6 @@ class RookCluster(object):
 
     def add_filesystem(self, spec):
         # TODO use spec.placement
-        # TODO use spec.min_size (and use max_size meaningfully)
         # TODO warn if spec.extended has entries we don't kow how
         #      to action.
 
@@ -223,7 +222,7 @@ class RookCluster(object):
             "spec": {
                 "onlyManageDaemons": True,
                 "metadataServer": {
-                    "activeCount": spec.max_size,
+                    "activeCount": spec.count,
                     "activeStandby": True
 
                 }
@@ -235,7 +234,6 @@ class RookCluster(object):
 
     def add_nfsgw(self, spec):
         # TODO use spec.placement
-        # TODO use spec.min_size (and use max_size meaningfully)
         # TODO warn if spec.extended has entries we don't kow how
         #      to action.
 
@@ -251,7 +249,7 @@ class RookCluster(object):
                     "pool": spec.extended["pool"]
                 },
                 "server": {
-                    "active": spec.max_size,
+                    "active": spec.count,
                 }
             }
         }
@@ -263,7 +261,6 @@ class RookCluster(object):
             self.rook_api_post("cephnfses/", body=rook_nfsgw)
 
     def add_objectstore(self, spec):
-  
         rook_os = {
             "apiVersion": ROOK_API_NAME,
             "kind": "CephObjectStore",

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -270,6 +270,10 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def remove_stateless_service(self, service_type, id_):
         pass
 
+    @deferred_write("update_stateless_service")
+    def update_stateless_service(self, service_type, spec):
+        pass
+
     @deferred_read
     def get_hosts(self):
         return [orchestrator.InventoryNode('localhost', [])]


### PR DESCRIPTION
Rook can scale the size of an NFS cluster up and down, so add the necessary CLI, orchestrator and rook infrastructure to allow that.