### PR TITLE
mimic: mds: inode filtering on 'dump cache' asok

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -285,3 +285,8 @@ class TestMisc(CephFSTestCase):
         here.
         """
         self._drop_cache_command_timeout(5)
+    
+    def test_dump_inode(self):
+        info = self.fs.mds_asok(['dump', 'inode', '1'])
+        assert(info['path'] == "/")
+

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -13078,3 +13078,13 @@ void MDCache::clear_dirty_bits_for_stray(CInode* diri) {
   }
 }
 
+bool MDCache::dump_inode(Formatter *f, uint64_t number) {
+  CInode *in = get_inode(number);
+  if (!in) {
+    return false;
+  }
+  f->open_object_section("inode");
+  in->dump(f, CInode::DUMP_DEFAULT | CInode::DUMP_PATH);
+  f->close_section();
+  return true;
+}

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -545,6 +545,7 @@ public:
 
   void clean_open_file_lists();
   void dump_openfiles(Formatter *f);
+  bool dump_inode(Formatter *f, uint64_t number);
 protected:
   // [rejoin]
   bool rejoins_pending;

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -328,6 +328,12 @@ void MDSDaemon::set_up_admin_socket()
                                      asok_hook,
                                      "List the opening files and their caps");
   assert(r == 0);
+  r = admin_socket->register_command("dump inode",
+				     "dump inode " 
+                                     "name=number,type=CephInt,req=true",
+				     asok_hook,
+				     "dump inode by inode number");
+  assert(r == 0);
 }
 
 void MDSDaemon::clean_up_admin_socket()

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2578,6 +2578,8 @@ bool MDSRankDispatcher::handle_asok_command(std::string_view command,
     command_dirfrag_ls(cmdmap, ss, f);
   } else if (command == "openfiles ls") {
     command_openfiles_ls(f);
+  } else if (command == "dump inode") {
+    command_dump_inode(f, cmdmap, ss);
   } else {
     return false;
   }
@@ -2998,6 +3000,22 @@ void MDSRank::command_openfiles_ls(Formatter *f)
 {
   Mutex::Locker l(mds_lock);
   mdcache->dump_openfiles(f);
+}
+
+void MDSRank::command_dump_inode(Formatter *f, const cmdmap_t &cmdmap, std::ostream &ss)
+{
+  Mutex::Locker l(mds_lock);
+  int64_t number;
+  bool got = cmd_getval(g_ceph_context, cmdmap, "number", number);
+  if (!got) {
+    ss << "missing inode number";
+    return;
+  }
+  
+  bool success = mdcache->dump_inode(f, number);
+  if (!success) {
+    ss << "dump inode failed, wrong inode number or the inode is not cached";
+  }
 }
 
 void MDSRank::dump_status(Formatter *f) const

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -485,6 +485,7 @@ class MDSRank {
         std::ostream &ss);
     void command_openfiles_ls(Formatter *f);
     void command_dump_tree(const cmdmap_t &cmdmap, std::ostream &ss, Formatter *f);
+    void command_dump_inode(Formatter *f, const cmdmap_t &cmdmap, std::ostream &ss);
 
     void cache_drop_send_reply(Formatter *f, C_MDS_Send_Command_Reply *reply, int r);
     void command_cache_drop(uint64_t timeout, Formatter *f, Context *on_finish);


### PR DESCRIPTION
http://tracker.ceph.com/issues/38689