### PR TITLE
fix clang build failures, and clean up warnings

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1731,7 +1731,7 @@ int parent_get(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
       return r;
     } else if (r == -ENOENT) {
       // examine oldest snapshot to see if it has a denormalized parent
-      auto parent_lambda = [hctx, &parent](const cls_rbd_snap& snap_meta) {
+      auto parent_lambda = [&parent](const cls_rbd_snap& snap_meta) {
         if (snap_meta.parent.exists()) {
           parent = snap_meta.parent;
         }

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -327,7 +327,7 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     return f.get();
   } else if (what == "df") {
     cluster_state.with_osdmap_and_pgmap(
-      [this, &f, &tstate](
+      [&f, &tstate](
 	const OSDMap& osd_map,
 	const PGMap &pg_map) {
 	PyEval_RestoreThread(tstate);

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -848,7 +848,7 @@ ceph_add_osd_perf_query(BaseMgrModule *self, PyObject *args)
             }
             d.regex_str = PyString_AsString(param_value);
             try {
-              d.regex = {d.regex_str.c_str()};
+              d.regex = d.regex_str.c_str();
             } catch (const std::regex_error& e) {
               derr << __func__ << " query " << query_param_name << " item " << j
                    << " contains invalid regex " << d.regex_str << dendl;

--- a/src/msg/async/crypto_onwire.cc
+++ b/src/msg/async/crypto_onwire.cc
@@ -225,7 +225,7 @@ ceph::bufferlist AES128GCM_OnWireRxHandler::authenticated_decrypt_update(
 
   ceph::bufferlist outbl;
   outbl.push_back(std::move(plainnode));
-  return std::move(outbl);
+  return outbl;
 }
 
 

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -161,7 +161,7 @@ static ceph::bufferlist segment_onwire_bufferlist(ceph::bufferlist&& bl)
   if (padding_size) {
     bl.append_zero(padding_size);
   }
-  return bl;
+  return std::move(bl);
 }
 
 template <class T, uint16_t... SegmentAlignmentVs>

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -18,7 +18,8 @@ clang = False
 def filter_unsupported_flags(flags):
     if clang:
         return [f for f in flags if not (f == '-mcet' or
-                                         f.startswith('-fcf-protection'))]
+                                         f.startswith('-fcf-protection') or
+                                         f == '-fstack-clash-protection')]
     else:
         return flags
 

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -26,7 +26,8 @@ clang = False
 def filter_unsupported_flags(flags):
     if clang:
         return [f for f in flags if not (f == '-mcet' or
-                                         f.startswith('-fcf-protection'))]
+                                         f.startswith('-fcf-protection') or
+                                         f == '-fstack-clash-protection')]
     else:
         return flags
 

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -18,7 +18,8 @@ clang = False
 def filter_unsupported_flags(flags):
     if clang:
         return [f for f in flags if not (f == '-mcet' or
-                                         f.startswith('-fcf-protection'))]
+                                         f.startswith('-fcf-protection') or
+                                         f == '-fstack-clash-protection')]
     else:
         return flags
 

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -18,7 +18,8 @@ clang = False
 def filter_unsupported_flags(flags):
     if clang:
         return [f for f in flags if not (f == '-mcet' or
-                                         f.startswith('-fcf-protection'))]
+                                         f.startswith('-fcf-protection') or
+                                         f == '-fstack-clash-protection')]
     return flags
 
 def monkey_with_compiler(compiler):

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1012,7 +1012,6 @@ int RGWLC::bucket_lc_process(string& shard_id)
 
     orule.build();
 
