### PR TITLE
mgr/deepsea: always use 'password' parameter for salt-api auth

### DIFF
--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -441,7 +441,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
     def _login(self):
         resp = self._do_request('POST', 'login', data = {
             "eauth": self.get_module_option('salt_api_eauth'),
-            "sharedsecret" if self.get_module_option('salt_api_eauth') == 'sharedsecret' else 'password': self.get_module_option('salt_api_password'),
+            "password": self.get_module_option('salt_api_password'),
             "username": self.get_module_option('salt_api_username')
         })
         self._token = resp.json()['return'][0]['token']


### PR DESCRIPTION
Prior to https://github.com/saltstack/salt/commit/71d5601507, the
salt-api expected the password to be sent using the 'sharedsecret'
parameter if using shared secrets, and the 'password' parameter
for other authentication types.  The above commit unifies this so
that we always only need to use the 'password' parameter.

Signed-off-by: Tim Serong <tserong@suse.com>