### PR TITLE
rgw multisite: add perf counters to data sync

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -83,6 +83,7 @@ set(librgw_common_srcs
   rgw_pubsub.cc
   rgw_sync.cc
   rgw_data_sync.cc
+  rgw_sync_counters.cc
   rgw_sync_module.cc
   rgw_sync_module_aws.cc
   rgw_sync_module_es.cc

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2156,7 +2156,7 @@ static void get_data_sync_status(const string& source_zone, list<string>& status
     flush_ss(ss, status);
     return;
   }
-  RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone);
+  RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone, nullptr);
 
   int ret = sync.init();
   if (ret < 0) {
@@ -7015,7 +7015,7 @@ next:
       cerr << "ERROR: source zone not specified" << std::endl;
       return EINVAL;
     }
-    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone);
+    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone, nullptr);
 
     int ret = sync.init();
     if (ret < 0) {
@@ -7079,7 +7079,7 @@ next:
       return EINVAL;
     }
 
-    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone);
+    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone, nullptr);
 
     int ret = sync.init();
     if (ret < 0) {
@@ -7108,7 +7108,7 @@ next:
       return ret;
     }
 
-    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone, sync_module);
+    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone, nullptr, sync_module);
 
     ret = sync.init();
     if (ret < 0) {

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -6,6 +6,7 @@
 #include "rgw_zone.h"
 #include "rgw_coroutine.h"
 #include "rgw_cr_rados.h"
+#include "rgw_sync_counters.h"
 
 #include "services/svc_zone.h"
 #include "services/svc_zone_utils.h"
@@ -585,6 +586,7 @@ int RGWAsyncFetchRemoteObj::_send_request()
 
   rgw_obj dest_obj(bucket_info.bucket, dest_key.value_or(key));
 
+  std::optional<uint64_t> bytes_transferred;
   int r = store->fetch_remote_obj(obj_ctx,
                        user_id,
                        NULL, /* req_info */
@@ -611,10 +613,20 @@ int RGWAsyncFetchRemoteObj::_send_request()
                        NULL, /* string *petag, */
                        NULL, /* void (*progress_cb)(off_t, void *), */
                        NULL, /* void *progress_data*); */
-                       &zones_trace);
+                       &zones_trace,
+                       &bytes_transferred);
 
   if (r < 0) {
     ldout(store->ctx(), 0) << "store->fetch_remote_obj() returned r=" << r << dendl;
+    if (counters) {
+      counters->inc(sync_counters::l_fetch_err, 1);
+    }
+  } else if (counters) {
+    if (bytes_transferred) {
+      counters->inc(sync_counters::l_fetch, *bytes_transferred);
+    } else {
+      counters->inc(sync_counters::l_fetch_not_modified);
+    }
   }
   return r;
 }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1669,7 +1669,7 @@ RGWCoroutine *RGWDefaultDataSyncModule::sync_object(RGWDataSyncEnv *sync_env, RG
   return new RGWFetchRemoteObjCR(sync_env->async_rados, sync_env->store, sync_env->source_zone, bucket_info,
 				 std::nullopt,
                                  key, std::nullopt, versioned_epoch,
-                                 true, zones_trace);
+                                 true, zones_trace, sync_env->counters);
 }
 
 RGWCoroutine *RGWDefaultDataSyncModule::remove_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key,
@@ -1746,7 +1746,7 @@ RGWCoroutine *RGWArchiveDataSyncModule::sync_object(RGWDataSyncEnv *sync_env, RG
   return new RGWFetchRemoteObjCR(sync_env->async_rados, sync_env->store, sync_env->source_zone,
                                  bucket_info, std::nullopt,
                                  key, dest_key, versioned_epoch,
-                                 true, zones_trace);
+                                 true, zones_trace, nullptr);
 }
 
 RGWCoroutine *RGWArchiveDataSyncModule::remove_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4280,7 +4280,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
                string *petag,
                void (*progress_cb)(off_t, void *),
                void *progress_data,
-               rgw_zone_set *zones_trace)
+               rgw_zone_set *zones_trace,
+               std::optional<uint64_t>* bytes_transferred)
 {
   /* source is in a different zonegroup, copy from there */
 
@@ -4494,6 +4495,9 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     goto set_err_state;
   }
 
+  if (bytes_transferred) {
+    *bytes_transferred = cb.get_data_len();
+  }
   return 0;
 set_err_state:
   if (copy_if_newer && ret == -ERR_NOT_MODIFIED) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1919,7 +1919,8 @@ public:
                        string *petag,
                        void (*progress_cb)(off_t, void *),
                        void *progress_data,
