### PR TITLE
cephfs-shell: Use colorama module instead of colorize

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -168,7 +168,7 @@ def print_long(shell, file_name, is_dir, human_readable):
     info = cephfs.stat(file_name)
     file_name = os.path.basename(file_name.decode('utf-8'))
     if is_dir:
-        file_name = shell.colorize(file_name+'/',  'blue')
+        file_name = colorama.Style.BRIGHT + colorama.Fore.CYAN + file_name + '/' + colorama.Style.RESET_ALL
     if human_readable:
         shell.poutput('{}\t{:10s} {} {} {} {}'.format(
             mode_notation(info.st_mode),
@@ -590,7 +590,7 @@ exists.')
                     print_long(self, cephfs.getcwd().decode(
                         'utf-8') + dir_name + '/' + path, is_dir, False)
                 elif is_dir:
-                    values.append(self.colorize(path + '/', 'blue'))
+                    values.append(colorama.Style.BRIGHT + colorama.Fore.CYAN + path + '/')
                 else:
                     values.append(path)
             if not args.long:


### PR DESCRIPTION
Remove references to colorize attributes. As in cmd2 module, colorize attribute
is deleted. Instead use colorama module.

Fixes: https://tracker.ceph.com/issues/38996
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

