### PR TITLE
nautilus: qa/rgw: point test repos at ceph-nautilus branch

### DIFF
--- a/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
@@ -4,12 +4,12 @@ tasks:
 - rgw: [client.0]
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-nautilus
       rgw_server: client.0
       stages: prepare
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-nautilus
       rgw_server: client.0
       stages: check
 overrides:

--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -4,7 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-nautilus
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -1,7 +1,7 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-nautilus
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/verify/tasks/ragweed.yaml
+++ b/qa/suites/rgw/verify/tasks/ragweed.yaml
@@ -1,6 +1,6 @@
 tasks:
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-nautilus
       rgw_server: client.0
       stages: prepare,check

--- a/qa/suites/rgw/verify/tasks/s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests.yaml
@@ -1,5 +1,5 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-nautilus
       rgw_server: client.0

--- a/qa/suites/upgrade/luminous-x/parallel/2-workload/rgw_ragweed_prepare.yaml
+++ b/qa/suites/upgrade/luminous-x/parallel/2-workload/rgw_ragweed_prepare.yaml
@@ -8,7 +8,7 @@ workload:
       - client.1
     - ragweed:
         client.1:
-          default-branch: ceph-master
+          default-branch: ceph-nautilus
           rgw_server: client.1
           stages: prepare
     - print: "**** done rgw ragweed prepare 2-workload"

--- a/qa/suites/upgrade/luminous-x/parallel/5-final-workload/rgw_ragweed_check.yaml
+++ b/qa/suites/upgrade/luminous-x/parallel/5-final-workload/rgw_ragweed_check.yaml
@@ -5,7 +5,7 @@ rgw-final-workload:
   full_sequential:
   - ragweed:
       client.1:
-        default-branch: ceph-master
+        default-branch: ceph-nautilus
         rgw_server: client.1
         stages: check
   - print: "**** done ragweed check 4-final-workload"

--- a/qa/suites/upgrade/luminous-x/parallel/5-final-workload/rgw_swift.yaml
+++ b/qa/suites/upgrade/luminous-x/parallel/5-final-workload/rgw_swift.yaml
@@ -5,6 +5,6 @@ rgw-final-workload:
   full_sequential:
   - swift:
       client.1:
-        force-branch: ceph-master
+        force-branch: ceph-nautilus
         rgw_server: client.1
   - print: "**** done swift 4-final-workload"

--- a/qa/suites/upgrade/mimic-x/parallel/2-workload/rgw_ragweed_prepare.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/2-workload/rgw_ragweed_prepare.yaml
@@ -8,7 +8,7 @@ workload:
       - client.1
     - ragweed:
         client.1:
-          default-branch: ceph-master
+          default-branch: ceph-nautilus
           rgw_server: client.1
           stages: prepare
     - print: "**** done rgw ragweed prepare 2-workload"

--- a/qa/suites/upgrade/mimic-x/parallel/5-final-workload/rgw_ragweed_check.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/5-final-workload/rgw_ragweed_check.yaml
@@ -5,7 +5,7 @@ rgw-final-workload:
   full_sequential:
   - ragweed:
       client.1:
-        default-branch: ceph-master
+        default-branch: ceph-nautilus
         rgw_server: client.1
         stages: check
   - print: "**** done ragweed check 4-final-workload"

--- a/qa/suites/upgrade/mimic-x/parallel/5-final-workload/rgw_swift.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/5-final-workload/rgw_swift.yaml
@@ -5,6 +5,6 @@ rgw-final-workload:
   full_sequential:
   - swift:
       client.1:
-        force-branch: ceph-master
+        force-branch: ceph-nautilus
         rgw_server: client.1
   - print: "**** done swift 4-final-workload"

--- a/qa/tasks/swift.py
+++ b/qa/tasks/swift.py
@@ -29,7 +29,7 @@ def download(ctx, config):
         ctx.cluster.only(client).run(
             args=[
                 'git', 'clone',
-                '-b', cconf.get('force-branch', 'ceph-master'),
+                '-b', cconf.get('force-branch', 'ceph-nautilus'),
                 teuth_config.ceph_git_base_url + 'swift.git',
                 '{tdir}/swift'.format(tdir=testdir),
                 ],


### PR DESCRIPTION
i added ceph-nautilus branches to the repos for s3-tests, swift, and ragweed. this updates the nautilus qa suites to target those branches instead of ceph-master