### PR TITLE
rgw: fix bug of apply default quota, for this create new a user may c…

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -467,8 +467,8 @@ void rgw::auth::RemoteApplier::create_account(const DoutPrefixProvider* dpp,
   user_info.display_name = info.acct_name;
 
   user_info.max_buckets = cct->_conf->rgw_user_max_buckets;
-  rgw_apply_default_bucket_quota(user_info.bucket_quota, cct->_conf);
-  rgw_apply_default_user_quota(user_info.user_quota, cct->_conf);
+  rgw_apply_default_bucket_quota(user_info.bucket_quota, *cct->_conf);
+  rgw_apply_default_user_quota(user_info.user_quota, *cct->_conf);
 
   int ret = rgw_store_user_info(store, user_info, nullptr, nullptr,
                                 real_time(), true);

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1980,7 +1980,7 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
   if (op_state.has_bucket_quota()) {
     user_info.bucket_quota = op_state.get_bucket_quota();
   } else {
-    rgw_apply_default_bucket_quota(user_info.bucket_quota, cct->_conf);
+    rgw_apply_default_bucket_quota(user_info.bucket_quota, *cct->_conf);
   }
 
   if (op_state.temp_url_key_specified) {
@@ -1994,7 +1994,7 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
   if (op_state.has_user_quota()) {
     user_info.user_quota = op_state.get_user_quota();
   } else {
-    rgw_apply_default_user_quota(user_info.user_quota, cct->_conf);
+    rgw_apply_default_user_quota(user_info.user_quota, *cct->_conf);
   }
 
   // update the request


### PR DESCRIPTION
rgw: fix bug of apply default quota, for this create new a user may core using beast

Fixes: http://tracker.ceph.com/issues/38847
Signed-off-by: liaoxin01 <liaoxin01@baidu.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

