### PR TITLE
mgr/dashboard: Fix iSCSI mutual password input type

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
@@ -101,7 +101,7 @@
               <input id="mutual_password"
                      class="form-control"
                      formControlName="mutual_password"
-                     type="mutual_password">
+                     type="password">
 
               <span class="input-group-btn">
                 <button type="button"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -330,7 +330,7 @@
                         <input id="mutual_password"
                                class="form-control"
                                formControlName="mutual_password"
-                               type="mutual_password">
+                               type="password">
 
                         <span class="input-group-btn">
                           <button type="button"


### PR DESCRIPTION
ATM, the mutual password is visible by default because the input type is invalid:

![screenshot from 2019-03-08 16-14-51](https://user-images.githubusercontent.com/14297426/54040744-0087c400-41be-11e9-8bf1-c6b0eafe962c.png)


Signed-off-by: Ricardo Marques <rimarques@suse.com>
