### PR TITLE
mimic: rgw: nfs: skip empty (non-POSIX) path segments

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -1442,7 +1442,7 @@ public:
   int operator()(const boost::string_ref name, const rgw_obj_key& marker,
 		uint8_t type) {
 
-    assert(name.length() > 0); // XXX
+    assert(name.length() > 0); // all cases handled in callers
 
     /* hash offset of name in parent (short name) for NFS readdir cookie */
     uint64_t off = XXH64(name.data(), name.length(), fh_key::seed);
@@ -1527,6 +1527,12 @@ public:
 			     << " prefix=" << prefix << " "
 			     << " cpref=" << sref
 			     << dendl;
+
+      if (sref.empty()) {
+	/* null path segment--could be created in S3 but has no NFS
+	 * interpretation */
+	return;
+      }
 
       this->operator()(sref, next_marker, RGW_FS_TYPE_DIRECTORY);
       ++ix;


### PR DESCRIPTION
http://tracker.ceph.com/issues/38772