### PR TITLE
nautilus: mon/MgrStatMonitor: ensure only one copy of initial service map

### DIFF
--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -34,6 +34,7 @@ void MgrStatMonitor::create_initial()
   dout(10) << __func__ << dendl;
   version = 0;
   service_map.epoch = 1;
+  pending_service_map_bl.clear();
   encode(service_map, pending_service_map_bl, CEPH_FEATURES_ALL);
 }
 
@@ -59,7 +60,8 @@ void MgrStatMonitor::update_from_paxos(bool *need_bootstrap)
 	       << dendl;
     }
     catch (buffer::error& e) {
-      derr << "failed to decode mgrstat state; luminous dev version?" << dendl;
+      derr << "failed to decode mgrstat state; luminous dev version? "
+	   << e.what() << dendl;
     }
   }
   check_subs();


### PR DESCRIPTION
https://tracker.ceph.com/issues/38853