### PR TITLE
ceph-volume: `simple scan` will now scan all running ceph-disk OSDs

### DIFF
--- a/doc/ceph-volume/simple/scan.rst
+++ b/doc/ceph-volume/simple/scan.rst
@@ -9,6 +9,7 @@ PLAIN formats is fully supported.
 
 The command has the ability to inspect a running OSD, by inspecting the
 directory where the OSD data is stored, or by consuming the data partition.
+The command can also scan all running OSDs if no path or device is provided.
 
 Once scanned, information will (by default) persist the metadata as JSON in
 a file in ``/etc/ceph/osd``. This ``JSON`` file will use the naming convention
@@ -30,6 +31,16 @@ the contents to ``stdout`` (no file will be written)::
 
 
 .. _ceph-volume-simple-scan-directory:
+
+Running OSDs scan
+-----------------
+Using this command without providing an OSD directory or device will scan the
+directories of any currently running OSDs. If a running OSD was not created
+by ceph-disk it will be ignored and not scanned.
+
+To scan all running ceph-disk OSDs, the command would look like::
+
+    ceph-volume simple scan
 
 Directory scan
 --------------

--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -280,6 +280,10 @@ directory as well.
 
 Optionally, the JSON blob can be sent to stdout for further inspection.
 
+Usage on all running OSDs::
+
+    ceph-voume simple scan
+
 Usage on data devices::
 
     ceph-volume simple scan <data device>
@@ -295,7 +299,7 @@ Optional arguments:
 * [--stdout]            Send the JSON blob to stdout
 * [--force]             If the JSON file exists at destination, overwrite it
 
-Required Positional arguments:
+Optional Positional arguments:
 
 * <DATA DEVICE or OSD DIR>  Actual data partition or a path to the running OSD
 

--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -7,6 +7,7 @@ import os
 from textwrap import dedent
 from ceph_volume import decorators, terminal, conf
 from ceph_volume.api import lvm
+from ceph_volume.systemd import systemctl
 from ceph_volume.util import arg_validators, system, disk, encryption
 from ceph_volume.util.device import Device
 
@@ -330,25 +331,40 @@ class Scan(object):
             metavar='OSD_PATH',
             type=arg_validators.OSDPath(),
             nargs='?',
+            default=None,
             help='Path to an existing OSD directory or OSD data partition'
         )
 
-        if len(self.argv) == 0:
-            print(sub_command_help)
-            return
-
         args = parser.parse_args(self.argv)
-        device = Device(args.osd_path)
-        if device.is_partition:
-            if device.ceph_disk.type != 'data':
-                label = device.ceph_disk.partlabel
-                msg = 'Device must be the ceph data partition, but PARTLABEL reported: "%s"' % label
-                raise RuntimeError(msg)
+        paths = []
+        if args.osd_path:
+            paths.append(args.osd_path)
+        else:
+            osd_ids = systemctl.get_running_osd_ids()
+            for osd_id in osd_ids:
+                paths.append("/var/lib/ceph/osd/{}-{}".format(
+                    conf.cluster,
+                    osd_id,
+                ))
 
         # Capture some environment status, so that it can be reused all over
         self.device_mounts = system.get_mounts(devices=True)
         self.path_mounts = system.get_mounts(paths=True)
-        self.encryption_metadata = encryption.legacy_encrypted(args.osd_path)
-        self.is_encrypted = self.encryption_metadata['encrypted']
 
-        self.scan(args)
+        for path in paths:
+            args.osd_path = path
+            device = Device(args.osd_path)
+            if device.is_partition:
+                if device.ceph_disk.type != 'data':
+                    label = device.ceph_disk.partlabel
+                    msg = 'Device must be the ceph data partition, but PARTLABEL reported: "%s"' % label
+                    raise RuntimeError(msg)
+
+            self.encryption_metadata = encryption.legacy_encrypted(args.osd_path)
+            self.is_encrypted = self.encryption_metadata['encrypted']
+
+            device = Device(self.encryption_metadata['device'])
+            if not device.is_ceph_disk_member:
+                terminal.warning("Ignoring %s because it's not a ceph-disk created osd." % path)
+            else:
+                self.scan(args)

--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -41,7 +41,7 @@ def parse_keyring(file_contents):
 
 class Scan(object):
 
