### PR TITLE
mon/ConfigMonitor: make 'config reset' idempotent

### DIFF
--- a/qa/workunits/mon/config.sh
+++ b/qa/workunits/mon/config.sh
@@ -6,19 +6,6 @@ function expect_false()
 	if "$@"; then return 1; else return 0; fi
 }
 
-# some of the commands are just not idempotent.
-function without_test_dup_command()
-{
-  if [ -z ${CEPH_CLI_TEST_DUP_COMMAND+x} ]; then
-    $@
-  else
-    local saved=${CEPH_CLI_TEST_DUP_COMMAND}
-    unset CEPH_CLI_TEST_DUP_COMMAND
-    $@
-    CEPH_CLI_TEST_DUP_COMMAND=saved
-  fi
-}
-
 ceph config dump
 
 # value validation
@@ -64,9 +51,6 @@ ceph config get mon.a debug_asok | grep 11
 ceph config rm mon debug_asok
 ceph config get mon.a debug_asok | grep 33
 ceph config rm global debug_asok
-without_test_dup_command ceph config reset
-ceph config get mon.a debug_asok | grep 33
-without_test_dup_command ceph config reset
 
 # help
 ceph config help debug_asok | grep debug_asok
@@ -122,5 +106,10 @@ ceph config assimilate-conf -i $t1 | tee $t2
 grep keyring $t2
 expect_false grep debug_asok $t2
 rm -f $t1 $t2
+
+expect_false ceph config reset
+expect_false ceph config reset -1
+# we are at end of testing, so it's okay to revert everything
+ceph config reset 0
 
 echo OK

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -521,12 +521,10 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
     }
     goto update;
   } else if (prefix == "config reset") {
-    int64_t num = -1;
-    cmd_getval(g_ceph_context, cmdmap, "num", num);
-    int64_t revert_to = num;
-    if (revert_to < 0) // revert to last version
-      revert_to = version - 1;
-    if (revert_to > (int64_t)version) {
+    int64_t revert_to = -1;
+    cmd_getval(g_ceph_context, cmdmap, "num", revert_to);
+    if (revert_to < 0 ||
+        revert_to > (int64_t)version) {
       err = -EINVAL;
       ss << "must specify a valid historical version to revert to; "
          << "see 'ceph config log' for a list of avialable configuration "

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1193,9 +1193,8 @@ COMMAND("config log name=num,type=CephInt,req=False",
 	"Show recent history of config changes",
 	"config", "r")
 COMMAND("config reset " \
-	"name=num,type=CephInt,range=0,req=False",
-	"Revert configuration to a historical version specified by <num>, "
-        "or simply revert to last version",
+	"name=num,type=CephInt,range=0",
+	"Revert configuration to a historical version specified by <num>",
 	"config", "rw")
 COMMAND("config generate-minimal-conf",
 	"Generate a minimal ceph.conf file",


### PR DESCRIPTION
This partially revert 1bc9c86d08cfb408768c080ed5ea1ea82325ed57.
It's generally not a good idea if the command is not idempotent.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--wip-config-reset-again
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

