### PR TITLE
osd: avoid push raw clone when head missing

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1404,11 +1404,11 @@ int ReplicatedBackend::prep_push_to_replica(
     hobject_t head = soid;
     head.snap = CEPH_NOSNAP;
 
-    // try to base push off of clones that succeed/preceed poid
-    // we need the head (and current SnapSet) locally to do that.
+    // if we are missing head, the snaps of clone will not present.
+    // push raw clone will cause peer's SnapMapper cheat.
     if (get_parent()->get_local_missing().is_missing(head)) {
-      dout(15) << "push_to_replica missing head " << head << ", pushing raw clone" << dendl;
-      return prep_push(obc, soid, peer, pop, cache_dont_need);
+      dout(15) << "push_to_replica missing head " << head << ", drop" << dendl;
+      return -EINVAL;
     }
 
     SnapSetContext *ssc = obc->ssc;


### PR DESCRIPTION
if we are missing head, the snaps of clone will not present.
push raw clone will cause peer's SnapMapper cheat.

Fixes: http://tracker.ceph.com/issues/23030

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

