### PR TITLE
mon/MonClient: weight-based mon selection

### DIFF
--- a/doc/rados/configuration/mon-lookup-dns.rst
+++ b/doc/rados/configuration/mon-lookup-dns.rst
@@ -42,10 +42,15 @@ With those records now existing we can create the SRV TCP records with the name 
 
 ::
 
-    _ceph-mon._tcp.example.com. 60 IN SRV 10 60 6789 mon1.example.com.
-    _ceph-mon._tcp.example.com. 60 IN SRV 10 60 6789 mon2.example.com.
-    _ceph-mon._tcp.example.com. 60 IN SRV 10 60 6789 mon3.example.com.
+    _ceph-mon._tcp.example.com. 60 IN SRV 10 20 6789 mon1.example.com.
+    _ceph-mon._tcp.example.com. 60 IN SRV 10 30 6789 mon2.example.com.
+    _ceph-mon._tcp.example.com. 60 IN SRV 20 50 6789 mon3.example.com.
 
-In this case the Monitors are running on port *6789*, and their priority and weight are all *10* and *60* respectively.
+Now all Monitors are running on port *6789*, with priorities 10, 10, 20 and weights 20, 30, 50 respectively.
 
-The current implementation in clients and daemons will *only* respect the priority set in SRV records, and they will only connect to the monitors with lowest-numbered priority. The targets with the same priority will be selected at random.
+Monitor clients choose monitor by referencing the SRV records. If a cluster has multiple Monitor SRV records
+with the same priority value, clients and daemons will load balance the connections to Monitors in proportion
+to the values of the SRV weight fields.
+
+For the above example, this will result in approximate 40% of the clients and daemons connecting to mon1,
+60% of them connecting to mon2. However, if neither of them is reachable, then mon3 will be reconsidered as a fallback.

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1177,6 +1177,19 @@ function test_mon_mon()
   expect_false ceph mon feature set abcd --yes-i-really-mean-it
 }
 
+function test_mon_priority_and_weight()
+{
+    for i in 0 1 65535; do
+      ceph mon set-weight a $i
+      w=$(ceph mon dump --format=json-pretty 2>/dev/null | jq '.mons[0].weight')
+      [[ "$w" == "$i" ]]
+    done
+
+    for i in -1 65536; do
+      expect_false ceph mon set-weight a $i
+    done
+}
+
 function gen_secrets_file()
 {
   # lets assume we can have the following types

--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -337,7 +337,7 @@ int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
 
     auto rdata = ns_rr_rdata(rr);
     uint16_t priority = ns_get16(rdata); rdata += NS_INT16SZ;
-    rdata += NS_INT16SZ;	// weight
+    uint16_t weight = ns_get16(rdata); rdata += NS_INT16SZ;
     uint16_t port = ns_get16(rdata); rdata += NS_INT16SZ;
     memset(full_target, 0, sizeof(full_target));
     ns_name_uncompress(ns_msg_base(handle), ns_msg_end(handle),
@@ -360,7 +360,7 @@ int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
 	return -EINVAL;
       }
       target = target.substr(0, end);
-      (*srv_hosts)[target] = {priority, addr};
+      (*srv_hosts)[target] = {priority, weight, addr};
     }
   }
   return 0;

