### PR TITLE
mount.ceph.c: do not pass nofail to the kernel

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -150,6 +150,8 @@ static char *parse_options(const char *data, int *filesys_flags)
 			skip = 1;  /* ignore */
 		} else if (strncmp(data, "_netdev", 7) == 0) {
 			skip = 1;  /* ignore */
+		} else if (strncmp(data, "nofail", 6) == 0) {
+			skip = 1;  /* ignore */
 
 		} else if (strncmp(data, "secretfile", 10) == 0) {
 			if (!value || !*value) {


### PR DESCRIPTION
nofail is a userspace level option and shouldn't be passed to the kernel

Fixes: https://tracker.ceph.com/issues/23262

Signed-off-by: Kenneth Waegeman <kenneth.waegeman@ugent.be>
