### PR TITLE
mgr/dashboard: Validate iSCSI images features

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -16,6 +16,7 @@ from ..rest_client import RequestException
 from ..security import Scope
 from ..services.iscsi_client import IscsiClient
 from ..services.iscsi_cli import IscsiGatewaysConfig
+from ..services.rbd import format_bitmask
 from ..exceptions import DashboardException
 from ..tools import TaskManager
 
@@ -365,13 +366,21 @@ class IscsiTarget(RESTController):
                     if img.features() & required_rbd_features != required_rbd_features:
                         raise DashboardException(msg='Image {} cannot be exported using {} '
                                                      'backstore because required features are '
-                                                     'missing'.format(image, backstore),
+                                                     'missing (required features are '
+                                                     '{})'.format(image,
+                                                                  backstore,
+                                                                  format_bitmask(
+                                                                      required_rbd_features)),
                                                  code='image_missing_required_features',
                                                  component='iscsi')
                     if img.features() & supported_rbd_features != img.features():
                         raise DashboardException(msg='Image {} cannot be exported using {} '
                                                      'backstore because it contains unsupported '
-                                                     'features'.format(image, backstore),
+                                                     'features (supported features are '
+                                                     '{})'.format(image,
+                                                                  backstore,
+                                                                  format_bitmask(
+                                                                      supported_rbd_features)),
                                                  code='image_contains_unsupported_features',
                                                  component='iscsi')
 

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -350,14 +350,31 @@ class IscsiTarget(RESTController):
         for disk in disks:
             pool = disk['pool']
             image = disk['image']
-            IscsiTarget._validate_image_exists(pool, image)
+            backstore = disk['backstore']
+            required_rbd_features = settings['required_rbd_features'][backstore]
+            supported_rbd_features = settings['supported_rbd_features'][backstore]
+            IscsiTarget._validate_image(pool, image, backstore, required_rbd_features,
+                                        supported_rbd_features)
 
     @staticmethod
-    def _validate_image_exists(pool, image):
+    def _validate_image(pool, image, backstore, required_rbd_features, supported_rbd_features):
         try:
             ioctx = mgr.rados.open_ioctx(pool)
             try:
