### PR TITLE
osd: ECBackend safer _failed_push

### DIFF
--- a/src/messages/MOSDPGBackfill.h
+++ b/src/messages/MOSDPGBackfill.h
@@ -19,7 +19,7 @@
 
 class MOSDPGBackfill : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 3;
+  static constexpr int HEAD_VERSION = 4;
   static constexpr int COMPAT_VERSION = 3;
 public:
   enum {
@@ -41,6 +41,7 @@ public:
   spg_t pgid;
   hobject_t last_backfill;
   pg_stat_t stats;
+  map<hobject_t, eversion_t> mark_missing;
 
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -70,6 +71,9 @@ public:
 	last_backfill.pool == -1)
       last_backfill.pool = pgid.pool();
     decode(pgid.shard, p);
+    if (header.version >= 4) {
+      decode(mark_missing, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
@@ -86,6 +90,7 @@ public:
     encode(stats, payload);
 
     encode(pgid.shard, payload);
+    encode(mark_missing, payload);
   }
 
   MOSDPGBackfill()

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3604,6 +3604,7 @@ void PeeringState::recover_got(
 
 void PeeringState::update_backfill_progress(
   const hobject_t &updated_backfill,
+  const map<hobject_t, eversion_t> &mark_missing,
   const pg_stat_t &updated_stats,
   bool preserve_local_num_bytes,
   ObjectStore::Transaction &t) {
@@ -3619,6 +3620,12 @@ void PeeringState::update_backfill_progress(
 	       << " replaces local " << info.stats.stats.sum.num_bytes << dendl;
     info.stats = updated_stats;
   }
+
+  for(map<hobject_t, eversion_t>::const_iterator i = mark_missing.begin();
+      i != mark_missing.end();
+      ++i) {
+    pg_log.missing_add(i->first, i->second, eversion_t()); 
+  } 
 
   dirty_info = true;
   write_if_dirty(t);

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1683,6 +1683,7 @@ public:
   /// Update info/stats to reflect backfill progress
   void update_backfill_progress(
     const hobject_t &updated_backfill,
+    const map<hobject_t, eversion_t> &mark_missing,
     const pg_stat_t &updated_stats,
     bool preserve_local_num_bytes,
     ObjectStore::Transaction &t);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4126,6 +4126,7 @@ void PrimaryLogPG::do_backfill(OpRequestRef op)
       ObjectStore::Transaction t;
       recovery_state.update_backfill_progress(
 	m->last_backfill,
+        m->mark_missing,
 	m->stats,
 	m->op == MOSDPGBackfill::OP_BACKFILL_PROGRESS,
 	t);
@@ -11515,10 +11516,12 @@ void PrimaryLogPG::on_failed_pull(
   finish_recovery_op(soid);  // close out this attempt,
   finish_degraded_object(soid);
 
+  backfills_failed.emplace(soid, v);
+  backfills_in_flight.erase(soid);
+
   if (from.count(pg_whoami)) {
     dout(0) << " primary missing oid " << soid << " version " << v << dendl;
     primary_error(soid, v);
-    backfills_in_flight.erase(soid);
   }
 }
 
@@ -12161,6 +12164,7 @@ void PrimaryLogPG::_clear_recovery_state()
   }
   ceph_assert(backfills_in_flight.empty());
   pending_backfill_updates.clear();
+  backfills_failed.clear();
   ceph_assert(recovering.empty());
   pgbackend->clear_recovery_state();
 }
@@ -12822,6 +12826,7 @@ uint64_t PrimaryLogPG::recover_backfill(
 
     backfills_in_flight.clear();
     pending_backfill_updates.clear();
+    backfills_failed.clear();
   }
 
   for (set<pg_shard_t>::const_iterator i = get_backfill_targets().begin();
@@ -13088,6 +13093,16 @@ uint64_t PrimaryLogPG::recover_backfill(
       i->second);
     new_last_backfill = i->first;
   }
+  map<hobject_t, eversion_t> mark_missing;
+  for (map<hobject_t, eversion_t>::iterator i = backfills_failed.begin();
+       i != backfills_failed.end();) {
+    if (i->first <= new_last_backfill) {
+      mark_missing.insert(*i);
+      backfills_failed.erase(i++);
+    } else {
+      ++i; 
+    }
+  }
   dout(10) << "possible new_last_backfill at " << new_last_backfill << dendl;
 
   ceph_assert(!pending_backfill_updates.empty() ||
@@ -13130,6 +13145,7 @@ uint64_t PrimaryLogPG::recover_backfill(
         // Use default priority here, must match sub_op priority
       }
       m->last_backfill = pinfo.last_backfill;
+      m->mark_missing = mark_missing;
       m->stats = pinfo.stats;
       osd->send_message_osd_cluster(bt.osd, m, get_osdmap_epoch());
       dout(10) << " peer " << bt

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1077,9 +1077,13 @@ protected:
    *   - are on the peer or are in backfills_in_flight
    *   - are not included in pg stats (yet)
    *   - have their stats in pending_backfill_updates on the primary
+   *
+   * objects in backfill_failed is usually because ec primary reconstruct object 
+   * failed, so if we go on do backfill , we need update the backtarget
    */
   set<hobject_t> backfills_in_flight;
   map<hobject_t, pg_stat_t> pending_backfill_updates;
+  map<hobject_t, eversion_t> backfills_failed;
 
   void dump_recovery_info(Formatter *f) const override {
     f->open_array_section("waiting_on_backfill");
@@ -1113,6 +1117,14 @@ protected:
 	f->dump_stream("object") << *i;
       }
       f->close_section();
+    }
+    {
+      f->open_array_section("backfills_failed");
+      for (map<hobject_t, eversion_t>::const_iterator i = backfills_failed.begin();
+           i != backfills_failed.end();
+           ++i) {
+        f->dump_stream("object") << i->first;
+      }
     }
     {
       f->open_array_section("recovering");


### PR DESCRIPTION
on the ECBackend, if we failed_push when recover backfill,
we could report the object into failed list, and normally
remove the object from backfills_in_flight, when we rollforwad
peers last_backfill, we pass the failed objects too, and this
could let peer record the object as missing.


Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

