### PR TITLE
rpm: use %_python_buildid to specify python-remoto dep

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -525,7 +525,7 @@ BuildArch:	noarch
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
-Requires:       python-remoto
+Requires:       python%{_python_buildid}-remoto
 %description mgr-ssh
 ceph-mgr-ssh is a ceph-mgr module for orchestration functions using
 direct SSH connections for management operations.


### PR DESCRIPTION
Without this patch, the Python 2 version of python-remoto is always installed,
even on Python 3 systems.

Signed-off-by: Nathan Cutler <ncutler@suse.com>