### PR TITLE
mgr/dashboard: Add whitelist to guard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -53,6 +53,7 @@ describe('ModuleStatusGuardService', () => {
     httpClient = TestBed.get(HttpClient);
     router = TestBed.get(Router);
     route = new ActivatedRouteSnapshot();
+    route.url = [];
     route.data = {
       moduleStatusGuardConfig: {
         apiPath: 'bar',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
@@ -36,6 +36,9 @@ import { ServicesModule } from './services.module';
   providedIn: ServicesModule
 })
 export class ModuleStatusGuardService implements CanActivate, CanActivateChild {
+  // TODO: Hotfix - remove WHITELIST'ing when a generic ErrorComponent is implemented
+  static readonly WHITELIST: string[] = ['501'];
+
   constructor(private http: HttpClient, private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot) {
@@ -47,6 +50,9 @@ export class ModuleStatusGuardService implements CanActivate, CanActivateChild {
   }
 
   private doCheck(route: ActivatedRouteSnapshot) {
+    if (route.url.length > 0 && ModuleStatusGuardService.WHITELIST.includes(route.url[0].path)) {
+      return observableOf(true);
+    }
     const config = route.data['moduleStatusGuardConfig'];
     return this.http.get(`/api/${config.apiPath}/status`).pipe(
       map((resp: any) => {


### PR DESCRIPTION
After PR https://github.com/ceph/ceph/pull/26572, when RGW is not
  configured, accessing /rgw drop-down (daemons, users or buckets)
  results in nothing apparently happening (not even an error).

  Under the curtains, what is happening is that the ModuleStatusGuard
  has redirected the route to the rgw/501, but as this route is now
  under parent rgw route handler, which sets CanActivateChild guards,
  this results in a new ModuleStatusGuard invokation, a subsequent
  failure and a new redirection to rgw/501.

  Several approaches could be taken here:
  - Remove error pages from lazy-loaded modules. Probably it does not
  make sense to have a 501 page per component.
  - Add some whitelist to avoid this kind of loop (e.g.: 501, or any
      error page).
  - Set a max number of redirections (cautionary measure).

Fixes: https://tracker.ceph.com/issues/39125
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

