### PR TITLE
nautilus: rgw: ldap: fix early return in LDAPAuthEngine::init w/uri not empty()

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4299,7 +4299,7 @@ std::mutex rgw::auth::s3::LDAPEngine::mtx;
 void rgw::auth::s3::LDAPEngine::init(CephContext* const cct)
 {
   if (! cct->_conf->rgw_s3_auth_use_ldap ||
-      ! cct->_conf->rgw_ldap_uri.empty()) {
+      cct->_conf->rgw_ldap_uri.empty()) {
     return;
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38754