### PR TITLE
rgw: nfs: svc-enable RGWLib

### DIFF
--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -129,6 +129,7 @@ namespace rgw {
   public:
     CephContext* cct;
     RGWUserInfo* user;
+    boost::optional<RGWSysObjectCtx> sysobj_ctx;
 
     /* unambiguiously return req_state */
     inline struct req_state* get_state() { return this->RGWRequest::s; }
@@ -159,7 +160,10 @@ namespace rgw {
       RGWRequest::init_state(_s);
       RGWHandler::init(rados_ctx->get_store(), _s, io);
 
+      sysobj_ctx.emplace(store->svc.sysobj);
+
       get_state()->obj_ctx = rados_ctx;
+      get_state()->sysobj_ctx = &(sysobj_ctx.get());
       get_state()->req_id = store->svc.zone_utils->unique_id(id);
       get_state()->trans_id = store->svc.zone_utils->unique_trans_id(id);
 
@@ -195,7 +199,10 @@ namespace rgw {
 	RGWRequest::init_state(&rstate);
 	RGWHandler::init(rados_ctx.get_store(), &rstate, &io_ctx);
 
+	sysobj_ctx.emplace(store->svc.sysobj);
+
 	get_state()->obj_ctx = &rados_ctx;
+	get_state()->sysobj_ctx = &(sysobj_ctx.get());
 	get_state()->req_id = store->svc.zone_utils->unique_id(id);
 	get_state()->trans_id = store->svc.zone_utils->unique_trans_id(id);
 

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -80,7 +80,7 @@ class RadosWriter : public DataProcessor {
   RGWRados *const store;
   const RGWBucketInfo& bucket_info;
   RGWObjectCtx& obj_ctx;
-  const rgw_obj& head_obj;
+  const rgw_obj head_obj;
   RGWSI_RADOS::Obj stripe_obj; // current stripe object
   RawObjSet written; // set of written objects for deletion
 


### PR DESCRIPTION
Add minimal svc_sys_obj.h boilerplate to RGWLibRequest.  Fix a
trivial illegal access from RGWPutObjProcessor's RadosWriter
when the request object is not stack allocated.

Fixes: https://tracker.ceph.com/issues/38769

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

