### PR TITLE
rbd: krbd: return -ETIMEDOUT in polling

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -241,11 +241,16 @@ static int wait_for_udev_add(struct udev_monitor *mon, const krbd_spec& spec,
   for (;;) {
     struct pollfd fds[1];
     struct udev_device *dev;
+    int r;
 
     fds[0].fd = udev_monitor_get_fd(mon);
     fds[0].events = POLLIN;
-    if (poll(fds, 1, POLL_TIMEOUT) < 0)
+    r = poll(fds, 1, POLL_TIMEOUT);
+    if (r < 0)
       return -errno;
+
+    if (r == 0)
+      return -ETIMEDOUT;
 
     dev = udev_monitor_receive_device(mon);
     if (!dev)
@@ -572,11 +577,16 @@ static int wait_for_udev_remove(struct udev_monitor *mon, dev_t devno)
   for (;;) {
     struct pollfd fds[1];
     struct udev_device *dev;
+    int r;
 
     fds[0].fd = udev_monitor_get_fd(mon);
     fds[0].events = POLLIN;
-    if (poll(fds, 1, POLL_TIMEOUT) < 0)
+    r = poll(fds, 1, POLL_TIMEOUT);
+    if (r < 0)
       return -errno;
+
+    if (r == 0)
+      return -ETIMEDOUT;
 
     dev = udev_monitor_receive_device(mon);
     if (!dev)


### PR DESCRIPTION
We don't want to wait on uevent forever, but the return value
of polling in timeout is 0 rather than a negative value.

manpage of poll as below:

RETURN VALUE
       On success, a positive number is returned; this is the number of structures which
       have nonzero revents fields (in other words, those descriptors with events or errors reported).
       A value of 0  indicates that the call timed out and no file descriptors were ready.
       On error, -1 is returned, and errno is set appropriately.

Fixes: http://tracker.ceph.com/issues/38792
Signed-off-by: Dongsheng Yang <dongsheng.yang@easystack.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

