### PR TITLE
msg/async/Protocol*: send keep alive if existing wins

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1998,6 +1998,8 @@ CtPtr ProtocolV1::handle_connect_message_2() {
                     << " existing_state="
                     << connection->get_state_name(existing->state) << dendl;
       reply.global_seq = exproto->peer_global_seq;
+      // make sure we notice if existing connection is no longer functioning
+      existing->send_keepalive();
       existing->lock.unlock();
       return send_connect_message_reply(CEPH_MSGR_TAG_RETRY_GLOBAL, reply,
                                         authorizer_reply);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2646,12 +2646,10 @@ CtPtr ProtocolV2::handle_existing_connection(AsyncConnectionRef existing) {
     ceph_assert(connection->peer_addrs->msgr2_addr() >
                 messenger->get_myaddrs().msgr2_addr());
 
-    existing->lock.unlock();
     // make sure we follow through with opening the existing
-		// connection (if it isn't yet open) since we know the peer
-		// has something to send to us.
+    // connection (if it isn't yet open) since we know the peer
+    // has something to send to us.
     existing->send_keepalive();
-    existing->lock.lock();
     auto wait = WaitFrame::Encode(session_stream_handlers);
     return WRITE(wait, "wait", read_frame);
   }

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2464,6 +2464,8 @@ CtPtr ProtocolV2::handle_reconnect(ceph::bufferlist &payload)
     ldout(cct, 1) << __func__
                   << " existing racing replace happened while replacing."
                   << " existing=" << existing << dendl;
+    // make sure we notice if existing connection is no longer functioning
+    existing->send_keepalive();
     auto retry = RetryGlobalFrame::Encode(session_stream_handlers,
                                           exproto->peer_global_seq);
     return WRITE(retry, "session retry", read_frame);
@@ -2571,6 +2573,8 @@ CtPtr ProtocolV2::handle_existing_connection(AsyncConnectionRef existing) {
     ldout(cct, 1) << __func__
                   << " existing racing replace happened while replacing."
                   << " existing=" << existing << dendl;
+    // make sure we notice if existing connection is no longer functioning
+    existing->send_keepalive();
     auto wait = WaitFrame::Encode(session_stream_handlers);
     return WRITE(wait, "wait", read_frame);
   }


### PR DESCRIPTION
This is a follow-up fix of https://github.com/ceph/ceph/pull/25754.

It turns out the existing connection would win the connection race
and then be stuck at the __replacing__ stage forever without being
aware of the underlying Pipe is actually broken.

Fix by forcing existing sending keepalive periodically __too__.

Fixes: http://tracker.ceph.com/issues/38493
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

