### PR TITLE
librbd: look for pool metadata in default namespace

### DIFF
--- a/src/librbd/api/Config.cc
+++ b/src/librbd/api/Config.cc
@@ -50,11 +50,13 @@ static std::set<std::string_view> EXCLUDE_IMAGE_OPTIONS {
   };
 
 struct Options : Parent {
-  librados::IoCtx& io_ctx;
+  librados::IoCtx m_io_ctx;
 
-  Options(librados::IoCtx& io_ctx, bool image_apply_only_options)
-    : io_ctx(io_ctx) {
-    CephContext *cct = reinterpret_cast<CephContext *>(io_ctx.cct());
+  Options(librados::IoCtx& io_ctx, bool image_apply_only_options) {
+    m_io_ctx.dup(io_ctx);
+    m_io_ctx.set_namespace("");
+
+    CephContext *cct = reinterpret_cast<CephContext *>(m_io_ctx.cct());
 
     const std::string rbd_key_prefix("rbd_");
     const std::string rbd_mirror_key_prefix("rbd_mirror_");
@@ -77,7 +79,7 @@ struct Options : Parent {
   }
 
   int init() {
-    CephContext *cct = (CephContext *)io_ctx.cct();
+    CephContext *cct = (CephContext *)m_io_ctx.cct();
 
     for (auto& [k,v] : *this) {
       int r = cct->_conf.get_val(k, &v.first);
@@ -91,7 +93,7 @@ struct Options : Parent {
     while (more_results) {
       std::map<std::string, bufferlist> pairs;
 
-      int r = librbd::api::PoolMetadata<>::list(io_ctx, last_key, MAX_KEYS,
+      int r = librbd::api::PoolMetadata<>::list(m_io_ctx, last_key, MAX_KEYS,
                                                 &pairs);
       if (r < 0) {
         return r;

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -47,6 +47,8 @@ RefreshRequest<I>::RefreshRequest(I &image_ctx, bool acquiring_lock,
     m_on_finish(create_async_context_callback(m_image_ctx, on_finish)),
     m_error_result(0), m_flush_aio(false), m_exclusive_lock(nullptr),
     m_object_map(nullptr), m_journal(nullptr), m_refresh_parent(nullptr) {
+  m_pool_metadata_io_ctx.dup(image_ctx.md_ctx);
+  m_pool_metadata_io_ctx.set_namespace("");
 }
 
 template <typename I>
@@ -553,7 +555,7 @@ void RefreshRequest<I>::send_v2_get_pool_metadata() {
   librados::AioCompletion *comp =
     create_rados_callback<klass, &klass::handle_v2_get_pool_metadata>(this);
   m_out_bl.clear();
-  m_image_ctx.md_ctx.aio_operate(RBD_INFO, comp, &op, &m_out_bl);
+  m_pool_metadata_io_ctx.aio_operate(RBD_INFO, comp, &op, &m_out_bl);
   comp->release();
 }
 

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -145,6 +145,7 @@ private:
   uint64_t m_flags = 0;
   uint64_t m_op_features = 0;
 
+  librados::IoCtx m_pool_metadata_io_ctx;
   std::string m_last_metadata_key;
   std::map<std::string, bufferlist> m_metadata;
 

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -264,8 +264,6 @@ public:
       expect.WillOnce(Return(r));
     } else {
       expect.WillOnce(DoDefault());
-      EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(RBD_INFO, _, StrEq("rbd"), StrEq("metadata_list"), _, _, _));
       EXPECT_CALL(*mock_image_ctx.image_watcher, is_unregistered())
         .WillOnce(Return(false));
     }


### PR DESCRIPTION
when applying pool level config overrides

Fixes: https://tracker.ceph.com/issues/38928
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

