### PR TITLE
common,osd: set osd_memory_target based on POD_MEMORY_REQUEST or cgroup limit

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -453,7 +453,8 @@ int md_config_t::parse_config_files(ConfigValues& values,
   return 0;
 }
 
-void md_config_t::parse_env(ConfigValues& values,
+void md_config_t::parse_env(unsigned entity_type,
+			    ConfigValues& values,
 			    const ConfigTracker& tracker,
 			    const char *args_var)
 {

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -475,6 +475,19 @@ void md_config_t::parse_env(unsigned entity_type,
       _set_val(values, tracker, dir, *o, CONF_ENV, &err);
     }
   }
+  const char *pod_req = getenv("POD_MEMORY_REQUEST");
+  if (pod_req) {
+    uint64_t v = atoll(pod_req);
+    if (v) {
+      switch (entity_type) {
+      case CEPH_ENTITY_TYPE_OSD:
+	_set_val(values, tracker, stringify(v),
+		 *find_option("osd_memory_target"),
+		 CONF_ENV, nullptr);
+	break;
+      }
+    }
+  }
   if (getenv(args_var)) {
     vector<const char *> env_args;
     env_to_vec(env_args, args_var);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -129,7 +129,8 @@ public:
 			 std::ostream *warnings, int flags);
 
   // Absorb config settings from the environment
-  void parse_env(ConfigValues& values, const ConfigTracker& tracker,
+  void parse_env(unsigned entity_type,
+		 ConfigValues& values, const ConfigTracker& tracker,
 		 const char *env_var = "CEPH_ARGS");
 
   // Absorb config settings from argv

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -304,9 +304,10 @@ public:
     call_observers(rev_obs);
     return ret;
   }
-  void parse_env(const char *env_var = "CEPH_ARGS") {
+  void parse_env(unsigned entity_type,
+		 const char *env_var = "CEPH_ARGS") {
     std::lock_guard l{lock};
-    config.parse_env(values, obs_mgr, env_var);
+    config.parse_env(entity_type, values, obs_mgr, env_var);
   }
   int parse_argv(std::vector<const char*>& args, int level=CONF_CMDLINE) {
     std::lock_guard l{lock};

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4013,6 +4013,13 @@ std::vector<Option> get_global_options() {
     .add_see_also("bluestore_cache_autotune")
     .set_description("When tcmalloc and cache autotuning is enabled, try to keep this many bytes mapped in memory."),
 
+    Option("osd_memory_target_cgroup_limit_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.8)
+    .set_min_max(0.0, 1.0)
+    .add_see_also("osd_memory_target")
+    .set_description("Set the default value for osd_memory_target to the cgroup memory limit (if set) times this value")
+    .set_long_description("A value of 0 disables this feature."),
+
     Option("osd_memory_base", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(768_M)
     .add_see_also("bluestore_cache_autotune")

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -259,6 +259,11 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
     }
     fclose(f);
   }
+  uint64_t cgroup_limit;
+  if (get_cgroup_memory_limit(&cgroup_limit) == 0 &&
+      cgroup_limit > 0) {
+    (*m)["mem_cgroup_limit"] = boost::lexical_cast<string>(cgroup_limit);
+  }
 
   // processor
   f = fopen(PROCPREFIX "/proc/cpuinfo", "r");

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -135,6 +135,38 @@ static void distro_detect(map<string, string> *m, CephContext *cct)
   }
 }
 
+int get_cgroup_memory_limit(uint64_t *limit)
+{
+  // /sys/fs/cgroup/memory/memory.limit_in_bytes
+
+  // the magic value 9223372036854771712 or 0x7ffffffffffff000
+  // appears to mean no limit.
+  FILE *f = fopen(PROCPREFIX "/sys/fs/cgroup/memory/memory.limit_in_bytes", "r");
+  if (!f) {
+    return -errno;
+  }
+  char buf[100];
+  int ret = 0;
+  long long value;
+  char *line = fgets(buf, sizeof(buf), f);
+  if (!line) {
+    ret = -EINVAL;
+    goto out;
+  }
+  if (sscanf(line, "%lld", &value) != 1) {
+    ret = -EINVAL;
+  }
+  if (value == 0x7ffffffffffff000) {
+    *limit = 0;  // no limit
+  } else {
+    *limit = value;
+  }
+out:
+  fclose(f);
+  return ret;
+}
+
+
 void collect_sys_info(map<string, string> *m, CephContext *cct)
 {
   // version

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -137,7 +137,7 @@ void global_pre_init(
   }
 
   // environment variables override (CEPH_ARGS, CEPH_KEYRING)
-  conf.parse_env();
+  conf.parse_env(cct->get_module_type());
 
   // command line (as passed by caller)
   conf.parse_argv(args);

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -73,6 +73,9 @@ WRITE_CLASS_ENCODER(ceph_data_stats)
 
 int get_fs_stats(ceph_data_stats_t &stats, const char *path);
 
+/// get memory limit for the current cgroup
+int get_cgroup_memory_limit(uint64_t *limit);
+
 /// collect info from @p uname(2), @p /proc/meminfo and @p /proc/cpuinfo
 void collect_sys_info(map<string, string> *m, CephContext *cct);
 

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -249,7 +249,7 @@ public:
   int conf_parse_env(const char *name)
   {
     auto& conf = cct->_conf;
-    conf.parse_env(name);
+    conf.parse_env(cct->get_module_type(), name);
     conf.apply_changes(nullptr);
     return 0;
   }
@@ -382,7 +382,7 @@ extern "C" int ceph_create(struct ceph_mount_info **cmount, const char * const i
   }
 
   CephContext *cct = common_preinit(iparams, CODE_ENVIRONMENT_LIBRARY, 0);
-  cct->_conf.parse_env(); // environment variables coverride
+  cct->_conf.parse_env(cct->get_module_type()); // environment variables coverride
   cct->_conf.apply_changes(nullptr);
   int ret = ceph_create_with_context(cmount, cct);
   cct->put();

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -92,7 +92,7 @@ static CephContext *rados_create_cct(const char * const clustername,
   CephContext *cct = common_preinit(*iparams, CODE_ENVIRONMENT_LIBRARY, 0);
   if (clustername)
     cct->_conf->cluster = clustername;
-  cct->_conf.parse_env(); // environment variables override
+  cct->_conf.parse_env(cct->get_module_type()); // environment variables override
   cct->_conf.apply_changes(nullptr);
 
   TracepointProvider::initialize<tracepoint_traits>(cct);
@@ -248,7 +248,7 @@ extern "C" int _rados_conf_read_file(rados_t cluster, const char *path_list)
     tracepoint(librados, rados_conf_read_file_exit, ret);
     return ret;
   }
-  conf.parse_env(); // environment variables override
+  conf.parse_env(client->cct->get_module_type()); // environment variables override
 
   conf.apply_changes(nullptr);
   client->cct->_conf.complain_about_parse_errors(client->cct);
@@ -322,7 +322,7 @@ extern "C" int _rados_conf_parse_env(rados_t cluster, const char *env)
   tracepoint(librados, rados_conf_parse_env_enter, cluster, env);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
   auto& conf = client->cct->_conf;
-  conf.parse_env(env);
+  conf.parse_env(client->cct->get_module_type(), env);
   conf.apply_changes(nullptr);
   tracepoint(librados, rados_conf_parse_env_exit, 0);
   return 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -26,6 +26,7 @@
 #include "include/intarith.h"
 #include "include/stringify.h"
 #include "include/str_map.h"
+#include "include/util.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "common/PriorityCache.h"
@@ -4029,6 +4030,7 @@ const char **BlueStore::get_tracked_conf_keys() const
     "bluestore_max_blob_size_ssd",
     "bluestore_max_blob_size_hdd",
     "osd_memory_target",
+    "osd_memory_target_cgroup_limit_ratio",
     "osd_memory_base",
     "osd_memory_cache_min",
     "bluestore_cache_autotune",
@@ -4200,6 +4202,23 @@ void BlueStore::_set_blob_size()
 
 int BlueStore::_set_cache_sizes()
 {
+  // set osd_memory_target *default* based on cgroup limit?
+  // (do this before we fetch the osd_memory_target value!)
+  double cgroup_ratio = cct->_conf.get_val<double>(
+    "osd_memory_target_cgroup_limit_ratio");
+  if (cgroup_ratio > 0.0) {
+    uint64_t cgroup_limit = 0;
+    if (get_cgroup_memory_limit(&cgroup_limit) == 0 &&
+	cgroup_limit) {
+      uint64_t def = cgroup_limit * cgroup_ratio;
+      dout(10) << __func__ << " osd_memory_target_cgroup_limit_ratio "
+	       << cgroup_ratio << ", cgroup_limit " << cgroup_limit
+	       << ", defaulting osd_memory_target to " << def
+	       << dendl;
+      cct->_conf.set_val_default("osd_memory_target", stringify(def));
+    }
+  }
+
   ceph_assert(bdev);
   cache_autotune = cct->_conf.get_val<bool>("bluestore_cache_autotune");
   cache_autotune_interval =

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4028,6 +4028,11 @@ const char **BlueStore::get_tracked_conf_keys() const
     "bluestore_max_blob_size",
     "bluestore_max_blob_size_ssd",
     "bluestore_max_blob_size_hdd",
+    "osd_memory_target",
+    "osd_memory_base",
+    "osd_memory_cache_min",
+    "bluestore_cache_autotune",
+    "bluestore_cache_autotune_interval",
     NULL
   };
   return KEYS;

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -102,7 +102,7 @@ void do_out_buffer(string& outbl, char **outbuf, size_t *outbuflen) {
 librados::TestRadosClient *create_rados_client() {
   CephInitParameters iparams(CEPH_ENTITY_TYPE_CLIENT);
   CephContext *cct = common_preinit(iparams, CODE_ENVIRONMENT_LIBRARY, 0);
-  cct->_conf.parse_env();
+  cct->_conf.parse_env(cct->get_module_type());
   cct->_conf.apply_changes(nullptr);
 
   auto rados_client =
@@ -152,7 +152,7 @@ extern "C" int rados_conf_parse_env(rados_t cluster, const char *var) {
   librados::TestRadosClient *client =
     reinterpret_cast<librados::TestRadosClient*>(cluster);
   auto& conf = client->cct()->_conf;
-  conf.parse_env(var);
+  conf.parse_env(client->cct()->get_module_type(), var);
   conf.apply_changes(NULL);
   return 0;
 }
@@ -163,7 +163,7 @@ extern "C" int rados_conf_read_file(rados_t cluster, const char *path) {
   auto& conf = client->cct()->_conf;
   int ret = conf.parse_config_files(path, NULL, 0);
   if (ret == 0) {
-    conf.parse_env();
+    conf.parse_env(client->cct()->get_module_type());
     conf.apply_changes(NULL);
     conf.complain_about_parse_errors(client->cct());
   } else if (ret == -ENOENT) {

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -450,7 +450,7 @@ int PoolReplayer<I>::init_rados(const std::string &cluster_name,
     }
   }
 
-  cct->_conf.parse_env();
+  cct->_conf.parse_env(cct->get_module_type());
 
   // librados::Rados::conf_parse_env
   std::vector<const char*> args;
@@ -461,7 +461,7 @@ int PoolReplayer<I>::init_rados(const std::string &cluster_name,
     cct->put();
     return r;
   }
-  cct->_conf.parse_env();
+  cct->_conf.parse_env(cct->get_module_type());
 
   if (!m_args.empty()) {
     // librados::Rados::conf_parse_argv

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1044,7 +1044,7 @@ static int parse_args(vector<const char*>& args, std::ostream *err_msg,
   } else {
     config.parse_config_files(nullptr, nullptr, 0);
   }
-  config.parse_env();
+  config.parse_env(g_ceph_context->get_module_type());
   config.parse_argv(args);
   cfg->poolname = config.get_val<std::string>("rbd_default_pool");
 


### PR DESCRIPTION
This is an initial, minimal pass at this.

- default osd_memory_target to .8x the cgroup limit, if present
- set osd_memory_target to POD_MEMORY_REQUEST, if present

There are many possible enhancements:

- we could make the .8 tunable
- we could make the .8 dynamically tunable at runtime

I'm most interested in first getting something basic in place for kubernetes, and second for ceph in a random container (say, ceph-nano or ceph-ansible).  I think this covers both when combined with @leseb's rook change at https://github.com/rook/rook/pull/2764