### PR TITLE
test/test_weighted_shuffle: enlarge epsilon

### DIFF
--- a/src/test/test_weighted_shuffle.cc
+++ b/src/test/test_weighted_shuffle.cc
@@ -27,7 +27,7 @@ TEST(WeightedShuffle, Basic) {
   // verify that the probability that the nth choice is selected as the first
   // one is the nth weight divided by the sum of all weights
   const auto total_weight = std::accumulate(weights.begin(), weights.end(), 0);
-  constexpr float epsilon = 0.01;
+  constexpr float epsilon = 0.02;
   for (unsigned i = 0; i < choices.size(); i++) {
     const auto& f = frequency[choices[i]];
     const auto& w = weights[i];


### PR DESCRIPTION
be more permissive to address the following failure:
```
test_weighted_shuffle.cc:36: Failure
The difference between float(w) / total_weight and float(f.front()) /
samples is 0.010334432125091553, which exceeds epsilon, where
float(w) / total_weight evaluates to 0.53763443231582642,
float(f.front()) / samples evaluates to 0.52730000019073486, and
epsilon evaluates to 0.0099999997764825821
```
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

