### PR TITLE
common/options: default daemon pid_file = $run_dir/$cluster-$name.pid

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -478,6 +478,8 @@ std::vector<Option> get_global_options() {
     .add_see_also({"setuser", "setgroup"}),
 
     Option("pid_file", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_daemon_default("$run_dir/$cluster-$name.pid")
     .set_description("path to write a pid file (if any)")
     .add_service({"mon", "mgr", "osd", "mds"})
     .add_tag("service"),

--- a/src/test/cli/ceph-conf/show-config.t
+++ b/src/test/cli/ceph-conf/show-config.t
@@ -2,5 +2,6 @@
   admin_socket = /var/run/ceph/ceph-osd.0.asok
   log_file = /var/log/ceph/ceph-osd.0.log
   mon_debug_dump_location = /var/log/ceph/ceph-osd.0.tdump
+  pid_file = /var/run/ceph/ceph-osd.0.pid
   $ CEPH_ARGS="--fsid 96a3abe6-7552-4635-a79b-f3c096ff8b95" ceph-conf -n osd.0 --show-config -c /dev/null | grep fsid
   fsid = 96a3abe6-7552-4635-a79b-f3c096ff8b95


### PR DESCRIPTION
the previous default value for pid_file is empty, so multi daemon
running instances may be started, which is not we want.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

