### PR TITLE
nautilus: ceph-mgr-diskprediction-local requires numpy and scipy on SUSE, but these packages do not exist on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -503,7 +503,7 @@ Requires:       python3-scipy
 Requires:       python2-scipy
 %endif
 %endif
-%if 0%{?rhel} <= 7
+%if 0%{?rhel} == 7
 Requires:       numpy
 Requires:       scipy
 %endif


### PR DESCRIPTION
http://tracker.ceph.com/issues/38863