### PR TITLE
[RFC] increase messenger IOPS on write op

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -845,7 +845,7 @@ void AsyncConnection::_stop() {
 }
 
 bool AsyncConnection::is_queued() const {
-  return outcoming_bl.length();
+  return outcoming_bl.length() || wqueue->has_msgs_to_send();
 }
 
 void AsyncConnection::shutdown_socket() {

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -33,13 +33,15 @@
 #define SEQ_MASK  0x7fffffff
 
 void WriteQueue::fillin_iovec() {
-  /* Forward to protocol */
-  /* XXX TODO */
+  if (!is_outcoming_full())
+    /* Forward to protocol */
+    con->protocol->fillin_iovec(this);
 }
 
 void WriteQueue::fillin_bufferlist() {
-  /* Forward to protocol */
-  /* XXX TODO */
+  if (!is_outcoming_full())
+    /* Forward to protocol */
+    con->protocol->fillin_bufferlist(this);
 }
 
 bufferlist::buffers_t::const_iterator

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -202,6 +202,8 @@ class AsyncConnection : public Connection {
                 bool more=false);
   ssize_t _try_send(bool more=false);
 
+  ssize_t send_wqueue();
+
   void _connect();
   void _stop();
   void fault();

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -346,7 +346,6 @@ class AsyncConnection : public Connection {
   DispatchQueue *dispatch_queue;
 
   WriteQueue *wqueue;
-  bufferlist outcoming_bl;
   bool open_write = false;
 
   std::mutex write_lock;

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 
 #include "PosixStack.h"
+#include "AsyncConnection.h"
 
 #include "include/buffer.h"
 #include "include/str_list.h"
@@ -152,6 +153,35 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
 
     return static_cast<ssize_t>(sent_bytes);
   }
+
+  ssize_t send(WriteQueue *wqueue) {
+    struct msghdr msg;
+    ssize_t sent;
+
+    /* Keep iovec always full */
+    wqueue->fillin_iovec();
+    if (!wqueue->has_msgs_in_outcoming())
+      /* Nothing to send */
+      return 0;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov    = &*wqueue->iovec_beg_it;
+    msg.msg_iovlen = wqueue->iovec_end_it - wqueue->iovec_beg_it;
+
+    /* We do not expect EINTR from non-blocking call! */
+    sent = ::sendmsg(_fd, &msg, MSG_DONTWAIT | MSG_NOSIGNAL);
+    if (sent > 0)
+      wqueue->advance(sent);
+    else if (sent < 0 && errno == EAGAIN)
+      /*
+       * Because of dispatch_event_external we can be called at any time,
+       * so handle EAGAIN
+       */
+      sent = 0;
+
+    return sent;
+  }
+
   void shutdown() override {
     ::shutdown(_fd, SHUT_RDWR);
   }

--- a/src/msg/async/Protocol.h
+++ b/src/msg/async/Protocol.h
@@ -128,6 +128,9 @@ public:
   // send keepalive
   virtual void send_keepalive() = 0;
 
+  virtual void fillin_iovec(WriteQueue *wqueue) = 0;
+  virtual void fillin_bufferlist(WriteQueue *wqueue) = 0;
+
   virtual void read_event() = 0;
   virtual void write_event() = 0;
   virtual bool is_queued() = 0;

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -223,6 +223,17 @@ public:
   virtual void write_event() override;
   virtual bool is_queued() override;
 
+  void fillin_outcoming(WriteQueue *wqueue,
+			bool (WriteQueue::*fillin_from_mem)(
+			  void *mem,
+			  unsigned int beg,
+			  unsigned int end),
+			bool (WriteQueue::*fillin_from_bufl)(
+			  bufferlist &bufl,
+			  unsigned int beg));
+  virtual void fillin_iovec(WriteQueue *wqueue) override;
+  virtual void fillin_bufferlist(WriteQueue *wqueue) override;
+
   // Client Protocol
 private:
   int global_seq;
@@ -255,6 +266,8 @@ private:
   CtPtr handle_ack_seq(char *buffer, int r);
   CtPtr handle_in_seq_write(int r);
   CtPtr client_ready();
+
+  void prepare_for_write(QueuedMessage *qmsg);
 
   // Server Protocol
 protected:

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -106,7 +106,7 @@ protected:
   std::atomic<WriteStatus> can_write;
   std::list<Message *> sent;  // the first bufferlist need to inject seq
   // priority queue for outbound msgs
-  std::map<int, std::list<std::pair<bufferlist, Message *>>> out_q;
+  std::map<int, std::list<QueuedMessage>> out_q;
   bool keepalive;
 
   __u32 connect_seq, peer_global_seq;
@@ -268,6 +268,9 @@ private:
   CtPtr client_ready();
 
   void prepare_for_write(QueuedMessage *qmsg);
+  bool flush_out_q();
+  void enqueue_ack();
+  void enqueue_keepalive(struct ceph_timespec *ts = nullptr);
 
   // Server Protocol
 protected:

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -104,7 +104,6 @@ protected:
 
   enum class WriteStatus { NOWRITE, REPLACING, CANWRITE, CLOSED };
   std::atomic<WriteStatus> can_write;
-  std::list<Message *> sent;  // the first bufferlist need to inject seq
   // priority queue for outbound msgs
   std::map<int, std::list<QueuedMessage>> out_q;
   bool keepalive;
@@ -173,7 +172,6 @@ protected:
   CtPtr handle_message(char *buffer, int r);
 
   CtPtr handle_keepalive2(char *buffer, int r);
-  void append_keepalive_or_ack(bool ack = false, utime_t *t = nullptr);
   CtPtr handle_keepalive2_ack(char *buffer, int r);
   CtPtr handle_tag_ack(char *buffer, int r);
 
@@ -193,11 +191,6 @@ protected:
 
   void session_reset();
   void randomize_out_seq();
-
-  Message *_get_next_outgoing(bufferlist *bl);
-
-  void prepare_send_message(uint64_t features, Message *m, bufferlist &bl);
-  ssize_t write_message(Message *m, bufferlist &bl, bool more);
 
   void requeue_sent();
   uint64_t discard_requeued_up_to(uint64_t out_seq, uint64_t seq);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -144,7 +144,7 @@ void ProtocolV2::reset_session() {
 
   connection->dispatch_queue->discard_queue(connection->conn_id);
   discard_out_queue();
-  connection->outcoming_bl.clear();
+  connection->wqueue->outbl.clear();
 
   connection->dispatch_queue->queue_remote_reset(connection);
 
@@ -519,7 +519,7 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
 			     m->get_payload(),
 			     m->get_middle(),
 			     m->get_data());
-  connection->outcoming_bl.append(message.get_buffer(session_stream_handlers));
+  connection->wqueue->outbl.append(message.get_buffer(session_stream_handlers));
 
   ldout(cct, 5) << __func__ << " sending message m=" << m
                 << " seq=" << m->get_seq() << " " << *m << dendl;
@@ -529,14 +529,14 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
                  << " src=" << entity_name_t(messenger->get_myname())
                  << " off=" << header2.data_off
                  << dendl;
-  ssize_t total_send_size = connection->outcoming_bl.length();
+  ssize_t total_send_size = connection->wqueue->outbl.length();
   ssize_t rc = connection->_try_send(more);
   if (rc < 0) {
     ldout(cct, 1) << __func__ << " error sending " << m << ", "
                   << cpp_strerror(rc) << dendl;
   } else {
     connection->logger->inc(
-        l_msgr_send_bytes, total_send_size - connection->outcoming_bl.length());
+        l_msgr_send_bytes, total_send_size - connection->wqueue->outbl.length());
     ldout(cct, 10) << __func__ << " sending " << m
                    << (rc ? " continuely." : " done.") << dendl;
   }
