### PR TITLE
messages,osd: remove MPGStats::had_map_for

### DIFF
--- a/src/messages/MPGStats.h
+++ b/src/messages/MPGStats.h
@@ -29,14 +29,12 @@ public:
   osd_stat_t osd_stat;
   map<int64_t, store_statfs_t> pool_stat;
   epoch_t epoch = 0;
-  utime_t had_map_for;
   
   MPGStats() : MessageInstance(MSG_PGSTATS, 0, HEAD_VERSION, COMPAT_VERSION) {}
-  MPGStats(const uuid_d& f, epoch_t e, utime_t had)
+  MPGStats(const uuid_d& f, epoch_t e)
     : MessageInstance(MSG_PGSTATS, 0, HEAD_VERSION, COMPAT_VERSION),
       fsid(f),
-      epoch(e),
-      had_map_for(had)
+      epoch(e)
   {}
 
 private:
@@ -55,7 +53,7 @@ public:
     encode(osd_stat, payload, features);
     encode(pg_stat, payload);
     encode(epoch, payload);
-    encode(had_map_for, payload);
+    encode(utime_t{}, payload);
     encode(pool_stat, payload, features);
   }
   void decode_payload() override {
@@ -65,7 +63,8 @@ public:
     decode(osd_stat, p);
     decode(pg_stat, p);
     decode(epoch, p);
-    decode(had_map_for, p);
+    utime_t dummy;
+    decode(dummy, p);
     if (header.version >= 2)
       decode(pool_stat, p);
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7628,11 +7628,10 @@ MPGStats* OSD::collect_pg_stats()
   // their stats are always enqueued for sending.
   RWLock::RLocker l(map_lock);
 
-  utime_t had_for = ceph_clock_now() - had_map_since;
   osd_stat_t cur_stat = service.get_osd_stat();
   cur_stat.os_perf_stat = store->get_cur_stats();
 
-  auto m = new MPGStats(monc->get_fsid(), osdmap->get_epoch(), had_for);
+  auto m = new MPGStats(monc->get_fsid(), osdmap->get_epoch());
   m->osd_stat = cur_stat;
 
   std::lock_guard lec{min_last_epoch_clean_lock};
@@ -8207,8 +8206,6 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
       service.set_epochs(&boot_epoch, &up_epoch, NULL);
     }
   }
-
-  had_map_since = ceph_clock_now();
 
   epoch_t _bind_epoch = service.get_bind_epoch();
   if (osdmap->is_up(whoami) &&

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1855,7 +1855,6 @@ protected:
 
   pool_pg_num_history_t pg_num_history;
 
-  utime_t         had_map_since;
   RWLock          map_lock;
   list<OpRequestRef>  waiting_for_osdmap;
   deque<utime_t> osd_markdown_log;

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -537,8 +537,7 @@ class OSDStub : public TestStub
   void send_pg_stats() {
     dout(10) << __func__
 	     << " pgs " << pgs.size() << " osdmap " << osdmap << dendl;
-    utime_t now = ceph_clock_now();
-    MPGStats *mstats = new MPGStats(monc.get_fsid(), osdmap.get_epoch(), now);
+    MPGStats *mstats = new MPGStats(monc.get_fsid(), osdmap.get_epoch());
 
     mstats->set_tid(1);
     mstats->osd_stat = osd_stat;


### PR DESCRIPTION
MPGStats::had_map_for was added back in 7844d0e5, the last release that
still checks this field was mimic -- monitor sends OSD incremental
osdmaps if the monitor finds that the pg_stats' had_map_for is greater
than 30 and the epoch is less than that of latest osdmap.

but DaemonServer as the new consumer of MPGStats does not check
had_map_for anymore -- it simply updates the cluster state with the
pg_stats reported by OSD. and we direct OSD to mgr for sending pg_stats
since mimic. so, we can safely drop the support of had_map_for in
octopus, as it has been 2 releases.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

