### PR TITLE
mon: bulk set/unset of osd flags

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1526,6 +1526,19 @@ function test_mon_osd()
   done
   [[ $flags_found -eq 0 ]]
 
+  # this is a rather unlikely scenario, but lets try checking whether it
+  # still works when someone doesn't have the required flags in their map
+  # (e.g., from an upgrade or botched osd), and we need to fail setting
+  # pglog_hardlimit.
+  ceph config set mon mon_debug_osd_force_is_sure true
+  expect_false ceph osd set pglog_hardlimit
+  expect_false ceph osd set pglog_hardlimit noout
+  ceph osd set pglog_hardlimit --yes-i-really-mean-it
+  ceph osd set pglog_hardlimit noout --yes-i-really-mean-it
+  ceph osd unset noout
+  expect_false ceph osd unset pglog_hardlimit
+  ceph config set mon mon_debug_osd_force_is_sure false
+
   # these are no-ops but should succeed.
 
   ceph osd set noup

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1495,6 +1495,37 @@ function test_mon_osd()
   expect_false ceph osd require-osd-release nautilus
   expect_false ceph osd require-osd-release mimic
   expect_false ceph osd require-osd-release luminous
+
+  # test bulk set/unset
+  ceph osd set noin noout nodown
+  # check flags were set
+  flags_found=0
+  for f in $(ceph osd dump --format=json | jq -cM '.flags_set[]' | \
+			 sed -ne 's/"//gp')
+  do
+	if [[ "$f" == "noin" ]] || \
+	   [[ "$f" == "noout" ]] || \
+	   [[ "$f" == "nodown" ]]; then
+		  flags_found=$((flags_found + 1))
+	fi
+  done
+  [[ $flags_found -eq 3 ]]
+
+  ceph osd unset noin noout nodown
+  # check flags were unset
+  flags_found=0
+  for f in $(ceph osd dump --format=json | jq -cM '.flags_set[]' | \
+			 sed -ne 's/"//gp')
+  do
+	if [[ "$f" == "noin" ]] || \
+	   [[ "$f" == "noout" ]] || \
+	   [[ "$f" == "nodown" ]]; then
+	  flags_found=1
+	  break
+	fi
+  done
+  [[ $flags_found -eq 0 ]]
+
   # these are no-ops but should succeed.
 
   ceph osd set noup

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1958,6 +1958,13 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_CLUSTER_CREATE)
     .set_description("do not set any monmap features for new mon clusters"),
 
+    Option("mon_debug_osd_force_is_sure", Option::TYPE_BOOL,
+	   Option::LEVEL_DEV)
+    .set_default(false)
+    .add_service("mon")
+    .set_description("force `is_sure` arguments even "
+		     "if otherwise not needed"),
+
     Option("mon_inject_transaction_delay_max", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(10.0)
     .add_service("mon")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -799,13 +799,13 @@ COMMAND("osd erasure-code-profile ls", \
 COMMAND("osd set " \
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|" \
 	"noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|" \
-	"notieragent|nosnaptrim|pglog_hardlimit " \
+	"notieragent|nosnaptrim|pglog_hardlimit,n=N,req=true " \
         "name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"set <key>", "osd", "rw")
 COMMAND("osd unset " \
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|"\
 	"noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|" \
-	"notieragent|nosnaptrim", \
+	"notieragent|nosnaptrim,n=N,req=true", \
 	"unset <key>", "osd", "rw")
 COMMAND("osd require-osd-release "\
 	"name=release,type=CephChoices,strings=luminous|mimic|nautilus|octopus " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7364,7 +7364,9 @@ int OSDMonitor::_handle_special_flag(
       return -EINVAL;
     }
 
-    if (!osdmap.get_num_up_osds() && !is_sure) {
+    bool needs_is_sure = g_conf().get_val<bool>(
+	"mon_debug_osd_force_is_sure");
+    if ((needs_is_sure || !osdmap.get_num_up_osds()) && !is_sure) {
       ss << "Not advisable to continue since no OSDs are up. Pass "
 	 << "--yes-i-really-mean-it if you really wish to continue.";
       return -EPERM;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -546,8 +546,23 @@ private:
     epoch_t epoch,
     MonitorDBStore::TransactionRef t);
 
-  bool prepare_set_flag(MonOpRequestRef op, int flag);
-  bool prepare_unset_flag(MonOpRequestRef op, int flag);
+  bool _do_set_unset_flags(MonOpRequestRef op,
+			   uint64_t flags,
+			   bool is_set);
+
+  bool prepare_set_flag(MonOpRequestRef op, uint64_t flags);
+  bool prepare_unset_flag(MonOpRequestRef op, uint64_t flags);
+
+  int _handle_special_flag(string name,
+			   uint64_t flag,
+			   bool is_set,
+			   bool sure,
+			   stringstream &ss);
+  int prepare_set_unset_flags(MonOpRequestRef op,
+			      vector<string> flags,
+			      bool is_set,
+			      bool sure,
+			      stringstream &ss);
 
   void _pool_op_reply(MonOpRequestRef op,
                       int ret, epoch_t epoch, bufferlist *blp=NULL);


### PR DESCRIPTION
We'll now allow bulk setting and unsetting of osdmap flags.
This PR depends on (the now merged) PR #26444 and supersedes PR #22749

Fixes: http://tracker.ceph.com/issues/22147

Signed-off-by: Joao Eduardo Luis \<joao@suse.de>