### PR TITLE
qa/suites/upgrade/mimic-x/parallel: run master rados/test.sh

### DIFF
--- a/qa/suites/upgrade/mimic-x/parallel/5-final-workload/rados_mon_thrash.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/5-final-workload/rados_mon_thrash.yaml
@@ -12,7 +12,6 @@ tasks:
       thrash_delay: 1
   - print: "**** done mon_thrash 4-final-workload"
   - workunit:
-      branch: mimic
       clients:
         client.1:
           - rados/test.sh


### PR DESCRIPTION
We rename ceph_test_rados_api_tier to add _pp, so the mimic version doesn't
work.  And in any case, at this stage the client host has master installed.

Signed-off-by: Sage Weil <sage@redhat.com>