### PR TITLE
mimic: mgr/dashboard: show I/O stats in Pool list

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -134,10 +134,10 @@
                 <th i18n>Name</th>
                 <th i18n>PG status</th>
                 <th i18n>Usage</th>
-                <th colspan="2"
-                    i18n>Read</th>
-                <th colspan="2"
-                    i18n>Write</th>
+                <th i18n width="10%">Read Bytes</th>
+                <th i18n width="10%">Read Ops</th>
+                <th i18n width="10%">Write Bytes</th>
+                <th i18n width="10%">Write Ops</th>
               </tr>
             </thead>
             <tbody>
@@ -150,16 +150,16 @@
                   <cd-usage-bar [totalBytes]="pool.stats.bytes_used.latest +  pool.stats.max_avail.latest" [usedBytes]="pool.stats.bytes_used.latest"></cd-usage-bar>
                 </td>
                 <td>
-                  {{ pool.stats.rd_bytes.rate | dimless }}
+                  {{ pool.stats.rd_bytes.rate | dimless:1 }}
                 </td>
                 <td>
-                  {{ pool.stats.rd.rate | dimless }} ops
+                  {{ pool.stats.rd.rate | dimless:1 }} ops
                 </td>
                 <td>
-                  {{ pool.stats.wr_bytes.rate | dimless }}
+                  {{ pool.stats.wr_bytes.rate | dimless:1 }}
                 </td>
                 <td>
-                  {{ pool.stats.wr.rate | dimless }} ops
+                  {{ pool.stats.wr.rate | dimless:1 }} ops
                 </td>
               </tr>
             </tbody>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless.pipe.spec.ts
@@ -9,6 +9,26 @@ describe('DimlessPipe', () => {
     expect(pipe).toBeTruthy();
   });
 
+  it('transforms 1230.4567 with default decimals (4)', () => {
+    const value = 1234.5678;
+    expect(pipe.transform(value)).toBe('1.2346k');
+  });
+
+  it('transforms 1230.4567 with 0 decimals', () => {
+    const value = 1234.5678;
+    expect(pipe.transform(value, 0)).toBe('1k');
+  });
+
+  it('transforms 1230.4567 with 1 decimal', () => {
+    const value = 1234.5678;
+    expect(pipe.transform(value, 1)).toBe('1.2k');
+  });
+
+  it('transforms 55.01 with 1 decimal', () => {
+    const value = 55.01;
+    expect(pipe.transform(value, 1)).toBe('55');
+  });
+
   it('transforms 1000^0', () => {
     const value = Math.pow(1000, 0);
     expect(pipe.transform(value)).toBe('1');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless.pipe.ts
@@ -1,13 +1,19 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { FormatterService } from '../services/formatter.service';
 
+import * as _ from 'lodash';
+
 @Pipe({
   name: 'dimless'
 })
 export class DimlessPipe implements PipeTransform {
   constructor(private formatter: FormatterService) {}
 
-  transform(value: any, args?: any): any {
+  transform(value: any, decimals?: number): any {
+    if (_.isUndefined(decimals)) {
+      decimals = 4;
+    }
+
     return this.formatter.format_number(value, 1000, [
       '',
       'k',
@@ -18,6 +24,6 @@ export class DimlessPipe implements PipeTransform {
       'E',
       'Z',
       'Y'
-    ]);
+    ], decimals);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
@@ -61,6 +61,7 @@ describe('FormatterService', () => {
       expect(service.format_number('1.2', 1024, formats)).toBe('1.2B');
       expect(service.format_number('1', 1024, formats)).toBe('1B');
       expect(service.format_number('1024', 1024, formats)).toBe('1KiB');
+      expect(service.format_number(55.000001, 1000, formats, 1)).toBe('55B');
       expect(service.format_number(23.45678 * Math.pow(1024, 3), 1024, formats)).toBe('23.4568GiB');
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
@@ -26,9 +26,16 @@ export class FormatterService {
     if (!_.isNumber(n)) {
       return '-';
     }
-    const unit = n < 1 ? 0 : Math.floor(Math.log(n) / Math.log(divisor));
-    const truncatedFloat = this.truncate(n / Math.pow(divisor, unit), decimals);
-    return truncatedFloat === '' ? '-' : truncatedFloat + units[unit];
+    let unit = n < 1 ? 0 : Math.floor(Math.log(n) / Math.log(divisor));
+    unit = unit >= units.length ? units.length - 1 : unit;
+    let result = _.round(n / Math.pow(divisor, unit), decimals).toString();
+    if (result === '') {
+      return '-';
+    }
+    if (units[unit] !== '') {
+      result = `${result}${units[unit]}`;
+    }
+    return result;
   }
 
   /**

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import time
-import collections
-from collections import defaultdict
 import json
 
 from mgr_module import CommandResult
@@ -83,15 +80,7 @@ class CephService(object):
         pools_w_stats = []
 
         pg_summary = mgr.get("pg_summary")
-        pool_stats = defaultdict(lambda: defaultdict(
-            lambda: collections.deque(maxlen=10)))
-
-        df = mgr.get("df")
-        pool_stats_dict = dict([(p['id'], p['stats']) for p in df['pools']])
-        now = time.time()
-        for pool_id, stats in pool_stats_dict.items():
-            for stat_name, stat_val in stats.items():
-                pool_stats[pool_id][stat_name].appendleft((now, stat_val))
+        pool_stats = mgr.get_updated_pool_stats()
 
         for pool in pools:
             pool['pg_status'] = pg_summary['by_pool'][pool['pool'].__str__()]
@@ -100,7 +89,7 @@ class CephService(object):
 
             def get_rate(series):
                 if len(series) >= 2:
-                    return differentiate(*series[0:1])
+                    return differentiate(*list(series)[-2:])
                 return 0
 
             for stat_name, stat_series in stats.items():


### PR DESCRIPTION
* Applied same fix as in nautilus.
* Adapted Pool list columns to avoid constant resizing.
* Added 'decimals' argument to dimless pipe in order for
  stats to fit in Pool list columns.

Fixes: https://tracker.ceph.com/issues/38284

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

