### PR TITLE
qa: ignore MON_DOWN for volume-client testing

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/volume-client/task/test/test.yaml
+++ b/qa/suites/fs/basic_functional/tasks/volume-client/task/test/test.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - MON_DOWN
 tasks:
   - cephfs_test_runner:
       modules:

--- a/qa/suites/kcephfs/recovery/tasks/volume-client.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/volume-client.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - MON_DOWN
 tasks:
   - cephfs_test_runner:
       fail_on_skip: false


### PR DESCRIPTION
The test restarts the monitors.

Fixes: http://tracker.ceph.com/issues/38704
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

