### PR TITLE
mds: Fix use of auto prototype, it is a non std extension

### DIFF
--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -327,7 +327,8 @@ public:
    * Mutator helper for Filesystem objects: expose a non-const
    * Filesystem pointer to `fn` and update epochs appropriately.
    */
-  void modify_filesystem(fs_cluster_id_t fscid, auto&& fn)
+  template<typename T>
+  void modify_filesystem(fs_cluster_id_t fscid, T&& fn)
   {
     auto& fs = filesystems.at(fscid);
     fn(fs);
@@ -338,7 +339,8 @@ public:
    * Apply a mutation to the mds_info_t structure for a particular
    * daemon (identified by GID), and make appropriate updates to epochs.
    */
-  void modify_daemon(mds_gid_t who, auto&& fn)
+  template<typename T>
+  void modify_daemon(mds_gid_t who, T&& fn)
   {
     const auto& fscid = mds_roles.at(who);
     if (fscid == FS_CLUSTER_ID_NONE) {


### PR DESCRIPTION
Clang complains:
```
In file included from /home/jenkins/workspace/ceph-master/src/msg/Message.cc:128:
In file included from /home/jenkins/workspace/ceph-master/src/messages/MFSMap.h:20:
/home/jenkins/workspace/ceph-master/src/mds/FSMap.h:330:49: error: 'auto' not allowed in function prototype
  void modify_filesystem(fs_cluster_id_t fscid, auto&& fn)
                                                ^~~~
/home/jenkins/workspace/ceph-master/src/mds/FSMap.h:341:37: error: 'auto' not allowed in function prototype
  void modify_daemon(mds_gid_t who, auto&& fn)
                                    ^~~~
```



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug