### PR TITLE
mimic: librbd: avoid aggregate-initializing IsWriteOpVisitor

### DIFF
--- a/src/librbd/io/ImageDispatchSpec.cc
+++ b/src/librbd/io/ImageDispatchSpec.cc
@@ -84,7 +84,7 @@ void ImageDispatchSpec<I>::fail(int r) {
 
 template <typename I>
 bool ImageDispatchSpec<I>::is_write_op() const {
-  return boost::apply_visitor(IsWriteOpVisitor{}, m_request);
+  return boost::apply_visitor(IsWriteOpVisitor(), m_request);
 }
 
 template <typename I>


### PR DESCRIPTION
http://tracker.ceph.com/issues/38684