### PR TITLE
mds: Autotuning of mds_cache_memory_limit based on the rss usage

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -15,7 +15,7 @@
 :Description: The memory limit the MDS should enforce for its cache.
               Administrators should use this instead of ``mds cache size``.
 :Type:  64-bit Integer Unsigned
-:Default: ``1073741824``
+:Default: ``1GB``
 
 ``mds cache autotune``
 
@@ -27,13 +27,19 @@
 
 :Description: Sets an upper bound for the ``mds_cache_memory_limit``.
 :Type:  64-bit Integer Unsigned
-:Default: ``1073741824``
+:Default: ``2GB``
 
-``mds memory cache resize interval``
+``mds cache resize interval``
 
-:Description: When mds_cache_autotune is set to true, wait this many seconds between resizing caches.
+:Description: Interval between resizing caches(``mds_cache_autotune`` must be set to ``true``).
+:Type:  64-bit Integer Signed
+:Default: ``60``
+
+``mds memory target cgroup limit ratio``
+
+:Description: Set the default value for mds_memory_target to the cgroup memory limit (if set) times this value
 :Type:  Float
-:Default: ``5``
+:Default: ``0.8``
 
 ``mds cache reservation``
 

--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -17,6 +17,24 @@
 :Type:  64-bit Integer Unsigned
 :Default: ``1073741824``
 
+``mds cache autotune``
+
+:Description: If ``true``, enables autotuning of the MDS cache.
+:Type:  Boolean
+:Default: ``false``
+
+``mds memory target``
+
+:Description: Sets an upper bound for the ``mds_cache_memory_limit``.
+:Type:  64-bit Integer Unsigned
+:Default: ``1073741824``
+
+``mds memory cache resize interval``
+
+:Description: When mds_cache_autotune is set to true, wait this many seconds between resizing caches.
+:Type:  Float
+:Default: ``5``
+
 ``mds cache reservation``
 
 :Description: The cache reservation (memory or inodes) for the MDS cache to maintain.

--- a/qa/tasks/fs.py
+++ b/qa/tasks/fs.py
@@ -7,9 +7,55 @@ import logging
 import re
 import time
 
+from gevent import sleep
+from gevent.greenlet import Greenlet
+from gevent.event import Event
+
 from tasks.cephfs.filesystem import Filesystem
 
 log = logging.getLogger(__name__)
