### PR TITLE
rpm: immutable-object-cache related changes

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -586,7 +586,6 @@ Summary:	Ceph daemon for immutable object cache
 Group:		System/Filesystems
 %endif
 Requires:	ceph-common = %{_epoch_prefix}%{version}-%{release}
-Requires:	libradospp1 = %{_epoch_prefix}%{version}-%{release}
 %description immutable-object-cache
 Daemon for immutable object cache.
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -580,14 +580,14 @@ Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Daemon for mirroring RBD images between Ceph clusters, streaming
 changes asynchronously.
 
-%package -n ceph-immutable-object-cache
+%package immutable-object-cache
 Summary:	Ceph daemon for immutable object cache
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif
 Requires:	ceph-common = %{_epoch_prefix}%{version}-%{release}
 Requires:	libradospp1 = %{_epoch_prefix}%{version}-%{release}
-%description -n ceph-immutable-object-cache
+%description immutable-object-cache
 Daemon for immutable object cache.
 
 %package -n rbd-nbd
@@ -1746,13 +1746,13 @@ if [ $1 -ge 1 ] ; then
   fi
 fi
 
-%files -n ceph-immutable-object-cache
+%files immutable-object-cache
 %{_bindir}/ceph-immutable-object-cache
 %{_mandir}/man8/ceph-immutable-object-cache.8*
 %{_unitdir}/ceph-immutable-object-cache@.service
 %{_unitdir}/ceph-immutable-object-cache.target
 
-%post -n ceph-immutable-object-cache
+%post immutable-object-cache
 %if 0%{?suse_version}
 if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target >/dev/null 2>&1 || :
@@ -1765,7 +1765,7 @@ if [ $1 -eq 1 ] ; then
 /usr/bin/systemctl start ceph-immutable-object-cache.target >/dev/null 2>&1 || :
 fi
 
-%preun -n ceph-immutable-object-cache
+%preun immutable-object-cache
 %if 0%{?suse_version}
 %service_del_preun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
 %endif
@@ -1773,7 +1773,7 @@ fi
 %systemd_preun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
 %endif
 
-%postun -n ceph-immutable-object-cache
+%postun immutable-object-cache
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
 DISABLE_RESTART_ON_UPDATE="yes"

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -585,7 +585,7 @@ Summary:	Ceph daemon for immutable object cache
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif
-Requires:	ceph-common = %{_epoch_prefix}%{version}-%{release}
+Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 %description immutable-object-cache
 Daemon for immutable object cache.
 

--- a/debian/control
+++ b/debian/control
@@ -427,8 +427,7 @@ Description: debugging symbols for rbd-fuse
 
 Package: ceph-immutable-object-cache
 Architecture: linux-any
-Depends: ceph-common (= ${binary:Version}),
-         librados2 (= ${binary:Version}),
+Depends: librados2 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
 Description: Ceph daemon for immutable object cache


### PR DESCRIPTION
* use "%package immutable-object-cache" not "%package
  ceph-immutable-object-cache" for naming subpackage of
  "ceph-immutable-object-cache". this would result in package name of
  "ceph-immutable-object-cache". see
  http://ftp.rpm.org/max-rpm/s1-rpm-subpack-spec-file-changes.html
* remove "libradospp1" from immutable-object-cache's runtime
  dependencies. this package was removed in 65c8733b .

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

