### PR TITLE
nautilus: mon/MonmapMonitor: clean up empty created stamp in monmap

### DIFF
--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -72,6 +72,8 @@ class MonmapMonitor : public PaxosService {
 
   void check_sub(Subscription *sub);
 
+  void tick() override;
+
 private:
   void check_subs();
   bufferlist monmap_bl;


### PR DESCRIPTION
Some old clusters have an empty created timestamp.  This is mostly
harmless, but it is confusing/wrong, and it does currently break the
telemetry module with errors like

 ValueError: time data '0.000000' does not match format '%Y-%m-%d %H:%M:%S.%f'

from 'ceph telemetry show'.

If we detect an empty created stamp, look at old monmap and use the oldest
modified stamp we can find.

Fixes: http://tracker.ceph.com/issues/39085
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 3046d17f61d1fa11fe2f35f7cfe9428312a78593)