### PR TITLE
rgw: make secret cache separately configurable and provide options to disable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,6 +499,11 @@ if(WITH_RADOSGW)
   else()
     message(WARNING "ssl not found: rgw civetweb may fail to dlopen libssl libcrypto")
   endif()  # OPENSSL_FOUND
+
+  option(ENABLE_KEYSTONE_SECRET_CACHE "keystone secret key shortcut" ON)
+  if (ENABLE_KEYSTONE_SECRET_CACHE)
+    set(CEPH_KEYSTONE_SECRET_CACHE 1 CACHE INTERNAL "fetch and cache keystone secret keys")
+  endif (ENABLE_KEYSTONE_SECRET_CACHE)
 endif (WITH_RADOSGW)
 
 #option for CephFS

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5722,6 +5722,14 @@ std::vector<Option> get_rgw_options() {
         "Implicitly create new users in their own tenant with the same name when "
         "authenticating via Keystone."),
 
+    Option("rgw_keystone_secret_cache_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1000)
+    .set_description("Keystone secret key cache size")
+    .set_long_description(
+        "Max number of Keystone secret keys that will be cached. Token that is not cached "
+        "requires RGW to access the Keystone server when authenticating. "
+        "Zero disables use of secret keys and falls back to using token validation."),
+
     Option("rgw_cross_domain_policy", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("<allow-access-from domain=\"*\" secure=\"false\" />")
     .set_description("RGW handle cross domain policy")
@@ -6429,6 +6437,7 @@ std::vector<Option> get_rgw_options() {
         "A user can create this many buckets. Zero means unlimmited, negative number means "
         "user cannot create any buckets (although user will retain buckets already created."),
 
+// )
     Option("rgw_objexp_gc_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(10_min)
     .set_description("Swift objects expirer garbage collector interval"),

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -357,4 +357,7 @@
 /* Define if unit tests are built. */
 #cmakedefine UNIT_TESTS_BUILT
 
+/* define if rgw keystone secret key cache should be supported */
+#cmakedefine CEPH_KEYSTONE_SECRET_CACHE
+
 #endif /* CONFIG_H */


### PR DESCRIPTION
 rgw: keystone: options to separately size or disable the keystone secret cache
    
    A new configuration option "rgw_keystone_secret_cache_size" is provided to
    control the size of the secret cache independently of the keystone cache.
    Because users can easily make multiple keystone tokens (in some cases
    a new token is created on every access), the keystone cache may need
    a fairly large size in order to be effective.  The secret cache never
    needs to be larger than the number of active users.
    
    When "rgw_keystone_secret_cache_size" is set to zero the secret
    cache is entirely disabled.  This forces rgw to always use the token
    validation logic that used to be the only way to operate.  Sites that
    are particularly security conscious may require this mode of operation.
    This option may be changed dynamically at runtime without restarting rgw.
    
    Sites that are particularly concerned about security may want to provably
    and entirely remove the logic that fetches secret keys from keystone.
    The compile-time option "ENABLE_KEYSTONE_SECRET_CACHE=OFF" will remove
    the code that uses the secret cache at build time.  Some parts of the
    secret cache are left in order to simplify the ifdef logic.
    
    Signed-off-by: Marcus Watts <mwatts@redhat.com>

