### PR TITLE
mimic:common/buffer add advance(unsigned int) ,Since advance(uint) is called in many places

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1195,6 +1195,29 @@ public:
   }
 
   template<bool is_const>
+  void buffer::list::iterator_impl<is_const>::advance(unsigned int o)
+  {
+    const unsigned int max_adv = std::numeric_limits<unsigned int>::max();
+    assert(o <= max_adv - p_off);
+    assert(o <= max_adv - off);
+    p_off += o;
+    while (p_off > 0) {
+      if (p == ls->end())
+        throw end_of_buffer();
+      if (p_off >= p->length()) {
+        // skip this buffer
+        p_off -= p->length();
+        p++;
+      } else {
+        // somewhere in this buffer!
+        break;
+      }
+    }
+    off += o;
+    return;
+  }
+
+  template<bool is_const>
   void buffer::list::iterator_impl<is_const>::seek(unsigned o)
   {
     p = ls->begin();
@@ -1394,6 +1417,11 @@ public:
   {}
 
   void buffer::list::iterator::advance(int o)
+  {
+    buffer::list::iterator_impl<false>::advance(o);
+  }
+
+  void buffer::list::iterator::advance(unsigned int o)
   {
     buffer::list::iterator_impl<false>::advance(o);
   }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -410,6 +410,7 @@ namespace buffer CEPH_BUFFER_API {
       }
 
       void advance(int o);
+      void advance(unsigned int o);
       void seek(unsigned o);
       char operator*() const;
       iterator_impl& operator++();
@@ -456,6 +457,7 @@ namespace buffer CEPH_BUFFER_API {
       iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po);
 
       void advance(int o);
+      void advance(unsigned int o);
       void seek(unsigned o);
       using iterator_impl<false>::operator*;
       char operator*();


### PR DESCRIPTION
There is only advance(int) ,but advance(unsigned int ) is called in many place .For example ,data_blp.advance in msg/async/AsyncConnection.cc and blp.advance(offset) in msg/simple/Pipe.cc.
So add the function advance(unsigned int) to avoid int overflow.
Signed-off-by: Shen Hang <harryshen18@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

