### PR TITLE
msg/AsyncConnection: fix the deadlock of lossless_peer connection

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -183,6 +183,7 @@ void ProtocolV1::fault() {
     // backoff!
     if (state == WAIT) {
       backoff.set_from_double(cct->_conf->ms_max_backoff);
+      connect_seq++;
     } else if (backoff == utime_t()) {
       backoff.set_from_double(cct->_conf->ms_initial_backoff);
     } else {


### PR DESCRIPTION
Lossess_peer connection may reconnect failed because of connection race. Increase the
connect_seq if the race occur to break the deadlock.

think about this case:
1. A and B connect with AsyncConnection and the Policy is lossess_peer;
2. network errors occurs, both A and B try to reconnect and increase the connect_seq;
3. connection race happens because the connect_seq of A and B is equal;
4. A may get  "connect got WAIT", and B may get "reconnect: Operation already in progress";
5. the reconnection will never be success, no matter how many times they try.

Increase the connect_seq if A receives "connect got WAIT" will break the deadlock, and A and B can
reconnect successfully.

Signed-off-by: Xiaofei Cui <cuixiaofei@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

