### PR TITLE
osd: stringify as int

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8457,7 +8457,8 @@ void OSD::check_osdmap_features()
   if (osdmap->require_osd_release != last_require_osd_release) {
     dout(1) << __func__ << " require_osd_release " << last_require_osd_release
 	    << " -> " << to_string(osdmap->require_osd_release) << dendl;
-    store->write_meta("require_osd_release", stringify(osdmap->require_osd_release));
+    store->write_meta("require_osd_release",
+		      stringify((int)osdmap->require_osd_release));
     last_require_osd_release = osdmap->require_osd_release;
   }
 }


### PR DESCRIPTION
Otherwise we get

$ hexdump -C require_osd_release
00000000  0e 0a                                             |..|
00000002

Signed-off-by: Sage Weil <sage@redhat.com>