### PR TITLE
mount.ceph.c: do not pass nofail to the kernel

### DIFF
--- a/doc/radosgw/config.rst
+++ b/doc/radosgw/config.rst
@@ -399,7 +399,7 @@ according to the ``rgw keystone accepted roles`` configurable.
 Keystone itself needs to be configured to point to the Ceph Object Gateway as an
 object-storage endpoint::
 
-	keystone service-create --name swift --type-object store
+	keystone service-create --name swift --type object-store
 	keystone endpoint-create --service-id <id> --publicurl http://radosgw.example.com/swift/v1 \
 		--internalurl http://radosgw.example.com/swift/v1 --adminurl http://radosgw.example.com/swift/v1
 

--- a/doc/radosgw/manual-install.rst
+++ b/doc/radosgw/manual-install.rst
@@ -46,6 +46,16 @@ You may also clone Ceph's Apache and FastCGI git repositories::
 
        rgw print continue = false
 
+OpenStack horizon support
+-------------------------
+
+As of `OpenStack Grizzly
+<http://www.openstack.org/software/grizzly/>`_ the `Horizon
+<https://github.com/openstack/horizon>`_ dashboard `does not send
+<https://bugs.launchpad.net/horizon/+bug/1200534>`_ which will trigger
+a ``411 Length Required`` error from libapache2-mod-fastcgi when
+uploading an object. The recommended workaround is to install the
+package from the ceph repositories as instructed above.
 
 Apache Configuration
 ====================

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -148,6 +148,8 @@ static char *parse_options(const char *data, int *filesys_flags)
 			skip = 1;  /* ignore */
 		} else if (strncmp(data, "_netdev", 7) == 0) {
 			skip = 1;  /* ignore */
+		} else if (strncmp(data, "nofail", 6) == 0) {
+			skip = 1;  /* ignore */
 
 		} else if (strncmp(data, "secretfile", 10) == 0) {
 			if (!value || !*value) {


### PR DESCRIPTION
nofail is a userspace level option and shouldn't be passed to the kernel
    
Fixes: https://tracker.ceph.com/issues/23262
   
Signed-off-by: Kenneth Waegeman <kenneth.waegeman@ugent.be>