+
+class MemoryWatchdog(Greenlet):
+    def __init__(self, ctx, config):
+        super(MemoryWatchdog, self).__init__()
+        self.ctx = ctx
+        self.config = config
+        self.e = None
+        self.logger = log.getChild('memory_watch')
+        self.cluster = config.get('cluster', 'ceph')
+        self.name = 'memorywatchdog'
+        self.stopping = Event()
+
+    def _run(self):
+        try:
+            self.watch()
+        except Exception as e:
+            self.e = e
+            self.logger.exception("exception:")
+            # allow successful completion so gevent doesn't see an exception...
+
+    def log(self, x):
+        """Write data to logger"""
+        self.logger.info(x)
+
+    def stop(self):
+        self.stopping.set()
+
+    def watch(self):
+        self.log("MemoryWatchdog starting")
+
+        while not self.stopping.is_set():
+            status = self.fs.status()
+            max_mds = status.get_fsmap(self.fs.id)['mdsmap']['max_mds']
+            ranks = list(status.get_ranks(self.fs.id))
+            actives = filter(lambda info: "up:active" == info['state'] and "laggy_since" not in info, ranks)
+            for rank in actives:
+                mem_info = self.fs.rank_asok(["perf", "dump"], rank)["mds_mem"]
+                self.log("Usage statistic for mds ", self.get_rank(rank=rank, status=status)["name"])
+                self.log(mem_info)
+                assertGreaterEqual(((int(self.fs.get_config("mds_memory_target")) * 125)/100), mem_info["rss"], "rss usage has exceeded the mds_memory_target")
+
+        self.log("MemoryWatchdog finished")
 
 def clients_evicted(ctx, config):
     """

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -533,6 +533,18 @@ void md_config_t::parse_env(unsigned entity_type,
 			    "osd_memory_target", stringify(pod_limit));
 	  }
 	}
+      case CEPH_ENTITY_TYPE_MDS:
+        {
+          double cgroup_ratio = get_val<double>(
+            values, "mds_memory_target_cgroup_limit_ratio");  
+          if (cgroup_ratio > 0.0) {
+            pod_limit = v * cgroup_ratio;
+            // set mds_memory_target *default* based on cgroup limit, so that
+            // it can be overridden by any explicit settings elsewhere.
+            set_val_default(values, tracker,
+                            "mds_memory_target", stringify(pod_limit));
+          }
+        }
       }
     }
   }
@@ -557,6 +569,12 @@ void md_config_t::parse_env(unsigned entity_type,
 	       *find_option("osd_memory_target"),
 	       CONF_ENV, &err);
       break;
+
+    case CEPH_ENTITY_TYPE_MDS:
+      _set_val(values, tracker, stringify(pod_request),
+               *find_option("mds_memory_target"),
+               CONF_ENV, &err);
+
     }
   }
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7436,6 +7436,20 @@ std::vector<Option> get_mds_options() {
     .set_description("target maximum memory usage of MDS cache")
     .set_long_description("This sets a target maximum memory usage of the MDS cache and is the primary tunable to limit the MDS memory usage. The MDS will try to stay under a reservation of this limit (by default 95%; 1 - mds_cache_reservation) by trimming unused metadata in its cache and recalling cached items in the client caches. It is possible for the MDS to exceed this limit due to slow recall from clients. The mds_health_cache_threshold (150%) sets a cache full threshold for when the MDS signals a cluster health warning."),
 
+    Option("mds_cache_autotune", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Enable autotuning of mds_cache_memory_limit")
+    .set_long_description("When set, mds_cache_memory_limit is automatically tuned as per the rss usage periodically whose time interval is defined by mds_cache_resize_interval."),
+
+    Option("mds_memory_target", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .set_default(1*(1LL<<30))
+    .set_description("Upper bound for the mds_cache_memory_limit")
+    .set_long_description("When cache autotuning is enabled, sets an upper bound for mds_cache_memory_limit" ),
+
+    Option("mds_memory_cache_resize_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(5)
+    .set_description("When mds_cache_autotune is set to true, wait this many seconds between resizing caches."),
+
     Option("mds_cache_reservation", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(.05)
     .set_description("amount of memory to reserve for future cached objects"),

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -186,6 +186,10 @@ class MDCache {
   uint64_t cache_limit_memory(void) {
     return cache_memory_limit;
   }
+  uint64_t cache_memory_target(void) {
+    return memory_target;
+  }
+
   double cache_toofull_ratio(void) const {
     double inode_reserve = cache_inode_limit*(1.0-cache_reservation);
     double memory_reserve = cache_memory_limit*(1.0-cache_reservation);
@@ -1256,10 +1260,16 @@ class MDCache {
   void finish_uncommitted_fragment(dirfrag_t basedirfrag, int op);
   void rollback_uncommitted_fragment(dirfrag_t basedirfrag, frag_vec_t&& old_frags);
 
+  // -- cache autotuning --
+  void adjust_cache_memory_limit();
+
+  bool cache_autotune;
   uint64_t cache_inode_limit;
   uint64_t cache_memory_limit;
+  uint64_t memory_target;
   double cache_reservation;
   double cache_health_threshold;
+  double cache_resize_interval;
 
   std::array<CInode *, NUM_STRAY> strays{}; // my stray dir
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -18,6 +18,7 @@
 #include <string_view>
 #include <thread>
 
+#include "common/MemoryModel.h"
 #include "common/DecayCounter.h"
 #include "include/types.h"
 #include "include/filepath.h"
@@ -122,6 +123,8 @@ class MDCache {
 
   using clock = ceph::coarse_mono_clock;
   using time = ceph::coarse_mono_time;
+  
+  time last_cache_resize_time = clock::zero();
 
   // -- discover --
   struct discover_info_t {
@@ -180,16 +183,14 @@ class MDCache {
   explicit MDCache(MDSRank *m, PurgeQueue &purge_queue_);
   ~MDCache();
 
+  void resize();
+
   uint64_t cache_limit_inodes(void) {
     return cache_inode_limit;
   }
   uint64_t cache_limit_memory(void) {
     return cache_memory_limit;
   }
-  uint64_t cache_memory_target(void) {
-    return memory_target;
-  }
-
   double cache_toofull_ratio(void) const {
     double inode_reserve = cache_inode_limit*(1.0-cache_reservation);
     double memory_reserve = cache_memory_limit*(1.0-cache_reservation);
@@ -1270,6 +1271,8 @@ class MDCache {
   double cache_reservation;
   double cache_health_threshold;
   double cache_resize_interval;
+
+  MemoryModel mm;
 
   std::array<CInode *, NUM_STRAY> strays{}; // my stray dir
 

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -150,6 +150,8 @@ class MDSRank {
     mds_rank_t get_nodeid() const { return whoami; }
     int64_t get_metadata_pool();
 
+    uint64_t get_mds_memory_target() const { return memory_target }
+
     // Reference to global MDS::mds_lock, so that users of MDSRank don't
     // carry around references to the outer MDS, and we can substitute
     // a separate lock here in future potentially.
@@ -582,6 +584,8 @@ private:
 
     // "task" string that gets displayed in ceph status
     inline static const std::string SCRUB_STATUS_KEY = "scrub status";
+
+    uint64_t memory_target;
 
     void get_task_status(std::map<std::string, std::string> *status);
     void schedule_update_timer_task();


### PR DESCRIPTION
Implement a new config mds_memory_target which when set to `true`(default `false`), enables autotuning of the mds_cache_memory_limit. The resizing logic is based on the experimental result that the rss usage is approximately 1.25 times the mds_cache_memory_limit.
Fixes: https://tracker.ceph.com/issues/36663
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

