### PR TITLE
mgr/dashboard: enable coverage for API tests

### DIFF
--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -4,7 +4,7 @@ bcrypt==3.1.4
 cheroot==6.0.0
 CherryPy==13.1.0
 configparser==3.5.0
-coverage==4.4.2
+coverage==4.5.2
 enum34==1.1.6
 funcsigs==1.0.2
 isort==4.2.15


### PR DESCRIPTION
* Fixed: install in system the 'coverage' version set in
  requirements.txt as dashboard/module.py uses system version.
* Updated 'coverage' to latest stable version.
* Added teuthology missing dependency:
  backports.ssl-match-hostname
* More precise coverage measurement through CherryPy Bus API.
  Coverage is saved after each request due to: https://github.com/ceph/ceph/pull/26823
* Coverage report shown when no ceph-mgr running
  (cleanup_teuthology).

Fixes: https://tracker.ceph.com/issues/36176

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

