### PR TITLE
build: LLVM ld does not like the versioning scheme

### DIFF
--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -15,10 +15,7 @@ fi
 #	-D CMAKE_CXX_COMPILER="/usr/local/bin/clang++-devel" \
 #	-D CMAKE_C_COMPILER="/usr/local/bin/clang-devel" \
 COMPILE_FLAGS="-O0 -g"
-if [ `sysctl -n kern.osreldate` -le 1102000 ]; then
-    # We need to use the llvm linker for linking ceph-dencoder
-    COMPILE_FLAGS="$COMPILE_FLAGS -fuse-ld=/usr/bin/ld.lld"
-fi
+COMPILE_FLAGS="${COMPILE_FLAGS} -fuse-ld=/usr/local/bin/ld -Wno-unused-command-line-argument"
 CMAKE_CXX_FLAGS_DEBUG="$CXX_FLAGS_DEBUG $COMPILE_FLAGS"
 CMAKE_C_FLAGS_DEBUG="$C_FLAGS_DEBUG $COMPILE_FLAGS"
 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -201,6 +201,7 @@ EOF
 if [ x$(uname)x = xFreeBSDx ]; then
     $SUDO pkg install -yq \
         devel/babeltrace \
+        devel/binutils \
         devel/git \
         devel/gperf \
         devel/gmake \


### PR DESCRIPTION
There is a few essentail differences between the way versioning
and a version-map is interpreted for binutils ld and LLVM ld.
The easy way out for the time being is to use the one that works.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug