### PR TITLE
src/script/kubejacker: Fix and simplify

### DIFF
--- a/src/script/kubejacker/Dockerfile
+++ b/src/script/kubejacker/Dockerfile
@@ -1,34 +1,16 @@
-from BASEIMAGE
+FROM ceph/ceph:latest
+# for openSUSE, use:
+# FROM registry.opensuse.org/home/ssebastianwagner/rook-ceph/images/opensuse/leap:latest
 
-# Some apt-get commands fail in docker builds because they try
-# and do interactive prompts
-ENV TERM linux
 
-# Baseline rook images may be from before the `rook` ceph-mgr module,
-# so let's install the dependencies of that
-# New RGW dependency since luminous: liboath
-# For the dashboard, if the rook images are pre-Mimic: ython-bcrypt librdmacm
-
-RUN (grep -q rhel /etc/os-release && ( \
-        yum install -y python-pip && \
-        yum install -y liboath && \
-        yum install -y python-bcrypt librdmacm && \
-        pip install kubernetes==6.0.0 \
-    )) || (grep -q suse /etc/os-release && ( \
-        zypper --non-interactive --gpg-auto-import-keys install --no-recommends --auto-agree-with-licenses --replacefiles --details \
-            python3-kubernetes \
-            liboauth-devel \
-            python-bcrypt \
-            lz4 \
-            librdmacm1 \
-            libopenssl1_1 \
-    ))
-
-ADD bin.tar.gz /usr/bin/
-ADD lib.tar.gz /usr/lib64/
+#ADD bin.tar.gz /usr/bin/
+#ADD lib.tar.gz /usr/lib64/
 
 # Assume developer is using default paths (i.e. /usr/local), so
 # build binaries will be looking for libs there.
-ADD eclib.tar.gz /usr/local/lib64/ceph/erasure-code/
-ADD clslib.tar.gz /usr/local/lib64/rados-classes/
+#ADD eclib.tar.gz /usr/local/lib64/ceph/erasure-code/
+#ADD clslib.tar.gz /usr/local/lib64/rados-classes/
+
 ADD mgr_plugins.tar.gz /usr/local/lib64/ceph/mgr
+# for openSUSE, use:
+# ADD mgr_plugins.tar.gz /usr/share/ceph/mgr

--- a/src/script/kubejacker/kubejacker.sh
+++ b/src/script/kubejacker/kubejacker.sh
@@ -8,14 +8,11 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 # Run me from your build dir!  I look for binaries in bin/, lib/ etc.
 BUILDPATH=$(pwd)
 
-# PREREQUISITE: a built rook image to use as a base, either self built
-# or from dockerhub.  If you ran "make" in your rook source checkout
-# you'll have one like build-<hash>/rook-amd64
-DEFAULT_BASEIMAGE="`docker image ls | grep ceph-amd64 | cut -d " " -f 1`"
-BASEIMAGE="${BASEIMAGE:-$DEFAULT_BASEIMAGE}"
 
 # PREREQUISITE: a repo that you can push to.  You are probably running
 # a local docker registry that your kubelet nodes also have access to.
+REPO=${REPO:-"$1"}
+
 if [ -z "$REPO" ]
 then
     echo "ERROR: no \$REPO set!"
@@ -25,8 +22,8 @@ fi
 
 # The output image name: this should match whatever is configured as
 # the image name in your Rook cluster CRD object.
-IMAGE=rook/ceph
-TAG=$(git rev-parse --short HEAD)
+IMAGE=ceph/ceph
+TAG=latest
 
 # The namespace where ceph containers are running in your
 # test cluster: used for bouncing the containers.
@@ -34,24 +31,23 @@ NAMESPACE=rook-ceph
 
 mkdir -p kubejacker
 cp $SCRIPTPATH/Dockerfile kubejacker
-sed -i s@BASEIMAGE@$BASEIMAGE@ kubejacker/Dockerfile
 
 # TODO: let user specify which daemon they're interested
 # in -- doing all bins all the time is too slow and bloaty
-BINS="ceph-mgr ceph-mon ceph-mds ceph-osd rados radosgw-admin radosgw"
-pushd bin
-strip $BINS  #TODO: make stripping optional
-tar czf $BUILDPATH/kubejacker/bin.tar.gz $BINS
-popd
+#BINS="ceph-mgr ceph-mon ceph-mds ceph-osd rados radosgw-admin radosgw"
+#pushd bin
+#strip $BINS  #TODO: make stripping optional
+#tar czf $BUILDPATH/kubejacker/bin.tar.gz $BINS
+#popd
 
 # We need ceph-common to support the binaries
 # We need librados/rbd to support mgr modules
 # that import the python bindings
-LIBS="libceph-common.so.0 libceph-common.so librados.so.2 librados.so librados.so.2.0.0 librbd.so librbd.so.1 librbd.so.1.12.0"
-pushd lib
-strip $LIBS  #TODO: make stripping optional
-tar czf $BUILDPATH/kubejacker/lib.tar.gz $LIBS
-popd
+#LIBS="libceph-common.so.0 libceph-common.so librados.so.2 librados.so librados.so.2.0.0 librbd.so librbd.so.1 librbd.so.1.12.0"
+#pushd lib
+#strip $LIBS  #TODO: make stripping optional
+#tar czf $BUILDPATH/kubejacker/lib.tar.gz $LIBS
+#popd
 
 pushd ../src/pybind/mgr
 find ./ -name "*.pyc" -exec rm -f {} \;
@@ -59,26 +55,26 @@ find ./ -name "*.pyc" -exec rm -f {} \;
 tar --exclude=node_modules --exclude=tests --exclude-backups -czf $BUILDPATH/kubejacker/mgr_plugins.tar.gz *
 popd
 
-ECLIBS="libec_*.so*"
-pushd lib
-strip $ECLIBS  #TODO: make stripping optional
-tar czf $BUILDPATH/kubejacker/eclib.tar.gz $ECLIBS
-popd
+#ECLIBS="libec_*.so*"
+#pushd lib
+#strip $ECLIBS  #TODO: make stripping optional
+#tar czf $BUILDPATH/kubejacker/eclib.tar.gz $ECLIBS
+#popd
 
-CLSLIBS="libcls_*.so*"
-pushd lib
-strip $CLSLIBS  #TODO: make stripping optional
-tar czf $BUILDPATH/kubejacker/clslib.tar.gz $CLSLIBS
-popd
+#CLSLIBS="libcls_*.so*"
+#pushd lib
+#strip $CLSLIBS  #TODO: make stripping optional
+#tar czf $BUILDPATH/kubejacker/clslib.tar.gz $CLSLIBS
+#popd
 
 pushd kubejacker
-docker build -t $REPO/$IMAGE:$TAG .
+docker build -t $REPO/ceph/ceph:latest .
 popd
 
 # Push the image to the repository
-docker tag $REPO/$IMAGE:$TAG $REPO/$IMAGE:latest
-docker push $REPO/$IMAGE:latest
-docker push $REPO/$IMAGE:$TAG 
+#docker tag $REPO/$IMAGE:$TAG $REPO/$IMAGE:latest
+docker push $REPO/ceph/ceph:latest
+#docker push $REPO/$IMAGE:$TAG
 
 # Finally, bounce the containers to pick up the new image
 kubectl -n $NAMESPACE delete pod -l app=rook-ceph-mds


### PR DESCRIPTION
Unfortunately, kubejacker script is not widely used. 

In the meantime, simplify it to my needs, as I don't need to push new binaries right now.

Also: updated to new `ceph/ceph` base image

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

