### PR TITLE
mon/ConfigMonitor: add 'config ls'

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -176,6 +176,31 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
     } else {
       odata.append(ss.str());
     }
+  } else if (prefix == "config ls") {
+    ostringstream ss;
+    if (f) {
+      f->open_array_section("options");
+    }
+    for (auto& i : ceph_options) {
+      if (f) {
+	f->dump_string("option", i.name);
+      } else {
+	ss << i.name << "\n";
+      }
+    }
+    for (auto& i : mon->mgrmon()->get_mgr_module_options()) {
+      if (f) {
+	f->dump_string("option", i.first);
+      } else {
+	ss << i.first << "\n";
+      }
+    }
+    if (f) {
+      f->close_section();
+      f->flush(odata);
+    } else {
+      odata.append(ss.str());
+    }
   } else if (prefix == "config dump") {
     list<pair<string,Section*>> sections = {
       make_pair("global", &config_map.global)

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -81,6 +81,9 @@ public:
 
   const MgrMap &get_map() const { return map; }
 
+  const std::map<std::string,Option>& get_mgr_module_options() {
+    return mgr_module_options;
+  }
   const Option *find_module_option(const string& name);
 
   bool in_use() const { return map.epoch > 0; }

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1162,6 +1162,9 @@ COMMAND("config help " \
 	"name=key,type=CephString",
 	"Describe a configuration option",
 	"config", "r")
+COMMAND("config ls",
+	"List available configuration options",
+	"config", "r")
 COMMAND("config assimilate-conf",
 	"Assimilate options from a conf, and return a new, minimal conf file",
 	"config", "rw")


### PR DESCRIPTION
I started to rathole on whether to have a detail view and what should be included and how ugly it was as a TextTable with the config descriptions, so this is just the minimal ability to list available options.