### PR TITLE
os/bluestore: make bluefs spillover messages nicer

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2966,7 +2966,7 @@ void PGMap::get_health_checks(
 
     for (auto& a : osd_sum.os_alerts) {
       int left = max;
-      string s0 = " osd:";
+      string s0 = " osd.";
       s0 += stringify(a.first);
       for (auto& aa : a.second) {
         string s(s0);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5655,9 +5655,12 @@ int BlueStore::_balance_bluefs_freespace()
   if (bluefs_shared_bdev == BlueFS::BDEV_SLOW) {
     auto& p = bluefs_usage[bluefs_shared_bdev];
     if (p.first != p.second) {
-      string s("spilled over to slow device: ");
-      s += stringify(byte_u_t(p.second - p.first));
-      _set_spillover_alert(s.c_str());
+      auto& db = bluefs_usage[BlueFS::BDEV_DB];
+      ostringstream ss;
+      ss << "spilled over " << byte_u_t(p.second - p.first)
+	 << " metadata from 'db' device (" << byte_u_t(db.second - db.first)
+	 << " used of " << byte_u_t(db.second) << ") to slow device";
+      _set_spillover_alert(ss.str());
       clear_alert = false;
     }
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2711,7 +2711,7 @@ private:
     failed_cmode.clear();
   }
 
-  void _set_spillover_alert(const char* s) {
+  void _set_spillover_alert(const string& s) {
     std::lock_guard l(qlock);
     spillover_alert = s;
   }

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -566,7 +566,7 @@ EOF
         bluestore_block_path = spdk:$(get_pci_selector)"
             else
                 BLUESTORE_OPTS="        bluestore block db path = $CEPH_DEV_DIR/osd\$id/block.db.file
-        bluestore block db size = 67108864
+        bluestore block db size = 1073741824
         bluestore block db create = true
         bluestore block wal path = $CEPH_DEV_DIR/osd\$id/block.wal.file
         bluestore block wal size = 1048576000


### PR DESCRIPTION
Was

 osd:50 spilled over to slow device: 1.3 GiB

Now

 osd.50 spilled over 1.3 GiB metadata from 'db' device (9.5 GiB used of 10 GiB) to slow device

Signed-off-by: Sage Weil <sage@redhat.com>