### PR TITLE
doc/rbd/iscsi-target-cli: Update auth command

### DIFF
--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -218,7 +218,7 @@ to create a iSCSI target and export a RBD image as LUN 0.
 
    ::
 
-       > /iscsi-target...at:rh7-client>  auth chap=myiscsiusername/myiscsipassword
+       > /iscsi-target...at:rh7-client>  auth username=myiscsiusername password=myiscsipassword
 
    .. warning::
       CHAP must always be configured. Without CHAP, the target will


### PR DESCRIPTION
`auth` command is now using separate parameters for username and password (instead of a single `chap` parameter)