### PR TITLE
cephfs: add new standby-replay fs flag

### DIFF
--- a/doc/cephfs/standby.rst
+++ b/doc/cephfs/standby.rst
@@ -58,9 +58,10 @@ forms of the 'fail' command:
 Managing failover
 -----------------
 
-If an MDS daemon stops communicating with the monitor, the monitor will
-wait ``mds_beacon_grace`` seconds (default 15 seconds) before marking
-the daemon as *laggy*.
+If an MDS daemon stops communicating with the monitor, the monitor will wait
+``mds_beacon_grace`` seconds (default 15 seconds) before marking the daemon as
+*laggy*. If a standby is available, the monitor will immediately replace the
+laggy daemon.
 
 Each file system may specify a number of standby daemons to be considered
 healthy. This number includes daemons in standby-replay waiting for a rank to
@@ -76,148 +77,25 @@ Each file system may set the number of standby daemons wanted using:
 Setting ``count`` to 0 will disable the health check.
 
 
-Configuring standby daemons
----------------------------
+Configuring standby-replay
+--------------------------
 
-There are four configuration settings that control how a daemon
-will behave while in standby:
+Each CephFS file system may be configured to add standby-replay daemons.  These
+standby daemons follow the active MDS's metadata journal to reduce failover
+time in the event the active MDS becomes unavailable. Each active MDS may have
+only one standby-replay daemon following it.
 
-::
-
-    mds_standby_replay
-    mds_standby_for_name
-    mds_standby_for_rank
-    mds_standby_for_fscid
-
-These may be set in the ceph.conf on the host where the MDS daemon
-runs (as opposed to on the monitor).  The daemon loads these settings
-when it starts, and sends them to the monitor.
-
-By default, if none of these settings are used, all MDS daemons
-which do not hold a rank will be used as standbys for any rank.
-
-The settings which associate a standby daemon with a particular
-name or rank do not guarantee that the daemon will *only* be used
-for that rank.  They mean that when several standbys are available,
-the associated standby daemon will be used.  If a rank is failed,
-and a standby is available, it will be used even if it is associated
-with a different rank or named daemon.
-
-mds_standby_replay
-~~~~~~~~~~~~~~~~~~
-
-If this is set to true, then the standby daemon will continuously read
-the metadata journal of an up rank.  This will give it
-a warm metadata cache, and speed up the process of failing over
-if the daemon serving the rank fails.
-
-An up rank may only have one standby replay daemon assigned to it,
-if two daemons are both set to be standby replay then one of them
-will arbitrarily win, and the other will become a normal non-replay
-standby.
-
-Once a daemon has entered the standby replay state, it will only be
-used as a standby for the rank that it is following.  If another rank
-fails, this standby replay daemon will not be used as a replacement,
-even if no other standbys are available.
-
-*Historical note:* In Ceph prior to v10.2.1, this setting (when ``false``) is
-always true when ``mds_standby_for_*`` is also set.
-
-mds_standby_for_name
-~~~~~~~~~~~~~~~~~~~~
-
-Set this to make the standby daemon only take over a failed rank
-if the last daemon to hold it matches this name.
-
-mds_standby_for_rank
-~~~~~~~~~~~~~~~~~~~~
-
-Set this to make the standby daemon only take over the specified
-rank.  If another rank fails, this daemon will not be used to
-replace it.
-
-Use in conjunction with ``mds_standby_for_fscid`` to be specific
-about which filesystem's rank you are targeting, if you have
-multiple filesystems.
-
-mds_standby_for_fscid
-~~~~~~~~~~~~~~~~~~~~~
-
-If ``mds_standby_for_rank`` is set, this is simply a qualifier to
-say which filesystem's rank is referred to.
-
-If ``mds_standby_for_rank`` is not set, then setting FSCID will
-cause this daemon to target any rank in the specified FSCID.  Use
-this if you have a daemon that you want to use for any rank, but
-only within a particular filesystem.
-
-mon_force_standby_active
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-This setting is used on monitor hosts.  It defaults to true.
-
-If it is false, then daemons configured with mds_standby_replay=true
-will **only** become active if the rank/name that they have
-been configured to follow fails.  On the other hand, if this
-setting is true, then a daemon configured with mds_standby_replay=true
-may be assigned some other rank.
-
-Examples
---------
-
-These are example ceph.conf snippets.  In practice you can either
-copy a ceph.conf with all daemons' configuration to all your servers,
-or you can have a different file on each server that contains just
-that server's daemons' configuration.
-
-Simple pair
-~~~~~~~~~~~
-
-Two MDS daemons 'a' and 'b' acting as a pair, where whichever one is not
-currently assigned a rank will be the standby replay follower
-of the other.
+Configuring standby-replay on a file system is done using:
 
 ::
 
-    [mds.a]
-    mds standby replay = true
-    mds standby for rank = 0
+    ceph fs set <fs name> allow_standby_replay <bool>
 
-    [mds.b]
-    mds standby replay = true
-    mds standby for rank = 0
+Once set, the monitors will assign available standby daemons to follow the
+active MDSs in that file system.
 
-Floating standby
-~~~~~~~~~~~~~~~~
-
-Three MDS daemons 'a', 'b' and 'c', in a filesystem that has
-``max_mds`` set to 2.
-
-::
-    
-    # No explicit configuration required: whichever daemon is
-    # not assigned a rank will go into 'standby' and take over
-    # for whichever other daemon fails.
-
-Two MDS clusters
-~~~~~~~~~~~~~~~~
-
-With two filesystems, I have four MDS daemons, and I want two
-to act as a pair for one filesystem and two to act as a pair
-for the other filesystem.
-
-::
-
-    [mds.a]
-    mds standby for fscid = 1
-
-    [mds.b]
-    mds standby for fscid = 1
-
-    [mds.c]
-    mds standby for fscid = 2
-
-    [mds.d]
-    mds standby for fscid = 2
-
+Once an MDS has entered the standby-replay state, it will only be used as a
+standby for the rank that it is following. If another rank fails, this
+standby-replay daemon will not be used as a replacement, even if no other
+standbys are available. For this reason, it is advised that if standby-replay
+is used then every active MDS should have a standby-replay daemon.

--- a/doc/man/8/ceph-mds.rst
+++ b/doc/man/8/ceph-mds.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **ceph-mds** -i <*ID*> [flags] [ --hot-standby <*rank*> ]
+| **ceph-mds** -i <*ID*> [flags]
 
 
 Description
@@ -26,11 +26,6 @@ Once the daemon has started, the monitor cluster will normally assign
 it a logical rank, or put it in a standby pool to take over for
 another daemon that crashes. Some of the specified options can cause
 other behaviors.
-
-If you specify --hot-standby, you must specify the rank on the command
-line. Alternatively, you can specify one of the mds_standby_for_[rank|name]
-parameters in the config.  The command line specification overrides the config,
-and specifying the rank overrides specifying the name.
 
 
 Options
@@ -67,10 +62,6 @@ Options
 
    Connect to specified monitor (instead of looking through
    ``ceph.conf``).
-
-.. option:: --hot-standby <rank>
-
-   Start as a hot standby for MDS <rank>.
 
 .. option:: --id/-i ID
 

--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -428,6 +428,12 @@ These changes occurred between the Mimic and Nautilus releases.
   ``mds_recall_warning_decay_rate`` (default: 60s) sets the threshold
   for this warning.
 
+* The MDS mds_standby_for_*, mon_force_standby_active, and mds_standby_replay
+  configuration options have been obsoleted. Instead, the operator may now set
+  the new "allow_standby_replay" flag on the CephFS file system. This setting
+  causes standbys to become standby-replay for any available rank in the file
+  system.
+
 * The Telegraf module for the Manager allows for sending statistics to
   an Telegraf Agent over TCP, UDP or a UNIX Socket. Telegraf can then
   send the statistics to databases like InfluxDB, ElasticSearch, Graphite

--- a/qa/cephfs/clusters/1-mds-1-client-coloc.yaml
+++ b/qa/cephfs/clusters/1-mds-1-client-coloc.yaml
@@ -1,6 +1,6 @@
 roles:
 - [mon.a, mgr.y, mds.a, osd.0, osd.1, osd.2, osd.3, client.0]
-- [mon.b, mon.c, mgr.x, mds.a-s, osd.4, osd.5, osd.6, osd.7]
+- [mon.b, mon.c, mgr.x, mds.b, osd.4, osd.5, osd.6, osd.7]
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/1-mds-1-client.yaml
+++ b/qa/cephfs/clusters/1-mds-1-client.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mgr.y, mds.a, mds.x-s, osd.0, osd.1, osd.2, osd.3]
-- [mon.b, mon.c, mgr.x, mds.y-s, osd.4, osd.5, osd.6, osd.7]
+- [mon.a, mgr.y, mds.a, mds.c, osd.0, osd.1, osd.2, osd.3]
+- [mon.b, mon.c, mgr.x, mds.b, osd.4, osd.5, osd.6, osd.7]
 - [client.0]
 openstack:
 - volumes: # attached to each instance

--- a/qa/cephfs/clusters/1-mds-2-client-coloc.yaml
+++ b/qa/cephfs/clusters/1-mds-2-client-coloc.yaml
@@ -1,6 +1,6 @@
 roles:
 - [mon.a, mgr.y, mds.a, osd.0, osd.1, osd.2, osd.3, client.0]
-- [mon.b, mon.c, mgr.x, mds.a-s, osd.4, osd.5, osd.6, osd.7, client.1]
+- [mon.b, mon.c, mgr.x, mds.b, osd.4, osd.5, osd.6, osd.7, client.1]
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/1-mds-2-client.yaml
+++ b/qa/cephfs/clusters/1-mds-2-client.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mgr.y, mds.a, mds.x-s, osd.0, osd.1, osd.2, osd.3]
-- [mon.b, mon.c, mgr.x, mds.y-s, osd.4, osd.5, osd.6, osd.7]
+- [mon.a, mgr.y, mds.a, mds.c, osd.0, osd.1, osd.2, osd.3]
+- [mon.b, mon.c, mgr.x, mds.b, osd.4, osd.5, osd.6, osd.7]
 - [client.0]
 - [client.1]
 openstack:

--- a/qa/cephfs/clusters/1-mds-3-client.yaml
+++ b/qa/cephfs/clusters/1-mds-3-client.yaml
@@ -1,6 +1,6 @@
 roles:
 - [mon.a, mgr.y, mds.a, osd.0, osd.1, osd.2, osd.3]
-- [mon.b, mon.c, mgr.x, mds.a-s, osd.4, osd.5, osd.6, osd.7]
+- [mon.b, mon.c, mgr.x, mds.b, osd.4, osd.5, osd.6, osd.7]
 - [client.0]
 - [client.1]
 - [client.2]

--- a/qa/cephfs/clusters/1-mds-4-client-coloc.yaml
+++ b/qa/cephfs/clusters/1-mds-4-client-coloc.yaml
@@ -1,6 +1,6 @@
 roles:
 - [mon.a, mgr.y, mds.a, osd.0, osd.1, osd.2, osd.3, client.0, client.1]
