### PR TITLE
osdc: remove lderr() hexdump from handle_osd_op_reply

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3475,9 +3475,6 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     } else {
       m->claim_data(*op->outbl);
     }
-    lderr(cct) << __func__ << " data:\n";
-    op->outbl->hexdump(*_dout);
-    *_dout << dendl;
     op->outbl = 0;
   }
 


### PR DESCRIPTION
this new lderr is quite spammy for radosgw/radosgw-admin. is it really an error, or was it just there for debugging?