### PR TITLE
rpm: use python3.4 on RHEL7 by default

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -87,7 +87,13 @@
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
 %{!?tmpfiles_create: %global tmpfiles_create systemd-tmpfiles --create}
+%if 0%{?rhel} == 7
+%{!?python3_pkgversion: %global python3_pkgversion 34}
+%{!?python3_version: %global python3_version 3.4}
+%else
 %{!?python3_pkgversion: %global python3_pkgversion 3}
+%{!?python3_version: %global python3_version 3}
+%endif
 # define _python_buildid macro which will expand to the empty string when
 # building with python2
 %global _python_buildid %{?_defined_if_python2_absent:%{python3_pkgversion}}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,7 +220,7 @@ endif()
 option(WITH_PYTHON2 "build python2 bindings" ON)
 if(WITH_PYTHON2)
   find_package(PythonInterp 2 REQUIRED)
-  find_package(PythonLibs 2 REQUIRED)
+  find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT REQUIRED)
 endif()
 
 set(WITH_PYTHON3 "OFF" CACHE STRING "build python3 bindings with specified python3 version")
@@ -229,7 +229,7 @@ if(WITH_PYTHON3)
     set(WITH_PYTHON3 "3")
   endif()
   find_package(Python3Interp ${WITH_PYTHON3} REQUIRED)
-  find_package(Python3Libs ${PYTHON3_VERSION_MAJOR}.${PYTHON3_VERSION_MINOR} REQUIRED)
+  find_package(Python3Libs ${PYTHON3_VERSION_STRING} EXACT REQUIRED)
 endif()
 
 # the major version of the python bindings as a dependency of other


### PR DESCRIPTION
python3.4 is the native python3 before 7.6

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

