### PR TITLE
doc: change ruleset to id in crush map file

### DIFF
--- a/doc/rados/operations/crush-map-edits.rst
+++ b/doc/rados/operations/crush-map-edits.rst
@@ -372,7 +372,7 @@ A rule takes the following form::
 
 	rule <rulename> {
 
-		ruleset <ruleset>
+		id [a unique whole numeric ID]
 		type [ replicated | erasure ]
 		min_size <min-size>
 		max_size <max-size>
@@ -382,11 +382,9 @@ A rule takes the following form::
 	}
 
 
-``ruleset``
+``id``
 
-:Description: A unique whole number for identifying the rule. The name ``ruleset``
-              is a carry-over from the past, when it was possible to have multiple
-              CRUSH rules per pool.
+:Description: A unique whole number for identifying the rule.
 
 :Purpose: A component of the rule mask.
 :Type: Integer


### PR DESCRIPTION
ruleset is not used after merging below patch
   commit f9a095deb1e74642d88bc9015684b0be113cc5f9
       crush: s/ruleset/id/ in decompiled output
       Moving away from the 'ruleset' terminology.

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

