### PR TITLE
mgr/dashboard: Display the number of iSCSI active sessions

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -29,10 +29,17 @@ class IscsiUi(BaseController):
     @ReadPermission
     def status(self):
         status = {'available': False}
-        if not IscsiGatewaysConfig.get_gateways_config()['gateways']:
+        gateways = IscsiGatewaysConfig.get_gateways_config()['gateways']
+        if not gateways:
             status['message'] = 'There are no gateways defined'
             return status
         try:
+            for gateway in gateways.keys():
+                try:
+                    IscsiClient.instance(gateway_name=gateway).ping()
+                except RequestException:
+                    status['message'] = 'Gateway {} is inaccessible'.format(gateway)
+                    return status
             config = IscsiClient.instance().get_config()
             if config['version'] != IscsiUi.REQUIRED_CEPH_ISCSI_CONFIG_VERSION:
                 status['message'] = 'Unsupported `ceph-iscsi` config version. Expected {} but ' \
@@ -104,6 +111,7 @@ class IscsiTarget(RESTController):
         targets = []
         for target_iqn in config['targets'].keys():
             target = IscsiTarget._config_to_target(target_iqn, config)
+            IscsiTarget._set_info(target)
             targets.append(target)
         return targets
 
@@ -111,7 +119,9 @@ class IscsiTarget(RESTController):
         config = IscsiClient.instance().get_config()
         if target_iqn not in config['targets']:
             raise cherrypy.HTTPError(404)
-        return IscsiTarget._config_to_target(target_iqn, config)
+        target = IscsiTarget._config_to_target(target_iqn, config)
+        IscsiTarget._set_info(target)
+        return target
 
     @iscsi_target_task('delete', {'target_iqn': '{target_iqn}'})
     def delete(self, target_iqn):
@@ -537,6 +547,15 @@ class IscsiTarget(RESTController):
             'acl_enabled': acl_enabled
         }
         return target
+
+    @staticmethod
+    def _set_info(target):
+        if not target['portals']:
+            return
+        target_iqn = target['target_iqn']
+        gateway_name = target['portals'][0]['host']
+        target_info = IscsiClient.instance(gateway_name=gateway_name).get_targetinfo(target_iqn)
+        target['info'] = target_info
 
     @staticmethod
     def _sorted_portals(portals):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -101,6 +101,11 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
         name: this.i18n('Images'),
         prop: 'cdImages',
         flexGrow: 2
+      },
+      {
+        name: this.i18n('# Sessions'),
+        prop: 'info.num_sessions',
+        flexGrow: 1
       }
     ];
 

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -4326,6 +4326,13 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="99e094878070eebc1b972bac02aaa33b2bf83b35" datatype="html">
+        <source># Sessions</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="9a541ec1a4319fffc16ad3b3ab2c2b6d251a829d" datatype="html">
         <source>Hostname</source>
         <context-group purpose="location">

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -198,3 +198,8 @@ class IscsiClient(RestClient):
         return request({
             'action': action
         })
+
+    @RestClient.api_get('/api/targetinfo/{target_iqn}')
+    def get_targetinfo(self, target_iqn, request=None):
+        logger.debug("iSCSI: Getting targetinfo: %s", target_iqn)
+        return request()

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -431,7 +431,10 @@ iscsi_target_response = {
             'members': ['iqn.1994-05.com.redhat:rh7-client2']
         }
     ],
-    'target_controls': {}
+    'target_controls': {},
+    'info': {
+        'num_sessions': 0
+    }
 }
 
 
@@ -627,3 +630,8 @@ class IscsiClientMock(object):
 
     def update_targetauth(self, target_iqn, action):
         self.config['targets'][target_iqn]['acl_enabled'] = (action == 'enable_acl')
+
+    def get_targetinfo(self, _):
+        return {
+            'num_sessions': 0
+        }


### PR DESCRIPTION
This PR will display the number of active sessions for each iSCSI target:

![Screenshot from 2019-03-28 14-59-34](https://user-images.githubusercontent.com/14297426/55168111-24f61100-516a-11e9-8d2d-fb9f7c6a6027.png)


Fixes: https://tracker.ceph.com/issues/38989

Signed-off-by: Ricardo Marques <rimarques@suse.com>
