### PR TITLE
mon/OSDMonitor: Track when pool quotas exceed object counts or bytes, and out…

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6232,10 +6232,9 @@ bool OSDMonitor::update_pools_status()
 
     bool pool_is_full_objects = pool.quota_max_objects > 0 &&
       (uint64_t)sum.num_objects >= pool.quota_max_objects;
-    bool pool_is_full = ((pool.quota_max_bytes > 0 &&
-			  (uint64_t)sum.num_bytes >= pool.quota_max_bytes) ||
-			 pool_is_full_objects);
-    
+    bool pool_is_full_bytes = (pool.quota_max_bytes > 0 &&
+			       (uint64_t)sum.num_bytes >= pool.quota_max_bytes);
+    bool pool_is_full = pool_is_full_objects || pool_is_full_bytes;    
 
     if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
       if (pool_is_full)
@@ -6248,6 +6247,7 @@ bool OSDMonitor::update_pools_status()
       clear_pool_flags(it->first,
                        pg_pool_t::FLAG_FULL_QUOTA |
 		       pg_pool_t::FLAG_FULL_QUOTA_OBJECTS |
+		       pg_pool_t::FLAG_FULL_QUOTA_BYTES |
 		       pg_pool_t::FLAG_FULL);
       ret = true;
     } else {
@@ -6276,6 +6276,9 @@ bool OSDMonitor::update_pools_status()
                        pg_pool_t::FLAG_BACKFILLFULL);
       if (pool_is_full_objects) {
 	set_pool_flags(it->first, pg_pool_t::FLAG_FULL_QUOTA_OBJECTS);
+      }
+      if (pool_is_full_bytes) {
+	set_pool_flags(it->first, pg_pool_t::FLAG_FULL_QUOTA_BYTES);
       }
       ret = true;
     }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6242,7 +6242,12 @@ bool OSDMonitor::update_pools_status()
     bool changed_objects = was_full_objects != pool_is_full_objects;
     bool changed_bytes = was_full_bytes != pool_is_full_bytes;
 
-    if (!changed_objects && !changed_bytes) {
+    if (!changed_objects && !changed_bytes &&
+	(pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA == pool_is_full))) {
+      /* this if conditions is a bit complicated to deal with 
+	 the situation where we had an incorrect QUOTA_BYTES
+	 or QUOTA_OBJECTS flag set when it shouldn't be.
+	 See https://github.com/ceph/ceph/pull/26873#discussion_r267674431 */
       continue;
     }
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6236,9 +6236,17 @@ bool OSDMonitor::update_pools_status()
 			       (uint64_t)sum.num_bytes >= pool.quota_max_bytes);
     bool pool_is_full = pool_is_full_objects || pool_is_full_bytes;    
 
-    if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
-      if (pool_is_full)
-        continue;
+    bool was_full_objects = pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA_OBJECTS);
+    bool was_full_bytes = pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA_BYTES);
+
+    bool changed_objects = was_full_objects != pool_is_full_objects;
+    bool changed_bytes = was_full_bytes != pool_is_full_bytes;
+
+    if (!changed_objects && !changed_bytes) {
+      continue;
+    }
+
+    if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA) && !pool_is_full) {
 
       mon->clog->info() << "pool '" << pool_name
                        << "' no longer out of quota; removing NO_QUOTA flag";
@@ -6251,35 +6259,31 @@ bool OSDMonitor::update_pools_status()
 		       pg_pool_t::FLAG_FULL);
       ret = true;
     } else {
-      if (!pool_is_full)
-	continue;
-
-      if (pool.quota_max_bytes > 0 &&
-          (uint64_t)sum.num_bytes >= pool.quota_max_bytes) {
-        mon->clog->warn() << "pool '" << pool_name << "' is full"
-                         << " (reached quota's max_bytes: "
-                         << byte_u_t(pool.quota_max_bytes) << ")";
+      int flags_to_set = 0;
+      if (pool_is_full_bytes) {
+	flags_to_set |= pg_pool_t::FLAG_FULL_QUOTA_BYTES;
+	if (changed_bytes) {
+	  mon->clog->warn() << "pool '" << pool_name << "' is full"
+			    << " (reached quota's max_bytes: "
+			    << byte_u_t(pool.quota_max_bytes) << ")";
+	}
       }
-      if (pool.quota_max_objects > 0 &&
-		 (uint64_t)sum.num_objects >= pool.quota_max_objects) {
-        mon->clog->warn() << "pool '" << pool_name << "' is full"
-                         << " (reached quota's max_objects: "
-                         << pool.quota_max_objects << ")";
+      if (pool_is_full_objects) {
+	flags_to_set |= pg_pool_t::FLAG_FULL_QUOTA_OBJECTS;
+	if (changed_objects) {
+	  mon->clog->warn() << "pool '" << pool_name << "' is full"
+			    << " (reached quota's max_objects: "
+			    << pool.quota_max_objects << ")";
+	}
       }
       // set both FLAG_FULL_QUOTA and FLAG_FULL
       // note that below we try to cancel FLAG_BACKFILLFULL/NEARFULL too
       // since FLAG_FULL should always take precedence
-      set_pool_flags(it->first,
-                     pg_pool_t::FLAG_FULL_QUOTA | pg_pool_t::FLAG_FULL);
+      flags_to_set |= (pg_pool_t::FLAG_FULL_QUOTA | pg_pool_t::FLAG_FULL);
       clear_pool_flags(it->first,
                        pg_pool_t::FLAG_NEARFULL |
                        pg_pool_t::FLAG_BACKFILLFULL);
-      if (pool_is_full_objects) {
-	set_pool_flags(it->first, pg_pool_t::FLAG_FULL_QUOTA_OBJECTS);
-      }
-      if (pool_is_full_bytes) {
-	set_pool_flags(it->first, pg_pool_t::FLAG_FULL_QUOTA_BYTES);
-      }
+      set_pool_flags(it->first, flags_to_set);
       ret = true;
     }
   }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5562,7 +5562,13 @@ void OSDMap::check_health(health_check_map_t *checks) const
         if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
           // may run out of space too,
           // but we want EQUOTA taking precedence
-          ss << "pool '" << pool_name << "' is full (running out of quota)";
+	  if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA_OBJECTS)) {
+	    ss << "pool '" << pool_name << "' is full (reached objects quota "
+	       << pool.quota_max_objects << ")";
+	  } else {
+	    ss << "pool '" << pool_name << "' is full (reached size quota "
+	       << byte_u_t(pool.quota_max_bytes) << ")";
+          }
         } else {
           ss << "pool '" << pool_name << "' is full (no space)";
         }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5565,7 +5565,8 @@ void OSDMap::check_health(health_check_map_t *checks) const
 	  if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA_OBJECTS)) {
 	    ss << "pool '" << pool_name << "' is full (reached objects quota "
 	       << pool.quota_max_objects << ")";
-	  } else {
+	  }
+	  if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA_BYTES)) {
 	    ss << "pool '" << pool_name << "' is full (reached size quota "
 	       << byte_u_t(pool.quota_max_bytes) << ")";
           }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1693,7 +1693,8 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     encode(snaps, bl, features);
     encode(removed_snaps, bl);
     encode(auid, bl);
-    encode(flags, bl);
+    uint64_t peer_flags = flags & ~(FLAG_FULL_QUOTA_OBJECTS|FLAG_FULL_QUOTA_BYTES);
+    encode(peer_flags, bl);
     encode((uint32_t)0, bl); // crash_replay_interval
     return;
   }
@@ -1720,7 +1721,8 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     encode(snaps, bl, features);
     encode(removed_snaps, bl);
     encode(auid, bl);
-    encode(flags, bl);
+    uint64_t peer_flags = flags & ~(FLAG_FULL_QUOTA_OBJECTS|FLAG_FULL_QUOTA_BYTES);
+    encode(peer_flags, bl);
     encode((uint32_t)0, bl); // crash_replay_interval
     encode(min_size, bl);
     encode(quota_max_bytes, bl);
@@ -1747,7 +1749,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     return;
   }
 