-- [mon.b, mon.c, mgr.x, mds.a-s, osd.4, osd.5, osd.6, osd.7, client.2, client.3]
+- [mon.b, mon.c, mgr.x, mds.b, osd.4, osd.5, osd.6, osd.7, client.2, client.3]
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/1-mds-4-client.yaml
+++ b/qa/cephfs/clusters/1-mds-4-client.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mgr.y, mds.a, mds.x-s, osd.0, osd.1, osd.2, osd.3]
-- [mon.b, mon.c, mgr.x, mds.y-s, osd.4, osd.5, osd.6, osd.7]
+- [mon.a, mgr.y, mds.a, mds.b, osd.0, osd.1, osd.2, osd.3]
+- [mon.b, mon.c, mgr.x, mds.c, osd.4, osd.5, osd.6, osd.7]
 - [client.0]
 - [client.1]
 - [client.2]

--- a/qa/cephfs/clusters/1a3s-mds-1c-client.yaml
+++ b/qa/cephfs/clusters/1a3s-mds-1c-client.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mgr.y, mds.a, mds.w-s, osd.0, osd.1, osd.2, osd.3, client.0]
-- [mon.b, mon.c, mgr.x, mds.x-s, mds.y-s, osd.4, osd.5, osd.6, osd.7]
+- [mon.a, mgr.y, mds.a, mds.c, osd.0, osd.1, osd.2, osd.3, client.0]
+- [mon.b, mon.c, mgr.x, mds.b, mds.d, osd.4, osd.5, osd.6, osd.7]
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/1a3s-mds-2c-client.yaml
+++ b/qa/cephfs/clusters/1a3s-mds-2c-client.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mgr.y, mds.a, mds.w-s, osd.0, osd.1, osd.2, osd.3, client.0]
-- [mon.b, mon.c, mgr.x, mds.x-s, mds.y-s, osd.4, osd.5, osd.6, osd.7, client.1]
+- [mon.a, mgr.y, mds.a, mds.c, osd.0, osd.1, osd.2, osd.3, client.0]
+- [mon.b, mon.c, mgr.x, mds.b, mds.d, osd.4, osd.5, osd.6, osd.7, client.1]
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/3-mds.yaml
+++ b/qa/cephfs/clusters/3-mds.yaml
@@ -2,6 +2,9 @@ roles:
 - [mon.a, mon.c, mgr.y, mds.a, osd.0, osd.1, osd.2, osd.3]
 - [mon.b, mgr.x, mds.b, mds.c, osd.4, osd.5, osd.6, osd.7]
 - [client.0, client.1]
+overrides:
+  ceph:
+    max_mds: 3
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/9-mds.yaml
+++ b/qa/cephfs/clusters/9-mds.yaml
@@ -2,6 +2,9 @@ roles:
 - [mon.a, mon.c, mgr.y, mds.a, mds.b, mds.c, mds.d, osd.0, osd.1, osd.2, osd.3]
 - [mon.b, mgr.x, mds.e, mds.f, mds.g, mds.h, mds.i, osd.4, osd.5, osd.6, osd.7]
 - [client.0, client.1]
+overrides:
+  ceph:
+    max_mds: 9
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/fixed-2-ucephfs.yaml
+++ b/qa/cephfs/clusters/fixed-2-ucephfs.yaml
@@ -1,6 +1,6 @@
 roles:
 - [mon.a, mgr.y, mds.a, osd.0, osd.1, osd.2, osd.3, client.0]
-- [mon.b, mon.c, mgr.x, mds.a-s, osd.4, osd.5, osd.6, osd.7]
+- [mon.b, mon.c, mgr.x, mds.b, osd.4, osd.5, osd.6, osd.7]
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/clusters/fixed-3-cephfs.yaml
+++ b/qa/clusters/fixed-3-cephfs.yaml
@@ -1,6 +1,6 @@
 roles:
 - [mon.a, mds.a, mgr.x, osd.0, osd.1]
-- [mon.b, mds.a-s, mon.c, mgr.y, osd.2, osd.3]
+- [mon.b, mds.b, mon.c, mgr.y, osd.2, osd.3]
 - [client.0]
 openstack:
 - volumes: # attached to each instance

--- a/qa/suites/experimental/multimds/clusters/7-multimds.yaml
+++ b/qa/suites/experimental/multimds/clusters/7-multimds.yaml
@@ -1,7 +1,7 @@
 roles:
-- [mon.a, mgr.x, mds.a, mds.a-s]
-- [mon.b, mgr.y, mds.b, mds.b-s]
-- [mon.c, mgr.z, mds.c, mds.c-s]
+- [mon.a, mgr.x, mds.a, mds.d]
+- [mon.b, mgr.y, mds.b, mds.e]
+- [mon.c, mgr.z, mds.c, mds.f]
 - [osd.0]
 - [osd.1]
 - [osd.2]

--- a/qa/suites/multimds/thrash/clusters/3-mds-2-standby.yaml
+++ b/qa/suites/multimds/thrash/clusters/3-mds-2-standby.yaml
@@ -1,4 +1,4 @@
 roles:
-- [mon.a, mon.c, mds.a, osd.0, osd.1, osd.2, mds.d-s]
-- [mon.b, mgr.x, mds.b, mds.c, osd.3, osd.4, osd.5, mds.e-s]
+- [mon.a, mon.c, mds.a, mds.c, mds.e, osd.0, osd.1, osd.2]
+- [mon.b, mgr.x, mds.b, mds.d, osd.3, osd.4, osd.5]
 - [client.0]

--- a/qa/suites/multimds/thrash/clusters/9-mds-3-standby.yaml
+++ b/qa/suites/multimds/thrash/clusters/9-mds-3-standby.yaml
@@ -1,4 +1,4 @@
 roles:
-- [mon.a, mon.c, mds.a, mds.b, mds.c, mds.d, osd.0, osd.1, osd.2, mds.j-s, mds.k-s]
-- [mon.b, mgr.x, mds.e, mds.f, mds.g, mds.h, mds.i, osd.3, osd.4, osd.5, mds.l-s]
+- [mon.a, mon.c, mds.a, mds.c, mds.e, mds.g, mds.i, mds.k, osd.0, osd.1, osd.2]
+- [mon.b, mgr.x, mds.b, mds.d, mds.f, mds.h, mds.j, mds.l, osd.3, osd.4, osd.5]
 - [client.0]

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -410,11 +410,9 @@ def cephfs_setup(ctx, config):
         fs = Filesystem(ctx, name='cephfs', create=True,
                         ec_profile=config.get('cephfs_ec_profile', None))
 
-        is_active_mds = lambda role: 'mds.' in role and not role.endswith('-s') and '-s-' not in role
-        all_roles = [item for remote_roles in mdss.remotes.values() for item in remote_roles]
-        num_active = len([r for r in all_roles if is_active_mds(r)])
-
-        fs.set_max_mds(config.get('max_mds', num_active))
+        max_mds = config.get('max_mds', 1)
+        if max_mds > 1:
+            fs.set_max_mds(max_mds)
 
     yield
 
@@ -494,9 +492,6 @@ def skeleton_config(ctx, roles, ips, mons, cluster='ceph'):
             if is_mds(role):
                 name = teuthology.ceph_role(role)
                 conf.setdefault(name, {})
