### PR TITLE
[RFC] osd: tier flush potentially leading to inconsistent

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2005,6 +2005,15 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     }
   }
 
+  if (m->has_flag(CEPH_OSD_FLAG_FLUSH)) {
+    if (m->get_map_epoch() < info.flushed_thru) {
+      osd->reply_op_error(op, -EAGAIN);
+      return;
+    } else if (m->get_map_epoch() != info.flushed_thru) {
+      info.flushed_thru = m->get_map_epoch();
+    }
+  }
+
   if ((m->get_flags() & (CEPH_OSD_FLAG_BALANCE_READS |
 			 CEPH_OSD_FLAG_LOCALIZE_READS)) &&
       op->may_read() &&
@@ -10097,6 +10106,7 @@ int PrimaryLogPG::start_flush(
       dsnapc,
       ceph::real_clock::from_ceph_timespec(oi.mtime),
       (CEPH_OSD_FLAG_IGNORE_OVERLAY |
+       CEPH_OSD_FLAG_FLUSH |
        CEPH_OSD_FLAG_ENFORCE_SNAPC),
       NULL /* no callback, we'll rely on the ordering w.r.t the next op */);
   }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3207,7 +3207,7 @@ void pg_history_t::generate_test_instances(list<pg_history_t*>& o)
 
 void pg_info_t::encode(ceph::buffer::list &bl) const
 {
-  ENCODE_START(32, 26, bl);
+  ENCODE_START(33, 26, bl);
   encode(pgid.pgid, bl);
   encode(last_update, bl);
   encode(last_complete, bl);
@@ -3227,6 +3227,7 @@ void pg_info_t::encode(ceph::buffer::list &bl) const
   encode(last_backfill, bl);
   encode(last_backfill_bitwise, bl);
   encode(last_interval_started, bl);
+  encode(flushed_thru, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -3254,6 +3255,9 @@ void pg_info_t::decode(ceph::buffer::list::const_iterator &bl)
     decode(last_interval_started, bl);
   } else {
     last_interval_started = last_epoch_started;
+  }
+  if (struct_v >= 33) { 
+    decode(flushed_thru, bl);
   }
   DECODE_FINISH(bl);
 }
@@ -3290,6 +3294,7 @@ void pg_info_t::dump(Formatter *f) const
   f->dump_int("dne", dne());
   f->dump_int("incomplete", is_incomplete());
   f->dump_int("last_epoch_started", last_epoch_started);
+  f->dump_int("flushed_thru", flushed_thru);
 
   f->open_object_section("hit_set_history");
   hit_set.dump(f);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2724,6 +2724,7 @@ struct pg_info_t {
   eversion_t last_complete;    ///< last version pg was complete through.
   epoch_t last_epoch_started;  ///< last epoch at which this pg started on this osd
   epoch_t last_interval_started; ///< first epoch of last_epoch_started interval
+  epoch_t flushed_thru;		///< the last epoch occured flush
   
   version_t last_user_version; ///< last user object version applied to store
 
@@ -2753,12 +2754,14 @@ struct pg_info_t {
       l.purged_snaps == r.purged_snaps &&
       l.stats == r.stats &&
       l.history == r.history &&
-      l.hit_set == r.hit_set;
+      l.hit_set == r.hit_set &&
+      l.flushed_thru == r.flushed_thru;
   }
 
   pg_info_t()
     : last_epoch_started(0),
       last_interval_started(0),
+      flushed_thru(0),
       last_user_version(0),
       last_backfill(hobject_t::get_max()),
       last_backfill_bitwise(false)
@@ -2768,6 +2771,7 @@ struct pg_info_t {
     : pgid(p),
       last_epoch_started(0),
       last_interval_started(0),
+      flushed_thru(0),
       last_user_version(0),
       last_backfill(hobject_t::get_max()),
       last_backfill_bitwise(false)


### PR DESCRIPTION
When flush clone object, we will generate delete op, this uesd to let
head in base pool make clone correctly. but the delete op is send from
tier pg to base pg, so if tier pg partition happen, it will still send
to base pg. so we need extra info to avoid the case.

Detail:

Let's say tier pg has a partited one called pg[1,2]p1, p1 is disconnected
with others and monitor, so it will not receive new osdmap, and keep
active state. the auth pg is already become pg[2,3]p2 ,and start to flush.

When osd.1 reconnect and before advance to new osdmap, the agent_work
may start to flush, and send delete and copy_from to base pool, delete
will be handle and remove head, but copy_from will fail, because the flush
already occured.. and the head in base pool will be deleted wrongly and
can not recovery.

Change:
1. I introduce a new member called flushed_thru into pg_info_t. 
2. delete and copy_from generated when do flush will take the flag of CEPH_OSD_FLAG_FLUSH to
    let it be distinguishable.
3.  when these ops processing, we update the pg_info_t flushed_thru.
4.  If we receive the ops with older epoch than current flushed_thru, reply error.

Fixes: https://tracker.ceph.com/issues/38787

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

