### PR TITLE
nautilus: osd/OSDMap: add 'zone' to default crush map

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3957,9 +3957,10 @@ int OSDMap::_build_crush_types(CrushWrapper& crush)
   crush.set_type_name(6, "pod");
   crush.set_type_name(7, "room");
   crush.set_type_name(8, "datacenter");
-  crush.set_type_name(9, "region");
-  crush.set_type_name(10, "root");
-  return 10;
+  crush.set_type_name(9, "zone");
+  crush.set_type_name(10, "region");
+  crush.set_type_name(11, "root");
+  return 11;
 }
 
 int OSDMap::build_simple_crush_map(CephContext *cct, CrushWrapper& crush,

--- a/src/test/cli/osdmaptool/create-print.t
+++ b/src/test/cli/osdmaptool/create-print.t
@@ -31,8 +31,9 @@
   type 6 pod
   type 7 room
   type 8 datacenter
-  type 9 region
-  type 10 root
+  type 9 zone
+  type 10 region
+  type 11 root
   
   # buckets
   host localhost {

--- a/src/test/cli/osdmaptool/create-racks.t
+++ b/src/test/cli/osdmaptool/create-racks.t
@@ -265,8 +265,9 @@
   type 6 pod
   type 7 room
   type 8 datacenter
-  type 9 region
-  type 10 root
+  type 9 zone
+  type 10 region
+  type 11 root
   
   # buckets
   host cephstore5522 {

--- a/src/test/cli/osdmaptool/crush.t
+++ b/src/test/cli/osdmaptool/crush.t
@@ -6,5 +6,5 @@
   osdmaptool: exported crush map to oc
   $ osdmaptool --import-crush oc myosdmap
   osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: imported 485 byte crush map from oc
+  osdmaptool: imported 497 byte crush map from oc
   osdmaptool: writing epoch 3 to myosdmap

--- a/src/test/cli/osdmaptool/tree.t
+++ b/src/test/cli/osdmaptool/tree.t
@@ -20,7 +20,7 @@
               "id": -1,
               "name": "default",
               "type": "root",
-              "type_id": 10,
+              "type_id": 11,
               "children": [
                   -3
               ]

--- a/src/test/crush/crush-choose-args-expected-one-more-0.txt
+++ b/src/test/crush/crush-choose-args-expected-one-more-0.txt
@@ -22,8 +22,9 @@ type 5 pdu
 type 6 pod
 type 7 room
 type 8 datacenter
-type 9 region
-type 10 root
+type 9 zone
+type 10 region
+type 11 root
 
 # buckets
 host HOST {

--- a/src/test/crush/crush-choose-args-expected-one-more-3.txt
+++ b/src/test/crush/crush-choose-args-expected-one-more-3.txt
@@ -22,8 +22,9 @@ type 5 pdu
 type 6 pod
 type 7 room
 type 8 datacenter
-type 9 region
-type 10 root
+type 9 zone
+type 10 region
+type 11 root
 
 # buckets
 host HOST {


### PR DESCRIPTION
This lets use have a root -> region -> zone -> host hierarchy, like you
will see in the public cloud.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 39f4e77d13377763a579f2afcd9341c00ca5b319)