### PR TITLE
msg/async/AsyncConnection: optimize check loopback connection.

### DIFF
--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -53,6 +53,7 @@ struct Connection : public RefCountedObject {
 private:
   uint64_t features;
 public:
+  bool is_loopback;
   bool failed; // true if we are a lossy connection that has failed.
 
   int rx_buffers_version;
@@ -81,6 +82,7 @@ public:
       msgr(m),
       peer_type(-1),
       features(0),
+      is_loopback(false),
       failed(false),
       rx_buffers_version(0) {
   }

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -516,7 +516,7 @@ int AsyncConnection::send_message(Message *m)
   else if (m->get_type() == CEPH_MSG_OSD_OPREPLY)
     OID_EVENT_TRACE_WITH_MSG(m, "SEND_MSG_OSD_OPREPLY_BEGIN", true);
 
-  if (async_msgr->get_myaddrs() == get_peer_addrs()) { //loopback connection
+  if (is_loopback) { //loopback connection
     ldout(async_msgr->cct, 20) << __func__ << " " << *m << " local" << dendl;
     std::lock_guard<std::mutex> l(write_lock);
     if (protocol->is_connected()) {

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -392,6 +392,7 @@ public:
    */
   void init_local_connection() {
     Mutex::Locker l(lock);
+    local_connection->is_loopback = true;
     _init_local_connection();
   }
 


### PR DESCRIPTION
when send_message, we should check connection whether
loopback_connection which using address. In fact we can only check
address when set_peer_addr/set_peer_addrs.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

