### PR TITLE
mgr/deepsea: return ganesha and iscsi endpoint URLs

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -116,7 +116,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @_read_cli('orchestrator service ls',
                "name=host,type=CephString,req=false "
-               "name=svc_type,type=CephChoices,strings=mon|mgr|osd|mds|nfs|rgw|rbd-mirror,req=false "
+               "name=svc_type,type=CephChoices,strings=mon|mgr|osd|mds|iscsi|nfs|rgw|rbd-mirror,req=false "
                "name=svc_id,type=CephString,req=false "
                "name=format,type=CephChoices,strings=json|plain,req=false",
                'List services known to orchestrator')

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -118,13 +118,14 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
                "name=host,type=CephString,req=false "
                "name=svc_type,type=CephChoices,strings=mon|mgr|osd|mds|iscsi|nfs|rgw|rbd-mirror,req=false "
                "name=svc_id,type=CephString,req=false "
-               "name=format,type=CephChoices,strings=json|plain,req=false",
+               "name=format,type=CephChoices,strings=json|plain,req=false "
+               "name=refresh,type=CephBool,req=false",
                'List services known to orchestrator')
-    def _list_services(self, host=None, svc_type=None, svc_id=None, format='plain'):
+    def _list_services(self, host=None, svc_type=None, svc_id=None, format='plain', refresh=False):
         # XXX this is kind of confusing for people because in the orchestrator
         # context the service ID for MDS is the filesystem ID, not the daemon ID
 
-        completion = self.describe_service(svc_type, svc_id, host)
+        completion = self.describe_service(svc_type, svc_id, host, refresh=refresh)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         services = completion.result


### PR DESCRIPTION
This updates describe_service() to include nfs and iscsi services
(deepsea internally refers to these as "ganesha" and "igw" roles).
Additionally, if deepsea sets any of container_id, service, version,
rados_config_location, service_url, status or status_desc, these will
come through now too.

This relies on https://github.com/SUSE/DeepSea/pull/1606 for the new
functionality, but if run against an older version of deepsea, it will
continue to operate as it did before, it just won't include
rados_config_location or service_url data.

Signed-off-by: Tim Serong <tserong@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