-                if '-s-' in name:
-                    standby_mds = name[name.find('-s-') + 3:]
-                    conf[name]['mds standby for name'] = standby_mds
     return conf
 
 def create_simple_monmap(ctx, remote, conf, mons,

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -793,6 +793,9 @@ class Filesystem(MDSCluster):
         name = self.get_rank(rank=rank, status=status)['name']
         self.mds_signal(name, signal)
 
+    def rank_freeze(self, yes, rank=0):
+        self.mon_manager.raw_cluster_cmd("mds", "freeze", "{}:{}".format(self.id, rank), str(yes).lower())
+
     def rank_fail(self, rank=0):
         self.mon_manager.raw_cluster_cmd("mds", "fail", "{}:{}".format(self.id, rank))
 

--- a/qa/tasks/cephfs/test_snapshots.py
+++ b/qa/tasks/cephfs/test_snapshots.py
@@ -1,4 +1,5 @@
 import logging
+import signal
 import time
 from textwrap import dedent
 from tasks.cephfs.fuse_mount import FuseMount
@@ -13,36 +14,30 @@ MDS_RESTART_GRACE = 60
 class TestSnapshots(CephFSTestCase):
     MDSS_REQUIRED = 3
 
-    def _check_subtree(self, status, rank, path):
-        got_subtrees = self.fs.mds_asok(["get", "subtrees"], mds_id=status.get_rank(self.fs.id, rank)['name'])
+    def _check_subtree(self, rank, path, status=None):
+        got_subtrees = self.fs.rank_asok(["get", "subtrees"], rank=rank, status=status)
         for s in got_subtrees:
             if s['dir']['path'] == path and s['auth_first'] == rank:
                 return True
         return False
 
-    def _stop_standby_mds(self):
-        for i in self.fs.get_standby_daemons():
-            self.fs.mds_stop(i)
-            self.fs.mds_fail(i)
-        self.wait_until_equal(lambda: len(self.fs.get_standby_daemons()), expect_val=0, timeout=30)
+    def _get_snapclient_dump(self, rank=0, status=None):
+        return self.fs.rank_asok(["dump", "snaps"], rank=rank, status=status)
 
-    def _get_snapclient_dump(self, rank_id):
-        return self.fs.mds_asok(["dump", "snaps"], rank_id)
+    def _get_snapserver_dump(self, rank=0, status=None):
+        return self.fs.rank_asok(["dump", "snaps", "--server"], rank=rank, status=status)
 
-    def _get_snapserver_dump(self, rank0_id):
-        return self.fs.mds_asok(["dump", "snaps", "--server"], rank0_id)
+    def _get_last_created_snap(self, rank=0, status=None):
+        return int(self._get_snapserver_dump(rank,status=status)["last_created"])
 
-    def _get_last_created_snap(self, rank0_id):
-        return int(self._get_snapserver_dump(rank0_id)["last_created"])
+    def _get_last_destroyed_snap(self, rank=0, status=None):
+        return int(self._get_snapserver_dump(rank,status=status)["last_destroyed"])
 
-    def _get_last_destroyed_snap(self, rank0_id):
-        return int(self._get_snapserver_dump(rank0_id)["last_destroyed"])
+    def _get_pending_snap_update(self, rank=0, status=None):
+        return self._get_snapserver_dump(rank,status=status)["pending_update"]
 
-    def _get_pending_snap_update(self, rank0_id):
-        return self._get_snapserver_dump(rank0_id)["pending_update"]
-
-    def _get_pending_snap_destroy(self, rank0_id):
-        return self._get_snapserver_dump(rank0_id)["pending_destroy"]
+    def _get_pending_snap_destroy(self, rank=0, status=None):
+        return self._get_snapserver_dump(rank,status=status)["pending_destroy"]
 
     def test_kill_mdstable(self):
         """
@@ -53,24 +48,16 @@ class TestSnapshots(CephFSTestCase):
 
         self.fs.set_allow_new_snaps(True);
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
+        status = self.fs.wait_for_daemons()
 
         grace = float(self.fs.get_config("mds_beacon_grace", service_type="mon"))
-
-        self._stop_standby_mds()
-
-        status = self.fs.status()
-        rank0_id=status.get_rank(self.fs.id, 0)['name']
-        rank1_id=status.get_rank(self.fs.id, 1)['name']
-        self.set_conf("mds.{0}".format(rank0_id), "mds standby for rank", 0)
-        self.set_conf("mds.{0}".format(rank1_id), "mds standby for rank", 1)
 
         # setup subtrees
         self.mount_a.run_shell(["mkdir", "-p", "d1/dir"])
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(status, 1, '/d1'), timeout=30)
+        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
 
-        last_created = self._get_last_created_snap(rank0_id)
+        last_created = self._get_last_created_snap(rank=0,status=status)
 
         # mds_kill_mdstable_at:
         #  1: MDSTableServer::handle_prepare
@@ -79,18 +66,23 @@ class TestSnapshots(CephFSTestCase):
         #  6: MDSTableServer::_commit_logged
         for i in [1,2,5,6]:
             log.info("testing snapserver mds_kill_mdstable_at={0}".format(i))
-            self.fs.mds_asok(['config', 'set', "mds_kill_mdstable_at", "{0}".format(i)], rank0_id)
-            proc = self.mount_a.run_shell(["mkdir", "d1/dir/.snap/s1{0}".format(i)], wait=False)
-            self.wait_until_true(lambda: "laggy_since" in self.fs.status().get_mds(rank0_id), timeout=grace*2);
-            self.delete_mds_coredump(rank0_id);
 
-            self.mds_cluster.mds_fail_restart(rank0_id)
-            self.wait_for_daemon_start([rank0_id])
-            self.fs.wait_for_state('up:active', rank=0, timeout=MDS_RESTART_GRACE)
+            status = self.fs.status()
+            rank0 = self.fs.get_rank(rank=0, status=status)
+            self.fs.rank_freeze(True, rank=0)
+            self.fs.rank_asok(['config', 'set', "mds_kill_mdstable_at", "{0}".format(i)], rank=0, status=status)
+            proc = self.mount_a.run_shell(["mkdir", "d1/dir/.snap/s1{0}".format(i)], wait=False)
+            self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(rank=0), timeout=grace*2);
+            self.delete_mds_coredump(rank0['name']);
+
+            self.fs.rank_fail(rank=0)
+            self.fs.mds_restart(rank0['name'])
+            self.wait_for_daemon_start([rank0['name']])
+            status = self.fs.wait_for_daemons()
 
             proc.wait()
             last_created += 1
-            self.wait_until_true(lambda: self._get_last_created_snap(rank0_id) == last_created, timeout=30)
+            self.wait_until_true(lambda: self._get_last_created_snap(rank=0) == last_created, timeout=30)
 
         self.set_conf("mds", "mds_reconnect_timeout", "5")
 
@@ -99,39 +91,45 @@ class TestSnapshots(CephFSTestCase):
         # set mds_kill_mdstable_at, also kill snapclient
         for i in [2,5,6]:
             log.info("testing snapserver mds_kill_mdstable_at={0}, also kill snapclient".format(i))
-            last_created = self._get_last_created_snap(rank0_id)
+            status = self.fs.status()
+            last_created = self._get_last_created_snap(rank=0, status=status)
 
-            self.fs.mds_asok(['config', 'set', "mds_kill_mdstable_at", "{0}".format(i)], rank0_id)
+            rank0 = self.fs.get_rank(rank=0, status=status)
+            rank1 = self.fs.get_rank(rank=1, status=status)
+            self.fs.rank_freeze(True, rank=0) # prevent failover...
+            self.fs.rank_freeze(True, rank=1) # prevent failover...
+            self.fs.rank_asok(['config', 'set', "mds_kill_mdstable_at", "{0}".format(i)], rank=0, status=status)
             proc = self.mount_a.run_shell(["mkdir", "d1/dir/.snap/s2{0}".format(i)], wait=False)
-            self.wait_until_true(lambda: "laggy_since" in self.fs.status().get_mds(rank0_id), timeout=grace*2);
-            self.delete_mds_coredump(rank0_id);
+            self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(rank=0), timeout=grace*2);
+            self.delete_mds_coredump(rank0['name']);
 
-            self.mds_cluster.mds_stop(rank1_id)
-            self.mds_cluster.mds_fail(rank1_id);
+            self.fs.rank_signal(signal.SIGKILL, rank=1)
 
             self.mount_a.kill()
             self.mount_a.kill_cleanup()
 
-            self.mds_cluster.mds_fail_restart(rank0_id)
-            self.wait_for_daemon_start([rank0_id])
+            self.fs.rank_fail(rank=0)
+            self.fs.mds_restart(rank0['name'])
+            self.wait_for_daemon_start([rank0['name']])
 
             self.fs.wait_for_state('up:resolve', rank=0, timeout=MDS_RESTART_GRACE)
             if i in [2,5]:
-                self.assertEqual(len(self._get_pending_snap_update(rank0_id)), 1)
+                self.assertEqual(len(self._get_pending_snap_update(rank=0)), 1)
             elif i == 6:
-                self.assertEqual(len(self._get_pending_snap_update(rank0_id)), 0)
-                self.assertGreater(self._get_last_created_snap(rank0_id), last_created)
+                self.assertEqual(len(self._get_pending_snap_update(rank=0)), 0)
+                self.assertGreater(self._get_last_created_snap(rank=0), last_created)
 
-            self.mds_cluster.mds_restart(rank1_id)
-            self.wait_for_daemon_start([rank1_id])
+            self.fs.rank_fail(rank=1)
+            self.fs.mds_restart(rank1['name'])
+            self.wait_for_daemon_start([rank1['name']])
             self.fs.wait_for_state('up:active', rank=0, timeout=MDS_RESTART_GRACE)
 
             if i in [2,5]:
-                self.wait_until_true(lambda: len(self._get_pending_snap_update(rank0_id)) == 0, timeout=30)
+                self.wait_until_true(lambda: len(self._get_pending_snap_update(rank=0)) == 0, timeout=30)
                 if i == 2:
-                    self.assertEqual(self._get_last_created_snap(rank0_id), last_created)
+                    self.assertEqual(self._get_last_created_snap(rank=0), last_created)
                 else:
-                    self.assertGreater(self._get_last_created_snap(rank0_id), last_created)
+                    self.assertGreater(self._get_last_created_snap(rank=0), last_created)
 
             self.mount_a.mount()
             self.mount_a.wait_until_mounted()
@@ -144,32 +142,36 @@ class TestSnapshots(CephFSTestCase):
         #  7: MDSTableClient::handle_request (got ack)
         for i in [3,4,7]:
             log.info("testing snapclient mds_kill_mdstable_at={0}".format(i))
-            last_created = self._get_last_created_snap(rank0_id)
+            last_created = self._get_last_created_snap(rank=0)
 
-            self.fs.mds_asok(['config', 'set', "mds_kill_mdstable_at", "{0}".format(i)], rank1_id)
+            status = self.fs.status()
+            rank1 = self.fs.get_rank(rank=1, status=status)
+            self.fs.rank_freeze(True, rank=1) # prevent failover...
+            self.fs.rank_asok(['config', 'set', "mds_kill_mdstable_at", "{0}".format(i)], rank=1, status=status)
             proc = self.mount_a.run_shell(["mkdir", "d1/dir/.snap/s3{0}".format(i)], wait=False)
-            self.wait_until_true(lambda: "laggy_since" in self.fs.status().get_mds(rank1_id), timeout=grace*2);
-            self.delete_mds_coredump(rank1_id);
+            self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(rank=1), timeout=grace*2);
+            self.delete_mds_coredump(rank1['name']);
 
             self.mount_a.kill()
             self.mount_a.kill_cleanup()
 
             if i in [3,4]:
-                self.assertEqual(len(self._get_pending_snap_update(rank0_id)), 1)
+                self.assertEqual(len(self._get_pending_snap_update(rank=0)), 1)
             elif i == 7:
-                self.assertEqual(len(self._get_pending_snap_update(rank0_id)), 0)
-                self.assertGreater(self._get_last_created_snap(rank0_id), last_created)
+                self.assertEqual(len(self._get_pending_snap_update(rank=0)), 0)
+                self.assertGreater(self._get_last_created_snap(rank=0), last_created)
 
-            self.mds_cluster.mds_fail_restart(rank1_id)
-            self.wait_for_daemon_start([rank1_id])
-            self.fs.wait_for_state('up:active', rank=1, timeout=MDS_RESTART_GRACE)
+            self.fs.rank_fail(rank=1)
+            self.fs.mds_restart(rank1['name'])
+            self.wait_for_daemon_start([rank1['name']])
+            status = self.fs.wait_for_daemons(timeout=MDS_RESTART_GRACE)
 
             if i in [3,4]:
-                self.wait_until_true(lambda: len(self._get_pending_snap_update(rank0_id)) == 0, timeout=30)
+                self.wait_until_true(lambda: len(self._get_pending_snap_update(rank=0)) == 0, timeout=30)
                 if i == 3:
-                    self.assertEqual(self._get_last_created_snap(rank0_id), last_created)
+                    self.assertEqual(self._get_last_created_snap(rank=0), last_created)
                 else:
-                    self.assertGreater(self._get_last_created_snap(rank0_id), last_created)
+                    self.assertGreater(self._get_last_created_snap(rank=0), last_created)
 
             self.mount_a.mount()
             self.mount_a.wait_until_mounted()
@@ -180,31 +182,39 @@ class TestSnapshots(CephFSTestCase):
         #  3: MDSTableClient::handle_request (got agree)
         #  8: MDSTableServer::handle_rollback
         log.info("testing snapclient mds_kill_mdstable_at=3, snapserver mds_kill_mdstable_at=8")
-        last_created = self._get_last_created_snap(rank0_id)
+        last_created = self._get_last_created_snap(rank=0)
 
-        self.fs.mds_asok(['config', 'set', "mds_kill_mdstable_at", "8".format(i)], rank0_id)
-        self.fs.mds_asok(['config', 'set', "mds_kill_mdstable_at", "3".format(i)], rank1_id)
+        status = self.fs.status()
+        rank0 = self.fs.get_rank(rank=0, status=status)
+        rank1 = self.fs.get_rank(rank=1, status=status)
+        self.fs.rank_freeze(True, rank=0)
+        self.fs.rank_freeze(True, rank=1)
+        self.fs.rank_asok(['config', 'set', "mds_kill_mdstable_at", "8".format(i)], rank=0, status=status)
+        self.fs.rank_asok(['config', 'set', "mds_kill_mdstable_at", "3".format(i)], rank=1, status=status)
         proc = self.mount_a.run_shell(["mkdir", "d1/dir/.snap/s4".format(i)], wait=False)
-        self.wait_until_true(lambda: "laggy_since" in self.fs.status().get_mds(rank1_id), timeout=grace*2);
-        self.delete_mds_coredump(rank1_id);
+        self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(rank=1), timeout=grace*2);
+        self.delete_mds_coredump(rank1['name']);
 
         self.mount_a.kill()
         self.mount_a.kill_cleanup()
 
-        self.assertEqual(len(self._get_pending_snap_update(rank0_id)), 1)
+        self.assertEqual(len(self._get_pending_snap_update(rank=0)), 1)
 
-        self.mds_cluster.mds_fail_restart(rank1_id)
+        self.fs.rank_fail(rank=1)
+        self.fs.mds_restart(rank1['name'])
+        self.wait_for_daemon_start([rank1['name']])
 
         # rollback triggers assertion
-        self.wait_until_true(lambda: "laggy_since" in self.fs.status().get_mds(rank0_id), timeout=grace*2);
-        self.delete_mds_coredump(rank0_id);
-
-        self.mds_cluster.mds_fail_restart(rank0_id)
-        self.wait_for_daemon_start([rank0_id])
+        self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(rank=0), timeout=grace*2);
+        self.delete_mds_coredump(rank0['name']);
+        self.fs.rank_fail(rank=0)
+        self.fs.mds_restart(rank0['name'])
+        self.wait_for_daemon_start([rank0['name']])
         self.fs.wait_for_state('up:active', rank=0, timeout=MDS_RESTART_GRACE)
-        # mds.1 should re-send rollack message
-        self.wait_until_true(lambda: len(self._get_pending_snap_update(rank0_id)) == 0, timeout=30)
-        self.assertEqual(self._get_last_created_snap(rank0_id), last_created)
+
+        # mds.1 should re-send rollback message
+        self.wait_until_true(lambda: len(self._get_pending_snap_update(rank=0)) == 0, timeout=30)
+        self.assertEqual(self._get_last_created_snap(rank=0), last_created)
 
         self.mount_a.mount()
         self.mount_a.wait_until_mounted()
@@ -215,92 +225,81 @@ class TestSnapshots(CephFSTestCase):
         """
         self.fs.set_allow_new_snaps(True);
         self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
+        status = self.fs.wait_for_daemons()
 
         grace = float(self.fs.get_config("mds_beacon_grace", service_type="mon"))
-
-        self._stop_standby_mds()
-
-        status = self.fs.status()
-        rank0_id=status.get_rank(self.fs.id, 0)['name']
-        rank1_id=status.get_rank(self.fs.id, 1)['name']
-        rank2_id=status.get_rank(self.fs.id, 2)['name']
-        self.set_conf("mds.{0}".format(rank0_id), "mds standby for rank", 0)
-        self.set_conf("mds.{0}".format(rank1_id), "mds standby for rank", 1)
-        self.set_conf("mds.{0}".format(rank2_id), "mds standby for rank", 2)
 
         self.mount_a.run_shell(["mkdir", "-p", "d0/d1/dir"])
         self.mount_a.run_shell(["mkdir", "-p", "d0/d2/dir"])
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d0/d1", "ceph.dir.pin", "1")
         self.mount_a.setfattr("d0/d2", "ceph.dir.pin", "2")
-        self.wait_until_true(lambda: self._check_subtree(status, 2, '/d0/d2'), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(status, 1, '/d0/d1'), timeout=5)
-        self.wait_until_true(lambda: self._check_subtree(status, 0, '/d0'), timeout=5)
+        self.wait_until_true(lambda: self._check_subtree(2, '/d0/d2', status=status), timeout=30)
+        self.wait_until_true(lambda: self._check_subtree(1, '/d0/d1', status=status), timeout=5)
+        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
 
-        def _check_snapclient_cache(snaps_dump, cache_dump=None, rank_id=-1):
+        def _check_snapclient_cache(snaps_dump, cache_dump=None, rank=0):
             if cache_dump is None:
-                cache_dump = self._get_snapclient_dump(rank_id)
+                cache_dump = self._get_snapclient_dump(rank=rank)
             for key, value in cache_dump.iteritems():
                 if value != snaps_dump[key]:
                     return False
             return True;
 
         # sync after mksnap
-        last_created = self._get_last_created_snap(rank0_id)
-        self.mount_a.run_shell(["mkdir", Raw("d0/d1/dir/.snap/{s1,s2}")])
-        self.wait_until_true(lambda: len(self._get_pending_snap_update(rank0_id)) == 0, timeout=30)
-        self.assertGreater(self._get_last_created_snap(rank0_id), last_created)
+        last_created = self._get_last_created_snap(rank=0)
+        self.mount_a.run_shell(["mkdir", "d0/d1/dir/.snap/s1", "d0/d1/dir/.snap/s2"])
+        self.wait_until_true(lambda: len(self._get_pending_snap_update(rank=0)) == 0, timeout=30)
+        self.assertGreater(self._get_last_created_snap(rank=0), last_created)
 
-        snaps_dump = self._get_snapserver_dump(rank0_id)
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank0_id));
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank1_id));
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank2_id));
+        snaps_dump = self._get_snapserver_dump(rank=0)
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=0));
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=1));
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=2));
 
         # sync after rmsnap
