### PR TITLE
mgr/dashboard: Removes distracting search behavior

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -98,11 +98,13 @@ describe('TableComponent', () => {
     });
 
     describe('test search', () => {
-      const doSearch = (search: string, expectedLength: number, firstObject: object) => {
+      const doSearch = (search: string, expectedLength: number, firstObject?: object) => {
         component.search = search;
         component.updateFilter();
         expect(component.rows.length).toBe(expectedLength);
-        expect(component.rows[0]).toEqual(firstObject);
+        if (firstObject) {
+          expect(component.rows[0]).toEqual(firstObject);
+        }
       };
 
       it('should search for 13', () => {
@@ -159,10 +161,10 @@ describe('TableComponent', () => {
         doSearch('poker+array:score21', 6, { a: 15, b: 225, c: [-5, 'score21'], d: false });
       });
 
-      it('should not search if column name is incomplete', () => {
-        doSearch(`'poker array'`, 100, { a: 0, b: 0, c: [-0, 'score6'], d: true });
-        doSearch('pok', 100, { a: 0, b: 0, c: [-0, 'score6'], d: true });
-        doSearch('pok:', 100, { a: 0, b: 0, c: [-0, 'score6'], d: true });
+      it('should search if column name is incomplete', () => {
+        doSearch(`'poker array'`, 0);
+        doSearch('pok', 0);
+        doSearch('pok:', 100);
       });
 
       it('should restore full table after search', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -495,18 +495,11 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       .replace('+', ' ')
       .split(':');
     const columnsClone = [...columns];
-    const dataClone = [...data];
-    const filterColumns = (columnName: string) =>
-      columnsClone.filter((c) => c.name.toLowerCase().indexOf(columnName) !== -1);
     if (searchTerms.length === 2) {
-      columns = filterColumns(searchTerms[0]);
+      columns = columnsClone.filter((c) => c.name.toLowerCase().indexOf(searchTerms[0]) !== -1);
     }
-    const searchTerm: string = _.last(searchTerms);
-    data = this.basicDataSearch(searchTerm, data, columns);
+    data = this.basicDataSearch(_.last(searchTerms), data, columns);
     // Checks if user searches for column but he is still typing
-    if (data.length === 0 && searchTerms.length === 1 && filterColumns(searchTerm).length > 0) {
-      data = dataClone;
-    }
     return this.subSearch(data, currentSearch, columnsClone);
   }
 


### PR DESCRIPTION
The behavior was to not search anything if the search included a
subset of a column name, with the thought in mind that the user would
like to search a specific column for a value.

Now the column name is only ignored after you typed in ':' in order to see
the data in the table again before specifying a more concrete value to
search for.

Fixes: https://tracker.ceph.com/issues/37701
Signed-off-by: Stephan Müller <smueller@suse.com>

![2019-04-08 16-03](https://user-images.githubusercontent.com/16167865/55730549-c3129280-5a18-11e9-824e-94d3b246b2c0.gif)