### PR TITLE
mgr/orchestrator: device lights

### DIFF
--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -182,10 +182,19 @@ Example::
     ^^^^^^^^^^^^^^^^^^^
     ::
 
-        ceph orchestrator device ident-on <host> <devname>
-        ceph orchestrator device ident-off <host> <devname>
-        ceph orchestrator device fault-on <host> <devname>
-        ceph orchestrator device fault-off <host> <devname>
+        ceph orchestrator device ident-on <dev_id>
+        ceph orchestrator device ident-on <dev_name> <host>
+        ceph orchestrator device fault-on <dev_id>
+        ceph orchestrator device fault-on <dev_name> <host>
+
+        ceph orchestrator device ident-off <dev_id> [--force=true]
+        ceph orchestrator device ident-off <dev_id> <host> [--force=true]
+        ceph orchestrator device fault-off <dev_id> [--force=true]
+        ceph orchestrator device fault-off <dev_id> <host> [--force=true]
+
+    where ``dev_id`` is the device id as listed in ``osd metadata``,
+    ``dev_name`` is the name of the device on the system and ``host`` is the host as
+    returned by ``orchestrator host ls``
 
         ceph orchestrator osd ident-on {primary,journal,db,wal,all} <osd-id>
         ceph orchestrator osd ident-off {primary,journal,db,wal,all} <osd-id>

--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -260,6 +260,9 @@ OSD management
 
 .. py:currentmodule:: orchestrator
 
+.. automethod:: Orchestrator.blink_device_light
+.. autoclass:: DeviceLightLoc
+
 .. _orchestrator-osd-replace:
 
 OSD Replacement

--- a/qa/suites/rados/mgr/tasks/orchestrator_cli.yaml
+++ b/qa/suites/rados/mgr/tasks/orchestrator_cli.yaml
@@ -8,8 +8,8 @@ tasks:
       log-whitelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
