### PR TITLE
mgr/dashboard: iSCSI - Support iSCSI passwords with '/'

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -73,16 +73,10 @@ class Iscsi(BaseController):
 
     def _get_discoveryauth(self):
         config = IscsiClient.instance().get_config()
-        user = ''
-        password = ''
-        chap = config['discovery_auth']['chap']
-        if chap:
-            user, password = chap.split('/')
-        mutual_user = ''
-        mutual_password = ''
-        chap_mutual = config['discovery_auth']['chap_mutual']
-        if chap_mutual:
-            mutual_user, mutual_password = chap_mutual.split('/')
+        user = config['discovery_auth']['username']
+        password = config['discovery_auth']['password']
+        mutual_user = config['discovery_auth']['mutual_username']
+        mutual_password = config['discovery_auth']['mutual_password']
         return {
             'user': user,
             'password': password,
@@ -425,12 +419,10 @@ class IscsiTarget(RESTController):
                             target_iqn, client_iqn, image_id)
                     user = client['auth']['user']
                     password = client['auth']['password']
-                    chap = '{}/{}'.format(user, password) if user and password else ''
                     m_user = client['auth']['mutual_user']
                     m_password = client['auth']['mutual_password']
-                    m_chap = '{}/{}'.format(m_user, m_password) if m_user and m_password else ''
                     IscsiClient.instance(gateway_name=gateway_name).create_client_auth(
-                        target_iqn, client_iqn, chap, m_chap)
+                        target_iqn, client_iqn, user, password, m_user, m_password)
                 TaskManager.current_task().inc_progress(task_progress_inc)
             for group in groups:
                 group_id = group['group_id']
@@ -490,14 +482,10 @@ class IscsiTarget(RESTController):
                     'image': image
                 }
                 luns.append(lun)
