### PR TITLE
rgw: data sync drains lease stack on lease failure

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1216,6 +1216,7 @@ public:
         if (lease_cr->is_done()) {
           tn->log(5, "failed to take lease");
           set_status("lease lock failed, early abort");
+          drain_all();
           return set_cr_error(lease_cr->get_ret_status());
         }
         set_sleeping(true);
@@ -1307,6 +1308,7 @@ public:
           if (lease_cr->is_done()) {
             tn->log(5, "failed to take lease");
             set_status("lease lock failed, early abort");
+            drain_all();
             return set_cr_error(lease_cr->get_ret_status());
           }
           set_sleeping(true);
@@ -3176,6 +3178,7 @@ int RGWRunBucketSyncCoroutine::operate()
       if (lease_cr->is_done()) {
         tn->log(5, "failed to take lease");
         set_status("lease lock failed, early abort");
+        drain_all();
         return set_cr_error(lease_cr->get_ret_status());
       }
       set_sleeping(true);


### PR DESCRIPTION
on lease failure, call drain_all() to collect the spawned lease stack. otherwise, the parent coroutine will inherit this spawned stack and may not drain or collect it manually. RGWDataSyncShardControlCR, for example, does not drain/collect because it only uses call() to run a single RGWDataSyncShardCR, so all lease stacks from RGWDataSyncShardCR just pile up in the RGWDataSyncShardControlCR

Fixes: http://tracker.ceph.com/issues/38479