-                       rgw_zone_set *zones_trace= nullptr);
+                       rgw_zone_set *zones_trace= nullptr,
+                       std::optional<uint64_t>* bytes_transferred = 0);
   /**
    * Copy an object.
    * dest_obj: the object to copy into

--- a/src/rgw/rgw_sync_counters.cc
+++ b/src/rgw/rgw_sync_counters.cc
@@ -1,0 +1,28 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/ceph_context.h"
+#include "rgw_sync_counters.h"
+
+namespace sync_counters {
+
+PerfCountersRef build(CephContext *cct, const std::string& name)
+{
+  PerfCountersBuilder b(cct, name, l_first, l_last);
+
+  // share these counters with ceph-mgr
+  b.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
+
+  b.add_u64_avg(l_fetch, "fetch bytes", "Number of object bytes replicated");
+  b.add_u64_counter(l_fetch_not_modified, "fetch not modified", "Number of objects already replicated");
+  b.add_u64_counter(l_fetch_err, "fetch errors", "Number of object replication errors");
+
+  b.add_time_avg(l_poll, "poll latency", "Average latency of replication log requests");
+  b.add_u64_counter(l_poll_err, "poll errors", "Number of replication log request errors");
+
+  auto logger = PerfCountersRef{ b.create_perf_counters(), cct };
+  cct->get_perfcounters_collection()->add(logger.get());
+  return logger;
+}
+
+} // namespace sync_counters

--- a/src/rgw/rgw_sync_counters.h
+++ b/src/rgw/rgw_sync_counters.h
@@ -1,0 +1,25 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "common/perf_counters_collection.h"
+
+namespace sync_counters {
+
+enum {
+  l_first = 805000,
+
+  l_fetch,
+  l_fetch_not_modified,
+  l_fetch_err,
+
+  l_poll,
+  l_poll_err,
+
+  l_last,
+};
+
+PerfCountersRef build(CephContext *cct, const std::string& name);
+
+} // namespace sync_counters

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -171,9 +171,9 @@ int RGWSI_Zone::do_start()
     ldout(cct, 0) << "WARNING: could not find zone config in zonegroup for local zone (" << zone_id() << "), will use defaults" << dendl;
   }
   *zone_public_config = zone_by_id[zone_id()];
-  for (auto ziter : zonegroup->zones) {
+  for (const auto& ziter : zonegroup->zones) {
     const string& id = ziter.first;
-    RGWZone& z = ziter.second;
+    const RGWZone& z = ziter.second;
     if (id == zone_id()) {
       continue;
     }
@@ -187,7 +187,7 @@ int RGWSI_Zone::do_start()
     if (zone_syncs_from(*zone_public_config, z) ||
         zone_syncs_from(z, *zone_public_config)) {
       if (zone_syncs_from(*zone_public_config, z)) {
-        zone_data_sync_from_map[id] = conn;
+        data_sync_source_zones.push_back(&z);
       }
       if (zone_syncs_from(z, *zone_public_config)) {
         zone_data_notify_to_map[id] = conn;

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -36,7 +36,7 @@ class RGWSI_Zone : public RGWServiceInstance
 
   RGWRESTConn *rest_master_conn{nullptr};
   map<string, RGWRESTConn *> zone_conn_map;
-  map<string, RGWRESTConn *> zone_data_sync_from_map;
+  std::vector<const RGWZone*> data_sync_source_zones;
   map<string, RGWRESTConn *> zone_data_notify_to_map;
   map<string, RGWRESTConn *> zonegroup_conn_map;
 
@@ -89,8 +89,8 @@ public:
     return zone_conn_map;
   }
 
-  map<string, RGWRESTConn *>& get_zone_data_sync_from_map() {
-    return zone_data_sync_from_map;
+  std::vector<const RGWZone*>& get_data_sync_source_zones() {
+    return data_sync_source_zones;
   }
 
   map<string, RGWRESTConn *>& get_zone_data_notify_to_map() {


### PR DESCRIPTION
adds a new set of perf counters for each source zone of data sync. counters track the replication of objects (count, errors, and bytes transferred) and requests for datalogs and bilogs (count, errors, and average latency)

Feature: http://tracker.ceph.com/issues/38549
```
~/ceph/build $ bin/ceph daemon run/c2/out/radosgw.8001.asok perf dump data-sync-from-na-1
{
    "data-sync-from-na-1": {
        "fetch bytes": {
            "avgcount": 59,
            "sum": 151501
        },
        "fetch not modified": 4,
        "fetch errors": 0,
        "poll latency": {
            "avgcount": 1134,
            "sum": 40.248893830,
            "avgtime": 0.035492851
        },
        "poll errors": 0
    }
}
~/ceph/build $ bin/ceph daemon run/c1/out/radosgw.8000.asok perf dump data-sync-from-na-2
{
    "data-sync-from-na-2": {
        "fetch bytes": {
            "avgcount": 0,
            "sum": 0
        },
        "fetch not modified": 59,
        "fetch errors": 0,
        "poll latency": {
            "avgcount": 1024,
            "sum": 35.935616820,
            "avgtime": 0.035093375
        },
        "poll errors": 0
    }
}
```