### PR TITLE
OSD: make osd_max_remote_backfills as remote reservations per OSD(0 m…

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -516,6 +516,9 @@ OPTION(osd_check_max_object_name_len_on_startup, OPT_BOOL)
 // Maximum number of backfills to or from a single osd
 OPTION(osd_max_backfills, OPT_U64)
 
+// Maximum number of backfills to a single osd (default 0, means the same value as osd_max_backfills)
+OPTION(osd_max_remote_backfills, OPT_U64)
+
 // Minimum recovery priority (255 = max, smaller = lower)
 OPTION(osd_min_recovery_priority, OPT_INT)
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2280,6 +2280,11 @@ std::vector<Option> get_global_options() {
     .set_description("Maximum number of concurrent local and remote backfills or recoveries per OSD ")
     .set_long_description("There can be osd_max_backfills local reservations AND the same remote reservations per OSD. So a value of 1 lets this OSD participate as 1 PG primary in recovery and 1 shard of another recovering PG."),
 
+    Option("osd_max_remote_backfills", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("Maximum number of concurrent remote backfills or recoveries per OSD(0 means the same value as osd_max_backfills)")
+    .set_long_description("There can be osd_max_remote_backfills remote reservations per OSD. So a value of 1 lets this OSD participate as 1 shard of another recovering PG."),
+
     Option("osd_min_recovery_priority", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description("Minimum priority below which recovery is not performed")

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -253,7 +253,7 @@ OSDService::OSDService(OSD *osd) :
   reserver_finisher(cct),
   local_reserver(cct, &reserver_finisher, cct->_conf->osd_max_backfills,
 		 cct->_conf->osd_min_recovery_priority),
-  remote_reserver(cct, &reserver_finisher, cct->_conf->osd_max_backfills,
+  remote_reserver(cct, &reserver_finisher, cct->_conf->osd_max_remote_backfills?cct->_conf->osd_max_remote_backfills:cct->_conf->osd_max_backfills,
 		  cct->_conf->osd_min_recovery_priority),
   pg_temp_lock("OSDService::pg_temp_lock"),
   snap_reserver(cct, &reserver_finisher,
@@ -9826,6 +9826,7 @@ const char** OSD::get_tracked_conf_keys() const
 {
   static const char* KEYS[] = {
     "osd_max_backfills",
+    "osd_max_remote_backfills",
     "osd_min_recovery_priority",
     "osd_max_trimming_pgs",
     "osd_op_complaint_time",
@@ -9865,7 +9866,10 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
   Mutex::Locker l(osd_lock);
   if (changed.count("osd_max_backfills")) {
     service.local_reserver.set_max(cct->_conf->osd_max_backfills);
-    service.remote_reserver.set_max(cct->_conf->osd_max_backfills);
+    service.remote_reserver.set_max(cct->_conf->osd_max_remote_backfills?cct->_conf->osd_max_remote_backfills:cct->_conf->osd_max_backfills);
+  }
+  if (changed.count("osd_max_remote_backfills")) {
+    service.remote_reserver.set_max(cct->_conf->osd_max_remote_backfills?cct->_conf->osd_max_remote_backfills:cct->_conf->osd_max_backfills);
   }
   if (changed.count("osd_min_recovery_priority")) {
     service.local_reserver.set_min_priority(cct->_conf->osd_min_recovery_priority);


### PR DESCRIPTION
…eans the same value as osd_max_backfills)

in the case of three copies, only one copy is left. we must backup it from A to B and C (one local_reserver to two remote_reserver)

in the case of HDD disk, we can restore the desired data first.(make the pg force-backfill or force-recovery; enlarge remote and local params of related osd only)
Signed-off-by: simon gao <simon29rock@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