-                rbd.Image(ioctx, image)
+                with rbd.Image(ioctx, image) as img:
+                    if img.features() & required_rbd_features != required_rbd_features:
+                        raise DashboardException(msg='Image {} cannot be exported using {} '
+                                                     'backstore because required features are '
+                                                     'missing'.format(image, backstore),
+                                                 code='image_missing_required_features',
+                                                 component='iscsi')
+                    if img.features() & supported_rbd_features != img.features():
+                        raise DashboardException(msg='Image {} cannot be exported using {} '
+                                                     'backstore because it contains unsupported '
+                                                     'features'.format(image, backstore),
+                                                 code='image_contains_unsupported_features',
+                                                 component='iscsi')
+
             except rbd.ImageNotFound:
                 raise DashboardException(msg='Image {} does not exist'.format(image),
                                          code='image_does_not_exist',

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -1,8 +1,62 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import six
+
 import rbd
+
 from .. import mgr
+
+
+RBD_FEATURES_NAME_MAPPING = {
+    rbd.RBD_FEATURE_LAYERING: "layering",
+    rbd.RBD_FEATURE_STRIPINGV2: "striping",
+    rbd.RBD_FEATURE_EXCLUSIVE_LOCK: "exclusive-lock",
+    rbd.RBD_FEATURE_OBJECT_MAP: "object-map",
+    rbd.RBD_FEATURE_FAST_DIFF: "fast-diff",
+    rbd.RBD_FEATURE_DEEP_FLATTEN: "deep-flatten",
+    rbd.RBD_FEATURE_JOURNALING: "journaling",
+    rbd.RBD_FEATURE_DATA_POOL: "data-pool",
+    rbd.RBD_FEATURE_OPERATIONS: "operations",
+}
+
+
+def format_bitmask(features):
+    """
+    Formats the bitmask:
+
+    >>> format_bitmask(45)
+    ['deep-flatten', 'exclusive-lock', 'layering', 'object-map']
+    """
+    names = [val for key, val in RBD_FEATURES_NAME_MAPPING.items()
+             if key & features == key]
+    return sorted(names)
+
+
+def format_features(features):
+    """
+    Converts the features list to bitmask:
+
+    >>> format_features(['deep-flatten', 'exclusive-lock', 'layering', 'object-map'])
+    45
+
+    >>> format_features(None) is None
+    True
+
+    >>> format_features('deep-flatten, exclusive-lock')
+    32
+    """
+    if isinstance(features, six.string_types):
+        features = features.split(',')
+
+    if not isinstance(features, list):
+        return None
+
+    res = 0
+    for key, value in RBD_FEATURES_NAME_MAPPING.items():
+        if value in features:
+            res = key | res
+    return res
 
 
 class RbdConfiguration(object):

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -98,8 +98,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         self.assertStatus(200)
         self.assertJsonBody([])
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_list(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_list(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw1"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
@@ -111,8 +111,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['target_iqn'] = target_iqn
         self.assertJsonBody([response])
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_create(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_create(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw2"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
@@ -124,8 +124,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['target_iqn'] = target_iqn
         self.assertJsonBody(response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_delete(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_delete(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw3"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
@@ -137,8 +137,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         self.assertStatus(200)
         self.assertJsonBody([])
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_add_client(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_add_client(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw4"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -168,8 +168,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
             })
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_change_client_password(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_change_client_password(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw5"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -181,8 +181,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['clients'][0]['auth']['password'] = 'mynewiscsipassword'
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_rename_client(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_rename_client(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw6"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -194,8 +194,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['clients'][0]['client_iqn'] = 'iqn.1994-05.com.redhat:rh7-client0'
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_add_disk(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_add_disk(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw7"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -221,8 +221,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['clients'][0]['luns'].append({"image": "lun3", "pool": "rbd"})
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_change_disk_image(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_change_disk_image(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw8"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -236,8 +236,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['clients'][0]['luns'][0]['image'] = 'lun0'
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_change_disk_controls(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_change_disk_controls(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw9"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -249,8 +249,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['disks'][0]['controls'] = {"qfull_timeout": 15}
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_rename_target(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_rename_target(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw10"
         new_target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw11"
         create_request = copy.deepcopy(iscsi_target_request)
@@ -261,8 +261,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['target_iqn'] = new_target_iqn
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_rename_group(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_rename_group(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw12"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -274,8 +274,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['groups'][0]['group_id'] = 'mygroup0'
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_add_client_to_group(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_add_client_to_group(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw13"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -307,8 +307,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['groups'][0]['members'].append('iqn.1994-05.com.redhat:rh7-client3')
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_remove_client_from_group(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_remove_client_from_group(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw14"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -320,8 +320,8 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         response['groups'][0]['members'].remove('iqn.1994-05.com.redhat:rh7-client2')
         self._update_iscsi_target(create_request, update_request, response)
 
-    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image_exists')
-    def test_remove_groups(self, _validate_image_exists_mock):
+    @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
+    def test_remove_groups(self, _validate_image_mock):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw15"
         create_request = copy.deepcopy(iscsi_target_request)
         create_request['target_iqn'] = target_iqn
@@ -481,6 +481,14 @@ class IscsiClientMock(object):
                 "minimum_gateways": 2
             },
             "default_backstore": "user:rbd",
+            "required_rbd_features": {
+                "rbd": 0,
+                "user:rbd": 4,
+            },
+            "supported_rbd_features": {
+                "rbd": 135,
+                "user:rbd": 61,
+            },
             "disk_default_controls": {
                 "user:rbd": {
                     "hw_max_sectors": 1024,


### PR DESCRIPTION
This PR changes the REST Api to validate the iSCSI target disks based on the required and supported features for the selected backstore.

It also changes the UI to filter the RBD images available in the iSCSI target form, so the user will not see images that don't match the required features.

Signed-off-by: Ricardo Marques <rimarques@suse.com>
