### PR TITLE
cephfs: expose snapshot creation time as new ceph.snap.btime vxattr

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -860,6 +860,7 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
     in->uid = st->uid;
     in->gid = st->gid;
     in->btime = st->btime;
+    in->snap_btime = st->snap_btime;
   }
 
   if ((new_version || (new_issued & CEPH_CAP_LINK_SHARED)) &&

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -276,9 +276,6 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
 {
   _reset_faked_inos();
 
-  _dir_vxattrs_name_size = _vxattrs_calcu_name_size(_dir_vxattrs);
-  _file_vxattrs_name_size = _vxattrs_calcu_name_size(_file_vxattrs);
-
   user_id = cct->_conf->client_mount_uid;
   group_id = cct->_conf->client_mount_gid;
 
@@ -11950,17 +11947,6 @@ const Client::VXattr *Client::_match_vxattr(Inode *in, const char *name)
     }
   }
   return NULL;
-}
-
-size_t Client::_vxattrs_calcu_name_size(const VXattr *vxattr)
-{
-  size_t len = 0;
-  while (!vxattr->name.empty()) {
-    if (!vxattr->hidden)
-      len += vxattr->name.length() + 1;
-    vxattr++;
-  }
-  return len;
 }
 
 int Client::ll_readlink(Inode *in, char *buf, size_t buflen, const UserPerm& perms)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11792,6 +11792,18 @@ size_t Client::_vxattrcb_dir_pin(Inode *in, char *val, size_t size)
   return snprintf(val, size, "%ld", (long)in->dir_pin);
 }
 
+bool Client::_vxattrcb_snap_btime_exists(Inode *in)
+{
+  return !in->snap_btime.is_zero();
+}
+
+size_t Client::_vxattrcb_snap_btime(Inode *in, char *val, size_t size)
+{
+  return snprintf(val, size, "%llu.09%lu",
+      (long long unsigned)in->snap_btime.sec(),
+      (long unsigned)in->snap_btime.nsec());
+}
+
 #define CEPH_XATTR_NAME(_type, _name) "ceph." #_type "." #_name
 #define CEPH_XATTR_NAME2(_type, _name, _name2) "ceph." #_type "." #_name "." #_name2
 
@@ -11872,6 +11884,14 @@ const Client::VXattr Client::_dir_vxattrs[] = {
     exists_cb: &Client::_vxattrcb_dir_pin_exists,
     flags: 0,
   },
+  {
+    name: "ceph.snap.btime",
+    getxattr_cb: &Client::_vxattrcb_snap_btime,
+    readonly: true,
+    hidden: false,
+    exists_cb: &Client::_vxattrcb_snap_btime_exists,
+    flags: 0,
+  },
   { name: "" }     /* Required table terminator */
 };
 
@@ -11889,6 +11909,14 @@ const Client::VXattr Client::_file_vxattrs[] = {
   XATTR_LAYOUT_FIELD(file, layout, object_size),
   XATTR_LAYOUT_FIELD(file, layout, pool),
   XATTR_LAYOUT_FIELD(file, layout, pool_namespace),
+  {
+    name: "ceph.snap.btime",
+    getxattr_cb: &Client::_vxattrcb_snap_btime,
+    readonly: true,
+    hidden: false,
+    exists_cb: &Client::_vxattrcb_snap_btime_exists,
+    flags: 0,
+  },
   { name: "" }     /* Required table terminator */
 };
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1165,6 +1165,9 @@ private:
   bool _vxattrcb_dir_pin_exists(Inode *in);
   size_t _vxattrcb_dir_pin(Inode *in, char *val, size_t size);
 
+  bool _vxattrcb_snap_btime_exists(Inode *in);
+  size_t _vxattrcb_snap_btime(Inode *in, char *val, size_t size);
+
   size_t _vxattrs_calcu_name_size(const VXattr *vxattrs);
 
   static const VXattr *_get_vxattrs(Inode *in);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1168,18 +1168,8 @@ private:
   bool _vxattrcb_snap_btime_exists(Inode *in);
   size_t _vxattrcb_snap_btime(Inode *in, char *val, size_t size);
 
