### PR TITLE
[RFC] ceph-volume: add lvmcache plugin

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -464,6 +464,29 @@ def extend_vg(vg, devices):
     return vg
 
 
+def reduce_vg(vg, devices):
+    """
+    Reduce a Volume Group. Command looks like::
+
+        vgreduce --force --yes group_name [device, ...]
+
+    :param vg: A VolumeGroup object
+    :param devices: A list of devices to remove from the VG. Optionally, a
+                    single device (as a string) can be used.
+    """
+    if not isinstance(devices, list):
+        devices = [devices]
+    process.run([
+        'vgreduce',
+        '--force',
+        '--yes',
+        vg.name] + devices
+    )
+
+    vg = get_vg(vg_name=vg.name)
+    return vg
+
+
 def remove_vg(vg_name):
     """
     Removes a volume group.

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -695,37 +695,33 @@ def get_vg(vg_name=None, vg_tags=None):
     return vgs.get(vg_name=vg_name, vg_tags=vg_tags)
 
 
-def create_lvmcache_pool(vg_name, cache_data_lv_name, cache_metadata_lv_name):
-    pool_data = vg_name + '/' + cache_data_lv_name
-    pool_md = vg_name + '/' + cache_metadata_lv_name
+def create_lvmcache_pool(vg_name, data_lv, metadata_lv):
     process.run([
         'lvconvert',
         '--yes',
         '--poolmetadataspare', 'n',
         '--type', 'cache-pool',
-        '--poolmetadata', pool_md, pool_data,
+        '--poolmetadata', metadata_lv.lv_path, data_lv.lv_path,
     ])
 
 
-def create_lvmcache(vg_name, data_lv_name, osd_lv_name):
-    pool_data = vg_name + '/' + data_lv_name
-    osd_data = vg_name + '/' + osd_lv_name
+def create_lvmcache(vg_name, cache_lv, origin_lv):
     process.run([
         'lvconvert',
         '--yes',
         '--type', 'cache',
-        '--cachepool', pool_data, osd_data
+        '--cachepool', cache_lv.lv_path, origin_lv.lv_path
     ])
 
 
-def set_lvmcache_caching_mode(caching_mode, vg_name, osd_lv_name):
+def set_lvmcache_caching_mode(caching_mode, vg_name, origin_lv):
     if caching_mode not in ['writeback', 'writethrough']:
+        print('Unknown caching mode: ' + caching_mode)
         return
 
-    osd_data = vg_name + '/' + osd_lv_name
     process.run([
         'lvchange',
-        '--cachemode', caching_mode, osd_data
+        '--cachemode', caching_mode, origin_lv.lv_path
     ])
 
 

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -306,14 +306,15 @@ def get_api_lvs():
 
     Command and delimited output should look like::
 
-        $ lvs --noheadings --readonly --separator=';' -o lv_tags,lv_path,lv_name,vg_name
+        $ lvs --noheadings --readonly --separator=';' -a -o lv_tags,lv_path,lv_name,vg_name
           ;/dev/ubuntubox-vg/root;root;ubuntubox-vg
           ;/dev/ubuntubox-vg/swap_1;swap_1;ubuntubox-vg
 
+    Note that the -a flag is passed as lvmcache volumes are hidden.
     """
     fields = 'lv_tags,lv_path,lv_name,vg_name,lv_uuid,lv_size'
     stdout, stderr, returncode = process.call(
-        ['lvs', '--noheadings', '--readonly', '--separator=";"', '-o', fields],
+        ['lvs', '--noheadings', '--readonly', '--separator=";"', '-a', '-o', fields],
         verbose_on_failure=False
     )
     return _output_parser(stdout, fields)

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -588,6 +588,7 @@ def create_lv(name, group, extents=None, size=None, tags=None, uuid_name=False, 
         }
 
     # XXX add CEPH_VOLUME_LVM_DEBUG to enable -vvvv on lv operations