--- a/src/common/dns_resolve.h
+++ b/src/common/dns_resolve.h
@@ -79,6 +79,7 @@ class DNSResolver {
 
     struct Record {
       uint16_t priority;
+      uint16_t weight;
       entity_addr_t addr;
     };
 

--- a/src/common/weighted_shuffle.h
+++ b/src/common/weighted_shuffle.h
@@ -1,0 +1,29 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+// https://stackoverflow.com/questions/50221136/c-weighted-stdshuffle/50223540
+#ifndef CEPH_WEIGHTED_SHUFFLE_H
+#define CEPH_WEIGHTED_SHUFFLE_H
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+template <class T, class U, class R>
+void weighted_shuffle(std::vector<T> &data, std::vector<U> &weights, R &&gen)
+{
+  auto itd = data.begin();
+  auto itw = weights.begin();
+
+  while (itd != data.end() && itw != weights.end()) {
+    std::discrete_distribution d(itw, weights.end());
+    auto i = d(gen);
+    if (i) {
+      std::iter_swap(itd, std::next(itd, i));
+      std::iter_swap(itw, std::next(itw, i));
+    }
+    ++itd;
+    ++itw;
+  }
+}
+
+#endif

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -385,17 +385,17 @@ void MonClient::handle_monmap(MMonMap *m)
     ldout(cct,10) << " can't identify which mon we were connected to" << dendl;
     _reopen_session();
   } else {
-    int new_rank = monmap.get_rank(m->get_source_addr());
-    if (new_rank < 0) {
-      ldout(cct, 10) << "mon." << new_rank << " at " << m->get_source_addrs()
+    auto new_name = monmap.get_name(con_addrs);
+    if (new_name.empty()) {
+      ldout(cct, 10) << "mon." << old_name << " at " << con_addrs
 		     << " went away" << dendl;
       // can't find the mon we were talking to (above)
       _reopen_session();
     } else if (messenger->should_use_msgr2() &&
-	       monmap.get_addrs(new_rank).has_msgr2() &&
+	       monmap.get_addrs(new_name).has_msgr2() &&
 	       !con_addrs.has_msgr2()) {
-      ldout(cct,1) << " mon." << new_rank << " has (v2) addrs "
-		   << monmap.get_addrs(new_rank) << " but i'm connected to "
+      ldout(cct,1) << " mon." << new_name << " has (v2) addrs "
+		   << monmap.get_addrs(new_name) << " but i'm connected to "
 		   << con_addrs << ", reconnecting" << dendl;
       _reopen_session();
     }

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -463,6 +463,11 @@ COMMAND("mon set-addrs " \
 	"name=addrs,type=CephString",
 	"set the addrs (IPs and ports) a specific monitor binds to",
 	"mon", "rw")
+COMMAND("mon set-weight " \
+        "name=name,type=CephString " \
+        "name=weight,type=CephInt,range=0|65535",
+        "set the weight for the specified mon",
+        "mon", "rw")
 COMMAND("mon enable-msgr2",
 	"enable the msgr2 protocol on port 3300",
 	"mon", "rw")

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -352,6 +352,7 @@ void MonMap::dump(Formatter *f) const
     f->dump_stream("addr") << get_addrs(*p).get_legacy_str();
     f->dump_stream("public_addr") << get_addrs(*p).get_legacy_str();
     f->dump_unsigned("priority", get_priority(*p));
+    f->dump_unsigned("weight", get_weight(*p));
     f->close_section();
   }
   f->close_section();

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -385,6 +385,11 @@ public:
     ceph_assert(it != mon_info.end());
     return it->second.weight;
   }
