### PR TITLE
qa: fs Ignore "ceph.dir.pin: No such attribute errors" in getfattr tests for old kernel client

### DIFF
--- a/qa/suites/multimds/basic/tasks/cephfs_test_exports.yaml
+++ b/qa/suites/multimds/basic/tasks/cephfs_test_exports.yaml
@@ -1,4 +1,5 @@
 tasks:
 - cephfs_test_runner:
+    fail_on_skip: false
     modules:
       - tasks.cephfs.test_exports

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from StringIO import StringIO
 from tasks.cephfs.fuse_mount import FuseMount
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 
@@ -24,7 +25,7 @@ class TestExports(CephFSTestCase):
                     self.assertTrue(s['export_pin'] == s['auth_first'])
                 return subtrees
             time.sleep(pause)
-        raise RuntimeError("rank {0} failed to reach desired subtree state", rank)
+        raise RuntimeError("rank {0} failed to reach desired subtree state".format(rank))
 
     def test_export_pin(self):
         self.fs.set_max_mds(2)
@@ -113,10 +114,45 @@ class TestExports(CephFSTestCase):
         else:
             self._wait_subtrees(status, 0, [('/1', 0), ('/1/4/5', 1), ('/a', 1), ('/a/b/aa/bb', 0)])
 
-        # Test getfattr
-        self.assertTrue(self.mount_a.getfattr("1", "ceph.dir.pin") == "0")
-        self.assertTrue(self.mount_a.getfattr("1/4", "ceph.dir.pin") == "-1")
-        self.assertTrue(self.mount_a.getfattr("1/4/5", "ceph.dir.pin") == "1")
+    def test_export_pin_getfattr(self):
+        self.fs.set_max_mds(2)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        self.mount_a.run_shell(["mkdir", "-p", "1/2/3"])
+        self._wait_subtrees(status, 0, [])
+
+        # pin /1 to rank 0
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees(status, 1, [('/1', 1)])
+
+        # pin /1/2 to rank 1
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
+        self._wait_subtrees(status, 1, [('/1', 1), ('/1/2', 1)])
+
+        # change pin /1/2 to rank 0
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
+        self._wait_subtrees(status, 1, [('/1', 1), ('/1/2', 0)])
+        self._wait_subtrees(status, 0, [('/1', 1), ('/1/2', 0)])
+
+         # change pin /1/2/3 to (presently) non-existent rank 2
+        self.mount_a.setfattr("1/2/3", "ceph.dir.pin", "2")
+        self._wait_subtrees(status, 0, [('/1', 1), ('/1/2', 0)])
+
+        if len(list(status.get_standbys())):
+            self.fs.set_max_mds(3)
+            self.fs.wait_for_state('up:active', rank=2)
+            self._wait_subtrees(status, 0, [('/1', 1), ('/1/2', 0), ('/1/2/3', 2)])
+
+        if not isinstance(self.mount_a, FuseMount):
+            p = self.mount_a.client_remote.run(args=['uname', '-r'], stdout=StringIO(), wait=True)
+            dir_pin = self.mount_a.getfattr("1", "ceph.dir.pin")
+            log.debug("mount.getfattr('1','ceph.dir.pin'): %s " % dir_pin)
+	    if str(p.stdout.getvalue()) < "5" and not(dir_pin):
+	        self.skipTest("Kernel does not support getting the extended attribute ceph.dir.pin")
+        self.assertTrue(self.mount_a.getfattr("1", "ceph.dir.pin") == "1")
+        self.assertTrue(self.mount_a.getfattr("1/2", "ceph.dir.pin") == "0")
         if (len(self.fs.get_active_names()) > 2):
             self.assertTrue(self.mount_a.getfattr("1/2/3", "ceph.dir.pin") == "2")
 


### PR DESCRIPTION
Tests for getfattr("ceph.dir.pin") were failing for the old kernel client packaged with RHEL. This PR allows the tests to be skipped in those cases.

Fixes: https://tracker.ceph.com/issues/38801
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

