### PR TITLE
rgw: support max-size unit REST quota parameter

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1862,8 +1862,8 @@ Valid parameters for quotas include:
   the maximum number of objects. A negative value disables this setting.
 
 - **Maximum Size:** The ``max-size`` option allows you to specify a quota
-  for the maximum number of bytes. The ``max-size-kb`` option allows you
-  to specify it in KiB. A negative value disables this setting.
+  size in B/Ki/Mi/Gi/Ti or B/K/M/G/T, where B is the default. The ``max-size-kb``
+  option allows you to specify it in KiB. A negative value disables this setting.
 
 - **Quota Type:** The ``quota-type`` option sets the scope for the quota.
   The options are ``bucket`` and ``user``.


### PR DESCRIPTION
Signed-off-by: Chenjiong Deng <dengchenjiong@umcloud.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

This PR add support for unit of max-size in user quota setting REST API , like "Bi", "Ki", "Mi", "Gi", "Ti", and compatible with old SI prefix(K, B, M, G).
PR #24062 implemented max-size REST, but it does not support unit like B, K, M, G via radosgw-admin.
