### PR TITLE
log: avoid logging anything when log_to_file=false

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -297,7 +297,8 @@ public:
     }
 
     // file
-    if (changed.count("log_file")) {
+    if (changed.count("log_file") ||
+	changed.count("log_to_file")) {
       if (conf->log_to_file) {
 	log->set_log_file(conf->log_file);
       } else {

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -635,7 +635,6 @@ CephContext::CephContext(uint32_t module_type_,
     crush_location(this)
 {
   _log = new ceph::logging::Log(&_conf->subsys);
-  _log->start();
 
   _log_obs = new LogObs(_log);
   _conf.add_observer(_log_obs);

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -154,7 +154,7 @@ void global_pre_init(
       _exit(1);
     }
   }
-
+  cct->_log->start();
   // do the --show-config[-val], if present in argv
   conf.do_argv_commands();
 

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -184,7 +184,8 @@ void Log::submit_entry(Entry&& e)
     *(volatile int *)(0) = 0xdead;
 
   // wait for flush to catch up
-  while (m_new.size() > m_max_new) {
+  while (is_started() &&
+	 m_new.size() > m_max_new) {
     if (m_stop) break; // force addition
     m_cond_loggers.wait(lock);
   }

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -106,6 +106,9 @@ void Log::set_log_stderr_prefix(std::string_view p)
 void Log::reopen_log_file()
 {
   std::scoped_lock lock(m_flush_mutex);
+  if (!is_started()) {
+    return;
+  }
   m_flush_mutex_holder = pthread_self();
   if (m_fd >= 0)
     VOID_TEMP_FAILURE_RETRY(::close(m_fd));
@@ -402,6 +405,7 @@ void Log::stop()
 
 void *Log::entry()
 {
+  reopen_log_file();
   {
     std::unique_lock lock(m_queue_mutex);
     m_queue_mutex_holder = pthread_self();


### PR DESCRIPTION
This PR allows you to set log_to_file=false on the monitor config db
and as a result prevent any daemon from opening/creating/logging to
their log file.

It essentially buffers early log messages in memory until we have
fetched the mon config,a nd only then starts logging (starting with
what is buffered).

Note that on crash or exit, we already explicitly flush, so we should
still catch errors.