### PR TITLE
pybind/rados: should pass "name" to cstr()

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -556,9 +556,9 @@ def decode_cstr(val, encoding="utf-8"):
     return val.decode(encoding)
 
 
-def flatten_dict(d):
+def flatten_dict(d, name):
     items = chain.from_iterable(d.items())
-    return cstr(''.join(i + '\0' for i in items))
+    return cstr(''.join(i + '\0' for i in items), name)
 
 
 cdef char* opt_str(s) except? NULL:
@@ -1532,7 +1532,7 @@ Rados object in state %s." % self.state)
         """
         service = cstr(service, 'service')
         daemon = cstr(daemon, 'daemon')
-        metadata_dict = flatten_dict(metadata)
+        metadata_dict = flatten_dict(metadata, 'metadata')
         cdef:
             char *_service = service
             char *_daemon = daemon
@@ -1545,7 +1545,7 @@ Rados object in state %s." % self.state)
 
     @requires(('metadata', dict))
     def service_daemon_update(self, status):
-        status_dict = flatten_dict(status)
+        status_dict = flatten_dict(status, 'status')
         cdef:
             char *_status = status_dict
 


### PR DESCRIPTION
it's a regression introduced by 6cb23f9c

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

