### PR TITLE
mon/ConfigMonitor: make 'num' of 'config reset' optional; allow target version 0

### DIFF
--- a/qa/workunits/mon/config.sh
+++ b/qa/workunits/mon/config.sh
@@ -6,6 +6,19 @@ function expect_false()
 	if "$@"; then return 1; else return 0; fi
 }
 
+# some of the commands are just not idempotent.
+function without_test_dup_command()
+{
+  if [ -z ${CEPH_CLI_TEST_DUP_COMMAND+x} ]; then
+    $@
+  else
+    local saved=${CEPH_CLI_TEST_DUP_COMMAND}
+    unset CEPH_CLI_TEST_DUP_COMMAND
+    $@
+    CEPH_CLI_TEST_DUP_COMMAND=saved
+  fi
+}
+
 ceph config dump
 
 # value validation
@@ -51,6 +64,9 @@ ceph config get mon.a debug_asok | grep 11
 ceph config rm mon debug_asok
 ceph config get mon.a debug_asok | grep 33
 ceph config rm global debug_asok
+without_test_dup_command ceph config reset
+ceph config get mon.a debug_asok | grep 33
+without_test_dup_command ceph config reset
 
 # help
 ceph config help debug_asok | grep debug_asok

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -540,7 +540,6 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
       err = 0;
       goto reply;
     }
-    ceph_assert(num > 0);
     ceph_assert((version_t)num < version);
     for (int64_t v = version; v > num; --v) {
       ConfigChangeSet ch;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1192,9 +1192,10 @@ COMMAND("config assimilate-conf",
 COMMAND("config log name=num,type=CephInt,req=False",
 	"Show recent history of config changes",
 	"config", "r")
-COMMAND("config reset" \
-	" name=num,type=CephInt",
-	"Revert configuration to previous state",
+COMMAND("config reset " \
+	"name=num,type=CephInt,range=0,req=False",
+	"Revert configuration to a historical version specified by <num>, "
+        "or simply revert to last version",
 	"config", "rw")
 COMMAND("config generate-minimal-conf",
 	"Generate a minimal ceph.conf file",


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