+    # TODO: do we need to add cache_metadata and cache data to this dict?
     type_path_tag = {
         'journal': 'ceph.journal_device',
         'data': 'ceph.data_device',
@@ -1195,6 +1196,12 @@ class Volume(object):
         for k, v in self.tags.items():
             tag = "%s=%s" % (k, v)
             process.run(['lvchange', '--deltag', tag, self.lv_path])
+
+    def clear_tag(self, key):
+        if self.tags.get(key):
+            current_value = self.tags[key]
+            tag = "%s=%s" % (key, current_value)
+            process.call(['lvchange', '--deltag', tag, self.lv_api['lv_path']])
 
     def set_tags(self, tags):
         """

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -683,6 +683,25 @@ def human_readable_size(size):
         suffix=suffixes[suffix_index])
 
 
+def size_from_human_readable(s):
+    """
+    Takes a human readable string and converts into a Size. If no unit is
+    passed, bytes is assumed.
+    """
+    if s[-1].isnumeric():
+        return Size(b=int(s))
+    n = float(s[:-1])
+    if s[-1].lower() == 't':
+        return Size(tb=n)
+    if s[-1].lower() == 'g':
+        return Size(gb=n)
+    if s[-1].lower() == 'm':
+        return Size(mb=n)
+    if s[-1].lower() == 'k':
+        return Size(kb=n)
+    return None
+
+
 def get_partitions_facts(sys_block_path):
     partition_metadata = {}
     for folder in os.listdir(sys_block_path):

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -12,6 +12,14 @@ smaller than 2GB because ceph-volume creates vgs with PE = 1GB.
 """
 
 
+# TODO handle OSD removal
+# TODO add a 'cache status' function that shows which OSDs are cached, cache mode, etc
+# TODO look into getting cache statistics
+# TODO add change caching mode
+# TODO  stderr: WARNING: Maximum supported pool metadata size is 16.00 GiB.
+# TODO  stderr: WARNING: recovery of pools without pool metadata spare LV is not automated.
+# TODO do we want a spare partition or not?
+
 # partition sizes in GB
 def _create_cache_lvs(vg_name, md_partition, data_partition, osdid):
     md_partition_size = disk.size_from_human_readable(disk.lsblk(md_partition)['SIZE'])

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -1,0 +1,139 @@
+import argparse
+import sys
+from ceph_volume.api import lvm as api
+
+"""
+The user is responsible for splitting the disk into data and metadata partitions.
+
+If we are to partition a disk to be used as a cache layer, no partition can be
+smaller than 2GB because ceph-volume creates vgs with PE = 1GB.
+
+"""
+
+# partition sizes in GB
+def _create_cache_lvs(vg_name, cache_md_partition, cache_data_partition, md_lv_size, data_lv_size):
+    cache_md_lv = api.create_lv('cache_metadata', vg_name, extents=None, size=md_lv_size, tags=None,
+        uuid_name=True, pv=cache_md_partition)
+    cache_data_lv = api.create_lv('cache_data', vg_name, extents=None, size=data_lv_size, tags=None,
+        uuid_name=True, pv=cache_data_partition)
+    
+    return cache_md_lv, cache_data_lv
+
+
+def _create_lvmcache(vg_name, osd_lv_name, cache_metadata_lv_name, cache_data_lv_name):
+    ''' TODO: test that cache is greater than meta to make sure the order of the
+        arguments was respected '''
+    api.create_lvmcache_pool(vg_name, cache_data_lv_name, cache_metadata_lv_name)
+    api.create_lvmcache(vg_name, cache_data_lv_name, osd_lv_name)
+    api.set_lvmcache_caching_mode('writeback', vg_name, osd_lv_name)
+
+
+def add_lvmcache(vgname, osd_lv_name, cache_md_partition, cache_data_partition, md_partition_size, data_partition_size):
+    """
+    High-level function to be called. Expects the user or orchestrator to have
+    partitioned the disk used for caching.
+    """
+    # TODO add pvcreate step?
+    vg = api.get_vg(vg_name=vgname)
+    api.extend_vg(vg, [cache_md_partition, cache_data_partition])
+    cache_md_lv, cache_data_lv = _create_cache_lvs(vg.name, cache_md_partition, cache_data_partition, md_partition_size, data_partition_size)
+    _create_lvmcache(vg.name, osd_lv_name, cache_md_lv.name, cache_data_lv.name)
+
+
+class Cache(object):
+
+    help_menu = 'Deploy Cache'
+    _help = """
+Deploy lvmcache. Usage:
+
+$> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --cachemetadata_size <metadata partition size> --cachedata_size <data partition size> --osddata <osd lvm name> --volumegroup <volume group>
+
+or:
+
+$> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --cachemetadata_size <metadata partition size> --cachedata_size <data partition size> --osdid <osd id>
+    """
+    name = 'cache'
+
+    def __init__(self, argv=None):
+        self.mapper = {
+        }
+        if argv is None:
+            self.argv = sys.argv
+        else:
+            self.argv = argv
+
+    
+    def help(self):
+        return self._help
+
+
+    def _get_split_args(self):
+        subcommands = self.mapper.keys()
+        slice_on_index = len(self.argv) + 1
+        pruned_args = self.argv[1:]
+        for count, arg in enumerate(pruned_args):
+            if arg in subcommands:
+                slice_on_index = count
+                break
+        return pruned_args[:slice_on_index], pruned_args[slice_on_index:]
+
+
+    def main(self, argv=None):
+        main_args, subcommand_args = self._get_split_args()
+        parser = argparse.ArgumentParser(
+            prog='cache',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.help(),
+        )
+        parser.add_argument(
+            '--cachemetadata',
+            help='Cache metadata partition',
+        )
+        parser.add_argument(
+            '--cachedata',
+            help='Cache data partition',
+        )
+        parser.add_argument(
+            '--cachemetadata_size',
+            help='Cache metadata partition size in GB',
+        )
+        parser.add_argument(
+            '--cachedata_size',
+            help='Cache data partition size in GB',
+        )
+        parser.add_argument(
+            '--osddata',
+            help='OSD data partition',
+        )
+        parser.add_argument(
+            '--osdid',
+            help='OSD id',
+        )
+        parser.add_argument(
+            '--volumegroup',
+            help='Volume group',
+        )
+        args = parser.parse_args(main_args)
+        if len(self.argv) <= 1:
+            return parser.print_help()
+
+        if args.osd_id and not args.osddata:
+            lvs = api.Volumes()
+            for lv in lvs:
+                if lv.tags['ceph.osd_id'] == args.osdid:
+                    osd_lv_name = lv.name
+                    vg_name = lv.vg_name
+        else:
+            osd_lv_name = args.osddata
+            vg_name = args.volumegroup
+
+        add_lvmcache(vg_name,
+            osd_lv_name,
+            args.cachemetadata,
+            args.cachedata,
+            args.cachemetadata_size,
+            args.cachedata_size)
+
+
+if __name__ == '__main__':
+    main.Cache()

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -223,22 +223,25 @@ $> ceph-volume cache rm --osdid <id>
         # This should be under if argv[0] == 'add'
         if args.osdid:
             lvs = api.Volumes()
+            lvs.filter(lv_tags={'ceph.osd_id': args.osdid})
+
+            # this loop might not be necessary, take any LV from lvs and it will work
+            # proof: we break after the first iteration
             for lv in lvs:
-                if lv.tags.get('ceph.osd_id', '') == args.osdid:
-                    # TODO make sure there is a db or wal partition
-                    osdid = args.osdid
-                    # TODO update the cache's name accordingly to this
-                    # TODO make sure there's a separate wal or db
-                    if args.data:
-                        origin_lv = api.get_lv(lv_path=lv.tags['ceph.block_device'])
-                    elif args.db:
-                        # TODO make sure 'ceph.db_device' and others are in tag. ie use tags.get()
-                        origin_lv = api.get_lv(lv_path=lv.tags['ceph.db_device'])
-                    elif args.wal:
-                        origin_lv = api.get_lv(lv_path=lv.tags['ceph.wal_device'])
-                    else:
-                        origin_lv = api.get_lv(lv_path=lv.tags['ceph.block_device'])
-                    break
+                # TODO make sure there is a db or wal partition
+                osdid = args.osdid
+                # TODO update the cache's name accordingly to this
+                # TODO make sure there's a separate wal or db
+                if args.data:
+                    origin_lv = api.get_lv(lv_path=lv.tags['ceph.block_device'])
+                elif args.db:
+                    # TODO make sure 'ceph.db_device' and others are in tag. ie use tags.get()
+                    origin_lv = api.get_lv(lv_path=lv.tags['ceph.db_device'])
+                elif args.wal:
+                    origin_lv = api.get_lv(lv_path=lv.tags['ceph.wal_device'])
+                else:
+                    origin_lv = api.get_lv(lv_path=lv.tags['ceph.block_device'])
+                break
             if not origin_lv:
                 print('Couldn\'t find origin LV for OSD ' + args.osdid)
                 return
@@ -264,8 +267,9 @@ $> ceph-volume cache rm --osdid <id>
             # TODO verify that the OSD has a cache
             if args.osdid and not args.origin:
                 lvs = api.Volumes()
+                lvs.filter(lv_tags={'ceph.osd_id': args.osdid})
                 for lv in lvs:
-                    if lv.tags.get('ceph.osd_id', '') == args.osdid and lv.tags.get('ceph.cache_lv', None):
+                    if lv.tags.get('ceph.cache_lv', None):
                         origin_lv = lv
                         break
             if not origin_lv:

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -34,17 +34,15 @@ def _create_cache_lvs(vg_name, md_partition, data_partition, osdid):
         'cache_md_osd.' + osdid,
         vg_name,
         size=str(md_lv_size._b) + 'B',
+        tags={'ceph.osd_id': osdid, 'ceph.type': 'cache_metadata', 'ceph.partition': md_partition},
         pv=md_partition)
