### PR TITLE
luminous: qa/rgw: reduce number of multisite log shards

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -7,5 +7,7 @@ overrides:
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
         rgw crypt require ssl: false
         rgw sync log trim interval: 0
+        rgw md log max shards: 4
+        rgw data log num shards: 4
   rgw:
     compression type: random


### PR DESCRIPTION
backport tracker http://tracker.ceph.com/issues/38608