### PR TITLE
msg/async: rework Frame hierarchy of v2. Clean up continuations

### DIFF
--- a/doc/dev/msgr2.rst
+++ b/doc/dev/msgr2.rst
@@ -121,7 +121,8 @@ Authentication
     __le32 method;  // CEPH_AUTH_{NONE, CEPHX, ...}
     __le32 num_preferred_modes;
     list<__le32> mode  // CEPH_CON_MODE_*
-    method specific payload
+    __le32 auth payload_len
+    auth payload (specific to the method)
 
 * TAG_AUTH_BAD_METHOD server -> client: reject client-selected auth method::
 
@@ -150,7 +151,8 @@ Authentication
 
     __le64 global_id
     __le32 connection mode // CEPH_CON_MODE_*
-    method specific payload
+    __le32 auth payload length
+    auth payload
 
   - The server is the one to decide authentication has completed and what
     the final connection mode will be.

--- a/src/msg/async/Protocol.h
+++ b/src/msg/async/Protocol.h
@@ -28,8 +28,8 @@ public:
 template <class C, typename... Args>
 class CtFun : public Ct<C> {
 private:
-  using fn = Ct<C> *(C::*)(Args...);
-  fn _f;
+  using fn_t = Ct<C> *(C::*)(Args...);
+  fn_t _f;
   std::tuple<Args...> _params;
 
   template <std::size_t... Is>
@@ -38,7 +38,7 @@ private:
   }
 
 public:
-  CtFun(fn f) : _f(f) {}
+  CtFun(fn_t f) : _f(f) {}
 
   inline void setParams(Args... args) { _params = std::make_tuple(args...); }
   inline Ct<C> *call(C *foo) const override {
@@ -46,10 +46,13 @@ public:
   }
 };
 
+
+template <class C> using CONTINUATION_TYPE = CtFun<C>;
+template <class C> using CONTINUATION_TX_TYPE = CtFun<C, int>;
+template <class C> using CONTINUATION_RX_TYPE = CtFun<C, char*, int>;
+
 #define CONTINUATION_DECL(C, F, ...)                    \
   CtFun<C, ##__VA_ARGS__> F##_cont { (&C::F) };
-
-#define CONTINUATION_PARAM(V, C, ...) CtFun<C, ##__VA_ARGS__> &V##_cont
 
 #define CONTINUATION(F) F##_cont
 #define CONTINUE(F, ...) (F##_cont.setParams(__VA_ARGS__), &F##_cont)

--- a/src/msg/async/Protocol.h
+++ b/src/msg/async/Protocol.h
@@ -47,21 +47,19 @@ public:
 };
 
 #define CONTINUATION_DECL(C, F, ...)                    \
-  std::unique_ptr<CtFun<C, ##__VA_ARGS__>> F##_cont_ =  \
-      std::make_unique<CtFun<C, ##__VA_ARGS__>>(&C::F); \
-  CtFun<C, ##__VA_ARGS__> *F##_cont = F##_cont_.get()
+  CtFun<C, ##__VA_ARGS__> F##_cont { (&C::F) };
 
-#define CONTINUATION_PARAM(V, C, ...) CtFun<C, ##__VA_ARGS__> *V##_cont
+#define CONTINUATION_PARAM(V, C, ...) CtFun<C, ##__VA_ARGS__> &V##_cont
 
 #define CONTINUATION(F) F##_cont
-#define CONTINUE(F, ...) F##_cont->setParams(__VA_ARGS__), F##_cont
+#define CONTINUE(F, ...) (F##_cont.setParams(__VA_ARGS__), &F##_cont)
 
 #define CONTINUATION_RUN(CT)                                      \
   {                                                               \
-    Ct<std::remove_reference<decltype(*this)>::type> *_cont = CT; \
-    while (_cont) {                                               \
+    Ct<std::remove_reference<decltype(*this)>::type> *_cont = &CT;\
+    do {                                                          \
       _cont = _cont->call(this);                                  \
-    }                                                             \
+    } while (_cont);                                              \
   }
 
 #define READ_HANDLER_CONTINUATION_DECL(C, F) \

--- a/src/msg/async/Protocol.h
+++ b/src/msg/async/Protocol.h
@@ -46,24 +46,18 @@ public:
   }
 };
 
