### PR TITLE
mimic: osd: fixup OpTracker destruct assert, waiting_for_osdmap take ref      with OpRequest

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3306,6 +3306,7 @@ int OSD::shutdown()
   op_shardedwq.drain();
   {
     finished.clear(); // zap waiters (bleh, this is messy)
+    waiting_for_osdmap.clear();
   }
 
   // unregister commands


### PR DESCRIPTION
https://tracker.ceph.com/issues/38646