### PR TITLE
mds: prevent too many request of mdslog for osd at once when the mds restarts (default 0, means no limited)

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -627,6 +627,13 @@ void MDLog::trim(int m)
 
   unsigned new_expiring_segments = 0;
 
+  unsigned max_expiring_segments = 0;
+  if (pre_segments_size > 0){
+    max_expiring_segments = max_segments/2;
+    assert(segments.size() >= pre_segments_size);
+    max_expiring_segments = std::max<unsigned>(max_expiring_segments,segments.size() - pre_segments_size);
+  }
+  
   map<uint64_t,LogSegment*>::iterator p = segments.begin();
   while (p != segments.end()) {
     if (stop < ceph_clock_now())
@@ -642,6 +649,10 @@ void MDLog::trim(int m)
     if (new_expiring_segments * 2 > num_remaining_segments)
       break;
 
+    if (max_expiring_segments > 0 &&
+	expiring_segments.size() >= max_expiring_segments)
+      break;
+    
     // look at first segment
     LogSegment *ls = p->second;
     ceph_assert(ls);
@@ -832,6 +843,8 @@ void MDLog::_trim_expired_segments()
 	     << ls->seq << "/0x" << std::hex << ls->offset << std::dec << dendl;
     expired_events -= ls->num_events;
     expired_segments.erase(ls);
+    if (pre_segments_size > 0)
+      pre_segments_size--;
     num_events -= ls->num_events;
       
     // this was the oldest segment, adjust expire pos
@@ -1460,6 +1473,7 @@ void MDLog::_replay_thread()
     if (mds->is_daemon_stopping()) {
       return;
     }
+    pre_segments_size = segments.size();  // get num of logs when replay is finished
     finish_contexts(g_ceph_context, waitfor_replay, r);  
   }
 

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -124,6 +124,7 @@ protected:
   map<uint64_t,LogSegment*> segments;
   set<LogSegment*> expiring_segments;
   set<LogSegment*> expired_segments;
+  std::size_t pre_segments_size = 0;            // the num of segments when the mds finished replay-journal, to calc the num of segments growing
   uint64_t event_seq;
   int expiring_events;
   int expired_events;


### PR DESCRIPTION

Fixes: http://tracker.ceph.com/issues/40028
Signed-off-by: simon gao <simon29rock@gmail.com>
