### PR TITLE
mimic: rgw: only update last_trim marker on ENODATA

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -1,3 +1,4 @@
+#include "include/compat.h"
 #include "rgw_rados.h"
 #include "rgw_coroutine.h"
 #include "rgw_cr_rados.h"
@@ -799,9 +800,10 @@ RGWSyncLogTrimCR::RGWSyncLogTrimCR(RGWRados *store, const std::string& oid,
 int RGWSyncLogTrimCR::request_complete()
 {
   int r = RGWRadosTimelogTrimCR::request_complete();
-  if (r < 0 && r != -ENODATA) {
+  if (r != -ENODATA) {
     return r;
   }
+  // nothing left to trim, update last_trim_marker
   if (*last_trim_marker < to_marker) {
     *last_trim_marker = to_marker;
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/38447