### PR TITLE
src/script: add run_mypy to run static type checking on Python code

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -710,7 +710,7 @@ class InventoryDevice(object):
     def __init__(self, blank=False, type=None, id=None, size=None,
                  rotates=False, available=False, dev_id=None, extended=None,
                  metadata_space_free=None):
-        # type: (bool, str, str, int, bool, bool. str, dict, bool) -> None
+        # type: (bool, str, str, int, bool, bool, str, dict, bool) -> None
 
         self.blank = blank
 

--- a/src/script/run_mypy.sh
+++ b/src/script/run_mypy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# needs to be executed form the src directory.
+# generates a report at src/mypy_report.txt
+
+python3 -m venv venv
+
+. venv/bin/activate
+
+pip install $(find * -name requirements.txt | awk '{print "-r  " $0}') mypy
+
+cat <<EOF > ./mypy.ini
+[mypy]
+strict_optional = True
+no_implicit_optional = True
+ignore_missing_imports = True
+warn_incomplete_stub = True
+check_untyped_defs = True
+show_error_context = True
+EOF
+
+
+echo "pybind:" > mypy_report.txt
+pushd pybind
+mypy --config-file=../mypy.ini  *.py | awk '{print "pybind/" $0}' >> ../mypy_report.txt
+popd
+
+echo "MGR Modules:" >> mypy_report.txt
+pushd pybind/mgr
+mypy --config-file=../../mypy.ini  $(find * -name '*.py' | grep -v -e venv -e tox -e env -e gyp -e node_modules) | awk '{print "pybind/mgr/" $0}' >> ../../mypy_report.txt
+popd
+
+echo "ceph-volume:" >> mypy_report.txt
+pushd ceph-volume/ceph_volume
+mypy --config-file=../../mypy.ini   $(find * -name '*.py' | grep -v -e venv -e tox -e env -e gyp -e node_modules -e tests) | awk '{print "ceph-volume/ceph_volume/" $0}' >> ../../mypy_report.txt
+popd
+


### PR DESCRIPTION
Inspired by #26028

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<details>
  <summary>Results. Click to expand</summary>
