### PR TITLE
ceph-volume: terminal: encode unicode when writing to stdout

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/test_terminal.py
+++ b/src/ceph-volume/ceph_volume/tests/test_terminal.py
@@ -1,4 +1,9 @@
+# -*- mode:python; tab-width:4; indent-tabs-mode:nil; coding:utf-8 -*-
+
+import codecs
+import io
 import pytest
+import sys
 from ceph_volume import terminal
 
 
@@ -66,3 +71,50 @@ class TestDispatch(object):
         with pytest.raises(SystemExit) as error:
             terminal.dispatch({'sub': BadSubCommand}, argv=['sub'])
         assert str(error.value) == '100'
+
+
+@pytest.fixture
+def stream():
+    def make_stream(buffer, encoding):
+        # mock a stdout with given encoding
+        if sys.version_info >= (3, 0):
+            stdout = sys.stdout
+            stream = io.TextIOWrapper(buffer,
+                                      encoding=encoding,
+                                      errors=stdout.errors,
+                                      newline=stdout.newlines,
+                                      line_buffering=stdout.line_buffering)
+        else:
+            stream = codecs.getwriter(encoding)(buffer)
+            # StreamWriter does not have encoding attached to it, it will ask
+            # the inner buffer for "encoding" attribute in this case
+            stream.encoding = encoding
+        return stream
+    return make_stream
+
+
+class TestWriteUnicode(object):
+
+    def setup(self):
+        self.octpus_and_squid_en = u'octpus and squid'
+        octpus_and_squid_zh = u'章鱼和鱿鱼'
+        self.message = self.octpus_and_squid_en + octpus_and_squid_zh
+
+    def test_stdout_writer(self, capsys):
+        # should work with whatever stdout is
+        terminal.stdout(self.message)
+        out, _ = capsys.readouterr()
+        assert self.octpus_and_squid_en in out
+
+    @pytest.mark.parametrize('encoding', ['ascii', 'utf8'])
+    def test_writer(self, encoding, stream, monkeypatch, capsys):
+        buffer = io.BytesIO()
+        # should keep writer alive
+        with capsys.disabled():
+            # we want to have access to the sys.stdout's attributes in
+            # make_stream(), not the ones of pytest.capture.EncodedFile
+            writer = stream(buffer, encoding)
+            monkeypatch.setattr(sys, 'stdout', writer)
+            terminal.stdout(self.message)
+            sys.stdout.flush()
+            assert self.octpus_and_squid_en.encode(encoding) in buffer.getvalue()


### PR DESCRIPTION
python determins the encoding of stdout and stderr based on the LC_CTYPE
and PYTHONIOENCODING env variable, by default, python3's sys.stdout uses
'utf-8' as its encoding, so it will be able to write unicode string even
the stdout is not attached to a tty device. but when it comes to
python2, it will default to ascii if neither of these variabls is set.
so, if we are writing unicode using `_Write` in an environment where
LC_CTYPE and/or PYTHONIOENCODING are using non UTF-8 encoding, it chokes
by raising `UnicodeEncodeError` exception.

in this change, we add a wrapper around `_Write._writer` so it is able
to write unicode string in such a non-unicode-friendly environment.

for more info related the encoding of stdout and stderr, see
https://docs.python.org/3/using/cmdline.html#envvar-PYTHONIOENCODING .

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

