### PR TITLE
mgr/dashboard: Change 'Client Recovery' title

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -158,7 +158,7 @@
         </span>
       </cd-info-card>
 
-      <cd-info-card cardTitle="Client Recovery"
+      <cd-info-card cardTitle="Recovery Throughput"
                     i18n-cardTitle
                     class="cd-col-5"
                     cardClass="card-medium"

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -3760,8 +3760,8 @@
           <context context-type="sourcefile">app/ceph/dashboard/health/health.component.html</context>
           <context context-type="linenumber">143</context>
         </context-group>
-      </trans-unit><trans-unit id="5277e7546d03a767761199b70deb8c77a921b390" datatype="html">
-        <source>Client Recovery</source>
+      </trans-unit><trans-unit id="275485415092cbae3a9f3cbb786ebe283cacfdd5" datatype="html">
+        <source>Recovery Throughput</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/dashboard/health/health.component.html</context>
           <context context-type="linenumber">161</context>


### PR DESCRIPTION
Rename 'Client Recovery' info-card title to 'Recovery Throughput' as:
- 'Client' is a misleading concept there, as long as all recovery is
server-side driven.
- No indication of the kind of metric (e.g.: IOPS, throughput, etc).

Fixes: https://tracker.ceph.com/issues/38657
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

