### PR TITLE
[osd/pg]:change default value of osd_allow_recovery_below_min_size to false

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2474,7 +2474,7 @@ std::vector<Option> get_global_options() {
     .add_service("osd"),
 
     Option("osd_allow_recovery_below_min_size", Option::TYPE_BOOL, Option::LEVEL_DEV)
-    .set_default(true)
+    .set_default(false)
     .set_description("allow replicated pools to recover with < min_size active members")
     .add_service("osd"),
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[pg]: [change default value of osd_allow_recovery_below_min_size to false ]

We encountered a sceneria. we scaled up the ceph cluster, added some osds in. Some osds switched between up and down frequently, when data was being rebalanced. After all osds were stable, some pgs were under min-size ,peerd and backfilling. They were not available. There is one common point between these unavailable pgs that osds in the upset after scale-up is totally different from before.   
Assumed a pg with up set [1,2,3] and up set [4,5,6] after scale-up. Osd 2,3 suddenly fell down when data was being rebalanced. Then the acting set would be [1] and the up set would be [4,5,6]. The pg would be peered and backfilling, since the default value of osd_allow_recovery_below_min_size is true. When 2 and 3 became up ,the pg would not be peering again. And the pg ,size of whose acting set is below minsize, would not be available。
So I think this parameter should be default set to false to avoid cluster being unavailbe, in case many users haven't noticed this parameter.
    

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Shen Hang] <[harryshen18@gmail.com]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