-        - \(MGR_INSIGHTS_WARNING\)
-        - \(insights_health_check
+        - \(DEVICE_IDENT_ON\)
+        - \(DEVICE_FAULT_ON\)
         - \(PG_
         - replacing it with standby
         - No standby daemons available

--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -14,8 +14,11 @@ log = logging.getLogger(__name__)
 class TestOrchestratorCli(MgrTestCase):
     MGRS_REQUIRED = 1
 
+    def _cmd(self, module, *args):
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd(module, *args)
+
     def _orch_cmd(self, *args):
-        return self.mgr_cluster.mon_manager.raw_cluster_cmd("orchestrator", *args)
+        return self._cmd("orchestrator", *args)
 
     def _progress_cmd(self, *args):
         return self.mgr_cluster.mon_manager.raw_cluster_cmd("progress", *args)
@@ -92,6 +95,21 @@ class TestOrchestratorCli(MgrTestCase):
 
         with self.assertRaises(CommandFailedError):
             self._orch_cmd("osd", "create", "notfound:device")
+
+    def test_blink_device_light(self):
+        def _ls_lights(what):
+            return json.loads(self._cmd("device", "ls-lights"))[what]
+
+        metadata = json.loads(self._cmd("osd", "metadata"))
+        dev_name_ids = [osd["device_ids"] for osd in metadata]
+        _, dev_id = [d.split('=') for d in dev_name_ids if len(d.split('=')) == 2][0]
+
+        for t in ["ident", "fault"]:
+            self.assertNotIn(dev_id, _ls_lights(t))
+            self._cmd("device", t + "-light-on", dev_id)
+            self.assertIn(dev_id, _ls_lights(t))
+            self._cmd("device", t + "-light-off", dev_id)
+            self.assertNotIn(dev_id, _ls_lights(t))
 
     def test_mds_add(self):
         self._orch_cmd("mds", "add", "service_name")

--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -108,8 +108,17 @@ class TestOrchestratorCli(MgrTestCase):
             self.assertNotIn(dev_id, _ls_lights(t))
             self._cmd("device", t + "-light-on", dev_id)
             self.assertIn(dev_id, _ls_lights(t))
+
+            health = {
+                'ident': 'DEVICE_IDENT_ON',
+                'fault': 'DEVICE_FAULT_ON',
+            }[t]
+            self.wait_for_health(health, 30)
+
             self._cmd("device", t + "-light-off", dev_id)
             self.assertNotIn(dev_id, _ls_lights(t))
+
+        self.wait_for_health_clear(30)
 
     def test_mds_add(self):
         self._orch_cmd("mds", "add", "service_name")

--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -106,7 +106,7 @@ class TestOrchestratorCli(MgrTestCase):
 
         for t in ["ident", "fault"]:
             self.assertNotIn(dev_id, _ls_lights(t))
-            self._cmd("device", t + "-light-on", dev_id)
+            self._cmd("device", "light", "on", dev_id, t)
             self.assertIn(dev_id, _ls_lights(t))
 
             health = {
@@ -115,7 +115,7 @@ class TestOrchestratorCli(MgrTestCase):
             }[t]
             self.wait_for_health(health, 30)
 
-            self._cmd("device", t + "-light-off", dev_id)
+            self._cmd("device", "light", "off", dev_id, t)
             self.assertNotIn(dev_id, _ls_lights(t))
 
         self.wait_for_health_clear(30)

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -6,14 +6,13 @@ Please see the ceph-mgr module developer's guide for more information.
 """
 import sys
 import time
-import fnmatch
+from collections import namedtuple
 from functools import wraps
 import uuid
 import string
 import random
 import datetime
-
-import six
+import copy
 
 from mgr_module import MgrModule, PersistentStoreDict
 from mgr_util import format_bytes

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -4,7 +4,6 @@ ceph-mgr orchestrator interface
 
 Please see the ceph-mgr module developer's guide for more information.
 """
-import copy
 import sys
 import time
 import fnmatch
@@ -446,6 +445,17 @@ class Orchestrator(object):
 
         Note that this can only remove OSDs that were successfully
         created (i.e. got an OSD ID).
+        """
+        raise NotImplementedError()
+
+    def blink_device_light(self, ident_fault, on, locations):
+        # type: (str, bool, List[DeviceLightLoc]) -> WriteCompletion
+        """
+        Instructs the orchestrator to enable or disable either the ident or the fault LED.
+
+        :param ident_fault: either ``"ident"`` or ``"fault"``
+        :param on: ``True`` = on.
+        :param locations: See :class:`orchestrator.DeviceLightLoc`
         """
         raise NotImplementedError()
 
@@ -942,6 +952,19 @@ class InventoryNode(object):
     def from_nested_items(cls, hosts):
         devs = InventoryDevice.from_ceph_volume_inventory_list
         return [cls(item[0], devs(item[1].data)) for item in hosts]
+
+
+class DeviceLightLoc(namedtuple('DeviceLightLoc', ['host', 'dev'])):
+    """
+    Describes a specific device on a specific host. Used for enabling or disabling LEDs
+    on devices.
+
+    hostname as in :func:`orchestrator.Orchestrator.get_hosts`
+
+    device_id: e.g. ``ABC1234DEF567-1R1234_ABC8DE0Q``.
+       See ``ceph osd metadata | jq '.[].device_ids'``
+    """
+    __slots__ = ()
 
 
 def _mk_orch_methods(cls):

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -46,6 +46,121 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         {'name': 'orchestrator'}
     ]
 
+    def __init__(self, *args, **kwargs):
+        super(OrchestratorCli, self).__init__(*args, **kwargs)
+        self.ident = set([])
+        self.fault = set([])
+        self.devs = {}
+        self._load()
+        self._refresh_health()
+
+    def _load(self):
+        active = self.get_store('active_devices')
+        if active:
+            decoded = json.loads(active)
+            self.ident = set(decoded.get('ident', []))
+            self.fault = set(decoded.get('fault', []))
+        self.log.debug('ident %s, fault %s' % (self.ident, self.fault))
+
+    def _save(self):
+        encoded = json.dumps({
+            'ident': list(self.ident),
+            'fault': list(self.fault),
+            })
+        self.set_store('active_devices', encoded)
+
+    def _refresh_health(self):
+        h = {}
+        if self.ident:
+            h['DEVICE_IDENT_ON'] = {
+                'severity': 'warning',
+                'summary': '%d devices have ident light turned on' % len(
+                    self.ident),
+                'detail': ['%s ident light enabled' % d for d in self.ident]
+            }
+        if self.fault:
+            h['DEVICE_FAULT_ON'] = {
+                'severity': 'warning',
+                'summary': '%d devices have fault light turned on' % len(
+                    self.fault),
+                'detail': ['%s fault light enabled' % d for d in self.fault]
+            }
+        self.set_health_checks(h)
+
+    def _get_devices(self):
+        d = self.get('devices')
+        dm = {}
+        for i in d['devices']:
+            dm[i['devid']] = i['location']
+        return dm
+
+    @CLIReadCommand(prefix='device ls-lights',
+                    desc='List currently active device indicator lights')
+    def _command_ls(self):
+        return HandleCommandResult(
+            stdout=json.dumps({
+                'ident': list(self.ident),
+                'fault': list(self.fault)
+                }, indent=4))
+
+    @CLIWriteCommand(prefix='device fault-light-on',
+                     args='name=devid,type=CephString',
+                     desc='Enable device *fault* light')
+    def _command_fault_on(self, devid):
+        self.log.debug('fault-on %s' % devid)
+        devs = self._get_devices()
+        if devid not in devs:
+            return HandleCommandResult(stderr='device %s not found' % devid,
+                                       retval=-errno.ENOENT)
+        self.fault.add(devid)
+        self._save()
+        self._refresh_health()
+        #self.remote('orchestrator', '_device_fault_on', devs[devid])
+        return HandleCommandResult(stdout='')
+
+    @CLIWriteCommand(prefix='device ident-light-on',
+                     args='name=devid,type=CephString',
+                     desc='Enable device *ident* light')
+    def _command_ident_on(self, devid):
+        self.log.debug('ident-on %s' % devid)
+        devs = self._get_devices()
+        if devid not in devs:
+            return HandleCommandResult(stderr='device %s not found' % devid,
+                                       retval=-errno.ENOENT)
+        self.ident.add(devid)
+        self._save()
+        self._refresh_health()
+        #self.remote('orchestrator', '_device_ident_on', devs[devid])
+        return HandleCommandResult(stdout='')
+
+    @CLIWriteCommand(prefix='device fault-light-off',
+                     args='name=devid,type=CephString name=force,type=CephBool,req=false',
+                     desc='Disable device *fault* light')
+    def _command_fault_off(self, devid, force=False):
+        self.log.debug('fault-off %s' % devid)
+        devs = self._get_devices()
+#        if devid in devs:
+#            self.remote('orchestrator', '_device_fault_off', devs[devid])
+        if devid in self.fault:
+            self.fault.remove(devid)
+            self._save()
+            self._refresh_health()
+        return HandleCommandResult(stdout='')
+
+    @CLIWriteCommand(prefix='device ident-light-off',
+                     args='name=devid,type=CephString name=force,type=CephBool,req=false',
+                     desc='Disable device *ident* light')
+    def _command_ident_off(self, devid, force=False):
+        self.log.debug('ident-off %s' % devid)
+        devs = self._get_devices()
+#        if devid in devs:
+#            self.remote('orchestrator', '_device_ident_off', devs[devid])
+        if devid in self.ident:
+            self.ident.remove(devid)
+            self._save()
+            self._refresh_health()
+        return HandleCommandResult(stdout='')
+
     def _select_orchestrator(self):
         return self.get_module_option("orchestrator")
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -246,6 +246,12 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def remove_osds(self, osd_ids, destroy=False):
         assert isinstance(osd_ids, list)
 
+    @deferred_write("blink_device_light")
+    def blink_device_light(self, ident_fault, on, locations):
+        assert ident_fault in ("ident", "fault")
+        assert len(locations)
+        return ''
+
     @deferred_write("service_action")
     def service_action(self, action, service_type, service_name=None, service_id=None):
         pass


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/39091
based on #26684

Add generic CLI commands to turn device lights on and off.

These will call out to the orchestrator, once it has the appropriate hook
implemented, which will in turn call out to salt or rook or ssh or whatever
to actually turn a light on or off.

Possible improvements:

* Provide a way to enable lights per OSD. aka
  `ceph osd {ident,fault}-off {primary,journal,db,wal,all} osd.124`
* Make is possible to enable lights on devices unknown to ceph. Remove `self.get('devices')`

But these improvements don't have any effect on the orchestrator interface method.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

