### PR TITLE
osd: prime splits/merges for fabricated merge target

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1876,6 +1876,8 @@ protected:
   void consume_map();
   void activate_map();
 
+  void _prime_pg_splits_and_merges(PGRef& pg);
+
   // osd map cache (past osd maps)
   OSDMapRef get_map(epoch_t e) {
     return service.get_map(e);


### PR DESCRIPTION
If we have to fabricate a merge target, we need to prime any future splits
it might have.  Otherwise a sequence like

- e100 1.f merge to 1.7
- e110 1.7 split to 1.f, 1.17, 1.1f

where we process all of the above in one go at, say, e120, will lead to
a crash in register_and_wake_split_child because 1.17 and/or 1.1f aren't
primed.

Fixes: http://tracker.ceph.com/issues/38483
Signed-off-by: Sage Weil <sage@redhat.com>