-            user = None
-            password = None
-            if '/' in client_config['auth']['chap']:
-                user, password = client_config['auth']['chap'].split('/', 1)
-            mutual_user = None
-            mutual_password = None
-            if '/' in client_config['auth']['chap_mutual']:
-                mutual_user, mutual_password = client_config['auth']['chap_mutual'].split('/', 1)
+            user = client_config['auth']['username']
+            password = client_config['auth']['password']
+            mutual_user = client_config['auth']['mutual_username']
+            mutual_password = client_config['auth']['mutual_password']
             client = {
                 'client_iqn': client_iqn,
                 'luns': luns,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
@@ -62,7 +62,7 @@
             <span class="help-block"
                   *ngIf="discoveryForm.showError('password', formDir, 'pattern')"
                   i18n>Passwords must have a length of 12 to 16 characters
-              and can only contain letters, '@', '-' or '_'.</span>
+              and can only contain letters, '@', '-', '_' or '/'.</span>
           </div>
         </div>
 
@@ -121,7 +121,7 @@
             <span class="help-block"
                   *ngIf="discoveryForm.showError('mutual_password', formDir, 'pattern')"
                   i18n>Passwords must have a length of 12 to 16 characters and
-              can only contain letters, '@', '-' or '_'.</span>
+              can only contain letters, '@', '-', '_' or '/'.</span>
           </div>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.ts
@@ -19,7 +19,7 @@ export class IscsiTargetDiscoveryModalComponent implements OnInit {
   discoveryForm: CdFormGroup;
 
   USER_REGEX = /[\w\.:@_-]{8,64}/;
-  PASSWORD_REGEX = /[\w@\-_]{12,16}/;
+  PASSWORD_REGEX = /[\w@\-_\/]{12,16}/;
 
   constructor(
     public bsModalRef: BsModalRef,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -290,7 +290,7 @@
                       <span class="help-block"
                             *ngIf="initiator.showError('password', formDir, 'pattern')"
                             i18n>Passwords must have a length of 12 to 16 characters
-                        and can only contain letters, '@', '-' or '_'.</span>
+                        and can only contain letters, '@', '-', '_' or '/'.</span>
                     </div>
                   </div>
 
@@ -350,7 +350,7 @@
                       <span class="help-block"
                             *ngIf="initiator.showError('mutual_password', formDir, 'pattern')"
                             i18n>Passwords must have a length of 12 to 16 characters and
-                        can only contain letters, '@', '-' or '_'.</span>
+                        can only contain letters, '@', '-', '_' or '/'.</span>
                     </div>
                   </div>
                 </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -73,7 +73,7 @@ export class IscsiTargetFormComponent implements OnInit {
 
   IQN_REGEX = /^iqn\.(19|20)\d\d-(0[1-9]|1[0-2])\.\D{2,3}(\.[A-Za-z0-9-]+)+(:[A-Za-z0-9-\.]+)*$/;
   USER_REGEX = /[\w\.:@_-]{8,64}/;
-  PASSWORD_REGEX = /[\w@\-_]{12,16}/;
+  PASSWORD_REGEX = /[\w@\-_\/]{12,16}/;
 
   constructor(
     private iscsiService: IscsiService,

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -798,9 +798,9 @@
           <context context-type="sourcefile">app/core/auth/user-form/user-form.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
-      </trans-unit><trans-unit id="4b2dd8635fba00476da25977e0884969821e62da" datatype="html">
+      </trans-unit><trans-unit id="fdfee5d7a27e1bdd97a176097277bee078de6aaf" datatype="html">
         <source>Passwords must have a length of 12 to 16 characters
-                        and can only contain letters, &apos;@&apos;, &apos;-&apos; or &apos;_&apos;.</source>
+                        and can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
           <context context-type="linenumber">292</context>
@@ -825,9 +825,9 @@
           <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
           <context context-type="linenumber">98</context>
         </context-group>
-      </trans-unit><trans-unit id="c58e136a292acf8ebccfa6d777fdff9f392b6ee2" datatype="html">
+      </trans-unit><trans-unit id="8406eb7415ee40e54d9ecb209abb056f06e3d666" datatype="html">
         <source>Passwords must have a length of 12 to 16 characters and
-                        can only contain letters, &apos;@&apos;, &apos;-&apos; or &apos;_&apos;.</source>
+                        can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/iscsi-target-form/iscsi-target-form.component.html</context>
           <context context-type="linenumber">352</context>
@@ -981,16 +981,16 @@
           <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
           <context context-type="linenumber">88</context>
         </context-group>
-      </trans-unit><trans-unit id="fcbd385c9738f3c376e7f0935c9ac1ae6f863476" datatype="html">
+      </trans-unit><trans-unit id="6682d1c00263bee204583a5d589b308b6be88b0f" datatype="html">
         <source>Passwords must have a length of 12 to 16 characters
-              and can only contain letters, &apos;@&apos;, &apos;-&apos; or &apos;_&apos;.</source>
+              and can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
           <context context-type="linenumber">64</context>
         </context-group>
-      </trans-unit><trans-unit id="fd0c0472536d61ac9f5bc62d5f9ed01673cf3603" datatype="html">
+      </trans-unit><trans-unit id="8800276925157c666b103c36ff7fe8ffe11980b4" datatype="html">
         <source>Passwords must have a length of 12 to 16 characters and
-              can only contain letters, &apos;@&apos;, &apos;-&apos; or &apos;_&apos;.</source>
+              can only contain letters, &apos;@&apos;, &apos;-&apos;, &apos;_&apos; or &apos;/&apos;.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html</context>
           <context context-type="linenumber">123</context>

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -149,12 +149,15 @@ class IscsiClient(RestClient):
         })
 
     @RestClient.api_put('/api/clientauth/{target_iqn}/{client_iqn}')
-    def create_client_auth(self, target_iqn, client_iqn, chap, chap_mutual, request=None):
-        logger.debug("iSCSI: Creating client auth: %s/%s/%s/%s",
-                     target_iqn, client_iqn, chap, chap_mutual)
+    def create_client_auth(self, target_iqn, client_iqn, username, password, mutual_username,
+                           mutual_password, request=None):
+        logger.debug("iSCSI: Creating client auth: %s/%s/%s/%s/%s/%s",
+                     target_iqn, client_iqn, username, password, mutual_username, mutual_password)
         return request({
-            'chap': chap,
-            'chap_mutual': chap_mutual
+            'username': username,
+            'password': password,
+            'mutual_username': mutual_username,
+            'mutual_password': mutual_password
         })
 
     @RestClient.api_put('/api/hostgroup/{target_iqn}/{group_name}')
@@ -174,15 +177,11 @@ class IscsiClient(RestClient):
     def update_discoveryauth(self, user, password, mutual_user, mutual_password, request=None):
         logger.debug("iSCSI: Updating discoveryauth: %s/%s/%s/%s", user, password, mutual_user,
                      mutual_password)
-        chap = ''
-        if user and password:
-            chap = '{}/{}'.format(user, password)
-        chap_mutual = ''
-        if mutual_user and mutual_password:
-            chap_mutual = '{}/{}'.format(mutual_user, mutual_password)
         return request({
-            'chap': chap,
-            'chap_mutual': chap_mutual
+            'username': user,
+            'password': password,
+            'mutual_username': mutual_user,
+            'mutual_password': mutual_password
         })
 
     @RestClient.api_put('/api/targetauth/{target_iqn}')

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -64,7 +64,9 @@ class IscsiClient(RestClient):
 
     @RestClient.api_get('/api/config')
     def get_config(self, request=None):
-        return request()
+        return request({
+            'decrypt_passwords': True
+        })
 
     @RestClient.api_put('/api/target/{target_iqn}')
     def create_target(self, target_iqn, target_controls, request=None):

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -443,8 +443,12 @@ class IscsiClientMock(object):
         self.config = {
             "created": "2019/01/17 08:57:16",
             "discovery_auth": {
-                "chap": "",
-                "chap_mutual": ""
+                "username": "",
+                "password": "",
+                "password_encryption_enabled": False,
+                "mutual_username": "",
+                "mutual_password": "",
+                "mutual_password_encryption_enabled": False
             },
             "disks": {},
             "epoch": 0,
@@ -542,8 +546,12 @@ class IscsiClientMock(object):
         target_config = self.config['targets'][target_iqn]
         target_config['clients'][client_iqn] = {
             "auth": {
-                "chap": "",
-                "chap_mutual": ""
+                "username": "",
+                "password": "",
+                "password_encryption_enabled": False,
+                "mutual_username": "",
+                "mutual_password": "",
+                "mutual_password_encryption_enabled": False
             },
             "group_name": "",
             "luns": {}
@@ -553,10 +561,12 @@ class IscsiClientMock(object):
         target_config = self.config['targets'][target_iqn]
         target_config['clients'][client_iqn]['luns'][image_id] = {}
 
-    def create_client_auth(self, target_iqn, client_iqn, chap, chap_mutual):
+    def create_client_auth(self, target_iqn, client_iqn, user, password, m_user, m_password):
         target_config = self.config['targets'][target_iqn]
-        target_config['clients'][client_iqn]['auth']['chap'] = chap
-        target_config['clients'][client_iqn]['auth']['chap_mutual'] = chap_mutual
+        target_config['clients'][client_iqn]['auth']['username'] = user
+        target_config['clients'][client_iqn]['auth']['password'] = password
+        target_config['clients'][client_iqn]['auth']['mutual_username'] = m_user
+        target_config['clients'][client_iqn]['auth']['mutual_password'] = m_password
 
     def create_group(self, target_iqn, group_name, members, image_ids):
         target_config = self.config['targets'][target_iqn]
@@ -597,16 +607,10 @@ class IscsiClientMock(object):
         return {'data': ips[self.gateway_name]}
 
     def update_discoveryauth(self, user, password, mutual_user, mutual_password):
-        chap = ''
-        if user and password:
-            chap = '{}/{}'.format(user, password)
-        chap_mutual = ''
-        if mutual_user and mutual_password:
-            chap_mutual = '{}/{}'.format(mutual_user, mutual_password)
-        self.config['discovery_auth'] = {
-            'chap': chap,
-            'chap_mutual': chap_mutual
-        }
+        self.config['discovery_auth']['username'] = user
+        self.config['discovery_auth']['password'] = password
+        self.config['discovery_auth']['mutual_username'] = mutual_user
+        self.config['discovery_auth']['mutual_password'] = mutual_password
 
     def update_targetauth(self, target_iqn, action):
         self.config['targets'][target_iqn]['acl_enabled'] = (action == 'enable_acl')


### PR DESCRIPTION
This PR adapts ceph dashboard according to  https://github.com/ceph/ceph-iscsi/pull/37

Signed-off-by: Ricardo Marques <rimarques@suse.com>
