### PR TITLE
ceph_release: nautilus is will be 'stable' for v14.2.0

### DIFF
--- a/src/ceph_release
+++ b/src/ceph_release
@@ -1,3 +1,3 @@
 14
 nautilus
-rc
+stable


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>