### PR TITLE
crimson/net: extract do_write_dispatch_sweep()

### DIFF
--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -90,6 +90,7 @@ class Protocol {
   bool need_keepalive = false;
   bool need_keepalive_ack = false;
   bool write_dispatching = false;
+  seastar::future<stop_t> do_write_dispatch_sweep();
   void write_event();
 };
 


### PR DESCRIPTION
Extract a worker which runs exclusively to consume `conn.out_q`, deal with keepalive/keepalive_ack and watch `Protocol::write_state`.

Also requested by https://github.com/ceph/ceph/pull/26710#discussion_r271780197 