### PR TITLE
mimic: os/bluestore: bitmap allocator might fail to return contiguous chunk despite having enough space

### DIFF
--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -83,3 +83,19 @@ void BitmapAllocator::shutdown()
   ldout(cct, 1) << __func__ << dendl;
   _shutdown();
 }
+
+void BitmapAllocator::dump()
+{
+  // bin -> interval count
+  std::map<size_t, size_t> bins_overall;
+  collect_stats(bins_overall);
+  auto it = bins_overall.begin();
+  while (it != bins_overall.end()) {
+    ldout(cct, 0) << __func__
+	            << " bin " << it->first
+		    << "(< " << byte_u_t((1 << (it->first + 1)) * get_min_alloc_size()) << ")"
+		    << " : " << it->second << " extents"
+		    << dendl;
+    ++it;
+  }
+}

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -35,9 +35,7 @@ public:
     return get_available();
   }
 
-  void dump() override
-  {
-  }
+  void dump() override;
   double get_fragmentation(uint64_t) override
   {
     return _get_fragmentation();

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -66,17 +66,16 @@ WRITE_CLASS_DENC(bluestore_cnode_t)
 
 ostream& operator<<(ostream& out, const bluestore_cnode_t& l);
 
-/// pextent: physical extent
-struct bluestore_pextent_t {
+template <typename OFFS_TYPE, typename LEN_TYPE>
+struct bluestore_interval_t
+{
   static const uint64_t INVALID_OFFSET = ~0ull;
 
-  uint64_t offset = 0;
-  uint32_t length = 0;
+  OFFS_TYPE offset = 0;
+  LEN_TYPE length = 0;
 
-  bluestore_pextent_t() {}
-  bluestore_pextent_t(uint64_t o, uint64_t l) : offset(o), length(l) {}
-  bluestore_pextent_t(const bluestore_pextent_t &ext) :
-    offset(ext.offset), length(ext.length) {}
+  bluestore_interval_t(){}
+  bluestore_interval_t(uint64_t o, uint64_t l) : offset(o), length(l) {}
 
   bool is_valid() const {
     return offset != INVALID_OFFSET;
@@ -85,9 +84,19 @@ struct bluestore_pextent_t {
     return offset != INVALID_OFFSET ? offset + length : INVALID_OFFSET;
   }
 
-  bool operator==(const bluestore_pextent_t& other) const {
+  bool operator==(const bluestore_interval_t& other) const {
     return offset == other.offset && length == other.length;
   }
+
+};
+
+/// pextent: physical extent
+struct bluestore_pextent_t : public bluestore_interval_t<uint64_t, uint32_t> 
+{
+  bluestore_pextent_t() {}
+  bluestore_pextent_t(uint64_t o, uint64_t l) : bluestore_interval_t(o, l) {}
+  bluestore_pextent_t(const bluestore_interval_t &ext) :
+    bluestore_interval_t(ext.offset, ext.length) {}
 
   DENC(bluestore_pextent_t, v, p) {
     denc_lba(v.offset, p);

--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -32,7 +32,6 @@ inline interval_t _align2units(uint64_t offset, uint64_t len, uint64_t min_lengt
   return interval_t();
 }
 
-
 interval_t AllocatorLevel01Loose::_get_longest_from_l0(uint64_t pos0,
   uint64_t pos1, uint64_t min_length, interval_t* tail) const
 {
@@ -507,4 +506,39 @@ bool AllocatorLevel01Loose::_allocate_l1(uint64_t length,
     }
   }
   return _is_empty_l1(l1_pos_start, l1_pos_end);
+}
+
+void AllocatorLevel01Loose::collect_stats(
+  std::map<size_t, size_t>& bins_overall)
+{
+  size_t free_seq_cnt = 0;
+  for (auto slot : l0) {
+    if (slot == all_slot_set) {
+      free_seq_cnt += CHILD_PER_SLOT_L0;
+    } else if(slot != all_slot_clear) {
+      size_t pos = 0;
+      do {
+	auto pos1 = find_next_set_bit(slot, pos);
+	if (pos1 == pos) {
+	  free_seq_cnt++;
+	  pos = pos1 + 1;
+	} else {
+	  if (free_seq_cnt) {
+	    bins_overall[cbits(free_seq_cnt) - 1]++;
+	    free_seq_cnt = 0;
+	  }
+	  if (pos1 < bits_per_slot) {
+	    free_seq_cnt = 1;
+	  }
+          pos = pos1 + 1;
+	}
+      } while (pos < bits_per_slot);
+    } else if (free_seq_cnt) {
+      bins_overall[cbits(free_seq_cnt) - 1]++;
+      free_seq_cnt = 0;
+    }
+  }
+  if (free_seq_cnt) {
+    bins_overall[cbits(free_seq_cnt) - 1]++;
+  }
 }

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -21,7 +21,7 @@ typedef uint64_t slot_t;
 struct interval_t
 {
   uint64_t offset = 0;
-  uint32_t length = 0;
+  uint64_t length = 0;
 
   interval_t() {}
   interval_t(uint64_t o, uint64_t l) : offset(o), length(l) {}
@@ -36,7 +36,7 @@ typedef std::vector<slot_t> slot_vector_t;
 #include "os/bluestore/bluestore_types.h"
 #include "include/mempool.h"
 
-typedef bluestore_pextent_t interval_t;
+typedef bluestore_interval_t<uint64_t, uint64_t> interval_t;
 typedef PExtentVector interval_vector_t;
 
 typedef mempool::bluestore_alloc::vector<slot_t> slot_vector_t;

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -155,7 +155,6 @@ class AllocatorLevel01Loose : public AllocatorLevel01
     interval_vector_t* res)
   {
     auto it = res->rbegin();
-
     if (max_length) {
       if (it != res->rend() && it->offset + it->length == offset) {
 	auto l = max_length - it->length;
@@ -635,6 +634,11 @@ protected:
     assert(max_length == 0 || (max_length % min_length) == 0);
     assert(length >= min_length);
     assert((length % min_length) == 0);
+
+    uint64_t cap = 1ull << 31;
+    if (max_length == 0 || max_length >= cap) {
+      max_length = cap;
+    }
 
     uint64_t l1_w = slotset_width * l1._children_per_slot();
 

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -86,6 +86,9 @@ public:
   virtual ~AllocatorLevel()
   {}
 
+  virtual void collect_stats(
+    std::map<size_t, size_t>& bins_overall) = 0;
+
 };
 
 class AllocatorLevel01 : public AllocatorLevel
@@ -464,6 +467,8 @@ public:
     }
     return res * l0_granularity;
   }
+  void collect_stats(
+    std::map<size_t, size_t>& bins_overall) override;
 };
 
 class AllocatorLevel01Compact : public AllocatorLevel01
@@ -473,6 +478,11 @@ class AllocatorLevel01Compact : public AllocatorLevel01
     return 8;
   }
 public:
+  void collect_stats(
+    std::map<size_t, size_t>& bins_overall) override
+  {
+    // not implemented
+  }
 };
 
 template <class L1>
@@ -500,6 +510,12 @@ public:
   inline uint64_t get_min_alloc_size() const
   {
     return l1.get_min_alloc_size();
+  }
+  void collect_stats(
+    std::map<size_t, size_t>& bins_overall) override {
+
+      std::lock_guard l(lock);
+      l1.collect_stats(bins_overall);
   }
 
 protected:

--- a/src/test/objectstore/fastbmap_allocator_test.cc
+++ b/src/test/objectstore/fastbmap_allocator_test.cc
@@ -346,7 +346,7 @@ TEST(TestAllocatorLevel01, test_l2)
   ASSERT_EQ(0, al2.debug_get_free());
   for (uint64_t i = 0; i < capacity; i += _1m) {
     interval_vector_t r;
-    r.emplace_back(interval_t(i, _1m));
+    r.emplace_back(i, _1m);
     al2.free_l2(r);
     if (0 == (i % (1 * 1024 * _1m))) {
       std::cout << "free1 " << i / 1024 / 1024 << " mb of "
@@ -378,7 +378,7 @@ TEST(TestAllocatorLevel01, test_l2)
 
   for (uint64_t i = 0; i < capacity; i += 0x2000) {
     interval_vector_t r;
-    r.emplace_back(interval_t(i, 0x1000));
+    r.emplace_back(i, 0x1000);
     al2.free_l2(r);
     if (0 == (i % (1 * 1024 * _1m))) {
       std::cout << "free2 " << i / 1024 / 1024 << " mb of "
@@ -864,5 +864,47 @@ TEST(TestAllocatorLevel01, test_4G_alloc_bug)
       ASSERT_EQ(allocated4, _1m);
       ASSERT_EQ(a4[0].offset, 0u);
       ASSERT_EQ(a4[0].length, _1m);
+  }
+}
+
+TEST(TestAllocatorLevel01, test_4G_alloc_bug2)
+{
+  {
+    TestAllocatorLevel02 al2;
+    uint64_t capacity = 0x8000 * _1m; // = 32GB
+    al2.init(capacity, 0x10000);
+
+    for (uint64_t i = 0; i < capacity; i += _1m) {
+      uint64_t allocated4 = 0;
+      interval_vector_t a4;
+      al2.allocate_l2(_1m, _1m, &allocated4, &a4);
+      ASSERT_EQ(a4.size(), 1u);
+      ASSERT_EQ(allocated4, _1m);
+      ASSERT_EQ(a4[0].offset, i);
+      ASSERT_EQ(a4[0].length, _1m);
+    }
+    ASSERT_EQ(0u , al2.debug_get_free());
+
+    interval_vector_t r;
+    r.emplace_back(0x5fec30000, 0x13d0000);
+    r.emplace_back(0x628000000, 0x80000000);
+    r.emplace_back(0x6a8000000, 0x80000000);
+    r.emplace_back(0x728100000, 0x70000);
+    al2.free_l2(r);
+
+    std::map<size_t, size_t> bins_overall;
+    al2.collect_stats(bins_overall);
+
+    std::cout << "!!!!!!!!!!!!!!" << std::endl;
+
+    uint64_t allocated4 = 0;
+    interval_vector_t a4;
+    al2.allocate_l2(0x3e000000, _1m, &allocated4, &a4);
+    ASSERT_EQ(a4.size(), 2u);
+    ASSERT_EQ(allocated4, 0x3e000000u);
+    ASSERT_EQ(a4[0].offset, 0x5fed00000u);
+    ASSERT_EQ(a4[0].length, 0x1300000u);
+    ASSERT_EQ(a4[1].offset, 0x628000000u);
+    ASSERT_EQ(a4[1].length, 0x3cd00000u);
   }
 }

--- a/src/test/objectstore/fastbmap_allocator_test.cc
+++ b/src/test/objectstore/fastbmap_allocator_test.cc
@@ -895,8 +895,6 @@ TEST(TestAllocatorLevel01, test_4G_alloc_bug2)
     std::map<size_t, size_t> bins_overall;
     al2.collect_stats(bins_overall);
 
-    std::cout << "!!!!!!!!!!!!!!" << std::endl;
-
     uint64_t allocated4 = 0;
     interval_vector_t a4;
     al2.allocate_l2(0x3e000000, _1m, &allocated4, &a4);
@@ -906,5 +904,25 @@ TEST(TestAllocatorLevel01, test_4G_alloc_bug2)
     ASSERT_EQ(a4[0].length, 0x1300000u);
     ASSERT_EQ(a4[1].offset, 0x628000000u);
     ASSERT_EQ(a4[1].length, 0x3cd00000u);
+  }
+}
+
+TEST(TestAllocatorLevel01, test_4G_alloc_bug3)
+{
+  {
+    TestAllocatorLevel02 al2;
+    uint64_t capacity = 0x8000 * _1m; // = 32GB
+    al2.init(capacity, 0x10000);
+    std::cout << "Init L2 cont aligned" << std::endl;
+
+      uint64_t allocated4 = 0;
+      interval_vector_t a4;
+      al2.allocate_l2(4096ull * _1m, _1m, &allocated4, &a4);
+      ASSERT_EQ(a4.size(), 2u); // allocator has to split into 2 allocations
+      ASSERT_EQ(allocated4, 4096ull * _1m);
+      ASSERT_EQ(a4[0].offset, 0u);
+      ASSERT_EQ(a4[0].length, 2048ull * _1m);
+      ASSERT_EQ(a4[1].offset, 2048ull * _1m);
+      ASSERT_EQ(a4[1].length, 2048ull * _1m);
   }
 }

--- a/src/test/objectstore/fastbmap_allocator_test.cc
+++ b/src/test/objectstore/fastbmap_allocator_test.cc
@@ -483,6 +483,7 @@ TEST(TestAllocatorLevel01, test_l2_unaligned)
     uint64_t capacity = num_l2_entries * 256 * 512 * 4096; // 3x512 MB
     al2.init(capacity, 0x1000);
     std::cout << "Init L2 Unaligned" << std::endl;
+
     for (uint64_t i = 0; i < capacity; i += _1m / 2) {
       uint64_t allocated4 = 0;
       interval_vector_t a4;
@@ -589,8 +590,16 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
     TestAllocatorLevel02 al2;
     uint64_t num_l2_entries = 3;
     uint64_t capacity = num_l2_entries * 256 * 512 * 4096; // 3x512 MB
-    al2.init(capacity, 0x1000);
+    uint64_t num_chunks = capacity / 4096;
+    al2.init(capacity, 4096);
     std::cout << "Init L2 cont aligned" << std::endl;
+
+    std::map<size_t, size_t> bins_overall;
+    al2.collect_stats(bins_overall);
+    ASSERT_EQ(bins_overall.size(), 1u);
+//    std::cout<<bins_overall.begin()->first << std::endl;
+    ASSERT_EQ(bins_overall[cbits(num_chunks) - 1], 1u);
+
     for (uint64_t i = 0; i < capacity / 2; i += _1m) {
       uint64_t allocated4 = 0;
       interval_vector_t a4;
@@ -602,11 +611,22 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
     }
     ASSERT_EQ(capacity / 2, al2.debug_get_free());
 
+    bins_overall.clear();
+    al2.collect_stats(bins_overall);
+    ASSERT_EQ(bins_overall.size(), 1u);
+    ASSERT_EQ(bins_overall[cbits(num_chunks / 2) - 1], 1u);
+
     {
+      size_t to_release = 2 * _1m + 0x1000;
       // release 2M + 4K at the beginning
       interval_vector_t r;
-      r.emplace_back(0, 2 * _1m + 0x1000);
+      r.emplace_back(0, to_release);
       al2.free_l2(r);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall.size(), 2u);
+      ASSERT_EQ(bins_overall[cbits(to_release / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits(num_chunks / 2) - 1], 1u);
     }
     {
       // allocate 4K within the deallocated range
@@ -627,22 +647,38 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
       ASSERT_EQ(allocated4, _1m);
       ASSERT_EQ(a4[0].offset, _1m);
       ASSERT_EQ(a4[0].length, _1m);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall.size(), 3u);
+      ASSERT_EQ(bins_overall[0], 1u);
+      ASSERT_EQ(bins_overall[cbits((_1m - 0x1000) / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits(num_chunks / 2) - 1], 1u);
     }
     {
       // and allocate yet another 8K within the deallocated range
       uint64_t allocated4 = 0;
       interval_vector_t a4;
       al2.allocate_l2(0x2000, 0x1000, &allocated4, &a4);
-      ASSERT_EQ(a4.size(), 1);
-      ASSERT_EQ(allocated4, 0x2000);
-      ASSERT_EQ(a4[0].offset, 0x1000);
-      ASSERT_EQ(a4[0].length, 0x2000);
+      ASSERT_EQ(a4.size(), 1u);
+      ASSERT_EQ(allocated4, 0x2000u);
+      ASSERT_EQ(a4[0].offset, 0x1000u);
+      ASSERT_EQ(a4[0].length, 0x2000u);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall[0], 1u);
+      ASSERT_EQ(bins_overall[cbits((_1m - 0x3000) / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits(num_chunks / 2) - 1], 1u);
     }
     {
       // release just allocated 1M
       interval_vector_t r;
       r.emplace_back(_1m, _1m);
       al2.free_l2(r);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall.size(), 2u);
+      ASSERT_EQ(bins_overall[cbits((2 * _1m - 0x3000) / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits(num_chunks / 2) - 1], 1u);
     }
     {
       // allocate 3M - should go to the second 1M chunk and @capacity/2
@@ -655,6 +691,12 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
       ASSERT_EQ(a4[0].length, _1m);
       ASSERT_EQ(a4[1].offset, capacity / 2);
       ASSERT_EQ(a4[1].length, 2 * _1m);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall.size(), 3u);
+      ASSERT_EQ(bins_overall[0], 1u);
+      ASSERT_EQ(bins_overall[cbits((_1m - 0x3000) / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits((num_chunks - 512) / 2) - 1], 1u);
     }
     {
       // release allocated 1M in the second meg chunk except
@@ -662,15 +704,27 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
       interval_vector_t r;
       r.emplace_back(_1m + 0x1000, _1m);
       al2.free_l2(r);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall.size(), 3u);
+      ASSERT_EQ(bins_overall[cbits(_1m / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits((_1m - 0x3000) / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits((num_chunks - 512) / 2) - 1], 1u);
     }
     {
       // release 2M @(capacity / 2)
       interval_vector_t r;
       r.emplace_back(capacity / 2, 2 * _1m);
       al2.free_l2(r);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall.size(), 3u);
+      ASSERT_EQ(bins_overall[cbits(_1m / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits((_1m - 0x3000) / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits((num_chunks) / 2) - 1], 1u);
     }
     {
-      // allocate 3x512K - should go to the second halves of
+      // allocate 4x512K - should go to the second halves of
       // the first and second 1M chunks and @(capacity / 2)
       uint64_t allocated4 = 0;
       interval_vector_t a4;
@@ -683,18 +737,42 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
       ASSERT_EQ(a4[1].length, _1m / 2);
       ASSERT_EQ(a4[2].offset, capacity / 2);
       ASSERT_EQ(a4[2].length, _1m);
+
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall.size(), 3u);
+      ASSERT_EQ(bins_overall[0], 1u);
+      // below we have 512K - 4K & 512K - 12K chunks which both fit into
+      // the same bin = 6
+      ASSERT_EQ(bins_overall[6], 2u);
+      ASSERT_EQ(bins_overall[cbits((num_chunks - 256) / 2) - 1], 1u);
+
     }
     {
       // cleanup first 2M except except the last 4K chunk
       interval_vector_t r;
       r.emplace_back(0, 2 * _1m - 0x1000);
       al2.free_l2(r);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+
+      ASSERT_EQ(bins_overall.size(), 3u);
+      ASSERT_EQ(bins_overall[0], 1u);
+      ASSERT_EQ(bins_overall[cbits((_2m - 0x1000) / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits((num_chunks - 256) / 2) - 1], 1u);
     }
     {
       // release 2M @(capacity / 2)
       interval_vector_t r;
       r.emplace_back(capacity / 2, 2 * _1m);
       al2.free_l2(r);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+
+      ASSERT_EQ(bins_overall.size(), 3u);
+      ASSERT_EQ(bins_overall[0], 1u);
+      ASSERT_EQ(bins_overall[cbits((_2m - 0x1000) / 0x1000) - 1], 1u);
+      ASSERT_EQ(bins_overall[cbits(num_chunks / 2) - 1], 1u);
     }
     {
       // allocate 132M using 4M granularity should go to (capacity / 2)
@@ -704,12 +782,20 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
       ASSERT_EQ(a4.size(), 1);
       ASSERT_EQ(a4[0].offset, capacity / 2);
       ASSERT_EQ(a4[0].length, 132 * _1m);
+
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+      ASSERT_EQ(bins_overall.size(), 3u);
     }
     {
       // cleanup left 4K chunk in the first 2M
       interval_vector_t r;
       r.emplace_back(2 * _1m - 0x1000, 0x1000);
       al2.free_l2(r);
+      bins_overall.clear();
+      al2.collect_stats(bins_overall);
+
+      ASSERT_EQ(bins_overall.size(), 2u);
     }
     {
       // release 132M @(capacity / 2)
@@ -760,6 +846,6 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
     }
 
   }
-
   std::cout << "Done L2 cont aligned" << std::endl;
 }
+

--- a/src/test/objectstore/fastbmap_allocator_test.cc
+++ b/src/test/objectstore/fastbmap_allocator_test.cc
@@ -849,3 +849,20 @@ TEST(TestAllocatorLevel01, test_l2_contiguous_alignment)
   std::cout << "Done L2 cont aligned" << std::endl;
 }
 
+TEST(TestAllocatorLevel01, test_4G_alloc_bug)
+{
+  {
+    TestAllocatorLevel02 al2;
+    uint64_t capacity = 0x8000 * _1m; // = 32GB
+    al2.init(capacity, 0x10000);
+    std::cout << "Init L2 cont aligned" << std::endl;
+
+      uint64_t allocated4 = 0;
+      interval_vector_t a4;
+      al2.allocate_l2(_1m, _1m, &allocated4, &a4);
+      ASSERT_EQ(a4.size(), 1u); // the bug caused no allocations here
+      ASSERT_EQ(allocated4, _1m);
+      ASSERT_EQ(a4[0].offset, 0u);
+      ASSERT_EQ(a4[0].length, _1m);
+  }
+}


### PR DESCRIPTION
https://tracker.ceph.com/issues/38910