### PR TITLE
luminous: osd/PrimaryLogPG: handle object !exists in handle_watch_timeout

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9906,6 +9906,10 @@ void PrimaryLogPG::handle_watch_timeout(WatchRef watch)
     dout(10) << "handle_watch_timeout not active, no-op" << dendl;
     return;
   }
+  if (!obc->obs.exists) {
+    dout(10) << __func__ << " object " << obc->obs.oi.soid << " dne" << dendl;
+    return;
+  }
   if (is_degraded_or_backfilling_object(obc->obs.oi.soid)) {
     callbacks_for_degraded_object[obc->obs.oi.soid].push_back(
       watch->get_delayed_cb()


### PR DESCRIPTION
http://tracker.ceph.com/issues/38506