### PR TITLE
mds: avoid check session connection's features when issuing caps

### DIFF
--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -245,9 +245,6 @@ public:
   
   // -- replication
   void encode_replica(mds_rank_t mds, bufferlist& bl, bool need_recover) {
-    if (!is_replicated())
-      lock.replicate_relax();
-
     __u32 nonce = add_replica(mds);
     encode(nonce, bl);
     encode(first, bl);

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3160,7 +3160,8 @@ int CInode::get_xlocker_mask(client_t client) const
     (linklock.gcaps_xlocker_mask(client) << linklock.get_cap_shift());
 }
 
-int CInode::get_caps_allowed_for_client(Session *session, mempool_inode *file_i) const
+int CInode::get_caps_allowed_for_client(Session *session, Capability *cap,
+					mempool_inode *file_i) const
 {
   client_t client = session->get_client();
   int allowed;
@@ -3174,13 +3175,23 @@ int CInode::get_caps_allowed_for_client(Session *session, mempool_inode *file_i)
   }
 
   if (!is_dir()) {
-    if ((file_i->inline_data.version != CEPH_INLINE_NONE &&
-	 !session->get_connection()->has_feature(
-	   CEPH_FEATURE_MDS_INLINE_DATA)) ||
-	(!file_i->layout.pool_ns.empty() &&
-	 !session->get_connection()->has_feature(
-	   CEPH_FEATURE_FS_FILE_LAYOUT_V2)))
-      allowed &= ~(CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR);
+    if (file_i->inline_data.version == CEPH_INLINE_NONE &&
+	file_i->layout.pool_ns.empty()) {
+      // noop
+    } else if (cap) {
+      if ((file_i->inline_data.version != CEPH_INLINE_NONE &&
+	   cap->is_noinline()) ||
+	  (!file_i->layout.pool_ns.empty() &&
+	   cap->is_nopoolns()))
+	allowed &= ~(CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR);
+    } else {
+      auto& conn = session->get_connection();
+      if ((file_i->inline_data.version != CEPH_INLINE_NONE &&
+	   !conn->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)) ||
+	  (!file_i->layout.pool_ns.empty() &&
+	   !conn->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)))
+	allowed &= ~(CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR);
+    }
   }
   return allowed;
 }
@@ -3475,7 +3486,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
      */
     ecap.caps = valid ? get_caps_allowed_by_type(CAP_ANY) : CEPH_STAT_CAP_INODE;
     if (last == CEPH_NOSNAP || is_any_caps())
-      ecap.caps = ecap.caps & get_caps_allowed_for_client(session, file_i);
+      ecap.caps = ecap.caps & get_caps_allowed_for_client(session, nullptr, file_i);
     ecap.seq = 0;
     ecap.mseq = 0;
     ecap.realm = 0;
