### PR TITLE
pick_address: error out in dual stack mode if both addr types cannot be provided

### DIFF
--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -237,8 +237,16 @@ static int fill_in_one_address(
   const struct sockaddr *found = find_ip_in_subnet_list(cct, ifa, ipv, networks,
 							interfaces, numa_node);
   if (!found) {
-    lderr(cct) << "unable to find any IP address in networks '" << networks
-	       << "' interfaces '" << interfaces << "'" << dendl;
+    std::string ip_type = "";
+    if ((ipv & CEPH_PICK_ADDRESS_IPV4) && (ipv & CEPH_PICK_ADDRESS_IPV6)) {
+      ip_type = "IPv4 or IPv6";
+    } else if (ipv & CEPH_PICK_ADDRESS_IPV4) {
+      ip_type = "IPv4";
+    } else {
+      ip_type = "IPv6";
+    }
+    lderr(cct) << "unable to find any " << ip_type << " address in networks '"
+               << networks << "' interfaces '" << interfaces << "'" << dendl;
     return -1;
   }
 


### PR DESCRIPTION
When ms_bind_ipv4 and ms_bind_ipv6 options are enabled, if the
public_network or cluster_network settings only contain networks of a
single type (either IPv4 or IPv6) then pick_addresses function must
fail.
    
Fixes: http://tracker.ceph.com/issues/38307
    
Signed-off-by: Ricardo Dias <rdias@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

