### PR TITLE
common/options: make secure mode non-experimental, and prefer/require it for mons

### DIFF
--- a/src/auth/AuthRegistry.cc
+++ b/src/auth/AuthRegistry.cc
@@ -99,9 +99,7 @@ void AuthRegistry::_parse_mode_list(const string& s,
     if (i == "crc") {
       v->push_back(CEPH_CON_MODE_CRC);
     } else if (i == "secure") {
-      if (cct->check_experimental_feature_enabled("ms-mode-secure")) {
-	v->push_back(CEPH_CON_MODE_SECURE);
-      }
+      v->push_back(CEPH_CON_MODE_SECURE);
     } else {
       lderr(cct) << "WARNING: unknown connection mode " << i << dendl;
     }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -841,7 +841,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("ms_type"),
 
     Option("ms_mon_cluster_mode", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("crc")
+    .set_default("secure crc")
     .set_description("Connection modes (crc, secure) for intra-mon connections in order of preference")
     .add_see_also("ms_mon_service_mode")
     .add_see_also("ms_mon_client_mode")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -868,19 +868,19 @@ std::vector<Option> get_global_options() {
     .add_see_also("ms_client_mode"),
 
     Option("ms_cluster_mode", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("crc")
+    .set_default("crc secure")
     .set_description("Connection modes (crc, secure) for intra-cluster connections in order of preference")
     .add_see_also("ms_service_mode")
     .add_see_also("ms_client_mode"),
 
     Option("ms_service_mode", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("crc")
+    .set_default("crc secure")
     .set_description("Allowed connection modes (crc, secure) for connections to daemons")
     .add_see_also("ms_cluster_mode")
     .add_see_also("ms_client_mode"),
 
     Option("ms_client_mode", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("crc")
+    .set_default("crc secure")
     .set_description("Connection modes (crc, secure) for connections from clients in order of preference")
     .add_see_also("ms_cluster_mode")
     .add_see_also("ms_service_mode"),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -850,7 +850,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("ms_client_mode"),
 
     Option("ms_mon_service_mode", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("crc")
+    .set_default("secure crc")
     .set_description("Allowed connection modes (crc, secure) for connections to mons")
     .add_see_also("ms_service_mode")
     .add_see_also("ms_mon_cluster_mode")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -859,7 +859,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("ms_client_mode"),
 
     Option("ms_mon_client_mode", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("crc")
+    .set_default("secure crc")
     .set_description("Connection modes (crc, secure) for connections from clients to monitors in order of preference")
     .add_see_also("ms_mon_service_mode")
     .add_see_also("ms_mon_cluster_mode")


### PR DESCRIPTION
Let's enable this in master so we get lots of testing.  We can backport the config change to nautilus when we are comfortable.