### PR TITLE
mgr/diskprediction_cloud: Fixed cannot use string.maketrans in the python 3

### DIFF
--- a/src/pybind/mgr/diskprediction_cloud/module.py
+++ b/src/pybind/mgr/diskprediction_cloud/module.py
@@ -9,8 +9,12 @@ import errno
 import json
 from mgr_module import MgrModule
 import os
-from string import maketrans
 from threading import Event
+
+try:
+    from string import maketrans
+except ImportError:
+    maketrans = str.maketrans
 
 from .common import DP_MGR_STAT_ENABLED, DP_MGR_STAT_DISABLED
 from .task import MetricsRunner, SmartRunner, PredictRunner, TestRunner
@@ -22,16 +26,30 @@ CUSTOMER_ALPHABET = "ABCDEFG&HIJKLMN@OQRS.TUV(WXYZabcd)efghijlmn-opqrstu*vwxyz01
 ORIGIN_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
 
-def encode_string(value):
+def get_transtable():
+    transtable = maketrans(CUSTOMER_ALPHABET, ORIGIN_ALPHABET)
+    return transtable
+
+
+def get_reverse_transtable():
     transtable = maketrans(ORIGIN_ALPHABET, CUSTOMER_ALPHABET)
-    e = base64.b64encode(value)
-    return e.translate(transtable)[:-1]
+    return transtable
+
+
+def encode_string(value):
+    if len(value) == 0:
+        return ""
+    transtable = get_transtable()
+    e = str((base64.b64encode(str(value).encode())).decode("utf-8")[:-1])
+    return e.translate(transtable)
 
 
 def decode_string(value):
-    transtable = maketrans(CUSTOMER_ALPHABET, ORIGIN_ALPHABET)
+    if len(value) == 0:
+        return ""
+    transtable = get_reverse_transtable()
     e = str(value).translate(transtable) + "="
-    return base64.b64decode(e)
+    return base64.b64decode(e).decode("utf-8")
 
 
 class Module(MgrModule):


### PR DESCRIPTION
Fixed python 3.7 cannot use string.maketrans library.
Fixes: https://tracker.ceph.com/issues/38521

Signed-off-by: Rick Chen rick.chen@prophetstor.com

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

