### PR TITLE
mgr/rook: Fix creation of bluestore OSDs

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -377,7 +377,7 @@ class RookCluster(object):
         #       - name: "gravel1.rockery"
         #         devices:
         #          - name: "sdb"
-        #         storeConfig:
+        #         config:
         #           storeType: bluestore
 
         current_cluster = self.rook_api_get(
@@ -398,7 +398,7 @@ class RookCluster(object):
 
         if drive_group.hosts(all_hosts)[0] not in [n['name'] for n in current_nodes]:
             pd = { "name": drive_group.hosts(all_hosts)[0],
-                   "storeConfig": { "storeType": drive_group.objectstore }}
+                   "config": { "storeType": drive_group.objectstore }}
 
             if block_devices:
                 pd["devices"] = [{'name': d} for d in block_devices]


### PR DESCRIPTION
See https://rook.io/docs/rook/v0.9/ceph-cluster-crd.html
    Storage Configuration: Specific devices

Fixes http://tracker.ceph.com/issues/39062

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

