### PR TITLE
mimic: common/str_map: fix trim() on empty string

### DIFF
--- a/src/common/str_map.cc
+++ b/src/common/str_map.cc
@@ -57,6 +57,9 @@ int get_json_str_map(
   return 0;
 }
 string trim(const string& str) {
+  if (str.empty()) {
+    return str;
+  }
   size_t start = 0;
   size_t end = str.size() - 1;
   while (start <= end && isspace(str[start]) != 0) {

--- a/src/common/str_map.cc
+++ b/src/common/str_map.cc
@@ -17,6 +17,8 @@
 #include "include/str_map.h"
 #include "include/str_list.h"
 
+#include <boost/algorithm/string.hpp>
+
 #include "json_spirit/json_spirit.h"
 
 using namespace std;
@@ -56,22 +58,13 @@ int get_json_str_map(
   }
   return 0;
 }
+
 string trim(const string& str) {
-  if (str.empty()) {
-    return str;
-  }
-  size_t start = 0;
-  size_t end = str.size() - 1;
-  while (start <= end && isspace(str[start]) != 0) {
-    ++start;
-  }
-  while (start <= end && isspace(str[end]) != 0) {
-    --end;
-  }
-  if (start <= end) {
-    return str.substr(start, end - start + 1);
-  }
-  return string();
+  return boost::algorithm::trim_copy_if(
+    str,
+    [](unsigned char c) {
+      return std::isspace(c);
+    });
 }
 
 int get_str_map(

--- a/src/test/common/test_str_map.cc
+++ b/src/test/common/test_str_map.cc
@@ -66,6 +66,18 @@ TEST(str_map, plaintext) {
   }
 }
 
+TEST(str_map, empty_values) {
+  {
+    map<string,string> str_map;
+    ASSERT_EQ(0, get_str_map("M= P= L=",
+			     &str_map));
+    ASSERT_EQ(3u, str_map.size());
+    ASSERT_EQ("", str_map["M"]);
+    ASSERT_EQ("", str_map["P"]);
+    ASSERT_EQ("", str_map["L"]);
+  }
+}
+
 /* 
  * Local Variables:
  * compile-command: "cd ../.. ; make -j4 && 


### PR DESCRIPTION
https://tracker.ceph.com/issues/38587