### PR TITLE
Namespace Cleanup: include

### DIFF
--- a/src/include/CompatSet.h
+++ b/src/include/CompatSet.h
@@ -77,7 +77,7 @@ struct CompatSet {
       remove(f.id);
     }
 
-    void encode(bufferlist& bl) const {
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       /* See below, mask always has the lowest bit set in memory, but
        * unset in the encoding */
@@ -85,7 +85,7 @@ struct CompatSet {
       encode(names, bl);
     }
 
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       using ceph::decode;
       decode(mask, bl);
       decode(names, bl);
@@ -111,7 +111,7 @@ struct CompatSet {
       }
     }
 
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       for (auto p = names.cbegin(); p != names.cend(); ++p) {
 	char s[18];
 	snprintf(s, sizeof(s), "feature_%llu", (unsigned long long)p->first);
@@ -222,19 +222,19 @@ struct CompatSet {
     return true;
   }
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     compat.encode(bl);
     ro_compat.encode(bl);
     incompat.encode(bl);
   }
-  
-  void decode(bufferlist::const_iterator& bl) {
+
+  void decode(ceph::buffer::list::const_iterator& bl) {
     compat.decode(bl);
     ro_compat.decode(bl);
     incompat.decode(bl);
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->open_object_section("compat");
     compat.dump(f);
     f->close_section();

--- a/src/include/Distribution.h
+++ b/src/include/Distribution.h
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,25 +7,28 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 
 #ifndef CEPH_DISTRIBUTION_H
 #define CEPH_DISTRIBUTION_H
 
+#include <cstdlib>
 #include <vector>
 
+#include "ceph_assert.h"
+
 class Distribution {
-  vector<float> p;
-  vector<int> v;
+  std::vector<float> p;
+  std::vector<int> v;
 
  public:
-  //Distribution() { 
+  //Distribution() {
   //}
-  
+
   unsigned get_width() {
     return p.size();
   }
@@ -42,10 +45,10 @@ class Distribution {
   void random() {
     float sum = 0.0;
     for (unsigned i=0; i<p.size(); i++) {
-      p[i] = (float)(rand() % 10000);
+      p[i] = (float)(std::rand() % 10000);
       sum += p[i];
     }
-    for (unsigned i=0; i<p.size(); i++) 
+    for (unsigned i=0; i<p.size(); i++)
       p[i] /= sum;
   }
 

--- a/src/include/blobhash.h
+++ b/src/include/blobhash.h
@@ -14,6 +14,7 @@
 #ifndef CEPH_BLOBHASH_H
 #define CEPH_BLOBHASH_H
 
+#include <cstdint>
 #include "hash.h"
 
 /*
@@ -24,17 +25,17 @@
 
 class blobhash {
 public:
-  uint32_t operator()(const char *p, unsigned len) {
+  std::uint32_t operator()(const char *p, unsigned len) {
     static rjhash<uint32_t> H;
-    uint32_t acc = 0;
+    std::uint32_t acc = 0;
     while (len >= sizeof(acc)) {
-      acc ^= *(uint32_t*)p;
-      p += sizeof(uint32_t);
-      len -= sizeof(uint32_t);
+      acc ^= *(std::uint32_t*)p;
+      p += sizeof(std::uint32_t);
+      len -= sizeof(std::uint32_t);
     }
     int sh = 0;
     while (len) {
-      acc ^= (uint32_t)*p << sh;
+      acc ^= (std::uint32_t)*p << sh;
       sh += 8;
       len--;
       p++;

--- a/src/include/btree_map.h
+++ b/src/include/btree_map.h
@@ -10,8 +10,9 @@
 #include "include/encoding.h"
 
 template<class T, class U>
-inline void encode(const btree::btree_map<T,U>& m, bufferlist& bl)
+inline void encode(const btree::btree_map<T,U>& m, ceph::bufferlist& bl)
 {
+  using ceph::encode;
   __u32 n = (__u32)(m.size());
   encode(n, bl);
   for (typename btree::btree_map<T,U>::const_iterator p = m.begin(); p != m.end(); ++p) {
@@ -20,8 +21,9 @@ inline void encode(const btree::btree_map<T,U>& m, bufferlist& bl)
   }
 }
 template<class T, class U>
-inline void encode(const btree::btree_map<T,U>& m, bufferlist& bl, uint64_t features)
+inline void encode(const btree::btree_map<T,U>& m, ceph::bufferlist& bl, uint64_t features)
 {
+  using ceph::encode;
   __u32 n = (__u32)(m.size());
   encode(n, bl);
   for (typename btree::btree_map<T,U>::const_iterator p = m.begin(); p != m.end(); ++p) {
@@ -30,8 +32,9 @@ inline void encode(const btree::btree_map<T,U>& m, bufferlist& bl, uint64_t feat
   }
 }
 template<class T, class U>
-inline void decode(btree::btree_map<T,U>& m, bufferlist::const_iterator& p)
+inline void decode(btree::btree_map<T,U>& m, ceph::bufferlist::const_iterator& p)
 {
+  using ceph::decode;
   __u32 n;
   decode(n, p);
   m.clear();
@@ -42,16 +45,19 @@ inline void decode(btree::btree_map<T,U>& m, bufferlist::const_iterator& p)
   }
 }
 template<class T, class U>
-inline void encode_nohead(const btree::btree_map<T,U>& m, bufferlist& bl)
+inline void encode_nohead(const btree::btree_map<T,U>& m, ceph::bufferlist& bl)
 {
+  using ceph::encode;
   for (typename btree::btree_map<T,U>::const_iterator p = m.begin(); p != m.end(); ++p) {
     encode(p->first, bl);
     encode(p->second, bl);
   }
 }
 template<class T, class U>
-inline void decode_nohead(int n, btree::btree_map<T,U>& m, bufferlist::const_iterator& p)
+inline void decode_nohead(int n, btree::btree_map<T,U>& m,
+			  ceph::bufferlist::const_iterator& p)
 {
+  using ceph::decode;
   m.clear();
   while (n--) {
     T k;

--- a/src/include/ceph_assert.h
+++ b/src/include/ceph_assert.h
@@ -70,7 +70,7 @@ extern void __ceph_assert_warn(const char *assertion, const char *file, int line
 #define assert_warn(expr)							\
   ((expr)								\
    ? _CEPH_ASSERT_VOID_CAST (0)					\
-   : __ceph_assert_warn (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION))
+   : ::ceph::__ceph_assert_warn (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION))
 
 }
 
@@ -84,20 +84,20 @@ using namespace ceph;
  * debug-only thing, like it is in many projects.
  */
 #define ceph_abort(msg, ...)                                            \
-  __ceph_abort( __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, "abort() called")
+  ::ceph::__ceph_abort( __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, "abort() called")
 
 #define ceph_abort_msg(msg)                                             \
-  __ceph_abort( __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, msg) 
+  ::ceph::__ceph_abort( __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, msg) 
 
 #define ceph_abort_msgf(...)                                             \
-  __ceph_abortf( __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__)
+  ::ceph::__ceph_abortf( __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__)
 
 #ifdef __SANITIZE_ADDRESS__
 #define ceph_assert(expr)                           \
   do {                                              \
     ((expr))                                        \
     ? _CEPH_ASSERT_VOID_CAST (0)                    \
-    : __ceph_assert_fail(__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION); \
+      : ::ceph::__ceph_assert_fail(__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION); \
   } while (false)
 #else
 #define ceph_assert(expr)							\
@@ -105,7 +105,7 @@ using namespace ceph;
    {__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION}; \
    ((expr) \
    ? _CEPH_ASSERT_VOID_CAST (0) \
-   : __ceph_assert_fail(assert_data_ctx)); } while(false)
+    : ::ceph::__ceph_assert_fail(assert_data_ctx)); } while(false)
 #endif
 
 // this variant will *never* get compiled out to NDEBUG in the future.
@@ -115,7 +115,7 @@ using namespace ceph;
   do {                                              \
     ((expr))                                        \
     ? _CEPH_ASSERT_VOID_CAST (0)                    \
-    : __ceph_assert_fail(__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION); \
+      : ::ceph::__ceph_assert_fail(__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION); \
   } while(false)
 #else
 #define ceph_assert_always(expr)							\
@@ -123,7 +123,7 @@ using namespace ceph;
    {__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION}; \
    ((expr) \
    ? _CEPH_ASSERT_VOID_CAST (0) \
-   : __ceph_assert_fail(assert_data_ctx)); } while(false)
+    : ::ceph::__ceph_assert_fail(assert_data_ctx)); } while(false)
 #endif
 
 // Named by analogy with printf.  Along with an expression, takes a format
