### PR TITLE
rpm: use python 3.6 as the default python3

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -88,8 +88,8 @@
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
 %{!?tmpfiles_create: %global tmpfiles_create systemd-tmpfiles --create}
 %if 0%{?rhel} == 7
-%{!?python3_pkgversion: %global python3_pkgversion 34}
-%{!?python3_version: %global python3_version 3.4}
+%{!?python3_pkgversion: %global python3_pkgversion 36}
+%{!?python3_version: %global python3_version 3.6}
 %else
 %{!?python3_pkgversion: %global python3_pkgversion 3}
 %{!?python3_version: %global python3_version 3}


### PR DESCRIPTION
see
https://lists.fedoraproject.org/archives/list/epel-announce@lists.fedoraproject.org/message/EGUMKAIMPK2UD5VSHXM53BH2MBDGDWMO/
,

EPEL7 is now using python3.6 as the native python3. some packages,
cmake3-data for instance depends on python3.6 after EPEL7 switched over
to py3.6. so, when we install the build-time dependencies, there are
three cases:
- none of the packages installed by `yum-builddep` installs the python3
  related rpm macros, so the systemstays with whatever python3 it was
  using. in this case, `rpmbuild` won't complain, as the
  `python3_pkgversion` and `python_version` are consistent before and
  after `yum-builddep`.
- system does not have python3 installed before `yum-builddep`. so
  it was using python34 for preparing the "BuildRequires". but some
  of the packages installed by `yum-builddep` installs python36, and
  also the updated `python-rpm-macros` packages, which points
  `python3_version` and `python3_pkgversion` to 3.6 and 36 respectively.
  in this case, `rpmbuild` will complain, because the python36 related
  dependencies are missing. what the system has is python34
  dependencies.
- system does not have python3 installed before `yum-builddep`. so
  it was using python34 for preparing the "BuildRequires". but some
  of the packages installed by `yum-builddep` installs python34, and
  also the updated `python-rpm-macros` packages, which points
  `python3_version` and `python3_pkgversion` to 3.4 and 34 respectively.
  in this case, `rpmbuild` won't complain, as the
  `python3_pkgversion` and `python_version` are also consistent before and
  after `yum-builddep`.

as we cannot tell if the system has python3 or what the python3 version
the system has before `yum-builddep`, so what we can do is to ensure
`rpmbuild` has what it needs to build Ceph. so let's just stick with
python3.6.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