@@ -555,12 +555,12 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
 void ProtocolV2::append_keepalive() {
   ldout(cct, 10) << __func__ << dendl;
   auto keepalive_frame = KeepAliveFrame::Encode();
-  connection->outcoming_bl.append(keepalive_frame.get_buffer(session_stream_handlers));
+  connection->wqueue->outbl.append(keepalive_frame.get_buffer(session_stream_handlers));
 }
 
 void ProtocolV2::append_keepalive_ack(utime_t &timestamp) {
   auto keepalive_ack_frame = KeepAliveFrameAck::Encode(timestamp);
-  connection->outcoming_bl.append(keepalive_ack_frame.get_buffer(session_stream_handlers));
+  connection->wqueue->outbl.append(keepalive_ack_frame.get_buffer(session_stream_handlers));
 }
 
 void ProtocolV2::handle_message_ack(uint64_t seq) {
@@ -638,7 +638,7 @@ void ProtocolV2::write_event() {
       uint64_t left = ack_left;
       if (left) {
         auto ack = AckFrame::Encode(in_seq);
-        connection->outcoming_bl.append(ack.get_buffer(session_stream_handlers));
+        connection->wqueue->outbl.append(ack.get_buffer(session_stream_handlers));
         ldout(cct, 10) << __func__ << " try send msg ack, acked " << left
                        << " messages" << dendl;
         ack_left -= left;
@@ -2698,7 +2698,7 @@ CtPtr ProtocolV2::reuse_connection(AsyncConnectionRef existing,
           std::lock_guard<std::mutex> l(existing->lock);
           existing->write_lock.lock();
           exproto->requeue_sent();
-          existing->outcoming_bl.clear();
+          existing->wqueue->outbl.clear();
           existing->open_write = false;
           existing->write_lock.unlock();
           if (exproto->state == NONE) {

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -438,6 +438,18 @@ void ProtocolV2::send_keepalive() {
   }
 }
 
+void ProtocolV2::fillin_iovec(WriteQueue *wqueue)
+{
+  /* Not yet implemented */
+  ceph_assert(0);
+}
+
+void ProtocolV2::fillin_bufferlist(WriteQueue *wqueue)
+{
+  /* Not yet implemented */
+  ceph_assert(0);
+}
+
 void ProtocolV2::read_event() {
   ldout(cct, 20) << __func__ << dendl;
 

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -202,6 +202,9 @@ public:
   virtual void write_event() override;
   virtual bool is_queued() override;
 
+  virtual void fillin_iovec(WriteQueue *wqueue) override;
+  virtual void fillin_bufferlist(WriteQueue *wqueue) override;
+
 private:
   // Client Protocol
   CONTINUATION_DECL(ProtocolV2, start_client_banner_exchange);

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -22,6 +22,7 @@
 #include "msg/msg_types.h"
 #include "msg/async/Event.h"
 
+class WriteQueue;
 class Worker;
 class ConnectedSocketImpl {
  public:
@@ -30,6 +31,7 @@ class ConnectedSocketImpl {
   virtual ssize_t read(char*, size_t) = 0;
   virtual ssize_t zero_copy_read(bufferptr&) = 0;
   virtual ssize_t send(bufferlist &bl, bool more) = 0;
+  virtual ssize_t send(WriteQueue *wqueue) = 0;
   virtual void shutdown() = 0;
   virtual void close() = 0;
   virtual int fd() const = 0;
@@ -106,6 +108,9 @@ class ConnectedSocket {
   /// Gets an object that sends data to the remote endpoint.
   ssize_t send(bufferlist &bl, bool more) {
     return _csi->send(bl, more);
+  }
+  ssize_t send(WriteQueue *wqueue) {
+    return _csi->send(wqueue);
   }
   /// Disables output to the socket.
   ///

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -218,6 +218,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   virtual ssize_t read(char* buf, size_t len) override;
   virtual ssize_t zero_copy_read(bufferptr &data) override;
   virtual ssize_t send(bufferlist &bl, bool more) override;
+  virtual ssize_t send(WriteQueue *wqueue) override;
   virtual void shutdown() override;
   virtual void close() override;
   virtual int fd() const override { return notify_fd; }


### PR DESCRIPTION
    Series introduces WriteQueue, which aims to keep all messages
    queued for sending in one list, keep iovec buffer or bufferlist always
    full and of fixed capacity for low-layer stack drivers.
    
     o All enqueued requests of type Message are wrapped with QueuedMessage,
       which has some bytes of static payload, which caches message lengths
       and information was the message encoded or not.
    
     o All QueuedMessages are kept inside ->msgs list for lossy and !lossy
       modes, which helps to avoid constant push_back() operations on sent
       vector.
    
     o WriteQueue keeps different kind of iov buffers for low-level stack
       driver: iovec (e.g. PosixStack, which support sendv() operations) and
       bufferlist, which is the default for all other stacks (RDMA and DPDK).
    
     o WriteQueue has the following main operations:
    
       ->enqueue()  - enqueues message or list of messages for writing
       ->fillin_*() - helpers which aim to fillin iovec or bufferlist
       ->advance()  - advances ->msgs on amount of bytes, pushing fully
                      written messages out of the list.

    The following are results, based on fio messenger engine
    https://github.com/ceph/ceph/pull/24678
    
    async+posix, localhost
    
                  master                        wqueue
    
    iodepth=8, crc=off
    
      512  IOPS=67.3k, BW=32.9MiB/s    IOPS=101k, BW=49.3MiB/s
       1k  IOPS=80.8k, BW=78.0MiB/s    IOPS=97.3k, BW=95.0MiB/s
       2k  IOPS=68.5k, BW=134MiB/s     IOPS=98.8k, BW=193MiB/s
       4k  IOPS=56.2k, BW=220MiB/s     IOPS=93.5k, BW=365MiB/s
     128k  IOPS=36.6k, BW=4571MiB/s    IOPS=37.4k, BW=4676MiB/s
     512k  IOPS=13.7k, BW=6828MiB/s    IOPS=14.1k, BW=7033MiB/s
       1m  IOPS=6476, BW=6476MiB/s     IOPS=6758, BW=6758MiB/s
    
    iodepth=8, crc=on
    
      512  IOPS=62.5k, BW=30.5MiB/s    IOPS=98.3k, BW=47.0MiB/s
       1k  IOPS=56.3k, BW=55.0MiB/s    IOPS=96.4k, BW=94.1MiB/s
       2k  IOPS=55.1k, BW=108MiB/s     IOPS=93.5k, BW=183MiB/s
       4k  IOPS=54.9k, BW=214MiB/s     IOPS=72.6k, BW=284MiB/s
     128k  IOPS=28.1k, BW=3516MiB/s    IOPS=29.1k, BW=3639MiB/s
     512k  IOPS=9510, BW=4755MiB/s     IOPS=10.1k, BW=5056MiB/s
       1m  IOPS=4193, BW=4192MiB/s     IOPS=4112, BW=4112MiB/s
    
    iodepth=128, crc=off
    
      512  IOPS=143k, BW=70.0MiB/s     IOPS=194k, BW=94.9MiB/s
       1k  IOPS=143k, BW=140MiB/s      IOPS=188k, BW=184MiB/s
       2k  IOPS=138k, BW=270MiB/s      IOPS=180k, BW=351MiB/s
       4k  IOPS=127k, BW=496MiB/s      IOPS=160k, BW=625MiB/s
     128k  IOPS=44.8k, BW=5594MiB/s    IOPS=46.4k, BW=5803MiB/s
     512k  IOPS=11.4k, BW=5676MiB/s    IOPS=11.4k, BW=5685MiB/s
       1m  IOPS=5726, BW=5704MiB/s     IOPS=5685, BW=5673MiB/s
    
    iodepth=128, crc=on
    
      512  IOPS=136k, BW=66.3MiB/s     IOPS=183k, BW=89.5MiB/s
       1k  IOPS=137k, BW=134MiB/s      IOPS=179k, BW=174MiB/s
       2k  IOPS=129k, BW=252MiB/s      IOPS=166k, BW=323MiB/s
       4k  IOPS=117k, BW=456MiB/s      IOPS=150k, BW=584MiB/s
     128k  IOPS=32.2k, BW=4025MiB/s    IOPS=33.5k, BW=4186MiB/s
     512k  IOPS=8449, BW=4217MiB/s     IOPS=8626, BW=4306MiB/s
       1m  IOPS=3934, BW=3931MiB/s     IOPS=3948, BW=3936MiB/s
    
    The WriteQueue implementation benefits from small block sizes,
    where we get up to 40% IOPS increase.

    This is RFC because ProtocolV2 is not yet touched, thus all these changes are 
    related to v1.  Also I would like to get early feedback on this part.

    Signed-off-by: Roman Penyaev <rpenyaev@suse.de>

Cc: @rjfd 
Cc: @yuyuyu101 
Cc: @majianpeng 
Cc: @ifed01 