### PR TITLE
init-ceph: wait longer before resending $signal

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -141,7 +141,7 @@ stop_daemon() {
 	    cmd=\"kill $signal \$pid\"
 	    printf \"\$cmd...\"
 	    \$cmd
-	    sleep 1
+	    sleep 2
 	    continue
 	done
     fi"


### PR DESCRIPTION
if ceph-osd takes longer than 1 seconds to unmount the objectstore, it
won't get a chance to fully persist all of its stuff to disk before
init-ceph kills it again.

in my case, `MemStore::_save()` fails to write $path/collections before
it gets killed, if it has more than 512 PGs.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

