### PR TITLE
crimson: update osd when peer gets authenticated 

### DIFF
--- a/src/auth/AuthClient.h
+++ b/src/auth/AuthClient.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
+#include "include/buffer_fwd.h"
 
-class EntityName;
+class AuthConnectionMeta;
+class Connection;
 class CryptoKey;
 
 class AuthClient {

--- a/src/crimson/auth/AuthServer.h
+++ b/src/crimson/auth/AuthServer.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <vector>
+#include "common/ceph_context.h"
 #include "auth/AuthAuthorizeHandler.h"
+#include "auth/AuthRegistry.h"
 #include "crimson/net/Fwd.h"
 
 namespace ceph::auth {
@@ -13,41 +15,32 @@ namespace ceph::auth {
 class AuthServer {
 public:
   // TODO:
-  // AuthRegistry auth_registry;
-
-  AuthServer() {}
+  AuthServer()
+    : auth_registry{&cct}
+  {}
   virtual ~AuthServer() {}
 
   // Get authentication methods and connection modes for the given peer type
   virtual std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
-  get_supported_auth_methods(
-    int peer_type) {
-    // std::vector<uint32_t> methods;
-    // std::vector<uint32_t> modes;
-    // auth_registry.get_supported_methods(peer_type, &methods, &modes);
-    return {{CEPH_AUTH_NONE}, {CEPH_AUTH_NONE}};
+  get_supported_auth_methods(int peer_type) {
+    std::vector<uint32_t> methods;
+    std::vector<uint32_t> modes;
+    auth_registry.get_supported_methods(peer_type, &methods, &modes);
+    return {methods, modes};
   }
-
   // Get support connection modes for the given peer type and auth method
   virtual uint32_t pick_con_mode(
     int peer_type,
     uint32_t auth_method,
     const std::vector<uint32_t>& preferred_modes) {
-    // return auth_registry.pick_mode(peer_type, auth_method, preferred_modes);
-    ceph_assert(auth_method == CEPH_AUTH_NONE);
-    ceph_assert(preferred_modes.size() &&
-                preferred_modes[0] == CEPH_CON_MODE_CRC);
-    return CEPH_CON_MODE_CRC;
+    return auth_registry.pick_mode(peer_type, auth_method, preferred_modes);
   }
-
   // return an AuthAuthorizeHandler for the given peer type and auth method
   AuthAuthorizeHandler *get_auth_authorize_handler(
     int peer_type,
     int auth_method) {
-    // return auth_registry.get_handler(peer_type, auth_method);
-    return nullptr;
+    return auth_registry.get_handler(peer_type, auth_method);
   }
-
   // Handle an authentication request on an incoming connection
   virtual int handle_auth_request(
     ceph::net::ConnectionRef conn,
@@ -56,6 +49,10 @@ public:
     uint32_t auth_method,
     const bufferlist& bl,
     bufferlist *reply) = 0;
+
+private:
+  CephContext cct; // for auth_registry
+  AuthRegistry auth_registry;
 };
 
 } // namespace ceph::auth

--- a/src/crimson/auth/AuthServer.h
+++ b/src/crimson/auth/AuthServer.h
@@ -29,15 +29,6 @@ public:
   }
 
   // Get support connection modes for the given peer type and auth method
-  virtual void get_supported_con_modes(
-    int peer_type,
-    uint32_t auth_method,
-    std::vector<uint32_t> *modes) {
-    // auth_registry.get_supported_modes(peer_type, auth_method, modes);
-    *modes = { CEPH_CON_MODE_CRC };
-  }
-
-  // Get support connection modes for the given peer type and auth method
   virtual uint32_t pick_con_mode(
     int peer_type,
     uint32_t auth_method,

--- a/src/crimson/common/auth_handler.h
+++ b/src/crimson/common/auth_handler.h
@@ -1,0 +1,18 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+class EntityName;
+class AuthCapsInfo;
+
+namespace ceph::common {
+class AuthHandler {
+public:
+  // the peer just got authorized
+  virtual void handle_authentication(const EntityName& name,
+				     uint64_t global_id,
+				     const AuthCapsInfo& caps) = 0;
+  virtual ~AuthHandler() = default;
+};
+}


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] implement `AuthClient`
- [ ] implement `AuthServer`
- [ ] pick v2 address in `osd.cc`
- [ ] connect to v2 addresses in `heatteat.cc` and `pg.cc`
- [ ] bind/connect to multiple v2 addresses

