### PR TITLE
os/bluestore: add check for zeroed BlueFS' superblock.

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -166,6 +166,9 @@ public:
   void set_no_exclusive_lock() {
     lock_exclusive = false;
   }
+  bool is_shared() const {
+    return lock_exclusive == false;
+  }
   
   uint64_t get_size() const { return size; }
   uint64_t get_block_size() const { return block_size; }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/25098
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>