### PR TITLE
os/bluestore: avoid "no available blob id" assertion

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -817,8 +817,9 @@ public:
     unsigned decode_some(bufferlist& bl);
 
     void bound_encode_spanning_blobs(size_t& p);
-    void encode_spanning_blobs(bufferlist::contiguous_appender& p);
-    void decode_spanning_blobs(bufferptr::const_iterator& p);
+    size_t encode_spanning_blobs(bufferlist::contiguous_appender& p,
+				 KeyValueDB::Transaction &txn);
+    void decode_spanning_blobs(KeyValueDB *db, bufferptr::const_iterator& p);
 
     BlobRef get_spanning_blob(int id) {
       auto& b = spanning_blob_map[id];

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -460,7 +460,7 @@ public:
 
   DENC_HELPERS;
   void bound_encode(size_t& p, uint64_t struct_v) const {
-    ceph_assert(struct_v == 1 || struct_v == 2);
+    ceph_assert(struct_v == 1 || struct_v == 2 || struct_v == 3);
     denc(extents, p);
     denc_varint(flags, p);
     denc_varint_lowz(logical_length, p);
@@ -473,7 +473,7 @@ public:
   }
 
   void encode(bufferlist::contiguous_appender& p, uint64_t struct_v) const {
-    ceph_assert(struct_v == 1 || struct_v == 2);
+    ceph_assert(struct_v == 1 || struct_v == 2 || struct_v == 3);
     denc(extents, p);
     denc_varint(flags, p);
     if (is_compressed()) {
@@ -493,7 +493,7 @@ public:
   }
 
   void decode(bufferptr::const_iterator& p, uint64_t struct_v) {
-    ceph_assert(struct_v == 1 || struct_v == 2);
+    ceph_assert(struct_v == 1 || struct_v == 2 || struct_v == 3);
     denc(extents, p);
     denc_varint(flags, p);
     if (is_compressed()) {


### PR DESCRIPTION
This implements spanning blob map sharding. Proposed implementation is pretty straightforward and lacks potential optimization tricks, e.g. shard item count is fixed and every spanning blob map shard is loaded along with onode loading. 
But  IMO this is rather a workaround to avoid assertions in production.  In fact we should rather redesign extent sharding one day.

Fixes: https://tracker.ceph.com/issues/38272

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

