### PR TITLE
mimic: qa: fsstress with valgrind may timeout

### DIFF
--- a/qa/cephfs/tasks/cfuse_workunit_suites_fsstress.yaml
+++ b/qa/cephfs/tasks/cfuse_workunit_suites_fsstress.yaml
@@ -1,5 +1,6 @@
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/fsstress.sh


### PR DESCRIPTION
http://tracker.ceph.com/issues/38540