### PR TITLE
script/ceph-release-notes: alternate merge commit format

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -41,7 +41,7 @@ reviewed_by_re = re.compile(r"Rev(.*)By", re.IGNORECASE)
 labels = {'bluestore', 'build/ops', 'cephfs', 'common', 'core', 'mgr',
           'mon', 'performance', 'pybind', 'rdma', 'rgw', 'rbd', 'tests',
           'tools'}
-merge_re = re.compile("Merge pull request #(\d+).*")
+merge_re = re.compile("Merge (pull request|PR) #(\d+).*")
 # prefixes is the list of commit description prefixes we recognize
 prefixes = ['bluestore', 'build/ops', 'cephfs', 'cephx', 'cli', 'cmake',
             'common', 'core', 'crush', 'doc', 'fs', 'librados', 'librbd',
@@ -147,7 +147,7 @@ def make_release_notes(gh, repo, ref, plaintext, verbose, strict, use_tags):
         merge = merge_re.match(commit.summary)
         if not merge:
             continue
-        number = merge.group(1)
+        number = merge.group(2)
         print ("Considering PR#" + number)
         # do not pick up ceph/ceph-qa-suite.git PRs
         if int(number) < 1311:


### PR DESCRIPTION
When PRs are merged via GitHub web GUI, the merge commit looks like
this:

    Merge pull request #27161 from cbodley/wip-qa-rgw-nautilus

however, nowadays PRs are also getting merged via the "hub" CLI tool,
which generates merge commits that look like this:

    Merge PR #27139 into nautilus

This commit adapts the regex so it matches both.

Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