-    ceph::real_time mtime;
     rgw_bucket_dir_entry o;
     for (; ol.get_obj(&o); ol.next()) {
       ldpp_dout(this, 20) << __func__ << "(): key=" << o.key << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2432,7 +2432,7 @@ int RGWRados::Bucket::update_bucket_id(const string& new_bucket_id)
 static inline std::string after_delim(std::string_view delim)
 {
   // assert: ! delim.empty()
-  char e = delim.back();
+  unsigned char e = delim.back();
   delim.remove_suffix(1);
   std::string result{delim.data(), delim.length()};
   if (e < 255) {

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -677,8 +677,6 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
                               bool verbose, ostream *out, Formatter *formatter,
 			      RGWReshard* reshard_log)
 {
-  Clock::time_point now;
-
   int ret = reshard_lock.lock();
   if (ret < 0) {
     return ret;

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -128,7 +128,7 @@ std::string TempURLEngine::convert_from_iso8601(std::string expires) const
    * for the HMAC calculations. We need to make the conversion. */
   struct tm date_t;
   if (!parse_iso8601(expires.c_str(), &date_t, nullptr, true)) {
-    return std::move(expires);
+    return expires;
   } else {
     return std::to_string(internal_timegm(&date_t));
   }

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -360,7 +360,6 @@ int RGWSI_RADOS::Pool::List::get_next(int max,
     return r;
   }
 
-  vector<rgw_bucket_dir_entry>::iterator iter;
   for (auto& o : objs) {
     oids->push_back(o.key.name);
   }

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -473,7 +473,7 @@ static void cache_list_dump_helper(Formatter* f,
 void RGWSI_SysObj_Cache::call_list(const std::optional<std::string>& filter, Formatter* f)
 {
   cache.for_each(
-    [this, &filter, f] (const string& name, const ObjectCacheEntry& entry) {
+    [&filter, f] (const string& name, const ObjectCacheEntry& entry) {
       if (!filter || name.find(*filter) != name.npos) {
 	cache_list_dump_helper(f, name, entry.info.meta.mtime,
                                entry.info.meta.size);

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -37,7 +37,7 @@ int RGWSI_SysObj_Core::get_rados_obj(RGWSI_Zone *zone_svc,
     return -EINVAL;
   }
 
-  *pobj = std::move(rados_svc->obj(obj));
+  *pobj = rados_svc->obj(obj);
   int r = pobj->open();
   if (r < 0) {
     return r;

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -296,7 +296,10 @@ TEST(BufferPtr, assignment) {
   //
   {
     bufferptr original(len);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
     original = original;
+#pragma clang diagnostic pop
     ASSERT_EQ(1, original.raw_nref());
     ASSERT_EQ((unsigned)0, original.offset());
     ASSERT_EQ(len, original.length());
@@ -741,7 +744,10 @@ TEST(BufferListIterator, operator_assign) {
   bl.append("ABC", 3);
   bufferlist::iterator i(&bl, 1);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
   i = i;
+#pragma clang diagnostic pop
   EXPECT_EQ('B', *i);
   bufferlist::iterator j;
   j = i;

--- a/src/test/common/test_interval_map.cc
+++ b/src/test/common/test_interval_map.cc
@@ -49,7 +49,7 @@ struct bufferlist_test_type {
       bufferlist merge(bufferlist &&left, bufferlist &&right) const {
 	bufferlist bl;
 	left.claim_append(right);
-	return left;
+	return std::move(left);
       }
       uint64_t length(const bufferlist &r) const {
 	return r.length();

--- a/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
@@ -116,7 +116,7 @@ struct ManagedLock<MockTestImageCtx> {
       });
 
     Context *release_ctx = new FunctionContext(
-      [this, post_release_ctx](int r) {
+      [post_release_ctx](int r) {
         if (r < 0) {
           MockManagedLock::get_instance().m_on_released->complete(r);
         } else {

--- a/src/tools/rbd/action/Config.cc
+++ b/src/tools/rbd/action/Config.cc
@@ -30,7 +30,6 @@ namespace po = boost::program_options;
 namespace {
 
 const std::string METADATA_CONF_PREFIX = "conf_";
-const uint32_t MAX_KEYS = 64;
 
 void add_config_entity_option(
     boost::program_options::options_description *positional) {


### PR DESCRIPTION
Fixed Clang break on newest update of Fedora 29 due to Obnoxious Python CFLAGS Behavior.

Also clean up a bunch of warnings while I'm at it.