### PR TITLE
deb,rpm: migrate ceph-disk osds to ceph-volume on upgrade

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1821,6 +1821,9 @@ fi
 %endif
 if [ $1 -eq 1 ] ; then
 /usr/bin/systemctl start ceph-osd.target >/dev/null 2>&1 || :
+# migrate ceph-disk osds to ceph-volume
+ceph-volume simple scan || :
+ceph-volume simple activate --all || :
 fi
 %if 0%{?sysctl_apply}
     %sysctl_apply 90-ceph-osd.conf

--- a/debian/ceph-osd.postinst
+++ b/debian/ceph-osd.postinst
@@ -25,6 +25,9 @@ case "$1" in
     configure)
 	[ -x /etc/init.d/procps ] && invoke-rc.d procps restart || :
 	[ -x /sbin/start ] && start ceph-osd-all || :
+	# migrate ceph-disk osds to ceph-volume
+	ceph-volume simple scan || :
+	ceph-volume simple activate --all || :
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 	:

--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -216,13 +216,6 @@ Instructions
         "ceph version 14.2.0 (...) nautilus (stable)": 22,
      }
 
-#. Scan for any OSDs deployed with the old ceph-disk tool to ensure
-   that ceph-volume can activate them after a host reboot.  On each
-   host containing OSDs,::
-
-     # ceph-volume simple scan
-     # ceph-volume simple activate --all
-
 #. Upgrade all CephFS MDS daemons.  For each CephFS file system,
 
    #. Reduce the number of ranks to 1.  (Make note of the original


### PR DESCRIPTION
This means that users don't have to take any special action when upgrading
to nautilus from a prior version in order to make their old ceph-disk
osds start up after a reboot.

Signed-off-by: Sage Weil <sage@redhat.com>