### PR TITLE
osd: remove redundant arguments for async recovery

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -932,10 +932,8 @@ void ECBackend::handle_sub_write(
   clear_temp_objs(op.temp_removed);
   dout(30) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
   // flag set to true during async recovery
-  bool async = false;
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(op.soid)) {
-    async = true;
     dout(30) << __func__ << " is_missing " << pmissing.is_missing(op.soid) << dendl;
     for (auto &&e: op.log_entries) {
       dout(30) << " add_next_event entry " << e << dendl;
@@ -949,8 +947,7 @@ void ECBackend::handle_sub_write(
     op.trim_to,
     op.roll_forward_to,
     !op.backfill_or_async_recovery,
-    localt,
-    async);
+    localt);
 
   if (!get_parent()->pg_is_undersized() &&
       (unsigned)get_parent()->whoami_shard().shard >=

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3792,8 +3792,7 @@ void PG::append_log(
   eversion_t trim_to,
   eversion_t roll_forward_to,
   ObjectStore::Transaction &t,
-  bool transaction_applied,
-  bool async)
+  bool transaction_applied)
 {
   if (transaction_applied)
     update_snap_map(logv, t);
@@ -3850,10 +3849,10 @@ void PG::append_log(
            << pg_log.get_log().approx_size() << dendl;
   dout(10) << __func__ << " transaction_applied = "
            << transaction_applied << dendl;
-  if (!transaction_applied || async)
+  if (!transaction_applied)
     dout(10) << __func__ << " " << pg_whoami
              << " is async_recovery or backfill target" << dendl;
-  pg_log.trim(trim_to, info, transaction_applied, async);
+  pg_log.trim(trim_to, info, transaction_applied);
 
   // update the local pg, pg log
   dirty_info = true;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2992,8 +2992,7 @@ protected:
     eversion_t trim_to,
     eversion_t roll_forward_to,
     ObjectStore::Transaction &t,
-    bool transaction_applied = true,
-    bool async = false);
+    bool transaction_applied = true);
   bool check_log_for_corruption(ObjectStore *store);
 
   std::string get_corrupt_pg_log_name() const;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -234,8 +234,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
        const eversion_t &trim_to,
        const eversion_t &roll_forward_to,
        bool transaction_applied,
-       ObjectStore::Transaction &t,
-       bool async = false) = 0;
+       ObjectStore::Transaction &t) = 0;
 
      virtual void pgb_set_object_snap_mapping(
        const hobject_t &soid,

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -181,8 +181,7 @@ void PGLog::clear_info_log(
 void PGLog::trim(
   eversion_t trim_to,
   pg_info_t &info,
-  bool transaction_applied,
-  bool async)
+  bool transaction_applied)
 {
   dout(10) << __func__ << " proposed trim_to = " << trim_to << dendl;
   // trim?
@@ -190,7 +189,7 @@ void PGLog::trim(
     dout(10) << __func__ << " missing = " << missing.num_missing() << dendl;
     // Don't assert for async_recovery_targets or backfill_targets
     // or whenever there are missing items
-    if (transaction_applied && !async && (missing.num_missing() == 0))
+    if (transaction_applied && (missing.num_missing() == 0))
       ceph_assert(trim_to <= info.last_complete);
 
     dout(10) << "trim " << log << " to " << trim_to << dendl;

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -707,8 +707,7 @@ public:
   void trim(
     eversion_t trim_to,
     pg_info_t &info,
-    bool transaction_applied = true,
-    bool async = false);
+    bool transaction_applied = true);
 
   void roll_forward_to(
     eversion_t roll_forward_to,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -436,12 +436,11 @@ public:
     const eversion_t &trim_to,
     const eversion_t &roll_forward_to,
     bool transaction_applied,
-    ObjectStore::Transaction &t,
-    bool async = false) override {
+    ObjectStore::Transaction &t) override {
     if (hset_history) {
       info.hit_set = *hset_history;
     }
-    append_log(logv, trim_to, roll_forward_to, t, transaction_applied, async);
+    append_log(logv, trim_to, roll_forward_to, t, transaction_applied);
   }
 
   void op_applied(const eversion_t &applied_version) override;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1052,10 +1052,8 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   }
 
   // flag set to true during async recovery
-  bool async = false;
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(soid)) {
-    async = true;
     dout(30) << __func__ << " is_missing " << pmissing.is_missing(soid) << dendl;
     for (auto &&e: log) {
       dout(30) << " add_next_event entry " << e << dendl;
@@ -1071,8 +1069,7 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
     m->pg_trim_to,
     m->pg_roll_forward_to,
     update_snaps,
-    rm->localt,
-    async);
+    rm->localt);
 
   rm->opt.register_on_commit(
     parent->bless_context(


### PR DESCRIPTION
the argument transaction_applied already indicates
whether the object is backfill or async recovery target,
and it does not need distinguish backfill from async recovery