### PR TITLE
mgr/BaseMgrStandbyModule: parse prefix properly

### DIFF
--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -97,7 +97,7 @@ class TestModuleSelftest(MgrTestCase):
             return self.mgr_cluster.mon_manager.raw_cluster_cmd(
                 "mgr", "self-test", "config", "get_localized", "testkey").strip()
 
-        self.assertEqual(get_localized_value(), "None")
+        self.assertEqual(get_localized_value(), "foo")
         self.mgr_cluster.mon_manager.raw_cluster_cmd(
             "config", "set", "mgr", "mgr/selftest/{}/testkey".format(
                 self.mgr_cluster.get_active_id()),

--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -65,7 +65,7 @@ ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
 {
   char *what = nullptr;
   char *prefix = nullptr;
-  if (!PyArg_ParseTuple(args, "ss:ceph_get_module_option", &what)) {
+  if (!PyArg_ParseTuple(args, "ss:ceph_get_module_option", &what, &prefix)) {
     derr << "Invalid args!" << dendl;
     return nullptr;
   }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/38705
Signed-off-by: Sage Weil <sage@redhat.com>