### PR TITLE
mgr/dashboard: Enable read only users to read again

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 
 import { configureTestBed } from '../../../testing/unit-test-helper';
+import { PrometheusNotification } from '../models/prometheus-alerts';
 import { PrometheusService } from './prometheus.service';
 import { SettingsService } from './settings.service';
 
@@ -33,10 +34,16 @@ describe('PrometheusService', () => {
     expect(req.request.method).toBe('GET');
   });
 
-  it('should call getNotificationSince', () => {
-    service.getNotificationSince({}).subscribe();
-    const req = httpTesting.expectOne('api/prometheus/get_notifications_since');
-    expect(req.request.method).toBe('POST');
+  it('should call getNotificationSince without a notification', () => {
+    service.getNotifications().subscribe();
+    const req = httpTesting.expectOne('api/prometheus/notifications?from=last');
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should call getNotificationSince with notification', () => {
+    service.getNotifications({ id: '42' } as PrometheusNotification).subscribe();
+    const req = httpTesting.expectOne('api/prometheus/notifications?from=42');
+    expect(req.request.method).toBe('GET');
   });
 
   describe('ifAlertmanagerConfigured', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.ts
@@ -23,10 +23,10 @@ export class PrometheusService {
     return this.http.get<PrometheusAlert[]>(this.baseURL, { params });
   }
 
-  getNotificationSince(notification): Observable<PrometheusNotification[]> {
-    return this.http.post<PrometheusNotification[]>(
-      `${this.baseURL}/get_notifications_since`,
-      notification
-    );
+  getNotifications(notification?: PrometheusNotification): Observable<PrometheusNotification[]> {
+    const url = `${this.baseURL}/notifications?from=${
+      notification && notification.id ? notification.id : 'last'
+    }`;
+    return this.http.get<PrometheusNotification[]>(url);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/prometheus-alerts.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/prometheus-alerts.ts
@@ -34,6 +34,7 @@ export class PrometheusNotification {
   commonAnnotations: object;
   groupKey: string;
   notified: string;
+  id: string;
   alerts: PrometheusNotificationAlert[];
   version: string;
   receiver: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.spec.ts
@@ -45,7 +45,7 @@ describe('PrometheusNotificationService', () => {
     spyOn(window, 'setTimeout').and.callFake((fn: Function) => fn());
 
     prometheusService = TestBed.get(PrometheusService);
-    spyOn(prometheusService, 'getNotificationSince').and.callFake(() => of(notifications));
+    spyOn(prometheusService, 'getNotifications').and.callFake(() => of(notifications));
 
     notifications = [prometheus.createNotification()];
   });
@@ -57,7 +57,7 @@ describe('PrometheusNotificationService', () => {
   describe('getLastNotification', () => {
     it('returns an empty object on the first call', () => {
       service.refresh();
-      expect(prometheusService.getNotificationSince).toHaveBeenCalledWith({});
+      expect(prometheusService.getNotifications).toHaveBeenCalledWith(undefined);
       expect(service['notifications'].length).toBe(1);
     });
 
@@ -65,18 +65,14 @@ describe('PrometheusNotificationService', () => {
       service.refresh();
       notifications = [prometheus.createNotification(1, 'resolved')];
       service.refresh();
-      expect(prometheusService.getNotificationSince).toHaveBeenCalledWith(
-        service['notifications'][0]
-      );
+      expect(prometheusService.getNotifications).toHaveBeenCalledWith(service['notifications'][0]);
       expect(service['notifications'].length).toBe(2);
 
       notifications = [prometheus.createNotification(2)];
       service.refresh();
       notifications = [prometheus.createNotification(3, 'resolved')];
       service.refresh();
-      expect(prometheusService.getNotificationSince).toHaveBeenCalledWith(
-        service['notifications'][2]
-      );
+      expect(prometheusService.getNotifications).toHaveBeenCalledWith(service['notifications'][2]);
       expect(service['notifications'].length).toBe(4);
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.ts
@@ -22,14 +22,9 @@ export class PrometheusNotificationService {
   }
 
   refresh() {
-    const last = this.getLastNotification();
     this.prometheusService
-      .getNotificationSince(last)
+      .getNotifications(_.last(this.notifications))
       .subscribe((notifications) => this.handleNotifications(notifications));
-  }
-
-  private getLastNotification() {
-    return _.last(this.notifications) || {};
   }
 
   private handleNotifications(notifications: PrometheusNotification[]) {


### PR DESCRIPTION
The dashboards prometheus receiver API needed to receive a POST from the frontend, but POSTs aren't allowed by default by any read only users. As a result the receiver API call had thrown a 403 error which redirected the user to the 403 error page. Now you can get the last notifications via GET. This prevents the redirection for read only users, as a result they can get the last notifications and also see all other allowed pages again.

Fixes: https://tracker.ceph.com/issues/39086
Signed-off-by: Stephan Müller <smueller@suse.com>
