### PR TITLE
luminous: os/bluestore: BlueFS enospc fix.

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2132,7 +2132,8 @@ private:
   int _reconcile_bluefs_freespace();
   int _balance_bluefs_freespace(PExtentVector *extents);
   void _commit_bluefs_freespace(const PExtentVector& extents);
-
+  int _balance_bluefs_freespace_standalone();
+  
   CollectionRef _get_collection(const coll_t& cid);
   void _queue_reap_collection(CollectionRef& c);
   void _reap_collections();


### PR DESCRIPTION
Fix problem with bluefs's freespace not being balanced when kv_sync_thread is sleeping.
This is fix for customer issue #1600138

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>


