### PR TITLE
mgr/dashboard: Add separate option to config SSL port

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -220,6 +220,7 @@ cluster-wide level (so they apply to all manager instances) as follows::
 
   $ ceph config set mgr mgr/dashboard/server_addr $IP
   $ ceph config set mgr mgr/dashboard/server_port $PORT
+  $ ceph config set mgr mgr/dashboard/ssl_server_port $PORT
 
 Since each ``ceph-mgr`` hosts its own instance of dashboard, it may also be
 necessary to configure them separately. The IP address and port for a specific
@@ -227,6 +228,7 @@ manager instance can be changed with the following commands::
 
   $ ceph config set mgr mgr/dashboard/$name/server_addr $IP
   $ ceph config set mgr mgr/dashboard/$name/server_port $PORT
+  $ ceph config set mgr mgr/dashboard/$name/ssl_server_port $PORT
 
 Replace ``$name`` with the ID of the ceph-mgr instance hosting the dashboard web
 app.

--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -110,7 +110,7 @@ class DashboardTestCase(MgrTestCase):
     @classmethod
     def setUpClass(cls):
         super(DashboardTestCase, cls).setUpClass()
-        cls._assign_ports("dashboard", "server_port")
+        cls._assign_ports("dashboard", "ssl_server_port")
         cls._load_module("dashboard")
         cls._base_uri = cls._get_uri("dashboard").rstrip('/')
 

--- a/qa/tasks/mgr/test_dashboard.py
+++ b/qa/tasks/mgr/test_dashboard.py
@@ -15,7 +15,7 @@ class TestDashboard(MgrTestCase):
     def setUp(self):
         super(TestDashboard, self).setUp()
 
-        self._assign_ports("dashboard", "server_port")
+        self._assign_ports("dashboard", "ssl_server_port")
         self._load_module("dashboard")
         self.mgr_cluster.mon_manager.raw_cluster_cmd("dashboard",
                                                      "create-self-signed-cert")

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -192,7 +192,7 @@ class TestModuleSelftest(MgrTestCase):
         self._load_module("selftest")
 
         # Use the dashboard to test that the mgr is still able to do its job
-        self._assign_ports("dashboard", "server_port")
+        self._assign_ports("dashboard", "ssl_server_port")
         self._load_module("dashboard")
         self.mgr_cluster.mon_manager.raw_cluster_cmd("dashboard",
                                                      "create-self-signed-cert")

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -16,8 +16,6 @@ from uuid import uuid4
 from OpenSSL import crypto
 from mgr_module import MgrModule, MgrStandbyModule, Option
 
-from .tools import str_to_bool
-
 try:
     import cherrypy
     from cherrypy._cptools import HandlerWrapperTool
@@ -126,19 +124,19 @@ class CherryPyConfig(object):
         :returns our URI
         """
         server_addr = self.get_localized_module_option('server_addr', '::')
-        ssl = str_to_bool(self.get_localized_module_option('ssl', 'True'))
-        def_server_port = 8443
+        ssl = self.get_localized_module_option('ssl', True)
         if not ssl:
-            def_server_port = 8080
+            server_port = self.get_localized_module_option('server_port', 8080)
+        else:
+            server_port = self.get_localized_module_option('ssl_server_port', 8443)
 
-        server_port = self.get_localized_module_option('server_port', def_server_port)
         if server_addr is None:
             raise ServerConfigException(
                 'no server_addr configured; '
                 'try "ceph config set mgr mgr/{}/{}/server_addr <ip>"'
                 .format(self.module_name, self.get_mgr_id()))
-        self.log.info('server_addr: %s server_port: %s', server_addr,
-                      server_port)
+        self.log.info('server: ssl=%s host=%s port=%d', 'yes' if ssl else 'no',
+                      server_addr, server_port)
 
         # Initialize custom handlers.
         cherrypy.tools.authenticate = AuthManagerTool()
@@ -265,7 +263,8 @@ class Module(MgrModule, CherryPyConfig):
 
     MODULE_OPTIONS = [
         Option(name='server_addr', type='str', default='::'),
-        Option(name='server_port', type='int', default=8443),
+        Option(name='server_port', type='int', default=8080),
+        Option(name='ssl_server_port', type='int', default=8443),
         Option(name='jwt_token_ttl', type='int', default=28800),
         Option(name='password', type='str', default=''),
         Option(name='url_prefix', type='str', default=''),


### PR DESCRIPTION
There is a need to introduce this new config option because the ``MgrModule::get_module_option()`` and ``MgrModule::get_localized_module_option()`` method will be refactored soon and will not support the ``default`` parameter anymore. Instead the default value must be configured in the ``MODULE_OPTIONS``. Currently we misuse the ``server_port`` depending on if SSL is enabled or not.

Fixes: https://tracker.ceph.com/issues/38331

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

