### PR TITLE
cmake: remove cython 0.29's subinterpreter check during install

### DIFF
--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -50,6 +50,7 @@ function(distutils_add_cython_module name src)
   string(REPLACE " " ";" cflags ${CMAKE_C_FLAGS})
   list(APPEND cflags -iquote${CMAKE_SOURCE_DIR}/src/include -w)
   # This little bit of magic wipes out __Pyx_check_single_interpreter()
+  # Note: this is reproduced in distutils_install_cython_module
   list(APPEND cflags -D'void0=dead_function\(void\)')
   list(APPEND cflags -D'__Pyx_check_single_interpreter\(ARG\)=ARG \#\# 0')
   set(PY_CC ${compiler_launcher} ${CMAKE_C_COMPILER} ${c_compiler_arg1} ${cflags})
@@ -80,7 +81,9 @@ function(distutils_install_cython_module name)
   install(CODE "
     set(ENV{CC} \"${PY_CC}\")
     set(ENV{LDSHARED} \"${PY_LDSHARED}\")
-    set(ENV{CPPFLAGS} \"-iquote${CMAKE_SOURCE_DIR}/src/include\")
+    set(ENV{CPPFLAGS} \"-iquote${CMAKE_SOURCE_DIR}/src/include
+                        -D'void0=dead_function\(void\)' \
+                        -D'__Pyx_check_single_interpreter\(ARG\)=ARG \#\# 0'\")
     set(ENV{LDFLAGS} \"-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\")
     set(ENV{CYTHON_BUILD_DIR} \"${CMAKE_CURRENT_BINARY_DIR}\")
     set(ENV{CEPH_LIBDIR} \"${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\")


### PR DESCRIPTION
Commit 3bde34af8a removed cython 0.29's subinterpreter check when
building the various python modules during `make`, but unforunately
they're *rebuilt* during `make install`, with the rebuild overwriting
the original build.  The original fix was of course missing from the
install stage...

Fixes: https://tracker.ceph.com/issues/38788
Signed-off-by: Tim Serong <tserong@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

