### PR TITLE
mimic: run-standalone.sh: Need double-quotes to handle | in core_pattern on all distributions

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -83,11 +83,6 @@ count=0
 errors=0
 userargs=""
 precore="$(sysctl -n $KERNCORE)"
-
-if [[ "${precore:0:1}" = "|" ]]; then
-  precore="${precore:1}"
-fi
-
 # If corepattern already set, avoid having to use sudo
 if [ "$precore" = "$COREPATTERN" ]; then
     precore=""

--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -46,7 +46,7 @@ fi
 
 function cleanup() {
     if [ -n "$precore" ]; then
-        sudo sysctl -w ${KERNCORE}=${precore}
+        sudo sysctl -w "${KERNCORE}=${precore}"
     fi
 }
 
@@ -87,7 +87,7 @@ precore="$(sysctl -n $KERNCORE)"
 if [ "$precore" = "$COREPATTERN" ]; then
     precore=""
 else
-    sudo sysctl -w ${KERNCORE}=${COREPATTERN}
+    sudo sysctl -w "${KERNCORE}=${COREPATTERN}"
 fi
 # Clean out any cores in core target directory (currently .)
 if ls $(dirname $(sysctl -n $KERNCORE)) | grep -q '^core\|core$' ; then


### PR DESCRIPTION
https://tracker.ceph.com/issues/38565