### PR TITLE
luminous: mds: wait for client to release shared cap when re-acquiring xlock

### DIFF
--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -506,8 +506,9 @@ public:
   }
   void put_xlock() {
     assert(state == LOCK_XLOCK || state == LOCK_XLOCKDONE ||
-	   state == LOCK_XLOCKSNAP || is_locallock() ||
-	   state == LOCK_LOCK /* if we are a master of a slave */);
+	   state == LOCK_XLOCKSNAP || state == LOCK_LOCK_XLOCK ||
+	   state == LOCK_LOCK  || /* if we are a master of a slave */
+	   is_locallock());
     --more()->num_xlock;
     parent->put(MDSCacheObject::PIN_LOCK);
     if (more()->num_xlock == 0) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/38669