### PR TITLE
nautilus: mon/Monitor.cc: print min_mon_release correctly

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1118,7 +1118,8 @@ void Monitor::bootstrap()
   if (monmap->min_mon_release &&
       monmap->min_mon_release + 2 < (int)ceph_release()) {
     derr << "current monmap has min_mon_release "
-	 << ceph_release() << " (" << ceph_release_name(monmap->min_mon_release)
+	 << (int)monmap->min_mon_release
+	 << " (" << ceph_release_name(monmap->min_mon_release)
 	 << ") which is >2 releases older than me " << ceph_release()
 	 << " (" << ceph_release_name(ceph_release()) << "), stopping."
 	 << dendl;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/38927
Signed-off-by: Neha Ojha <nojha@redhat.com>
(cherry picked from commit 21ca604a22eacbf5e1dbeffffa0dd38f84647505)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

