### PR TITLE
mgr: Make 3rd parameter optional in ceph_get_module_option

### DIFF
--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -401,7 +401,7 @@ ceph_get_module_option(BaseMgrModule *self, PyObject *args)
   char *module = nullptr;
   char *key = nullptr;
   char *prefix = nullptr;
-  if (!PyArg_ParseTuple(args, "ssz:ceph_get_module_option", &module, &key,
+  if (!PyArg_ParseTuple(args, "ss|s:ceph_get_module_option", &module, &key,
 			&prefix)) {
     derr << "Invalid args!" << dendl;
     return nullptr;

--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -65,7 +65,7 @@ ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
 {
   char *what = nullptr;
   char *prefix = nullptr;
-  if (!PyArg_ParseTuple(args, "sz:ceph_get_module_option", &what, &prefix)) {
+  if (!PyArg_ParseTuple(args, "s|s:ceph_get_module_option", &what, &prefix)) {
     derr << "Invalid args!" << dendl;
     return nullptr;
   }


### PR DESCRIPTION
Revert the following statement https://github.com/ceph/ceph/pull/26905#pullrequestreview-214467242.

Fixes: https://tracker.ceph.com/issues/38766

```
File "/usr/share/ceph/mgr/mgr_module.py", line 863, in _handle_command
2019-03-15T11:28:31.324 INFO:tasks.ceph.mgr.x.mira117.stderr:    return self.handle_command(inbuf, cmd)
2019-03-15T11:28:31.324 INFO:tasks.ceph.mgr.x.mira117.stderr:  File "/usr/share/ceph/mgr/selftest/module.py", line 114, in handle_command
2019-03-15T11:28:31.324 INFO:tasks.ceph.mgr.x.mira117.stderr:    self._self_test()
2019-03-15T11:28:31.325 INFO:tasks.ceph.mgr.x.mira117.stderr:  File "/usr/share/ceph/mgr/selftest/module.py", line 213, in _self_test
2019-03-15T11:28:31.325 INFO:tasks.ceph.mgr.x.mira117.stderr:    self._self_test_config()
2019-03-15T11:28:31.325 INFO:tasks.ceph.mgr.x.mira117.stderr:  File "/usr/share/ceph/mgr/selftest/module.py", line 313, in _self_test_config
2019-03-15T11:28:31.325 INFO:tasks.ceph.mgr.x.mira117.stderr:    assert self.get_module_option_ex("foo", "bar") is None
2019-03-15T11:28:31.325 INFO:tasks.ceph.mgr.x.mira117.stderr:  File "/usr/share/ceph/mgr/mgr_module.py", line 942, in get_module_option_ex
2019-03-15T11:28:31.325 INFO:tasks.ceph.mgr.x.mira117.stderr:    r = self._ceph_get_module_option(module, key)
2019-03-15T11:28:31.325 INFO:tasks.ceph.mgr.x.mira117.stderr:TypeError: ceph_get_module_option() takes exactly 3 arguments (2 given)
```

Signed-off-by: Volker Theile <vtheile@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
