### PR TITLE
librbd: make flush be queued by QOS throttler

### DIFF
--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -410,7 +410,7 @@ public:
   TokenBucketThrottle(CephContext *cct, const std::string &name,
                       uint64_t capacity, uint64_t avg,
                       SafeTimer *timer, Mutex *timer_lock);
-  
+
   ~TokenBucketThrottle();
 
   const std::string &get_name() {
@@ -424,12 +424,9 @@ public:
       });
     m_blockers.emplace_back(c, ctx);
   }
-  
+
   template <typename T, typename I, void(T::*MF)(int, I*, uint64_t)>
   bool get(uint64_t c, T *handler, I *item, uint64_t flag) {
-    if (0 == c)
-      return false;
-
     bool wait = false;
     uint64_t got = 0;
     std::lock_guard lock(m_lock);
@@ -439,7 +436,7 @@ public:
     } else {
       if (0 == m_throttle.max || 0 == m_avg)
         return false;
-  
+
       got = m_throttle.get(c);
       if (got < c) {
         // Not enough tokens, add a blocker for it.
@@ -452,7 +449,7 @@ public:
 
     return wait;
   }
-  
+
   int set_limit(uint64_t average, uint64_t burst);
   void set_schedule_tick_min(uint64_t tick);
 

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -428,10 +428,15 @@ public:
       }
       return m_items.front();
     }