+  void set_weight(const string& n, uint16_t v) {
+    auto it = mon_info.find(n);
+    ceph_assert(it != mon_info.end());
+    it->second.weight = v;
+  }
 
   void encode(bufferlist& blist, uint64_t con_features) const;
   void decode(bufferlist& blist) {

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -38,6 +38,8 @@ namespace ceph {
   class Formatter;
 }
 
+constexpr uint16_t DEFAULT_WEIGHT = 10;
+
 struct mon_info_t {
   /**
    * monitor name
@@ -56,6 +58,7 @@ struct mon_info_t {
    * the priority of the mon, the lower value the more preferred
    */
   uint16_t priority{0};
+  uint16_t weight{DEFAULT_WEIGHT};
 
   // <REMOVE ME>
   mon_info_t(const string& n, const entity_addr_t& p_addr, uint16_t p)
@@ -63,8 +66,9 @@ struct mon_info_t {
   {}
   // </REMOVE ME>
 
-  mon_info_t(const string& n, const entity_addrvec_t& p_addrs, uint16_t p)
-    : name(n), public_addrs(p_addrs), priority(p)
+  mon_info_t(const string& n, const entity_addrvec_t& p_addrs,
+             uint16_t p, uint16_t w)
+    : name(n), public_addrs(p_addrs), priority(p), weight(w)
   {}
   mon_info_t(const string &n, const entity_addrvec_t& p_addrs)
     : name(n), public_addrs(p_addrs)
@@ -135,9 +139,10 @@ class MonMap {
   uint8_t min_mon_release = 0;
 
   void _add_ambiguous_addr(const string& name,
-			   entity_addr_t addr,
-			   int priority,
-			   bool for_mkfs=false);
+                           entity_addr_t addr,
+                           int priority,
+                           int weight,
+                           bool for_mkfs);
 
 public:
   void calc_legacy_ranks();
@@ -205,8 +210,8 @@ public:
    * @param addr Monitor's public address
    */
   void add(const string &name, const entity_addrvec_t &addrv,
-	   int priority=0) {
-    add(mon_info_t(name, addrv, priority));
+	   int priority=0, int weight=DEFAULT_WEIGHT) {
+    add(mon_info_t(name, addrv, priority, weight));
   }
 
   /**

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -380,6 +380,11 @@ public:
     ceph_assert(it != mon_info.end());
     return it->second.priority;
   }
+  uint16_t get_weight(const string& n) const {
+    auto it = mon_info.find(n);
+    ceph_assert(it != mon_info.end());
+    return it->second.weight;
+  }
 
   void encode(bufferlist& blist, uint64_t con_features) const;
   void decode(bufferlist& blist) {

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -782,6 +782,23 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     pending_map.set_addrvec(name, av);
     pending_map.last_changed = ceph_clock_now();
     propose = true;
+  } else if (prefix == "mon set-weight") {
+    string name;
+    int64_t weight;
+    if (!cmd_getval(g_ceph_context, cmdmap, "name", name) ||
+        !cmd_getval(g_ceph_context, cmdmap, "weight", weight)) {
+      err = -EINVAL;
+      goto reply;
+    }
+    if (!pending_map.contains(name)) {
+      ss << "mon." << name << " does not exist";
+      err = -ENOENT;
+      goto reply;
+    }
+    err = 0;
+    pending_map.set_weight(name, weight);
+    pending_map.last_changed = ceph_clock_now();
+    propose = true;
   } else if (prefix == "mon enable-msgr2") {
     if (!monmap.get_required_features().contains_all(
 	  ceph::features::mon::FEATURE_NAUTILUS)) {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -893,4 +893,8 @@ add_executable(unittest_any test_any.cc)
 add_ceph_unittest(unittest_any)
 target_link_libraries(unittest_any)
 
+# unittest_weighted_shuffle
+add_executable(unittest_weighted_shuffle test_weighted_shuffle.cc)
+add_ceph_unittest(unittest_weighted_shuffle)
+
 #make check ends here

--- a/src/test/common/dns_resolve.cc
+++ b/src/test/common/dns_resolve.cc
@@ -148,15 +148,21 @@ TEST_F(DNSResolverTest, resolve_srv_hosts_empty_domain) {
   os << it->second.addr;
   ASSERT_EQ(os.str(), "v2:192.168.1.11:6789/0");
   os.str("");
+  ASSERT_EQ(it->second.priority, 10);
+  ASSERT_EQ(it->second.weight, 40);
   it = records.find("mon.b");
   ASSERT_NE(it, records.end());
   os << it->second.addr;
   ASSERT_EQ(os.str(), "v2:192.168.1.12:6789/0");
   os.str("");
+  ASSERT_EQ(it->second.priority, 10);
+  ASSERT_EQ(it->second.weight, 35);
   it = records.find("mon.c");
   ASSERT_NE(it, records.end());
   os << it->second.addr;
   ASSERT_EQ(os.str(), "v2:192.168.1.13:6789/0");
+  ASSERT_EQ(it->second.priority, 10);
+  ASSERT_EQ(it->second.weight, 25);
 }
 
 TEST_F(DNSResolverTest, resolve_srv_hosts_full_domain) {

--- a/src/test/test_weighted_shuffle.cc
+++ b/src/test/test_weighted_shuffle.cc
@@ -1,0 +1,43 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+// https://stackoverflow.com/questions/50221136/c-weighted-stdshuffle/50223540
+
+#include "common/weighted_shuffle.h"
+#include <map>
+#include "gtest/gtest.h"
+
+TEST(WeightedShuffle, Basic) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  std::vector<char> data{'a', 'b', 'c', 'd', 'e'};
+  // NB: differences between weights should be significant
+  // otherwise test might fail
+  std::vector<int> weights{100, 50, 25, 10, 1};
+  std::map<char, std::vector<int>> frequency {
+    {'a', {0, 0, 0, 0, 0}},
+    {'b', {0, 0, 0, 0, 0}},
+    {'c', {0, 0, 0, 0, 0}},
+    {'d', {0, 0, 0, 0, 0}},
+    {'e', {0, 0, 0, 0, 0}}
+  }; // count each element appearing in each position
+  const int samples = 10000;
+  for (auto i = 0; i < samples; i++) {
+    weighted_shuffle(data, weights, gen);
+    for (size_t j = 0; j < data.size(); ++j)
+      ++frequency[data[j]][j];
+  }
+
+  // verify each element gets a chance to stay at the header of array
+  // e.g., because we don't want to starve anybody!
+  EXPECT_TRUE(std::all_of(frequency.begin(), frequency.end(), [](auto& it) {
+      return it.second.front() > 0;
+    }));
+
+  // verify the probability (of staying at the array header)
+  // are produced according to their corresponding weight
+  EXPECT_TRUE(std::is_sorted(frequency.begin(), frequency.end(),
+    [](auto& lhs, auto& rhs) {
+      return lhs.second.front() > rhs.second.front();
+    }));
+}


### PR DESCRIPTION
Monitors now support both priority and weight configurations.
Clients and daemons which need to connect to Monitors will now do Monitor selection
 in the following order:
  - first choose Monitor by priority, the lower value the more preferred
  - if there are still multiple targets, then choosing by their corresponding weight.
    If no valid(non-zero) weights is detected, all targets will be selected at random.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

