### PR TITLE
doc/rados/configuration: fix typo in mon-lookup-dns

### DIFF
--- a/doc/rados/configuration/mon-lookup-dns.rst
+++ b/doc/rados/configuration/mon-lookup-dns.rst
@@ -1,5 +1,5 @@
 ===============================
-Looking op Monitors through DNS
+Looking up Monitors through DNS
 ===============================
 
 Since version 11.0.0 RADOS supports looking up Monitors through DNS.


### PR DESCRIPTION
Fix an annoying (for me anyway) typo in the title of the mon-lookup-dns file

Signed-off-by: Vanush "Misha" Paturyan <ektich@gmail.com>