-    help = 'Capture metadata from an OSD data partition or directory'
+    help = 'Capture metadata from all running ceph-disk OSDs, OSD data partition or directory'
 
     def __init__(self, argv):
         self.argv = argv
@@ -285,7 +285,7 @@ class Scan(object):
 
     def main(self):
         sub_command_help = dedent("""
-        Scan an OSD directory (or data device) for files and configurations
+        Scan running OSDs, an OSD directory (or data device) for files and configurations
         that will allow to take over the management of the OSD.
 
         Scanned OSDs will get their configurations stored in
@@ -300,13 +300,19 @@ class Scan(object):
 
             /etc/ceph/osd/0-a9d50838-e823-43d6-b01f-2f8d0a77afc2.json
 
-        To a scan an existing, running, OSD:
+        To scan all running OSDs:
+
+            ceph-volume simple scan
+
+        To a scan a specific running OSD:
 
             ceph-volume simple scan /var/lib/ceph/osd/{cluster}-{osd id}
 
         And to scan a device (mounted or unmounted) that has OSD data in it, for example /dev/sda1
 
             ceph-volume simple scan /dev/sda1
+
+        Scanning a device or directory that belongs to an OSD not created by ceph-disk will be ingored.
         """)
         parser = argparse.ArgumentParser(
             prog='ceph-volume simple scan',

--- a/src/ceph-volume/ceph_volume/systemd/systemctl.py
+++ b/src/ceph-volume/ceph_volume/systemd/systemctl.py
@@ -34,6 +34,22 @@ def is_active(unit):
     )
     return rc == 0
 
+def get_running_osd_ids():
+    out, err, rc = process.call([
+        'systemctl',
+        'show',
+        '--no-pager',
+        '--property=Id',
+        '--state=running',
+        'ceph-osd@*',
+    ])
+    osd_ids = []
+    for line in out:
+        if line:
+            # example line looks like: Id=ceph-osd@1.service
+            osd_id = line.split("@")[1].split(".service")[0]
+            osd_ids.append(osd_id)
+    return osd_ids
 
 def start_osd(id_):
     return start(osd_unit % id_)

--- a/src/ceph-volume/ceph_volume/systemd/systemctl.py
+++ b/src/ceph-volume/ceph_volume/systemd/systemctl.py
@@ -1,8 +1,11 @@
 """
 Utilities to control systemd units
 """
+import logging
+
 from ceph_volume import process
 
+logger = logging.getLogger(__name__)
 
 def start(unit):
     process.run(['systemctl', 'start', unit])
@@ -44,11 +47,15 @@ def get_running_osd_ids():
         'ceph-osd@*',
     ])
     osd_ids = []
-    for line in out:
-        if line:
-            # example line looks like: Id=ceph-osd@1.service
-            osd_id = line.split("@")[1].split(".service")[0]
-            osd_ids.append(osd_id)
+    if rc == 0:
+        for line in out:
+            if line:
+                # example line looks like: Id=ceph-osd@1.service
+                try:
+                    osd_id = line.split("@")[1].split(".service")[0]
+                    osd_ids.append(osd_id)
+                except (IndexError, TypeError):
+                    logger.warning("Failed to parse output from systemctl: %s", line)
     return osd_ids
 
 def start_osd(id_):

--- a/src/ceph-volume/ceph_volume/tests/devices/simple/test_scan.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/simple/test_scan.py
@@ -3,14 +3,6 @@ import pytest
 from ceph_volume.devices.simple import scan
 
 
-class TestScan(object):
-
-    def test_main_spits_help_with_no_arguments(self, capsys):
-        scan.Scan([]).main()
-        stdout, stderr = capsys.readouterr()
-        assert 'Scan an OSD directory (or data device) for files' in stdout
-
-
 class TestGetContents(object):
 
     def test_multiple_lines_are_left_as_is(self, tmpfile):

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-luks/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-luks/test.yml
@@ -4,31 +4,15 @@
   become: yes
   tasks:
 
-    - name: list all OSD directories
-      find:
-        paths: /var/lib/ceph/osd
-        file_type: directory
-      register: osd_paths
-
-    - name: scan all OSD directories
-      command: "ceph-volume --cluster={{ cluster }} simple scan {{ item.path }}"
+    - name: scan all running OSDs
+      command: "ceph-volume --cluster={{ cluster }} simple scan"
       environment:
         CEPH_VOLUME_DEBUG: 1
