### PR TITLE
pybind: fix use of WriteOpCtx and ReadOpCtx

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -1477,7 +1477,7 @@ class CephFSVolumeClient(object):
             raise CephFSVolumeClientError(msg)
 
         try:
-            with rados.WriteOpCtx(ioctx) as wop:
+            with rados.WriteOpCtx() as wop:
                 if version is not None:
                     wop.assert_version(version)
                 wop.write_full(data)

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -441,23 +441,23 @@ class TestIoctx(object):
     def test_set_omap(self):
         keys = ("1", "2", "3", "4")
         values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04")
-        with WriteOpCtx(self.ioctx) as write_op:
+        with WriteOpCtx() as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             write_op.set_flags(LIBRADOS_OPERATION_SKIPRWLOCKS)
             self.ioctx.operate_write_op(write_op, "hw")
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 4)
             eq(ret, 0)
             self.ioctx.operate_read_op(read_op, "hw")
             next(iter)
             eq(list(iter), [("2", b"bbb"), ("3", b"ccc"), ("4", b"\x04\x04\x04\x04")])
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_vals(read_op, "2", "", 4)
             eq(ret, 0)
             self.ioctx.operate_read_op(read_op, "hw")
             eq(("3", b"ccc"), next(iter))
             eq(list(iter), [("4", b"\x04\x04\x04\x04")])
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_vals(read_op, "", "2", 4)
             eq(ret, 0)
             read_op.set_flags(LIBRADOS_OPERATION_BALANCE_READS)
@@ -475,7 +475,7 @@ class TestIoctx(object):
 
         keys = ("1", "2", "3", "4")
         values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04")
-        with WriteOpCtx(self.ioctx) as write_op:
+        with WriteOpCtx() as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             comp = self.ioctx.operate_aio_write_op(write_op, "hw", cb, cb)
             comp.wait_for_complete()
@@ -485,7 +485,7 @@ class TestIoctx(object):
                     lock.wait()
             eq(comp.get_return_value(), 0)
 
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 4)
             eq(ret, 0)
             comp = self.ioctx.operate_aio_read_op(read_op, "hw", cb, cb)
@@ -499,7 +499,7 @@ class TestIoctx(object):
             eq(list(iter), [("2", b"bbb"), ("3", b"ccc"), ("4", b"\x04\x04\x04\x04")])
 
     def test_write_ops(self):
-        with WriteOpCtx(self.ioctx) as write_op:
+        with WriteOpCtx() as write_op:
             write_op.new(0)
             self.ioctx.operate_write_op(write_op, "write_ops")
             eq(self.ioctx.read('write_ops'), b'')
@@ -527,15 +527,15 @@ class TestIoctx(object):
     def test_get_omap_vals_by_keys(self):
         keys = ("1", "2", "3", "4")
         values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04")
-        with WriteOpCtx(self.ioctx) as write_op:
+        with WriteOpCtx() as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_vals_by_keys(read_op,("3","4",))
             eq(ret, 0)
             self.ioctx.operate_read_op(read_op, "hw")
             eq(list(iter), [("3", b"ccc"), ("4", b"\x04\x04\x04\x04")])
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_vals_by_keys(read_op,("3","4",))
             eq(ret, 0)
             with assert_raises(ObjectNotFound):
@@ -544,15 +544,15 @@ class TestIoctx(object):
     def test_get_omap_keys(self):
         keys = ("1", "2", "3")
         values = (b"aaa", b"bbb", b"ccc")
-        with WriteOpCtx(self.ioctx) as write_op:
+        with WriteOpCtx() as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_keys(read_op,"",2)
             eq(ret, 0)
             self.ioctx.operate_read_op(read_op, "hw")
             eq(list(iter), [("1", None), ("2", None)])
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_keys(read_op,"",2)
             eq(ret, 0)
             with assert_raises(ObjectNotFound):
@@ -561,13 +561,13 @@ class TestIoctx(object):
     def test_clear_omap(self):
         keys = ("1", "2", "3")
         values = (b"aaa", b"bbb", b"ccc")
-        with WriteOpCtx(self.ioctx) as write_op:
+        with WriteOpCtx() as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             self.ioctx.operate_write_op(write_op, "hw")
-        with WriteOpCtx(self.ioctx) as write_op_1:
+        with WriteOpCtx() as write_op_1:
             self.ioctx.clear_omap(write_op_1)
             self.ioctx.operate_write_op(write_op_1, "hw")
-        with ReadOpCtx(self.ioctx) as read_op:
+        with ReadOpCtx() as read_op:
             iter, ret = self.ioctx.get_omap_vals_by_keys(read_op,("1",))
             eq(ret, 0)
             self.ioctx.operate_read_op(read_op, "hw")


### PR DESCRIPTION
Both classes WriteOpCtx and ReadOpCtx don't take in arguments during instantiation.

Fixes: http://tracker.ceph.com/issues/38946
Signed-off-by: Ramana Raja <rraja@redhat.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

