### PR TITLE
mgr/MgrStandby: exit with 0 result code, as if we'd done an orderly shutdown

### DIFF
--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -264,7 +264,7 @@ void MgrStandby::handle_signal(int signum)
 {
   ceph_assert(signum == SIGINT || signum == SIGTERM);
   derr << "*** Got signal " << sig_str(signum) << " ***" << dendl;
-  _exit(128 + signum);
+  _exit(0);  // exit with 0 result code, as if we had done an orderly shutdown
   //shutdown();
 }
 


### PR DESCRIPTION
This matches the prior behavior with shutdown().  It also makes
teuthology happy.

Signed-off-by: Sage Weil <sage@redhat.com>