### PR TITLE
mgr: disable orderly shutdown

### DIFF
--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -22,7 +22,8 @@ overrides:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]
       mds: [--tool=memcheck]
-      mgr: [--tool=memcheck]
+# see https://tracker.ceph.com/issues/38621
+#      mgr: [--tool=memcheck]
   ceph-fuse:
     client.0:
       valgrind: [--tool=memcheck, --leak-check=full, --show-reachable=yes]

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -21,4 +21,5 @@ overrides:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]
       mds: [--tool=memcheck]
-      mgr: [--tool=memcheck]
+# https://tracker.ceph.com/issues/38621
+#      mgr: [--tool=memcheck]

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -16,4 +16,5 @@ overrides:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]
       mds: [--tool=memcheck]
-      mgr: [--tool=memcheck]
+# https://tracker.ceph.com/issues/38621
+#      mgr: [--tool=memcheck]

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -264,7 +264,8 @@ void MgrStandby::handle_signal(int signum)
 {
   ceph_assert(signum == SIGINT || signum == SIGTERM);
   derr << "*** Got signal " << sig_str(signum) << " ***" << dendl;
-  shutdown();
+  _exit(128 + signum);
+  //shutdown();
 }
 
 void MgrStandby::shutdown()


### PR DESCRIPTION
The python subinterpreter teardown is broken.  Just exit on SIGINT/SIGTERM instead
of trying to shut down.