### PR TITLE
mimic: ceph-volume: add --all flag to simple activate

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
@@ -22,6 +22,26 @@ class TestActivate(object):
         stdout, stderr = capsys.readouterr()
         assert 'Activate OSDs by mounting devices previously configured' in stdout
 
+    def test_activate_all(self, is_root, monkeypatch):
+        '''
+        make sure Activate calls activate for each file returned by glob
+        '''
+        mocked_glob = []
+        def mock_glob(glob):
+            path = os.path.dirname(glob)
+            mocked_glob.extend(['{}/{}.json'.format(path, file_) for file_ in
+                                ['1', '2', '3']])
+            return mocked_glob
+        activate_files = []
+        def mock_activate(self, args):
+            activate_files.append(args.json_config)
+        monkeypatch.setattr('glob.glob', mock_glob)
+        monkeypatch.setattr(activate.Activate, 'activate', mock_activate)
+        activate.Activate(['--all']).main()
+        assert activate_files == mocked_glob
+
+
+
 
 class TestEnableSystemdUnits(object):
 

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/activate/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/activate/test.yml
@@ -24,8 +24,6 @@
       register: osd_configs
 
     - name: activate all scanned OSDs
-      command: "ceph-volume --cluster={{ cluster }} simple activate --file {{ item.path }}"
+      command: "ceph-volume --cluster={{ cluster }} simple activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
-      with_items:
-        - "{{ osd_configs.files }}"


### PR DESCRIPTION
This is intended to behave similarly to the lvm activate --all argument.
When passed, c-v will scan /etc/ceph/osd/ (or the location specified by
CEPH_VOLUME_SIMPLE_JSON_DIR) for json files (glob *.json) and call activate
for each file.  This should greatly ease the take-over of ceph-disk OSDs
with manual commands and deployment tools like DeepSea and ceph-ansible.
Also adds a simple unit test and modifies the
simple/centos7/filestore/activate functional test to use --all.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
(cherry picked from commit 05af94c6fca66083107e96e9aa1db87619e77e66)

 Conflicts:
	src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/activate/test.yml
        resolved by removing everything after conflict marker


Backport of #26225 