-        last_destroyed = self._get_last_destroyed_snap(rank0_id)
+        last_destroyed = self._get_last_destroyed_snap(rank=0)
         self.mount_a.run_shell(["rmdir", "d0/d1/dir/.snap/s1"])
-        self.wait_until_true(lambda: len(self._get_pending_snap_destroy(rank0_id)) == 0, timeout=30)
-        self.assertGreater(self._get_last_destroyed_snap(rank0_id), last_destroyed)
+        self.wait_until_true(lambda: len(self._get_pending_snap_destroy(rank=0)) == 0, timeout=30)
+        self.assertGreater(self._get_last_destroyed_snap(rank=0), last_destroyed)
 
-        snaps_dump = self._get_snapserver_dump(rank0_id)
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank0_id));
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank1_id));
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank2_id));
+        snaps_dump = self._get_snapserver_dump(rank=0)
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=0));
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=1));
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=2));
 
         # sync during mds recovers
-        self.mds_cluster.mds_stop(rank2_id)
-        self.mds_cluster.mds_fail_restart(rank2_id)
-        self.wait_for_daemon_start([rank2_id])
-        self.fs.wait_for_state('up:active', rank=2, timeout=MDS_RESTART_GRACE)
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank2_id));
+        self.fs.rank_fail(rank=2)
+        status = self.fs.wait_for_daemons(timeout=MDS_RESTART_GRACE)
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=2));
 
-        self.mds_cluster.mds_stop(rank0_id)
-        self.mds_cluster.mds_stop(rank1_id)
-        self.mds_cluster.mds_fail_restart(rank0_id)
-        self.mds_cluster.mds_fail_restart(rank1_id)
-        self.wait_for_daemon_start([rank0_id, rank1_id])
+        self.fs.rank_fail(rank=0)
+        self.fs.rank_fail(rank=1)
+        status = self.fs.wait_for_daemons()
         self.fs.wait_for_state('up:active', rank=0, timeout=MDS_RESTART_GRACE)
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank0_id));
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank1_id));
-        self.assertTrue(_check_snapclient_cache(snaps_dump, rank_id=rank2_id));
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=0));
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=1));
+        self.assertTrue(_check_snapclient_cache(snaps_dump, rank=2));
 
         # kill at MDSTableClient::handle_notify_prep
-        self.fs.mds_asok(['config', 'set', "mds_kill_mdstable_at", "9"], rank2_id)
+        status = self.fs.status()
+        rank2 = self.fs.get_rank(rank=2, status=status)
+        self.fs.rank_freeze(True, rank=2)
+        self.fs.rank_asok(['config', 'set', "mds_kill_mdstable_at", "9"], rank=2, status=status)
         proc = self.mount_a.run_shell(["mkdir", "d0/d1/dir/.snap/s3"], wait=False)
-        self.wait_until_true(lambda: "laggy_since" in self.fs.status().get_mds(rank2_id), timeout=grace*2);
-        self.delete_mds_coredump(rank2_id);
+        self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(rank=2), timeout=grace*2);
+        self.delete_mds_coredump(rank2['name']);
 
         # mksnap should wait for notify ack from mds.2
         self.assertFalse(proc.finished);
 
         # mksnap should proceed after mds.2 fails
-        self.mds_cluster.mds_fail(rank2_id)
+        self.fs.rank_fail(rank=2)
         self.wait_until_true(lambda: proc.finished, timeout=30);
 
-        self.mds_cluster.mds_fail_restart(rank2_id)
-        self.wait_for_daemon_start([rank2_id])
-        self.fs.wait_for_state('up:active', rank=2, timeout=MDS_RESTART_GRACE)
+        self.fs.mds_restart(rank2['name'])
+        self.wait_for_daemon_start([rank2['name']])
+        status = self.fs.wait_for_daemons(timeout=MDS_RESTART_GRACE)
 
         self.mount_a.run_shell(["rmdir", Raw("d0/d1/dir/.snap/*")])
 
@@ -308,39 +307,41 @@ class TestSnapshots(CephFSTestCase):
         # the recovering mds should sync all mds' cache when it enters resolve stage
         self.set_conf("mds", "mds_reconnect_timeout", "5")
         for i in range(1, 4):
-            self.fs.mds_asok(['config', 'set', "mds_kill_mdstable_at", "4"], rank2_id)
-            last_created = self._get_last_created_snap(rank0_id)
+            status = self.fs.status()
+            rank2 = self.fs.get_rank(rank=2, status=status)
+            self.fs.rank_freeze(True, rank=2)
+            self.fs.rank_asok(['config', 'set', "mds_kill_mdstable_at", "4"], rank=2, status=status)
+            last_created = self._get_last_created_snap(rank=0)
             proc = self.mount_a.run_shell(["mkdir", "d0/d2/dir/.snap/s{0}".format(i)], wait=False)
-            self.wait_until_true(lambda: "laggy_since" in self.fs.status().get_mds(rank2_id), timeout=grace*2);
-            self.delete_mds_coredump(rank2_id);
+            self.wait_until_true(lambda: "laggy_since" in self.fs.get_rank(rank=2), timeout=grace*2);
+            self.delete_mds_coredump(rank2['name']);
 
             self.mount_a.kill()
             self.mount_a.kill_cleanup()
 
-            self.assertEqual(len(self._get_pending_snap_update(rank0_id)), 1)
+            self.assertEqual(len(self._get_pending_snap_update(rank=0)), 1)
 
             if i in [2,4]:
-                self.mds_cluster.mds_stop(rank0_id)
-                self.mds_cluster.mds_fail_restart(rank0_id)
+                self.fs.rank_fail(rank=0)
             if i in [3,4]:
-                self.mds_cluster.mds_stop(rank1_id)
-                self.mds_cluster.mds_fail_restart(rank1_id)
+                self.fs.rank_fail(rank=1)
 
