### PR TITLE
mgr/deepsea: use ceph_volume output in get_inventory()

### DIFF
--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -47,7 +47,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
     MODULE_OPTIONS = [
         {
             'name': 'salt_api_url',
-            'default': None
+            'default': ''
         },
         {
             'name': 'salt_api_eauth',
@@ -55,11 +55,11 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
         },
         {
             'name': 'salt_api_username',
-            'default': None
+            'default': ''
         },
         {
             'name': 'salt_api_password',
-            'default': None
+            'default': ''
         }
     ]
 

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -144,6 +144,8 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
                         dev.metadata_space_free = d['metadata_space_free']
                         devs.append(dev)
                     result.append(orchestrator.InventoryNode(node_name, devs))
+            else:
+                self.log.error(event_data['return'])
             return result
 
         with self._completion_lock:
@@ -189,6 +191,8 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
                         desc.service_instance = service_instance
                         desc.service_type = service_type
                         result.append(desc)
+            else:
+                self.log.error(event_data['return'])
             return result
 
         with self._completion_lock:

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -133,16 +133,9 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
             result = []
             if event_data['success']:
                 for node_name, node_devs in event_data["return"].items():
-                    devs = []
-                    for d in node_devs:
-                        dev = orchestrator.InventoryDevice()
-                        dev.blank = d['blank']
-                        dev.type = d['type']
-                        dev.id = d['id']
-                        dev.size = d['size']
-                        dev.extended = d['extended']
-                        dev.metadata_space_free = d['metadata_space_free']
-                        devs.append(dev)
+                    devs = list(map(lambda di:
+                        orchestrator.InventoryDevice.from_ceph_volume_inventory(di),
+                        node_devs))
                     result.append(orchestrator.InventoryNode(node_name, devs))
             else:
                 self.log.error(event_data['return'])


### PR DESCRIPTION
DeepSea is being updated to use ceph_volume internally (see https://github.com/SUSE/DeepSea/pull/1517 and https://github.com/jschmid1/DeepSea/pull/6). Once this is done, the mgr_orch.get_inventory runner will just be returning the raw ceph_volume output, so this PR updates the DeepSea mgr module to match. There's also a couple of small cleanup commits. We probably don't want to merge this until the DS PR is in though.


