### PR TITLE
mimic: ceph-disk/tests: use random unused port for CEPH_MON

### DIFF
--- a/src/ceph-disk/tests/ceph-disk.sh
+++ b/src/ceph-disk/tests/ceph-disk.sh
@@ -436,7 +436,7 @@ function run() {
     CEPH_DISK_ARGS+=" --statedir=$dir"
     CEPH_DISK_ARGS+=" --sysconfdir=$dir"
 
-    export CEPH_MON="127.0.0.1:7451" # git grep '\<7451\>' : there must be only one
+    export CEPH_MON="127.0.0.1:$(get_unused_port)"
     export CEPH_ARGS
     CEPH_ARGS+=" --fsid=$(uuidgen)"
     CEPH_ARGS+=" --auth-supported=none"


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/39066
Signed-off-by: Kefu Chai <kchai@redhat.com>

Conflicts:
	src/ceph-disk/tests/ceph-disk.sh: this change is not
cherry-picked from master. because ceph-disk was removed in nautilus. and
we need to run multiple luminous tests in parallel, hence the change.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
