### PR TITLE
mgr/dashboard: update vstart to use new ssl port

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -781,6 +781,7 @@ EOF
 
 start_mgr() {
     local mgr=0
+    local ssl=${DASHBOARD_SSL:-1}
     # avoid monitors on nearby ports (which test/*.sh use extensively)
     MGR_PORT=$(($CEPH_PORT + 1000))
     for name in x y z a b c d e f g h i j k l m n o p
@@ -799,11 +800,18 @@ start_mgr() {
 EOF
 
             if $with_mgr_dashboard ; then
-                ceph_adm config set mgr mgr/dashboard/$name/server_port $MGR_PORT --force
+                local port_option="ssl_server_port"
+                local http_proto="https"
+                if [ "$ssl" == "0" ]; then
+                    port_option="server_port"
+                    http_proto="http"
+                    ceph_adm config set mgr mgr/dashboard/ssl false --force
+                fi
+                ceph_adm config set mgr mgr/dashboard/$name/$port_option $MGR_PORT --force
                 if [ $mgr -eq 1 ]; then
-                    DASH_URLS="https://$IP:$MGR_PORT"
+                    DASH_URLS="$http_proto://$IP:$MGR_PORT"
                 else
-                    DASH_URLS+=", https://$IP:$MGR_PORT"
+                    DASH_URLS+=", $http_proto://$IP:$MGR_PORT"
                 fi
             fi
 	    MGR_PORT=$(($MGR_PORT + 1000))
@@ -827,8 +835,10 @@ EOF
         # setting login credentials for dashboard
         if $with_mgr_dashboard; then
             ceph_adm tell mgr dashboard ac-user-create admin admin administrator
-            if ! ceph_adm tell mgr dashboard create-self-signed-cert;  then
-                echo dashboard module not working correctly!
+            if [ "$ssl" != "0" ]; then
+                if ! ceph_adm tell mgr dashboard create-self-signed-cert;  then
+                    echo dashboard module not working correctly!
+                fi
             fi
         fi
 


### PR DESCRIPTION
Added a new vstart.sh environment var `DASHBOARD_SSL` (default: 1), to allow disabling SSL (`DASHBOARD_SSL=0`).

Fixes: #26914
Fixes: https://tracker.ceph.com/issues/39030
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>

Test:
```
Output of vstart without overriding DASHBOARD_SSL default:
...
dashboard urls: https://172.20.0.2:11000
// dashboard is accessible in the above link

Output of vstart with DASHBOARD_SSL=0:
...
dashboard urls: http://172.20.0.2:11000
// dashboard is accessible in the above link
```

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

