### PR TITLE
qa: unmount clients prior to marking fs down

### DIFF
--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -96,6 +96,8 @@ class TestClusterResize(CephFSTestCase):
         That marking a FS down does not generate a health warning
         """
 
+        self.mount_a.umount_wait()
+
         self.fs.set_down()
         try:
             self.wait_for_health("", 30)
@@ -111,6 +113,8 @@ class TestClusterResize(CephFSTestCase):
         That marking a FS down twice does not wipe old_max_mds.
         """
 
+        self.mount_a.umount_wait()
+
         self.grow(2)
         self.fs.set_down()
         self.fs.wait_for_daemons()
@@ -123,6 +127,8 @@ class TestClusterResize(CephFSTestCase):
         That setting max_mds undoes down.
         """
 
+        self.mount_a.umount_wait()
+
         self.fs.set_down()
         self.fs.wait_for_daemons()
         self.grow(2)
@@ -132,6 +138,8 @@ class TestClusterResize(CephFSTestCase):
         """
         That down setting toggles and sets max_mds appropriately.
         """
+
+        self.mount_a.umount_wait()
 
         self.fs.set_down()
         self.fs.wait_for_daemons()


### PR DESCRIPTION
Evicted RHEL7.5 clients may hang.

Fixes: http://tracker.ceph.com/issues/38677
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