@@ -131,17 +131,17 @@ using namespace ceph;
 #define assertf(expr, ...)                  \
   ((expr)								\
    ? _CEPH_ASSERT_VOID_CAST (0)					\
-   : __ceph_assertf_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__))
+   : ::ceph::__ceph_assertf_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__))
 #define ceph_assertf(expr, ...)                  \
   ((expr)								\
    ? _CEPH_ASSERT_VOID_CAST (0)					\
-   : __ceph_assertf_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__))
+   : ::ceph::__ceph_assertf_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__))
 
 // this variant will *never* get compiled out to NDEBUG in the future.
 // (ceph_assertf currently doesn't either, but in the future it might.)
 #define ceph_assertf_always(expr, ...)                  \
   ((expr)								\
    ? _CEPH_ASSERT_VOID_CAST (0)					\
-   : __ceph_assertf_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__))
+   : ::ceph::__ceph_assertf_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__))
 
 #endif

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -1,7 +1,11 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+
 #ifndef __CEPH_FEATURES
 #define __CEPH_FEATURES
 
-#include "sys/types.h"
+#include <cstdint>
+
+#include <sys/types.h>
 
 /*
  * Each time we reclaim bits for reuse we need to specify another
@@ -13,14 +17,14 @@
 #define CEPH_FEATURE_INCARNATION_3 ((1ull<<57)|(1ull<<28)) // SERVER_MIMIC
 
 #define DEFINE_CEPH_FEATURE(bit, incarnation, name)			\
-	const static uint64_t CEPH_FEATURE_##name = (1ULL<<bit);		\
-	const static uint64_t CEPH_FEATUREMASK_##name =			\
-		(1ULL<<bit | CEPH_FEATURE_INCARNATION_##incarnation);
+  const inline std::uint64_t CEPH_FEATURE_##name = (1ULL<<bit);		\
+  const inline std::uint64_t CEPH_FEATUREMASK_##name =			\
+							  (1ULL<<bit | CEPH_FEATURE_INCARNATION_##incarnation);
 
 // this bit is ignored but still advertised by release *when*
 #define DEFINE_CEPH_FEATURE_DEPRECATED(bit, incarnation, name, when) \
-	const static uint64_t DEPRECATED_CEPH_FEATURE_##name = (1ULL<<bit); \
-	const static uint64_t DEPRECATED_CEPH_FEATUREMASK_##name =		\
+  const inline std::uint64_t DEPRECATED_CEPH_FEATURE_##name = (1ULL<<bit); \
+  const inline std::uint64_t DEPRECATED_CEPH_FEATUREMASK_##name =	\
 		(1ULL<<bit | CEPH_FEATURE_INCARNATION_##incarnation);
 
 // this bit is ignored by release *unused* and not advertised by
@@ -269,10 +273,10 @@ DEFINE_CEPH_FEATURE_DEPRECATED(63, 1, RESERVED_BROKEN, LUMINOUS) // client-facin
  */
 #define CEPH_STATIC_ASSERT(x) (void)(sizeof(int[((x)==0) ? -1 : 0]))
 
