### PR TITLE
osd/PG: fix pg merge check for rc clusters

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2718,17 +2718,19 @@ void PG::merge_from(map<spg_t,PGRef>& sources, RecoveryCtx *rctx,
     dout(10) << __func__ << " target incomplete" << dendl;
     incomplete = true;
   }
-  if (info.pgid.pgid != last_pg_merge_meta.source_pgid.get_parent()) {
-    dout(10) << __func__ << " target doesn't match expected parent "
-	     << last_pg_merge_meta.source_pgid.get_parent()
-	     << " of source_pgid " << last_pg_merge_meta.source_pgid
-	     << dendl;
-    incomplete = true;
-  }
-  if (info.last_update != last_pg_merge_meta.target_version) {
-    dout(10) << __func__ << " target version doesn't match expected "
-	     << last_pg_merge_meta.target_version << dendl;
-    incomplete = true;
+  if (last_pg_merge_meta.source_pgid != pg_t()) {
+    if (info.pgid.pgid != last_pg_merge_meta.source_pgid.get_parent()) {
+      dout(10) << __func__ << " target doesn't match expected parent "
+	       << last_pg_merge_meta.source_pgid.get_parent()
+	       << " of source_pgid " << last_pg_merge_meta.source_pgid
+	       << dendl;
+      incomplete = true;
+    }
+    if (info.last_update != last_pg_merge_meta.target_version) {
+      dout(10) << __func__ << " target version doesn't match expected "
+	       << last_pg_merge_meta.target_version << dendl;
+      incomplete = true;
+    }
   }
 
   PGLogEntryHandler handler{this, rctx->transaction};
@@ -2753,16 +2755,18 @@ void PG::merge_from(map<spg_t,PGRef>& sources, RecoveryCtx *rctx,
 	       << dendl;
       incomplete = true;
     }
-    if (source->info.pgid.pgid != last_pg_merge_meta.source_pgid) {
-      dout(10) << __func__ << " source " << source->info.pgid.pgid
-	       << " doesn't match expected source pgid "
-	       << last_pg_merge_meta.source_pgid << dendl;
-      incomplete = true;
-    }
-    if (source->info.last_update != last_pg_merge_meta.source_version) {
-      dout(10) << __func__ << " source version doesn't match expected "
-	       << last_pg_merge_meta.target_version << dendl;
-      incomplete = true;
+    if (last_pg_merge_meta.source_pgid != pg_t()) {
+      if (source->info.pgid.pgid != last_pg_merge_meta.source_pgid) {
+	dout(10) << __func__ << " source " << source->info.pgid.pgid
+		 << " doesn't match expected source pgid "
+		 << last_pg_merge_meta.source_pgid << dendl;
+	incomplete = true;
+      }
+      if (source->info.last_update != last_pg_merge_meta.source_version) {
+	dout(10) << __func__ << " source version doesn't match expected "
+		 << last_pg_merge_meta.target_version << dendl;
+	incomplete = true;
+      }
     }
 
     // prepare log

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2009,13 +2009,16 @@ void pg_pool_t::decode(bufferlist::const_iterator& bl)
     decode(pg_num_target, bl);
     decode(pgp_num_target, bl);
     decode(pg_num_pending, bl);
-    epoch_t e;
-    decode(e, bl);
-    decode(e, bl);
+    epoch_t old_merge_last_epoch_clean, old_merge_last_epoch_started;
+    decode(old_merge_last_epoch_started, bl);
+    decode(old_merge_last_epoch_clean, bl);
     decode(last_force_op_resend, bl);
     decode(pg_autoscale_mode, bl);
     if (struct_v >= 29) {
       decode(last_pg_merge_meta, bl);
+    } else {
+      last_pg_merge_meta.last_epoch_clean = old_merge_last_epoch_clean;
+      last_pg_merge_meta.last_epoch_started = old_merge_last_epoch_started;
     }
   } else {
     pg_num_target = pg_num;


### PR DESCRIPTION
If a cluster had a pg merge pending before last_pg_merge_meta was
introduced then the source_pgid will be pg_t().  If that's the case,
skip these new checks.

Likewise, if we decode a legacy pg_pool_t, put the old merge les/lec
values into the correct location.

Signed-off-by: Sage Weil <sage@redhat.com>