### PR TITLE
doc: Updated dashboard iSCSI configuration, added labels

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -314,12 +314,18 @@ The default value is 45 seconds.
 Enabling iSCSI Management
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Ceph Dashboard can manage iSCSI targets using the REST API provided
-by the `rbd-target-api` service of the `ceph-iscsi <https://github.com/ceph/ceph-iscsi>`_
-project. Please make sure that it's installed and enabled on the iSCSI gateways.
+The Ceph Dashboard can manage iSCSI targets using the REST API provided by the
+`rbd-target-api` service of the :ref:`ceph-iscsi`. Please make sure that it's
+installed and enabled on the iSCSI gateways.
+
+.. note::
+  The iSCSI management functionality of Ceph Dashboard depends on the latest
+  version 3 of the `ceph-iscsi <https://github.com/ceph/ceph-iscsi>`_ project.
+  Make sure that your operating system provides the correct version, otherwise
+  the dashboard won't enable the managemement features.
 
 If ceph-iscsi REST API is configured in HTTPS mode and its using a self-signed
-certificate, then we need to configure the dashboard to avoid SSL certificate
+certificate, then you need to configure the dashboard to avoid SSL certificate
 verification when accessing ceph-iscsi API.
 
 To disable API SSL verification run the following commmand::

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -1,3 +1,5 @@
+.. _configuring-ceph:
+
 ==================
  Configuring Ceph
 ==================

--- a/doc/rbd/iscsi-overview.rst
+++ b/doc/rbd/iscsi-overview.rst
@@ -1,3 +1,5 @@
+.. _ceph-iscsi:
+
 ==================
 Ceph iSCSI Gateway
 ==================

--- a/doc/rbd/iscsi-requirements.rst
+++ b/doc/rbd/iscsi-requirements.rst
@@ -6,8 +6,8 @@ To implement the Ceph iSCSI gateway there are a few requirements. It is recommen
 to use two to four iSCSI gateway nodes for a highly available Ceph iSCSI gateway
 solution.
 
-For hardware recommendations, see the `Hardware Recommendation page <http://docs.ceph.com/docs/master/start/hardware-recommendations/>`_
-for more details.
+For hardware recommendations, see :ref:`hardware-recommendations` for more
+details.
 
 .. note::
     On the iSCSI gateway nodes, the memory footprint of the RBD images
@@ -46,4 +46,5 @@ cluster::
        ceph daemon osd.0 config set osd_heartbeat_grace 20
        ceph daemon osd.0 config set osd_heartbeat_interval 5
 
-For more details on setting Ceph's configuration options, see the `Configuration page <http://docs.ceph.com/docs/master/rados/configuration/>`_.
+For more details on setting Ceph's configuration options, see
+:ref:`configuring-ceph`.

--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -8,7 +8,7 @@ Major Changes from Mimic
 
 - *Dashboard*:
 
-  The Ceph Dashboard has gained a lot of new functionality:
+  The :ref:`mgr-dashboard` has gained a lot of new functionality:
 
   * Support for multiple users / roles
   * SSO (SAMLv2) for user authentication
@@ -27,7 +27,7 @@ Major Changes from Mimic
   * Embedded Grafana Dashboards (derived from Ceph Metrics)
   * CRUSH map viewer
   * NFS Ganesha management
-  * iSCSI target management (via ceph-iscsi)
+  * iSCSI target management (via :ref:`ceph-iscsi`)
   * RBD QoS configuration
   * Ceph Manager (ceph-mgr) module management
   * Prometheus alert Management

--- a/doc/start/hardware-recommendations.rst
+++ b/doc/start/hardware-recommendations.rst
@@ -1,3 +1,5 @@
+.. _hardware-recommendations:
+
 ==========================
  Hardware Recommendations
 ==========================


### PR DESCRIPTION
Added note about the requirement for the latest ceph-iscsi version 3 to the dashboard documentation. Added some doc references and replaced some URLs in the iSCSI docs with reST labels instead.

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>