### PR TITLE
Trivial comment and cleanup fixes for cephfs

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6322,7 +6322,7 @@ int Client::_lookup(Inode *dir, const string& dname, int mask, InodeRef *target,
 	ldout(cct, 20) << " bad lease, cap_ttl " << s.cap_ttl << ", cap_gen " << s.cap_gen
 		       << " vs lease_gen " << dn->lease_gen << dendl;
       }
-      // dir lease?
+      // dir shared caps?
       if (dir->caps_issued_mask(CEPH_CAP_FILE_SHARED, true)) {
 	if (dn->cap_shared_gen == dir->shared_gen &&
 	    (!dn->inode || dn->inode->caps_issued_mask(mask, true)))

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -7,6 +7,7 @@
  */
 
 #include <string.h>
+#include <stdbool.h>
 #include "msgr.h"
 
 /*
@@ -395,7 +396,7 @@ static inline int ceph_osd_op_mode_cache(int op)
 {
 	return op & CEPH_OSD_OP_MODE_CACHE;
 }
-static inline int ceph_osd_op_uses_extent(int op)
+static inline bool ceph_osd_op_uses_extent(int op)
 {
 	switch(op) {
 	case CEPH_OSD_OP_READ:

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3003,14 +3003,14 @@ void Locker::process_request_cap_release(MDRequestRef& mdr, client_t client, con
       if (dn) {
 	ClientLease *l = dn->get_client_lease(client);
 	if (l) {
-	  dout(10) << "process_cap_release removing lease on " << *dn << dendl;
+	  dout(10) << __func__ << " removing lease on " << *dn << dendl;
 	  dn->remove_client_lease(l, this);
 	} else {
-	  dout(7) << "process_cap_release client." << client
+	  dout(7) << __func__ << " client." << client
 		  << " doesn't have lease on " << *dn << dendl;
 	}
       } else {
-	dout(7) << "process_cap_release client." << client << " released lease on dn "
+	dout(7) << __func__ << " client." << client << " released lease on dn "
 		<< dir->dirfrag() << "/" << dname << " which dne" << dendl;
       }
     }
@@ -3020,7 +3020,7 @@ void Locker::process_request_cap_release(MDRequestRef& mdr, client_t client, con
   if (!cap)
     return;
 
-  dout(10) << "process_cap_release client." << client << " " << ccap_string(caps) << " on " << *in
+  dout(10) << __func__ << " client." << client << " " << ccap_string(caps) << " on " << *in
 	   << (mdr ? "" : " (DEFERRED, no mdr)")
 	   << dendl;
     

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -234,8 +234,8 @@ typedef boost::intrusive_ptr<MutationImpl> MutationRef;
 
 
 
-/** active_request_t
- * state we track for requests we are currently processing.
+/**
+ * MDRequestImpl: state we track for requests we are currently processing.
  * mostly information about locks held, so that we can drop them all
  * the request is finished or forwarded.  see request_*().
  */

--- a/src/mds/locks.c
+++ b/src/mds/locks.c
@@ -1,8 +1,3 @@
-// there must be a better way?
-typedef char bool;
-#define false 0
-#define true  1
-
 #include "include/int_types.h"
 
 #include <string.h>

--- a/src/mds/locks.h
+++ b/src/mds/locks.h
@@ -1,10 +1,10 @@
-
 #ifndef CEPH_MDS_LOCKS_H
 #define CEPH_MDS_LOCKS_H
+#include <stdbool.h>
 
 struct sm_state_t {
   int next;         // 0 if stable
-  char loner;
+  bool loner;
   int replica_state;
   char can_read;
   char can_read_projected;

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -542,8 +542,8 @@ void session_info_t::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("used_inos");
-  for (interval_set<inodeno_t>::const_iterator p = prealloc_inos.begin();
-       p != prealloc_inos.end();
+  for (interval_set<inodeno_t>::const_iterator p = used_inos.begin();
+       p != used_inos.end();
        ++p) {
     f->open_object_section("ino_range");
     f->dump_unsigned("start", p.get_start());


### PR DESCRIPTION
Just a small set of cleanups, mostly in the MDS code, but one comment fix in client. The only thing that might break something is the switch to stdbool.h, but it seems to be working properly for me.