### PR TITLE
Wip msg delay

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -140,6 +140,7 @@ OPTION(ms_pq_min_cost, OPT_U64)
 OPTION(ms_inject_socket_failures, OPT_U64)
 SAFE_OPTION(ms_inject_delay_type, OPT_STR)          // "osd mds mon client" allowed
 OPTION(ms_inject_delay_msg_type, OPT_STR)      // the type of message to delay). This is an additional restriction on the general type filter ms_inject_delay_type.
+OPTION(ms_inject_delay_min, OPT_DOUBLE)         // seconds
 OPTION(ms_inject_delay_max, OPT_DOUBLE)         // seconds
 OPTION(ms_inject_delay_probability, OPT_DOUBLE) // range [0, 1]
 OPTION(ms_inject_internal_delays, OPT_DOUBLE)   // seconds

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1034,19 +1034,19 @@ std::vector<Option> get_global_options() {
 
     Option("ms_inject_delay_msg_type", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("")
-    .set_description("Message type to inject delays for"),
+    .set_description("Message type to inject delays for, if delaying"),
 
     Option("ms_inject_delay_min", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(0)
-    .set_description("Min delay to inject"),
+    .set_description("Min delay to inject, if delaying"),
 
     Option("ms_inject_delay_max", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(1)
-    .set_description("Max delay to inject"),
+    .set_description("Max delay to inject, if delaying"),
 
     Option("ms_inject_delay_probability", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(0)
-    .set_description(""),
+    .set_description("Proportion of time we should inject delivery delays on target Pipes"),
 
     Option("ms_inject_internal_delays", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(0)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1033,7 +1033,7 @@ std::vector<Option> get_global_options() {
 
     Option("ms_inject_delay_min", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(0)
-    .set_description("Min delay to inject")
+    .set_description("Min delay to inject"),
 
     Option("ms_inject_delay_max", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(1)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1027,6 +1027,11 @@ std::vector<Option> get_global_options() {
     .set_description("Entity type to inject delays for")
     .set_flag(Option::FLAG_RUNTIME),
 
+    Option("ms_inject_delay_name", Option::TYPE_STR, Option::LEVEL_DEV)
+    .set_default("")
+    .set_description("Entity name to inject delays for")
+    .set_flag(Option::FLAG_RUNTIME),
+
     Option("ms_inject_delay_msg_type", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("")
     .set_description("Message type to inject delays for"),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1031,6 +1031,10 @@ std::vector<Option> get_global_options() {
     .set_default("")
     .set_description("Message type to inject delays for"),
 
+    Option("ms_inject_delay_min", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(0)
+    .set_description("Min delay to inject")
+
     Option("ms_inject_delay_max", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(1)
     .set_description("Max delay to inject"),

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1015,7 +1015,7 @@ CtPtr ProtocolV1::handle_message_footer(char *buffer, int r) {
       delay_period = ((cct->_conf->ms_inject_delay_max -
 		       cct->_conf->ms_inject_delay_min) *
 		      (double)(rand() % 10000) / 10000.0) +
-	             msgr->cct->_conf->ms_inject_delay_min;
+	             cct->_conf->ms_inject_delay_min;
       ldout(cct, 1) << "queue_received will delay after "
                     << (ceph_clock_now() + delay_period) << " on " << message
                     << " " << *message << dendl;

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1012,8 +1012,10 @@ CtPtr ProtocolV1::handle_message_footer(char *buffer, int r) {
   if (connection->delay_state) {
     double delay_period = 0;
     if (rand() % 10000 < cct->_conf->ms_inject_delay_probability * 10000.0) {
-      delay_period =
-          cct->_conf->ms_inject_delay_max * (double)(rand() % 10000) / 10000.0;
+      delay_period = ((cct->_conf->ms_inject_delay_max -
+		       cct->_conf->ms_inject_delay_min) *
+		      (double)(rand() % 10000) / 10000.0) +
+	             msgr->cct->_conf->ms_inject_delay_min;
       ldout(cct, 1) << "queue_received will delay after "
                     << (ceph_clock_now() + delay_period) << " on " << message
                     << " " << *message << dendl;

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1434,7 +1434,7 @@ CtPtr ProtocolV2::handle_message() {
       delay_period = ((cct->_conf->ms_inject_delay_max -
 		       cct->_conf->ms_inject_delay_min) *
 		      (double)(rand() % 10000) / 10000.0) +
-	             cct->_conf->ms_inject_delay_min);
+	             cct->_conf->ms_inject_delay_min;
           
       ldout(cct, 1) << "queue_received will delay after "
                     << (ceph_clock_now() + delay_period) << " on " << message

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1431,8 +1431,11 @@ CtPtr ProtocolV2::handle_message() {
   if (connection->delay_state) {
     double delay_period = 0;
     if (rand() % 10000 < cct->_conf->ms_inject_delay_probability * 10000.0) {
-      delay_period =
-          cct->_conf->ms_inject_delay_max * (double)(rand() % 10000) / 10000.0;
+      delay_period = ((cct->_conf->ms_inject_delay_max -
+		       cct->_conf->ms_inject_delay_min) *
+		      (double)(rand() % 10000) / 10000.0) +
+	             cct->_conf->ms_inject_delay_min);
+          
       ldout(cct, 1) << "queue_received will delay after "
                     << (ceph_clock_now() + delay_period) << " on " << message
                     << " " << *message << dendl;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1797,7 +1797,10 @@ void Pipe::reader()
         utime_t release;
         if (rand() % 10000 < msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
           release = m->get_recv_stamp();
-          release += msgr->cct->_conf->ms_inject_delay_max * (double)(rand() % 10000) / 10000.0;
+          release += ((msgr->cct->_conf->ms_inject_delay_max -
+		       msgr->cct->_conf->ms_inject_delay_min) *
+		      ((double)(rand() % 10000) / 10000.0)) +
+	             msgr->cct->_conf->ms_inject_delay_min;
           lsubdout(msgr->cct, ms, 1) << "queue_received will delay until " << release << " on " << m << " " << *m << dendl;
         }
         delay_thread->queue(release, m);


### PR DESCRIPTION
This PR lets us do more interesting things with the existing message delayed-delivery tooling:
*) we can set minimum delay times and evenly distribute the latency between the min and max
*) we can apply the delay to a set of named daemons, not merely daemon types