-            self.mds_cluster.mds_fail_restart(rank2_id)
-            self.wait_for_daemon_start([rank0_id, rank1_id, rank2_id])
+            self.fs.rank_fail(rank=2)
+            self.fs.mds_restart(rank2['name'])
+            self.wait_for_daemon_start([rank2['name']])
+            status = self.fs.wait_for_daemons(timeout=MDS_RESTART_GRACE)
 
-            self.fs.wait_for_state('up:active', rank=2, timeout=MDS_RESTART_GRACE)
-            rank0_cache = self._get_snapclient_dump(rank0_id)
-            rank1_cache = self._get_snapclient_dump(rank1_id)
-            rank2_cache = self._get_snapclient_dump(rank2_id)
+            rank0_cache = self._get_snapclient_dump(rank=0)
+            rank1_cache = self._get_snapclient_dump(rank=1)
+            rank2_cache = self._get_snapclient_dump(rank=2)
 
             self.assertGreater(int(rank0_cache["last_created"]), last_created)
             self.assertEqual(rank0_cache, rank1_cache);
             self.assertEqual(rank0_cache, rank2_cache);
 
-            self.wait_until_true(lambda: len(self._get_pending_snap_update(rank0_id)) == 0, timeout=30)
+            self.wait_until_true(lambda: len(self._get_pending_snap_update(rank=0)) == 0, timeout=30)
 
-            snaps_dump = self._get_snapserver_dump(rank0_id)
+            snaps_dump = self._get_snapserver_dump(rank=0)
             self.assertEqual(snaps_dump["last_created"], rank0_cache["last_created"])
             self.assertTrue(_check_snapclient_cache(snaps_dump, cache_dump=rank0_cache));
 
@@ -355,15 +356,13 @@ class TestSnapshots(CephFSTestCase):
         """
         self.fs.set_allow_new_snaps(True);
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
+        status = self.fs.wait_for_daemons()
 
         self.mount_a.run_shell(["mkdir", "-p", "d0/d1"])
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d0/d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(status, 1, '/d0/d1'), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(status, 0, '/d0'), timeout=5)
+        self.wait_until_true(lambda: self._check_subtree(1, '/d0/d1', status=status), timeout=30)
+        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
 
         self.mount_a.write_test_pattern("d0/d1/file_a", 8 * 1024 * 1024)
         self.mount_a.run_shell(["mkdir", "d0/.snap/s1"])
@@ -379,15 +378,13 @@ class TestSnapshots(CephFSTestCase):
         """
         self.fs.set_allow_new_snaps(True);
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
+        status = self.fs.wait_for_daemons()
 
         self.mount_a.run_shell(["mkdir", "d0", "d1"])
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(status, 1, '/d1'), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(status, 0, '/d0'), timeout=5)
+        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
+        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
 
         self.mount_a.run_shell(["mkdir", "d0/d3"])
         self.mount_a.run_shell(["mkdir", "d0/.snap/s1"])
@@ -409,16 +406,14 @@ class TestSnapshots(CephFSTestCase):
         """
         self.fs.set_allow_new_snaps(True);
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
+        status = self.fs.wait_for_daemons()
 
         self.mount_a.run_shell(["mkdir", "d0", "d1"])
 
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(status, 1, '/d1'), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(status, 0, '/d0'), timeout=5)
+        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
+        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
 
         self.mount_a.run_python(dedent("""
             import os

--- a/qa/tasks/mds_thrash.py
+++ b/qa/tasks/mds_thrash.py
@@ -269,10 +269,10 @@ class MDSThrasher(Greenlet):
             "powercycling requested but RemoteConsole is not "
             "initialized.  Check ipmi config.")
 
-    def revive_mds(self, mds, standby_for_rank=None):
+    def revive_mds(self, mds):
         """
         Revive mds -- do an ipmpi powercycle (if indicated by the config)
-        and then restart (using --hot-standby if specified.
+        and then restart.
         """
         if self.config.get('powercycle'):
             (remote,) = (self.ctx.cluster.only('mds.{m}'.format(m=mds)).
@@ -283,8 +283,6 @@ class MDSThrasher(Greenlet):
             remote.console.power_on()
             self.manager.make_admin_daemon_dir(self.ctx, remote)
         args = []
-        if standby_for_rank:
-            args.extend(['--hot-standby', standby_for_rank])
         self.ctx.daemons.get_daemon('mds', mds).restart(*args)
 
     def wait_for_stable(self, rank = None, gid = None):

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -354,7 +354,7 @@ class LocalDaemon(object):
 
         pid = self._get_pid()
         log.info("Killing PID {0} for {1}.{2}".format(pid, self.daemon_type, self.daemon_id))
-        os.kill(pid, signal.SIGKILL)
+        os.kill(pid, signal.SIGTERM)
 
         waited = 0
         while pid is not None:
@@ -362,7 +362,7 @@ class LocalDaemon(object):
             if new_pid is not None and new_pid != pid:
                 log.info("Killing new PID {0}".format(new_pid))
                 pid = new_pid
-                os.kill(pid, signal.SIGKILL)
+                os.kill(pid, signal.SIGTERM)
 
             if new_pid is None:
                 break

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -54,30 +54,14 @@
 
 static void usage()
 {
-  cout << "usage: ceph-mds -i <ID> [flags] [--hot-standby <rank>]\n"
+  cout << "usage: ceph-mds -i <ID> [flags]\n"
        << "  -m monitorip:port\n"
        << "        connect to monitor at given address\n"
        << "  --debug_mds n\n"
        << "        debug MDS level (e.g. 10)\n"
-       << "  --hot-standby rank\n"
-       << "        start up as a hot standby for rank\n"
        << std::endl;
   generic_server_usage();
 }
-
-
-static int parse_rank(const char *opt_name, const std::string &val)
-{
-  std::string err;
-  int ret = strict_strtol(val.c_str(), 10, &err);
-  if (!err.empty()) {
-    derr << "error parsing " << opt_name << ": failed to parse rank. "
-	 << "It must be an int." << "\n" << dendl;
-    exit(1);
-  }
-  return ret;
-}
-
 
 
 MDSDaemon *mds = NULL;
@@ -115,13 +99,7 @@ int main(int argc, const char **argv)
       break;
     }
     else if (ceph_argparse_witharg(args, i, &val, "--hot-standby", (char*)NULL)) {
-      int r = parse_rank("hot-standby", val);
-      dout(0) << "requesting standby_replay for mds." << r << dendl;
-      char rb[32];
-      snprintf(rb, sizeof(rb), "%d", r);
-      g_conf().set_val("mds_standby_for_rank", rb);
-      g_conf().set_val("mds_standby_replay", "true");
-      g_conf().apply_changes(nullptr);
+      dout(0) << "--hot-standby is obsolete and has no effect" << dendl;
     }
     else {
       derr << "Error: can't understand argument: " << *i << "\n" << dendl;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -241,7 +241,6 @@ OPTION(mon_allow_pool_delete, OPT_BOOL) // allow pool deletion
 OPTION(mon_fake_pool_delete, OPT_BOOL)  // fake pool deletion (add _DELETED suffix)
 OPTION(mon_globalid_prealloc, OPT_U32)   // how many globalids to prealloc
 OPTION(mon_osd_report_timeout, OPT_INT)    // grace period before declaring unresponsive OSDs dead
-OPTION(mon_force_standby_active, OPT_BOOL) // should mons force standby-replay mds to be active
 OPTION(mon_warn_on_legacy_crush_tunables, OPT_BOOL) // warn if crush tunables are too old (older than mon_min_crush_required_version)
 OPTION(mon_crush_min_required_version, OPT_STR)
 OPTION(mon_warn_on_crush_straw_calc_version_zero, OPT_BOOL) // warn if crush straw_calc_version==0
@@ -475,10 +474,6 @@ OPTION(mds_inject_traceless_reply_probability, OPT_DOUBLE) /* percentage
 OPTION(mds_wipe_sessions, OPT_BOOL)
 OPTION(mds_wipe_ino_prealloc, OPT_BOOL)
 OPTION(mds_skip_ino, OPT_INT)
-OPTION(mds_standby_for_name, OPT_STR)
-OPTION(mds_standby_for_rank, OPT_INT)
-OPTION(mds_standby_for_fscid, OPT_INT)
-OPTION(mds_standby_replay, OPT_BOOL)
 OPTION(mds_enable_op_tracker, OPT_BOOL) // enable/disable MDS op tracking
 OPTION(mds_op_history_size, OPT_U32)    // Max number of completed ops to track
 OPTION(mds_op_history_duration, OPT_U32) // Oldest completed op to track

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1593,11 +1593,6 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description("time before OSDs who do not report to the mons are marked down (seconds)"),
 
-    Option("mon_force_standby_active", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
-    .add_service("mon")
-    .set_description("allow use of MDS daemons in standby-replay as replacements"),
-
     Option("mon_warn_on_msgr2_not_enabled", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .add_service("mon")
@@ -7724,22 +7719,6 @@ std::vector<Option> get_mds_options() {
     Option("mds_skip_ino", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(0)
     .set_description(""),
-
-    Option("mds_standby_for_name", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("")
-    .set_description("standby for named MDS daemon when not active"),
-
-    Option("mds_standby_for_rank", Option::TYPE_INT, Option::LEVEL_BASIC)
-    .set_default(-1)
-    .set_description("allow MDS to become a standby:replay daemon"),
-
-    Option("mds_standby_for_fscid", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(-1)
-    .set_description("standby only for the file system with the given fscid"),
-
-    Option("mds_standby_replay", Option::TYPE_BOOL, Option::LEVEL_BASIC)
-    .set_default(false)
-    .set_description("allow MDS to standby replay for an active MDS"),
 
     Option("mds_enable_op_tracker", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -255,8 +255,9 @@ struct ceph_mon_subscribe_ack {
 #define CEPH_MDSMAP_ALLOW_SNAPS                  (1<<1)  /* cluster allowed to create snapshots */
 /* deprecated #define CEPH_MDSMAP_ALLOW_MULTIMDS (1<<2) cluster allowed to have >1 active MDS */
 /* deprecated #define CEPH_MDSMAP_ALLOW_DIRFRAGS (1<<3) cluster allowed to fragment directories */
-#define CEPH_MDSMAP_ALLOW_MULTIMDS_SNAPS	 (1<<4)  /* cluster alllowed to enable MULTIMDS
-							    and SNAPS at the same time */
+#define CEPH_MDSMAP_ALLOW_MULTIMDS_SNAPS	     (1<<4)  /* cluster alllowed to enable MULTIMDS
+                                                            and SNAPS at the same time */
+#define CEPH_MDSMAP_ALLOW_STANDBY_REPLAY         (1<<5)  /* cluster alllowed to enable MULTIMDS */
 
 #define CEPH_MDSMAP_DEFAULTS (CEPH_MDSMAP_ALLOW_SNAPS | \
 			      CEPH_MDSMAP_ALLOW_MULTIMDS_SNAPS)

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -65,10 +65,6 @@ void Beacon::init(const MDSMap &mdsmap)
   std::unique_lock lock(mutex);
 
   _notify_mdsmap(mdsmap);
