### PR TITLE
ceph.spec.in: add libstoragemgmt to mgr package

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -629,6 +629,7 @@ Provides:	ceph-test:/usr/bin/ceph-osdomap-tool
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 Requires:	lvm2
 Requires:	sudo
+Requires: libstoragemgmt
 %description osd
 ceph-osd is the object storage daemon for the Ceph distributed file
 system.  It is responsible for storing objects on a local file system


### PR DESCRIPTION
The libstoragemgmt package is needed so we can activate the drive
blink-led feature so we should pull that package.

Signed-off-by: Sébastien Han <seb@redhat.com>

