### PR TITLE
messages/MMonMgrDigest: use set_data() to avoid screwing up byte_throttler

### DIFF
--- a/src/messages/MMonMgrReport.h
+++ b/src/messages/MMonMgrReport.h
@@ -70,7 +70,7 @@ public:
       decode(digest, p);
       bufferlist bl;
       encode(digest, bl, features);
-      data.swap(bl);
+      set_data(bl);
     }
   }
   void decode_payload() override {


### PR DESCRIPTION
Use the existing set_data() helper to avoid breaking the byte_throttler
accounting.

Fixes e4ae368ff7a5396194f8bdd5692429af5457998b

Signed-off-by: Sage Weil <sage@redhat.com>