### PR TITLE
mds: qa/cephfs: relax min_caps_per_client check

### DIFF
--- a/qa/tasks/cephfs/test_client_limits.py
+++ b/qa/tasks/cephfs/test_client_limits.py
@@ -86,9 +86,7 @@ class TestClientLimits(CephFSTestCase):
         # which depend on the caps outstanding, cache size and overall ratio
         def expected_caps():
             num_caps = self.get_session(mount_a_client_id)['num_caps']
-            if num_caps < mds_min_caps_per_client:
-                raise RuntimeError("client caps fell below min!")
-            elif num_caps == mds_min_caps_per_client:
+            if num_caps <= mds_min_caps_per_client:
                 return True
             elif num_caps < cache_size:
                 return True
@@ -253,9 +251,7 @@ class TestClientLimits(CephFSTestCase):
         mount_a_client_id = self.mount_a.get_global_id()
         def expected_caps():
             num_caps = self.get_session(mount_a_client_id)['num_caps']
-            if num_caps < mds_min_caps_per_client:
-                raise RuntimeError("client caps fell below min!")
-            elif num_caps <= mds_max_caps_per_client:
+            if num_caps <= mds_max_caps_per_client:
                 return True
             else:
                 return False


### PR DESCRIPTION
new kernel client proactively release caps. caps count can go below
mds_min_caps_per_client

Fixes: http://tracker.ceph.com/issues/38270
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

