### PR TITLE
doc: fixed typo in leadership names

### DIFF
--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -50,7 +50,7 @@ the CLT itself.
 
 Current CLT members are:
 
- * Ahbishek Lekshmanan <abhishek@suse.com>
+ * Abhishek Lekshmanan <abhishek@suse.com>
  * Alfredo Deza <adeza@redhat.com>
  * Gregory Farnum <gfarnum@redhat.com>
  * Haomai Wang <haomai@xsky.com>


### PR DESCRIPTION
Signed-off-by: Servesha Dudhgaonkar <sdudhgao@redhat.com>