<pre>
pybind:
pybind/ceph_argparse.py:39: error: Cannot determine type of 'basestring'
pybind/ceph_argparse.py: note: In member "__init__" of class "CephInt":
pybind/ceph_argparse.py:159: error: Need type annotation for 'range'
pybind/ceph_argparse.py: note: In member "__init__" of class "CephFloat":
pybind/ceph_argparse.py:194: error: Need type annotation for 'range'
pybind/ceph_argparse.py: note: In function "descsort":
pybind/ceph_argparse.py:743: error: Name 'cmp' is not defined
pybind/ceph_argparse.py: note: In function "validate":
pybind/ceph_argparse.py:946: error: Need type annotation for 'd'
pybind/ceph_argparse.py:949: error: Need type annotation for 'arg_descs_by_name'
pybind/ceph_argparse.py:949: error: Argument 1 to "dict" has incompatible type "Generator[List[Any], None, None]"; expected "Iterable[Tuple[<nothing>, <nothing>]]"
pybind/ceph_argparse.py:1103: error: Incompatible types in assignment (expression has type "bool", target has type "Tuple[str, str]")
pybind/ceph_argparse.py: note: In function "validate_command":
pybind/ceph_argparse.py:1128: error: Need type annotation for 'found'
pybind/ceph_argparse.py:1129: error: Need type annotation for 'valid_dict'
pybind/ceph_argparse.py:1134: error: Need type annotation for 'bestcmds'
pybind/ceph_argparse.py:1191: error: Incompatible types in assignment (expression has type "ArgumentError", variable has type "Optional[ArgumentMissing]")
pybind/ceph_daemon.py:19: error: Module 'collections.abc' has no attribute 'OrderedDict'
pybind/ceph_daemon.py: note: In member "__repr__" of class "Termsize":
pybind/ceph_daemon.py:122: error: Not all arguments converted during string formatting
pybind/ceph_daemon.py: note: In member "__init__" of class "DaemonWatcher":
pybind/ceph_daemon.py:156: error: Need type annotation for '_stats_that_fit'
MGR Modules:
pybind/mgr/restful/common.py: note: In function "pool_update_commands":
pybind/mgr/restful/common.py:54: error: Need type annotation for 'commands'
pybind/mgr/restful/common.py: note: In function "crush_rule_osds":
pybind/mgr/restful/common.py:156: error: Need type annotation for 'osds'
pybind/mgr/dashboard/plugins/pluggy.py: note: In member "__init__" of class "_HookRelay":
pybind/mgr/dashboard/plugins/pluggy.py:79: error: Need type annotation for '_registry'
pybind/mgr/ssh/remotes.py:80: error: Name 'channel' is not defined
pybind/mgr/ssh/remotes.py:81: error: Name 'channel' is not defined
pybind/mgr/diskprediction_cloud/agent/predictor.py: note: In member "__init__" of class "PredictAgent":
pybind/mgr/diskprediction_cloud/agent/predictor.py:9: error: Need type annotation for 'data'
pybind/mgr/diskprediction_cloud/agent/predictor.py: note: In member "_get_cloud_prediction_result" of class "PredictAgent":
pybind/mgr/diskprediction_cloud/agent/predictor.py:36: error: Need type annotation for 'result'
pybind/mgr/dashboard/plugins/lru_cache.py: note: In function "lru_cache":
pybind/mgr/dashboard/plugins/lru_cache.py:20: error: Need type annotation for 'cache'
pybind/mgr/dashboard/plugins/ttl_cache.py: note: In function "ttl_cache":
pybind/mgr/dashboard/plugins/ttl_cache.py:20: error: Need type annotation for 'cache'
pybind/mgr/diskprediction_local/predictor.py: note: In member "__init__" of class "DiskFailurePredictor":
pybind/mgr/diskprediction_local/predictor.py:52: error: Need type annotation for 'model_context'
pybind/mgr/diskprediction_cloud/common/__init__.py: note: In member "__init__" of class "DummyResonse":
pybind/mgr/diskprediction_cloud/common/__init__.py:17: error: Need type annotation for 'resp_json'
pybind/mgr/diskprediction_cloud/agent/__init__.py: note: In member "__init__" of class "BaseAgent":
pybind/mgr/diskprediction_cloud/agent/__init__.py:11: error: Need type annotation for 'data'
pybind/mgr/diskprediction_cloud/agent/metrics/__init__.py: note: In member "__init__" of class "MetricsField":
pybind/mgr/diskprediction_cloud/agent/metrics/__init__.py:11: error: Need type annotation for 'tags'
pybind/mgr/diskprediction_cloud/agent/metrics/__init__.py:12: error: Need type annotation for 'fields'
pybind/mgr/diskprediction_cloud/agent/metrics/__init__.py: note: In member "_run" of class "MetricsAgent":
pybind/mgr/diskprediction_cloud/agent/metrics/__init__.py:42: error: Need type annotation for 'result'
pybind/mgr/diskprediction_cloud/common/client_pb2.py:1394: error: "GeneratedProtocolMessageType" has no attribute "MapValueEntry"
pybind/mgr/diskprediction_cloud/common/client_pb2.py:1409: error: "GeneratedProtocolMessageType" has no attribute "PhoneNumber"
pybind/mgr/diskprediction_cloud/common/client_pb2.py:1424: error: "GeneratedProtocolMessageType" has no attribute "File"
pybind/mgr/diskprediction_cloud/common/client_pb2.py:1561: error: "Descriptor" has no attribute "_options"
pybind/mgr/diskprediction_cloud/common/grpcclient.py: note: In member "_send_metrics" of class "GRPcClient":
pybind/mgr/diskprediction_cloud/common/grpcclient.py:86: error: Need type annotation for 'status_info'
pybind/mgr/diskprediction_cloud/common/grpcclient.py:110: error: Name 'long' is not defined
pybind/mgr/ansible/ansible_runner_svc.py: note: In member "get_result" of class "PlayBookExecution":
pybind/mgr/ansible/ansible_runner_svc.py:147: error: Need type annotation for 'result_events'
pybind/mgr/ansible/tests/test_client_playbooks.py: note: In member "test_playbook_get_result" of class "PlayBookExecutionTests":
pybind/mgr/ansible/tests/test_client_playbooks.py:271: error: Need type annotation for 'pb_events'
pybind/mgr/orchestrator.py:16: error: Invalid assignment target
pybind/mgr/orchestrator.py: note: In class "_Completion":
pybind/mgr/orchestrator.py:26: error: Invalid base class
pybind/mgr/orchestrator.py: note: In member "get_hosts" of class "Orchestrator":
pybind/mgr/orchestrator.py:212: error: "ReadCompletion" expects no type arguments, but 1 given
pybind/mgr/orchestrator.py: note: In member "get_inventory" of class "Orchestrator":
pybind/mgr/orchestrator.py:223: error: "ReadCompletion" expects no type arguments, but 1 given
pybind/mgr/orchestrator.py:223: error: Incompatible default for argument "node_filter" (default has type "None", argument has type "InventoryFilter")
pybind/mgr/orchestrator.py: note: In member "describe_service" of class "Orchestrator":
pybind/mgr/orchestrator.py:232: error: "ReadCompletion" expects no type arguments, but 1 given
pybind/mgr/orchestrator.py:232: error: Incompatible default for argument "service_type" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py:232: error: Incompatible default for argument "service_id" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py:232: error: Incompatible default for argument "node_name" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py: note: In member "service_action" of class "Orchestrator":
pybind/mgr/orchestrator.py:247: error: Incompatible default for argument "service_name" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py:247: error: Incompatible default for argument "service_id" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py: note: In member "upgrade_status" of class "Orchestrator":
pybind/mgr/orchestrator.py:358: error: "ReadCompletion" expects no type arguments, but 1 given
pybind/mgr/orchestrator.py: note: In member "upgrade_available" of class "Orchestrator":
pybind/mgr/orchestrator.py:368: error: "ReadCompletion" expects no type arguments, but 1 given
pybind/mgr/orchestrator.py: note: In member "__init__" of class "UpgradeStatusSpec":
pybind/mgr/orchestrator.py:420: error: Need type annotation for 'services_complete'
pybind/mgr/orchestrator.py: note: In member "__init__" of class "DeviceSelection":
pybind/mgr/orchestrator.py:514: error: Incompatible default for argument "paths" (default has type "None", argument has type "List[str]")
pybind/mgr/orchestrator.py:514: error: Incompatible default for argument "id_model" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py:514: error: Incompatible default for argument "size" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py:514: error: Incompatible default for argument "rotates" (default has type "None", argument has type "bool")
pybind/mgr/orchestrator.py:514: error: Incompatible default for argument "count" (default has type "None", argument has type "int")
pybind/mgr/orchestrator.py: note: In member "__init__" of class "DriveGroupSpec":
pybind/mgr/orchestrator.py:568: error: Syntax error in type annotation
pybind/mgr/orchestrator.py:568: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
pybind/mgr/orchestrator.py:568: error: The return type of "__init__" must be None
pybind/mgr/orchestrator.py:568: error: Incompatible default for argument "osds_per_device" (default has type "None", argument has type "int")
pybind/mgr/orchestrator.py:568: error: Incompatible default for argument "db_slots" (default has type "None", argument has type "int")
pybind/mgr/orchestrator.py:568: error: Incompatible default for argument "wal_slots" (default has type "None", argument has type "int")
pybind/mgr/orchestrator.py:614: error: Need type annotation for 'osd_id_claims'
pybind/mgr/orchestrator.py: note: In member "validate" of class "DriveGroupSpec":
pybind/mgr/orchestrator.py:636: error: Need type annotation for 's'
pybind/mgr/orchestrator.py: note: In member "__init__" of class "StatelessServiceSpec":
pybind/mgr/orchestrator.py:671: error: Need type annotation for 'extended'
pybind/mgr/orchestrator.py: note: In member "__init__" of class "InventoryFilter":
pybind/mgr/orchestrator.py:687: error: Incompatible default for argument "labels" (default has type "None", argument has type "List[str]")
pybind/mgr/orchestrator.py:687: error: Incompatible default for argument "nodes" (default has type "None", argument has type "List[str]")
pybind/mgr/orchestrator.py: note: In member "__init__" of class "InventoryDevice":
pybind/mgr/orchestrator.py:710: error: Incompatible default for argument "type" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py:710: error: Incompatible default for argument "id" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py:710: error: Incompatible default for argument "size" (default has type "None", argument has type "int")
pybind/mgr/orchestrator.py:710: error: Incompatible default for argument "dev_id" (default has type "None", argument has type "str")
pybind/mgr/orchestrator.py:710: error: Incompatible default for argument "extended" (default has type "None", argument has type "Dict[Any, Any]")
pybind/mgr/orchestrator.py:710: error: Incompatible default for argument "metadata_space_free" (default has type "None", argument has type "bool")
pybind/mgr/mgr_module.py: note: In member "device_class_counts" of class "CRUSHMap":
pybind/mgr/mgr_module.py:288: error: Need type annotation for 'result'
pybind/mgr/mgr_module.py: note: In class "CLICommand":
pybind/mgr/mgr_module.py:299: error: Need type annotation for 'COMMANDS'
pybind/mgr/mgr_module.py: note: In member "__init__" of class "CLICommand":
pybind/mgr/mgr_module.py:304: error: Need type annotation for 'args_dict'
pybind/mgr/mgr_module.py: note: In class "MgrStandbyModule":
pybind/mgr/mgr_module.py:390: error: Need type annotation for 'MODULE_OPTIONS'
pybind/mgr/mgr_module.py:391: error: Need type annotation for 'MODULE_OPTION_DEFAULTS'
pybind/mgr/mgr_module.py: note: In class "MgrModule":
pybind/mgr/mgr_module.py:463: error: Need type annotation for 'COMMANDS'
pybind/mgr/mgr_module.py:464: error: Need type annotation for 'MODULE_OPTIONS'
pybind/mgr/mgr_module.py:465: error: Need type annotation for 'MODULE_OPTION_DEFAULTS'
pybind/mgr/mgr_module.py: note: In member "get_all_perf_counters" of class "MgrModule":
pybind/mgr/mgr_module.py:1088: error: Need type annotation for 'result'
pybind/mgr/insights/health.py: note: In member "__init__" of class "HealthCheckAccumulator":
pybind/mgr/insights/health.py:26: error: Need type annotation for '_checks'
pybind/mgr/insights/health.py: note: In member "merge" of class "HealthCheckAccumulator":
pybind/mgr/insights/health.py:67: error: Cannot determine type of '_checks'
pybind/mgr/zabbix/module.py: note: In class "Module":
pybind/mgr/zabbix/module.py:52: error: Need type annotation for 'config'
pybind/mgr/zabbix/module.py: note: In member "get_pg_stats" of class "Module":
pybind/mgr/zabbix/module.py:151: error: Invalid index type "str" for "str"; expected type "Union[int, slice]"
pybind/mgr/zabbix/module.py:155: error: Unsupported operand types for + ("int" and "str")
pybind/mgr/zabbix/module.py:155: error: Invalid index type "str" for "str"; expected type "Union[int, slice]"
pybind/mgr/volumes/module.py:7: error: Name 'Queue' already defined (by an import)
pybind/mgr/volumes/module.py: note: In member "__init__" of class "Module":
pybind/mgr/volumes/module.py:83: error: Need type annotation for '_background_jobs'
pybind/mgr/test_orchestrator/module.py: note: In member "describe_service" of class "TestOrchestrator":
pybind/mgr/test_orchestrator/module.py:242: error: "object" has no attribute "__iter__"; maybe "__str__" or "__dir__"? (not iterable)
pybind/mgr/test_orchestrator/module.py:247: error: Incompatible types in assignment (expression has type "str", variable has type "None")
pybind/mgr/test_orchestrator/module.py:248: error: Incompatible types in assignment (expression has type "Union[str, Any]", variable has type "None")
pybind/mgr/test_orchestrator/module.py:248: error: Item "None" of "Optional[Match[str]]" has no attribute "group"
pybind/mgr/telemetry/module.py: note: In class "Module":
pybind/mgr/telemetry/module.py:21: error: Need type annotation for 'config'
pybind/mgr/telemetry/module.py: note: In member "__init__" of class "Module":
pybind/mgr/telemetry/module.py:111: error: Need type annotation for 'last_report'
pybind/mgr/telemetry/module.py: note: In member "gather_osd_metadata" of class "Module":
pybind/mgr/telemetry/module.py:186: error: Need type annotation for 'metadata'
pybind/mgr/telemetry/module.py: note: In member "gather_mon_metadata" of class "Module":
pybind/mgr/telemetry/module.py:200: error: Need type annotation for 'keys'
pybind/mgr/telemetry/module.py:203: error: Need type annotation for 'metadata'
pybind/mgr/telemetry/module.py: note: In member "compile_report" of class "Module":
pybind/mgr/telemetry/module.py:247: error: Incompatible types in assignment (expression has type "Dict[str, Any]", target has type "int")
pybind/mgr/telemetry/module.py:253: error: Incompatible types in assignment (expression has type "List[<nothing>]", target has type "int")
pybind/mgr/telemetry/module.py:256: error: "int" has no attribute "append"
pybind/mgr/telemetry/module.py:268: error: Incompatible types in assignment (expression has type "Dict[str, Any]", target has type "int")
pybind/mgr/telemetry/module.py:274: error: Incompatible types in assignment (expression has type "Dict[str, int]", target has type "int")
pybind/mgr/telemetry/module.py:278: error: Incompatible types in assignment (expression has type "Dict[<nothing>, <nothing>]", target has type "int")
pybind/mgr/telemetry/module.py:279: error: Unsupported target for indexed assignment
pybind/mgr/telemetry/module.py:280: error: Unsupported target for indexed assignment
pybind/mgr/telemetry/module.py:282: error: Incompatible types in assignment (expression has type "Dict[str, Any]", target has type "int")
pybind/mgr/telemetry/module.py:290: error: Incompatible types in assignment (expression has type "defaultdict[<nothing>, int]", target has type "int")
pybind/mgr/telemetry/module.py:292: error: Value of type "int" is not indexable
pybind/mgr/telemetry/module.py:292: error: Unsupported target for indexed assignment
pybind/mgr/telemetry/module.py: note: In member "self_test" of class "Module":
pybind/mgr/telemetry/module.py:383: error: Name 'self_test' already defined on line 334
pybind/mgr/telegraf/module.py:16: error: Name 'urlparse' already defined (possibly by an import)
pybind/mgr/telegraf/module.py: note: In member "__init__" of class "Module":
pybind/mgr/telegraf/module.py:62: error: Need type annotation for 'config'
pybind/mgr/telegraf/module.py: note: In member "get_pg_stats" of class "Module":
pybind/mgr/telegraf/module.py:136: error: Invalid index type "str" for "str"; expected type "Union[int, slice]"
pybind/mgr/telegraf/module.py:140: error: Invalid index type "str" for "str"; expected type "Union[int, slice]"
pybind/mgr/status/module.py: note: In member "handle_fs_status" of class "Module":
pybind/mgr/status/module.py:56: error: Need type annotation for 'mds_versions'
pybind/mgr/ssh/module.py: note: In member "_get_connection" of class "SSHOrchestrator":
pybind/mgr/ssh/module.py:243: error: Incompatible types in assignment (expression has type "IO[Any]", variable has type "None")
pybind/mgr/ssh/module.py:244: error: "None" has no attribute "write"
pybind/mgr/ssh/module.py:245: error: "None" has no attribute "flush"
pybind/mgr/ssh/module.py:246: error: "None" has no attribute "name"
pybind/mgr/ssh/module.py:263: error: "None" has no attribute "import_module"
pybind/mgr/ssh/module.py: note: In member "_get_hosts" of class "SSHOrchestrator":
pybind/mgr/ssh/module.py:380: error: Incompatible types in assignment (expression has type "Iterator[Tuple[Any, Any]]", variable has type "List[Tuple[Any, Any]]")
pybind/mgr/ssh/module.py: note: In function "get_inventory":
pybind/mgr/ssh/module.py:504: error: Incompatible types in assignment (expression has type "str", variable has type "datetime")
pybind/mgr/ssh/module.py: note: In member "_create_mon" of class "SSHOrchestrator":
pybind/mgr/ssh/module.py:614: error: Need type annotation for 'user_args'
pybind/mgr/selftest/module.py: note: In member "__init__" of class "Module":
pybind/mgr/selftest/module.py:109: error: Need type annotation for '_health'
pybind/mgr/selftest/module.py: note: In member "handle_command" of class "Module":
pybind/mgr/selftest/module.py:144: error: "RuntimeError" has no attribute "message"
pybind/mgr/selftest/module.py: note: In member "_health_set" of class "Module":
pybind/mgr/selftest/module.py:172: error: "Exception" has no attribute "message"
pybind/mgr/selftest/module.py:182: error: "Exception" has no attribute "message"
pybind/mgr/selftest/module.py: note: In member "_insights_set_now_offset" of class "Module":
pybind/mgr/selftest/module.py:200: error: Name 'long' is not defined
pybind/mgr/selftest/module.py:202: error: "Exception" has no attribute "message"
pybind/mgr/rook/rook_cluster.py: note: In member "add_nfsgw" of class "RookCluster":
pybind/mgr/rook/rook_cluster.py:260: error: Value of type "Collection[str]" is not indexable
pybind/mgr/rook/rook_cluster.py: note: In member "add_osds" of class "RookCluster":
pybind/mgr/rook/rook_cluster.py:354: error: Name 'List' is not defined
pybind/mgr/rook/rook_cluster.py:398: error: Dict entry 2 has incompatible type "str": "Dict[str, Any]"; expected "str": "Sequence[str]"
pybind/mgr/rook/rook_cluster.py:412: error: Argument 1 to "set" has incompatible type "Optional[List[str]]"; expected "Iterable[str]"
pybind/mgr/rook/rook_cluster.py:414: error: Dict entry 2 has incompatible type "str": "Dict[str, str]"; expected "str": "Sequence[str]"
pybind/mgr/rook/rook_cluster.py:420: error: Argument 1 to "set" has incompatible type "Optional[List[str]]"; expected "Iterable[str]"
pybind/mgr/rook/rook_cluster.py:422: error: Dict entry 2 has incompatible type "str": "Dict[str, str]"; expected "str": "Sequence[str]"
pybind/mgr/rook/rook_cluster.py:429: error: No return value expected
pybind/mgr/rook/rook_cluster.py:441: error: No return value expected
pybind/mgr/restful/hooks.py: note: In member "on_error" of class "ErrorHook":
pybind/mgr/restful/hooks.py:11: error: "None" has no attribute "log"
pybind/mgr/restful/module.py: note: In member "__init__" of class "CommandsRequest":
pybind/mgr/restful/module.py:58: error: Need type annotation for 'running'
pybind/mgr/restful/module.py:60: error: Need type annotation for 'finished'
pybind/mgr/restful/module.py:61: error: Need type annotation for 'failed'
pybind/mgr/restful/module.py: note: In member "run" of class "CommandsRequest":
pybind/mgr/restful/module.py:87: error: "CommandResult" has no attribute "command"
pybind/mgr/restful/module.py:91: error: "None" has no attribute "send_command"
pybind/mgr/restful/module.py: note: In member "__init__" of class "Module":
pybind/mgr/restful/module.py:240: error: Need type annotation for 'requests'
pybind/mgr/restful/module.py:243: error: Need type annotation for 'keys'
pybind/mgr/restful/module.py: note: In member "get_doc_api" of class "Module":
pybind/mgr/restful/module.py:468: error: Need type annotation for 'doc'
pybind/mgr/restful/module.py: note: In member "get_osd_pools" of class "Module":
pybind/mgr/restful/module.py:505: error: Need type annotation for 'osds'
pybind/mgr/restful/module.py:520: error: Item "None" of "Optional[Any]" has no attribute "__iter__" (not iterable)
pybind/mgr/rbd_support/module.py: note: In class "Module":
pybind/mgr/rbd_support/module.py:68: error: Need type annotation for 'MODULE_OPTIONS'
pybind/mgr/rbd_support/module.py:70: error: Need type annotation for 'user_queries'
pybind/mgr/rbd_support/module.py:71: error: Need type annotation for 'image_cache'
pybind/mgr/rbd_support/module.py:78: error: Need type annotation for 'image_name_cache'
pybind/mgr/rbd_support/module.py: note: In member "process_raw_osd_perf_counters" of class "Module":
pybind/mgr/rbd_support/module.py:262: error: Need type annotation for 'resolve_image_names'
pybind/mgr/rbd_support/module.py: note: In member "generate_report" of class "Module":
pybind/mgr/rbd_support/module.py:419: error: Need type annotation for 'pool_descriptors'
pybind/mgr/prometheus/module.py: note: In member "__init__" of class "Metric":
pybind/mgr/prometheus/module.py:91: error: Need type annotation for 'value'
pybind/mgr/prometheus/module.py: note: In member "str_expfmt" of class "Metric":
pybind/mgr/prometheus/module.py:139: error: Incompatible types in assignment (expression has type "str", variable has type "Iterator[Tuple[Any, Any]]")
pybind/mgr/prometheus/module.py:139: note: 'str' is missing following 'Iterator' protocol member:
pybind/mgr/prometheus/module.py:139: note:     __next__
pybind/mgr/prometheus/module.py:139: note: Following member(s) of "str" have conflicts:
pybind/mgr/prometheus/module.py:139: note:     Expected:
pybind/mgr/prometheus/module.py:139: note:         def __iter__(self) -> Iterator[Tuple[Any, Any]]
pybind/mgr/prometheus/module.py:139: note:     Got:
pybind/mgr/prometheus/module.py:139: note:         def __iter__(self) -> Iterator[str]
pybind/mgr/prometheus/module.py:141: error: Incompatible types in assignment (expression has type "str", variable has type "Iterator[Tuple[Any, Any]]")
pybind/mgr/prometheus/module.py:141: note: 'str' is missing following 'Iterator' protocol member:
pybind/mgr/prometheus/module.py:141: note:     __next__
pybind/mgr/prometheus/module.py:141: note: Following member(s) of "str" have conflicts:
pybind/mgr/prometheus/module.py:141: note:     Expected:
pybind/mgr/prometheus/module.py:141: note:         def __iter__(self) -> Iterator[Tuple[Any, Any]]
pybind/mgr/prometheus/module.py:141: note:     Got:
pybind/mgr/prometheus/module.py:141: note:         def __iter__(self) -> Iterator[str]
pybind/mgr/prometheus/module.py: note: In member "get_fs" of class "Module":
pybind/mgr/prometheus/module.py:351: error: Need type annotation for 'active_daemons'
pybind/mgr/prometheus/module.py: note: In member "get_pg_status" of class "Module":
pybind/mgr/prometheus/module.py:396: error: Need type annotation for 'reported_states'
pybind/mgr/prometheus/module.py: note: In member "get_metadata_and_osd_status" of class "Module":
pybind/mgr/prometheus/module.py:534: error: Need type annotation for 'pool_meta'
pybind/mgr/prometheus/module.py: note: In member "get_rbd_stats" of class "Module":
pybind/mgr/prometheus/module.py:583: error: Need type annotation for 'pools'
pybind/mgr/prometheus/module.py:619: error: Need type annotation for 'nspace_names'
pybind/mgr/progress/module.py: note: In member "_refresh" of class "Event":
pybind/mgr/progress/module.py:32: error: "None" has no attribute "log"
pybind/mgr/progress/module.py:34: error: "None" has no attribute "update_progress_event"
pybind/mgr/progress/module.py: note: In member "__init__" of class "Module":
pybind/mgr/progress/module.py:274: error: Need type annotation for '_events'
pybind/mgr/progress/module.py:275: error: Need type annotation for '_completed_events'
pybind/mgr/pg_autoscaler/module.py: note: In member "get_subtree_resource_status" of class "PgAutoscaler":
pybind/mgr/pg_autoscaler/module.py:168: error: Need type annotation for 'result'
pybind/mgr/pg_autoscaler/module.py: note: In function "get_subtree_resource_status":
pybind/mgr/pg_autoscaler/module.py:174: error: Need type annotation for 'root_ids'
pybind/mgr/pg_autoscaler/module.py:175: error: Need type annotation for 'osds'
pybind/mgr/pg_autoscaler/module.py:180: error: Need type annotation for 'pool_ids'
pybind/mgr/pg_autoscaler/module.py:181: error: Need type annotation for 'pool_names'
pybind/mgr/pg_autoscaler/module.py: note: In member "get_subtree_resource_status" of class "PgAutoscaler":
pybind/mgr/pg_autoscaler/module.py:192: error: "Dict[Any, Any]" has no attribute "itervalues"
pybind/mgr/pg_autoscaler/module.py:210: error: Incompatible types in assignment (expression has type "int", variable has type "None")
pybind/mgr/pg_autoscaler/module.py:211: error: Incompatible types in assignment (expression has type "int", variable has type "None")
pybind/mgr/pg_autoscaler/module.py:211: error: Unsupported operand types for * ("None" and "int")
pybind/mgr/pg_autoscaler/module.py:222: error: Incompatible types in assignment (expression has type "float", variable has type "None")
pybind/mgr/pg_autoscaler/module.py: note: In member "_maybe_adjust" of class "PgAutoscaler":
pybind/mgr/pg_autoscaler/module.py:340: error: Need type annotation for 'target_ratio_pools'
pybind/mgr/pg_autoscaler/module.py:344: error: Need type annotation for 'target_bytes_pools'
pybind/mgr/pg_autoscaler/module.py:359: error: Name 'cr_name' is not defined
pybind/mgr/pg_autoscaler/module.py:410: error: "Dict[Any, float]" has no attribute "iteritems"
pybind/mgr/pg_autoscaler/module.py:437: error: "Dict[Any, int]" has no attribute "iteritems"
pybind/mgr/osd_perf_query/module.py: note: In class "OSDPerfQuery":
pybind/mgr/osd_perf_query/module.py:86: error: Need type annotation for 'queries'
pybind/mgr/osd_perf_query/module.py: note: In member "handle_command" of class "OSDPerfQuery":
pybind/mgr/osd_perf_query/module.py:181: error: Incompatible types in assignment (expression has type "float", variable has type "int")
pybind/mgr/orchestrator_cli/module.py: note: In member "_list_devices" of class "OrchestratorCli":
pybind/mgr/orchestrator_cli/module.py:64: error: Incompatible default for argument "host" (default has type "None", argument has type "List[str]")
pybind/mgr/orchestrator_cli/module.py:79: error: Argument "node_filter" to "get_inventory" of "Orchestrator" has incompatible type "Optional[InventoryFilter]"; expected "InventoryFilter"
pybind/mgr/orchestrator_cli/module.py:84: error: "T" has no attribute "__iter__" (not iterable)
pybind/mgr/orchestrator_cli/module.py:90: error: "T" has no attribute "__iter__" (not iterable)
pybind/mgr/orchestrator_cli/module.py: note: In member "_create_osd" of class "OrchestratorCli":
pybind/mgr/orchestrator_cli/module.py:147: error: Incompatible default for argument "svc_arg" (default has type "None", argument has type "str")
pybind/mgr/orchestrator_cli/module.py:147: error: Incompatible default for argument "inbuf" (default has type "None", argument has type "str")
pybind/mgr/orchestrator_cli/module.py:183: error: "T" has no attribute "__iter__" (not iterable)
pybind/mgr/orchestrator_cli/test_orchestrator.py: note: In function "test_drive_selection":
pybind/mgr/orchestrator_cli/test_orchestrator.py:32: error: Item "None" of "Optional[DeviceSelection]" has no attribute "paths"
pybind/mgr/iostat/module.py: note: In member "handle_command" of class "Module":
pybind/mgr/iostat/module.py:43: error: Incompatible types in assignment (expression has type "float", variable has type "int")
pybind/mgr/iostat/module.py:44: error: Incompatible types in assignment (expression has type "float", variable has type "int")
pybind/mgr/iostat/module.py:50: error: Incompatible types in assignment (expression has type "float", variable has type "int")
pybind/mgr/iostat/module.py:51: error: Incompatible types in assignment (expression has type "float", variable has type "int")
pybind/mgr/iostat/module.py:63: error: List item 3 has incompatible type "int"; expected "str"
pybind/mgr/iostat/module.py:63: error: List item 4 has incompatible type "int"; expected "str"
pybind/mgr/iostat/module.py:63: error: List item 5 has incompatible type "int"; expected "str"
pybind/mgr/insights/module.py: note: In member "__init__" of class "Module":
pybind/mgr/insights/module.py:43: error: Need type annotation for '_pending_health'
pybind/mgr/insights/module.py: note: In member "do_report" of class "Module":
pybind/mgr/insights/module.py:242: error: Need type annotation for 'health_check_details'
pybind/mgr/insights/module.py:279: error: Dict entry 0 has incompatible type "str": "List[Any]"; expected "str": "Dict[str, Any]"
pybind/mgr/insights/module.py: note: In member "do_prune_health" of class "Module":
pybind/mgr/insights/module.py:298: error: Name 'errno' is not defined
pybind/mgr/insights/module.py: note: In member "testing_set_now_time_offset" of class "Module":
pybind/mgr/insights/module.py:310: error: Name 'long' is not defined
pybind/mgr/insights/module.py:311: error: Incompatible types in assignment (expression has type "timedelta", variable has type "None")
pybind/mgr/insights/module.py: note: In member "handle_command" of class "Module":
pybind/mgr/insights/module.py:320: error: Name 'cmd' is not defined
pybind/mgr/insights/tests/test_health.py: note: In member "test_empty_slot" of class "HealthHistoryTest":
pybind/mgr/insights/tests/test_health.py:192: error: Cannot assign to a method
pybind/mgr/insights/tests/test_health.py: note: In member "test_expires" of class "HealthHistoryTest":
pybind/mgr/insights/tests/test_health.py:204: error: Cannot assign to a method
pybind/mgr/insights/tests/test_health.py:210: error: Cannot assign to a method
pybind/mgr/insights/tests/test_health.py: note: In member "test_need_flush" of class "HealthHistoryTest":
pybind/mgr/insights/tests/test_health.py:216: error: Cannot assign to a method
pybind/mgr/insights/tests/test_health.py:232: error: Cannot assign to a method
pybind/mgr/insights/tests/test_health.py: note: In member "test_need_flush_edge" of class "HealthHistoryTest":
pybind/mgr/insights/tests/test_health.py:250: error: Cannot assign to a method
pybind/mgr/insights/tests/test_health.py:270: error: Cannot assign to a method
pybind/mgr/influx/module.py: note: In member "__init__" of class "Module":
pybind/mgr/influx/module.py:94: error: Need type annotation for 'config'
pybind/mgr/influx/module.py:95: error: Need type annotation for 'workers'
pybind/mgr/influx/module.py:96: error: Need type annotation for 'queue'
pybind/mgr/influx/module.py:97: error: Need type annotation for 'health_checks'
pybind/mgr/diskprediction_local/module.py: note: In class "Module":
pybind/mgr/diskprediction_local/module.py:30: error: Need type annotation for 'COMMANDS'
pybind/mgr/diskprediction_local/module.py: note: In member "_predict_life_expentancy" of class "Module":
pybind/mgr/diskprediction_local/module.py:127: error: Need type annotation for 'health_data'
pybind/mgr/diskprediction_local/module.py: note: In member "predict_all_devices" of class "Module":
pybind/mgr/diskprediction_local/module.py:242: error: Incompatible types in assignment (expression has type "None", variable has type "int")
pybind/mgr/diskprediction_local/module.py:243: error: Incompatible types in assignment (expression has type "None", variable has type "int")
pybind/mgr/diskprediction_cloud/common/clusterdata.py: note: In member "get_object_pg_info" of class "ClusterAPI":
pybind/mgr/diskprediction_cloud/common/clusterdata.py:196: error: Need type annotation for 'data_jaon'
pybind/mgr/diskprediction_cloud/common/clusterdata.py: note: In member "get_osd_smart" of class "ClusterAPI":
pybind/mgr/diskprediction_cloud/common/clusterdata.py:328: error: Need type annotation for 'osd_devices'
pybind/mgr/diskprediction_cloud/common/clusterdata.py: note: In member "get_device_health" of class "ClusterAPI":
pybind/mgr/diskprediction_cloud/common/clusterdata.py:356: error: Need type annotation for 'health_data'
pybind/mgr/diskprediction_cloud/common/clusterdata.py: note: In member "get_osd_device_id" of class "ClusterAPI":
pybind/mgr/diskprediction_cloud/common/clusterdata.py:377: error: Need type annotation for 'result'
pybind/mgr/diskprediction_cloud/common/clusterdata.py: note: In member "get_pgs_up_by_poolid" of class "ClusterAPI":
pybind/mgr/diskprediction_cloud/common/clusterdata.py:456: error: Need type annotation for 'pgs'
pybind/mgr/devicehealth/module.py: note: In member "scrape_all" of class "Module":
pybind/mgr/devicehealth/module.py:325: error: Need type annotation for 'did_device'
pybind/mgr/devicehealth/module.py: note: In member "show_device_metrics" of class "Module":
pybind/mgr/devicehealth/module.py:425: error: Need type annotation for 'res'
pybind/mgr/devicehealth/module.py: note: In member "check_health" of class "Module":
pybind/mgr/devicehealth/module.py:460: error: Need type annotation for 'health_warnings'
pybind/mgr/devicehealth/module.py: note: In member "mark_out_etc" of class "Module":
pybind/mgr/devicehealth/module.py:596: error: Not all arguments converted during string formatting
pybind/mgr/deepsea/module.py: note: In member "__init__" of class "DeepSeaOrchestrator":
pybind/mgr/deepsea/module.py:109: error: Need type annotation for '_all_completions'
pybind/mgr/deepsea/module.py: note: In member "get_inventory" of class "DeepSeaOrchestrator":
pybind/mgr/deepsea/module.py:152: error: Need type annotation for 'nodes'
pybind/mgr/deepsea/module.py:153: error: Need type annotation for 'roles'
pybind/mgr/dashboard/plugins/interfaces.py: note: In class "CanMgr":
pybind/mgr/dashboard/plugins/interfaces.py:9: error: Cannot determine type of 'mgr'
pybind/mgr/dashboard/plugins/interfaces.py: note: In class "CanLog":
pybind/mgr/dashboard/plugins/interfaces.py:14: error: Cannot determine type of 'logger'
pybind/mgr/dashboard/tools.py: note: In member "__init__" of class "ViewCache":
pybind/mgr/dashboard/tools.py:236: error: Need type annotation for 'cache_by_args'
pybind/mgr/dashboard/tools.py: note: In member "__call__" of class "ViewCache":
pybind/mgr/dashboard/tools.py:245: error: "Callable[[VarArg(Any), KwArg(Any)], Any]" has no attribute "reset"
pybind/mgr/dashboard/tools.py: note: In class "NotificationQueue":
pybind/mgr/dashboard/tools.py:255: error: Need type annotation for '_listeners'
pybind/mgr/dashboard/tools.py:258: error: Need type annotation for '_queue'
pybind/mgr/dashboard/tools.py: note: In class "TaskManager":
pybind/mgr/dashboard/tools.py:400: error: Need type annotation for '_executing_tasks'
pybind/mgr/dashboard/tools.py:401: error: Need type annotation for '_finished_tasks'
pybind/mgr/dashboard/tools.py: note: In function "get_request_body_params":
pybind/mgr/dashboard/tools.py:871: error: Need type annotation for 'params'
pybind/mgr/dashboard/__init__.py:42: error: Incompatible types in assignment (expression has type "Logger", variable has type "_LoggerProxy")
pybind/mgr/dashboard/module.py: note: In class "Module":
pybind/mgr/dashboard/module.py:246: error: Cannot determine type of 'SSO_COMMANDS'
pybind/mgr/dashboard/module.py:264: error: Need type annotation for '__pool_stats'
pybind/mgr/dashboard/controllers/__init__.py: note: In function "EndpointDoc":
pybind/mgr/dashboard/controllers/__init__.py:91: error: Need type annotation for 'splitted'
pybind/mgr/dashboard/controllers/__init__.py:98: error: Need type annotation for 'param_list'
pybind/mgr/dashboard/controllers/__init__.py: note: At top level:
pybind/mgr/dashboard/controllers/__init__.py:292: error: Need type annotation for 'ENDPOINT_MAP'
pybind/mgr/dashboard/controllers/__init__.py: note: In function "generate_controller_routes":
pybind/mgr/dashboard/controllers/__init__.py:321: error: Cannot determine type of 'ENDPOINT_MAP'
pybind/mgr/dashboard/services/ceph_service.py: note: In member "get_service_map" of class "CephService":
pybind/mgr/dashboard/services/ceph_service.py:43: error: Need type annotation for 'service_map'
pybind/mgr/dashboard/services/exception.py: note: In function "serialize_dashboard_exception":
pybind/mgr/dashboard/services/exception.py:81: error: Incompatible types in assignment (expression has type "Dict[str, Any]", target has type "str")
pybind/mgr/dashboard/services/access_control.py: note: In member "__init__" of class "Role":
pybind/mgr/dashboard/services/access_control.py:42: error: Need type annotation for 'scopes_permissions'
pybind/mgr/dashboard/services/access_control.py: note: In member "__init__" of class "User":
pybind/mgr/dashboard/services/access_control.py:177: error: Need type annotation for 'roles'
pybind/mgr/dashboard/services/access_control.py: note: In member "permissions_dict" of class "User":
pybind/mgr/dashboard/services/access_control.py:214: error: Need type annotation for 'perms'
pybind/mgr/dashboard/services/access_control.py: note: In function "load_access_control_db":
pybind/mgr/dashboard/services/access_control.py:362: error: "_ModuleProxy" has no attribute "ACCESS_CTRL_DB"
pybind/mgr/dashboard/services/sso.py: note: In function "load_sso_db":
pybind/mgr/dashboard/services/sso.py:89: error: "_ModuleProxy" has no attribute "SSO_DB"
pybind/mgr/dashboard/services/auth.py: note: In member "_check_authentication" of class "AuthManagerTool":
pybind/mgr/dashboard/services/auth.py:155: error: Module has no attribute "exceptions"
pybind/mgr/dashboard/services/auth.py:157: error: Module has no attribute "exceptions"
pybind/mgr/dashboard/controllers/cephfs.py: note: In member "__init__" of class "CephFS":
pybind/mgr/dashboard/controllers/cephfs.py:23: error: Need type annotation for 'cephfs_clients'
pybind/mgr/dashboard/controllers/cephfs.py: note: In member "mds_counters" of class "CephFS":
pybind/mgr/dashboard/controllers/cephfs.py:65: error: Need type annotation for 'result'
pybind/mgr/dashboard/controllers/cephfs.py: note: In member "fs_status" of class "CephFS":
pybind/mgr/dashboard/controllers/cephfs.py:105: error: Need type annotation for 'mds_versions'
pybind/mgr/dashboard/controllers/rbd_mirroring.py: note: In function "get_daemons_and_pools":
pybind/mgr/dashboard/controllers/rbd_mirroring.py:150: error: Argument 2 to "get" of "Mapping" has incompatible type "None"; expected "Union[Dict[str, Any], Dict[str, str]]"
pybind/mgr/dashboard/controllers/rbd_mirroring.py: note: In function "_get_pool_datum":
pybind/mgr/dashboard/controllers/rbd_mirroring.py:248: error: Argument after ** must be a mapping, not "object"
pybind/mgr/dashboard/controllers/rbd_mirroring.py: note: In class "RbdMirroringPoolMode":
pybind/mgr/dashboard/controllers/rbd_mirroring.py:345: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
pybind/mgr/dashboard/controllers/rbd_mirroring.py: note: In class "RbdMirroringPoolPeer":
pybind/mgr/dashboard/controllers/rbd_mirroring.py:381: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
pybind/mgr/dashboard/services/rbd.py: note: In member "list" of class "RbdConfiguration":
pybind/mgr/dashboard/services/rbd.py:24: error: Invalid type
pybind/mgr/dashboard/services/rbd.py: note: In member "set" of class "RbdConfiguration":
pybind/mgr/dashboard/services/rbd.py:59: error: "object" has no attribute "__enter__"
pybind/mgr/dashboard/services/rbd.py:64: error: "object" has no attribute "__enter__"
pybind/mgr/dashboard/services/rbd.py:67: error: "object" has no attribute "metadata_set"
pybind/mgr/dashboard/services/rbd.py:72: error: "object" has no attribute "__exit__"
pybind/mgr/dashboard/services/rbd.py:74: error: "object" has no attribute "__exit__"
pybind/mgr/dashboard/rest_client.py:27: error: Name 'SSLError' already defined (possibly by an import)
pybind/mgr/dashboard/rest_client.py: note: In member "_validate_level" of class "_ResponseValidator":
pybind/mgr/dashboard/rest_client.py:186: error: Item "List[Any]" of "Union[Dict[Any, Any], List[Any]]" has no attribute "keys"
pybind/mgr/dashboard/rest_client.py: note: In member "do_request" of class "RestClient":
pybind/mgr/dashboard/rest_client.py:447: error: Incompatible types in assignment (expression has type "bool", variable has type "Optional[Match[Any]]")
pybind/mgr/dashboard/controllers/rbd.py: note: In class "Rbd":
pybind/mgr/dashboard/controllers/rbd.py:122: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
pybind/mgr/dashboard/controllers/rbd.py: note: In class "RbdSnapshot":
pybind/mgr/dashboard/controllers/rbd.py:410: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
pybind/mgr/dashboard/controllers/rbd.py: note: In class "RbdTrash":
pybind/mgr/dashboard/controllers/rbd.py:495: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
pybind/mgr/dashboard/services/rgw_client.py: note: In member "instance" of class "RgwClient":
pybind/mgr/dashboard/services/rgw_client.py:198: error: Need type annotation for '_user_instances'
pybind/mgr/dashboard/services/rgw_client.py: note: In class "RgwClient":
pybind/mgr/dashboard/services/rgw_client.py:198: error: Need type annotation for '_user_instances'
pybind/mgr/dashboard/services/rgw_client.py: note: In member "_load_settings" of class "RgwClient":
pybind/mgr/dashboard/services/rgw_client.py:228: error: Cannot determine type of '_SYSTEM_USERID'
pybind/mgr/dashboard/services/rgw_client.py:231: error: Cannot determine type of '_SYSTEM_USERID'
pybind/mgr/dashboard/services/rgw_client.py: note: In member "instance" of class "RgwClient":
pybind/mgr/dashboard/services/rgw_client.py:239: error: Cannot determine type of '_SYSTEM_USERID'
pybind/mgr/dashboard/services/rgw_client.py: note: In member "admin_instance" of class "RgwClient":
pybind/mgr/dashboard/services/rgw_client.py:258: error: Cannot determine type of '_SYSTEM_USERID'
pybind/mgr/dashboard/services/rgw_client.py: note: In member "_reset_login" of class "RgwClient":
pybind/mgr/dashboard/services/rgw_client.py:261: error: Cannot determine type of '_SYSTEM_USERID'
pybind/mgr/dashboard/controllers/rgw.py: note: In member "status" of class "Rgw":
pybind/mgr/dashboard/controllers/rgw.py:43: error: Incompatible types in assignment (expression has type "str", target has type "Optional[bool]")
pybind/mgr/dashboard/controllers/rgw.py: note: In member "list" of class "RgwUser":
pybind/mgr/dashboard/controllers/rgw.py:172: error: Need type annotation for 'users'
pybind/mgr/dashboard/controllers/rgw.py:175: error: Need type annotation for 'params'
pybind/mgr/dashboard/services/iscsi_client.py: note: In class "IscsiClient":
pybind/mgr/dashboard/services/iscsi_client.py:21: error: Need type annotation for '_instances'
pybind/mgr/dashboard/controllers/iscsi.py: note: In member "status" of class "IscsiUi":
pybind/mgr/dashboard/controllers/iscsi.py:32: error: Incompatible types in assignment (expression has type "str", target has type "bool")
pybind/mgr/dashboard/controllers/iscsi.py: note: In member "_get_portals_by_host" of class "IscsiTarget":
pybind/mgr/dashboard/controllers/iscsi.py:567: error: Need type annotation for 'portals_by_host'
pybind/mgr/dashboard/plugins/feature_toggles.py: note: In member "get_options" of class "FeatureToggles":
pybind/mgr/dashboard/plugins/feature_toggles.py:28: error: Need type annotation for 'PREDISABLED_FEATURES'
pybind/mgr/dashboard/plugins/feature_toggles.py: note: At top level:
pybind/mgr/dashboard/plugins/feature_toggles.py:28: error: Need type annotation for 'PREDISABLED_FEATURES'
pybind/mgr/dashboard/plugins/feature_toggles.py: note: In member "setup" of class "FeatureToggles":
pybind/mgr/dashboard/plugins/feature_toggles.py:60: error: "object" has no attribute "__iter__"; maybe "__str__" or "__dir__"? (not iterable)
pybind/mgr/dashboard/plugins/feature_toggles.py: note: In function "register_commands":
pybind/mgr/dashboard/plugins/feature_toggles.py:80: error: Need type annotation for 'msg'
pybind/mgr/crash/module.py: note: In member "do_stat" of class "Module":
pybind/mgr/crash/module.py:132: error: No overload variant of "__setitem__" of "list" matches argument types "int", "Dict[str, object]"
pybind/mgr/crash/module.py:132: note: Possible overload variants:
pybind/mgr/crash/module.py:132: note:     def __setitem__(self, int, int) -> None
pybind/mgr/crash/module.py:132: note:     def __setitem__(self, slice, Iterable[int]) -> None
pybind/mgr/crash/module.py:144: error: Value of type "int" is not indexable
pybind/mgr/crash/module.py:145: error: Value of type "int" is not indexable
pybind/mgr/crash/module.py: note: In member "do_json_report" of class "Module":
pybind/mgr/crash/module.py:164: error: Need type annotation for 'report'
pybind/mgr/balancer/module.py: note: In member "__init__" of class "MappingState":
pybind/mgr/balancer/module.py:33: error: Need type annotation for 'pg_up'
pybind/mgr/balancer/module.py:34: error: Need type annotation for 'pg_up_by_poolid'
pybind/mgr/balancer/module.py: note: In member "__init__" of class "Plan":
pybind/mgr/balancer/module.py:57: error: Need type annotation for 'osd_weights'
pybind/mgr/balancer/module.py:58: error: Need type annotation for 'compat_ws'
pybind/mgr/balancer/module.py: note: In member "show" of class "Plan":
pybind/mgr/balancer/module.py:89: error: Need type annotation for 'osdlist'
pybind/mgr/balancer/module.py: note: In member "__init__" of class "Eval":
pybind/mgr/balancer/module.py:100: error: Need type annotation for 'root_ids'
pybind/mgr/balancer/module.py:101: error: Need type annotation for 'pool_name'
pybind/mgr/balancer/module.py:102: error: Need type annotation for 'pool_id'
pybind/mgr/balancer/module.py:103: error: Need type annotation for 'pool_roots'
pybind/mgr/balancer/module.py:104: error: Need type annotation for 'root_pools'
pybind/mgr/balancer/module.py:105: error: Need type annotation for 'target_by_root'
pybind/mgr/balancer/module.py:106: error: Need type annotation for 'count_by_pool'
pybind/mgr/balancer/module.py:107: error: Need type annotation for 'count_by_root'
pybind/mgr/balancer/module.py:108: error: Need type annotation for 'actual_by_pool'
pybind/mgr/balancer/module.py:109: error: Need type annotation for 'actual_by_root'
pybind/mgr/balancer/module.py:110: error: Need type annotation for 'total_by_pool'
pybind/mgr/balancer/module.py:111: error: Need type annotation for 'total_by_root'
pybind/mgr/balancer/module.py:112: error: Need type annotation for 'stats_by_pool'
pybind/mgr/balancer/module.py:113: error: Need type annotation for 'stats_by_root'
pybind/mgr/balancer/module.py:115: error: Need type annotation for 'score_by_pool'
pybind/mgr/balancer/module.py:116: error: Need type annotation for 'score_by_root'
pybind/mgr/balancer/module.py: note: In member "calc_stats" of class "Eval":
pybind/mgr/balancer/module.py:191: error: Dict entry 0 has incompatible type "str": "float"; expected "str": "int"
pybind/mgr/balancer/module.py:191: error: Dict entry 1 has incompatible type "str": "float"; expected "str": "int"
pybind/mgr/balancer/module.py:191: error: Dict entry 2 has incompatible type "str": "float"; expected "str": "int"
pybind/mgr/balancer/module.py:191: error: Dict entry 3 has incompatible type "str": "float"; expected "str": "int"
pybind/mgr/balancer/module.py: note: In class "Module":
pybind/mgr/balancer/module.py:404: error: Need type annotation for 'plans'
pybind/mgr/balancer/module.py: note: In member "handle_command" of class "Module":
pybind/mgr/balancer/module.py:473: error: Incompatible types in assignment (expression has type "Set[Union[str, Any]]", variable has type "List[str]")
pybind/mgr/balancer/module.py:487: error: Incompatible types in assignment (expression has type "Set[str]", variable has type "List[str]")
pybind/mgr/balancer/module.py: note: In member "serve" of class "Module":
pybind/mgr/balancer/module.py:608: error: Need type annotation for 'final'
pybind/mgr/balancer/module.py:612: error: Incompatible types in assignment (expression has type "Set[Any]", variable has type "List[Any]")
pybind/mgr/balancer/module.py: note: In member "calc_eval" of class "Module":
pybind/mgr/balancer/module.py:666: error: Need type annotation for 'actual_by_root'
pybind/mgr/balancer/module.py: note: In member "do_upmap" of class "Module":
pybind/mgr/balancer/module.py:919: error: Need type annotation for 'pools_by_crush_rule'
pybind/mgr/balancer/module.py:933: error: Argument 1 to "shuffle" has incompatible type "ValuesView[Any]"; expected "List[Any]"
pybind/mgr/balancer/module.py: note: In member "do_crush_compat" of class "Module":
pybind/mgr/balancer/module.py:988: error: Need type annotation for 'visited'
pybind/mgr/balancer/module.py:989: error: Need type annotation for 'overlap'
pybind/mgr/balancer/module.py:990: error: Need type annotation for 'root_ids'
pybind/mgr/balancer/module.py:1120: error: Incompatible types in assignment (expression has type "float", variable has type "int")
pybind/mgr/balancer/module.py: note: In member "execute" of class "Module":
pybind/mgr/balancer/module.py:1253: error: Need type annotation for 'osdlist'
pybind/mgr/ansible/module.py: note: In member "__init__" of class "AnsibleReadOperation":
pybind/mgr/ansible/module.py:61: error: Need type annotation for '_result'
pybind/mgr/ansible/module.py: note: In member "update_result" of class "AnsibleReadOperation":
pybind/mgr/ansible/module.py:140: error: Need type annotation for 'processed_result'
pybind/mgr/ansible/module.py: note: In member "__init__" of class "Module":
pybind/mgr/ansible/module.py:309: error: Need type annotation for 'all_completions'
pybind/mgr/ansible/module.py: note: In member "get_inventory" of class "Module":
pybind/mgr/ansible/module.py:384: error: Incompatible types in assignment (expression has type "Callable[[Any, Any, Any, Any], Any]", variable has type "None")
pybind/mgr/ansible/module.py: note: In member "create_osds" of class "Module":
pybind/mgr/ansible/module.py:415: error: Incompatible types in assignment (expression has type "Callable[[Any, Any, Any], Any]", variable has type "None")
pybind/mgr/ansible/module.py: note: In member "remove_osds" of class "Module":
pybind/mgr/ansible/module.py:440: error: Incompatible types in assignment (expression has type "Callable[[Any, Any, Any], Any]", variable has type "None")
pybind/mgr/ansible/module.py: note: In member "remove_host" of class "Module":
pybind/mgr/ansible/module.py:489: error: Need type annotation for 'operations'
pybind/mgr/ansible/module.py:490: error: Need type annotation for 'host_groups'
pybind/mgr/rook/module.py: note: In class "RookOrchestrator":
pybind/mgr/rook/module.py:138: error: Need type annotation for 'MODULE_OPTIONS'
pybind/mgr/rook/module.py: note: In member "describe_service" of class "RookOrchestrator":
pybind/mgr/rook/module.py:351: error: Incompatible types in assignment (expression has type "str", variable has type "None")
pybind/mgr/rook/module.py: note: In member "create_osds" of class "RookOrchestrator":
pybind/mgr/rook/module.py:407: error: Need type annotation for 'targets'
pybind/mgr/rook/module.py: note: In function "create_osds":
pybind/mgr/rook/module.py:407: error: Need type annotation for 'targets'
pybind/mgr/rook/module.py: note: In member "create_osds" of class "RookOrchestrator":
pybind/mgr/rook/module.py:407: error: Need type annotation for 'targets'
pybind/mgr/rook/module.py: note: In function "create_osds":
pybind/mgr/rook/module.py:429: error: "None" has no attribute "list_namespaced_pod"
pybind/mgr/restful/api/doc.py: note: In member "get" of class "Doc":
pybind/mgr/restful/api/doc.py:15: error: "None" has no attribute "get_doc_api"
pybind/mgr/restful/api/doc.py:15: error: Module has no attribute "api"
pybind/mgr/restful/decorators.py: note: In function "auth":
pybind/mgr/restful/decorators.py:21: error: Argument 1 to "split" of "bytes" has incompatible type "str"; expected "Optional[bytes]"
pybind/mgr/restful/decorators.py:24: error: "None" has no attribute "keys"
pybind/mgr/restful/decorators.py:30: error: "None" has no attribute "keys"
pybind/mgr/restful/decorators.py: note: In function "lock":
pybind/mgr/restful/decorators.py:43: error: "None" has no attribute "requests_lock"
pybind/mgr/diskprediction_cloud/agent/metrics/sai_host.py: note: In member "_collect_data" of class "SAIHostAgent":
pybind/mgr/diskprediction_cloud/agent/metrics/sai_host.py:36: error: Need type annotation for 'hosts'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py: note: In class "BaseDP":
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:13: error: Need type annotation for '_fields'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py: note: In member "__init__" of class "DBRelayAgent":
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:107: error: Need type annotation for '_host_nodes'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:108: error: Need type annotation for '_osd_nodes'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:109: error: Need type annotation for '_mon_nodes'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:110: error: Need type annotation for '_mds_nodes'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:111: error: Need type annotation for '_dev_nodes'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:112: error: Need type annotation for '_pool_nodes'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:113: error: Need type annotation for '_rbd_nodes'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:114: error: Need type annotation for '_fs_nodes'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py: note: In member "_init_pools" of class "DBRelayAgent":
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:410: error: Need type annotation for 'osds'
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py: note: In member "_init_fs" of class "DBRelayAgent":
pybind/mgr/diskprediction_cloud/agent/metrics/db_relay.py:469: error: Need type annotation for 'mds_hostnames'
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py: note: In member "_collect_data" of class "SAIDiskSmartAgent":
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:69: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:70: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:71: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:72: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:73: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:74: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:75: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:76: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:77: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:78: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:79: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:80: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:81: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:82: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:83: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:89: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:91: error: Unsupported target for indexed assignment
pybind/mgr/diskprediction_cloud/agent/metrics/sai_disk_smart.py:179: error: Incompatible types in assignment (expression has type "float", variable has type "None")
pybind/mgr/dashboard/tests/test_notification.py: note: In member "__init__" of class "Listener":
pybind/mgr/dashboard/tests/test_notification.py:15: error: Need type annotation for 'type1'
pybind/mgr/dashboard/tests/test_notification.py:16: error: Need type annotation for 'type1_ts'
pybind/mgr/dashboard/tests/test_notification.py:17: error: Need type annotation for 'type2'
pybind/mgr/dashboard/tests/test_notification.py:18: error: Need type annotation for 'type2_ts'
pybind/mgr/dashboard/tests/test_notification.py:19: error: Need type annotation for 'type1_3'
pybind/mgr/dashboard/tests/test_notification.py:20: error: Need type annotation for 'type1_3_ts'
pybind/mgr/dashboard/tests/test_notification.py:21: error: Need type annotation for 'all'
pybind/mgr/dashboard/tests/test_notification.py:22: error: Need type annotation for 'all_ts'
pybind/mgr/dashboard/tests/test_notification.py: note: In member "test_notifications2" of class "NotificationQueueTest":
pybind/mgr/dashboard/tests/test_notification.py:109: error: Incompatible types in assignment (expression has type "int", variable has type "str")
pybind/mgr/dashboard/tests/helper.py: note: In member "_task_request" of class "ControllerTestCase":
pybind/mgr/dashboard/tests/helper.py:122: error: Value of type "None" is not indexable
pybind/mgr/dashboard/tests/helper.py:123: error: Value of type "None" is not indexable
pybind/mgr/dashboard/tests/helper.py:132: error: Value of type "None" is not indexable
pybind/mgr/dashboard/tests/helper.py:133: error: Value of type "None" is not indexable
pybind/mgr/dashboard/tests/helper.py:136: error: Value of type "None" is not indexable
pybind/mgr/dashboard/tests/test_task.py: note: In class "TaskTest":
pybind/mgr/dashboard/tests/test_task.py:100: error: Need type annotation for 'TASK_FINISHED_MAP'
pybind/mgr/dashboard/controllers/docs.py: note: In member "_gen_tags" of class "Docs":
pybind/mgr/dashboard/controllers/docs.py:23: error: Cannot determine type of 'ENDPOINT_MAP'
pybind/mgr/dashboard/controllers/docs.py:28: error: Need type annotation for 'TAG_MAP'
pybind/mgr/dashboard/controllers/docs.py: note: In member "_gen_responses" of class "Docs":
pybind/mgr/dashboard/controllers/docs.py:211: error: Dict entry 0 has incompatible type "str": "Dict[str, Dict[str, Any]]"; expected "str": "str"
pybind/mgr/dashboard/controllers/docs.py: note: In member "_gen_paths" of class "Docs":
pybind/mgr/dashboard/controllers/docs.py:252: error: Cannot determine type of 'ENDPOINT_MAP'
pybind/mgr/dashboard/controllers/docs.py:268: error: Need type annotation for 'resp'
pybind/mgr/dashboard/controllers/docs.py:269: error: Need type annotation for 'p_info'
pybind/mgr/dashboard/controllers/docs.py:275: error: Need type annotation for 'params'
pybind/mgr/dashboard/controllers/osd.py: note: In member "list" of class "Osd":
pybind/mgr/dashboard/controllers/osd.py:36: error: Unsupported target for indexed assignment
pybind/mgr/dashboard/controllers/osd.py:37: error: Unsupported target for indexed assignment
pybind/mgr/dashboard/controllers/osd.py:38: error: Invalid tuple index type (actual type "str", expected type "Union[int, slice]")
pybind/mgr/dashboard/controllers/osd.py:41: error: Invalid tuple index type (actual type "str", expected type "Union[int, slice]")
pybind/mgr/dashboard/controllers/osd.py:42: error: Invalid tuple index type (actual type "str", expected type "Union[int, slice]")
pybind/mgr/dashboard/controllers/osd.py:45: error: Invalid tuple index type (actual type "str", expected type "Union[int, slice]")
pybind/mgr/dashboard/controllers/user.py: note: In member "set" of class "User":
pybind/mgr/dashboard/controllers/user.py:82: error: Need type annotation for 'user_roles'
pybind/mgr/dashboard/controllers/pool.py: note: In member "_serialize_pool" of class "Pool":
pybind/mgr/dashboard/controllers/pool.py:39: error: Incompatible types in assignment (expression has type "List[Any]", target has type "str")
pybind/mgr/dashboard/controllers/pool.py: note: In member "_get" of class "Pool":
pybind/mgr/dashboard/controllers/pool.py:61: error: Incompatible default for argument "attrs" (default has type "None", argument has type "str")
pybind/mgr/dashboard/controllers/pool.py: note: In member "get" of class "Pool":
pybind/mgr/dashboard/controllers/pool.py:69: error: Incompatible default for argument "attrs" (default has type "None", argument has type "str")
pybind/mgr/dashboard/controllers/prometheus.py: note: In class "PrometheusReceiver":
pybind/mgr/dashboard/controllers/prometheus.py:16: error: Need type annotation for 'notifications'
pybind/mgr/dashboard/controllers/logs.py: note: In member "__init__" of class "Logs":
pybind/mgr/dashboard/controllers/logs.py:20: error: Need type annotation for 'log_buffer'
pybind/mgr/dashboard/controllers/logs.py:21: error: Need type annotation for 'audit_buffer'
pybind/mgr/dashboard/controllers/auth.py: note: In member "check" of class "Auth":
pybind/mgr/dashboard/controllers/auth.py:74: error: Module has no attribute "exceptions"
pybind/mgr/dashboard/controllers/auth.py:76: error: Module has no attribute "exceptions"
pybind/mgr/dashboard/controllers/role.py: note: In member "list" of class "Role":
pybind/mgr/dashboard/controllers/role.py:47: error: Incompatible types in assignment (expression has type "List[Any]", variable has type "Dict[Any, Any]")
pybind/mgr/dashboard/services/tcmu_service.py: note: In member "get_iscsi_info" of class "TcmuService":
pybind/mgr/dashboard/services/tcmu_service.py:11: error: Need type annotation for 'daemons'
pybind/mgr/dashboard/services/tcmu_service.py:12: error: Need type annotation for 'images'
pybind/mgr/dashboard/services/tcmu_service.py: note: In member "get_iscsi_daemons_amount" of class "TcmuService":
pybind/mgr/dashboard/services/tcmu_service.py:90: error: Need type annotation for 'daemons'
pybind/mgr/restful/api/server.py: note: In member "get" of class "ServerFqdn":
pybind/mgr/restful/api/server.py:19: error: "None" has no attribute "get_server"
pybind/mgr/restful/api/server.py: note: In member "get" of class "Server":
pybind/mgr/restful/api/server.py:30: error: "None" has no attribute "list_servers"
pybind/mgr/restful/api/osd.py: note: In member "get" of class "OsdIdCommand":
pybind/mgr/restful/api/osd.py:19: error: "None" has no attribute "get_osd_by_id"
pybind/mgr/restful/api/osd.py: note: In member "post" of class "OsdIdCommand":
pybind/mgr/restful/api/osd.py:39: error: "None" has no attribute "get_osd_by_id"
pybind/mgr/restful/api/osd.py:49: error: "None" has no attribute "submit_request"
pybind/mgr/restful/api/osd.py: note: In member "get" of class "OsdId":
pybind/mgr/restful/api/osd.py:68: error: "None" has no attribute "get_osds"
pybind/mgr/restful/api/osd.py: note: In member "patch" of class "OsdId":
pybind/mgr/restful/api/osd.py:115: error: "None" has no attribute "submit_request"
pybind/mgr/restful/api/osd.py: note: In member "get" of class "Osd":
pybind/mgr/restful/api/osd.py:130: error: "None" has no attribute "get_osds"
pybind/mgr/restful/api/pool.py: note: In member "get" of class "PoolId":
pybind/mgr/restful/api/pool.py:19: error: "None" has no attribute "get_pool_by_id"
pybind/mgr/restful/api/pool.py: note: In member "patch" of class "PoolId":
pybind/mgr/restful/api/pool.py:44: error: "None" has no attribute "get_pool_by_id"
pybind/mgr/restful/api/pool.py:56: error: "None" has no attribute "submit_request"
pybind/mgr/restful/api/pool.py: note: In member "delete" of class "PoolId":
pybind/mgr/restful/api/pool.py:65: error: "None" has no attribute "get_pool_by_id"
pybind/mgr/restful/api/pool.py:71: error: "None" has no attribute "submit_request"
pybind/mgr/restful/api/pool.py: note: In member "get" of class "Pool":
pybind/mgr/restful/api/pool.py:87: error: "None" has no attribute "get"
pybind/mgr/restful/api/pool.py: note: In member "post" of class "Pool":
pybind/mgr/restful/api/pool.py:131: error: "None" has no attribute "submit_request"
pybind/mgr/restful/api/mon.py: note: In member "get" of class "MonName":
pybind/mgr/restful/api/mon.py:21: error: "None" has no attribute "get_mons"
pybind/mgr/restful/api/mon.py:24: error: Argument 1 to "len" has incompatible type "Iterator[Any]"; expected "Sized"
pybind/mgr/restful/api/mon.py:28: error: Value of type "Iterator[Any]" is not indexable
pybind/mgr/restful/api/mon.py: note: In member "get" of class "Mon":
pybind/mgr/restful/api/mon.py:39: error: "None" has no attribute "get_mons"
pybind/mgr/restful/api/config.py: note: In member "get" of class "ConfigOsd":
pybind/mgr/restful/api/config.py:15: error: "None" has no attribute "get"
pybind/mgr/restful/api/config.py: note: In member "patch" of class "ConfigOsd":
pybind/mgr/restful/api/config.py:36: error: "None" has no attribute "log"
pybind/mgr/restful/api/config.py:49: error: "None" has no attribute "submit_request"
pybind/mgr/restful/api/config.py: note: In member "get" of class "ConfigClusterKey":
pybind/mgr/restful/api/config.py:64: error: "None" has no attribute "get"
pybind/mgr/restful/api/config.py: note: In member "get" of class "ConfigCluster":
pybind/mgr/restful/api/config.py:75: error: "None" has no attribute "get"
pybind/mgr/restful/api/crush.py: note: In member "get" of class "CrushRule":
pybind/mgr/restful/api/crush.py:17: error: "None" has no attribute "get"
pybind/mgr/restful/api/request.py: note: In member "get" of class "RequestId":
pybind/mgr/restful/api/request.py:21: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py:24: error: Argument 1 to "len" has incompatible type "Iterator[Any]"; expected "Sized"
pybind/mgr/restful/api/request.py:28: error: Value of type "Iterator[Any]" is not indexable
pybind/mgr/restful/api/request.py: note: In member "delete" of class "RequestId":
pybind/mgr/restful/api/request.py:39: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py:40: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py:41: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py: note: In member "get" of class "Request":
pybind/mgr/restful/api/request.py:57: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py: note: In member "delete" of class "Request":
pybind/mgr/restful/api/request.py:67: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py:69: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py:71: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py:76: error: Argument 1 to "len" has incompatible type "Iterator[Any]"; expected "Sized"
pybind/mgr/restful/api/request.py:76: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py:77: error: Argument 1 to "len" has incompatible type "Iterator[Any]"; expected "Sized"
pybind/mgr/restful/api/request.py:77: error: "None" has no attribute "requests"
pybind/mgr/restful/api/request.py: note: In member "post" of class "Request":
pybind/mgr/restful/api/request.py:87: error: "None" has no attribute "submit_request"
pybind/mgr/diskprediction_cloud/task.py: note: In class "AgentRunner":
pybind/mgr/diskprediction_cloud/task.py:23: error: Need type annotation for 'agents'
pybind/mgr/dashboard/tests/test_api_auditing.py: note: In class "ApiAuditingTest":
pybind/mgr/dashboard/tests/test_api_auditing.py:32: error: Need type annotation for 'settings'
pybind/mgr/dashboard/tests/test_api_auditing.py: note: In member "setUp" of class "ApiAuditingTest":
pybind/mgr/dashboard/tests/test_api_auditing.py:57: error: "_ModuleProxy" has no attribute "cluster_log"
pybind/mgr/dashboard/tests/test_api_auditing.py: note: In member "_validate_cluster_log_msg" of class "ApiAuditingTest":
pybind/mgr/dashboard/tests/test_api_auditing.py:67: error: Item "None" of "Optional[Match[Any]]" has no attribute "group"
pybind/mgr/dashboard/tests/test_api_auditing.py:68: error: Item "None" of "Optional[Match[Any]]" has no attribute "group"
pybind/mgr/dashboard/tests/test_api_auditing.py:69: error: Item "None" of "Optional[Match[Any]]" has no attribute "group"
pybind/mgr/dashboard/tests/test_api_auditing.py:70: error: Item "None" of "Optional[Match[Any]]" has no attribute "group"
pybind/mgr/dashboard/tests/test_rest_tasks.py: note: In member "setup_server" of class "TaskControllerTest":
pybind/mgr/dashboard/tests/test_rest_tasks.py:53: error: "Type[TaskTest]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_rest_tasks.py:54: error: "Type[Task]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_grafana.py: note: In member "setup_server" of class "GrafanaTest":
pybind/mgr/dashboard/tests/test_grafana.py:14: error: "Type[Grafana]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_tools.py: note: In member "list" of class "FooResource":
pybind/mgr/dashboard/tests/test_tools.py:21: error: Need type annotation for 'elems'
pybind/mgr/dashboard/tests/test_tools.py: note: In member "create" of class "FooResource":
pybind/mgr/dashboard/tests/test_tools.py:21: error: Need type annotation for 'elems'
pybind/mgr/dashboard/tests/test_tools.py: note: In member "delete" of class "FooResource":
pybind/mgr/dashboard/tests/test_tools.py:21: error: Need type annotation for 'elems'
pybind/mgr/dashboard/tests/test_tools.py: note: In member "bulk_delete" of class "FooResource":
pybind/mgr/dashboard/tests/test_tools.py:21: error: Need type annotation for 'elems'
pybind/mgr/dashboard/tests/test_tools.py: note: In member "set" of class "FooResource":
pybind/mgr/dashboard/tests/test_tools.py:21: error: Need type annotation for 'elems'
pybind/mgr/dashboard/tests/test_tools.py: note: In class "FooResource":
pybind/mgr/dashboard/tests/test_tools.py:21: error: Need type annotation for 'elems'
pybind/mgr/dashboard/tests/test_settings.py: note: In class "SettingsTest":
pybind/mgr/dashboard/tests/test_settings.py:14: error: Need type annotation for 'CONFIG_KEY_DICT'
pybind/mgr/dashboard/tests/test_settings.py: note: In member "setUpClass" of class "SettingsTest":
pybind/mgr/dashboard/tests/test_settings.py:19: error: "Type[Options]" has no attribute "GRAFANA_API_HOST"
pybind/mgr/dashboard/tests/test_settings.py:20: error: "Type[Options]" has no attribute "GRAFANA_API_PORT"
pybind/mgr/dashboard/tests/test_settings.py:21: error: "Type[Options]" has no attribute "GRAFANA_ENABLED"
pybind/mgr/dashboard/tests/test_settings.py: note: In class "SettingsControllerTest":
pybind/mgr/dashboard/tests/test_settings.py:112: error: Need type annotation for 'config_values'
pybind/mgr/dashboard/tests/test_settings.py: note: In member "setup_server" of class "SettingsControllerTest":
pybind/mgr/dashboard/tests/test_settings.py:118: error: "Type[Settings]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_rbd_mirroring.py: note: In member "setup_server" of class "RbdMirroringSummaryControllerTest":
pybind/mgr/dashboard/tests/test_rbd_mirroring.py:63: error: "_ModuleProxy" has no attribute "url_prefix"
pybind/mgr/dashboard/tests/test_rbd_mirroring.py:66: error: "_ModuleProxy" has no attribute "version"
pybind/mgr/dashboard/tests/test_rbd_mirroring.py:71: error: "Type[RbdMirroringSummary]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_rbd_mirroring.py:72: error: "Type[Summary]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_controllers.py: note: In class "RTest":
pybind/mgr/dashboard/tests/test_controllers.py:43: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
pybind/mgr/dashboard/tests/test_access_control.py: note: In class "AccessControlTest":
pybind/mgr/dashboard/tests/test_access_control.py:19: error: Need type annotation for 'CONFIG_KEY_DICT'
pybind/mgr/dashboard/tests/test_access_control.py: note: In member "setUpClass" of class "AccessControlTest":
pybind/mgr/dashboard/tests/test_access_control.py:36: error: "_ModuleProxy" has no attribute "ACCESS_CONTROL_DB"
pybind/mgr/dashboard/tests/test_prometheus.py: note: In member "setup_server" of class "PrometheusControllerTest":
pybind/mgr/dashboard/tests/test_prometheus.py:22: error: "Type[Prometheus]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_rgw.py: note: In member "setup_server" of class "RgwUserControllerTestCase":
pybind/mgr/dashboard/tests/test_rgw.py:10: error: "Type[RgwUser]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_docs.py: note: In member "test_group_info_attr" of class "DocDecoratorsTest":
pybind/mgr/dashboard/tests/test_docs.py:39: error: "DecoratedController" has no attribute "doc_info"
pybind/mgr/dashboard/tests/test_docs.py:40: error: "DecoratedController" has no attribute "doc_info"
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "setup_server" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:16: error: "Type[Iscsi]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_iscsi.py:17: error: "Type[IscsiTarget]" has no attribute "_cp_config"
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "setUp" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:22: error: Incompatible types in assignment (expression has type "IscsiClientMock", variable has type "None")
pybind/mgr/dashboard/tests/test_iscsi.py:23: error: Cannot assign to a method
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_add_client" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:104: error: "object" has no attribute "append"
pybind/mgr/dashboard/tests/test_iscsi.py:116: error: "object" has no attribute "append"
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_change_client_password" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:135: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:138: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_rename_client" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:148: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:151: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_add_disk" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:161: error: "object" has no attribute "append"
pybind/mgr/dashboard/tests/test_iscsi.py:168: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:171: error: "object" has no attribute "append"
pybind/mgr/dashboard/tests/test_iscsi.py:178: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_change_disk_image" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:188: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:189: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:192: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:193: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_change_disk_controls" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:203: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:206: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_rename_group" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:228: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:231: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_add_client_to_group" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:241: error: "object" has no attribute "append"
pybind/mgr/dashboard/tests/test_iscsi.py:251: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:254: error: "object" has no attribute "append"
pybind/mgr/dashboard/tests/test_iscsi.py:264: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py: note: In member "test_remove_client_from_group" of class "IscsiTest":
pybind/mgr/dashboard/tests/test_iscsi.py:274: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_iscsi.py:277: error: Value of type "object" is not indexable
pybind/mgr/dashboard/tests/test_sso.py: note: In class "AccessControlTest":
pybind/mgr/dashboard/tests/test_sso.py:14: error: Need type annotation for 'CONFIG_KEY_DICT'
pybind/mgr/dashboard/tests/test_erasure_code_profile.py: note: In member "setup_server" of class "ErasureCodeProfileTest":
pybind/mgr/dashboard/tests/test_erasure_code_profile.py:25: error: "Type[ErasureCodeProfile]" has no attribute "_cp_config"
pybind/mgr/dashboard/services/ganesha.py: note: In member "_get_clusters_locations" of class "Ganesha":
pybind/mgr/dashboard/services/ganesha.py:23: error: Need type annotation for 'result'
pybind/mgr/dashboard/services/ganesha.py: note: In member "get_daemons_status" of class "Ganesha":
pybind/mgr/dashboard/services/ganesha.py:74: error: Need type annotation for 'result'
pybind/mgr/dashboard/services/ganesha.py: note: In member "__init__" of class "GaneshaConf":
pybind/mgr/dashboard/services/ganesha.py:749: error: Need type annotation for 'export_conf_blocks'
pybind/mgr/dashboard/services/ganesha.py:750: error: Need type annotation for 'daemons_conf_blocks'
pybind/mgr/dashboard/services/ganesha.py:751: error: Need type annotation for '_defaults'
pybind/mgr/dashboard/services/ganesha.py:752: error: Need type annotation for 'exports'
pybind/mgr/dashboard/services/ganesha.py: note: In member "validate" of class "GaneshaConf":
pybind/mgr/dashboard/services/ganesha.py:893: error: Item "None" of "Optional[Any]" has no attribute "pseudo"
pybind/mgr/dashboard/services/ganesha.py:895: error: Item "None" of "Optional[Any]" has no attribute "path"
pybind/mgr/dashboard/services/ganesha.py:896: error: Item "None" of "Optional[Any]" has no attribute "path"
pybind/mgr/dashboard/services/ganesha.py: note: In member "_persist_daemon_configuration" of class "GaneshaConf":
pybind/mgr/dashboard/services/ganesha.py:916: error: Need type annotation for 'daemon_map'
pybind/mgr/diskprediction_cloud/module.py:12: error: Module 'string' has no attribute 'maketrans'
pybind/mgr/diskprediction_cloud/module.py: note: In member "__init__" of class "Module":
pybind/mgr/diskprediction_cloud/module.py:124: error: Need type annotation for '_agents'
pybind/mgr/diskprediction_cloud/module.py:126: error: Need type annotation for 'prediction_result'
pybind/mgr/diskprediction_cloud/module.py:127: error: Need type annotation for 'config'
pybind/mgr/dashboard/tests/test_ganesha.py: note: In class "GaneshaConfTest":
pybind/mgr/dashboard/tests/test_ganesha.py:106: error: Need type annotation for 'CONFIG_KEY_DICT'
pybind/mgr/dashboard/tests/test_ganesha.py: note: In member "setUp" of class "GaneshaConfTest":
pybind/mgr/dashboard/tests/test_ganesha.py:138: error: "_ModuleProxy" has no attribute "rados"
pybind/mgr/dashboard/tests/test_ganesha.py:142: error: Cannot assign to a type
pybind/mgr/dashboard/tests/test_ganesha.py:143: error: "Callable[[], Any]" has no attribute "return_value"
pybind/mgr/dashboard/tests/test_ganesha.py:144: error: "Callable[[Any], Any]" has no attribute "return_value"
pybind/mgr/dashboard/tests/test_ganesha.py:146: error: Cannot assign to a type
pybind/mgr/dashboard/tests/test_ganesha.py: note: In member "test_update_export" of class "GaneshaConfTest":
pybind/mgr/dashboard/tests/test_ganesha.py:468: error: Cannot assign to a type
pybind/mgr/dashboard/tests/test_ganesha.py:474: error: "Callable[[], Any]" has no attribute "return_value"
pybind/mgr/dashboard/tests/test_ganesha.py: note: In member "test_create_export_rgw" of class "GaneshaConfTest":
pybind/mgr/dashboard/tests/test_ganesha.py:545: error: Cannot assign to a type
pybind/mgr/dashboard/tests/test_ganesha.py:551: error: "Callable[[], Any]" has no attribute "return_value"
pybind/mgr/dashboard/tests/test_ganesha.py: note: In member "test_create_export_cephfs" of class "GaneshaConfTest":
pybind/mgr/dashboard/tests/test_ganesha.py:600: error: Cannot assign to a type
pybind/mgr/dashboard/tests/test_ganesha.py:601: error: "Callable[[], Any]" has no attribute "return_value"
pybind/mgr/dashboard/tests/test_ganesha.py:602: error: "Callable[[Any], Any]" has no attribute "return_value"
pybind/mgr/dashboard/tests/test_ganesha.py:604: error: Cannot assign to a type
pybind/mgr/dashboard/tests/test_ganesha.py:605: error: "Callable[[Any, Any], Any]" has no attribute "return_value"
pybind/mgr/dashboard/tests/test_tcmu_iscsi.py: note: In member "setup_server" of class "TcmuIscsiControllerTest":
pybind/mgr/dashboard/tests/test_tcmu_iscsi.py:71: error: "_ModuleProxy" has no attribute "url_prefix"
pybind/mgr/dashboard/tests/test_tcmu_iscsi.py:72: error: "Type[TcmuIscsi]" has no attribute "_cp_config"
pybind/mgr/dashboard/controllers/nfsganesha.py: note: In member "status" of class "NFSGanesha":
pybind/mgr/dashboard/controllers/nfsganesha.py:39: error: Incompatible types in assignment (expression has type "str", target has type "Optional[bool]")
pybind/mgr/dashboard/controllers/nfsganesha.py: note: In class "NFSGaneshaExports":
pybind/mgr/dashboard/controllers/nfsganesha.py:47: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
pybind/mgr/dashboard/controllers/nfsganesha.py: note: In member "list" of class "NFSGaneshaService":
pybind/mgr/dashboard/controllers/nfsganesha.py:159: error: Name 'cluster_id' is not defined
ceph-volume:
ceph-volume/ceph_volume/devices/lvm/strategies/validators.py: note: In function "has_common_vg":
ceph-volume/ceph_volume/devices/lvm/strategies/validators.py:47: error: Need type annotation for 'ssd_vgs'
ceph-volume/ceph_volume/util/device.py: note: In member "__init__" of class "Device":
ceph-volume/ceph_volume/util/device.py:81: error: Need type annotation for 'lvs'
ceph-volume/ceph_volume/util/device.py:84: error: Need type annotation for 'pvs_api'
ceph-volume/ceph_volume/util/device.py:85: error: Need type annotation for 'disk_api'
ceph-volume/ceph_volume/util/device.py:86: error: Need type annotation for 'blkid_api'
ceph-volume/ceph_volume/util/device.py:87: error: Need type annotation for 'sys_api'
ceph-volume/ceph_volume/util/__init__.py:6: error: Name 'raw_input' is not defined
ceph-volume/ceph_volume/util/disk.py: note: In member "__init__" of class "Size":
ceph-volume/ceph_volume/util/disk.py:561: error: Need type annotation for '_formatters'
ceph-volume/ceph_volume/util/disk.py:563: error: "object" has no attribute "__iter__"; maybe "__str__" or "__dir__"? (not iterable)
ceph-volume/ceph_volume/util/disk.py:565: error: Need type annotation for '_factors'
ceph-volume/ceph_volume/util/disk.py:567: error: "object" has no attribute "__iter__"; maybe "__str__" or "__dir__"? (not iterable)
ceph-volume/ceph_volume/util/prepare.py: note: In function "_normalize_mount_flags":
ceph-volume/ceph_volume/util/prepare.py:270: error: Need type annotation for 'unique_flags'
ceph-volume/ceph_volume/util/prepare.py: note: In function "mount_osd":
ceph-volume/ceph_volume/util/prepare.py:298: error: Need type annotation for 'extras'
ceph-volume/ceph_volume/systemd/main.py: note: In function "main":
ceph-volume/ceph_volume/systemd/main.py:97: error: Unsupported operand types for > ("str" and "int")
ceph-volume/ceph_volume/systemd/main.py:97: note: Left operand is of type "Union[str, int]"
ceph-volume/ceph_volume/systemd/main.py:107: error: Unsupported operand types for - ("str" and "int")
ceph-volume/ceph_volume/systemd/main.py:107: note: Left operand is of type "Union[str, int]"
ceph-volume/ceph_volume/systemd/main.py:108: error: Argument 1 to "sleep" has incompatible type "Union[str, int]"; expected "float"
ceph-volume/ceph_volume/process.py: note: In function "log_descriptors":
ceph-volume/ceph_volume/process.py:58: error: Incompatible types in assignment (expression has type "str", variable has type "bytes")
ceph-volume/ceph_volume/devices/simple/scan.py: note: In member "scan_encrypted" of class "Scan":
ceph-volume/ceph_volume/devices/simple/scan.py:149: error: Need type annotation for 'osd_metadata'
ceph-volume/ceph_volume/devices/lvm/listing.py: note: In member "single_report" of class "List":
ceph-volume/ceph_volume/devices/lvm/listing.py:175: error: Need type annotation for 'report'
ceph-volume/ceph_volume/devices/lvm/listing.py: note: In member "full_report" of class "List":
ceph-volume/ceph_volume/devices/lvm/listing.py:229: error: Need type annotation for 'report'
ceph-volume/ceph_volume/devices/lvm/strategies/strategies.py: note: In member "__init__" of class "Strategy":
ceph-volume/ceph_volume/devices/lvm/strategies/strategies.py:19: error: Need type annotation for 'computed'
ceph-volume/ceph_volume/configuration.py:4: error: Name 'configparser' already defined (by an import)
ceph-volume/ceph_volume/configuration.py: note: In member "_read" of class "Conf":
ceph-volume/ceph_volume/configuration.py:206: error: "ParsingError" has no attribute "append"
ceph-volume/ceph_volume/api/lvm.py: note: In function "_is_vdo":
ceph-volume/ceph_volume/api/lvm.py:213: error: Need type annotation for 'devices'
ceph-volume/ceph_volume/api/lvm.py: note: In function "remove_lv":
ceph-volume/ceph_volume/api/lvm.py:523: error: "Volume" has no attribute "lv_path"
ceph-volume/ceph_volume/api/lvm.py: note: In member "as_dict" of class "Volume":
ceph-volume/ceph_volume/api/lvm.py:1105: error: Need type annotation for 'obj'
ceph-volume/ceph_volume/util/encryption.py: note: In function "status":
ceph-volume/ceph_volume/util/encryption.py:197: error: Need type annotation for 'metadata'
ceph-volume/ceph_volume/util/system.py: note: In function "get_mounts":
ceph-volume/ceph_volume/util/system.py:241: error: Need type annotation for 'devices_mounted'
ceph-volume/ceph_volume/util/system.py:242: error: Need type annotation for 'paths_mounted'
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py: note: In member "compute" of class "SingleType":
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:106: error: Incompatible types in assignment (expression has type "Dict[str, Dict[<nothing>, <nothing>]]", variable has type "int")
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:107: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:108: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:109: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:110: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:111: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:112: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:113: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:114: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:115: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:118: error: Unsupported target for indexed assignment
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py: note: In member "execute" of class "SingleType":
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:145: error: "None" has no attribute "sizing"
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:146: error: "None" has no attribute "sizing"
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:148: error: "None" has no attribute "name"
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:151: error: "None" has no attribute "name"
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:155: error: "None" has no attribute "name"
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:156: error: "None" has no attribute "name"
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py: note: In member "__init__" of class "MixedType":
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:184: error: Need type annotation for 'blank_journal_devs'
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py: note: In member "compute" of class "MixedType":
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:320: error: Incompatible types in assignment (expression has type "Dict[str, Dict[<nothing>, <nothing>]]", variable has type "int")
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:321: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:322: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:323: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:324: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:325: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:326: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:327: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:328: error: Value of type "int" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:331: error: Unsupported target for indexed assignment
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py: note: In member "execute" of class "MixedType":
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:369: error: "None" has no attribute "sizing"
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:371: error: "None" has no attribute "name"
ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py:378: error: "None" has no attribute "name"
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py: note: In member "compute" of class "SingleType":
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py:79: error: Need type annotation for 'osd'
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py: note: In member "execute" of class "SingleType":
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py:102: error: Incompatible types in assignment (expression has type "Dict[str, Any]", target has type "None")
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py:106: error: Value of type "None" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py:107: error: Value of type "None" is not indexable
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py: note: In member "compute" of class "MixedType":
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py:267: error: Need type annotation for 'osd'
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py: note: In member "execute" of class "MixedType":
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py:358: error: "None" has no attribute "sizing"
ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py:360: error: "None" has no attribute "name"
</pre>
</details>