-  size_t _vxattrs_calcu_name_size(const VXattr *vxattrs);
-
   static const VXattr *_get_vxattrs(Inode *in);
   static const VXattr *_match_vxattr(Inode *in, const char *name);
-
-  size_t _vxattrs_name_size(const VXattr *vxattrs) {
-	  if (vxattrs == _dir_vxattrs)
-		  return _dir_vxattrs_name_size;
-	  else if (vxattrs == _file_vxattrs)
-		  return _file_vxattrs_name_size;
-	  return 0;
-  }
 
   int _do_filelock(Inode *in, Fh *fh, int lock_type, int op, int sleep,
 		   struct flock *fl, uint64_t owner, bool removing=false);
@@ -1203,8 +1193,6 @@ private:
 
 
   uint32_t deleg_timeout = 0;
-  size_t _file_vxattrs_name_size;
-  size_t _dir_vxattrs_name_size;
 
   client_switch_interrupt_callback_t switch_interrupt_cb = nullptr;
   client_remount_callback_t remount_cb = nullptr;

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -156,6 +156,7 @@ struct Inode {
   // special stuff
   version_t version;           // auth only
   version_t xattr_version;
+  utime_t   snap_btime;        // snapshot creation (birth) time
 
   // inline data
   version_t  inline_version;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3324,7 +3324,21 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     }
   }
 
+  utime_t snap_btime;
   SnapRealm *realm = find_snaprealm();
+  if (snapid != CEPH_NOSNAP && realm) {
+    // add snapshot timestamp vxattr
+    map<snapid_t,const SnapInfo*> infomap;
+    realm->get_snap_info(infomap,
+                         snapid,  // min
+                         snapid); // max
+    if (!infomap.empty()) {
+      ceph_assert(infomap.size() == 1);
+      const SnapInfo *si = infomap.begin()->second;
+      snap_btime = si->stamp;
+    }
+  }
+
 
   bool no_caps = !valid ||
 		 session->is_stale() ||