@@ -3490,7 +3501,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     int issue = 0;
     if (!no_caps && cap) {
       int likes = get_caps_liked();
-      int allowed = get_caps_allowed_for_client(session, file_i);
+      int allowed = get_caps_allowed_for_client(session, cap, file_i);
       issue = (cap->wanted() | likes) & allowed;
       cap->issue_norevoke(issue);
       issue = cap->pending();
@@ -3666,22 +3677,23 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode(file_i->rstat.rctime, bl);
     dirfragtree.encode(bl);
     encode(symlink, bl);
-    if (session->get_connection()->has_feature(CEPH_FEATURE_DIRLAYOUTHASH)) {
+    auto& conn = session->get_connection();
+    if (conn->has_feature(CEPH_FEATURE_DIRLAYOUTHASH)) {
       encode(file_i->dir_layout, bl);
     }
     encode_xattrs();
-    if (session->get_connection()->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)) {
+    if (conn->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)) {
       encode(inline_version, bl);
       encode(inline_data, bl);
     }
-    if (session->get_connection()->has_feature(CEPH_FEATURE_MDS_QUOTA)) {
+    if (conn->has_feature(CEPH_FEATURE_MDS_QUOTA)) {
       mempool_inode *policy_i = ppolicy ? pi : oi;
       encode(policy_i->quota, bl);
     }
-    if (session->get_connection()->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
+    if (conn->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
       encode(layout.pool_ns, bl);
     }
-    if (session->get_connection()->has_feature(CEPH_FEATURE_FS_BTIME)) {
+    if (conn->has_feature(CEPH_FEATURE_FS_BTIME)) {
       encode(any_i->btime, bl);
       encode(any_i->change_attr, bl);
     }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3268,24 +3268,6 @@ bool CInode::issued_caps_need_gather(SimpleLock *lock)
   return false;
 }
 
-void CInode::replicate_relax_locks()
-{
-  //dout(10) << " relaxing locks on " << *this << dendl;
-  ceph_assert(is_auth());
-  ceph_assert(!is_replicated());
-  
-  authlock.replicate_relax();
-  linklock.replicate_relax();
-  dirfragtreelock.replicate_relax();
-  filelock.replicate_relax();
-  xattrlock.replicate_relax();
-  snaplock.replicate_relax();
-  nestlock.replicate_relax();
-  flocklock.replicate_relax();
-  policylock.replicate_relax();
-}
-
-
 
 // =============================================
 

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -1050,7 +1050,7 @@ public:
   int get_caps_allowed_by_type(int type) const;
   int get_caps_careful() const;
   int get_xlocker_mask(client_t client) const;
-  int get_caps_allowed_for_client(Session *s, mempool_inode *file_i) const;
+  int get_caps_allowed_for_client(Session *s, Capability *cap, mempool_inode *file_i) const;
 
   // caps issued, wanted
   int get_caps_issued(int *ploner = 0, int *pother = 0, int *pxlocker = 0,

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -839,10 +839,6 @@ public:
   void encode_replica(mds_rank_t rep, bufferlist& bl, uint64_t features, bool need_recover) {
     ceph_assert(is_auth());
     
-    // relax locks?
-    if (!is_replicated())
-      replicate_relax_locks();
-    
     __u32 nonce = add_replica(rep);
     using ceph::encode;
     encode(nonce, bl);
@@ -1058,7 +1054,6 @@ public:
   bool is_any_caps_wanted() const;
   int get_caps_wanted(int *ploner = 0, int *pother = 0, int shift = 0, int mask = -1) const;
   bool issued_caps_need_gather(SimpleLock *lock);
-  void replicate_relax_locks();
 
   // -- authority --
   mds_authority_t authority() const override;

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -72,18 +72,20 @@ public:
   MEMPOOL_CLASS_HELPERS();
 
   struct Export {
-    int64_t cap_id;
-    int32_t wanted;
-    int32_t issued;
-    int32_t pending;
+    int64_t cap_id = 0;
+    int32_t wanted = 0;
+    int32_t issued = 0;
+    int32_t pending = 0;
     snapid_t client_follows;
-    ceph_seq_t seq;
-    ceph_seq_t mseq;
+    ceph_seq_t seq = 0;
+    ceph_seq_t mseq = 0;
     utime_t last_issue_stamp;
-    Export() : cap_id(0), wanted(0), issued(0), pending(0), seq(0), mseq(0) {}
-    Export(int64_t id, int w, int i, int p, snapid_t cf, ceph_seq_t s, ceph_seq_t m, utime_t lis) :
+    uint32_t state = 0;
+    Export() {}
+    Export(int64_t id, int w, int i, int p, snapid_t cf,
+	   ceph_seq_t s, ceph_seq_t m, utime_t lis, unsigned st) :
       cap_id(id), wanted(w), issued(i), pending(p), client_follows(cf),
-      seq(s), mseq(m), last_issue_stamp(lis) {}
+      seq(s), mseq(m), last_issue_stamp(lis), state(st) {}
     void encode(bufferlist &bl) const;
     void decode(bufferlist::const_iterator &p);
     void dump(Formatter *f) const;
@@ -115,6 +117,12 @@ public:
   const static unsigned STATE_IMPORTING		= (1<<2);
   const static unsigned STATE_NEEDSNAPFLUSH	= (1<<3);
   const static unsigned STATE_CLIENTWRITEABLE	= (1<<4);
+  const static unsigned STATE_NOINLINE		= (1<<5);
+  const static unsigned STATE_NOPOOLNS		= (1<<6);
+  const static unsigned STATE_NOQUOTA		= (1<<7);
+
+  const static unsigned MASK_STATE_EXPORTED =
+    (STATE_CLIENTWRITEABLE | STATE_NOINLINE | STATE_NOPOOLNS | STATE_NOQUOTA);
 
   Capability(CInode *i=nullptr, Session *s=nullptr, uint64_t id=0);
   Capability(const Capability& other) = delete;
@@ -262,6 +270,10 @@ public:
     }
   }
 
+  bool is_noinline() const { return state & STATE_NOINLINE; }
+  bool is_nopoolns() const { return state & STATE_NOPOOLNS; }
+  bool is_noquota() const { return state & STATE_NOQUOTA; }
+
   CInode *get_inode() const { return inode; }
   Session *get_session() const { return session; }
   client_t get_client() const;
@@ -285,7 +297,7 @@ public:
   
   // -- exports --
   Export make_export() const {
-    return Export(cap_id, wanted(), issued(), pending(), client_follows, get_last_seq(), mseq+1, last_issue_stamp);
+    return Export(cap_id, wanted(), issued(), pending(), client_follows, get_last_seq(), mseq+1, last_issue_stamp, state);
   }
   void merge(const Export& other, bool auth_cap) {
     if (!is_stale()) {
@@ -301,6 +313,10 @@ public:
     }
 
     client_follows = other.client_follows;
+
+    state |= other.state & MASK_STATE_EXPORTED;
+    if ((other.state & STATE_CLIENTWRITEABLE) && !is_notable())
+      mark_notable();
 
     // wanted
     set_wanted(wanted() | other.wanted);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -1947,13 +1947,9 @@ void MDCache::broadcast_quota_to_client(CInode *in, client_t exclude_ct, bool qu
     mds->server->create_quota_realm(in);
 
   for (auto &p : in->client_caps) {
-    Session *session = mds->get_session(p.first);
-    if (!session ||
-	!session->get_connection() ||
-        !session->get_connection()->has_feature(CEPH_FEATURE_MDS_QUOTA))
-      continue;
-
     Capability *cap = &p.second;
+    if (cap->is_noquota())
+      continue;
 
     if (exclude_ct >= 0 && exclude_ct != p.first)
       goto update;
@@ -1990,7 +1986,7 @@ update:
     msg->ino = in->ino();
     msg->rstat = i->rstat;
     msg->quota = i->quota;
-    mds->send_message_client_counted(msg, session->get_connection());
+    mds->send_message_client_counted(msg, cap->get_session());
   }
   for (const auto &it : in->get_replicas()) {
     auto msg = MGatherCaps::create();

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -1596,12 +1596,6 @@ void Migrator::encode_export_inode(CInode *in, bufferlist& enc_state,
   dout(7) << "encode_export_inode " << *in << dendl;
   ceph_assert(!in->is_replica(mds->get_nodeid()));
 
-  // relax locks?
-  if (!in->is_replicated()) {
-    in->replicate_relax_locks();
-    dout(20) << " did replicate_relax_locks, now " << *in << dendl;
-  }
-
   encode(in->inode.ino, enc_state);
   encode(in->last, enc_state);
   in->encode_export(enc_state);
@@ -1739,9 +1733,6 @@ uint64_t Migrator::encode_export_dir(bufferlist& exportbl,
   for (auto &p : *dir) {
     CDentry *dn = p.second;
     CInode *in = dn->get_linkage()->get_inode();
-    
-    if (!dn->is_replicated())
-      dn->lock.replicate_relax();
 
     num_exported++;
     

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -563,10 +563,6 @@ public:
     state_flags &= ~LEASED;
   }
 
-  bool is_used() const {
-    return is_xlocked() || is_rdlocked() || is_wrlocked() || is_leased();
-  }
-
   bool needs_recover() const {
     return state_flags & NEED_RECOVER;
   }
@@ -657,15 +653,6 @@ public:
     state = get_replica_state();
   }
 
-  /** replicate_relax
-   * called on first replica creation.
-   */
-  void replicate_relax() {
-    ceph_assert(parent->is_auth());
-    ceph_assert(!parent->is_replicated());
-    if (state == LOCK_LOCK && !is_used())
-      state = LOCK_SYNC;
-  }
   bool remove_replica(int from) {
     if (is_gathering(from)) {
       remove_gather(from);


### PR DESCRIPTION
Session connection can be null for imported session. The fix is
recording which features client does not support in cap when cap
is newly added.

Fixes: https://tracker.ceph.com/issues/38652
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

