### PR TITLE
script/ceph-backport.sh: allow user to specify remote repo

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -37,7 +37,13 @@
 # redmine_user_id=[your_redmine_user_id]
 # github_token=[your_github_personal_access_token]
 # github_user=[your_github_username]
-# 
+#
+# you can also optionally add the remote repo's name in this file, like
+#
+# github_repo=[your_github_repo_name]
+#
+# If you don't add it, it will default to "origin".
+#
 # Obviously, since this file contains secrets, you should protect it from
 # exposure using all available means (restricted file privileges, encrypted
 # filesystem, etc.). Without correct values for these four variables, this
@@ -56,6 +62,7 @@ test "$redmine_key"     || failed_required_variable_check redmine_key
 test "$redmine_user_id" || failed_required_variable_check redmine_user_id
 test "$github_token"    || failed_required_variable_check github_token
 test "$github_user"     || failed_required_variable_check github_user
+: "${github_repo:=origin}"
 
 function usage () {
     echo "Usage:"
@@ -123,7 +130,8 @@ fi
 title=$(curl --silent 'http://tracker.ceph.com/issues/'$issue.json?key=$redmine_key | jq .issue.subject | tr -d '\\"')
 echo "Issue title: $title" 
 
-git push -u origin wip-$issue-$milestone
+git push -u $github_repo wip-$issue-$milestone
+
 number=$(curl --silent --data-binary '{"title":"'"$title"'","head":"'$github_user':wip-'$issue-$milestone'","base":"'$target_branch'","body":"http://tracker.ceph.com/issues/'$issue'"}' 'https://api.github.com/repos/ceph/ceph/pulls?access_token='$github_token | jq .number)
 echo "Opened pull request $number"
 

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -71,7 +71,7 @@ function usage () {
     exit 1
 }
 
-[[ $1 != ?(-)+([0-9]) ]] && usage
+[[ $1 =~ ^[0-9]+$ ]] || usage
 issue=$1
 echo "Backport issue: $issue"
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

