### PR TITLE
cmake: one more fix to make amqp support optional

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -3,13 +3,19 @@ add_executable(ceph_rgw_jsonparser
   rgw_jsonparser.cc)
 target_link_libraries(ceph_rgw_jsonparser
   rgw_a
-  global rabbitmq)
+  global)
+if(WITH_RADOSGW_AMQP_ENDPOINT)
+  target_link_libraries(ceph_rgw_jsonparser rabbitmq)
+endif()
 
 add_executable(ceph_rgw_multiparser
   rgw_multiparser.cc)
 target_link_libraries(ceph_rgw_multiparser
   rgw_a
-  global rabbitmq)
+  global)
+if(WITH_RADOSGW_AMQP_ENDPOINT)
+  target_link_libraries(ceph_rgw_multiparser rabbitmq)
+endif()
 
 install(TARGETS
   ceph_rgw_jsonparser


### PR DESCRIPTION
Turns out I missed one when I was working on #26625. This particular instance didn't come up until building the ceph-test RPM, which I'd skipped the other day :-/