### PR TITLE
crimson/osd: call at_exit() before stopping the engine

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -103,13 +103,6 @@ int main(int argc, char* argv[])
           reference_wrapper<ceph::net::Messenger>(client_msgr.local()),
           reference_wrapper<ceph::net::Messenger>(hb_front_msgr.local()),
           reference_wrapper<ceph::net::Messenger>(hb_back_msgr.local())).get();
-        if (config.count("mkfs")) {
-          osd.invoke_on(0, &OSD::mkfs,
-                        local_conf().get_val<uuid_d>("fsid"))
-            .then([] { seastar::engine().exit(0); }).get();
-        } else {
-          osd.invoke_on(0, &OSD::start).get();
-        }
         seastar::engine().at_exit([&] {
           return osd.stop();
         });
@@ -125,6 +118,14 @@ int main(int argc, char* argv[])
         seastar::engine().at_exit([] {
           return sharded_conf().stop();
         });
+
+        if (config.count("mkfs")) {
+          osd.invoke_on(0, &OSD::mkfs,
+                        local_conf().get_val<uuid_d>("fsid"))
+            .then([] { seastar::engine().exit(0); }).get();
+        } else {
+          osd.invoke_on(0, &OSD::start).get();
+        }
       });
     });
   } catch (...) {


### PR DESCRIPTION
if we mkfs and stop the engine, any calls using the engine should/will
fail after `seastar::engine().exit(0)`. in the case of reactor::at_exit(),
it has:

assert(!_stopping);

in this change, we register the at_exit() calls before scheduling the
`engine().exit(0)` call.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