-  uint8_t v = 28;
+  uint8_t v = 29;
   // NOTE: any new encoding dependencies must be reflected by
   // SIGNIFICANT_FEATURES
   if (!(features & CEPH_FEATURE_NEW_OSDOP_ENCODING)) {
@@ -1778,13 +1780,14 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
   encode(snaps, bl, features);
   encode(removed_snaps, bl);
   encode(auid, bl);
-  if (v >= 27) {
-    encode(flags, bl);
-  } else {
-    auto tmp = flags;
-    tmp &= ~(FLAG_SELFMANAGED_SNAPS | FLAG_POOL_SNAPS | FLAG_CREATING);
-    encode(tmp, bl);
+  uint64_t peer_flags = flags;
+  if (v < 29) {
+    peer_flags &= ~(FLAG_FULL_QUOTA_OBJECTS|FLAG_FULL_QUOTA_BYTES);
+    if (v < 27) {
+      peer_flags &= ~(FLAG_SELFMANAGED_SNAPS | FLAG_POOL_SNAPS | FLAG_CREATING);
+    }
   }
+  encode(peer_flags, bl);
   encode((uint32_t)0, bl); // crash_replay_interval
   encode(min_size, bl);
   encode(quota_max_bytes, bl);
@@ -1852,7 +1855,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
 
 void pg_pool_t::decode(bufferlist::const_iterator& bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(28, 5, 5, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(29, 5, 5, bl);
   decode(type, bl);
   decode(size, bl);
   decode(crush_rule, bl);
@@ -1882,7 +1885,12 @@ void pg_pool_t::decode(bufferlist::const_iterator& bl)
   }
 
   if (struct_v >= 4) {
-    decode(flags, bl);
+    uint64_t eflags;
+    decode(eflags, bl);
+    if (struct_v < 29) {
+      eflags &= ~(FLAG_FULL_QUOTA_OBJECTS|FLAG_FULL_QUOTA_BYTES);
+    }
+    flags = eflags;
     uint32_t crash_replay_interval;
     decode(crash_replay_interval, bl);
   } else {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1122,6 +1122,7 @@ struct pg_pool_t {
     FLAG_SELFMANAGED_SNAPS = 1<<13, // pool uses selfmanaged snaps
     FLAG_POOL_SNAPS = 1<<14,        // pool has pool snaps
     FLAG_CREATING = 1<<15,          // initial pool PGs are being created
+    FLAG_FULL_QUOTA_OBJECTS = 1<<16, // pool quota filled up on object count, not raw size. Also sets FULL_QUOTA
   };
 
   static const char *get_flag_name(int f) {
@@ -1137,6 +1138,7 @@ struct pg_pool_t {
     case FLAG_NOSCRUB: return "noscrub";
     case FLAG_NODEEP_SCRUB: return "nodeep-scrub";
     case FLAG_FULL_QUOTA: return "full_quota";
+    case FLAG_FULL_QUOTA_OBJECTS: return "full_quota_objects";
     case FLAG_NEARFULL: return "nearfull";
     case FLAG_BACKFILLFULL: return "backfillfull";
     case FLAG_SELFMANAGED_SNAPS: return "selfmanaged_snaps";
@@ -1182,6 +1184,8 @@ struct pg_pool_t {
       return FLAG_NODEEP_SCRUB;
     if (name == "full_quota")
       return FLAG_FULL_QUOTA;
+    if (name == "full_quota_objects")
+      return FLAG_FULL_QUOTA_OBJECTS;
     if (name == "nearfull")
       return FLAG_NEARFULL;
     if (name == "backfillfull")

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1123,6 +1123,7 @@ struct pg_pool_t {
     FLAG_POOL_SNAPS = 1<<14,        // pool has pool snaps
     FLAG_CREATING = 1<<15,          // initial pool PGs are being created
     FLAG_FULL_QUOTA_OBJECTS = 1<<16, // pool quota filled up on object count, not raw size. Also sets FULL_QUOTA
+    FLAG_FULL_QUOTA_BYTES = 1<<17, // pool quota filled up on bytes of data. Also sets FULL_QUOTA
   };
 
   static const char *get_flag_name(int f) {
@@ -1139,6 +1140,7 @@ struct pg_pool_t {
     case FLAG_NODEEP_SCRUB: return "nodeep-scrub";
     case FLAG_FULL_QUOTA: return "full_quota";
     case FLAG_FULL_QUOTA_OBJECTS: return "full_quota_objects";
+    case FLAG_FULL_QUOTA_BYTES: return "full_quota_bytes";
     case FLAG_NEARFULL: return "nearfull";
     case FLAG_BACKFILLFULL: return "backfillfull";
     case FLAG_SELFMANAGED_SNAPS: return "selfmanaged_snaps";
@@ -1186,6 +1188,8 @@ struct pg_pool_t {
       return FLAG_FULL_QUOTA;
     if (name == "full_quota_objects")
       return FLAG_FULL_QUOTA_OBJECTS;
+    if (name == "full_quota_bytes")
+      return FLAG_FULL_QUOTA_BYTES;
     if (name == "nearfull")
       return FLAG_NEARFULL;
     if (name == "backfillfull")


### PR DESCRIPTION
…put them

We add a separate pool FLAG_QUOTA_FULL_OBJECTS, which is set only
when the FLAG_QUOTA_FULL is set AND the quota exceeded is for the object
count. This lets us output the relevant exceeded quota from
OSDMap::check_health().

Fixes: http://tracker.ceph.com/issues/38653

Signed-off-by: Greg Farnum <gfarnum@redhat.com>