### PR TITLE
osd: transpose two wait lists in comment

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1323,14 +1323,14 @@ protected:
    *  - waiting_for_map
    *    - may start or stop blocking at any time (depending on client epoch)
    *  - waiting_for_peered
-   *    - !is_peered() or flushes_in_progress
+   *    - !is_peered()
    *    - only starts blocking on interval change; never restarts
+   *  - waiting_for_flush
+   *    - flushes_in_progress
+   *    - waiting for final flush during activate
    *  - waiting_for_active
    *    - !is_active()
    *    - only starts blocking on interval change; never restarts
-   *  - waiting_for_flush
-   *    - is_active() and flushes_in_progress
-   *    - waiting for final flush during activate
    *  - waiting_for_scrub
    *    - starts and stops blocking for varying intervals during scrub
    *  - waiting_for_unreadable_object


### PR DESCRIPTION
osd: transpose two wait lists in comment

see PrimaryLogPG::do_request(), we check for

1. is_peered(), then
2. flushes_in_progress, then
3. is_active()
4. scrubber.is_chunky_scrub_active() && write_blocked_by_scrub(head) in
   PrimaryLogPG::do_op() which is called by PrimaryLogPG::do_request().

while in PrimaryLogPG::on_change()

we requeue the waiting request in the reversed order,

1. requeue_ops(waiting_for_peered);
2. requeue_ops(waiting_for_flush);
3. requeue_ops(waiting_for_active);

so the comment is not in sync with the code. in this change,
"waiting_for_active" and "waiting_for_flush" are transposed in the
comment explaining blocked request wait lists.

Signed-off-by: Kefu Chai <kchai@redhat.com>