### PR TITLE
crush: various fixes for weight-sets, the osd_crush_update_weight_set option, and tests

### DIFF
--- a/qa/standalone/crush/crush-choose-args.sh
+++ b/qa/standalone/crush/crush-choose-args.sh
@@ -62,8 +62,8 @@ choose_args 0 {
   {
     bucket_id -1
     weight_set [
-      [ 3.000 ]
-      [ 3.000 ]
+      [ 2.000 ]
+      [ 2.000 ]
     ]
     ids [ -10 ]
   }
@@ -81,14 +81,17 @@ choose_args 0 {
 EOF
     crushtool -c $dir/map.txt -o $dir/map-new || return 1
     ceph osd setcrushmap -i $dir/map-new || return 1
+    ceph osd crush tree
 
     run_osd $dir 1 || return 1
+    ceph osd crush tree
     ceph osd getcrushmap > $dir/map-one-more || return 1
     crushtool -d $dir/map-one-more -o $dir/map-one-more.txt || return 1
     cat $dir/map-one-more.txt
     diff -u $dir/map-one-more.txt $CEPH_ROOT/src/test/crush/crush-choose-args-expected-one-more-3.txt || return 1
 
     destroy_osd $dir 1 || return 1
+    ceph osd crush tree
     ceph osd getcrushmap > $dir/map-one-less || return 1
     crushtool -d $dir/map-one-less -o $dir/map-one-less.txt || return 1
     diff -u $dir/map-one-less.txt $dir/map.txt || return 1

--- a/qa/standalone/crush/crush-choose-args.sh
+++ b/qa/standalone/crush/crush-choose-args.sh
@@ -159,6 +159,83 @@ EOF
     CEPH_ARGS="$ORIG_CEPH_ARGS"
 }
 
+function TEST_reweight() {
+    # reweight and reweight-compat behave appropriately
+    local dir=$1
+
+    ORIG_CEPH_ARGS="$CEPH_ARGS"
+    CEPH_ARGS+="--osd-crush-update-weight-set=false "
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+
+    ceph osd crush weight-set create-compat || return 1
+    ceph osd crush tree
+
+    ceph osd crush weight-set reweight-compat osd.0 2 || return 1
+    ceph osd crush tree
+    ceph osd crush tree | grep host | grep '6.00000  5.00000' || return 1
+
+    run_osd $dir 2 || return 1
+    ceph osd crush tree
+    ceph osd crush tree | grep host | grep '9.00000  5.00000' || return 1
+
+    ceph osd crush reweight osd.2 4
+    ceph osd crush tree
+    ceph osd crush tree | grep host | grep '10.00000  5.00000' || return 1
+
+    ceph osd crush weight-set reweight-compat osd.2 4
+    ceph osd crush tree
+    ceph osd crush tree | grep host | grep '10.00000  9.00000' || return 1
+}
+
+function TEST_move_bucket() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+
+    ceph osd crush weight-set create-compat || return 1
+    ceph osd crush weight-set reweight-compat osd.0 2 || return 1
+    ceph osd crush weight-set reweight-compat osd.1 2 || return 1
+    ceph osd crush tree
+    ceph osd crush tree | grep HOST | grep '6.00000  4.00000' || return 1
+
+    # moving a bucket adjusts the weights
+    ceph osd crush add-bucket RACK rack root=default || return 1
+    ceph osd crush move HOST rack=RACK || return 1
+    ceph osd crush tree
+    ceph osd crush tree | grep HOST | grep '6.00000  4.00000' || return 1
+    ceph osd crush tree | grep RACK | grep '6.00000  4.00000' || return 1
+
+    # weight-set reweight adjusts containing buckets
+    ceph osd crush weight-set reweight-compat osd.0 1 || return 1
+    ceph osd crush tree
+    ceph osd crush tree | grep HOST | grep '6.00000  3.00000' || return 1
+    ceph osd crush tree | grep RACK | grep '6.00000  3.00000' || return 1
+
+    # moving a leaf resets its weight-set to the canonical weight...
+    ceph config set mon osd_crush_update_weight_set true || return 1
+    ceph osd crush add-bucket FOO host root=default || return 1
+    ceph osd crush move osd.0 host=FOO || return 1
+    ceph osd crush tree
+    ceph osd crush tree | grep osd.0 | grep '3.00000  3.00000' || return 1
+    ceph osd crush tree | grep HOST | grep '3.00000  2.00000' || return 1
+    ceph osd crush tree | grep RACK | grep '3.00000  2.00000' || return 1
+
+    # ...or to zero.
+    ceph config set mon osd_crush_update_weight_set false || return 1
+    ceph osd crush move osd.1 host=FOO || return 1
+    ceph osd crush tree
+    ceph osd crush tree | grep osd.0 | grep '3.00000  3.00000' || return 1
+    ceph osd crush tree | grep osd.1 | grep '3.00000        0' || return 1
+    ceph osd crush tree | grep FOO | grep '6.00000  3.00000' || return 1
+}
+
 main crush-choose-args "$@"
 
 # Local Variables:

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1316,7 +1316,8 @@ int CrushWrapper::link_bucket(
 
 int CrushWrapper::create_or_move_item(
   CephContext *cct, int item, float weight, string name,
-  const map<string,string>& loc)  // typename -> bucketname
+  const map<string,string>& loc,  // typename -> bucketname
+  bool init_weight_sets)
 {
   int ret = 0;
   int old_iweight;
@@ -1337,7 +1338,8 @@ int CrushWrapper::create_or_move_item(
     ldout(cct, 5) << "create_or_move_item adding " << item
 		  << " weight " << weight
 		  << " at " << loc << dendl;
-    ret = insert_item(cct, item, weight, name, loc);
+    ret = insert_item(cct, item, weight, name, loc,
+		      item >= 0 && init_weight_sets);
     if (ret == 0)
       ret = 1;  // changed
   }

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1184,7 +1184,8 @@ int CrushWrapper::move_bucket(
   int bucket_weight = detach_bucket(cct, id);
 
   // insert the bucket back into the hierarchy
-  return insert_item(cct, id, bucket_weight / (float)0x10000, id_name, loc);
+  return insert_item(cct, id, bucket_weight / (float)0x10000, id_name, loc,
+		     false);
 }
 
 int CrushWrapper::detach_bucket(CephContext *cct, int item)

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -418,16 +418,16 @@ void CrushWrapper::update_choose_args(CephContext *cct)
       if (!b || b->alg != CRUSH_BUCKET_STRAW2) {
 	if (carg.ids) {
 	  if (cct)
-	    ldout(cct,0) << __func__ << " removing " << i.first << " bucket "
-			 << (-1-j) << " ids" << dendl;
+	    ldout(cct,10) << __func__ << " removing " << i.first << " bucket "
+			  << (-1-j) << " ids" << dendl;
 	  free(carg.ids);
 	  carg.ids = 0;
 	  carg.ids_size = 0;
 	}
 	if (carg.weight_set) {
 	  if (cct)
-	    ldout(cct,0) << __func__ << " removing " << i.first << " bucket "
-			 << (-1-j) << " weight_sets" << dendl;
+	    ldout(cct,10) << __func__ << " removing " << i.first << " bucket "
+			  << (-1-j) << " weight_sets" << dendl;
 	  for (unsigned p = 0; p < carg.weight_set_positions; ++p) {
 	    free(carg.weight_set[p].weights);
 	  }

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1055,7 +1055,8 @@ int CrushWrapper::get_leaves(const string &name, set<int> *leaves) const
 
 int CrushWrapper::insert_item(
   CephContext *cct, int item, float weight, string name,
-  const map<string,string>& loc)  // typename -> bucketname
+  const map<string,string>& loc,  // typename -> bucketname
+  bool init_weight_sets)
 {
   ldout(cct, 5) << "insert_item item " << item << " weight " << weight
 		<< " name " << name << " loc " << loc << dendl;
@@ -1155,7 +1156,8 @@ int CrushWrapper::insert_item(
   }
 
   // adjust the item's weight in location
-  if (adjust_item_weightf_in_loc(cct, item, weight, loc) > 0) {
+  if (adjust_item_weightf_in_loc(cct, item, weight, loc,
+				 item >= 0 && init_weight_sets) > 0) {
     if (item >= crush->max_devices) {
       crush->max_devices = item + 1;
       ldout(cct, 5) << "insert_item max_devices now " << crush->max_devices

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1528,7 +1528,8 @@ int CrushWrapper::adjust_item_weight_in_loc(
   return changed;
 }
 
-int CrushWrapper::adjust_subtree_weight(CephContext *cct, int id, int weight)
+int CrushWrapper::adjust_subtree_weight(CephContext *cct, int id, int weight,
+					bool update_weight_sets)
 {
   ldout(cct, 5) << __func__ << " " << id << " weight " << weight << dendl;
   crush_bucket *b = get_bucket(id);
@@ -1544,7 +1545,7 @@ int CrushWrapper::adjust_subtree_weight(CephContext *cct, int id, int weight)
     for (unsigned i=0; i<b->size; ++i) {
       int n = b->items[i];
       if (n >= 0) {
-	bucket_adjust_item_weight(cct, b, n, weight);
+	adjust_item_weight_in_bucket(cct, n, weight, b->id, update_weight_sets);
 	++changed;
 	++local_changed;
       } else {
@@ -1553,9 +1554,6 @@ int CrushWrapper::adjust_subtree_weight(CephContext *cct, int id, int weight)
 	  continue;
 	q.push_back(sub);
       }
-    }
-    if (local_changed) {
-      adjust_item_weight(cct, b->id, b->weight);
     }
   }
   return changed;

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -868,10 +868,12 @@ public:
    * @param weight initial item weight (if we need to create it)
    * @param name item name
    * @param loc location (map of type to bucket names)
+   * @param init_weight_sets initialize weight-set values to weight (vs 0)
    * @return 0 for no change, 1 for successful change, negative on error
    */
   int create_or_move_item(CephContext *cct, int item, float weight, string name,
-			  const map<string,string>& loc);
+			  const map<string,string>& loc,
+			  bool init_weight_sets=true);
 
   /**
    * remove all instances of an item from the map

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -964,8 +964,12 @@ public:
     }
     return adjust_item_weight(cct, id, (int)(weight * (float)0x10000));
   }
-  int adjust_item_weight_in_loc(CephContext *cct, int id, int weight, const map<string,string>& loc);
-  int adjust_item_weightf_in_loc(CephContext *cct, int id, float weight, const map<string,string>& loc) {
+  int adjust_item_weight_in_bucket(
+    CephContext *cct, int id, int weight, int bucket_id);
+  int adjust_item_weight_in_loc(CephContext *cct, int id, int weight,
+				const map<string,string>& loc);
+  int adjust_item_weightf_in_loc(CephContext *cct, int id, float weight,
+				 const map<string,string>& loc) {
     int r = validate_weightf(weight);
     if (r < 0) {
       return r;

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -956,25 +956,32 @@ public:
     }
     return 0;
   }
-  int adjust_item_weight(CephContext *cct, int id, int weight);
-  int adjust_item_weightf(CephContext *cct, int id, float weight) {
+  int adjust_item_weight(CephContext *cct, int id, int weight,
+			 bool update_weight_sets=true);
+  int adjust_item_weightf(CephContext *cct, int id, float weight,
+			  bool update_weight_sets=true) {
     int r = validate_weightf(weight);
     if (r < 0) {
       return r;
     }
-    return adjust_item_weight(cct, id, (int)(weight * (float)0x10000));
+    return adjust_item_weight(cct, id, (int)(weight * (float)0x10000),
+			      update_weight_sets);
   }
-  int adjust_item_weight_in_bucket(
-    CephContext *cct, int id, int weight, int bucket_id);
+  int adjust_item_weight_in_bucket(CephContext *cct, int id, int weight,
+				   int bucket_id,
+				   bool update_weight_sets);
   int adjust_item_weight_in_loc(CephContext *cct, int id, int weight,
-				const map<string,string>& loc);
+				const map<string,string>& loc,
+				bool update_weight_sets=true);
   int adjust_item_weightf_in_loc(CephContext *cct, int id, float weight,
-				 const map<string,string>& loc) {
+				 const map<string,string>& loc,
+				 bool update_weight_sets=true) {
     int r = validate_weightf(weight);
     if (r < 0) {
       return r;
     }
-    return adjust_item_weight_in_loc(cct, id, (int)(weight * (float)0x10000), loc);
+    return adjust_item_weight_in_loc(cct, id, (int)(weight * (float)0x10000),
+				     loc, update_weight_sets);
   }
   void reweight(CephContext *cct);
   void reweight_bucket(crush_bucket *b,
@@ -1288,7 +1295,9 @@ public:
 		 int *items, int *weights, int *idout);
   int bucket_add_item(crush_bucket *bucket, int item, int weight);
   int bucket_remove_item(struct crush_bucket *bucket, int item);
-  int bucket_adjust_item_weight(CephContext *cct, struct crush_bucket *bucket, int item, int weight);
+  int bucket_adjust_item_weight(
+    CephContext *cct, struct crush_bucket *bucket, int item, int weight,
+    bool adjust_weight_sets);
 
   void finalize() {
     ceph_assert(crush);

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -991,13 +991,16 @@ public:
 		       crush_choose_arg_map& arg_map,
 		       vector<uint32_t> *weightv);
 
-  int adjust_subtree_weight(CephContext *cct, int id, int weight);
-  int adjust_subtree_weightf(CephContext *cct, int id, float weight) {
+  int adjust_subtree_weight(CephContext *cct, int id, int weight,
+			    bool update_weight_sets=true);
+  int adjust_subtree_weightf(CephContext *cct, int id, float weight,
+			     bool update_weight_sets=true) {
     int r = validate_weightf(weight);
     if (r < 0) {
       return r;
     }
-    return adjust_subtree_weight(cct, id, (int)(weight * (float)0x10000));
+    return adjust_subtree_weight(cct, id, (int)(weight * (float)0x10000),
+				 update_weight_sets);
   }
 
   /// check if item id is present in the map hierarchy

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -801,9 +801,12 @@ public:
    * @param weight item weight
    * @param name item name
    * @param loc location (map of type to bucket names)
+   * @param init_weight_sets initialize weight-set weights to weight (vs 0)
    * @return 0 for success, negative on error
    */
-  int insert_item(CephContext *cct, int id, float weight, string name, const map<string,string>& loc);
+  int insert_item(CephContext *cct, int id, float weight, string name,
+		  const map<string,string>& loc,
+		  bool init_weight_sets=true);
 
   /**
    * move a bucket in the hierarchy to the given location

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -887,7 +887,7 @@ public:
    * @param item id to remove
    * @return 0 on success, negative on error
    */
-  int remove_root(int item);
+  int remove_root(CephContext *cct, int item);
 
   /**
    * remove all instances of an item nested beneath a certain point from the map
@@ -1313,9 +1313,9 @@ public:
   int get_rules_by_osd(int osd, set<int> *rules);
   bool _class_is_dead(int class_id);
   void cleanup_dead_classes();
-  int rebuild_roots_with_classes();
+  int rebuild_roots_with_classes(CephContext *cct);
   /* remove unused roots generated for class devices */
-  int trim_roots_with_class();
+  int trim_roots_with_class(CephContext *cct);
 
   int reclassify(
     CephContext *cct,

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9360,7 +9360,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       CrushWrapper newcrush;
       _get_pending_crush(newcrush);
 
-      err = newcrush.create_or_move_item(cct, osdid, weight, osd_name, loc);
+      err = newcrush.create_or_move_item(cct, osdid, weight, osd_name, loc,
+					 g_conf()->osd_crush_update_weight_set);
       if (err == 0) {
 	ss << "create-or-move updated item name '" << osd_name
 	   << "' weight " << weight
@@ -9403,7 +9404,9 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
       if (!newcrush.check_item_loc(cct, id, loc, (int *)NULL)) {
 	if (id >= 0) {
-	  err = newcrush.create_or_move_item(cct, id, 0, name, loc);
+	  err = newcrush.create_or_move_item(
+	    cct, id, 0, name, loc,
+	    g_conf()->osd_crush_update_weight_set);
 	} else {
 	  err = newcrush.move_bucket(cct, id, loc);
 	}
@@ -9624,7 +9627,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       goto reply;
     }
 
-    err = newcrush.adjust_item_weightf(cct, id, w);
+    err = newcrush.adjust_item_weightf(cct, id, w,
+				       g_conf()->osd_crush_update_weight_set);
     if (err < 0)
       goto reply;
     pending_inc.crush.clear();
@@ -9662,7 +9666,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       goto reply;
     }
 
-    err = newcrush.adjust_subtree_weightf(cct, id, w);
+    err = newcrush.adjust_subtree_weightf(cct, id, w,
+					  g_conf()->osd_crush_update_weight_set);
     if (err < 0)
       goto reply;
     pending_inc.crush.clear();

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1090,7 +1090,7 @@ TEST(CrushWrapper, remove_root) {
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_TRUE(c.name_exists("r11"));
   ASSERT_TRUE(c.name_exists("r12"));
-  ASSERT_EQ(c.remove_root(c.get_item_id("default")), 0);
+  ASSERT_EQ(c.remove_root(g_ceph_context, c.get_item_id("default")), 0);
   ASSERT_FALSE(c.name_exists("default"));
   ASSERT_FALSE(c.name_exists("r11"));
   ASSERT_FALSE(c.name_exists("r12"));
@@ -1122,7 +1122,7 @@ TEST(CrushWrapper, trim_roots_with_class) {
 
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_TRUE(c.name_exists("default~ssd"));
-  c.trim_roots_with_class();
+  c.trim_roots_with_class(g_ceph_context);
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_FALSE(c.name_exists("default~ssd"));
 }

--- a/src/test/crush/crush-choose-args-expected-one-more-3.txt
+++ b/src/test/crush/crush-choose-args-expected-one-more-3.txt
@@ -58,8 +58,8 @@ choose_args 0 {
   {
     bucket_id -1
     weight_set [
-      [ 6.000 ]
-      [ 6.000 ]
+      [ 5.000 ]
+      [ 5.000 ]
     ]
     ids [ -10 ]
   }

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -1171,7 +1171,7 @@ int main(int argc, const char **argv)
     modified = true;
   }
   if (rebuild_class_roots) {
-    int r = crush.rebuild_roots_with_classes();
+    int r = crush.rebuild_roots_with_classes(g_ceph_context);
     if (r < 0) {
       cerr << "failed to rebuidl roots with classes" << std::endl;
       return EXIT_FAILURE;


### PR DESCRIPTION
These changes make it possible to run a cluster with
```
ceph balancer mode crush-compat
ceph balancer on
ceph config set global osd_crush_update_weight_set false
```
This makes any OSD addition start with a zeroed weight-set weight so that the balancer can add it in gradually.

This is about 95% bug fixes, and a few very small changes to the monitor to make the option behave the way it was originally intended to.  And some tests.