### PR TITLE
admin/build-doc: keep-going when finding warnings

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -118,7 +118,7 @@ for target in $sphinx_targets; do
             ;;
     esac
     # Build with -W so that warnings are treated as errors and this fails
-    $vdir/bin/sphinx-build -W -a -b $builder $extra_opt -d doctrees \
+    $vdir/bin/sphinx-build -W --keep-going -a -b $builder $extra_opt -d doctrees \
                            $TOPDIR/doc $TOPDIR/build-doc/output/$target
 
 


### PR DESCRIPTION
This allows the build to fail, but also report a list of warnings so that
multiple runs are not required to find all the errors in doc changes

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

