### PR TITLE
mgr/devicehealth: Fix python 3 incompatiblity

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -547,7 +547,7 @@ class Module(MgrModule):
                 did += 1
             if to_mark_out:
                 self.mark_out_etc(to_mark_out)
-        for warning, ls in health_warnings.iteritems():
+        for warning, ls in iteritems(health_warnings):
             n = len(ls)
             if n:
                 checks[warning] = {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/38939
Signed-off-by: Marius Schiffer <marius@mschiffer.de>

Another one.
six was imported but not used.
Backport to nautilus.