### PR TITLE
rgw: clean up some logging

### DIFF
--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -199,27 +199,14 @@ static int lock_obj(cls_method_context_t hctx,
 
   if (!lockers.empty()) {
     if (exclusive) {
-      std::stringstream locker_list;
-      bool first = true;
-      // there could be multiple lockers if they are all shared
-      for (const auto& l : lockers) {
-	if (first) {
-	  first = false;
-	} else {
-	  locker_list << ", ";
-	}
-	locker_list << "{name:" << l.first.locker <<
-	  ", addr:" << l.second.addr <<
-	  ", exp:";
-	const auto& exp = l.second.expiration;
-	if (exp.is_zero()) {
-	  locker_list << "never}";
-	} else {
-	  locker_list << exp.to_real_time() << "}";
-	}
-      }
-      CLS_LOG(20, "could not exclusive-lock object, already locked by [%s]",
-	      locker_list.str().c_str());
+      auto locker_lister =
+	[&lockers]() -> std::string {
+	  std::stringstream locker_list;
+	  locker_list << lockers;
+	  return locker_list.str();
+	};
+      CLS_LOG(20, "could not exclusive-lock object, already locked by %s",
+	      locker_lister().c_str());
       return -EBUSY;
     }
 

--- a/src/cls/lock/cls_lock_types.h
+++ b/src/cls/lock/cls_lock_types.h
@@ -85,6 +85,11 @@ namespace rados {
           return false;
         }
         void dump(Formatter *f) const;
+	friend std::ostream& operator<<(std::ostream& out,
+					const locker_id_t& data) {
+	  out << data.locker;
+	  return out;
+	}
         static void generate_test_instances(list<locker_id_t*>& o);
       };
       WRITE_CLASS_ENCODER(locker_id_t)
@@ -114,6 +119,19 @@ namespace rados {
           DECODE_FINISH(bl);
         }
         void dump(Formatter *f) const;
+	friend std::ostream& operator<<(std::ostream& out,
+					const locker_info_t& data) {
+	  out << "{addr:" << data.addr << ", exp:";
+
+	  const auto& exp = data.expiration;
+	  if (exp.is_zero()) {
+	    out << "never}";
+	  } else {
+	    out << exp.to_real_time() << "}";
+	  }
+
+	  return out;
+	}
         static void generate_test_instances(list<locker_info_t *>& o);
       };
       WRITE_CLASS_ENCODER_FEATURES(locker_info_t)

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -250,27 +250,9 @@ public:
     index_io.type = IO::IndexIO;
     index_io.index = index;
 
-    // use lambda to assemble list, so it will only get executed if
-    // we're at the appropirate logging level
-    auto lister = [&rt]() -> std::string {
-      std::stringstream out;
-      bool first = true;
-
-      for (const auto& s : rt) {
-	if (first) {
-	  first = false;
-	} else {
-	  out << ", ";
-	}
-	out << s;
-      }
-
-      return out.str();
-    };
-
     ldpp_dout(dpp, 20) << __func__ <<
       " removing entries from gc log shard index=" << index << ", size=" <<
-      rt.size() << ", entries=[" << lister() << "]" << dendl;
+      rt.size() << ", entries=" << rt << dendl;
 
     int ret = gc->remove(index, rt, &index_io.c);
     rt.clear();


### PR DESCRIPTION
Some recently added logging ignored the fact that ceph logging can already handle std::vector and std::map and instead did things manually. This corrects two of those cases.

Fixes: https://tracker.ceph.com/issues/39131