### PR TITLE
mds: there is an assertion when calling Beacon::shutdown()

### DIFF
--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -56,7 +56,8 @@ void Beacon::shutdown()
   if (!finished) {
     finished = true;
     lock.unlock();
-    sender.join();
+    if (sender.joinable())
+      sender.join();
   }
 }
 


### PR DESCRIPTION
If you run MDSDaemon::init(), an exception occurs that causes MDSDaemon::suicide()--->Beacon::shutdown()--->sender.join();
this problem occurs because sender is just Default-constructed is in Beacon.h(std::thread sender;), there is no call to Beacon::init() to construct the sender, so the sender has no "joinable"

Fixes: http://tracker.ceph.com/issues/38822
Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

