### PR TITLE
common/config: use string_view for keys

### DIFF
--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -163,7 +163,7 @@ parse_bufferlist(ceph::bufferlist *bl, std::deque<std::string> *errors,
 }
 
 int ConfFile::
-read(const std::string &section, const std::string &key, std::string &val) const
+read(const std::string &section, const std::string_view key, std::string &val) const
 {
   string k(normalize_key_name(key));
 

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -250,13 +250,12 @@ trim_whitespace(std::string &str, bool strip_internal)
  * the field names of md_config_t and get a key in normal form.
  */
 std::string ConfFile::
-normalize_key_name(const std::string &key)
+normalize_key_name(std::string_view key)
 {
-  if (key.find_first_of(" \t\r\n\f\v\xa0") == string::npos) {
-    return key;
+  std::string k{key};
+  if (k.find_first_of(" \t\r\n\f\v\xa0") == k.npos) {
+    return k;
   }
-
-  string k(key);
   ConfFile::trim_whitespace(k, true);
   std::replace(k.begin(), k.end(), ' ', '_');
   return k;

--- a/src/common/ConfUtils.h
+++ b/src/common/ConfUtils.h
@@ -64,7 +64,7 @@ public:
   void clear();
   int parse_file(const std::string &fname, std::deque<std::string> *errors, std::ostream *warnings);
   int parse_bufferlist(ceph::bufferlist *bl, std::deque<std::string> *errors, std::ostream *warnings);
-  int read(const std::string &section, const std::string &key,
+  int read(const std::string &section, const std::string_view key,
 	      std::string &val) const;
 
   const_section_iter_t sections_begin() const;

--- a/src/common/ConfUtils.h
+++ b/src/common/ConfUtils.h
@@ -71,7 +71,7 @@ public:
   const_section_iter_t sections_end() const;
 
   static void trim_whitespace(std::string &str, bool strip_internal);
-  static std::string normalize_key_name(const std::string &key);
+  static std::string normalize_key_name(std::string_view key);
   friend std::ostream &operator<<(std::ostream &oss, const ConfFile &cf);
 
 private:

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -111,9 +111,7 @@ md_config_t::md_config_t(ConfigValues& values,
                 << std::endl;
       ceph_abort();
     }
-    schema.emplace(std::piecewise_construct,
-		   std::forward_as_tuple(i.name),
-		   std::forward_as_tuple(i));
+    schema.emplace(i.name, i);
   }
 
   // Define the debug_* options as well.
@@ -166,7 +164,7 @@ md_config_t::md_config_t(ConfigValues& values,
   // members if present.
   legacy_values = {
 #define OPTION(name, type) \
-    {std::string(STRINGIFY(name)), &ConfigValues::name},
+    {STRINGIFY(name), &ConfigValues::name},
 #define SAFE_OPTION(name, type) OPTION(name, type)
 #include "common/legacy_config_opts.h"
 #undef OPTION

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -240,7 +240,7 @@ void md_config_t::validate_schema()
   }
 }
 
-const Option *md_config_t::find_option(const string& name) const
+const Option *md_config_t::find_option(const std::string_view name) const
 {
   auto p = schema.find(name);
   if (p != schema.end()) {
@@ -251,7 +251,7 @@ const Option *md_config_t::find_option(const string& name) const
 
 void md_config_t::set_val_default(ConfigValues& values,
 				  const ConfigTracker& tracker,
-				  const string& name, const std::string& val)
+				  const string_view name, const std::string& val)
 {
   const Option *o = find_option(name);
   ceph_assert(o);
@@ -791,7 +791,7 @@ int md_config_t::injectargs(ConfigValues& values,
 
 void md_config_t::set_val_or_die(ConfigValues& values,
 				 const ConfigTracker& tracker,
-				 const std::string &key,
+				 const std::string_view key,
 				 const std::string &val)
 {
   std::stringstream err;
@@ -804,7 +804,7 @@ void md_config_t::set_val_or_die(ConfigValues& values,
 
 int md_config_t::set_val(ConfigValues& values,
 			 const ConfigTracker& tracker,
-			 const std::string &key, const char *val,
+			 const std::string_view key, const char *val,
 			 std::stringstream *err_ss)
 {
   if (key.empty()) {
@@ -837,7 +837,7 @@ int md_config_t::set_val(ConfigValues& values,
   return -ENOENT;
 }
 
-int md_config_t::rm_val(ConfigValues& values, const std::string& key)
+int md_config_t::rm_val(ConfigValues& values, const std::string_view key)
 {
   return _rm_val(values, key, CONF_OVERRIDE);
 }
@@ -921,7 +921,7 @@ void md_config_t::get_config_bl(
 }
 
 int md_config_t::get_val(const ConfigValues& values,
-			 const std::string &key, char **buf, int len) const
+			 const std::string_view key, char **buf, int len) const
 {
   string k(ConfFile::normalize_key_name(key));
   return _get_val_cstr(values, k, buf, len);
@@ -929,7 +929,7 @@ int md_config_t::get_val(const ConfigValues& values,
 
 int md_config_t::get_val(
   const ConfigValues& values,
-  const std::string &key,
+  const std::string_view key,
   std::string *val) const
 {
   return conf_stringify(get_val_generic(values, key), val);
@@ -937,7 +937,7 @@ int md_config_t::get_val(
 
 Option::value_t md_config_t::get_val_generic(
   const ConfigValues& values,
-  const std::string &key) const
+  const std::string_view key) const
 {
   string k(ConfFile::normalize_key_name(key));
   return _get_val(values, k);
@@ -945,7 +945,7 @@ Option::value_t md_config_t::get_val_generic(
 
 Option::value_t md_config_t::_get_val(
   const ConfigValues& values,
-  const std::string &key,
+  const std::string_view key,
   expand_stack_t *stack,
   std::ostream *err) const
 {
@@ -1164,7 +1164,7 @@ Option::value_t md_config_t::_expand_meta(
 
 int md_config_t::_get_val_cstr(
   const ConfigValues& values,
-  const std::string &key, char **buf, int len) const
+  const std::string& key, char **buf, int len) const
 {
   if (key.empty())
     return -EINVAL;
@@ -1237,7 +1237,7 @@ int md_config_t::get_all_sections(std::vector <std::string> &sections) const
 int md_config_t::get_val_from_conf_file(
   const ConfigValues& values,
   const std::vector <std::string> &sections,
-  const std::string &key,
+  const std::string_view key,
   std::string &out,
   bool emeta) const
 {
@@ -1255,13 +1255,11 @@ int md_config_t::get_val_from_conf_file(
 
 int md_config_t::_get_val_from_conf_file(
   const std::vector <std::string> &sections,
-  const std::string &key,
+  const std::string_view key,
   std::string &out) const
 {
-  std::vector <std::string>::const_iterator s = sections.begin();
-  std::vector <std::string>::const_iterator s_end = sections.end();
-  for (; s != s_end; ++s) {
-    int ret = cf.read(s->c_str(), key, out);
+  for (auto &s : sections) {
+    int ret = cf.read(s.c_str(), std::string{key}, out);
     if (ret == 0) {
       return 0;
     } else if (ret != -ENOENT) {
@@ -1332,13 +1330,13 @@ void md_config_t::_refresh(ConfigValues& values, const Option& opt)
 }
 
 int md_config_t::_rm_val(ConfigValues& values,
-			 const std::string& key,
+			 const std::string_view key,
 			 int level)
 {
   if (schema.count(key) == 0) {
     return -EINVAL;
   }
-  auto ret = values.rm_val(key, level);
+  auto ret = values.rm_val(std::string{key}, level);
   if (ret < 0) {
     return ret;
   }
@@ -1447,7 +1445,7 @@ void md_config_t::diff(
       // we only have a default value; exclude from diff
       return;
     }
-    f->open_object_section(name.c_str());
+    f->open_object_section(std::string{name}.c_str());
     const Option *o = find_option(name);
     dump(f, CONF_DEFAULT, _get_val_default(*o));
     for (auto& j : configs) {

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -263,7 +263,7 @@ void md_config_t::set_val_default(ConfigValues& values,
 int md_config_t::set_mon_vals(CephContext *cct,
     ConfigValues& values,
     const ConfigTracker& tracker,
-    const map<string,string>& kv,
+    const map<string,string,less<>>& kv,
     config_callback config_cb)
 {
   ignored_mon_values.clear();

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -146,12 +146,12 @@ public:
   void _clear_safe_to_start_threads();  // this is only used by the unit test
 
   /// Look up an option in the schema
-  const Option *find_option(const string& name) const;
+  const Option *find_option(const std::string_view name) const;
 
   /// Set a default value
   void set_val_default(ConfigValues& values,
 		       const ConfigTracker& tracker,
-		       const std::string& key, const std::string &val);
+		       const std::string_view key, const std::string &val);
 
   /// Set a values from mon
   int set_mon_vals(CephContext *cct,
@@ -169,21 +169,21 @@ public:
   // Set a configuration value, or crash
   // Metavariables will be expanded.
   void set_val_or_die(ConfigValues& values, const ConfigTracker& tracker,
-		      const std::string &key, const std::string &val);
+		      const std::string_view key, const std::string &val);
 
   // Set a configuration value.
   // Metavariables will be expanded.
   int set_val(ConfigValues& values, const ConfigTracker& tracker,
-	      const std::string &key, const char *val,
+	      const std::string_view key, const char *val,
               std::stringstream *err_ss=nullptr);
   int set_val(ConfigValues& values, const ConfigTracker& tracker,
-	      const std::string &key, const string& s,
+	      const std::string_view key, const std::string& s,
               std::stringstream *err_ss=nullptr) {
     return set_val(values, tracker, key, s.c_str(), err_ss);
   }
 
   /// clear override value
-  int rm_val(ConfigValues& values, const std::string& key);
+  int rm_val(ConfigValues& values, const std::string_view key);
 
   /// get encoded map<string,map<int32_t,string>> of entire config
   void get_config_bl(const ConfigValues& values,
@@ -196,12 +196,11 @@ public:
 
   // Get a configuration value.
   // No metavariables will be returned (they will have already been expanded)
-  int get_val(const ConfigValues& values, const std::string &key, char **buf, int len) const;
-  int get_val(const ConfigValues& values, const std::string &key, std::string *val) const;
-  Option::value_t get_val_generic(const ConfigValues& values, const std::string &key) const;
-  template<typename T> const T get_val(const ConfigValues& values, const std::string &key) const;
+  int get_val(const ConfigValues& values, const std::string_view key, char **buf, int len) const;
+  int get_val(const ConfigValues& values, const std::string_view key, std::string *val) const;
+  template<typename T> const T get_val(const ConfigValues& values, const std::string_view key) const;
   template<typename T, typename Callback, typename...Args>
-  auto with_val(const ConfigValues& values, const string& key,
+  auto with_val(const ConfigValues& values, const std::string_view key,
 		Callback&& cb, Args&&... args) const ->
     std::result_of_t<Callback(const T&, Args...)> {
     return std::forward<Callback>(cb)(
@@ -222,7 +221,7 @@ public:
   // Metavariables will be expanded if emeta is true.
   int get_val_from_conf_file(const ConfigValues& values,
 		   const std::vector <std::string> &sections,
-		   std::string const &key, std::string &out, bool emeta) const;
+		   const std::string_view key, std::string &out, bool emeta) const;
 
   /// dump all config values to a stream
   void show_config(const ConfigValues& values, std::ostream& out) const;
@@ -249,10 +248,12 @@ private:
   void validate_schema();
   void validate_default_settings();
 
+  Option::value_t get_val_generic(const ConfigValues& values,
+				  const std::string_view key) const;
   int _get_val_cstr(const ConfigValues& values,
-		    const std::string &key, char **buf, int len) const;
+		    const std::string& key, char **buf, int len) const;
   Option::value_t _get_val(const ConfigValues& values,
-			   const std::string &key,
+			   const std::string_view key,
 			   expand_stack_t *stack=0,
 			   std::ostream *err=0) const;
   Option::value_t _get_val(const ConfigValues& values,
@@ -263,7 +264,7 @@ private:
   Option::value_t _get_val_nometa(const ConfigValues& values,
 				  const Option& o) const;
 
-  int _rm_val(ConfigValues& values, const std::string& key, int level);
+  int _rm_val(ConfigValues& values, const std::string_view key, int level);
 
   void _refresh(ConfigValues& values, const Option& opt);
 
@@ -274,7 +275,7 @@ private:
 			std::vector <std::string> &sections) const;
 
   int _get_val_from_conf_file(const std::vector <std::string> &sections,
-			      const std::string &key, std::string &out) const;
+			      const std::string_view key, std::string &out) const;
 
   int parse_option(ConfigValues& values,
 		   const ConfigTracker& tracker,
@@ -356,7 +357,7 @@ public:
 
 template<typename T>
 const T md_config_t::get_val(const ConfigValues& values,
-			     const std::string &key) const {
+			     const std::string_view key) const {
   return boost::get<T>(this->get_val_generic(values, key));
 }
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -89,13 +89,13 @@ public:
   /*
    * Mapping from legacy config option names to class members
    */
-  std::map<std::string, member_ptr_t> legacy_values;
+  std::map<std::string_view, member_ptr_t> legacy_values;
 
   /**
    * The configuration schema, in the form of Option objects describing
    * possible settings.
    */
-  std::map<std::string, const Option&> schema;
+  std::map<std::string_view, const Option&> schema;
 
   /// values from mon that we failed to set
   std::map<std::string,std::string> ignored_mon_values;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -157,7 +157,7 @@ public:
   int set_mon_vals(CephContext *cct,
       ConfigValues& values,
       const ConfigTracker& tracker,
-      const map<std::string,std::string>& kv,
+      const map<std::string,std::string, std::less<>>& kv,
       config_callback config_cb);
 
   // Called by the Ceph daemons to make configuration changes at runtime

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -118,21 +118,21 @@ public:
   ConfigValues* operator->() noexcept {
     return &values;
   }
-  int get_val(const std::string& key, char** buf, int len) const {
+  int get_val(const std::string_view key, char** buf, int len) const {
     std::lock_guard l{lock};
     return config.get_val(values, key, buf, len);
   }
-  int get_val(const std::string &key, std::string *val) const {
+  int get_val(const std::string_view key, std::string *val) const {
     std::lock_guard l{lock};
     return config.get_val(values, key, val);
   }
   template<typename T>
-  const T get_val(const std::string& key) const {
+  const T get_val(const std::string_view key) const {
     std::lock_guard l{lock};
     return config.template get_val<T>(values, key);
   }
   template<typename T, typename Callback, typename...Args>
-  auto with_val(const string& key, Callback&& cb, Args&&... args) const {
+  auto with_val(const std::string_view key, Callback&& cb, Args&&... args) const {
     std::lock_guard l{lock};
     return config.template with_val<T>(values, key,
 				       std::forward<Callback>(cb),
@@ -144,7 +144,7 @@ public:
   const decltype(md_config_t::schema)& get_schema() const {
     return config.schema;
   }
-  const Option* get_schema(const std::string& key) const {
+  const Option* get_schema(const std::string_view key) const {
     auto found = config.schema.find(key);
     if (found == config.schema.end()) {
       return nullptr;
@@ -168,7 +168,7 @@ public:
     return config.get_all_sections(sections);
   }
   int get_val_from_conf_file(const std::vector<std::string>& sections,
-			     const std::string& key, std::string& out,
+			     const std::string_view key, std::string& out,
 			     bool emeta) const {
     std::lock_guard l{lock};
     return config.get_val_from_conf_file(values,
@@ -236,7 +236,7 @@ public:
     std::lock_guard l{lock};
     config.config_options(f);
   }
-  int rm_val(const std::string& key) {
+  int rm_val(const std::string_view key) {
     std::lock_guard l{lock};
     return config.rm_val(values, key);
   }
@@ -263,16 +263,16 @@ public:
         map_observer_changes(obs, key, rev_obs);
       }, oss);
   }
-  int set_val(const std::string& key, const std::string& s,
+  int set_val(const std::string_view key, const std::string& s,
               std::stringstream* err_ss=nullptr) {
     std::lock_guard l{lock};
     return config.set_val(values, obs_mgr, key, s, err_ss);
   }
-  void set_val_default(const std::string& key, const std::string& val) {
+  void set_val_default(const std::string_view key, const std::string& val) {
     std::lock_guard l{lock};
     config.set_val_default(values, obs_mgr, key, val);
   }
-  void set_val_or_die(const std::string& key, const std::string& val) {
+  void set_val_or_die(const std::string_view key, const std::string& val) {
     std::lock_guard l{lock};
     config.set_val_or_die(values, obs_mgr, key, val);
   }

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -277,7 +277,7 @@ public:
     config.set_val_or_die(values, obs_mgr, key, val);
   }
   int set_mon_vals(CephContext *cct,
-		   const map<std::string,std::string>& kv,
+		   const std::map<std::string,std::string,std::less<>>& kv,
 		   md_config_t::config_callback config_cb) {
     int ret;
     rev_obs_map_t rev_obs;

--- a/src/common/config_values.cc
+++ b/src/common/config_values.cc
@@ -4,7 +4,7 @@
 #include "config.h"
 
 ConfigValues::set_value_result_t
-ConfigValues::set_value(const std::string& key,
+ConfigValues::set_value(const std::string_view key,
                         Option::value_t&& new_value,
                         int level)
 {  
@@ -30,7 +30,7 @@ ConfigValues::set_value(const std::string& key,
   }
 }
 
-int ConfigValues::rm_val(const std::string& key, int level)
+int ConfigValues::rm_val(const std::string_view key, int level)
 {
   auto i = values.find(key);
   if (i == values.end()) {
@@ -50,7 +50,7 @@ int ConfigValues::rm_val(const std::string& key, int level)
 }
 
 std::pair<Option::value_t, bool>
-ConfigValues::get_value(const std::string& name, int level) const
+ConfigValues::get_value(const std::string_view name, int level) const
 {
   auto p = values.find(name);
   if (p != values.end() && !p->second.empty()) {
@@ -78,7 +78,7 @@ void ConfigValues::set_logging(int which, const char* val)
   }
 }
 
-bool ConfigValues::contains(const std::string& key) const
+bool ConfigValues::contains(const std::string_view key) const
 {
   return values.count(key);
 }

--- a/src/common/config_values.h
+++ b/src/common/config_values.h
@@ -17,7 +17,7 @@
 // debug logging settings, and some other "unnamed" settings, like entity name of
 // the daemon.
 class ConfigValues {
-  using values_t = std::map<std::string, map<int32_t,Option::value_t>>;
+  using values_t = std::map<std::string_view, map<int32_t,Option::value_t>>;
   values_t values;
   // for populating md_config_impl::legacy_values in ctor
   friend struct md_config_t;
@@ -80,21 +80,21 @@ public:
   /**
    * @return true if changed, false otherwise
    */
-  set_value_result_t set_value(const std::string& key,
+  set_value_result_t set_value(std::string_view key,
                                Option::value_t&& value,
                                int level);
-  int rm_val(const std::string& key, int level);
+  int rm_val(const std::string_view key, int level);
   void set_logging(int which, const char* val);
   /**
    * @param level the level of the setting, -1 for the one with the 
    *              highest-priority
    */
-  std::pair<Option::value_t, bool> get_value(const std::string& name,
+  std::pair<Option::value_t, bool> get_value(const std::string_view name,
                                              int level) const;
   template<typename Func> void for_each(Func&& func) const {
     for (const auto& [name,configs] : values) {
       func(name, configs);
     }
   }
-  bool contains(const std::string& key) const;
+  bool contains(const std::string_view key) const;
 };

--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -141,7 +141,8 @@ public:
     return get_config().get_osd_pool_default_min_size(*values, size);
   }
 
-  seastar::future<> set_mon_vals(const std::map<std::string,std::string>& kv) {
+  seastar::future<>
+  set_mon_vals(const std::map<std::string,std::string,std::less<>>& kv) {
     return do_change([kv, this](ConfigValues& values) {
       get_config().set_mon_vals(nullptr, values, obs_mgr, kv, nullptr);
     });

--- a/src/librbd/api/Config.cc
+++ b/src/librbd/api/Config.cc
@@ -79,10 +79,10 @@ struct Options : Parent {
   int init() {
     CephContext *cct = (CephContext *)io_ctx.cct();
 
-    for (auto &it : *this) {
-      int r = cct->_conf.get_val(std::string(it.first), &it.second.first);
+    for (auto& [k,v] : *this) {
+      int r = cct->_conf.get_val(k, &v.first);
       ceph_assert(r == 0);
-      it.second.second = RBD_CONFIG_SOURCE_CONFIG;
+      v.second = RBD_CONFIG_SOURCE_CONFIG;
     }
 
     std::string last_key = ImageCtx::METADATA_CONF_PREFIX;
@@ -222,7 +222,7 @@ void Config<I>::apply_pool_overrides(librados::IoCtx& io_ctx,
 
   for (auto& [k,v] : opts) {
     if (v.second == RBD_CONFIG_SOURCE_POOL) {
-      r = config->set_val(std::string(k), v.first);
+      r = config->set_val(k, v.first);
       if (r < 0) {
         lderr(cct) << "failed to override pool config " << k << "="
                    << v.first << ": " << cpp_strerror(r) << dendl;

--- a/src/librbd/api/Config.cc
+++ b/src/librbd/api/Config.cc
@@ -21,9 +21,9 @@ namespace {
 
 const uint32_t MAX_KEYS = 64;
 
-typedef std::map<std::string, std::pair<std::string, config_source_t>> Parent;
+typedef std::map<std::string_view, std::pair<std::string, config_source_t>> Parent;
 
-static std::set<std::string> EXCLUDE_OPTIONS {
+static std::set<std::string_view> EXCLUDE_OPTIONS {
     "rbd_auto_exclusive_lock_until_manual_request",
     "rbd_default_format",
     "rbd_default_map_options",
@@ -36,7 +36,7 @@ static std::set<std::string> EXCLUDE_OPTIONS {
     "rbd_validate_pool",
     "rbd_mirror_pool_replayers_refresh_interval"
   };
-static std::set<std::string> EXCLUDE_IMAGE_OPTIONS {
+static std::set<std::string_view> EXCLUDE_IMAGE_OPTIONS {
     "rbd_default_clone_format",
     "rbd_default_data_pool",
     "rbd_default_features",
@@ -80,7 +80,7 @@ struct Options : Parent {
     CephContext *cct = (CephContext *)io_ctx.cct();
 
     for (auto &it : *this) {
-      int r = cct->_conf.get_val(it.first.c_str(), &it.second.first);
+      int r = cct->_conf.get_val(std::string(it.first), &it.second.first);
       ceph_assert(r == 0);
       it.second.second = RBD_CONFIG_SOURCE_CONFIG;
     }
@@ -141,8 +141,8 @@ int Config<I>::list(librados::IoCtx& io_ctx,
     return r;
   }
 
-  for (auto &it : opts) {
-    options->push_back({it.first, it.second.first, it.second.second});
+  for (auto& [k,v] : opts) {
+    options->push_back({std::string{k}, v.first, v.second});
   }
 
   return 0;
@@ -200,8 +200,8 @@ int Config<I>::list(I *image_ctx, std::vector<config_option_t> *options) {
     }
   }
 
-  for (auto &it : opts) {
-    options->push_back({it.first, it.second.first, it.second.second});
+  for (auto& [k,v] : opts) {
+    options->push_back({std::string{k}, v.first, v.second});
   }
 
   return 0;
@@ -220,12 +220,12 @@ void Config<I>::apply_pool_overrides(librados::IoCtx& io_ctx,
     return;
   }
 
-  for (auto& pair : opts) {
-    if (pair.second.second == RBD_CONFIG_SOURCE_POOL) {
-      r = config->set_val(pair.first, pair.second.first);
+  for (auto& [k,v] : opts) {
+    if (v.second == RBD_CONFIG_SOURCE_POOL) {
+      r = config->set_val(std::string(k), v.first);
       if (r < 0) {
-        lderr(cct) << "failed to override pool config " << pair.first << "="
-                   << pair.second.first << ": " << cpp_strerror(r) << dendl;
+        lderr(cct) << "failed to override pool config " << k << "="
+                   << v.first << ": " << cpp_strerror(r) << dendl;
       }
     }
   }

--- a/src/messages/MConfig.h
+++ b/src/messages/MConfig.h
@@ -18,7 +18,10 @@ public:
   MConfig() : MessageInstance(MSG_CONFIG, HEAD_VERSION, COMPAT_VERSION) { }
   MConfig(const std::map<std::string,std::string,std::less<>>& c)
     : MessageInstance(MSG_CONFIG, HEAD_VERSION, COMPAT_VERSION),
-      config(c) {}
+      config{c} {}
+  MConfig(std::map<std::string,std::string,std::less<>>&& c)
+    : MessageInstance(MSG_CONFIG, HEAD_VERSION, COMPAT_VERSION),
+      config{std::move(c)} {}
 
   std::string_view get_type_name() const override {
     return "config";

--- a/src/messages/MConfig.h
+++ b/src/messages/MConfig.h
@@ -12,10 +12,11 @@ public:
   static constexpr int HEAD_VERSION = 1;
   static constexpr int COMPAT_VERSION = 1;
 
-  map<string,string> config;
+  // use transparent comparator so we can lookup in it by string_view keys
+  std::map<string,string,std::less<>> config;
 
   MConfig() : MessageInstance(MSG_CONFIG, HEAD_VERSION, COMPAT_VERSION) { }
-  MConfig(const map<string,string>& c)
+  MConfig(const std::map<std::string,std::string,std::less<>>& c)
     : MessageInstance(MSG_CONFIG, HEAD_VERSION, COMPAT_VERSION),
       config(c) {}
 

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -101,7 +101,7 @@ void ConfigMap::dump(Formatter *f) const
   f->close_section();
 }
 
-std::map<std::string,std::string>
+std::map<std::string,std::string,std::less<>>
 ConfigMap::generate_entity_map(
   const EntityName& name,
   const map<std::string,std::string>& crush_location,

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -101,12 +101,12 @@ void ConfigMap::dump(Formatter *f) const
   f->close_section();
 }
 
-void ConfigMap::generate_entity_map(
+std::map<std::string,std::string>
+ConfigMap::generate_entity_map(
   const EntityName& name,
   const map<std::string,std::string>& crush_location,
   const CrushWrapper *crush,
   const std::string& device_class,
-  std::map<std::string,std::string> *out,
   std::map<std::string,pair<std::string,const MaskedOption*>> *src)
 {
   // global, then by type, then by full name.
@@ -119,6 +119,7 @@ void ConfigMap::generate_entity_map(
   if (q != by_id.end()) {
     sections.push_back(make_pair(name.to_str(), &q->second));
   }
+  std::map<std::string,std::string,std::less<>> out;
   MaskedOption *prev = nullptr;
   for (auto s : sections) {
     for (auto& i : s.second->options) {
@@ -142,13 +143,14 @@ void ConfigMap::generate_entity_map(
 	  prev->get_precision(crush) < o.get_precision(crush)) {
 	continue;
       }
-      (*out)[i.first] = o.raw_value;
+      out[i.first] = o.raw_value;
       if (src) {
 	(*src)[i.first] = make_pair(s.first, &o);
       }
       prev = &o;
     }
   }
+  return out;
 }
 
 bool ConfigMap::parse_mask(

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -120,7 +120,7 @@ struct ConfigMap {
     by_id.clear();
   }
   void dump(Formatter *f) const;
-  std::map<std::string,std::string> generate_entity_map(
+  std::map<std::string,std::string,std::less<>> generate_entity_map(
     const EntityName& name,
     const map<std::string,std::string>& crush_location,
     const CrushWrapper *crush,

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -120,12 +120,11 @@ struct ConfigMap {
     by_id.clear();
   }
   void dump(Formatter *f) const;
-  void generate_entity_map(
+  std::map<std::string,std::string> generate_entity_map(
     const EntityName& name,
     const map<std::string,std::string>& crush_location,
     const CrushWrapper *crush,
     const std::string& device_class,
-    std::map<std::string,std::string> *out,
     std::map<std::string,pair<std::string,const MaskedOption*>> *src=0);
 
   static bool parse_mask(

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -424,7 +424,7 @@ void ConfigMonitor::handle_get_config(MonOpRequestRef op)
     osdmap.crush.get(),
     m->device_class);
   dout(20) << " config is " << out << dendl;
-  m->get_connection()->send_message(new MConfig(out));
+  m->get_connection()->send_message(new MConfig{std::move(out)});
 }
 
 bool ConfigMonitor::prepare_update(MonOpRequestRef op)

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -64,7 +64,7 @@ struct MonSession : public RefCountedObject {
   uint64_t proxy_tid = 0;
 
   string remote_host;                ///< remote host name
-  map<string,string> last_config;    ///< most recently shared config
+  map<std::string,std::string,std::less<>> last_config;    ///< most recently shared config
   bool any_config = false;
 
   MonSession(Connection *c)


### PR DESCRIPTION
the contained char sequences are either static char strings or strings
in `Option` instances. so no need to keep another copy of string around.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

