### PR TITLE
fio_ceph_messenger: catch up v2 proto changes by using dummy auth

### DIFF
--- a/src/test/fio/ceph-messenger.fio
+++ b/src/test/fio/ceph-messenger.fio
@@ -6,6 +6,8 @@ iodepth=128
 ioengine=libfio_ceph_messenger.so
 #ceph_conf_file=ceph-messenger.conf
 
+# In order to select protocol explicitly add 'v1:' or 'v2:' prefix.
+# By default v2 is used.
 hostname=127.0.0.1
 port=5555
 

--- a/src/test/fio/fio_ceph_messenger.cc
+++ b/src/test/fio/fio_ceph_messenger.cc
@@ -12,6 +12,7 @@
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
 #include "common/perf_counters.h"
+#include "auth/DummyAuth.h"
 #include "ring_buffer.h"
 
 #include <fio.h>
@@ -93,6 +94,7 @@ static std::string ptr_to_str(void *ptr)
  * global context refcounter, sigh.
  */
 static std::atomic<int> ctx_ref(1);
+static DummyAuthClientServer *g_dummy_auth;
 
 static void create_or_get_ceph_context(struct ceph_msgr_options *o)
 {
@@ -116,6 +118,8 @@ static void create_or_get_ceph_context(struct ceph_msgr_options *o)
 
   common_init_finish(g_ceph_context);
   g_ceph_context->_conf.apply_changes(NULL);
+  g_dummy_auth = new DummyAuthClientServer(g_ceph_context);
+  g_dummy_auth->auth_registry.refresh_config();
 }
 
 static void put_ceph_context(void)
@@ -131,6 +135,7 @@ static void put_ceph_context(void)
     ostr << ">>>>>>>>>>>>>  PERFCOUNTERS END  <<<<<<<<<<<<" << std::endl;
 
     delete f;
+    delete g_dummy_auth;
     dout(0) <<  ostr.str() << dendl;
   }
 
@@ -304,6 +309,8 @@ static Messenger *create_messenger(struct ceph_msgr_options *o)
   } else {
     msgr->set_default_policy(Messenger::Policy::lossless_client(0));
   }
+  msgr->set_auth_client(g_dummy_auth);
+  msgr->set_auth_server(g_dummy_auth);
   msgr->start();
 
   return msgr;


### PR DESCRIPTION
This change makes v2 protocol work by adding dummy auth. 

@rjfd Ricardo, please review. Change was lost and was not included in the original patch which you merged yesterday :(