-static inline void ____build_time_check_for_reserved_bits(void) {
-	CEPH_STATIC_ASSERT((CEPH_FEATURES_ALL &
-			    (CEPH_FEATURE_RESERVED |
-			     DEPRECATED_CEPH_FEATURE_RESERVED_BROKEN)) == 0);
+inline void ____build_time_check_for_reserved_bits(void) {
+  CEPH_STATIC_ASSERT((CEPH_FEATURES_ALL &
+		      (CEPH_FEATURE_RESERVED |
+		       DEPRECATED_CEPH_FEATURE_RESERVED_BROKEN)) == 0);
 }
 
 #endif

--- a/src/include/ceph_frag.h
+++ b/src/include/ceph_frag.h
@@ -1,6 +1,8 @@
 #ifndef FS_CEPH_FRAG_H
 #define FS_CEPH_FRAG_H
 
+#include "int_types.h"
+
 /*
  * "Frags" are a way to describe a subset of a 32-bit number space,
  * using a mask and a value to match against that mask.  Any given frag

--- a/src/include/cephfs/ceph_statx.h
+++ b/src/include/cephfs/ceph_statx.h
@@ -16,7 +16,8 @@
 
 #ifndef CEPH_CEPH_STATX_H
 #define CEPH_CEPH_STATX_H
-#include <stdint.h>
+#include <cstdint>
+#include <sys/stat.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/include/compact_map.h
+++ b/src/include/compact_map.h
@@ -297,21 +297,21 @@ public:
       return const_iterator(this);
     return const_iterator(this, map->upper_bound(k));
   }
-  void encode(bufferlist &bl) const {
+  void encode(ceph::bufferlist &bl) const {
     using ceph::encode;
     if (map)
       encode(*map, bl);
     else
       encode((uint32_t)0, bl);
   }
-  void encode(bufferlist &bl, uint64_t features) const {
+  void encode(ceph::bufferlist &bl, uint64_t features) const {
     using ceph::encode;
     if (map)
       encode(*map, bl, features);
     else
       encode((uint32_t)0, bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::bufferlist::const_iterator& p) {
     using ceph::decode;
     using ceph::decode_nohead;
     uint32_t n;
@@ -325,16 +325,17 @@ public:
 };
 
 template<class Key, class T, class Map>
-inline void encode(const compact_map_base<Key, T, Map>& m, bufferlist& bl) {
+inline void encode(const compact_map_base<Key, T, Map>& m, ceph::bufferlist& bl) {
   m.encode(bl);
 }
 template<class Key, class T, class Map>
-inline void encode(const compact_map_base<Key, T, Map>& m, bufferlist& bl,
+inline void encode(const compact_map_base<Key, T, Map>& m, ceph::bufferlist& bl,
 		   uint64_t features) {
   m.encode(bl, features);
 }
 template<class Key, class T, class Map>
-inline void decode(compact_map_base<Key, T, Map>& m, bufferlist::const_iterator& p) {
+inline void decode(compact_map_base<Key, T, Map>& m,
+                   ceph::bufferlist::const_iterator& p) {
   m.decode(p);
 }
 

--- a/src/include/compact_set.h
+++ b/src/include/compact_set.h
@@ -258,14 +258,14 @@ public:
       return const_iterator(this);
     return const_iterator(this, set->upper_bound(t));
   }
-  void encode(bufferlist &bl) const {
+  void encode(ceph::bufferlist &bl) const {
     using ceph::encode;
     if (set)
       encode(*set, bl);
     else
       encode((uint32_t)0, bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::bufferlist::const_iterator& p) {
     using ceph::decode;
     uint32_t n;
     decode(n, p);
@@ -278,11 +278,11 @@ public:
 };
 
 template<class T, class Set>
-inline void encode(const compact_set_base<T, Set>& m, bufferlist& bl) {
+inline void encode(const compact_set_base<T, Set>& m, ceph::bufferlist& bl) {
   m.encode(bl);
 }
 template<class T, class Set>
-inline void decode(compact_set_base<T, Set>& m, bufferlist::const_iterator& p) {
+inline void decode(compact_set_base<T, Set>& m, ceph::bufferlist::const_iterator& p) {
   m.decode(p);
 }
 

--- a/src/include/elist.h
+++ b/src/include/elist.h
@@ -15,6 +15,10 @@
 #ifndef CEPH_ELIST_H
 #define CEPH_ELIST_H
 
+#include <cstdlib>
+
+#include "ceph_assert.h"
+
 /*
  * elist: embedded list.
  *
@@ -33,7 +37,7 @@ class elist {
 public:
   struct item {
     item *_prev, *_next;
-    
+
     item(T i=0) : _prev(this), _next(this) {}
     ~item() { 
       ceph_assert(!is_on_list());
@@ -42,7 +46,7 @@ public:
     item(const item& other) = delete;
     const item& operator= (const item& right) = delete;
 
-    
+
     bool empty() const { return _prev == this; }
     bool is_on_list() const { return !empty(); }
 

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -1334,7 +1334,7 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   decode(struct_v, bl);						\
   decode(struct_compat, bl);						\
   if (v < struct_compat)						\
-    throw buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, v, struct_compat)); \
+    throw ::ceph::buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, v, struct_compat)); \
   __u32 struct_len;							\
   decode(struct_len, bl);						\
   if (struct_len > bl.get_remaining())					\
@@ -1352,10 +1352,10 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
     __u8 struct_compat;							\
     decode(struct_compat, bl);					\
     if (v < struct_compat)						\
-      throw buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, v, struct_compat)); \
+      throw ::ceph::buffer::malformed_input(DECODE_ERR_OLDVERSION(__PRETTY_FUNCTION__, v, struct_compat)); \
   } else if (skip_v) {							\
     if (bl.get_remaining() < skip_v)					\
-      throw buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
+      throw ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
     bl.advance(skip_v);							\
   }									\
   unsigned struct_end = 0;						\
@@ -1363,7 +1363,7 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
     __u32 struct_len;							\
     decode(struct_len, bl);						\
     if (struct_len > bl.get_remaining())				\
-      throw buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
+      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
     struct_end = bl.get_off() + struct_len;				\
   }									\
   do {
@@ -1394,7 +1394,7 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
     __u8 struct_compat;							\
     decode(struct_compat, bl);						\
     if (v < struct_compat)						\
-      throw buffer::malformed_input(DECODE_ERR_OLDVERSION(		\
+      throw ::ceph::buffer::malformed_input(DECODE_ERR_OLDVERSION(	\
 	__PRETTY_FUNCTION__, v, struct_compat));			\
   }									\
   unsigned struct_end = 0;						\
@@ -1402,7 +1402,7 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
     __u32 struct_len;							\
     decode(struct_len, bl);						\
     if (struct_len > bl.get_remaining())				\
-      throw buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
+      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
     struct_end = bl.get_off() + struct_len;				\
   }									\
   do {
@@ -1439,7 +1439,7 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   } while (false);							\
   if (struct_end) {							\
     if (bl.get_off() > struct_end)					\
-      throw buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
+      throw ::ceph::buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
     if (bl.get_off() < struct_end)					\
       bl.advance(struct_end - bl.get_off());				\
   }
@@ -1455,9 +1455,9 @@ inline ssize_t decode_file(int fd, std::string &str)
   bufferlist bl;
   __u32 len = 0;
   bl.read_fd(fd, sizeof(len));
-  decode(len, bl);                                                                                                  
+  decode(len, bl);
   bl.read_fd(fd, len);
-  decode(str, bl);                                                                                                  
+  decode(str, bl);
   return bl.length();
 }
 

--- a/src/include/filepath.h
+++ b/src/include/filepath.h
@@ -38,14 +38,14 @@
 
 class filepath {
   inodeno_t ino;   // base inode.  ino=0 implies pure relative path.
-  string path;     // relative path.
+  std::string path;     // relative path.
 
   /** bits - path segments
    * this is ['a', 'b', 'c'] for both the aboslute and relative case.
    *
    * NOTE: this value is LAZILY maintained... i.e. it's a cache
    */
-  mutable vector<string> bits;
+  mutable std::vector<std::string> bits;
   bool encoded;
 
   void rebuild_path() {
@@ -74,7 +74,7 @@ class filepath {
  public:
   filepath() : ino(0), encoded(false) { }
   filepath(std::string_view s, inodeno_t i) : ino(i), path(s), encoded(false) { }
-  filepath(const string& s, inodeno_t i) : ino(i), path(s), encoded(false) { }
+  filepath(const std::string& s, inodeno_t i) : ino(i), path(s), encoded(false) { }
   filepath(const char* s, inodeno_t i) : ino(i), path(s), encoded(false) { }
   filepath(const filepath& o) {
     ino = o.ino;
@@ -113,7 +113,7 @@ class filepath {
 
   // accessors
   inodeno_t get_ino() const { return ino; }
-  const string& get_path() const { return path; }
+  const std::string& get_path() const { return path; }
   const char *c_str() const { return path.c_str(); }
 
   int length() const { return path.length(); }
@@ -127,12 +127,12 @@ class filepath {
   bool pure_relative() const { return ino == 0; }
   bool ino_relative() const { return ino > 0; }
   
-  const string& operator[](int i) const {
+  const std::string& operator[](int i) const {
     if (bits.empty() && path.length() > 0) parse_bits();
     return bits[i];
   }
 
-  const string& last_dentry() const {
+  const std::string& last_dentry() const {
     if (bits.empty() && path.length() > 0) parse_bits();
     ceph_assert(!bits.empty());
     return bits[ bits.size()-1 ];
@@ -166,7 +166,7 @@ class filepath {
       parse_bits();
     bits.pop_back();
     rebuild_path();
-  }    
+  }
   void push_dentry(std::string_view s) {
     if (bits.empty() && path.length() > 0) 
       parse_bits();
@@ -175,13 +175,13 @@ class filepath {
     path += s;
     bits.emplace_back(s);
   }
-  void push_dentry(const string& s) {
+  void push_dentry(const std::string& s) {
     push_dentry(std::string_view(s));
   }
   void push_dentry(const char *cs) {
     push_dentry(std::string_view(cs, strlen(cs)));
   }
-  void push_front_dentry(const string& s) {
+  void push_front_dentry(const std::string& s) {
     bits.insert(bits.begin(), s);
     rebuild_path();
   }
@@ -192,14 +192,14 @@ class filepath {
   }
 
   // encoding
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 1;
     encode(struct_v, bl);
     encode(ino, bl);
     encode(path, bl);
   }
-  void decode(bufferlist::const_iterator& blp) {
+  void decode(ceph::buffer::list::const_iterator& blp) {
     using ceph::decode;
     bits.clear();
     __u8 struct_v;
@@ -208,11 +208,11 @@ class filepath {
     decode(path, blp);
     encoded = true;
   }
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_unsigned("base_ino", ino);
     f->dump_string("relative_path", path);
   }
-  static void generate_test_instances(list<filepath*>& o) {
+  static void generate_test_instances(std::list<filepath*>& o) {
     o.push_back(new filepath);
     o.push_back(new filepath("/usr/bin", 0));
     o.push_back(new filepath("/usr/sbin", 1));
@@ -234,7 +234,7 @@ class filepath {
 
 WRITE_CLASS_ENCODER(filepath)
 
-inline ostream& operator<<(ostream& out, const filepath& path)
+inline std::ostream& operator<<(std::ostream& out, const filepath& path)
 {
   if (path.get_ino()) {
     out << '#' << path.get_ino();

--- a/src/include/frag.h
+++ b/src/include/frag.h
@@ -15,12 +15,11 @@
 #ifndef CEPH_FRAG_H
 #define CEPH_FRAG_H
 
-#include <boost/container/small_vector.hpp>
-
+#include <cstdint>
+#include <cstdio>
 #include <iostream>
 
-#include <stdint.h>
-#include <stdio.h>
+#include <boost/container/small_vector.hpp>
 
 #include "buffer.h"
 #include "compact_map.h"
@@ -90,7 +89,7 @@ public:
 
   // constructors
   void from_unsigned(unsigned e) { _enc = e; }
-  
+
   // accessors
   unsigned value() const { return ceph_frag_value(_enc); }
   unsigned bits() const { return ceph_frag_bits(_enc); }
@@ -151,12 +150,12 @@ public:
     return false;
   }
 
-  void encode(bufferlist& bl) const {
-    encode_raw(_enc, bl);
+  void encode(ceph::buffer::list& bl) const {
+    ceph::encode_raw(_enc, bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     __u32 v;
-    decode_raw(v, p);
+    ceph::decode_raw(v, p);
     _enc = v;
   }
 
@@ -170,13 +169,13 @@ inline std::ostream& operator<<(std::ostream& out, const frag_t& hb)
   unsigned num = hb.bits();
   if (num) {
     unsigned val = hb.value();
-    for (unsigned bit = 23; num; num--, bit--) 
+    for (unsigned bit = 23; num; num--, bit--)
       out << ((val & (1<<bit)) ? '1':'0');
   }
   return out << '*';
 }
 
-inline void encode(const frag_t &f, bufferlist& bl) { f.encode(bl); }
+inline void encode(const frag_t &f, ceph::buffer::list& bl) { f.encode(bl); }
 inline void decode(frag_t &f, bufferlist::const_iterator& p) { f.decode(p); }
 
 using frag_vec_t = boost::container::small_vector<frag_t, 4>;
@@ -458,15 +457,15 @@ public:
   }
 
   // encoding
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(_splits, bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     using ceph::decode;
     decode(_splits, p);
   }
-  void encode_nohead(bufferlist& bl) const {
+  void encode_nohead(ceph::buffer::list& bl) const {
     using ceph::encode;
     for (compact_map<frag_t,int32_t>::const_iterator p = _splits.begin();
 	 p != _splits.end();
@@ -475,7 +474,7 @@ public:
       encode(p->second, bl);
     }
   }
-  void decode_nohead(int n, bufferlist::const_iterator& p) {
+  void decode_nohead(int n, ceph::buffer::list::const_iterator& p) {
     using ceph::decode;
     _splits.clear();
     while (n-- > 0) {
@@ -508,7 +507,7 @@ public:
     out << ")";
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->open_array_section("splits");
     for (compact_map<frag_t,int32_t>::const_iterator p = _splits.begin();
          p != _splits.end();

--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -29,6 +29,7 @@ struct inodeno_t {
 } __attribute__ ((__may_alias__));
 WRITE_CLASS_ENCODER(inodeno_t)
 
+namespace ceph {
 template<>
 struct denc_traits<inodeno_t> {
   static constexpr bool supported = true;
@@ -45,6 +46,7 @@ struct denc_traits<inodeno_t> {
     denc(o.val, p);
   }
 };
+}
 
 inline ostream& operator<<(ostream& out, const inodeno_t& ino) {
   return out << hex << "0x" << ino.val << dec;

--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -18,11 +18,11 @@ struct inodeno_t {
   inodeno_t operator+=(inodeno_t o) { val += o.val; return *this; }
   operator _inodeno_t() const { return val; }
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(val, bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     using ceph::decode;
     decode(val, p);
   }
@@ -48,8 +48,8 @@ struct denc_traits<inodeno_t> {
 };
 }
 
-inline ostream& operator<<(ostream& out, const inodeno_t& ino) {
-  return out << hex << "0x" << ino.val << dec;
+inline std::ostream& operator<<(std::ostream& out, const inodeno_t& ino) {
+  return out << std::hex << "0x" << ino.val << std::dec;
 }
 
 namespace std {
@@ -92,7 +92,7 @@ struct file_layout_t {
   uint32_t object_size;   ///< until objects are this big
 
   int64_t pool_id;        ///< rados pool id
-  string pool_ns;         ///< rados pool namespace
+  std::string pool_ns;         ///< rados pool namespace
 
   file_layout_t(uint32_t su=0, uint32_t sc=0, uint32_t os=0)
     : stripe_unit(su),
@@ -114,15 +114,15 @@ struct file_layout_t {
 
   bool is_valid() const;
 
-  void encode(bufferlist& bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<file_layout_t*>& o);
+  void encode(ceph::buffer::list& bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<file_layout_t*>& o);
 };
 WRITE_CLASS_ENCODER_FEATURES(file_layout_t)
 
 WRITE_EQ_OPERATORS_5(file_layout_t, stripe_unit, stripe_count, object_size, pool_id, pool_ns);
 
-ostream& operator<<(ostream& out, const file_layout_t &layout);
+std::ostream& operator<<(std::ostream& out, const file_layout_t &layout);
 
 #endif

--- a/src/include/hash.h
+++ b/src/include/hash.h
@@ -1,6 +1,8 @@
 #ifndef CEPH_HASH_H
 #define CEPH_HASH_H
 
+#include <cstdlib>
+#include <cstdint>
 #include "acconfig.h"
 
 // Robert Jenkins' function for mixing 32-bit values
@@ -23,7 +25,7 @@
 
 template <class _Key> struct rjhash { };
 
-inline uint64_t rjhash64(uint64_t key) {
+inline std::uint64_t rjhash64(std::uint64_t key) {
   key = (~key) + (key << 21); // key = (key << 21) - key - 1;
   key = key ^ (key >> 24);
   key = (key + (key << 3)) + (key << 8); // key * 265
@@ -34,7 +36,7 @@ inline uint64_t rjhash64(uint64_t key) {
   return key;
 }
 
-inline uint32_t rjhash32(uint32_t a) {
+inline std::uint32_t rjhash32(std::uint32_t a) {
   a = (a+0x7ed55d16) + (a<<12);
   a = (a^0xc761c23c) ^ (a>>19);
   a = (a+0x165667b1) + (a<<5);
@@ -45,14 +47,14 @@ inline uint32_t rjhash32(uint32_t a) {
 }
 
 
-template<> struct rjhash<uint32_t> {
-  inline size_t operator()(const uint32_t x) const {
+template<> struct rjhash<std::uint32_t> {
+  inline std::size_t operator()(const std::uint32_t x) const {
     return rjhash32(x);
   }
 };
 
-template<> struct rjhash<uint64_t> {
-  inline size_t operator()(const uint64_t x) const {
+template<> struct rjhash<std::uint64_t> {
+  inline std::size_t operator()(const std::uint64_t x) const {
     return rjhash64(x);
   }
 };

--- a/src/include/health.h
+++ b/src/include/health.h
@@ -26,6 +26,7 @@ inline void decode(health_status_t& hs, bufferlist::const_iterator& p) {
   decode(v, p);
   hs = health_status_t(v);
 }
+namespace ceph {
 template<>
 struct denc_traits<health_status_t> {
   static constexpr bool supported = true;
@@ -53,6 +54,7 @@ struct denc_traits<health_status_t> {
     v = health_status_t(tmp);
   }
 };
+}
 
 inline std::ostream& operator<<(std::ostream &oss, const health_status_t status) {
   switch (status) {

--- a/src/include/health.h
+++ b/src/include/health.h
@@ -15,12 +15,12 @@ enum health_status_t {
   HEALTH_OK = 2,
 };
 
-inline void encode(health_status_t hs, bufferlist& bl) {
+inline void encode(health_status_t hs, ceph::buffer::list& bl) {
   using ceph::encode;
   uint8_t v = hs;
   encode(v, bl);
 }
-inline void decode(health_status_t& hs, bufferlist::const_iterator& p) {
+inline void decode(health_status_t& hs, ceph::buffer::list::const_iterator& p) {
   using ceph::decode;
   uint8_t v;
   decode(v, p);
@@ -39,18 +39,21 @@ struct denc_traits<health_status_t> {
   static void encode(const health_status_t& v,
 		     buffer::list::contiguous_appender& p,
 		     uint64_t f=0) {
-    ::denc((uint8_t)v, p);
+    using ceph::denc;
+    denc((uint8_t)v, p);
   }
   static void decode(health_status_t& v, buffer::ptr::const_iterator& p,
 		     uint64_t f=0) {
     uint8_t tmp;
-    ::denc(tmp, p);
+    using ceph::denc;
+    denc(tmp, p);
     v = health_status_t(tmp);
   }
   static void decode(health_status_t& v, buffer::list::const_iterator& p,
 		     uint64_t f=0) {
     uint8_t tmp;
-    ::denc(tmp, p);
+    using ceph::denc;
+    denc(tmp, p);
     v = health_status_t(tmp);
   }
 };

--- a/src/include/inline_memory.h
+++ b/src/include/inline_memory.h
@@ -14,15 +14,19 @@
 #ifndef CEPH_INLINE_MEMORY_H
 #define CEPH_INLINE_MEMORY_H
 
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+
 #if defined(__GNUC__)
 
 // optimize for the common case, which is very small copies
 static inline void *maybe_inline_memcpy(void *dest, const void *src, size_t l,
-				       size_t inline_len)
+					size_t inline_len)
   __attribute__((always_inline));
 
 void *maybe_inline_memcpy(void *dest, const void *src, size_t l,
-			 size_t inline_len)
+			  size_t inline_len)
 {
   if (l > inline_len) {
     return memcpy(dest, src, l);

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -336,31 +336,31 @@ class interval_set {
   }
 
   void bound_encode(size_t& p) const {
-    denc_traits<Map>::bound_encode(m, p);
+    ceph::denc_traits<Map>::bound_encode(m, p);
   }
-  void encode(bufferlist::contiguous_appender& p) const {
-    denc(m, p);
+  void encode(ceph::buffer::list::contiguous_appender& p) const {
+    ceph::denc(m, p);
   }
-  void decode(bufferptr::const_iterator& p) {
-    denc(m, p);
+  void decode(ceph::buffer::ptr::const_iterator& p) {
+    ceph::denc(m, p);
     _size = 0;
     for (const auto& i : m) {
       _size += i.second;
     }
   }
-  void decode(bufferlist::iterator& p) {
-    denc(m, p);
+  void decode(ceph::buffer::list::iterator& p) {
+    ceph::denc(m, p);
     _size = 0;
     for (const auto& i : m) {
       _size += i.second;
     }
   }
 
-  void encode_nohead(bufferlist::contiguous_appender& p) const {
-    denc_traits<Map>::encode_nohead(m, p);
+  void encode_nohead(ceph::buffer::list::contiguous_appender& p) const {
+    ceph::denc_traits<Map>::encode_nohead(m, p);
   }
-  void decode_nohead(int n, bufferptr::const_iterator& p) {
-    denc_traits<Map>::decode_nohead(n, m, p);
+  void decode_nohead(int n, ceph::buffer::ptr::const_iterator& p) {
+    ceph::denc_traits<Map>::decode_nohead(n, m, p);
     _size = 0;
     for (const auto& i : m) {
       _size += i.second;
@@ -732,6 +732,7 @@ private:
 
 // declare traits explicitly because (1) it's templatized, and (2) we
 // want to include _nohead variants.
+namespace ceph {
 template<typename T, typename Map>
 struct denc_traits<interval_set<T,Map>> {
   static constexpr bool supported = true;
@@ -762,6 +763,7 @@ struct denc_traits<interval_set<T,Map>> {
     v.decode_nohead(n, p);
   }
 };
+}
 
 
 template<class T, typename Map>

--- a/src/include/lru.h
+++ b/src/include/lru.h
@@ -17,10 +17,9 @@
 #ifndef CEPH_LRU_H
 #define CEPH_LRU_H
 
-#include <math.h>
-#include <stdint.h>
+#include <cmath>
+#include <cstdint>
 
-#include "common/config.h"
 #include "xlist.h"
 
 class LRUObject {

--- a/src/include/object.h
+++ b/src/include/object.h
@@ -126,6 +126,7 @@ struct snapid_t {
 inline void encode(snapid_t i, bufferlist &bl) { encode(i.val, bl); }
 inline void decode(snapid_t &i, bufferlist::const_iterator &p) { decode(i.val, p); }
 
+namespace ceph {
 template<>
 struct denc_traits<snapid_t> {
   static constexpr bool supported = true;
@@ -142,6 +143,7 @@ struct denc_traits<snapid_t> {
     denc(o.val, p);
   }
 };
+}
 
 inline ostream& operator<<(ostream& out, const snapid_t& s) {
   if (s == CEPH_NOSNAP)

--- a/src/include/page.h
+++ b/src/include/page.h
@@ -14,5 +14,3 @@ namespace ceph {
 #define CEPH_PAGE_SIZE ceph::_page_size
 #define CEPH_PAGE_MASK ceph::_page_mask
 #define CEPH_PAGE_SHIFT ceph::_page_shift
-
-

--- a/src/include/rangeset.h
+++ b/src/include/rangeset.h
@@ -22,22 +22,26 @@
  *
  */
 
+#include <iostream>
 #include <map>
+#include <utility>
+
+#include "fs_types.h"
 
 //typedef int T;
 
 template <class T>
 struct _rangeset_base {
-  map<T,T> ranges;  // pair(first,last) (inclusive, e.g. [first,last])
-                    
-  typedef typename map<T,T>::iterator mapit;
+  std::map<T,T> ranges;  // pair(first,last) (inclusive, e.g. [first,last])
+
+  typedef typename std::map<T,T>::iterator mapit;
 
   // get iterator for range including val.  or ranges.end().
   mapit get_range_for(T val) {
     mapit it = ranges.lower_bound(val);
     if (it == ranges.end()) {
       // search backwards
-      typename map<T,T>::reverse_iterator it = ranges.rbegin();
+      typename std::map<T,T>::reverse_iterator it = ranges.rbegin();
       if (it == ranges.rend()) return ranges.end();
       if (it->first <= val && it->second >= val)
         return ranges.find(it->first);
@@ -60,15 +64,16 @@ class rangeset_iterator :
 {
   //typedef typename map<T,T>::iterator mapit;
 
-  map<T,T> ranges;
-  typename map<T,T>::iterator it;
+  std::map<T,T> ranges;
+  typename std::map<T,T>::iterator it;
   T current;
 
 public:
   // cons
   rangeset_iterator() {}
 
-  rangeset_iterator(typename map<T,T>::iterator& it, map<T,T>& ranges) {
+  rangeset_iterator(typename std::map<T,T>::iterator& it,
+		    std::map<T,T>& ranges) {
     this->ranges = ranges;
     this->it = it;
     if (this->it != ranges.end())
@@ -103,7 +108,7 @@ public:
 template <class T>
 class rangeset
 {
-  typedef typename map<T,T>::iterator map_iterator;
+  typedef typename std::map<T,T>::iterator map_iterator;
 
   _rangeset_base<T> theset;
   inodeno_t _size;
@@ -133,7 +138,7 @@ public:
   }
 
   void map_insert(T v1, T v2) {
-    theset.ranges.insert(pair<T,T>(v1,v2));
+    theset.ranges.insert(std::pair<T,T>(v1,v2));
     _size += v2 - v1+1;
   }
 
@@ -169,14 +174,14 @@ public:
 
     if (right != theset.ranges.end()) {
       // add to right range
-      theset.ranges.insert(pair<T,T>(val, right->second));
+      theset.ranges.insert(std::pair<T,T>(val, right->second));
       theset.ranges.erase(val+1);
       _size++;
       return;
     }
 
     // new range
-    theset.ranges.insert(pair<T,T>(val,val));
+    theset.ranges.insert(std::pair<T,T>(val,val));
     _size++;
     return;
   }
@@ -215,10 +220,10 @@ public:
 
     // beginning
     if (val == it->first) {
-      theset.ranges.insert(pair<T,T>(val+1, it->second));
+      theset.ranges.insert(std::pair<T,T>(val+1, it->second));
       theset.ranges.erase(it);
       _size--;
-      return;      
+      return;
     }
 
     // end
@@ -229,18 +234,18 @@ public:
     }
 
     // middle split
-    theset.ranges.insert(pair<T,T>(it->first, val-1));
-    theset.ranges.insert(pair<T,T>(val+1, it->second));
+    theset.ranges.insert(std::pair<T,T>(it->first, val-1));
+    theset.ranges.insert(std::pair<T,T>(val+1, it->second));
     theset.ranges.erase(it);
     _size--;
     return;
   }
 
   void dump() {
-    for (typename map<T,T>::iterator it = theset.ranges.begin();
+    for (auto it = theset.ranges.begin();
          it != theset.ranges.end();
          it++) {
-      cout << " " << it->first << "-" << it->second << endl;
+      std::cout << " " << it->first << "-" << it->second << std::endl;
     }
   }
 

--- a/src/include/rbd_types.h
+++ b/src/include/rbd_types.h
@@ -1,3 +1,4 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 /*
  * Ceph - scalable distributed file system
  *

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -2,6 +2,7 @@
 #define CEPH_STAT_H
 
 #include <acconfig.h>
+#include <stdint.h>
 
 #include <sys/stat.h>
 

--- a/src/include/timegm.h
+++ b/src/include/timegm.h
@@ -1,3 +1,4 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 //  (C) Copyright Howard Hinnant
 //  (C) Copyright 2010-2011 Vicente J. Botet Escriba
 //  Use, modification and distribution are subject to the Boost Software License,
@@ -19,7 +20,8 @@
 #ifndef BOOST_CHRONO_IO_TIME_POINT_IO_H
 #define BOOST_CHRONO_IO_TIME_POINT_IO_H
 
-#include <time.h>
+#include <cstdint>
+#include <ctime>
 
 static int32_t is_leap(int32_t year) {
   if(year % 400 == 0)
@@ -51,7 +53,7 @@ static int32_t days_from_1jan(int32_t year,int32_t month,int32_t day) {
   return days[is_leap(year)][month-1] + day - 1;
 }
 
-static  time_t internal_timegm(tm const *t) {
+inline time_t internal_timegm(tm const *t) {
   int year = t->tm_year + 1900;
   int month = t->tm_mon;
   if(month > 11)

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -14,6 +14,11 @@
 #ifndef CEPH_UTIL_H
 #define CEPH_UTIL_H
 
+#include <cstdint>
+#include <list>
+#include <map>
+#include <string>
+
 #include "common/Formatter.h"
 #include "include/types.h"
 
@@ -33,7 +38,7 @@ struct ceph_data_stats
     avail_percent(0)
   { }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     ceph_assert(f != NULL);
     f->dump_int("total", byte_total);
     f->dump_int("used", byte_used);
@@ -41,7 +46,7 @@ struct ceph_data_stats
     f->dump_int("avail_percent", avail_percent);
   }
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(byte_total, bl);
     encode(byte_used, bl);
@@ -50,7 +55,7 @@ struct ceph_data_stats
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator &p) {
+  void decode(ceph::buffer::list::const_iterator &p) {
     DECODE_START(1, p);
     decode(byte_total, p);
     decode(byte_used, p);
@@ -59,7 +64,7 @@ struct ceph_data_stats
     DECODE_FINISH(p);
   }
 
-  static void generate_test_instances(list<ceph_data_stats*>& ls) {
+  static void generate_test_instances(std::list<ceph_data_stats*>& ls) {
     ls.push_back(new ceph_data_stats);
     ls.push_back(new ceph_data_stats);
     ls.back()->byte_total = 1024*1024;
@@ -77,21 +82,25 @@ int get_fs_stats(ceph_data_stats_t &stats, const char *path);
 int get_cgroup_memory_limit(uint64_t *limit);
 
 /// collect info from @p uname(2), @p /proc/meminfo and @p /proc/cpuinfo
-void collect_sys_info(map<string, string> *m, CephContext *cct);
+void collect_sys_info(std::map<std::string, std::string> *m, CephContext *cct);
 
 /// dump service ids grouped by their host to the specified formatter
 /// @param f formatter for the output
 /// @param services a map from hostname to a list of service id hosted by this host
 /// @param type the service type of given @p services, for example @p osd or @p mon.
-void dump_services(Formatter* f, const map<string, list<int> >& services, const char* type);
+void dump_services(ceph::Formatter* f,
+		   const std::map<std::string,std::list<int> >& services,
+		   const char* type);
 /// dump service names grouped by their host to the specified formatter
 /// @param f formatter for the output
 /// @param services a map from hostname to a list of service name hosted by this host
 /// @param type the service type of given @p services, for example @p osd or @p mon.
-void dump_services(Formatter* f, const map<string, list<string> >& services, const char* type);
+void dump_services(ceph::Formatter* f,
+		   const std::map<std::string, std::list<std::string>>& services,
+		   const char* type);
 
-string cleanbin(bufferlist &bl, bool &b64);
-string cleanbin(string &str);
+std::string cleanbin(ceph::buffer::list &bl, bool &b64);
+std::string cleanbin(std::string &str);
 
 namespace ceph::util {
 

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -1,3 +1,4 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
 #ifndef _CEPH_UUID_H
 #define _CEPH_UUID_H
 
@@ -53,12 +54,12 @@ struct uuid_d {
     return (char*)uuid.data;
   }
 
-  void encode(bufferlist& bl) const {
-    ::encode_raw(uuid, bl);
+  void encode(ceph::buffer::list& bl) const {
+    ceph::encode_raw(uuid, bl);
   }
 
-  void decode(bufferlist::const_iterator& p) const {
-    ::decode_raw(uuid, p);
+  void decode(ceph::bufferlist::const_iterator& p) const {
+    ceph::decode_raw(uuid, p);
   }
 };
 WRITE_CLASS_ENCODER(uuid_d)

--- a/src/mgr/OSDPerfMetricTypes.h
+++ b/src/mgr/OSDPerfMetricTypes.h
@@ -76,6 +76,7 @@ std::ostream& operator<<(std::ostream& os,
 
 typedef std::vector<OSDPerfMetricSubKeyDescriptor> OSDPerfMetricKeyDescriptor;
 
+namespace ceph {
 template<>
 struct denc_traits<OSDPerfMetricKeyDescriptor> {
   static constexpr bool supported = true;
@@ -125,6 +126,7 @@ struct denc_traits<OSDPerfMetricKeyDescriptor> {
     }
   }
 };
+}
 
 typedef std::pair<uint64_t,uint64_t> PerformanceCounter;
 typedef std::vector<PerformanceCounter> PerformanceCounters;
@@ -196,6 +198,7 @@ std::ostream& operator<<(std::ostream& os,
 
 typedef std::vector<PerformanceCounterDescriptor> PerformanceCounterDescriptors;
 
+namespace ceph {
 template<>
 struct denc_traits<PerformanceCounterDescriptors> {
   static constexpr bool supported = true;
@@ -233,6 +236,7 @@ struct denc_traits<PerformanceCounterDescriptors> {
     }
   }
 };
+}
 
 struct OSDPerfMetricLimit {
   PerformanceCounterDescriptor order_by;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -112,6 +112,7 @@ ostream& operator<<(ostream& out, const bluestore_pextent_t& o);
 
 typedef mempool::bluestore_cache_other::vector<bluestore_pextent_t> PExtentVector;
 
+namespace ceph {
 template<>
 struct denc_traits<PExtentVector> {
   static constexpr bool supported = true;
@@ -144,6 +145,7 @@ struct denc_traits<PExtentVector> {
     }
   }
 };
+}
 
 /// extent_map: a map of reference counted extents
 struct bluestore_extent_ref_map_t {


### PR DESCRIPTION
I've long wanted to clean up the `using namespace` in headers pattern, but doing the whole thing in ONE GIGANTIC PUSH always ended up taking so long as to never get finished

So let's try a chunk at a time. Here's everything in src/include cleaned up so that it should work without `using namespace ceph` or `using namespace std`