### PR TITLE
vstart.sh: add options to use crimson-osd and seastar smp setting

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -36,9 +36,13 @@ int main(int argc, char* argv[])
                                               CEPH_ENTITY_TYPE_OSD,
                                               &cluster,
                                               &conf_file_list);
+  namespace bpo = boost::program_options;
   seastar::app_template app;
   app.add_options()
-    ("mkfs", "create a [new] data directory");
+    ("mkfs", "create a [new] data directory")
+    ("key", bpo::value<std::string>()->default_value(""), "Authentication key")
+    ("osd-uuid", bpo::value<boost::uuids::uuid>()->default_value(uuid_d().uuid), "uuid label for a new OSD")
+    ;
   seastar::sharded<OSD> osd;
 
   using ceph::common::sharded_conf;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -128,6 +128,7 @@ if [ `uname` = FreeBSD ]; then
 else
     objectstore="bluestore"
 fi
+ceph_osd=ceph-osd
 rgw_frontend="beast"
 rgw_compression=""
 lockdep=${LOCKDEP:-1}
@@ -193,12 +194,15 @@ usage=$usage"\t--bluestore-spdk <vendor>:<device>: enable SPDK and specify the P
 usage=$usage"\t--msgr1: use msgr1 only\n"
 usage=$usage"\t--msgr2: use msgr2 only\n"
 usage=$usage"\t--msgr21: use msgr2 and msgr1\n"
+usage=$usage"\t--crimson: use crimson-osd instead of ceph-osd\n"
+usage=$usage"\t--smp: set crimson-osd thread number\n"
 
 usage_exit() {
 	printf "$usage"
 	exit
 }
 
+SEASTAR_ARGS=""
 while [ $# -ge 1 ]; do
 case $1 in
     -d | --debug )
@@ -226,6 +230,14 @@ case $1 in
 	;;
     --short )
 	    short=1
+	    ;;
+    --crimson )
+        ceph_osd=crimson-osd
+        ;;
+    --smp )
+	    [ -z "$2" ] && usage_exit
+	    SEASTAR_ARGS="--smp $2"
+	    shift
 	    ;;
     --msgr1 )
 	msgr="1"
@@ -754,7 +766,7 @@ EOF
 	    echo "{\"cephx_secret\": \"$OSD_SECRET\"}" > $CEPH_DEV_DIR/osd$osd/new.json
             ceph_adm osd new $uuid -i $CEPH_DEV_DIR/osd$osd/new.json
 	    rm $CEPH_DEV_DIR/osd$osd/new.json
-            $SUDO $CEPH_BIN/ceph-osd -i $osd $ARGS --mkfs --key $OSD_SECRET --osd-uuid $uuid
+            $SUDO $CEPH_BIN/$ceph_osd -i $osd $ARGS --mkfs --key $OSD_SECRET --osd-uuid $uuid $SEASTAR_ARGS
 
             local key_fn=$CEPH_DEV_DIR/osd$osd/keyring
 	    cat > $key_fn<<EOF
@@ -765,7 +777,7 @@ EOF
             ceph_adm -i "$key_fn" auth add osd.$osd osd "allow *" mon "allow profile osd" mgr "allow profile osd"
         fi
         echo start osd.$osd
-        run 'osd' $SUDO $CEPH_BIN/ceph-osd -i $osd $ARGS $COSD_ARGS
+        run 'osd' $SUDO $CEPH_BIN/$ceph_osd -i $osd $ARGS $COSD_ARGS $SEASTAR_ARGS
     done
 }
 


### PR DESCRIPTION
--crimson : use crimson-osd instead of ceph-osd
--smp: set seastar thread number

Signed-off-by: chunmei Liu <chunmei.liu@intel.com>
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

