### PR TITLE
mgr/dashboard: Fixes tooltip behavior

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.component.ts
@@ -2,13 +2,23 @@ import { Component, ViewContainerRef } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { ToastsManager } from 'ng2-toastr';
+import { TooltipConfig } from 'ngx-bootstrap/tooltip';
 
 import { AuthStorageService } from './shared/services/auth-storage.service';
 
 @Component({
   selector: 'cd-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
+  providers: [
+    {
+      provide: TooltipConfig,
+      useFactory: (): TooltipConfig =>
+        Object.assign(new TooltipConfig(), {
+          container: 'body'
+        })
+    }
+  ]
 })
 export class AppComponent {
   title = 'cd';


### PR DESCRIPTION
The problem was that the tool tip element was added to the current parent
element which caused the CSS to make the last
button in a button group look like the fore last button as a rectangle
but the last element should have a rounded corner.

Before:
![Peek 2019-03-25 13-09](https://user-images.githubusercontent.com/1897962/54918720-4dc69e00-4eff-11e9-887a-5b29667eebb2.gif)

Fixes: https://tracker.ceph.com/issues/38932
Signed-off-by: Stephan Müller <smueller@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug