### PR TITLE
msg: disable rx_buffers

### DIFF
--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -214,14 +214,18 @@ public:
   }
 
   void post_rx_buffer(ceph_tid_t tid, bufferlist& bl) {
+#if 0
     Mutex::Locker l(lock);
     ++rx_buffers_version;
     rx_buffers[tid] = pair<bufferlist,int>(bl, rx_buffers_version);
+#endif
   }
 
   void revoke_rx_buffer(ceph_tid_t tid) {
+#if 0
     Mutex::Locker l(lock);
     rx_buffers.erase(tid);
+#endif
   }
 
   utime_t get_last_keepalive() const {

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -798,6 +798,9 @@ CtPtr ProtocolV1::read_message_data_prepare() {
 
   if (data_len) {
     // get a buffer
+#if 0
+    // rx_buffers is broken by design... see
+    //  http://tracker.ceph.com/issues/22480
     map<ceph_tid_t, pair<bufferlist, int> >::iterator p =
         connection->rx_buffers.find(current_header.tid);
     if (p != connection->rx_buffers.end()) {
@@ -815,6 +818,12 @@ CtPtr ProtocolV1::read_message_data_prepare() {
       alloc_aligned_buffer(data_buf, data_len, data_off);
       data_blp = data_buf.begin();
     }
+#else
+    ldout(cct, 20) << __func__ << " allocating new rx buffer at offset "
+		   << data_off << dendl;
+    alloc_aligned_buffer(data_buf, data_len, data_off);
+    data_blp = data_buf.begin();
+#endif
   }
 
   msg_left = data_len;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2485,11 +2485,13 @@ int Objecter::op_cancel(OSDSession *s, ceph_tid_t tid, int r)
     return -ENOENT;
   }
 
+#if 0
   if (s->con) {
     ldout(cct, 20) << " revoking rx buffer for " << tid
 		   << " on " << s->con << dendl;
     s->con->revoke_rx_buffer(tid);
   }
+#endif
 
   ldout(cct, 10) << __func__ << " tid " << tid << " in session " << s->osd
 		 << dendl;
@@ -3246,6 +3248,7 @@ void Objecter::_send_op(Op *op)
   ConnectionRef con = op->session->con;
   ceph_assert(con);
 
+#if 0
   // preallocated rx buffer?
   if (op->con) {
     ldout(cct, 20) << " revoking rx buffer for " << op->tid << " on "
@@ -3261,6 +3264,7 @@ void Objecter::_send_op(Op *op)
     op->con = con;
     op->con->post_rx_buffer(op->tid, *op->outbl);
   }
+#endif
 
   op->incarnation = op->session->incarnation;
 
@@ -3450,9 +3454,10 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 
   // got data?
   if (op->outbl) {
+#if 0
     if (op->con)
       op->con->revoke_rx_buffer(op->tid);
-    m->claim_data(*op->outbl);
+#endif
     op->outbl = 0;
   }
 


### PR DESCRIPTION
This is broken by design, and reproducibly producing crashes in msg/simple.

Fixes: http://tracker.ceph.com/issues/22480