-    void requeue(T *item) {
+    void requeue_front(T *item) {
       std::lock_guard pool_locker(m_pool->_lock);
       _void_process_finish(nullptr);
       m_items.push_front(item);
+    }
+    void requeue_back(T *item) {
+      std::lock_guard pool_locker(m_pool->_lock);
+      _void_process_finish(nullptr);
+      m_items.push_back(item);
     }
     void signal() {
       std::lock_guard pool_locker(m_pool->_lock);

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -129,7 +129,7 @@ public:
 
   void start_op();
 
-  uint64_t tokens_requested(uint64_t flag);
+  bool tokens_requested(uint64_t flag, uint64_t *tokens);
 
   bool was_throttled(uint64_t flag) {
     return m_throttled_flag & flag;

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -661,7 +661,7 @@ void ImageRequestWQ<I>::handle_throttle_ready(int r, ImageDispatchSpec<I> *item,
   ceph_assert(m_io_throttled.load() > 0);
   item->set_throttled(flag);
   if (item->were_all_throttled()) {
-    this->requeue(item);
+    this->requeue_front(item);
     --m_io_throttled;
     this->signal();
   }
@@ -910,7 +910,7 @@ void ImageRequestWQ<I>::handle_acquire_lock(
   } else {
     // since IO was stalled for acquire -- original IO order is preserved
     // if we requeue this op for work queue processing
-    this->requeue(req);
+    this->requeue_front(req);
   }
 
   ceph_assert(m_io_blockers.load() > 0);
@@ -929,7 +929,7 @@ void ImageRequestWQ<I>::handle_refreshed(
   } else {
     // since IO was stalled for refresh -- original IO order is preserved
     // if we requeue this op for work queue processing
-    this->requeue(req);
+    this->requeue_front(req);
   }
 
   ceph_assert(m_io_blockers.load() > 0);

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -685,9 +685,8 @@ bool ImageRequestWQ<I>::needs_throttle(ImageDispatchSpec<I> *item) {
     }
 
     throttle = t.second;
-    tokens = item->tokens_requested(flag);
-
-    if (throttle->get<ImageRequestWQ<I>, ImageDispatchSpec<I>,
+    if (item->tokens_requested(flag, &tokens) &&
+        throttle->get<ImageRequestWQ<I>, ImageDispatchSpec<I>,
 	      &ImageRequestWQ<I>::handle_throttle_ready>(
 		tokens, this, item, flag)) {
       blocked = true;

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -661,7 +661,7 @@ void ImageRequestWQ<I>::handle_throttle_ready(int r, ImageDispatchSpec<I> *item,
   ceph_assert(m_io_throttled.load() > 0);
   item->set_throttled(flag);
   if (item->were_all_throttled()) {
-    this->requeue_front(item);
+    this->requeue_back(item);
     --m_io_throttled;
     this->signal();
   }

--- a/src/test/librbd/io/test_mock_ImageRequestWQ.cc
+++ b/src/test/librbd/io/test_mock_ImageRequestWQ.cc
@@ -104,7 +104,7 @@ struct ThreadPool::PointerWQ<librbd::io::ImageDispatchSpec<librbd::MockTestImage
   MOCK_METHOD0(process_finish, void());
 
   MOCK_METHOD0(front, ImageDispatchSpec*());
-  MOCK_METHOD1(requeue, void(ImageDispatchSpec*));
+  MOCK_METHOD1(requeue_front, void(ImageDispatchSpec*));
 
   MOCK_METHOD0(dequeue, void*());
   MOCK_METHOD1(queue, void(ImageDispatchSpec*));
@@ -170,8 +170,8 @@ struct TestMockIoImageRequestWQ : public TestMockFixture {
     EXPECT_CALL(image_request_wq, queue(_));
   }
 
-  void expect_requeue(MockImageRequestWQ &image_request_wq) {
-    EXPECT_CALL(image_request_wq, requeue(_));
+  void expect_requeue_front(MockImageRequestWQ &image_request_wq) {
+    EXPECT_CALL(image_request_wq, requeue_front(_));
   }
 
   void expect_front(MockImageRequestWQ &image_request_wq,
@@ -425,7 +425,7 @@ TEST_F(TestMockIoImageRequestWQ, BPSQosNoBurst) {
   expect_tokens_requested(mock_queued_image_request, 2, true);
   expect_dequeue(mock_image_request_wq, &mock_queued_image_request);
   expect_all_throttled(mock_queued_image_request, true);
-  expect_requeue(mock_image_request_wq);
+  expect_requeue_front(mock_image_request_wq);
   expect_signal(mock_image_request_wq);
   ASSERT_TRUE(mock_image_request_wq.invoke_dequeue() == nullptr);
 }
@@ -449,7 +449,7 @@ TEST_F(TestMockIoImageRequestWQ, BPSQosWithBurst) {
   expect_tokens_requested(mock_queued_image_request, 2, true);
   expect_dequeue(mock_image_request_wq, &mock_queued_image_request);
   expect_all_throttled(mock_queued_image_request, true);
-  expect_requeue(mock_image_request_wq);
+  expect_requeue_front(mock_image_request_wq);
   expect_signal(mock_image_request_wq);
   ASSERT_TRUE(mock_image_request_wq.invoke_dequeue() == nullptr);
 }

--- a/src/test/librbd/io/test_mock_ImageRequestWQ.cc
+++ b/src/test/librbd/io/test_mock_ImageRequestWQ.cc
@@ -105,6 +105,7 @@ struct ThreadPool::PointerWQ<librbd::io::ImageDispatchSpec<librbd::MockTestImage
 
   MOCK_METHOD0(front, ImageDispatchSpec*());
   MOCK_METHOD1(requeue_front, void(ImageDispatchSpec*));
+  MOCK_METHOD1(requeue_back, void(ImageDispatchSpec*));
 
   MOCK_METHOD0(dequeue, void*());
   MOCK_METHOD1(queue, void(ImageDispatchSpec*));
@@ -170,8 +171,8 @@ struct TestMockIoImageRequestWQ : public TestMockFixture {
     EXPECT_CALL(image_request_wq, queue(_));
   }
 
-  void expect_requeue_front(MockImageRequestWQ &image_request_wq) {
-    EXPECT_CALL(image_request_wq, requeue_front(_));
+  void expect_requeue_back(MockImageRequestWQ &image_request_wq) {
+    EXPECT_CALL(image_request_wq, requeue_back(_));
   }
 
   void expect_front(MockImageRequestWQ &image_request_wq,
@@ -425,7 +426,7 @@ TEST_F(TestMockIoImageRequestWQ, BPSQosNoBurst) {
   expect_tokens_requested(mock_queued_image_request, 2, true);
   expect_dequeue(mock_image_request_wq, &mock_queued_image_request);
   expect_all_throttled(mock_queued_image_request, true);
-  expect_requeue_front(mock_image_request_wq);
+  expect_requeue_back(mock_image_request_wq);
   expect_signal(mock_image_request_wq);
   ASSERT_TRUE(mock_image_request_wq.invoke_dequeue() == nullptr);
 }
@@ -449,7 +450,7 @@ TEST_F(TestMockIoImageRequestWQ, BPSQosWithBurst) {
   expect_tokens_requested(mock_queued_image_request, 2, true);
   expect_dequeue(mock_image_request_wq, &mock_queued_image_request);
   expect_all_throttled(mock_queued_image_request, true);
-  expect_requeue_front(mock_image_request_wq);
+  expect_requeue_back(mock_image_request_wq);
   expect_signal(mock_image_request_wq);
   ASSERT_TRUE(mock_image_request_wq.invoke_dequeue() == nullptr);
 }


### PR DESCRIPTION
Previously we started tracking it only since it was enqueued and
the flush operation was skipping those aio, which had visible
effect if QOS was enabled.

Fixes: https://tracker.ceph.com/issues/38706
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

