### PR TITLE
mds: remove superfluous error in StrayManager::advance_delayed()

### DIFF
--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2505,7 +2505,7 @@ void Migrator::handle_export_prep(const MExportDirPrep::const_ref &m, bool did_a
     dout(7) << " not doing assim on " << *dir << dendl;
   }
 
-  C_MDS_ExportPrepFactory cf(this, m);
+  MDSGatherBuilder gather(g_ceph_context);
 
   if (!finished.empty())
     mds->queue_waiters(finished);
@@ -2532,8 +2532,8 @@ void Migrator::handle_export_prep(const MExportDirPrep::const_ref &m, bool did_a
 	CDir *bound = cache->get_dirfrag(dirfrag_t(p->first, leaf));
 	if (!bound) {
 	  dout(7) << "  opening bounding dirfrag " << leaf << " on " << *in << dendl;
-	  cache->open_remote_dirfrag(in, leaf, cf.build());
-	  return;
+	  cache->open_remote_dirfrag(in, leaf, gather.new_sub());
+	  continue;
 	}
 
 	if (!bound->state_test(CDir::STATE_IMPORTBOUND)) {
@@ -2545,6 +2545,13 @@ void Migrator::handle_export_prep(const MExportDirPrep::const_ref &m, bool did_a
 	}
 	import_bounds.insert(bound);
       }
+    }
+
+    if (gather.has_subs()) {
+      C_MDS_ExportPrepFactory cf(this, m);
+      gather.set_finisher(cf.build());
+      gather.activate();
+      return;
     }
 
     dout(7) << " all ready, noting auth and freezing import region" << dendl;

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -370,17 +370,7 @@ void StrayManager::advance_delayed()
       continue;
     }
 
-    const bool purging = eval_stray(dn);
-    if (!purging) {
-      derr << "Dentry " << *dn << " was purgeable but no longer is!" << dendl;
-      /*
-       * This can happen if a stray is purgeable, but has gained an extra
-       * reference by virtue of having its backtrace updated.
-       * FIXME perhaps we could simplify this further by
-       * avoiding writing the backtrace of purge-ready strays, so
-       * that this code could be more rigid?
-       */
-    }
+    eval_stray(dn);
   }
   logger->set(l_mdc_num_strays_delayed, num_strays_delayed);
 }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/38679
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

