### PR TITLE
rgw: Adding tcp_nodelay option to Beast

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -59,6 +59,19 @@ Options
 :Type: String
 :Default: None
 
+``tcp_nodelay``
+
+:Description: If set the socket option will disable Nagle's algorithm on 
+              the connection which means that packets will be sent as soon 
+              as possible instead of waiting for a full buffer or timeout to occur.
+
+              ``1`` Disable Nagel's algorithm for all sockets.
+
+              ``0`` Keep the default: Nagel's algorithm enabled.
+
+:Type: Integer (0 or 1)
+:Default: 0
+
 
 Civetweb
 ========

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -238,6 +238,7 @@ class AsioFrontend {
     tcp::acceptor acceptor;
     tcp::socket socket;
     bool use_ssl = false;
+    bool use_nodelay = false;
 
     explicit Listener(boost::asio::io_context& context)
       : acceptor(context), socket(context) {}
@@ -301,7 +302,7 @@ unsigned short parse_port(const char *input, boost::system::error_code& ec)
   }
   return port;
 }
-
+	
 tcp::endpoint parse_endpoint(boost::asio::string_view input,
                              unsigned short default_port,
                              boost::system::error_code& ec)
@@ -404,7 +405,14 @@ int AsioFrontend::init()
     listeners.emplace_back(context);
     listeners.back().endpoint = endpoint;
   }
-
+  // parse tcp nodelay
+  auto nodelay = config.find("tcp_nodelay");
+  if (nodelay != config.end()) {
+    for (auto& l : listeners) {
+      l.use_nodelay = (nodelay->second == "1");
+    }
+  }
+  
   // start listeners
   for (auto& l : listeners) {
     l.acceptor.open(l.endpoint.protocol(), ec);
@@ -522,6 +530,8 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
     throw ec;
   }
   auto socket = std::move(l.socket);
+  tcp::no_delay options(l.use_nodelay);
+  socket.set_option(options,ec);
   l.acceptor.async_accept(l.socket,
                           [this, &l] (boost::system::error_code ec) {
                             accept(l, ec);


### PR DESCRIPTION
rgw: Adding tcp_nodelay option to Beast

beast frontend option to set the TCP_NODELAY socket option to match the tcp_nodelay option in civetweb.

Fixes: https://tracker.ceph.com/issues/34308 
Signed-off-by: Or Friedmann ofriedma@redhat.com
