### PR TITLE
Revert "msg/async/Protocol*: send keep alive if existing wins"

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -2007,8 +2007,6 @@ CtPtr ProtocolV1::handle_connect_message_2() {
                     << " existing_state="
                     << connection->get_state_name(existing->state) << dendl;
       reply.global_seq = exproto->peer_global_seq;
-      // make sure we notice if existing connection is no longer functioning
-      existing->send_keepalive();
       existing->lock.unlock();
       return send_connect_message_reply(CEPH_MSGR_TAG_RETRY_GLOBAL, reply,
                                         authorizer_reply);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2316,8 +2316,6 @@ CtPtr ProtocolV2::handle_reconnect(ceph::bufferlist &payload)
     ldout(cct, 1) << __func__
                   << " existing racing replace happened while replacing."
                   << " existing=" << existing << dendl;
-    // make sure we notice if existing connection is no longer functioning
-    existing->send_keepalive();
     auto retry = RetryGlobalFrame::Encode(session_stream_handlers,
                                           exproto->peer_global_seq);
     return WRITE(retry, "session retry", read_frame);
@@ -2425,8 +2423,6 @@ CtPtr ProtocolV2::handle_existing_connection(AsyncConnectionRef existing) {
     ldout(cct, 1) << __func__
                   << " existing racing replace happened while replacing."
                   << " existing=" << existing << dendl;
-    // make sure we notice if existing connection is no longer functioning
-    existing->send_keepalive();
     auto wait = WaitFrame::Encode(session_stream_handlers);
     return WRITE(wait, "wait", read_frame);
   }


### PR DESCRIPTION
This reverts commit 61b9432ef9a3847eceb96f8d5a854567c49bbf61.

If we are in the middle of replacing, we can not queue any further
write events into the old center because we may end up replacing
existing connection's center with a new one, and hence executing
the newly queued write events in the old thread.

See **transfer_existing** for a detailed description.

Also the patch does not make a lot of sense for the original issue
it tried to resolve, because **send_keepalive** is a pure noop if the
underlying connection is not ready, which is obviously true for the
case demonstrated in http://tracker.ceph.com/issues/38493..

Fixes: http://tracker.ceph.com/issues/38569
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

