### PR TITLE
mimic: rgw: don't crash on missing /etc/mime.types

### DIFF
--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -192,10 +192,8 @@ const char *rgw_find_mime_by_ext(string& ext)
 int rgw_tools_init(CephContext *cct)
 {
   ext_mime_map = new std::map<std::string, std::string>;
-  int ret = ext_mime_map_init(cct, cct->_conf->rgw_mime_types_file.c_str());
-  if (ret < 0)
-    return ret;
-
+  ext_mime_map_init(cct, cct->_conf->rgw_mime_types_file.c_str());
+  // ignore errors; missing mime.types is not fatal
   return 0;
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38919