### PR TITLE
[RFC][DNM] ceph-volume: add support for conf bootstrap cli args

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -126,6 +126,18 @@ Ceph Conf: {ceph_path}
             default='/var/log/ceph/',
             help='Change the log path (defaults to /var/log/ceph)',
         )
+        parser.add_argument(
+            '--mon-host',
+            help='List of monitors for the cluster',
+        )
+        parser.add_argument(
+            '--mon-dns-serv-name',
+            help='The name of the DNS SRV record to check to identify the cluster monitors via DNS',
+        )
+        parser.add_argument(
+            '--keyring',
+            help='Authentication credentials to use to authenticate with the monitor',
+        )
         args = parser.parse_args(main_args)
         conf.log_path = args.log_path
         if os.path.isdir(conf.log_path):
@@ -137,7 +149,7 @@ Ceph Conf: {ceph_path}
         # them
         configuration.load_ceph_conf_path(cluster_name=args.cluster)
         try:
-            conf.ceph = configuration.load(conf.path)
+            conf.ceph = configuration.load(conf.path, args)
         except exceptions.ConfigurationError as error:
             # we warn only here, because it is possible that the configuration
             # file is not needed, or that it will be loaded by some other means

--- a/src/ceph-volume/ceph_volume/tests/test_configuration.py
+++ b/src/ceph-volume/ceph_volume/tests/test_configuration.py
@@ -115,3 +115,20 @@ class TestLoad(object):
             conf.write(tabbed_conf)
         result = configuration.load(conf_path)
         assert result.get('global', commented) == ''
+
+    def test_load_with_cli_overrides(self, tmpdir, factory):
+        conf_path = os.path.join(str(tmpdir), 'ceph.conf')
+        with open(conf_path, 'w') as conf:
+            conf.write(tabbed_conf)
+        args = factory(mon_host='mon1')
+        cfg = configuration.load(conf_path, args)
+        cfg.is_valid = lambda: True
+        assert cfg.get_safe('global', 'mon_host') == 'mon1'
+
+    def test_load_without_cli_overrides(self, tmpdir, factory):
+        conf_path = os.path.join(str(tmpdir), 'ceph.conf')
+        with open(conf_path, 'w') as conf:
+            conf.write(tabbed_conf)
+        cfg = configuration.load(conf_path)
+        cfg.is_valid = lambda: True
+        assert cfg.get_safe('global', 'mon_host') == None

--- a/src/ceph-volume/ceph_volume/util/ceph_cli.py
+++ b/src/ceph-volume/ceph_volume/util/ceph_cli.py
@@ -1,0 +1,28 @@
+'''
+Utility function to call the ceph binary
+'''
+from ceph_volume import conf
+
+
+def get_cmd(cmd, user=None, keyring=None):
+    base_cmd = [
+        'ceph',
+        '--cluster', conf.cluster,
+    ]
+    if user:
+        base_cmd.extend(['--name', user,])
+    if keyring:
+        base_cmd.extend(['--keyring', keyring,])
+    else:
+        keyring = conf.ceph.get_safe('global', 'keyring')
+        if keyring:
+            base_cmd.extend(['--keyring', keyring,])
+
+    mon_host =  conf.ceph.get_safe('global', 'mon_host')
+    if mon_host:
+        base_cmd.extend(['--mon-host', mon_host,])
+    mon_dns_serv_name =  conf.ceph.get_safe('global', 'mon_dns_serv_name')
+    if mon_dns_serv_name:
+        base_cmd.extend(['--mon-dns-serv-name', mon_dns_serv_name,])
+
+    return base_cmd + cmd

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -2,7 +2,7 @@ import base64
 import os
 import logging
 from ceph_volume import process, conf
-from ceph_volume.util import constants, system
+from ceph_volume.util import constants, system, ceph_cli
 from ceph_volume.util.device import Device
 from .prepare import write_keyring
 from .disk import lsblk, device_family, get_part_entry_type
@@ -122,16 +122,14 @@ def get_dmcrypt_key(osd_id, osd_fsid, lockbox_keyring=None):
     name = 'client.osd-lockbox.%s' % osd_fsid
     config_key = 'dm-crypt/osd/%s/luks' % osd_fsid
 
+    cmd = [
+        'config-key',
+        'get',
+        config_key
+    ]
+
     stdout, stderr, returncode = process.call(
-        [
-            'ceph',
-            '--cluster', conf.cluster,
-            '--name', name,
-            '--keyring', lockbox_keyring,
-            'config-key',
-            'get',
-            config_key
-        ],
+        ceph_cli.get_cmd(cmd, name, lockbox_keyring),
         show_command=True
     )
     if returncode != 0:


### PR DESCRIPTION
This adds cli args to ceph-volume, that are needed to function without ceph.conf according to http://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#bootstrap-options.

RFC mostly regarding the approach, there're other places that need a similar solution (e.g. calls to `ceph-osd`).

Fixes: http://tracker.ceph.com/issues/38279