### PR TITLE
rgw: pubsub HandleObjEvent ignores errors from missing subs

### DIFF
--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -1217,6 +1217,7 @@ public:
             yield PSManager::call_get_subscription_cr(sync_env, env->manager, this, *oiter, *siter, &sub);
             if (retcode < 0) {
               last_sub_conf_error = retcode;
+              retcode = 0; // not fatal
               continue;
             }
             sub_conf_found = true;


### PR DESCRIPTION
pubsub events with missing subscriptions should not return ENOENT errors back through sync_object() to RGWRunBucketSyncCoroutine. in general, errors from sync_object() will block sync and be retried until success. but in the case of ENOENT, we misinterpret the error in RGWDataSyncSingleEntryCR:
```c++
      if (sync_status == -ENOENT) {                                                
        // this was added when 'tenant/' was added to datalog entries, because     
        // preexisting tenant buckets could never sync and would stay in the
        // error_repo forever
        tn->log(0, SSTR("WARNING: skipping data log entry for missing bucket " << raw_key));
        sync_status = 0;
      }
```
so in the end these ENOENT errors don't break anything, but we shouldn't rely on this unrelated check