@@ -3583,7 +3597,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
    * note: encoding matches MClientReply::InodeStat
    */
   if (session->info.has_feature(CEPHFS_FEATURE_REPLY_ENCODING)) {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(oi->ino, bl);
     encode(snapid, bl);
     encode(oi->rdev, bl);
@@ -3625,6 +3639,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode(any_i->btime, bl);
     encode(any_i->change_attr, bl);
     encode(file_i->export_pin, bl);
+    encode(snap_btime, bl);
     ENCODE_FINISH(bl);
   }
   else {

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -112,7 +112,7 @@ struct InodeStat {
   version_t xattr_version = 0;
   ceph_mds_reply_cap cap;
   file_layout_t layout;
-  utime_t ctime, btime, mtime, atime;
+  utime_t ctime, btime, mtime, atime, snap_btime;
   uint32_t time_warp_seq = 0;
   uint64_t size = 0, max_size = 0;
   uint64_t change_attr = 0;
@@ -190,6 +190,9 @@ struct InodeStat {
       } else {
         dir_pin = -ENODATA;
       }
+      if (struct_v >= 3) {
+        decode(snap_btime, p);
+      } // else remains zero
       DECODE_FINISH(p);
     }
     else {

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -2257,5 +2257,33 @@ TEST(LibCephFS, SnapXattrs) {
   utime_t new_btime = utime_t(strtoull(gxattrv2, NULL, 10), strtoull(s + 1, NULL, 10));
   ASSERT_LT(btime, new_btime);
 
+  // check that the snap.btime vxattr appears in listxattr()
+  char xattrlist[512];
+  int len = ceph_listxattr(cmount, c_temp, xattrlist, sizeof(xattrlist));
+  ASSERT_GT(len, 0);
+  ASSERT_GE(sizeof(xattrlist), (size_t)len);
+  char *p = xattrlist;
+  int found = 0;
+  while (len > 0) {
+    if (strcmp(p, "ceph.snap.btime") == 0)
+      found++;
+    len -= strlen(p) + 1;
+    p += strlen(p) + 1;
+  }
+  ASSERT_EQ(found, 1);
+
+  // listxattr() shouldn't return snap.btime vxattr for non-snaps
+  len = ceph_listxattr(cmount, test_snap_xattr_file, xattrlist, sizeof(xattrlist));
+  ASSERT_GE(sizeof(xattrlist), (size_t)len);
+  p = xattrlist;
+  found = 0;
+  while (len > 0) {
+    if (strcmp(p, "ceph.snap.btime") == 0)
+      found++;
+    len -= strlen(p) + 1;
+    p += strlen(p) + 1;
+  }
+  ASSERT_EQ(found, 0);
+
   ceph_shutdown(cmount);
 }

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -2185,3 +2185,67 @@ TEST(LibCephFS, OperationsOnDotDot) {
 
   ceph_shutdown(cmount);
 }
+
+TEST(LibCephFS, SnapXattrs) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, NULL), 0);
+
+  char test_snap_xattr_file[256];
+  char c_temp[PATH_MAX];
+  char gxattrv[128];
+  char gxattrv2[128];
+  int xbuflen = sizeof(gxattrv);
+  pid_t mypid = getpid();
+
+  sprintf(test_snap_xattr_file, "test_snap_xattr_%d", mypid);
+  int fd = ceph_open(cmount, test_snap_xattr_file, O_CREAT, 0666);
+  ASSERT_GT(fd, 0);
+  ceph_close(cmount, fd);
+
+  sprintf(c_temp, "/.snap/test_snap_xattr_snap_%d", mypid);
+  ASSERT_EQ(0, ceph_mkdir(cmount, c_temp, 0777));
+
+  int alen = ceph_getxattr(cmount, c_temp, "ceph.snap.btime", (void *)gxattrv, xbuflen);
+  // xattr value is secs.nsecs (don't assume zero-term)
+  ASSERT_LT(0, alen);
+  ASSERT_LT(alen, xbuflen);
+  gxattrv[alen] = '\0';
+  char *s = strchrnul(gxattrv, '.');
+  ASSERT_LT(s, gxattrv + alen);
+  ASSERT_EQ('.', *s);
+  *s = '\0';
+  utime_t btime = utime_t(strtoull(gxattrv, NULL, 10), strtoull(s + 1, NULL, 10));
+  *s = '.';  // restore for later strcmp
+
+  // file within the snapshot should carry the same btime
+  sprintf(c_temp, "/.snap/test_snap_xattr_snap_%d/%s", mypid, test_snap_xattr_file);
+
+  int alen2 = ceph_getxattr(cmount, c_temp, "ceph.snap.btime", (void *)gxattrv2, xbuflen);
+  ASSERT_EQ(alen, alen2);
+  ASSERT_EQ(0, strncmp(gxattrv, gxattrv2, alen));
+
+  // non-snap file shouldn't carry the xattr
+  alen = ceph_getxattr(cmount, test_snap_xattr_file, "ceph.snap.btime", (void *)gxattrv2, xbuflen);
+  ASSERT_EQ(-ENODATA, alen);
+
+  // create a second snapshot
+  sprintf(c_temp, "/.snap/test_snap_xattr_snap2_%d", mypid);
+  ASSERT_EQ(0, ceph_mkdir(cmount, c_temp, 0777));
+
+  // check that the btime for the newer snapshot is > older
+  alen = ceph_getxattr(cmount, c_temp, "ceph.snap.btime", (void *)gxattrv2, xbuflen);
+  ASSERT_LT(0, alen);
+  ASSERT_LT(alen, xbuflen);
+  gxattrv2[alen] = '\0';
+  s = strchrnul(gxattrv2, '.');
+  ASSERT_LT(s, gxattrv2 + alen);
+  ASSERT_EQ('.', *s);
+  *s = '\0';
+  utime_t new_btime = utime_t(strtoull(gxattrv2, NULL, 10), strtoull(s + 1, NULL, 10));
+  ASSERT_LT(btime, new_btime);
+
+  ceph_shutdown(cmount);
+}


### PR DESCRIPTION
Samba requires the snapshot creation time for the purpose of tracking and identifying Previous Versions for files and directories.

Fixes: https://tracker.ceph.com/issues/38838