### PR TITLE
rpm: Try replacing fixed "python34" with "%{_python_buildid}

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -264,8 +264,8 @@ BuildRequires:	python2-Cython
 %endif
 %if 0%{?rhel} == 7
 BuildRequires:	python34-devel
-BuildRequires:	python34-setuptools
-BuildRequires:	python34-Cython
+BuildRequires:	python%{_python_buildid}-setuptools
+BuildRequires:	python%{_python_buildid}-Cython
 %else
 BuildRequires:	python3-devel
 BuildRequires:	python3-setuptools


### PR DESCRIPTION
centos builds are failing; looks like a 3.4 version of
Cython is explicitly installed, but python3 -> python3.6
can't find it.  Try making the python34 deps be
sensitive to the python 3 version in the rpm macros.

Signed-off-by: Dan Mick <dan.mick@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

