### PR TITLE
qa/suites/upgrade/luminous-x: disable c-o-t import/export tests between versions

### DIFF
--- a/qa/suites/upgrade/luminous-x/stress-split-erasure-code/3-thrash/default.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split-erasure-code/3-thrash/default.yaml
@@ -23,4 +23,5 @@ stress-tasks:
     chance_thrash_pg_upmap_items: 0
     chance_force_recovery: 0
     aggressive_pg_num_changes: false
+    disable_objectstore_tool_tests: true
 - print: "**** done thrashosds 3-thrash"


### PR DESCRIPTION
We had this off in the stress-split portion, but not stress-split-erasure-code.

Fixes: http://tracker.ceph.com/issues/38294