### PR TITLE
doc: remove `Developer Guide` from index

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -103,7 +103,6 @@ about Ceph, see our `Architecture`_ section.
    mgr/dashboard
    api/index
    architecture
-   Developer Guide <dev/index>
    dev/internals
    governance
    ceph-volume/index


### PR DESCRIPTION
Because it's already included in `dev/internals`

This fixes the left navigation frame where the developer doc is listed twice righ now.


Another idea would be to remove the `*` from

```
.. toctree::
   :glob:

   *
```
from `dev/internals.rst`

relates to #23253

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

