### PR TITLE
mimic: qa: ignore MON_DOWN for volume-client testing

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/volume-client/test.yaml
+++ b/qa/suites/fs/basic_functional/tasks/volume-client/test.yaml
@@ -5,6 +5,10 @@ overrides:
       global:
         ms type: simple
 
+overrides:
+  ceph:
+    log-whitelist:
+      - MON_DOWN
 tasks:
   - cephfs_test_runner:
       modules:

--- a/qa/suites/kcephfs/recovery/tasks/volume-client.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/volume-client.yaml
@@ -5,6 +5,10 @@ overrides:
       global:
         ms type: simple
 
+overrides:
+  ceph:
+    log-whitelist:
+      - MON_DOWN
 tasks:
   - cephfs_test_runner:
       fail_on_skip: false


### PR DESCRIPTION
http://tracker.ceph.com/issues/38736