### PR TITLE
qa/standalone: make sure an osd is running before create_rbd_pool

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -496,13 +496,17 @@ function test_run_mon() {
 
     setup $dir || return 1
 
-    run_mon $dir a --mon-initial-members=a || return 1
+    run_mon $dir a --mon-initial-members=a --osd_pool_default_size=1 || return 1
+    run_osd $dir 0 || return 1
     create_rbd_pool || return 1
-    # rbd has not been deleted / created, hence it has pool id 0
+    # rbd has not been deleted / created, hence it has pool id 1
     ceph osd dump | grep "pool 1 'rbd'" || return 1
     kill_daemons $dir || return 1
 
-    run_mon $dir a || return 1
+    run_mon $dir a --osd_pool_default_size=3 || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
     create_rbd_pool || return 1
     # rbd has been deleted / created, hence it does not have pool id 0
     ! ceph osd dump | grep "pool 1 'rbd'" || return 1
@@ -1550,6 +1554,7 @@ function test_wait_for_clean() {
 
     setup $dir || return 1
     run_mon $dir a --osd_pool_default_size=1 || return 1
+    run_osd $dir 0 || return 1
     run_mgr $dir x || return 1
     create_rbd_pool || return 1
     ! WAIT_FOR_CLEAN_TIMEOUT=1 wait_for_clean || return 1

--- a/qa/standalone/erasure-code/test-erasure-eio.sh
+++ b/qa/standalone/erasure-code/test-erasure-eio.sh
@@ -33,7 +33,6 @@ function run() {
         setup $dir || return 1
         run_mon $dir a || return 1
 	run_mgr $dir x || return 1
-	create_rbd_pool || return 1
 
         # check that erasure code plugins are preloaded
         CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1

--- a/qa/standalone/mon/misc.sh
+++ b/qa/standalone/mon/misc.sh
@@ -39,7 +39,6 @@ function TEST_osd_pool_get_set() {
 
     setup $dir || return 1
     run_mon $dir a || return 1
-    create_rbd_pool || return 1
     create_pool $TEST_POOL 8
 
     local flag

--- a/qa/standalone/mon/osd-crush.sh
+++ b/qa/standalone/mon/osd-crush.sh
@@ -220,7 +220,7 @@ function TEST_crush_ls_node() {
 
 function TEST_crush_reject_empty() {
     local dir=$1
-    run_mon $dir a || return 1
+    run_mon $dir a --osd_pool_default_size=1 || return 1
     # should have at least one OSD
     run_osd $dir 0 || return 1
     create_rbd_pool || return 1

--- a/qa/standalone/osd/osd-force-create-pg.sh
+++ b/qa/standalone/osd/osd-force-create-pg.sh
@@ -26,7 +26,7 @@ function TEST_reuse_id() {
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
 
-    ceph osd pool create foo 2 || return 1
+    ceph osd pool create foo 50 || return 1
     wait_for_clean || return 1
 
     kill_daemons $dir TERM osd.0

--- a/qa/standalone/osd/osd-rep-recov-eio.sh
+++ b/qa/standalone/osd/osd-rep-recov-eio.sh
@@ -27,13 +27,14 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--osd-objectstore=filestore "
+    CEPH_ARGS+="--osd-objectstore=filestore --osd_pool_default_size=1 "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
         setup $dir || return 1
         run_mon $dir a || return 1
 	run_mgr $dir x || return 1
+	run_osd $dir 0 || return 1
 	create_rbd_pool || return 1
 
         $func $dir || return 1


### PR DESCRIPTION
'rbd pool init' now does IO.

Fixes: http://tracker.ceph.com/issues/38585
Signed-off-by: Sage Weil <sage@redhat.com>