### PR TITLE
mgr/dashboard: auth ttl expired error

### DIFF
--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -43,7 +43,7 @@ class JwtManager(object):
             cls.init()
         ttl = mgr.get_module_option('jwt_token_ttl', cls.JWT_TOKEN_TTL)
         ttl = int(ttl)
-        now = int(time.mktime(time.gmtime()))
+        now = int(time.time())
         payload = {
             'iss': 'ceph-dashboard',
             'jti': str(uuid.uuid4()),


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/38428

```python
now = int(time.mktime(time.gmtime()))  
```
this time is UTC zore . ttl defult 2880 .in china now+ttl is local time.

so login  is show 'AMT: Token has expired'
```python
change  now = int(calendar.timegm(time.gmtime()))
```

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