-    cache_md_lv.set_tag('ceph.type', 'cache_metadata')
-    cache_md_lv.set_tag('ceph.partition', md_partition)
 
     cache_data_lv = api.create_lv(
         'cache_osd.' + osdid,
         vg_name,
         size=str(data_lv_size._b) + 'B',
+        tags={'ceph.osd_id': osdid, 'ceph.type': 'cache_data', 'ceph.partition': data_partition},
         pv=data_partition)
-    cache_data_lv.set_tag('ceph.type', 'cache_data')
-    cache_data_lv.set_tag('ceph.partition', data_partition)
 
     return cache_md_lv, cache_data_lv
 

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -29,7 +29,7 @@ def _create_cache_lvs(vg_name, md_partition, data_partition, osdid):
     md_lv_size = md_partition_size - disk.Size(gb=1)
     data_lv_size = data_partition_size - disk.Size(gb=1)
 
-    # TODO: update these new LVs' tags (ceph.cluster_fsid, etc.)
+    # TODO: update these new LVs' tags (ceph.osd_id, ceph.cluster_fsid, etc.)
     cache_md_lv = api.create_lv(
         'cache_md_osd.' + osdid,
         vg_name,
@@ -49,21 +49,24 @@ def _create_cache_lvs(vg_name, md_partition, data_partition, osdid):
     return cache_md_lv, cache_data_lv
 
 
-def _create_lvmcache(vg_name, osd_lv_name, cache_metadata_lv_name, cache_data_lv_name):
-    osd_lv = api.get_lv(lv_name=osd_lv_name, vg_name=vg_name)
+def _create_lvmcache(vg_name, origin_lv, cache_metadata_lv, cache_data_lv):
     # TODO: test that cache data is greater than metadata
-    api.create_lvmcache_pool(vg_name, cache_data_lv_name, cache_metadata_lv_name)
-    api.create_lvmcache(vg_name, cache_data_lv_name, osd_lv_name)
+    api.create_lvmcache_pool(vg_name, cache_data_lv, cache_metadata_lv)
+    api.create_lvmcache(vg_name, cache_data_lv, origin_lv)
 
-    osd_lv.set_tag('ceph.cache_lv', cache_data_lv_name)
-    api.set_lvmcache_caching_mode('writeback', vg_name, osd_lv_name)
+    # TODO do we need this tag?
+    origin_lv.set_tag('ceph.cache_lv', cache_data_lv.lv_name)
+    api.set_lvmcache_caching_mode('writeback', vg_name, origin_lv)
 
-    _cache_data_lv_name = '[' + cache_data_lv_name + ']'
+    _cache_data_lv_name = '[' + cache_data_lv.name + ']'
     cache_lv = api.get_lv(lv_name=_cache_data_lv_name, vg_name=vg_name)
+    cache_lv.set_tag('ceph.osd_id', origin_lv.tags['ceph.osd_id'])
+    cache_lv.set_tag('ceph.type', 'cache')
+
     return cache_lv
 
 
-def add_lvmcache(vgname, osd_lv_name, md_partition, cache_data_partition, osdid):
+def add_lvmcache(vgname, origin_lv, md_partition, cache_data_partition, osdid):
     """
     High-level function to be called. Expects the user or orchestrator to have
     partitioned the disk used for caching.
@@ -78,8 +81,8 @@ def add_lvmcache(vgname, osd_lv_name, md_partition, cache_data_partition, osdid)
         cache_data_partition,
         osdid
     )
-    cachelv = _create_lvmcache(vg.name, osd_lv_name, cache_md_lv.name,
-        cache_data_lv.name)
+    cachelv = _create_lvmcache(vg.name, origin_lv, cache_md_lv,
+        cache_data_lv)
 
     return cachelv
 
@@ -116,7 +119,9 @@ $> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data 
 
 or:
 
-$> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --osdid <osd id>
+$> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --osdid <osd id> [--data|--db|--wal]
+
+--data, --db and --wal indicate which partition to cache
 
 Remove cache:
 
@@ -172,25 +177,56 @@ $> ceph-volume cache rm --osdid <id>
             '--volumegroup',
             help='Volume group',
         )
+        parser.add_argument(
+            '--data',
+            action='store_true',
+            help='cache the OSD\'s data',
+        )
+        parser.add_argument(
+            '--db',
+            action='store_true',
+            help='cache the OSD\'s db',
+        )
+        parser.add_argument(
+            '--wal',
+            action='store_true',
+            help='cache the OSD\'s wal',
+        )
         args = parser.parse_args(main_args)
+
         if len(self.argv) <= 1:
             return parser.print_help()
 
+        # TODO make sure OSD is on bluestore
+
+        # This should be under if argv[0] == 'add'
         if args.osdid and not args.osddata:
             lvs = api.Volumes()
             for lv in lvs:
                 if lv.tags.get('ceph.osd_id', '') == args.osdid:
-                    osd_lv_name = lv.name
-                    vg_name = lv.vg_name
+                    # TODO make sure there is a db or wal partition
                     osdid = args.osdid
+                    # TODO update the cache's name accordingly to this
+                    # TODO make sure there's a separate wal or db
+                    if args.data:
+                        origin_lv = api.get_lv(lv_path=lv.tags['ceph.block_device'])
+                    elif args.db:
+                        origin_lv = api.get_lv(lv_path=lv.tags['ceph.db_device'])
+                    elif args.wal:
+                        origin_lv = api.get_lv(lv_path=lv.tags['ceph.wal_device'])
+                    else:
+                        origin_lv = api.get_lv(lv_path=lv.tags['ceph.block_device'])
+                    vg_name = origin_lv.vg_name
                     break
         else:
-            osd_lv_name = args.osddata
+            # osddata is already the LV's name, so no need to look for
+            # --data, --db or --wal flags.
+            # note: it should actually be --originlv instead of --osddata
             vg_name = args.volumegroup
             lvs = api.Volumes()
             for lv in lvs:
                 if lv.name == args.osddata:
-                    osd_lv_name = lv.name
+                    origin_lv = lv
                     vg_name = lv.vg_name
                     osdid = lv.tags.get('ceph.osd_id', None)
                     break
@@ -199,13 +235,21 @@ $> ceph-volume cache rm --osdid <id>
         if self.argv[0] == 'add':
             add_lvmcache(
                 vg_name,
-                osd_lv_name,
+                origin_lv,
                 args.cachemetadata,
                 args.cachedata,
                 osdid)
         elif self.argv[0] == 'rm':
             # TODO verify that the OSD has a cache
-            rm_lvmcache(vg_name, osd_lv_name)
+
+            if args.osdid and not args.osddata:
+                lvs = api.Volumes()
+                for lv in lvs:
+                    if lv.tags.get('ceph.osd_id', '') == args.osdid and lv.tags.get('ceph.cache_lv', None):
+                        origin_lv = lv
+                        vg_name = origin_lv.vg_name
+                        break
+            rm_lvmcache(vg_name, origin_lv.name)
 
 
 if __name__ == '__main__':

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -82,11 +82,12 @@ def get_lvs_caching_info():
     return api._output_parser(stdout, fields)
 
 
+# TODO add osdid to cache info
 def print_cache_info(osdid=None):
     # TODO filter on osdid optionally
     osd_id_width = 8
     rows, columns = get_terminal_size()
-    column_width = int((columns - osd_id_width) / 4)
+    column_width = min(int((columns - osd_id_width) / 4), 18)
     s = '{0:>{w}}'.format('OSD', w=osd_id_width)
     # TODO change 'partition' to something else
     s = s + '{0:>{w}}'.format('Partition', w=column_width)
@@ -118,18 +119,20 @@ def get_lvs_caching_stats():
 
 
 def print_cache_stats(osdid=None):
+    # TODO print hit rate
     osd_id_width = 8
     rows, columns = get_terminal_size()
-    column_width = int(columns / 4)
-    s = ''
+    column_width = min(int(columns / 4), 18)
+    h = ''
     if not osdid:
-        s = '{0:>{w}}'.format('OSD', w=osd_id_width)
-        column_width = int((columns - osd_id_width) / 4)
-    s = s + '{0:>{w}}'.format('Read hits', w=column_width)
-    s = s + '{0:>{w}}'.format('Read misses', w=column_width)
-    s = s + '{0:>{w}}'.format('Write hits', w=column_width)
-    s = s + '{0:>{w}}'.format('Write misses', w=column_width)
-    print(s)
+        h = '{0:>{w}}'.format('OSD', w=osd_id_width)
+        column_width = min(int((columns - osd_id_width) / 4), 18)
+    h = h + '{0:>{w}}'.format('Read hits', w=column_width)
+    h = h + '{0:>{w}}'.format('Read misses', w=column_width)
+    h = h + '{0:>{w}}'.format('Write hits', w=column_width)
+    h = h + '{0:>{w}}'.format('Write misses', w=column_width)
+    if osdid:
+        print(h)
 
     # TODO refactor this. Look at the mgr's iostat plugin.
     # TODO show the table's header again when it disappears
@@ -145,12 +148,15 @@ def print_cache_stats(osdid=None):
                     if not osdid or (osdid and v.tags['ceph.osd_id'] == osdid):
                         s = ''
                         if not osdid:
+                            print(h)
                             s = '{0:>{w}}'.format(v.tags['ceph.osd_id'], w=osd_id_width)
                         s = s + '{0:>{w}}'.format(item['cache_read_hits'], w=column_width)
                         s = s + '{0:>{w}}'.format(item['cache_read_misses'], w=column_width)
                         s = s + '{0:>{w}}'.format(item['cache_write_hits'], w=column_width)
                         s = s + '{0:>{w}}'.format(item['cache_write_misses'], w=column_width)
                         print(s)
+                        if not osdid:
+                            print()
             time.sleep(1)
         except KeyboardInterrupt:
             print('Interrupted')

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -26,6 +26,12 @@ smaller than 2GB because ceph-volume creates vgs with PE = 1GB.
 #   LVs are either lock, journal or wal. Will probably need to be done by the
 #   orchestrator.
 # TODO raise exceptions instead of print+return
+# TODO add error handling at every step
+
+
+def get_terminal_size():
+    rows, columns = os.popen('stty size', 'r').read().split()
+    return int(rows), int(columns)
 
 
 def get_lvs_caching_info():
@@ -39,18 +45,24 @@ def get_lvs_caching_info():
 
 def print_cache_info(osdid=None):
     # TODO filter on osdid optionally
-    column_width = 12
-    s = '{0:>{w}}'.format('OSD', w=column_width)
+    osd_id_width = 8
+    rows, columns = get_terminal_size()
+    column_width = int((columns - osd_id_width) / 4)
+    s = '{0:>{w}}'.format('OSD', w=osd_id_width)
     # TODO change 'partition' to something else
     s = s + '{0:>{w}}'.format('Partition', w=column_width)
     s = s + '{0:>{w}}'.format('Cache mode', w=column_width)
+    s = s + '{0:>{w}}'.format('Cache policy', w=column_width)
+    s = s + '{0:>{w}}'.format('Cache settings', w=column_width)
     print(s)
     for item in get_lvs_caching_info():
         if item['cache_mode'] is not "" and item['lv_tags'] is not "":
             v = api.Volume(**item)
-            s = '{0:>{w}}'.format(v.tags['ceph.osd_id'], w=column_width)
+            s = '{0:>{w}}'.format(v.tags['ceph.osd_id'], w=osd_id_width)
             s = s + '{0:>{w}}'.format(v.tags['ceph.type'], w=column_width)
             s = s + '{0:>{w}}'.format(item['cache_mode'], w=column_width)
+            s = s + '{0:>{w}}'.format(item['cache_policy'], w=column_width)
+            s = s + '{0:>{w}}'.format(item['cache_settings'], w=column_width)
             print(s)
 
 

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -1,5 +1,8 @@
 import argparse
 import sys
+import time
+import os
+import json
 from ceph_volume.api import lvm as api
 from ceph_volume.util import disk
 from ceph_volume import process
@@ -27,6 +30,24 @@ smaller than 2GB because ceph-volume creates vgs with PE = 1GB.
 #   orchestrator.
 # TODO raise exceptions instead of print+return
 # TODO add error handling at every step
+
+
+def pretty(s):
+    print(json.dumps(s, indent=4, sort_keys=True))
+
+
+def pretty_lv(lv):
+    print('-------------')
+    print('lv_name: ' + lv.lv_name)
+    print('type: ' + lv.tags.get('ceph.type', ''))
+    print('osdid: ' + lv.tags.get('ceph.osd_id', ''))
+    print('vg_name: ' + lv.vg_name)
+    print('lv_path: ' + lv.lv_path)
+    print('\ntags:')
+    pretty(lv.tags)
+    print('\nreport')
+    pretty(lv.report())
+    print('-------------')
 
 
 def get_terminal_size():
@@ -316,6 +337,12 @@ $> ceph-volume cache stats
             help='cache the OSD\'s wal',
         )
         args = parser.parse_args(main_args)
+
+        if self.argv[0] == 'debug':
+            lvs = api.Volumes()
+            for lv in lvs:
+                pretty_lv(lv)
+            return
 
         if len(self.argv) <= 1:
             return parser.print_help()

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -43,26 +43,33 @@ def _create_cache_lvs(vg_name, md_partition, data_partition):
     md_lv_size = md_partition_size - disk.Size(gb=1)
     data_lv_size = data_partition_size - disk.Size(gb=1)
 
+    # TODO: update tags
     cache_md_lv = api.create_lv('cache_metadata', vg_name, extents=None,
-        size=str(md_lv_size._b) + 'B', tags=None, uuid_name=True, pv=md_partition)
-    cache_md_lv.set_tag('cachetype', 'metadata')
-    cache_md_lv.set_tag('partition', md_partition)
+        size=str(md_lv_size._b) + 'B', tags=None, uuid_name=False, pv=md_partition)
+    cache_md_lv.set_tag('ceph.cachetype', 'metadata')
+    cache_md_lv.set_tag('ceph.partition', md_partition)
     cache_data_lv = api.create_lv('cache_data', vg_name, extents=None,
-        size=str(data_lv_size._b) + 'B', tags=None, uuid_name=True, pv=data_partition)
-    cache_data_lv.set_tag('cachetype', 'data')
-    cache_md_lv.set_tag('partition', data_partition)
-    cache_md_lv.set_tag('metadata', cache_md_lv.name)
+        size=str(data_lv_size._b) + 'B', tags=None, uuid_name=False, pv=data_partition)
+    cache_data_lv.set_tag('ceph.cachetype', 'data')
+    cache_data_lv.set_tag('ceph.partition', data_partition)
+    # TODO: this tags is probably not needed, we can get it using '_cmeta'
+    cache_md_lv.set_tag('ceph.metadata', cache_md_lv.name)
 
     return cache_md_lv, cache_data_lv
 
 
 def _create_lvmcache(vg_name, osd_lv_name, cache_metadata_lv_name, cache_data_lv_name):
+    osd_lv = api.get_lv(lv_name=osd_lv_name, vg_name=vg_name)
     # TODO: test that cache data is greater than metadata
     api.create_lvmcache_pool(vg_name, cache_data_lv_name, cache_metadata_lv_name)
-    cachelv = api.create_lvmcache(vg_name, cache_data_lv_name, osd_lv_name)
+    api.create_lvmcache(vg_name, cache_data_lv_name, osd_lv_name)
+
+    osd_lv.set_tag('ceph.cache_lv', cache_data_lv_name)
     api.set_lvmcache_caching_mode('writeback', vg_name, osd_lv_name)
 
-    return cachelv
+    _cache_data_lv_name = '[' + cache_data_lv_name + ']'
+    cache_lv = api.get_lv(lv_name=_cache_data_lv_name, vg_name=vg_name)
+    return cache_lv
 
 
 def add_lvmcache(vgname, osd_lv_name, md_partition, cache_data_partition):
@@ -80,15 +87,24 @@ def add_lvmcache(vgname, osd_lv_name, md_partition, cache_data_partition):
     return cachelv
 
 
-def rm_lvmcache(vgname, cache_data_lv):
-    lv = api.get_lv(lv_name=cache_data_lv, vg_name=vgname)
-    vg = api.get_vg(vg_name=vgname)
-    if lv is None:
-        print("Couldn't find LV " + vgname + "/" + cache_data_lv)
+def rm_lvmcache(vgname, osd_lv_name):
+    osd_lv = api.get_lv(lv_name=osd_lv_name, vg_name=vgname)
+    if osd_lv.tags['ceph.cache_lv'] is None or len(osd_lv.tags['ceph.cache_lv']) == 0:
+        print('Can\'t find cache data lv')
         return
-    api.remove_lv(lv)
-    md_lv = api.get_lv(lv_name=lv.tags['metadata'], vg_name=vgname)
-    api.reduce_vg(vg, lv.tags['partition'], md_lv.tags['partition'])
+    vg = api.get_vg(vg_name=vgname)
+    cache_lv_name = osd_lv.tags['ceph.cache_lv']
+
+    # get the partitions before removing the LVs
+    data_lv_name = '[' + osd_lv.tags['ceph.cache_lv'] + '_cdata]'
+    meta_lv_name = '[' + osd_lv.tags['ceph.cache_lv'] + '_cmeta]'
+    data_lv = api.get_lv(lv_name=data_lv_name, vg_name=vgname)
+    meta_lv = api.get_lv(lv_name=meta_lv_name, vg_name=vgname)
+    data_partition = data_lv.tags['ceph.partition']
+    md_partition = meta_lv.tags['ceph.partition']
+
+    api.remove_lv(vgname + '/' + cache_lv_name)
+    api.reduce_vg(vg, [data_partition, md_partition])
 
 
 class Cache(object):
@@ -102,6 +118,10 @@ $> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data 
 or:
 
 $> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --osdid <osd id>
+
+Remove cache:
+
+$> ceph-volume cache rm --osdid <id>
     """
     name = 'cache'
 
@@ -171,11 +191,16 @@ $> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data 
             osd_lv_name = args.osddata
             vg_name = args.volumegroup
 
-        add_lvmcache(
-            vg_name,
-            osd_lv_name,
-            args.cachemetadata,
-            args.cachedata)
+        # TODO make sure the OSD exists (ie is on this node)
+        if self.argv[0] == 'add':
+            add_lvmcache(
+                vg_name,
+                osd_lv_name,
+                args.cachemetadata,
+                args.cachedata)
+        elif self.argv[0] == 'rm':
+            # TODO verify that the OSD has a cache
+            rm_lvmcache(vg_name, osd_lv_name)
 
 
 if __name__ == '__main__':

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -166,6 +166,7 @@ $> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data 
                 if lv.tags.get('ceph.osd_id', '') == args.osdid:
                     osd_lv_name = lv.name
                     vg_name = lv.vg_name
+                    break
         else:
             osd_lv_name = args.osddata
             vg_name = args.volumegroup

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -40,6 +40,17 @@ def add_lvmcache(vgname, osd_lv_name, cache_md_partition, cache_data_partition, 
     _create_lvmcache(vg.name, osd_lv_name, cache_md_lv.name, cache_data_lv.name)
 
 
+def rm_lvmcache(vgname, cache_data_lv):
+    lv = api.get_lv(lv_name=cache_data_lv, vg_name=vgname)
+    vg = api.get_vg(vg_name=vgname)
+    if lv is None:
+        print("Couldn't find LV " + vgname + "/" + cache_data_lv)
+        return
+    api.remove_lv(lv)
+    md_lv = api.get_lv(lv_name=lv.tags['metadata'], vg_name=vgname)
+    api.reduce_vg(vg, lv.tags['partition'], md_lv.tags['partition'])
+
+
 class Cache(object):
 
     help_menu = 'Deploy Cache'

--- a/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
+++ b/src/ceph-volume/plugin/cache/ceph_volume_cache/main.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 from ceph_volume.api import lvm as api
+from ceph_volume.util import disk
 
 """
 The user is responsible for splitting the disk into data and metadata partitions.
@@ -10,34 +11,73 @@ smaller than 2GB because ceph-volume creates vgs with PE = 1GB.
 
 """
 
+
+# Not very elegant, probably needs to be replaced or at least moved to util
+def strToSize(s):
+    n = float(s[:-1])
+    if s[-1].lower() == 't':
+        return disk.Size(tb=n)
+    if s[-1].lower() == 'g':
+        return disk.Size(gb=n)
+    if s[-1].lower() == 'm':
+        return disk.Size(mb=n)
+    if s[-1].lower() == 'k':
+        return disk.Size(kb=n)
+    return None
+
+
 # partition sizes in GB
-def _create_cache_lvs(vg_name, cache_md_partition, cache_data_partition, md_lv_size, data_lv_size):
-    cache_md_lv = api.create_lv('cache_metadata', vg_name, extents=None, size=md_lv_size, tags=None,
-        uuid_name=True, pv=cache_md_partition)
-    cache_data_lv = api.create_lv('cache_data', vg_name, extents=None, size=data_lv_size, tags=None,
-        uuid_name=True, pv=cache_data_partition)
-    
+def _create_cache_lvs(vg_name, md_partition, data_partition):
+    md_partition_size = strToSize(disk.lsblk(md_partition)['SIZE'])
+    data_partition_size = strToSize(disk.lsblk(data_partition)['SIZE'])
+
+    if not md_partition_size >= disk.Size(gb=2):
+        print('Metadata partition is too small')
+        return
+    if not data_partition_size >= disk.Size(gb=2):
+        print('Data partition is too small')
+        return
+
+    # ceph-volume creates volumes with extent size = 1GB
+    # when a new lv is created, one extent needs to be used by LVM itself
+    md_lv_size = md_partition_size - disk.Size(gb=1)
+    data_lv_size = data_partition_size - disk.Size(gb=1)
+
+    cache_md_lv = api.create_lv('cache_metadata', vg_name, extents=None,
+        size=str(md_lv_size._b) + 'B', tags=None, uuid_name=True, pv=md_partition)
+    cache_md_lv.set_tag('cachetype', 'metadata')
+    cache_md_lv.set_tag('partition', md_partition)
+    cache_data_lv = api.create_lv('cache_data', vg_name, extents=None,
+        size=str(data_lv_size._b) + 'B', tags=None, uuid_name=True, pv=data_partition)
+    cache_data_lv.set_tag('cachetype', 'data')
+    cache_md_lv.set_tag('partition', data_partition)
+    cache_md_lv.set_tag('metadata', cache_md_lv.name)
+
     return cache_md_lv, cache_data_lv
 
 
 def _create_lvmcache(vg_name, osd_lv_name, cache_metadata_lv_name, cache_data_lv_name):
-    ''' TODO: test that cache is greater than meta to make sure the order of the
-        arguments was respected '''
+    # TODO: test that cache data is greater than metadata
     api.create_lvmcache_pool(vg_name, cache_data_lv_name, cache_metadata_lv_name)
-    api.create_lvmcache(vg_name, cache_data_lv_name, osd_lv_name)
+    cachelv = api.create_lvmcache(vg_name, cache_data_lv_name, osd_lv_name)
     api.set_lvmcache_caching_mode('writeback', vg_name, osd_lv_name)
 
+    return cachelv
 
-def add_lvmcache(vgname, osd_lv_name, cache_md_partition, cache_data_partition, md_partition_size, data_partition_size):
+
+def add_lvmcache(vgname, osd_lv_name, md_partition, cache_data_partition):
     """
     High-level function to be called. Expects the user or orchestrator to have
     partitioned the disk used for caching.
     """
     # TODO add pvcreate step?
     vg = api.get_vg(vg_name=vgname)
-    api.extend_vg(vg, [cache_md_partition, cache_data_partition])
-    cache_md_lv, cache_data_lv = _create_cache_lvs(vg.name, cache_md_partition, cache_data_partition, md_partition_size, data_partition_size)
-    _create_lvmcache(vg.name, osd_lv_name, cache_md_lv.name, cache_data_lv.name)
+    # TODO don't fail if the LVs are already part of the vg
+    api.extend_vg(vg, [md_partition, cache_data_partition])
+    cache_md_lv, cache_data_lv = _create_cache_lvs(vg.name, md_partition, cache_data_partition)
+    cachelv = _create_lvmcache(vg.name, osd_lv_name, cache_md_lv.name, cache_data_lv.name)
+
+    return cachelv
 
 
 def rm_lvmcache(vgname, cache_data_lv):
@@ -57,11 +97,11 @@ class Cache(object):
     _help = """
 Deploy lvmcache. Usage:
 
-$> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --cachemetadata_size <metadata partition size> --cachedata_size <data partition size> --osddata <osd lvm name> --volumegroup <volume group>
+$> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --osddata <osd lvm name> --volumegroup <volume group>
 
 or:
 
-$> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --cachemetadata_size <metadata partition size> --cachedata_size <data partition size> --osdid <osd id>
+$> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data partition> --osdid <osd id>
     """
     name = 'cache'
 
@@ -105,14 +145,6 @@ $> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data 
             help='Cache data partition',
         )
         parser.add_argument(
-            '--cachemetadata_size',
-            help='Cache metadata partition size in GB',
-        )
-        parser.add_argument(
-            '--cachedata_size',
-            help='Cache data partition size in GB',
-        )
-        parser.add_argument(
             '--osddata',
             help='OSD data partition',
         )
@@ -128,22 +160,21 @@ $> ceph-volume cache add --cachemetadata <metadata partition> --cachedata <data 
         if len(self.argv) <= 1:
             return parser.print_help()
 
-        if args.osd_id and not args.osddata:
+        if args.osdid and not args.osddata:
             lvs = api.Volumes()
             for lv in lvs:
-                if lv.tags['ceph.osd_id'] == args.osdid:
+                if lv.tags.get('ceph.osd_id', '') == args.osdid:
                     osd_lv_name = lv.name
                     vg_name = lv.vg_name
         else:
             osd_lv_name = args.osddata
             vg_name = args.volumegroup
 
-        add_lvmcache(vg_name,
+        add_lvmcache(
+            vg_name,
             osd_lv_name,
             args.cachemetadata,
-            args.cachedata,
-            args.cachemetadata_size,
-            args.cachedata_size)
+            args.cachedata)
 
 
 if __name__ == '__main__':

--- a/src/ceph-volume/plugin/cache/setup.py
+++ b/src/ceph-volume/plugin/cache/setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""The setup script."""
+
+from setuptools import setup
+
+requirements = [ ]
+
+setup_requirements = [ ]
+
+setup(
+    author='Mohamad Gebai',
+    author_email='mgebai@suse.com',
+    description="Manage a software cache layer in front of OSDs",
+    install_requires=requirements,
+    license="BSD license",
+    url='https://github.com/ceph/ceph/src/ceph-volume/plugin/cache',
+    version='0.1.0',
+    zip_safe=False,
+    entry_points = dict(
+        ceph_volume_handlers = [
+            'cache = ceph_volume_cache.main:Cache',
+        ],
+    ),
+)


### PR DESCRIPTION
This is an RFC to discuss what an lvmcache plugin would like if there's interest in having one for ceph-volume. This is a proof of concept. To use a free disk as an lvm cache:

1. Partition the disk into (at least) two partitions: one for the cache's metadata and one for the cache's data
2. Create a cache by running:

```
$> ceph-volume cache add --osdid <id> --cachemetadata <metadata partition> --cachedata <data partition>

or:

$> ceph-volume cache add --osddata <osd lv> --cachemetadata <metadata partition> --cachedata <data partition>
```
3. The same disk can be used for sevaral OSDs

Some questions I have:
- Is there any interest in having such a plugin?
- What would the interface look like for users and orchestrators?
- Would we expect the user/orchestrator to partition the disk?
- Would we support caching only the OSD data? Or also potentially caching the DB or WAL partitions?

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

