### PR TITLE
mgr/crash: include entity (instead of daemon) in 'crash ls'

### DIFF
--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -80,10 +80,8 @@ class Module(MgrModule):
     def do_ls(self, cmd, inbuf):
         keys = []
         for k, meta in self.timestamp_filter(lambda ts: True):
-            process_name = meta.get('process_name', 'unknown')
-            if not process_name:
-                process_name = 'unknown'
-            keys.append("%s %s" % (k.replace('crash/', ''), process_name))
+            entity_name = meta.get('entity_name', 'unknown')
+            keys.append("%s %s" % (k.replace('crash/', ''), entity_name))
         keys.sort()
         return 0, '\n'.join(keys), ''
 


### PR DESCRIPTION
The daemon name is implied by the entity, and the entity is more useful.

Signed-off-by: Sage Weil <sage@redhat.com>