### PR TITLE
osd: clear osd op reply output only when writes success

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1719,7 +1719,7 @@ void OSDService::reply_op_error(OpRequestRef op, int err, eversion_t v,
   int flags;
   flags = m->get_flags() & (CEPH_OSD_FLAG_ACK|CEPH_OSD_FLAG_ONDISK);
 
-  MOSDOpReply *reply = new MOSDOpReply(m, err, osdmap->get_epoch(), flags, true);
+  MOSDOpReply *reply = new MOSDOpReply(m, err, osdmap->get_epoch(), flags, err >= 0);
   reply->set_reply_versions(v, uv);
   m->get_connection()->send_message(reply);
 }


### PR DESCRIPTION
As described in https://github.com/ceph/ceph/commit/18f08cd9c0a3972149eef635fb1035dfc4fcb662,
if the op is failed, we should return data.

Signed-off-by: huangjun <huangjun@xsky.com>