### PR TITLE
auth/cephx: fix encode_encrypt error handling

### DIFF
--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -174,7 +174,7 @@ int CephxClientHandler::handle_response(
 	    auto p = cbl.cbegin();
 	    string err;
 	    if (decode_decrypt(cct, *connection_secret, *session_key, p,
-			       err) < 0) {
+			       err)) {
 	      lderr(cct) << __func__ << " failed to decrypt connection_secret"
 			 << dendl;
 	    } else {

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -179,7 +179,7 @@ int CephxServiceHandler::handle_request(
 	    }
 	    std::string err;
 	    if (encode_encrypt(cct, *pconnection_secret, session_key, cbl,
-			       err) < 0) {
+			       err)) {
 	      lderr(cct) << __func__ << " failed to encrypt connection secret, "
 			 << err << dendl;
 	      ret = -EACCES;


### PR DESCRIPTION
**encode_encrypt** returns 0 on success, 1 otherwise

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

