### PR TITLE
common: add --log-early command line option

### DIFF
--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -106,6 +106,10 @@ void common_init_finish(CephContext *cct)
   cct->init_crypto();
   ZTracer::ztrace_init();
 
+  if (!cct->_log->is_started()) {
+    cct->_log->start();
+  }
+
   int flags = cct->get_init_flags();
   if (!(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
     cct->start_service_thread();

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -570,6 +570,9 @@ int md_config_t::parse_argv(ConfigValues& values,
     else if (ceph_argparse_flag(args, i, "--no-mon-config", (char*)NULL)) {
       values.no_mon_config = true;
     }
+    else if (ceph_argparse_flag(args, i, "--log-early", (char*)NULL)) {
+      values.log_early = true;
+    }
     else if (ceph_argparse_flag(args, i, "--mon-config", (char*)NULL)) {
       values.no_mon_config = false;
     }

--- a/src/common/config_values.h
+++ b/src/common/config_values.h
@@ -28,6 +28,7 @@ public:
   std::string cluster;
   ceph::logging::SubsystemMap subsys;
   bool no_mon_config = false;
+  bool log_early = false;
   // Set of configuration options that have changed since the last
   // apply_changes
   using changed_set_t = std::set<std::string>;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -142,6 +142,11 @@ void global_pre_init(
   // command line (as passed by caller)
   conf.parse_argv(args);
 
+  if (conf->log_early &&
+      !cct->_log->is_started()) {
+    cct->_log->start();
+  }
+
   if (!conf->no_mon_config) {
     // make sure our mini-session gets legacy values
     conf.apply_changes(nullptr);
@@ -154,7 +159,10 @@ void global_pre_init(
       _exit(1);
     }
   }
-  cct->_log->start();
+  if (!cct->_log->is_started()) {
+    cct->_log->start();
+  }
+
   // do the --show-config[-val], if present in argv
   conf.do_argv_commands();
 

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -79,6 +79,11 @@ public:
   {
     int ret;
 
+    if (cct->_conf->log_early &&
+	!cct->_log->is_started()) {
+      cct->_log->start();
+    }
+
     {
       MonClient mc_bootstrap(cct);
       ret = mc_bootstrap.get_monmap_and_config();

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -77,8 +77,6 @@ public:
 
   int init()
   {
-    common_init_finish(cct);
-
     int ret;
 
     {
@@ -87,6 +85,8 @@ public:
       if (ret < 0)
 	return ret;
     }
+
+    common_init_finish(cct);
 
     //monmap
     monclient = new MonClient(cct);

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -238,6 +238,11 @@ int librados::RadosClient::connect()
     return -EISCONN;
   state = CONNECTING;
 
+  if (cct->_conf->log_early &&
+      !cct->_log->is_started()) {
+    cct->_log->start();
+  }
+
   {
     MonClient mc_bootstrap(cct);
     err = mc_bootstrap.get_monmap_and_config();

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -82,6 +82,8 @@ class Log : private Thread
   void _log_message(const char *s, bool crash);
 
 public:
+  using Thread::is_started;
+
   Log(const SubsystemMap *s);
   ~Log() override;
 


### PR DESCRIPTION
Sometime it is important and useful to see the logs from the bootstrap
phase where we are getting the initial configs from the monitors.  Add
a command-line option --log-early to do that.

Signed-off-by: Sage Weil <sage@redhat.com>