-  standby_for_rank = mds_rank_t(g_conf()->mds_standby_for_rank);
-  standby_for_name = g_conf()->mds_standby_for_name;
-  standby_for_fscid = fs_cluster_id_t(g_conf()->mds_standby_for_fscid);
-  standby_replay = g_conf()->mds_standby_replay;
 
   sender = std::thread([this]() {
     std::unique_lock<std::mutex> lock(mutex);
@@ -208,10 +204,6 @@ bool Beacon::_send()
       last_seq,
       CEPH_FEATURES_SUPPORTED_DEFAULT);
 
-  beacon->set_standby_for_rank(standby_for_rank);
-  beacon->set_standby_for_name(standby_for_name);
-  beacon->set_standby_for_fscid(standby_for_fscid);
-  beacon->set_standby_replay(standby_replay);
   beacon->set_health(health);
   beacon->set_compat(compat);
   // piggyback the sys info on beacon msg

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -98,10 +98,6 @@ private:
   std::string name;
   version_t epoch = 0;
   CompatSet compat;
-  mds_rank_t standby_for_rank = MDS_RANK_NONE;
-  std::string standby_for_name;
-  fs_cluster_id_t standby_for_fscid = FS_CLUSTER_ID_NONE;
-  bool standby_replay = false;
   MDSMap::DaemonState want_state = MDSMap::STATE_BOOT;
 
   // Internal beacon state

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -383,8 +383,7 @@ void FSMap::get_health_checks(health_check_map_t *checks) const
     std::set<mds_rank_t> stuck_failed;
 
     for (const auto &rank : fs->mds_map.failed) {
-      const mds_gid_t replacement = find_replacement_for(
-          {fs->fscid, rank}, {}, g_conf()->mon_force_standby_active);
+      auto&& replacement = find_replacement_for({fs->fscid, rank}, {});
       if (replacement == MDS_GID_NONE) {
         stuck_failed.insert(rank);
       }
@@ -598,22 +597,20 @@ void FSMap::decode(bufferlist::const_iterator& p)
 
       // Construct mds_roles, standby_daemons, and remove
       // standbys from the MDSMap in the Filesystem.
-      for (auto &p : migrate_fs->mds_map.mds_info) {
-        if (p.second.state == MDSMap::STATE_STANDBY_REPLAY) {
-          // In legacy MDSMap, standby replay daemons don't have
-          // rank set, but since FSMap they do.
-          p.second.rank = p.second.standby_for_rank;
-        }
-        if (p.second.rank == MDS_RANK_NONE) {
-          if (p.second.state != MDSMap::STATE_STANDBY) {
+      for (const auto& [gid, info] : migrate_fs->mds_map.mds_info) {
+        if (info.state == MDSMap::STATE_STANDBY_REPLAY) {
+          /* drop any legacy standby-replay daemons */
+          drop_gids.insert(gid);
+        } else if (info.rank == MDS_RANK_NONE) {
+          if (info.state != MDSMap::STATE_STANDBY) {
             // Old MDSMaps can have down:dne here, which
             // is invalid in an FSMap (#17837)
-            drop_gids.insert(p.first);
+            drop_gids.insert(gid);
           } else {
-            insert(p.second); // into standby_daemons
+            insert(info); // into standby_daemons
           }
         } else {
-          mds_roles[p.first] = migrate_fs->fscid;
+          mds_roles[gid] = migrate_fs->fscid;
         }
       }
       for (const auto &p : standby_daemons) {
@@ -714,88 +711,30 @@ void Filesystem::print(std::ostream &out) const
   mds_map.print(out);
 }
 
-mds_gid_t FSMap::find_standby_for(mds_role_t role, std::string_view name) const
+mds_gid_t FSMap::find_replacement_for(mds_role_t role, std::string_view name) const
 {
-  mds_gid_t result = MDS_GID_NONE;
+  auto&& fs = get_filesystem(role.fscid);
 
   // First see if we have a STANDBY_REPLAY
-  auto fs = get_filesystem(role.fscid);
-  for (const auto &i : fs->mds_map.mds_info) {
-    const auto &info = i.second;
+  for (const auto& [gid, info] : fs->mds_map.mds_info) {
     if (info.rank == role.rank && info.state == MDSMap::STATE_STANDBY_REPLAY) {
-      return info.global_id;
+      return gid;
     }
   }
 
   // See if there are any STANDBY daemons available
-  for (const auto &i : standby_daemons) {
-    const auto &gid = i.first;
-    const auto &info = i.second;
-    ceph_assert(info.state == MDSMap::STATE_STANDBY);
+  for (const auto& [gid, info] : standby_daemons) {
     ceph_assert(info.rank == MDS_RANK_NONE);
+    ceph_assert(info.state == MDSMap::STATE_STANDBY);
 
     if (info.laggy()) {
       continue;
     }
 
-    // The mds_info_t may or may not tell us exactly which filesystem
-    // the standby_for_rank refers to: lookup via legacy_client_fscid
-    mds_role_t target_role = {
-      info.standby_for_fscid == FS_CLUSTER_ID_NONE ?
-        legacy_client_fscid : info.standby_for_fscid,
-      info.standby_for_rank};
-
-    if ((target_role.rank == role.rank && target_role.fscid == role.fscid)
-        || (name.length() && info.standby_for_name == name)) {
-      // It's a named standby for *me*, use it.
-      return gid;
-    } else if (
-        info.standby_for_rank < 0 && info.standby_for_name.length() == 0 &&
-        (info.standby_for_fscid == FS_CLUSTER_ID_NONE ||
-         info.standby_for_fscid == role.fscid)) {
-        // It's not a named standby for anyone, use it if we don't find
-        // a named standby for me later, unless it targets another FSCID.
-        result = gid;
-      }
+    return gid;
   }
 
-  return result;
-}
-
-mds_gid_t FSMap::find_unused_for(mds_role_t role,
-				 bool force_standby_active) const {
-  for (const auto &i : standby_daemons) {
-    const auto &gid = i.first;
-    const auto &info = i.second;
-    ceph_assert(info.state == MDSMap::STATE_STANDBY);
-
-    if (info.laggy() || info.rank >= 0)
-      continue;
-
-    if (info.standby_for_fscid != FS_CLUSTER_ID_NONE &&
-        info.standby_for_fscid != role.fscid)
-      continue;
-    if (info.standby_for_rank != MDS_RANK_NONE &&
-        info.standby_for_rank != role.rank)
-      continue;
-
-    // To be considered 'unused' a daemon must either not
-    // be selected for standby-replay or the force_standby_active
-    // setting must be enabled to use replay daemons anyway.
-    if (!info.standby_replay || force_standby_active) {
-      return gid;
-    }
-  }
   return MDS_GID_NONE;
-}
-
-mds_gid_t FSMap::find_replacement_for(mds_role_t role, std::string_view name,
-                               bool force_standby_active) const {
-  const mds_gid_t standby = find_standby_for(role, name);
-  if (standby)
-    return standby;
-  else
-    return find_unused_for(role, force_standby_active);
 }
 
 void FSMap::sanity() const
@@ -854,7 +793,7 @@ void FSMap::sanity() const
 
 void FSMap::promote(
     mds_gid_t standby_gid,
-    const Filesystem::ref& filesystem,
+    Filesystem& filesystem,
     mds_rank_t assigned_rank)
 {
   ceph_assert(gid_exists(standby_gid));
@@ -864,7 +803,7 @@ void FSMap::promote(
     ceph_assert(standby_daemons.at(standby_gid).state == MDSMap::STATE_STANDBY);
   }
 
-  MDSMap &mds_map = filesystem->mds_map;
+  MDSMap &mds_map = filesystem.mds_map;
 
   // Insert daemon state to Filesystem
   if (!is_standby_replay) {
@@ -889,7 +828,7 @@ void FSMap::promote(
   }
   info.rank = assigned_rank;
   info.inc = epoch;
-  mds_roles[standby_gid] = filesystem->fscid;
+  mds_roles[standby_gid] = filesystem.fscid;
 
   // Update the rank state in Filesystem
   mds_map.in.insert(assigned_rank);

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -193,6 +193,8 @@ public:
     return result;
   }
 
+  mds_gid_t get_available_standby() const;
+
   /**
    * Resolve daemon name to GID
    */

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -265,7 +265,7 @@ public:
    */
   void promote(
       mds_gid_t standby_gid,
-      const Filesystem::ref& filesystem,
+      Filesystem& filesystem,
       mds_rank_t assigned_rank);
 
   /**
@@ -325,11 +325,9 @@ public:
    * Mutator helper for Filesystem objects: expose a non-const
    * Filesystem pointer to `fn` and update epochs appropriately.
    */
-  void modify_filesystem(
-      const fs_cluster_id_t fscid,
-      std::function<void(Filesystem::ref)> fn)
+  void modify_filesystem(fs_cluster_id_t fscid, auto&& fn)
   {
-    auto fs = filesystems.at(fscid);
+    auto& fs = filesystems.at(fscid);
     fn(fs);
     fs->mds_map.epoch = epoch;
   }
@@ -338,20 +336,18 @@ public:
    * Apply a mutation to the mds_info_t structure for a particular
    * daemon (identified by GID), and make appropriate updates to epochs.
    */
-  void modify_daemon(
-      mds_gid_t who,
-      std::function<void(MDSMap::mds_info_t *info)> fn)
+  void modify_daemon(mds_gid_t who, auto&& fn)
   {
-    if (mds_roles.at(who) == FS_CLUSTER_ID_NONE) {
-      auto &info = standby_daemons.at(who);
-      fn(&info);
+    const auto& fscid = mds_roles.at(who);
+    if (fscid == FS_CLUSTER_ID_NONE) {
+      auto& info = standby_daemons.at(who);
+      fn(info);
       ceph_assert(info.state == MDSMap::STATE_STANDBY);
       standby_epochs[who] = epoch;
     } else {
-      const auto &fs = filesystems[mds_roles.at(who)];
-      auto &info = fs->mds_map.mds_info.at(who);
-      fn(&info);
-
+      auto& fs = filesystems.at(fscid);
+      auto& info = fs->mds_map.mds_info.at(who);
+      fn(info);
       fs->mds_map.epoch = epoch;
     }
   }
@@ -404,7 +400,7 @@ public:
   void update_export_targets(mds_gid_t who, const std::set<mds_rank_t> &targets)
   {
     auto fscid = mds_roles.at(who);
-    modify_filesystem(fscid, [who, &targets](auto fs) {
+    modify_filesystem(fscid, [who, &targets](auto&& fs) {
       fs->mds_map.mds_info.at(who).export_targets = targets;
     });
   }
@@ -458,12 +454,7 @@ public:
     return false;
   }
 
-  mds_gid_t find_standby_for(mds_role_t mds, std::string_view name) const;
-
-  mds_gid_t find_unused_for(mds_role_t mds, bool force_standby_active) const;
-
-  mds_gid_t find_replacement_for(mds_role_t mds, std::string_view name,
-                                 bool force_standby_active) const;
+  mds_gid_t find_replacement_for(mds_role_t mds, std::string_view name) const;
 
   void get_health(list<pair<health_status_t,std::string> >& summary,
 		  list<pair<health_status_t,std::string> > *detail) const;

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -893,8 +893,7 @@ void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
 
   monc->sub_got("mdsmap", mdsmap->get_epoch());
 
-  // Calculate my effective rank (either my owned rank or my
-  // standby_for_rank if in standby replay)
+  // Calculate my effective rank (either my owned rank or the rank I'm following if STATE_STANDBY_REPLAY
   mds_rank_t whoami = mdsmap->get_rank_gid(mds_gid_t(monc->get_global_id()));
 
   // verify compatset
@@ -915,11 +914,6 @@ void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
       dout(10) << " peer mds gid " << p.first << " removed from map" << dendl;
       messenger->mark_down_addrs(p.second.addrs);
     }
-  }
-
-  if (whoami == MDS_RANK_NONE && 
-      new_state == MDSMap::STATE_STANDBY_REPLAY) {
-    whoami = mdsmap->get_mds_info_gid(mds_gid_t(monc->get_global_id())).standby_for_rank;
   }
 
   // see who i am

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -866,8 +866,6 @@ out:
   return r;
 }
 
-/* This function deletes the passed message before returning. */
-
 void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
 {
   version_t epoch = m->get_epoch();

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -89,6 +89,7 @@ void MDSMap::mds_info_t::dump(Formatter *f) const
   }
   f->close_section();
   f->dump_unsigned("features", mds_features);
+  f->dump_unsigned("flags", flags);
 }
 
 void MDSMap::mds_info_t::print_summary(ostream &out) const
@@ -105,6 +106,9 @@ void MDSMap::mds_info_t::print_summary(ostream &out) const
   }
   if (!export_targets.empty()) {
     out << " export_targets=" << export_targets;
+  }
+  if (is_frozen()) {
+    out << " frozen";
   }
 }
 
@@ -504,7 +508,7 @@ void MDSMap::get_health_checks(health_check_map_t *checks) const
 
 void MDSMap::mds_info_t::encode_versioned(bufferlist& bl, uint64_t features) const
 {
-  __u8 v = 8;
+  __u8 v = 9;
   if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
     v = 7;
   }
@@ -527,6 +531,7 @@ void MDSMap::mds_info_t::encode_versioned(bufferlist& bl, uint64_t features) con
   encode(mds_features, bl);
   encode(FS_CLUSTER_ID_NONE, bl); /* standby_for_fscid */
   encode(false, bl);
+  encode(flags, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -578,6 +583,9 @@ void MDSMap::mds_info_t::decode(bufferlist::const_iterator& bl)
   if (struct_v >= 7) {
     bool standby_replay;
     decode(standby_replay, bl);
+  }
+  if (struct_v >= 8) {
+    decode(flags, bl);
   }
   DECODE_FINISH(bl);
 }

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -242,6 +242,15 @@ public:
   bool allows_snaps() const { return test_flag(CEPH_MDSMAP_ALLOW_SNAPS); }
   bool was_snaps_ever_allowed() const { return ever_allowed_features & CEPH_MDSMAP_ALLOW_SNAPS; }
 
+  void set_standby_replay_allowed() {
+    set_flag(CEPH_MDSMAP_ALLOW_STANDBY_REPLAY);
+    ever_allowed_features |= CEPH_MDSMAP_ALLOW_STANDBY_REPLAY;
+    explicitly_allowed_features |= CEPH_MDSMAP_ALLOW_STANDBY_REPLAY;
+  }
+  void clear_standby_replay_allowed() { clear_flag(CEPH_MDSMAP_ALLOW_STANDBY_REPLAY); }
+  bool allows_standby_replay() const { return test_flag(CEPH_MDSMAP_ALLOW_STANDBY_REPLAY); }
+  bool was_standby_replay_ever_allowed() const { return ever_allowed_features & CEPH_MDSMAP_ALLOW_STANDBY_REPLAY; }
+
   void set_multimds_snaps_allowed() {
     set_flag(CEPH_MDSMAP_ALLOW_MULTIMDS_SNAPS);
     ever_allowed_features |= CEPH_MDSMAP_ALLOW_MULTIMDS_SNAPS;

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -100,27 +100,22 @@ public:
   } DaemonState;
 
   struct mds_info_t {
-    mds_gid_t global_id;
+    mds_gid_t global_id = MDS_GID_NONE;
     std::string name;
-    mds_rank_t rank;
-    int32_t inc;
-    MDSMap::DaemonState state;
-    version_t state_seq;
+    mds_rank_t rank = MDS_RANK_NONE;
+    int32_t inc = 0;
+    MDSMap::DaemonState state = STATE_STANDBY;
+    version_t state_seq = 0;
     entity_addrvec_t addrs;
     utime_t laggy_since;
-    mds_rank_t standby_for_rank;
+    mds_rank_t standby_for_rank = MDS_RANK_NONE;
     std::string standby_for_name;
-    fs_cluster_id_t standby_for_fscid;
-    bool standby_replay;
+    fs_cluster_id_t standby_for_fscid = FS_CLUSTER_ID_NONE;
+    bool standby_replay = false;
     std::set<mds_rank_t> export_targets;
     uint64_t mds_features = 0;
 
-    mds_info_t() : global_id(MDS_GID_NONE), rank(MDS_RANK_NONE), inc(0),
-                   state(STATE_STANDBY), state_seq(0),
-                   standby_for_rank(MDS_RANK_NONE),
-                   standby_for_fscid(FS_CLUSTER_ID_NONE),
-                   standby_replay(false)
-    { }
+    mds_info_t() = default;
 
     bool laggy() const { return !(laggy_since == utime_t()); }
     void clear_laggy() { laggy_since = utime_t(); }

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -120,7 +120,7 @@ public:
     bool laggy() const { return !(laggy_since == utime_t()); }
     void clear_laggy() { laggy_since = utime_t(); }
 
-    entity_addrvec_t get_addrs() const {
+    const entity_addrvec_t& get_addrs() const {
       return addrs;
     }
 

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -110,11 +110,23 @@ public:
     utime_t laggy_since;
     std::set<mds_rank_t> export_targets;
     uint64_t mds_features = 0;
+    uint64_t flags = 0;
+    enum mds_flags : uint64_t {
+      FROZEN = 1 << 0,
+    };
 
     mds_info_t() = default;
 
     bool laggy() const { return !(laggy_since == utime_t()); }
     void clear_laggy() { laggy_since = utime_t(); }
+
+    bool is_degraded() const {
+      return STATE_REPLAY <= state && state <= STATE_CLIENTREPLAY;
+    }
+
+    void freeze() { flags |= mds_flags::FROZEN; }
+    void unfreeze() { flags &= ~mds_flags::FROZEN; }
+    bool is_frozen() const { return flags&mds_flags::FROZEN; }
 
     const entity_addrvec_t& get_addrs() const {
       return addrs;
@@ -541,29 +553,33 @@ public:
     return is_clientreplay(m) || is_active(m) || is_stopping(m);
   }
 
-  bool is_followable(mds_rank_t r) const {
-    bool has_followable_rank = false;
-    for (const auto& p : mds_info) {
-      auto& info = p.second;
-      if (info.rank == r) {
-        if (info.state == STATE_ACTIVE) {
-          has_followable_rank = true;
-        } else {
-          return false;
-        }
-      }
-      if (p.second.state == STATE_STANDBY_REPLAY) {
-        return false;
+  mds_gid_t get_standby_replay(mds_rank_t r) const {
+    for (auto& [gid,info] : mds_info) {
+      if (info.rank == r && info.state == STATE_STANDBY_REPLAY) {
+        return gid;
       }
     }
-    return has_followable_rank;
+    return MDS_GID_NONE;
+  }
+  bool has_standby_replay(mds_rank_t r) const {
+    return get_standby_replay(r) != MDS_GID_NONE;
+  }
+
+  bool is_followable(mds_rank_t r) const {
+    if (auto it1 = up.find(r); it1 != up.end()) {
+      if (auto it2 = mds_info.find(it1->second); it2 != mds_info.end()) {
+        auto& info = it2->second;
+        if (!info.is_degraded() && !has_standby_replay(r)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   bool is_laggy_gid(mds_gid_t gid) const {
-    if (!mds_info.count(gid))
-      return false;
-    std::map<mds_gid_t,mds_info_t>::const_iterator p = mds_info.find(gid);
-    return p->second.laggy();
+    auto it = mds_info.find(gid);
+    return it == mds_info.end() ? false : it->second.laggy();
   }
 
   // degraded = some recovery in process.  fixes active membership and
@@ -571,11 +587,10 @@ public:
   bool is_degraded() const {
     if (!failed.empty() || !damaged.empty())
       return true;
-    for (std::map<mds_gid_t,mds_info_t>::const_iterator p = mds_info.begin();
-	 p != mds_info.end();
-	 ++p)
-      if (p->second.state >= STATE_REPLAY && p->second.state <= STATE_CLIENTREPLAY)
-	return true;
+    for (const auto& p : mds_info) {
+      if (p.second.is_degraded())
+        return true;
+    }
     return false;
   }
   bool is_any_failed() const {

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2391,17 +2391,12 @@ void MDSRankDispatcher::handle_mds_map(
     // might not include barriers from the previous incarnation of this MDS)
     set_osd_epoch_barrier(objecter->with_osdmap(
 			    std::mem_fn(&OSDMap::get_epoch)));
-  }
 
-  if (is_active()) {
+    /* Now check if we should hint to the OSD that a read may follow */
     bool found = false;
-    MDSMap::mds_info_t info = mdsmap->get_info(whoami);
-
-    for (map<mds_gid_t,MDSMap::mds_info_t>::const_iterator p = mdsmap->get_mds_info().begin();
-       p != mdsmap->get_mds_info().end();
-       ++p) {
-      if (p->second.state == MDSMap::STATE_STANDBY_REPLAY &&
-	  (p->second.standby_for_rank == whoami ||(info.name.length() && p->second.standby_for_name == info.name))) {
+    for (const auto& p : mdsmap->get_mds_info()) {
+      auto& info = p.second;
+      if (info.state == MDSMap::STATE_STANDBY_REPLAY && info.rank == whoami) {
 	found = true;
 	break;
       }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2393,15 +2393,7 @@ void MDSRankDispatcher::handle_mds_map(
 			    std::mem_fn(&OSDMap::get_epoch)));
 
     /* Now check if we should hint to the OSD that a read may follow */
-    bool found = false;
-    for (const auto& p : mdsmap->get_mds_info()) {
-      auto& info = p.second;
-      if (info.state == MDSMap::STATE_STANDBY_REPLAY && info.rank == whoami) {
-	found = true;
-	break;
-      }
-    }
-    if (found)
+    if (mdsmap->has_standby_replay(whoami))
       mdlog->set_write_iohint(0);
     else
       mdlog->set_write_iohint(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -6,7 +6,6 @@
 #include "common/Formatter.h"
 
 const mds_gid_t MDS_GID_NONE = mds_gid_t(0);
-const mds_rank_t MDS_RANK_NONE = mds_rank_t(-1);
 
 
 /*

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -75,14 +75,15 @@
 
 
 typedef int32_t mds_rank_t;
-typedef int32_t fs_cluster_id_t;
+constexpr mds_rank_t MDS_RANK_NONE = -1;
 
 BOOST_STRONG_TYPEDEF(uint64_t, mds_gid_t)
 extern const mds_gid_t MDS_GID_NONE;
-constexpr fs_cluster_id_t FS_CLUSTER_ID_NONE = {-1};
+
+typedef int32_t fs_cluster_id_t;
+constexpr fs_cluster_id_t FS_CLUSTER_ID_NONE = -1;
 // The namespace ID of the anonymous default filesystem from legacy systems
-constexpr fs_cluster_id_t FS_CLUSTER_ID_ANONYMOUS = {0};
-extern const mds_rank_t MDS_RANK_NONE;
+constexpr fs_cluster_id_t FS_CLUSTER_ID_ANONYMOUS = 0;
 
 class mds_role_t
 {

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -188,16 +188,16 @@ private:
   static constexpr int COMPAT_VERSION = 6;
 
   uuid_d fsid;
-  mds_gid_t global_id;
+  mds_gid_t global_id = MDS_GID_NONE;
   string name;
 
-  MDSMap::DaemonState state;
+  MDSMap::DaemonState state = MDSMap::STATE_NULL;
   version_t seq = 0;
 
-  mds_rank_t      standby_for_rank;
+  mds_rank_t      standby_for_rank = MDS_RANK_NONE;
   string          standby_for_name;
-  fs_cluster_id_t standby_for_fscid;
-  bool            standby_replay;
+  fs_cluster_id_t standby_for_fscid = FS_CLUSTER_ID_NONE;
+  bool            standby_replay = false;
 
   CompatSet compat;
 
@@ -205,21 +205,17 @@ private:
 
   map<string, string> sys_info;
 
-  uint64_t mds_features;
+  uint64_t mds_features = 0;
 
 protected:
-  MMDSBeacon()
-    : MessageInstance(MSG_MDS_BEACON, 0, HEAD_VERSION, COMPAT_VERSION),
-    global_id(0), state(MDSMap::STATE_NULL), standby_for_rank(MDS_RANK_NONE),
-    standby_for_fscid(FS_CLUSTER_ID_NONE), standby_replay(false),
-    mds_features(0) {
+  MMDSBeacon() : MessageInstance(MSG_MDS_BEACON, 0, HEAD_VERSION, COMPAT_VERSION)
+  {
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
   MMDSBeacon(const uuid_d &f, mds_gid_t g, const string& n, epoch_t les, MDSMap::DaemonState st, version_t se, uint64_t feat) :
     MessageInstance(MSG_MDS_BEACON, les, HEAD_VERSION, COMPAT_VERSION),
     fsid(f), global_id(g), name(n), state(st), seq(se),
-    standby_for_rank(MDS_RANK_NONE), standby_for_fscid(FS_CLUSTER_ID_NONE),
-    standby_replay(false), mds_features(feat) {
+    mds_features(feat) {
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
   ~MMDSBeacon() override {}

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -7,6 +7,7 @@ set(lib_mon_srcs
   PaxosService.cc
   OSDMonitor.cc
   MDSMonitor.cc
+  CommandHandler.cc
   FSCommands.cc
   MgrMonitor.cc
   MgrStatMonitor.cc

--- a/src/mon/CommandHandler.cc
+++ b/src/mon/CommandHandler.cc
@@ -1,0 +1,43 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat Ltd
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#include "CommandHandler.h"
+
+#include "common/strtol.h"
+#include "include/ceph_assert.h"
+
+#include <ostream>
+#include <string>
+#include <string_view>
+
+int CommandHandler::parse_bool(std::string_view str, bool* result, std::ostream& ss)
+{
+  ceph_assert(result != nullptr);
+
+  std::string interr;
+  int64_t n = strict_strtoll(str.data(), 10, &interr);
+
+  if (str == "false" || str == "no"
+      || (interr.length() == 0 && n == 0)) {
+    *result = false;
+    return 0;
+  } else if (str == "true" || str == "yes"
+      || (interr.length() == 0 && n == 1)) {
+    *result = true;
+    return 0;
+  } else {
+    ss << "value must be false|no|0 or true|yes|1";
+    return -EINVAL;
+  }
+}

--- a/src/mon/CommandHandler.h
+++ b/src/mon/CommandHandler.h
@@ -1,0 +1,35 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat Ltd
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+
+#ifndef COMMAND_HANDLER_H_
+#define COMMAND_HANDLER_H_
+
+#include <ostream>
+#include <string_view>
+
+class CommandHandler
+{
+public:
+  /**
+   * Parse true|yes|1 style boolean string from `bool_str`
+   * `result` must be non-null.
+   * `ss` will be populated with error message on error.
+   *
+   * @return 0 on success, else -EINVAL
+   */
+  int parse_bool(std::string_view str, bool* result, std::ostream& ss);
+};
+
+#endif

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -974,30 +974,6 @@ FileSystemCommandHandler::load(Paxos *paxos)
   return handlers;
 }
 
-int FileSystemCommandHandler::parse_bool(
-      const std::string &bool_str,
-      bool *result,
-      std::ostream &ss)
-{
-  ceph_assert(result != nullptr);
-
-  string interr;
-  int64_t n = strict_strtoll(bool_str.c_str(), 10, &interr);
-
-  if (bool_str == "false" || bool_str == "no"
-      || (interr.length() == 0 && n == 0)) {
-    *result = false;
-    return 0;
-  } else if (bool_str == "true" || bool_str == "yes"
-      || (interr.length() == 0 && n == 1)) {
-    *result = true;
-    return 0;
-  } else {
-    ss << "value must be false|no|0 or true|yes|1";
-    return -EINVAL;
-  }
-}
-
 int FileSystemCommandHandler::_check_pool(
     OSDMap &osd_map,
     const int64_t pool_id,

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -588,6 +588,21 @@ public:
       {
         fs->mds_map.set_session_autoclose((uint32_t)n);
       });
+    } else if (var == "allow_standby_replay") {
+      bool allow = false;
+      int r = parse_bool(val, &allow, ss);
+      if (r != 0) {
+        return r;
+      }
+
+      auto f = [allow](auto& fs) {
+        if (allow) {
+          fs->mds_map.set_standby_replay_allowed();
+        } else {
+          fs->mds_map.clear_standby_replay_allowed();
+        }
+      };
+      fsmap.modify_filesystem(fs->fscid, std::move(f));
     } else if (var == "min_compat_client") {
       int vno = ceph_release_from_name(val.c_str());
       if (vno <= 0) {

--- a/src/mon/FSCommands.h
+++ b/src/mon/FSCommands.h
@@ -17,6 +17,7 @@
 #define FS_COMMANDS_H_
 
 #include "Monitor.h"
+#include "CommandHandler.h"
 
 #include "osd/OSDMap.h"
 #include "mds/FSMap.h"
@@ -24,22 +25,10 @@
 #include <string>
 #include <sstream>
 
-class FileSystemCommandHandler
+class FileSystemCommandHandler : protected CommandHandler
 {
 protected:
   std::string prefix;
-
-  /**
-   * Parse true|yes|1 style boolean string from `bool_str`
-   * `result` must be non-null.
-   * `ss` will be populated with error message on error.
-   *
-   * @return 0 on success, else -EINVAL
-   */
-  int parse_bool(
-      const std::string &bool_str,
-      bool *result,
-      std::ostream &ss);
 
   /**
    * Return 0 if the pool is suitable for use with CephFS, or

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -104,12 +104,9 @@ class MDSMonitor : public PaxosService, public PaxosFSMap {
   };
   map<mds_gid_t, beacon_info_t> last_beacon;
 
-  bool try_standby_replay(FSMap &fsmap, const MDSMap::mds_info_t& finfo,
-      const Filesystem &leader_fs, const MDSMap::mds_info_t& ainfo);
-
   std::list<std::shared_ptr<FileSystemCommandHandler> > handlers;
 
-  bool maybe_promote_standby(FSMap &fsmap, std::shared_ptr<Filesystem> &fs);
+  bool maybe_promote_standby(FSMap& fsmap, Filesystem& fs);
   bool maybe_resize_cluster(FSMap &fsmap, fs_cluster_id_t fscid);
   void maybe_replace_gid(FSMap &fsmap, mds_gid_t gid,
       const MDSMap::mds_info_t& info, bool *mds_propose, bool *osd_propose);

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -26,13 +26,14 @@
 #include "PaxosService.h"
 #include "msg/Messenger.h"
 #include "messages/MMDSBeacon.h"
+#include "CommandHandler.h"
 
 class MMonCommand;
 class MMDSLoadTargets;
 class MMDSMap;
 class FileSystemCommandHandler;
 
-class MDSMonitor : public PaxosService, public PaxosFSMap {
+class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHandler {
  public:
   MDSMonitor(Monitor *mn, Paxos *p, string service_name);
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -396,7 +396,7 @@ COMMAND("fs set " \
 	"name=var,type=CephChoices,strings=max_mds|max_file_size"
         "|allow_new_snaps|inline_data|cluster_down|allow_dirfrags|balancer" \
         "|standby_count_wanted|session_timeout|session_autoclose" \
-        "|down|joinable|min_compat_client " \
+        "|allow_standby_replay|down|joinable|min_compat_client " \
 	"name=val,type=CephString "					\
 	"name=yes_i_really_mean_it,type=CephBool,req=false",			\
 	"set fs parameter <var> to <val>", "mds", "rw")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -322,6 +322,9 @@ COMMAND_WITH_FLAG("mds set " \
 	"name=val,type=CephString "					\
 	"name=yes_i_really_mean_it,type=CephBool,req=false",			\
 	"set mds parameter <var> to <val>", "mds", "rw", FLAG(OBSOLETE))
+COMMAND_WITH_FLAG("mds freeze name=role_or_gid,type=CephString"
+	" name=val,type=CephString",
+	"freeze MDS yes/no", "mds", "rw", FLAG(HIDDEN))
 // arbitrary limit 0-20 below; worth standing on head to make it
 // relate to actual state definitions?
 // #include "include/ceph_fs.h"


### PR DESCRIPTION
This PR obsoletes all of the `standby_for_*` and `mds_standby_replay` MDS config options. Operators can no longer specify what fs/rank/name a standby should preferentially wait to takeover for. The main reason for this is that it's confusing due to the cyclical nature of the config options during failover (a standbys for b which also standbys for a?). Additionally, the MDSMonitor would ignore these directives if no other standby could be used.

Instead, all standbys in the cluster are equal.

Finally, standby-replay is now indicated by setting a flag on the FS:

`ceph fs set <name> allow_standby_replay true`

The MDSMonitor will promote available standbys to become standby-replay during its regular ticks.