### PR TITLE
crimson/osd: lower debug level on i/o path

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -959,7 +959,7 @@ seastar::future<> PG::share_pg_info()
 
 seastar::future<> PG::wait_for_active()
 {
-  logger().info("wait_for_active: {}", pg_state_string(info.stats.state));
+  logger().debug("wait_for_active: {}", pg_state_string(info.stats.state));
   if (test_state(PG_STATE_ACTIVE)) {
     return seastar::now();
   } else {


### PR DESCRIPTION
hopefully it can reduce the contribution of cpu cycles of
PG::wait_for_active()

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

