### PR TITLE
rgw: normalize v6 endpoint behaviour for the beast frontend

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -23,21 +23,21 @@ Options
 
 ``port`` and ``ssl_port``
 
-:Description: Sets the listening port number. Can be specified multiple
+:Description: Sets the ipv4 & ipv6 listening port number. Can be specified multiple
               times as in ``port=80 port=8000``.
-
 :Type: Integer
 :Default: ``80``
 
 
 ``endpoint`` and ``ssl_endpoint``
 
-:Description: Sets the listening address in the form ``address[:port]``,
-              where the address is an IPv4 address string in dotted decimal
-              form, or an IPv6 address in hexadecimal notation surrounded
-              by square brackets. The optional port defaults to 80 for
-              ``endpoint`` and 443 for ``ssl_endpoint``. Can be specified
-              multiple times as in ``endpoint=[::1] endpoint=192.168.0.100:8000``.
+:Description: Sets the listening address in the form ``address[:port]``, where
+              the address is an IPv4 address string in dotted decimal form, or
+              an IPv6 address in hexadecimal notation surrounded by square
+              brackets. Specifying a IPv6 endpoint would listen to v6 only. The
+              optional port defaults to 80 for ``endpoint`` and 443 for
+              ``ssl_endpoint``. Can be specified multiple times as in
+              ``endpoint=[::1] endpoint=192.168.0.100:8000``.
 
 :Type: Integer
 :Default: None


### PR DESCRIPTION
Make endpoint v6 behaviour explicit
http://tracker.ceph.com/issues/39038
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary 
- [ ] Includes tests for new functionality or reproducer for bug

