### PR TITLE
ceph-mon: reset process name to 'ceph-mon' on startup

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -203,6 +203,10 @@ entity_addrvec_t make_mon_addrs(entity_addr_t a)
 
 int main(int argc, const char **argv)
 {
+  // reset our process name, in case we did a respawn, so that it's not
+  // left as "exe".
+  ceph_pthread_setname(pthread_self(), "ceph-mon");
+
   int err;
 
   bool mkfs = false;


### PR DESCRIPTION
After a respawn the process name ends up as 'exe' (because we do execve
on /proc/$pid/exe).  Reset to 'ceph-mon' so that killall works.

Fixes: http://tracker.ceph.com/issues/38604
Signed-off-by: Sage Weil <sage@redhat.com>