### PR TITLE
mgr/dashboard: Fix iSCSI disk diff calculation

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -252,7 +252,7 @@ class IscsiTarget(RESTController):
                 return True
         # Check if any disk inside this group has changed
         for disk in new_group['disks']:
-            image_id = '{}.{}'.format(disk['pool'], disk['image'])
+            image_id = '{}/{}'.format(disk['pool'], disk['image'])
             if IscsiTarget._target_lun_deletion_required(target, new_target_iqn,
                                                          new_target_controls, new_portals,
                                                          new_disks, image_id):
@@ -291,7 +291,7 @@ class IscsiTarget(RESTController):
     @staticmethod
     def _get_disk(disks, image_id):
         for disk in disks:
-            if '{}.{}'.format(disk['pool'], disk['image']) == image_id:
+            if '{}/{}'.format(disk['pool'], disk['image']) == image_id:
                 return disk
         return None
 


### PR DESCRIPTION
The separator is now a '/' instead of '.'

Fixes: https://tracker.ceph.com/issues/39109

Signed-off-by: Ricardo Marques <rimarques@suse.com>
