### PR TITLE
common/config: parse --default-$option as a default value

### DIFF
--- a/qa/standalone/osd/osd-config.sh
+++ b/qa/standalone/osd/osd-config.sh
@@ -74,6 +74,22 @@ function TEST_config_track() {
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log reopen || return 1
 }
 
+function TEST_default_adjustment() {
+    a=$(ceph-osd --no-mon-config --show-config-value rgw_torrent_origin)
+    b=$(ceph-osd --no-mon-config --show-config-value rgw_torrent_origin --default-rgw-torrent-origin default)
+    c=$(ceph-osd --no-mon-config --show-config-value rgw_torrent_origin --default-rgw-torrent-origin arg)
+    [ "$a" != "default" ] || return 1
+    [ "$b" = "default" ] || return 1
+    [ "$c" = "arg" ] || return 1
+
+    a=$(ceph-osd --no-mon-config --show-config-value log_to_file)
+    b=$(ceph-osd --no-mon-config --show-config-value log_to_file --default-log-to-file=false)
+    c=$(ceph-osd --no-mon-config --show-config-value log_to_file --default-log-to-file=false --log-to-file)
+    [ "$a" = "true" ] || return 1
+    [ "$b" = "false" ] || return 1
+    [ "$c" = "true" ] || return 1
+}
+
 main osd-config "$@"
 
 # Local Variables:

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -674,7 +674,17 @@ int md_config_t::parse_option(ConfigValues& values,
     std::string as_option("--");
     as_option += opt.name;
     option_name = opt.name;
-    if (opt.type == Option::TYPE_BOOL) {
+    if (ceph_argparse_witharg(
+	  args, i, &val, err,
+	  string(string("--default-") + opt.name).c_str(), (char*)NULL)) {
+      if (!err.str().empty()) {
+        error_message = err.str();
+	ret = -EINVAL;
+	break;
+      }
+      ret = _set_val(values, tracker,  val, opt, CONF_DEFAULT, &error_message);
+      break;
+    } else if (opt.type == Option::TYPE_BOOL) {
       int res;
       if (ceph_argparse_binary_flag(args, i, &res, oss, as_option.c_str(),
 				    (char*)NULL)) {


### PR DESCRIPTION
Sometimes it is useful to specify an alternative default value for an
option via the command line such that it has a lower priority than the
mon config database, config file, the rest of the command line, or the
environment.

Signed-off-by: Sage Weil <sage@redhat.com>