### PR TITLE
CMakeLists.txt: debug PG refs in debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,11 @@ endif(WITH_BABELTRACE)
 
 option(DEBUG_GATHER "C_Gather debugging is enabled" ON)
 option(ENABLE_COVERAGE "Coverage is enabled" OFF)
-option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  option(PG_DEBUG_REFS "PG Ref debugging is enabled" ON)
+else()
+  option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
+endif()
 
 option(WITH_TESTS "enable the build of ceph-test package scripts/binaries" ON)
 set(UNIT_TESTS_BUILT ${WITH_TESTS})

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -47,6 +47,7 @@
 	osd debug shutdown = true
         osd debug op order = true
         osd debug verify stray on activate = true
+	osd shutdown pgref assert = true
 
 	osd open classes on start = true
         osd debug pg log writeout = true


### PR DESCRIPTION
I can't decide if this is a good idea.  On one hand, it will help us find leaks the first time they happen in qa.  On the other hand, this moves the debug build further away from being usable in production.  And I /thank/ i squashed the pg leak...