### PR TITLE
doc: update documentation for the MANY_OBJECTS_PER_PG warning

### DIFF
--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -96,8 +96,8 @@ Ceph configuration file.
 
 :Description: Issue a ``HEALTH_WARN`` in cluster log if the average object number
               of a certain pool is greater than ``mon pg warn max object skew`` times
-              the average object number of the whole pool. (a non-positive number
-              disables this)
+              the average object number of the whole pool. (zero or a non-positive
+              number disables this). Note that this option applies to the managers.
 :Type: Float
 :Default: ``10``
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -663,7 +663,7 @@ not contain as much data have too many PGs.  See the discussion of
 *TOO_MANY_PGS* above.
 
 The threshold can be raised to silence the health warning by adjusting
-the ``mon_pg_warn_max_object_skew`` config option on the monitors.
+the ``mon_pg_warn_max_object_skew`` config option on the managers.
 
 
 POOL_APP_NOT_ENABLED


### PR DESCRIPTION
The current documentation for the `MANY_OBJECTS_PER_PG` warning states that `The threshold can be raised to silence the health warning by adjusting the mon_pg_warn_max_object_skew config option on the monitors`. It seems that this is not true (at least) since the luminous times, and this option should be adjusted on the managers.

I encountered this problem and I spend quite sometime injecting the `mon_pg_warn_max_object_skew` to the monitors, added the option ceph.conf and restarted the monitors several times but the warning was not going away. I had to download the code to see what's happening and I found out this:

```
$ git grep -A 3 mon_pg_warn_max_object_skew src/common/options.cc
src/common/options.cc:1480:    Option("mon_pg_warn_max_object_skew", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
src/common/options.cc-1481-    .set_default(10.0)
src/common/options.cc-1482-    .set_description("max skew few average in objects per pg")
src/common/options.cc-1483-    .add_service("mgr"),
```

After I restarted the `ceph-mgr` service, the warning went away.