### PR TITLE
rgw: beast: check for ssl certificates early while parsing

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -451,18 +451,17 @@ int AsioFrontend::init_ssl()
   // ssl configuration
   auto cert = config.find("ssl_certificate");
   const bool have_cert = cert != config.end();
-  if (have_cert) {
-    // only initialize the ssl context if it's going to be used
-    ssl_context = boost::in_place(ssl::context::tls);
+  if (!have_cert) {
+    lderr(ctx()) << "no ssl_certificate configured for ssl_port" << dendl;
+    return -EINVAL;
   }
+
+  // only initialize the ssl context if it's going to be used
+  ssl_context = boost::in_place(ssl::context::tls);
 
   auto key = config.find("ssl_private_key");
   const bool have_private_key = key != config.end();
   if (have_private_key) {
-    if (!have_cert) {
-      lderr(ctx()) << "no ssl_certificate configured for ssl_private_key" << dendl;
-      return -EINVAL;
-    }
     ssl_context->use_private_key_file(key->second, ssl::context::pem, ec);
     if (ec) {
       lderr(ctx()) << "failed to add ssl_private_key=" << key->second
@@ -470,31 +469,25 @@ int AsioFrontend::init_ssl()
       return -ec.value();
     }
   }
-  if (have_cert) {
-    ssl_context->use_certificate_chain_file(cert->second, ec);
+  ssl_context->use_certificate_chain_file(cert->second, ec);
+  if (ec) {
+    lderr(ctx()) << "failed to use ssl_certificate=" << cert->second
+		 << ": " << ec.message() << dendl;
+    return -ec.value();
+  }
+  if (!have_private_key) {
+    // attempt to use it as a private key if a separate one wasn't provided
+    ssl_context->use_private_key_file(cert->second, ssl::context::pem, ec);
     if (ec) {
       lderr(ctx()) << "failed to use ssl_certificate=" << cert->second
-          << ": " << ec.message() << dendl;
+		   << " as a private key: " << ec.message() << dendl;
       return -ec.value();
-    }
-    if (!have_private_key) {
-      // attempt to use it as a private key if a separate one wasn't provided
-      ssl_context->use_private_key_file(cert->second, ssl::context::pem, ec);
-      if (ec) {
-        lderr(ctx()) << "failed to use ssl_certificate=" << cert->second
-            << " as a private key: " << ec.message() << dendl;
-        return -ec.value();
-      }
     }
   }
 
   // parse ssl endpoints
   auto ports = config.equal_range("ssl_port");
   for (auto i = ports.first; i != ports.second; ++i) {
-    if (!have_cert) {
-      lderr(ctx()) << "no ssl_certificate configured for ssl_port" << dendl;
-      return -EINVAL;
-    }
     auto port = parse_port(i->second.c_str(), ec);
     if (ec) {
       lderr(ctx()) << "failed to parse ssl_port=" << i->second << dendl;
@@ -507,10 +500,6 @@ int AsioFrontend::init_ssl()
 
   auto endpoints = config.equal_range("ssl_endpoint");
   for (auto i = endpoints.first; i != endpoints.second; ++i) {
-    if (!have_cert) {
-      lderr(ctx()) << "no ssl_certificate configured for ssl_endpoint" << dendl;
-      return -EINVAL;
-    }
     auto endpoint = parse_endpoint(i->second, 443, ec);
     if (ec) {
       lderr(ctx()) << "failed to parse ssl_endpoint=" << i->second << dendl;


### PR DESCRIPTION
Since ports/endpoints without a configured ssl_certificate will be invalid
anyway error out early if that is the case.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

