### PR TITLE
common/options: osd_memory_target et al are TYPE_SIZE

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4006,12 +4006,12 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description(""),
 
-    Option("osd_memory_target", Option::TYPE_UINT, Option::LEVEL_BASIC)
+    Option("osd_memory_target", Option::TYPE_SIZE, Option::LEVEL_BASIC)
     .set_default(4_G)
     .add_see_also("bluestore_cache_autotune")
     .set_description("When tcmalloc and cache autotuning is enabled, try to keep this many bytes mapped in memory."),
 
-    Option("osd_memory_base", Option::TYPE_UINT, Option::LEVEL_DEV)
+    Option("osd_memory_base", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(768_M)
     .add_see_also("bluestore_cache_autotune")
     .set_description("When tcmalloc and cache autotuning is enabled, estimate the minimum amount of memory in bytes the OSD will need."),
@@ -4022,7 +4022,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("bluestore_cache_autotune")
     .set_description("When tcmalloc and cache autotuning is enabled, estimate the percent of memory fragmentation."),
 
-    Option("osd_memory_cache_min", Option::TYPE_UINT, Option::LEVEL_DEV)
+    Option("osd_memory_cache_min", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(128_M)
     .add_see_also("bluestore_cache_autotune")
     .set_description("When tcmalloc and cache autotuning is enabled, set the minimum amount of memory used for caches."),

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4127,11 +4127,11 @@ int BlueStore::_set_cache_sizes()
   cache_autotune = cct->_conf.get_val<bool>("bluestore_cache_autotune");
   cache_autotune_interval =
       cct->_conf.get_val<double>("bluestore_cache_autotune_interval");
-  osd_memory_target = cct->_conf.get_val<uint64_t>("osd_memory_target");
-  osd_memory_base = cct->_conf.get_val<uint64_t>("osd_memory_base");
+  osd_memory_target = cct->_conf.get_val<Option::size_t>("osd_memory_target");
+  osd_memory_base = cct->_conf.get_val<Option::size_t>("osd_memory_base");
   osd_memory_expected_fragmentation =
       cct->_conf.get_val<double>("osd_memory_expected_fragmentation");
-  osd_memory_cache_min = cct->_conf.get_val<uint64_t>("osd_memory_cache_min");
+  osd_memory_cache_min = cct->_conf.get_val<Option::size_t>("osd_memory_cache_min");
   osd_memory_cache_resize_interval = 
       cct->_conf.get_val<double>("osd_memory_cache_resize_interval");
 


### PR DESCRIPTION
This makes us interpret "2G" and 2 GiB, not 2 billion bytes.

Signed-off-by: Sage Weil <sage@redhat.com>