### PR TITLE
mimic: osd/PGLog.h: print olog_can_rollback_to before deciding to rollback

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -999,6 +999,11 @@ protected:
 		       << " attempting to rollback"
 		       << dendl;
     bool can_rollback = true;
+    // We are going to make an important decision based on the
+    // olog_can_rollback_to value we have received, better known it.
+    ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
+                       << " olog_can_rollback_to: "
+                       << olog_can_rollback_to << dendl;
     /// Distinguish between 4) and 5)
     for (list<pg_log_entry_t>::const_reverse_iterator i = entries.rbegin();
 	 i != entries.rend();


### PR DESCRIPTION
http://tracker.ceph.com/issues/38904