### PR TITLE
test/crimson: update to accomodate Dispatcher changes

### DIFF
--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -56,10 +56,9 @@ struct Server {
       return seastar::make_ready_future<ceph::net::msgr_tag_t, bufferlist>(
           0, bufferlist{});
     }
-    seastar::future<std::unique_ptr<AuthAuthorizer>>
-    ms_get_authorizer(peer_type_t) override {
-      return seastar::make_ready_future<std::unique_ptr<AuthAuthorizer>>(
-          new DummyAuthAuthorizer{});
+    std::unique_ptr<AuthAuthorizer> authorizer = std::make_unique<DummyAuthAuthorizer>();
+    AuthAuthorizer* ms_get_authorizer(peer_type_t) const override {
+      return authorizer.get();
     }
   } dispatcher;
   Server(ceph::net::Messenger& msgr)


### PR DESCRIPTION
Dispatcher::ms_get_authorizer() was changed in f22d433a, so update the
test accordingly

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

