### PR TITLE
mgr/orchestrator: Remove `(add|test|remove)_stateful_service_rule`

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -374,37 +374,6 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def add_stateful_service_rule(self, service_type, stateful_service_spec,
-                                  placement_spec):
-        """
-        Stateful service rules serve two purposes:
-         - Optionally delegate device selection to the orchestrator
-         - Enable the orchestrator to auto-assimilate new hardware if it
-           matches the placement spec, without any further calls from ceph-mgr.
-
-        To create a confidence-inspiring UI workflow, use test_stateful_service_rule
-        beforehand to show the user where stateful services will be placed
-        if they proceed.
-        """
-        raise NotImplementedError()
-
-    def test_stateful_service_rule(self, service_type, stateful_service_spec,
-                                   placement_spec):
-        """
-        See add_stateful_service_rule.
-        """
-        raise NotImplementedError()
-
-    def remove_stateful_service_rule(self, service_type, id_):
-        """
-        This will remove the *rule* but not the services that were
-        created as a result.  Those should be converted into statically
-        placed services as if they had been created with add_stateful_service,
-        so that they can be removed with remove_stateless_service
-        if desired.
-        """
-        raise NotImplementedError()
-
 
 class UpgradeSpec(object):
     # Request to orchestrator to initiate an upgrade to a particular


### PR DESCRIPTION
Reasons are:

1. No orchestrator implements this interface
2. The distinction between DriveGroups end `stateful_service_rule` is not clear
3. Has not been discussed in #21046 nor https://github.com/jcsp/ceph/pull/6 nor #23412
4. It is not documented.

This is supposed to be some form of persistent drive group. I'm not sure, if we should aim for this at this point. 

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
