### PR TITLE
doc: fix parameter to set pg autoscale mode

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -29,7 +29,7 @@ For example to enable autoscaling on pool ``foo``,::
 You can also configure the default ``pg_autoscale_mode`` that is
 applied to any pools that are created in the future with::
 
-  ceph config set global osd_pool_default_autoscale_mode <mode>
+  ceph config set global osd_pool_default_pg_autoscale_mode <mode>
 
 Viewing PG scaling recommendations
 ----------------------------------


### PR DESCRIPTION
osd_pool_default_pg_autoscale_mode is the right parameter to
set placement-group autoscale mode.

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