-using rx_buffer_t = ceph::bufferptr;
-// FIXME: std::function in AsyncConnection requires us to be copy-
-// constructible just in the case - even if nobody actually copies
-// the std::functions there. This inhibits usage of unique_ptr of
-// ptr_node inside. Reworking the callback mechanism might help but
-// for now we can go with regular bptr.
-//
-//    std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>;
+using rx_buffer_t =
+    std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>;
 
 template <class C>
 class CtRxNode : public Ct<C> {
   using fn_t = Ct<C> *(C::*)(rx_buffer_t&&, int r);
   fn_t _f;
 
+public:
   mutable rx_buffer_t node;
   int r;
 
-public:
   CtRxNode(fn_t f) : _f(f) {}
   void setParams(rx_buffer_t &&node, int r) {
     this->node = std::move(node);

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -145,9 +145,9 @@ protected:
   State state;
 
   void run_continuation(CtPtr pcontinuation);
-  CtPtr read(CONTINUATION_PARAM(next, ProtocolV1, char *, int), int len,
+  CtPtr read(CONTINUATION_RX_TYPE<ProtocolV1> &next, int len,
              char *buffer = nullptr);
-  CtPtr write(CONTINUATION_PARAM(next, ProtocolV1, int), bufferlist &bl);
+  CtPtr write(CONTINUATION_TX_TYPE<ProtocolV1> &next,bufferlist &bl);
   inline CtPtr _fault() {  // helper fault method that stops continuation
     fault();
     return nullptr;

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -144,7 +144,7 @@ protected:
 
   State state;
 
-  void run_continuation(CtPtr continuation);
+  void run_continuation(CtPtr pcontinuation);
   CtPtr read(CONTINUATION_PARAM(next, ProtocolV1, char *, int), int len,
              char *buffer = nullptr);
   CtPtr write(CONTINUATION_PARAM(next, ProtocolV1, int), bufferlist &bl);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -92,7 +92,6 @@ ProtocolV2::ProtocolV2(AsyncConnection *connection)
       replacing(false),
       can_write(false),
       bannerExchangeCallback(nullptr),
-      next_payload_len(0),
       next_tag(static_cast<Tag>(0)),
       keepalive(false) {
 }
@@ -806,11 +805,9 @@ CtPtr ProtocolV2::_handle_peer_banner(rx_buffer_t &&buffer, int r) {
     return _fault();
   }
 
-  next_payload_len = payload_len;
-
   INTERCEPT(state == BANNER_CONNECTING ? 5 : 6);
 
-  return READ(next_payload_len, _handle_peer_banner_payload);
+  return READ(payload_len, _handle_peer_banner_payload);
 }
 
 CtPtr ProtocolV2::_handle_peer_banner_payload(rx_buffer_t &&buffer, int r) {

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -497,7 +497,7 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
                            footer.flags,      header.compat_version,
                            header.reserved};
 
-  auto message = MessageHeaderFrame::Encode(session_stream_handlers,
+  auto message = MessageFrame::Encode(session_stream_handlers,
 			     header2,
 			     m->get_payload(),
 			     m->get_middle(),
@@ -1290,7 +1290,7 @@ CtPtr ProtocolV2::handle_message() {
 #endif
   recv_stamp = ceph_clock_now();
 
-  auto header_frame = MessageHeaderFrame::Decode(
+  auto header_frame = MessageFrame::Decode(
     std::move(rx_segments_data[SegmentIndex::Msg::HEADER]));
   // XXX: paranoid copy just to avoid oops
   ceph_msg_header2 current_header = header_frame.header();

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1291,40 +1291,32 @@ CtPtr ProtocolV2::handle_message() {
 #endif
   recv_stamp = ceph_clock_now();
 
-  auto header_frame = MessageFrame::Decode(
-    std::move(rx_segments_data[SegmentIndex::Msg::HEADER]));
+  // we need to get the size before std::moving segments data
+  const size_t cur_msg_size = get_current_msg_size();
+  auto msg_frame = MessageFrame::Decode(std::move(rx_segments_data));
+
   // XXX: paranoid copy just to avoid oops
-  ceph_msg_header2 current_header = header_frame.header();
-
-  ldout(cct, 20) << __func__
-		 << " got envelope type=" << current_header.type
-		 << " src " << peer_name
-		 << " off " << current_header.data_off
-                 << dendl;
-
-  INTERCEPT(16);
-
-  const auto front_len = \
-    rx_segments_desc[SegmentIndex::Msg::FRONT].length;
-  const auto middle_len = \
-    rx_segments_desc[SegmentIndex::Msg::MIDDLE].length;
-  const auto data_len = \
-    rx_segments_desc[SegmentIndex::Msg::DATA].length;
+  ceph_msg_header2 current_header = msg_frame.header();
 
   ldout(cct, 5) << __func__
-		<< " got " << front_len
-		<< " + " << middle_len
-		<< " + " << data_len
-		<< " byte message" << dendl;
+		<< " got " << msg_frame.front_len()
+		<< " + " << msg_frame.middle_len()
+		<< " + " << msg_frame.data_len()
+		<< " byte message."
+		<< " envelope type=" << current_header.type
+		<< " src " << peer_name
+		<< " off " << current_header.data_off
+                << dendl;
 
+  INTERCEPT(16);
   ceph_msg_header header{current_header.seq,
                          current_header.tid,
                          current_header.type,
                          current_header.priority,
                          current_header.version,
-                         front_len,
-                         middle_len,
-                         data_len,
+                         msg_frame.front_len(),
+                         msg_frame.middle_len(),
+                         msg_frame.data_len(),
                          current_header.data_off,
                          peer_name,
                          current_header.compat_version,
@@ -1333,9 +1325,9 @@ CtPtr ProtocolV2::handle_message() {
   ceph_msg_footer footer{0, 0, 0, 0, current_header.flags};
 
   Message *message = decode_message(cct, 0, header, footer,
-      rx_segments_data[SegmentIndex::Msg::FRONT],
-      rx_segments_data[SegmentIndex::Msg::MIDDLE],
-      rx_segments_data[SegmentIndex::Msg::DATA],
+      msg_frame.front(),
+      msg_frame.middle(),
+      msg_frame.data(),
       connection);
   if (!message) {
     ldout(cct, 1) << __func__ << " decode message failed " << dendl;
@@ -1348,11 +1340,6 @@ CtPtr ProtocolV2::handle_message() {
 
   message->set_byte_throttler(connection->policy.throttler_bytes);
   message->set_message_throttler(connection->policy.throttler_messages);
-
-  const uint32_t cur_msg_size = \
-    rx_segments_desc[SegmentIndex::Msg::FRONT].length + \
-    rx_segments_desc[SegmentIndex::Msg::MIDDLE].length + \
-    rx_segments_desc[SegmentIndex::Msg::DATA].length;
 
   // store reservation size in message, so we don't get confused
   // by messages entering the dispatch queue through other paths.

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -80,7 +80,6 @@ if(connection->interceptor) { \
 
 ProtocolV2::ProtocolV2(AsyncConnection *connection)
     : Protocol(2, connection),
-      temp_buffer(nullptr),
       state(NONE),
       peer_required_features(0),
       client_cookie(0),
@@ -96,11 +95,9 @@ ProtocolV2::ProtocolV2(AsyncConnection *connection)
       next_payload_len(0),
       next_tag(static_cast<Tag>(0)),
       keepalive(false) {
-  temp_buffer = new char[4096];
 }
 
 ProtocolV2::~ProtocolV2() {
-  delete[] temp_buffer;
 }
 
 void ProtocolV2::connect() {
@@ -808,9 +805,6 @@ CtPtr ProtocolV2::_handle_peer_banner(rx_buffer_t &&buffer, int r) {
     lderr(cct) << __func__ << " decode banner payload len failed " << dendl;
     return _fault();
   }
-
-  ceph_assert(payload_len <= 4096);  // if we need more then we need to increase
-                                     // temp_buffer size as well
 
   next_payload_len = payload_len;
 

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -735,12 +735,11 @@ CtPtr ProtocolV2::write(const std::string &desc,
         run_continuation(next);
       });
 
-  if (r <= 0) {
-    if (r < 0) {
-      ldout(cct, 1) << __func__ << " " << desc << " write failed r=" << r
-                    << " (" << cpp_strerror(r) << ")" << dendl;
-      return _fault();
-    }
+  if (r < 0) {
+    ldout(cct, 1) << __func__ << " " << desc << " write failed r=" << r
+                  << " (" << cpp_strerror(r) << ")" << dendl;
+    return _fault();
+  } else if (r == 0) {
     next.setParams();
     return &next;
   }

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -749,9 +749,9 @@ CtPtr ProtocolV2::write(const std::string &desc,
   return nullptr;
 }
 
-CtPtr ProtocolV2::_banner_exchange(CtPtr callback) {
+CtPtr ProtocolV2::_banner_exchange(CtRef callback) {
   ldout(cct, 20) << __func__ << dendl;
-  bannerExchangeCallback = callback;
+  bannerExchangeCallback = &callback;
 
   bufferlist banner_payload;
   encode((uint64_t)CEPH_MSGR2_SUPPORTED_FEATURES, banner_payload, 0);
@@ -1646,7 +1646,7 @@ CtPtr ProtocolV2::start_client_banner_exchange() {
 
   global_seq = messenger->get_global_seq();
 
-  return _banner_exchange(&CONTINUATION(post_client_banner_exchange));
+  return _banner_exchange(CONTINUATION(post_client_banner_exchange));
 }
 
 CtPtr ProtocolV2::post_client_banner_exchange() {
@@ -2089,7 +2089,7 @@ CtPtr ProtocolV2::start_server_banner_exchange() {
 
   state = BANNER_ACCEPTING;
 
-  return _banner_exchange(&CONTINUATION(post_server_banner_exchange));
+  return _banner_exchange(CONTINUATION(post_server_banner_exchange));
 }
 
 CtPtr ProtocolV2::post_server_banner_exchange() {

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -93,14 +93,10 @@ private:
   using ProtFuncPtr = void (ProtocolV2::*)();
   Ct<ProtocolV2> *bannerExchangeCallback;
 
-public:
-
   boost::container::static_vector<ceph::msgr::v2::segment_t,
 				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_desc;
   boost::container::static_vector<ceph::bufferlist,
 				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_data;
-private:
-
   ceph::msgr::v2::Tag next_tag;
   utime_t backoff;  // backoff time
   utime_t recv_stamp;

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -142,7 +142,7 @@ private:
   READ_HANDLER_CONTINUATION_DECL(ProtocolV2, _handle_peer_banner);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV2, _handle_peer_banner_payload);
 
-  Ct<ProtocolV2> *_banner_exchange(Ct<ProtocolV2> *callback);
+  Ct<ProtocolV2> *_banner_exchange(Ct<ProtocolV2> &callback);
   Ct<ProtocolV2> *_wait_for_peer_banner();
   Ct<ProtocolV2> *_handle_peer_banner(char *buffer, int r);
   Ct<ProtocolV2> *_handle_peer_banner_payload(char *buffer, int r);

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -154,7 +154,7 @@ private:
   CONTINUATION_DECL(ProtocolV2, read_frame);
   CONTINUATION_DECL(ProtocolV2, finish_auth);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_preamble_main);
-  READ_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_segment);
+  READ_BPTR_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_segment);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_epilogue_main);
   CONTINUATION_DECL(ProtocolV2, throttle_message);
   CONTINUATION_DECL(ProtocolV2, throttle_bytes);
@@ -164,7 +164,7 @@ private:
   Ct<ProtocolV2> *finish_auth();
   Ct<ProtocolV2> *handle_read_frame_preamble_main(char *buffer, int r);
   Ct<ProtocolV2> *read_frame_segment();
-  Ct<ProtocolV2> *handle_read_frame_segment(char *buffer, int r);
+  Ct<ProtocolV2> *handle_read_frame_segment(rx_buffer_t &&rx_buffer, int r);
   Ct<ProtocolV2> *handle_read_frame_epilogue_main(char *buffer, int r);
   Ct<ProtocolV2> *handle_read_frame_dispatch();
   Ct<ProtocolV2> *handle_frame_payload();

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -115,8 +115,6 @@ private:
   void run_continuation(Ct<ProtocolV2> *pcontinuation);
   void run_continuation(Ct<ProtocolV2> &continuation);
 
-  Ct<ProtocolV2> *read(CONTINUATION_RX_TYPE<ProtocolV2> &next,
-                       int len, char *buffer = nullptr);
   Ct<ProtocolV2> *read(CONTINUATION_RXBPTR_TYPE<ProtocolV2> &next,
                        rx_buffer_t&& buffer);
   template <class F>
@@ -142,30 +140,30 @@ private:
   void handle_message_ack(uint64_t seq);
 
   CONTINUATION_DECL(ProtocolV2, _wait_for_peer_banner);
-  READ_HANDLER_CONTINUATION_DECL(ProtocolV2, _handle_peer_banner);
-  READ_HANDLER_CONTINUATION_DECL(ProtocolV2, _handle_peer_banner_payload);
+  READ_BPTR_HANDLER_CONTINUATION_DECL(ProtocolV2, _handle_peer_banner);
+  READ_BPTR_HANDLER_CONTINUATION_DECL(ProtocolV2, _handle_peer_banner_payload);
 
   Ct<ProtocolV2> *_banner_exchange(Ct<ProtocolV2> &callback);
   Ct<ProtocolV2> *_wait_for_peer_banner();
-  Ct<ProtocolV2> *_handle_peer_banner(char *buffer, int r);
-  Ct<ProtocolV2> *_handle_peer_banner_payload(char *buffer, int r);
+  Ct<ProtocolV2> *_handle_peer_banner(rx_buffer_t &&buffer, int r);
+  Ct<ProtocolV2> *_handle_peer_banner_payload(rx_buffer_t &&buffer, int r);
   Ct<ProtocolV2> *handle_hello(ceph::bufferlist &payload);
 
   CONTINUATION_DECL(ProtocolV2, read_frame);
   CONTINUATION_DECL(ProtocolV2, finish_auth);
-  READ_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_preamble_main);
+  READ_BPTR_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_preamble_main);
   READ_BPTR_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_segment);
-  READ_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_epilogue_main);
+  READ_BPTR_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_epilogue_main);
   CONTINUATION_DECL(ProtocolV2, throttle_message);
   CONTINUATION_DECL(ProtocolV2, throttle_bytes);
   CONTINUATION_DECL(ProtocolV2, throttle_dispatch_queue);
 
   Ct<ProtocolV2> *read_frame();
   Ct<ProtocolV2> *finish_auth();
-  Ct<ProtocolV2> *handle_read_frame_preamble_main(char *buffer, int r);
+  Ct<ProtocolV2> *handle_read_frame_preamble_main(rx_buffer_t &&buffer, int r);
   Ct<ProtocolV2> *read_frame_segment();
   Ct<ProtocolV2> *handle_read_frame_segment(rx_buffer_t &&rx_buffer, int r);
-  Ct<ProtocolV2> *handle_read_frame_epilogue_main(char *buffer, int r);
+  Ct<ProtocolV2> *handle_read_frame_epilogue_main(rx_buffer_t &&buffer, int r);
   Ct<ProtocolV2> *handle_read_frame_dispatch();
   Ct<ProtocolV2> *handle_frame_payload();
 

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -112,7 +112,8 @@ private:
   bool keepalive;
 
   ostream &_conn_prefix(std::ostream *_dout);
-  void run_continuation(Ct<ProtocolV2> *continuation);
+  void run_continuation(Ct<ProtocolV2> *pcontinuation);
+  void run_continuation(Ct<ProtocolV2> &continuation);
 
   Ct<ProtocolV2> *read(CONTINUATION_PARAM(next, ProtocolV2, char *, int),
                        int len, char *buffer = nullptr);

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -93,8 +93,6 @@ private:
   using ProtFuncPtr = void (ProtocolV2::*)();
   Ct<ProtocolV2> *bannerExchangeCallback;
 
-  uint32_t next_payload_len;
-
 public:
 
   boost::container::static_vector<ceph::msgr::v2::segment_t,

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -117,6 +117,8 @@ private:
 
   Ct<ProtocolV2> *read(CONTINUATION_RX_TYPE<ProtocolV2> &next,
                        int len, char *buffer = nullptr);
+  Ct<ProtocolV2> *read(CONTINUATION_RXBPTR_TYPE<ProtocolV2> &next,
+                       rx_buffer_t&& buffer);
   template <class F>
   Ct<ProtocolV2> *write(const std::string &desc,
                         CONTINUATION_TYPE<ProtocolV2> &next,

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -243,6 +243,7 @@ private:
 
   uint32_t get_onwire_size(uint32_t logical_size) const;
   uint32_t get_epilogue_size() const;
+  size_t get_current_msg_size() const;
 };
 
 #endif /* _MSG_ASYNC_PROTOCOL_V2_ */

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -68,7 +68,6 @@ public:
   ceph::crypto::onwire::rxtx_t session_stream_handlers;
 private:
   entity_name_t peer_name;
-  char *temp_buffer;
   State state;
   uint64_t peer_required_features;
 

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -115,13 +115,14 @@ private:
   void run_continuation(Ct<ProtocolV2> *pcontinuation);
   void run_continuation(Ct<ProtocolV2> &continuation);
 
-  Ct<ProtocolV2> *read(CONTINUATION_PARAM(next, ProtocolV2, char *, int),
+  Ct<ProtocolV2> *read(CONTINUATION_RX_TYPE<ProtocolV2> &next,
                        int len, char *buffer = nullptr);
   template <class F>
   Ct<ProtocolV2> *write(const std::string &desc,
-                        CONTINUATION_PARAM(next, ProtocolV2), F &frame);
+                        CONTINUATION_TYPE<ProtocolV2> &next,
+			F &frame);
   Ct<ProtocolV2> *write(const std::string &desc,
-                        CONTINUATION_PARAM(next, ProtocolV2),
+                        CONTINUATION_TYPE<ProtocolV2> &next,
                         bufferlist &buffer);
 
   void requeue_sent();

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -148,6 +148,7 @@ private:
   Ct<ProtocolV2> *handle_hello(ceph::bufferlist &payload);
 
   CONTINUATION_DECL(ProtocolV2, read_frame);
+  CONTINUATION_DECL(ProtocolV2, finish_auth);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_preamble_main);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_segment);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV2, handle_read_frame_epilogue_main);
@@ -156,6 +157,7 @@ private:
   CONTINUATION_DECL(ProtocolV2, throttle_dispatch_queue);
 
   Ct<ProtocolV2> *read_frame();
+  Ct<ProtocolV2> *finish_auth();
   Ct<ProtocolV2> *handle_read_frame_preamble_main(char *buffer, int r);
   Ct<ProtocolV2> *read_frame_segment();
   Ct<ProtocolV2> *handle_read_frame_segment(char *buffer, int r);

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -67,8 +67,6 @@ public:
   // TODO: move into auth_meta?
   ceph::crypto::onwire::rxtx_t session_stream_handlers;
 private:
-  enum class AuthFlag : uint64_t { ENCRYPTED = 1, SIGNED = 2 };
-
   entity_name_t peer_name;
   char *temp_buffer;
   State state;

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -312,8 +312,6 @@ protected:
       for (const auto &elem : t) {
         encode(elem, this->get_payload_segment(), features);
       }
-    } else if constexpr (std::is_same<T, ceph_msg_header2 const>()) {
-      this->get_payload_segment().append((char *)&t, sizeof(t));
     } else {
       encode(t, this->get_payload_segment(), features);
     }
@@ -332,10 +330,6 @@ protected:
       for (uint32_t i = 0; i < size; ++i) {
         decode(t[i], ti);
       }
-    } else if constexpr (std::is_same<T, ceph_msg_header2>()) {
-      auto ptr = ti.get_current_ptr();
-      ti.advance(sizeof(T));
-      t = *(T *)ptr.raw_c_str();
     } else {
       decode(t, ti);
     }

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -467,25 +467,19 @@ protected:
   using ControlFrame::ControlFrame;
 };
 
-template <class T, typename... Args>
-struct SignedEncryptedFrame : public ControlFrame<T, Args...> {
-protected:
-  SignedEncryptedFrame() : ControlFrame<T, Args...>() {}
-};
-
 struct ClientIdentFrame
-    : public SignedEncryptedFrame<ClientIdentFrame, 
-                                  entity_addrvec_t,  // my addresses
-                                  entity_addr_t,  // target address
-                                  int64_t,  // global_id
-                                  uint64_t,  // global seq
-                                  uint64_t,  // supported features
-                                  uint64_t,  // required features
-                                  uint64_t,  // flags
-                                  uint64_t> {  // client cookie
+    : public ControlFrame<ClientIdentFrame,
+                          entity_addrvec_t,  // my addresses
+                          entity_addr_t,  // target address
+                          int64_t,  // global_id
+                          uint64_t,  // global seq
+                          uint64_t,  // supported features
+                          uint64_t,  // required features
+                          uint64_t,  // flags
+                          uint64_t> {  // client cookie
   static const Tag tag = Tag::CLIENT_IDENT;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline entity_addrvec_t &addrs() { return get_val<0>(); }
   inline entity_addr_t &target_addr() { return get_val<1>(); }
@@ -497,21 +491,21 @@ struct ClientIdentFrame
   inline uint64_t &cookie() { return get_val<7>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
 struct ServerIdentFrame
-    : public SignedEncryptedFrame<ServerIdentFrame,
-                                  entity_addrvec_t,  // my addresses
-                                  int64_t,  // global_id
-                                  uint64_t,  // global seq
-                                  uint64_t,  // supported features
-                                  uint64_t,  // required features
-                                  uint64_t,  // flags
-                                  uint64_t> {  // server cookie
+    : public ControlFrame<ServerIdentFrame,
+                          entity_addrvec_t,  // my addresses
+                          int64_t,  // global_id
+                          uint64_t,  // global seq
+                          uint64_t,  // supported features
+                          uint64_t,  // required features
+                          uint64_t,  // flags
+                          uint64_t> {  // server cookie
   static const Tag tag = Tag::SERVER_IDENT;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline entity_addrvec_t &addrs() { return get_val<0>(); }
   inline int64_t &gid() { return get_val<1>(); }
@@ -522,20 +516,20 @@ struct ServerIdentFrame
   inline uint64_t &cookie() { return get_val<6>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
 struct ReconnectFrame
-    : public SignedEncryptedFrame<ReconnectFrame, 
-                                  entity_addrvec_t,  // my addresses
-                                  uint64_t,  // client cookie
-                                  uint64_t,  // server cookie
-                                  uint64_t,  // global sequence
-                                  uint64_t,  // connect sequence
-                                  uint64_t> { // message sequence
+    : public ControlFrame<ReconnectFrame,
+                          entity_addrvec_t,  // my addresses
+                          uint64_t,  // client cookie
+                          uint64_t,  // server cookie
+                          uint64_t,  // global sequence
+                          uint64_t,  // connect sequence
+                          uint64_t> { // message sequence
   static const Tag tag = Tag::SESSION_RECONNECT;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline entity_addrvec_t &addrs() { return get_val<0>(); }
   inline uint64_t &client_cookie() { return get_val<1>(); }
@@ -545,84 +539,84 @@ struct ReconnectFrame
   inline uint64_t &msg_seq() { return get_val<5>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
-struct ResetFrame : public SignedEncryptedFrame<ResetFrame,
-                                                bool> {  // full reset
+struct ResetFrame : public ControlFrame<ResetFrame,
+                                        bool> {  // full reset
   static const Tag tag = Tag::SESSION_RESET;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline bool &full() { return get_val<0>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
-struct RetryFrame : public SignedEncryptedFrame<RetryFrame,
-                                                uint64_t> {  // connection seq
+struct RetryFrame : public ControlFrame<RetryFrame,
+                                        uint64_t> {  // connection seq
   static const Tag tag = Tag::SESSION_RETRY;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline uint64_t &connect_seq() { return get_val<0>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
-struct RetryGlobalFrame : public SignedEncryptedFrame<RetryGlobalFrame,
-                                                      uint64_t> { // global seq
+struct RetryGlobalFrame : public ControlFrame<RetryGlobalFrame,
+                                              uint64_t> { // global seq
   static const Tag tag = Tag::SESSION_RETRY_GLOBAL;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline uint64_t &global_seq() { return get_val<0>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
-struct WaitFrame : public SignedEncryptedFrame<WaitFrame> {
+struct WaitFrame : public ControlFrame<WaitFrame> {
   static const Tag tag = Tag::WAIT;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
-struct ReconnectOkFrame : public SignedEncryptedFrame<ReconnectOkFrame,
-                                                      uint64_t> { // message seq
+struct ReconnectOkFrame : public ControlFrame<ReconnectOkFrame,
+                                              uint64_t> { // message seq
   static const Tag tag = Tag::SESSION_RECONNECT_OK;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline uint64_t &msg_seq() { return get_val<0>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
 struct IdentMissingFeaturesFrame 
-    : public SignedEncryptedFrame<IdentMissingFeaturesFrame,
-                                  uint64_t> { // missing features mask
+    : public ControlFrame<IdentMissingFeaturesFrame,
+                          uint64_t> { // missing features mask
   static const Tag tag = Tag::IDENT_MISSING_FEATURES;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline uint64_t &features() { return get_val<0>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
-struct KeepAliveFrame : public SignedEncryptedFrame<KeepAliveFrame,
-                                                    utime_t> {  // timestamp
+struct KeepAliveFrame : public ControlFrame<KeepAliveFrame,
+                                            utime_t> {  // timestamp
   static const Tag tag = Tag::KEEPALIVE2;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   static KeepAliveFrame Encode() {
     return KeepAliveFrame::Encode(ceph_clock_now());
@@ -631,31 +625,31 @@ struct KeepAliveFrame : public SignedEncryptedFrame<KeepAliveFrame,
   inline utime_t &timestamp() { return get_val<0>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
-struct KeepAliveFrameAck : public SignedEncryptedFrame<KeepAliveFrameAck,
-                                                       utime_t> { // ack timestamp
+struct KeepAliveFrameAck : public ControlFrame<KeepAliveFrameAck,
+                                               utime_t> { // ack timestamp
   static const Tag tag = Tag::KEEPALIVE2_ACK;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline utime_t &timestamp() { return get_val<0>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
-struct AckFrame : public SignedEncryptedFrame<AckFrame,
-                                              uint64_t> { // message sequence
+struct AckFrame : public ControlFrame<AckFrame,
+                                      uint64_t> { // message sequence
   static const Tag tag = Tag::ACK;
-  using SignedEncryptedFrame::Encode;
-  using SignedEncryptedFrame::Decode;
+  using ControlFrame::Encode;
+  using ControlFrame::Decode;
 
   inline uint64_t &seq() { return get_val<0>(); }
 
 protected:
-  using SignedEncryptedFrame::SignedEncryptedFrame;
+  using ControlFrame::ControlFrame;
 };
 
 // This class is used for encoding/decoding header of the message frame.

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -305,9 +305,7 @@ protected:
 
   template <typename T>
   inline void _encode_payload_each(T &t) {
-    if constexpr (std::is_same<T, bufferlist const>()) {
-      this->get_payload_segment().claim_append((bufferlist &)t);
-    } else if constexpr (std::is_same<T, std::vector<uint32_t> const>()) {
+    if constexpr (std::is_same<T, std::vector<uint32_t> const>()) {
       encode((uint32_t)t.size(), this->get_payload_segment(), features);
       for (const auto &elem : t) {
         encode(elem, this->get_payload_segment(), features);
@@ -319,11 +317,7 @@ protected:
 
   template <typename T>
   inline void _decode_payload_each(T &t, bufferlist::const_iterator &ti) const {
-    if constexpr (std::is_same<T, bufferlist>()) {
-      if (ti.get_remaining()) {
-        t.append(ti.get_current_ptr());
-      }
-    } else if constexpr (std::is_same<T, std::vector<uint32_t>>()) {
+    if constexpr (std::is_same<T, std::vector<uint32_t>>()) {
       uint32_t size;
       decode(size, ti);
       t.resize(size);


### PR DESCRIPTION
This PR is mostly clean up. However, it brings two changes affecting the on-wire protocol:
  * removal of the `ceph::bufferlist` optimization in `ControlFrame` (`msg/async, v2: drop the bl onwire space optimization in ControlFrames`),
  * making `num_segments` dynamic -- we don't transmit empty segments anymore (`msg/async, v2: limit the num_segments to non-empty segments`).