-      with_items:
-        - "{{ osd_paths.files }}"
-
-    - name: list all OSD JSON files
-      find:
-        paths: /etc/ceph/osd
-        file_type: file
-      register: osd_configs
 
     - name: activate all scanned OSDs
-      command: "ceph-volume --cluster={{ cluster }} simple activate --file {{ item.path }}"
+      command: "ceph-volume --cluster={{ cluster }} simple activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
-      with_items:
-        - "{{ osd_configs.files }}"
 
 # zap tests
 

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/activate/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/activate/test.yml
@@ -4,31 +4,15 @@
   become: yes
   tasks:
 
-    - name: list all OSD directories
-      find:
-        paths: /var/lib/ceph/osd
-        file_type: directory
-      register: osd_paths
-
-    - name: scan all OSD directories
-      command: "ceph-volume --cluster={{ cluster }} simple scan {{ item.path }}"
+    - name: scan all running OSDs
+      command: "ceph-volume --cluster={{ cluster }} simple scan"
       environment:
         CEPH_VOLUME_DEBUG: 1
-      with_items:
-        - "{{ osd_paths.files }}"
-
-    - name: list all OSD JSON files
-      find:
-        paths: /etc/ceph/osd
-        file_type: file
-      register: osd_configs
 
     - name: activate all scanned OSDs
-      command: "ceph-volume --cluster={{ cluster }} simple activate --file {{ item.path }}"
+      command: "ceph-volume --cluster={{ cluster }} simple activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
-      with_items:
-        - "{{ osd_configs.files }}"
 
 # zap tests
 

--- a/src/ceph-volume/ceph_volume/tests/systemd/test_systemctl.py
+++ b/src/ceph-volume/ceph_volume/tests/systemd/test_systemctl.py
@@ -1,0 +1,9 @@
+from ceph_volume.systemd import systemctl
+
+class TestSystemctl(object):
+
+    def test_get_running_osd_ids(self, stub_call):
+        stdout = ['Id=ceph-osd@1.service', '', 'Id=ceph-osd@2.service']
+        stub_call((stdout, [], 0))
+        osd_ids = systemctl.get_running_osd_ids()
+        assert osd_ids == ['1', '2']

--- a/src/ceph-volume/ceph_volume/tests/systemd/test_systemctl.py
+++ b/src/ceph-volume/ceph_volume/tests/systemd/test_systemctl.py
@@ -1,9 +1,21 @@
+import pytest
 from ceph_volume.systemd import systemctl
 
 class TestSystemctl(object):
 
-    def test_get_running_osd_ids(self, stub_call):
-        stdout = ['Id=ceph-osd@1.service', '', 'Id=ceph-osd@2.service']
+    @pytest.mark.parametrize("stdout,expected", [
+        (['Id=ceph-osd@1.service', '', 'Id=ceph-osd@2.service'], ['1','2']),
+        (['Id=ceph-osd1.service',], []),
+        (['Id=ceph-osd@1'], ['1']),
+        ([], []),
+    ])
+    def test_get_running_osd_ids(self, stub_call, stdout, expected):
         stub_call((stdout, [], 0))
         osd_ids = systemctl.get_running_osd_ids()
-        assert osd_ids == ['1', '2']
+        assert osd_ids == expected
+
+    def test_returns_empty_list_on_nonzero_return_code(self, stub_call):
+        stdout = ['Id=ceph-osd@1.service', '', 'Id=ceph-osd@2.service']
+        stub_call((stdout, [], 1))
+        osd_ids = systemctl.get_running_osd_ids()
+        assert osd_ids == []

--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -4,7 +4,7 @@ envlist = py27, py35, py36, flake8
 [testenv]
 deps=
   pytest
-commands=py.test -v {posargs:ceph_volume/tests}
+commands=py.test -v {posargs:ceph_volume/tests} --ignore=ceph_volume/tests/functional
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
Running ``ceph-volume simple scan`` without any arguments will now look for any running ceph-disk OSDs and scan them. This will be useful when bulk migrating ceph-disk OSDs to ceph-volume.