### PR TITLE
luminous: qa: ignore slow metadata io wrn during osd thrash

### DIFF
--- a/qa/suites/powercycle/osd/whitelist_health.yaml
+++ b/qa/suites/powercycle/osd/whitelist_health.yaml
@@ -3,4 +3,5 @@ overrides:
     log-whitelist:
       - \(MDS_TRIM\)
       - \(MDS_SLOW_REQUEST\)
+      - MDS_SLOW_METADATA_IO
       - Behind on trimming


### PR DESCRIPTION
http://tracker.ceph.com/issues/38665