### PR TITLE
rgw: reject bucket tagging requests and document unsupported

### DIFF
--- a/doc/radosgw/s3.rst
+++ b/doc/radosgw/s3.rst
@@ -74,6 +74,8 @@ The following table describes the support status for current Amazon S3 functiona
 +---------------------------------+-----------------+----------------------------------------+
 | **Object Tagging**              | Supported       | See :ref:`tag_policy` for Policy verbs |
 +---------------------------------+-----------------+----------------------------------------+
+| **Bucket Tagging**              | Not Supported   |                                        |
++---------------------------------+-----------------+----------------------------------------+
 | **Storage Class**               | Supported       | See :ref:`storage_classes`             |
 +---------------------------------+-----------------+----------------------------------------+
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3196,6 +3196,8 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_put()
     return new RGWPutLC_ObjStore_S3;
   } else if(is_policy_op()) {
     return new RGWPutBucketPolicy;
+  } else if (is_tagging_op()) {
+    return nullptr;
   }
   return new RGWCreateBucket_ObjStore_S3;
 }

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -555,6 +555,9 @@ protected:
   bool is_policy_op() {
     return s->info.args.exists("policy");
   }
+  bool is_tagging_op() const {
+    return s->info.args.exists("tagging");
+  }
   RGWOp *get_obj_op(bool get_data);
 
   RGWOp *op_get() override;


### PR DESCRIPTION
clarify that the [PUT Bucket tagging](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTtagging.html) feature is not supported, and reject PUT bucket requests with ?tagging with 405 Method Not Allowed