### PR TITLE
tools/ceph_kvstore_tool: Move summary output to print_summary

### DIFF
--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -179,6 +179,19 @@ bool StoreTool::rm_prefix(const string& prefix)
   return (ret == 0);
 }
 
+void StoreTool::print_summary(const uint64_t total_keys, const uint64_t total_size,
+                              const uint64_t total_txs, const string& store_path,
+                              const string& other_path, const int duration) const
+{
+  std::cout << "summary:" << std::endl;
+  std::cout << "  copied " << total_keys << " keys" << std::endl;
+  std::cout << "  used " << total_txs << " transactions" << std::endl;
+  std::cout << "  total size " << byte_u_t(total_size) << std::endl;
+  std::cout << "  from '" << store_path << "' to '" << other_path << "'"
+            << std::endl;
+  std::cout << "  duration " << duration << " seconds" << std::endl;
+}
+
 int StoreTool::copy_store_to(const string& type, const string& other_path,
                              const int num_keys_per_tx,
                              const string& other_type)
@@ -238,13 +251,8 @@ int StoreTool::copy_store_to(const string& type, const string& other_path,
 
   } while (it->valid());
 
-  std::cout << "summary:" << std::endl;
-  std::cout << "  copied " << total_keys << " keys" << std::endl;
-  std::cout << "  used " << total_txs << " transactions" << std::endl;
-  std::cout << "  total size " << byte_u_t(total_size) << std::endl;
-  std::cout << "  from '" << store_path << "' to '" << other_path << "'"
-            << std::endl;
-  std::cout << "  duration " << duration() << " seconds" << std::endl;
+  print_summary(total_keys, total_size, total_txs, store_path, other_path,
+                duration());
 
   return 0;
 }

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -62,6 +62,9 @@ public:
 	   ceph::bufferlist& val);
   bool rm(const std::string& prefix, const std::string& key);
   bool rm_prefix(const std::string& prefix);
+  void print_summary(const uint64_t total_keys, const uint64_t total_size,
+                     const uint64_t total_txs, const std::string& store_path,
+                     const std::string& other_path, const int duration) const;
   int copy_store_to(const std::string& type, const std::string& other_path,
                     const int num_keys_per_tx, const std::string& other_type);
   void compact();


### PR DESCRIPTION
Post 301a64212f0a38a3b5db4bd1bd0f15e26ff055cf we are still seeing an ICE
in the copy_store_to code. Moving the summary printing to its own
function alleviates the issue.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

