### PR TITLE
doc/rgw: update civetweb rgw_frontends config example

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -7,7 +7,8 @@ HTTP Frontends
 .. contents::
 
 The Ceph Object Gateway supports two embedded HTTP frontend libraries
-that can be configured with ``rgw_frontends``.
+that can be configured with ``rgw_frontends``. See `Config Reference`_
+for details about the syntax.
 
 Beast
 =====
@@ -133,10 +134,7 @@ Options
 The following is an example of the ``/etc/ceph/ceph.conf`` file with some of these options set: ::
  
  [client.rgw.gateway-node1]
- rgw_frontends = civetweb 
- request_timeout_ms = 30000 
- error_log_file = /var/log/radosgw/civetweb.error.log 
- access_log_file = /var/log/radosgw/civetweb.access.log
+ rgw_frontends = civetweb request_timeout_ms=30000 error_log_file=/var/log/radosgw/civetweb.error.log access_log_file=/var/log/radosgw/civetweb.access.log
 
 A complete list of supported options can be found in the `Civetweb User Manual`_.
 
@@ -157,3 +155,4 @@ Some frontend options are generic and supported by all frontends:
 
 
 .. _Civetweb User Manual: https://civetweb.github.io/civetweb/UserManual.html
+.. _Config Reference: ../config-ref


### PR DESCRIPTION
all of these civetweb options have to be on the same line as rgw_frontends

Fixes: https://tracker.ceph.com/issues/37770