### PR TITLE
nautilus: mgr/dashboard: Display the number of active sessions for each iSCSI target

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -101,6 +101,11 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
         name: this.i18n('Images'),
         prop: 'cdImages',
         flexGrow: 2
+      },
+      {
+        name: this.i18n('# Sessions'),
+        prop: 'info.num_sessions',
+        flexGrow: 1
       }
     ];
 

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -4338,6 +4338,13 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="99e094878070eebc1b972bac02aaa33b2bf83b35" datatype="html">
+        <source># Sessions</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="9a541ec1a4319fffc16ad3b3ab2c2b6d251a829d" datatype="html">
         <source>Hostname</source>
         <context-group purpose="location">

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -198,3 +198,8 @@ class IscsiClient(RestClient):
         return request({
             'action': action
         })
+
+    @RestClient.api_get('/api/targetinfo/{target_iqn}')
+    def get_targetinfo(self, target_iqn, request=None):
+        logger.debug("iSCSI: Getting targetinfo: %s", target_iqn)
+        return request()

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -431,7 +431,10 @@ iscsi_target_response = {
             'members': ['iqn.1994-05.com.redhat:rh7-client2']
         }
     ],
-    'target_controls': {}
+    'target_controls': {},
+    'info': {
+        'num_sessions': 0
+    }
 }
 
 
@@ -635,3 +638,8 @@ class IscsiClientMock(object):
 
     def update_targetauth(self, target_iqn, action):
         self.config['targets'][target_iqn]['acl_enabled'] = (action == 'enable_acl')
+
+    def get_targetinfo(self, _):
+        return {
+            'num_sessions': 0
+        }


### PR DESCRIPTION
https://tracker.ceph.com/issues/39112