### PR TITLE
tools/ceph-kvstore-tool: print db stats

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -305,7 +305,8 @@ void BlueFS::dump_block_extents(ostream& out)
         << " : own 0x" << block_all[i]
         << " = 0x" << owned
         << " : using 0x" << owned - free
-        << std::dec << "\n";
+	<< std::dec << "(" << byte_u_t(owned - free) << ")"
+        << "\n";
   }
 }
 

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -18,4 +18,5 @@
     compact-prefix <prefix>
     compact-range <prefix> <start> <end>
     destructive-repair  (use only as last resort! may corrupt healthy data)
+    stats
   

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -47,6 +47,7 @@ void usage(const char *pname)
     << "  compact-prefix <prefix>\n"
     << "  compact-range <prefix> <start> <end>\n"
     << "  destructive-repair  (use only as last resort! may corrupt healthy data)\n"
+    << "  stats\n"
     << std::endl;
 }
 
@@ -97,7 +98,8 @@ int main(int argc, const char *argv[])
   }
 
   bool need_open_db = (cmd != "destructive-repair");
-  StoreTool st(type, path, need_open_db);
+  bool need_stats = (cmd == "stats");
+  StoreTool st(type, path, need_open_db, need_stats);
 
   if (cmd == "destructive-repair") {
     int ret = st.destructive_repair();
@@ -343,6 +345,8 @@ int main(int argc, const char *argv[])
     string start(url_unescape(argv[5]));
     string end(url_unescape(argv[6]));
     st.compact_range(prefix, start, end);
+  } else if (cmd == "stats") {
+    st.print_stats();
   } else {
     std::cerr << "Unrecognized command: " << cmd << std::endl;
     return 1;

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -43,7 +43,8 @@ class StoreTool
 public:
   StoreTool(const std::string& type,
 	    const std::string& path,
-	    bool need_open_db=true);
+	    bool need_open_db = true,
+	    bool need_stats = false);
   int load_bluestore(const std::string& path, bool need_open_db);
   uint32_t traverse(const std::string& prefix,
                     const bool do_crc,
@@ -74,4 +75,6 @@ public:
 		     const std::string& start,
 		     const std::string& end);
   int destructive_repair();
+
+  int print_stats() const;
 };


### PR DESCRIPTION
Signed-off-by: Igor Fedotov <ifedotov@suse.com>

In fact this command will provide zeros for most of compaction stuff as completed compactions are required to provide most of numbers. But one can use it to learn per-level DB statistics: (amount of files,
occupied space, etc).
Here is output extract:
db_statistics {
    "rocksdb_compaction_statistics": "",
    "": "",
    "": "** Compaction Stats [default] **",
    "": "Level    Files   Size     Score Read(GB)  Rn(GB) Rnp1(GB) Write(GB) Wnew(GB) Moved(GB) W-Amp Rd(MB/s) Wr(MB/s) Comp(sec) Comp(cnt) Avg(sec) KeyIn KeyDrop",
    "": "----------------------------------------------------------------------------------------------------------------------------------------------------------",
    "": "  L0      3/0   667.25 MB   2.6      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0         0         0    0.000       0      0",
    "": "  L1      5/0   246.06 MB   1.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0         0         0    0.000       0      0",
    "": "  L2     39/0    2.45 GB   1.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0         0         0    0.000       0      0",
    "": "  L3     11/0   707.18 MB   0.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0         0         0    0.000       0      0",
    "": " Sum     58/0    4.03 GB   0.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0         0         0    0.000       0      0",
    "": " Int      0/0    0.00 KB   0.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0         0         0    0.000       0      0",


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

