### PR TITLE
mimic: spdk: update to latest spdk-18.05 branch

### DIFF
--- a/cmake/modules/BuildSPDK.cmake
+++ b/cmake/modules/BuildSPDK.cmake
@@ -30,10 +30,10 @@ macro(build_spdk)
   endforeach()
   set_target_properties(spdk::env_dpdk PROPERTIES
     INTERFACE_LINK_LIBRARIES "${DPDK_LIBRARIES};rt")
-  if(LINUX)
-    set_target_properties(spdk::lvol PROPERTIES
-      INTERFACE_LINK_LIBRARIES ${UUID_LIBRARIES})
-  endif()
+  set_target_properties(spdk::lvol PROPERTIES
+    INTERFACE_LINK_LIBRARIES spdk::util)
+  set_target_properties(spdk::util PROPERTIES
+    INTERFACE_LINK_LIBRARIES ${UUID_LIBRARIES})
   set(SPDK_INCLUDE_DIR "${source_dir}/include")
   unset(source_dir)
 endmacro()


### PR DESCRIPTION
also bump dpdk to to spdk-18.05 branch. this should fix the build
failure on Fedora 28

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 8098e549643cd98f527ee923d6e3ab804cfe5b65)

Conflicts:
	src/spdk

This fixes a problem building mimic with gcc8.

```
rte_table_hash_cuckoo.c:139:16: error: cast between incompatible function types from ‘rte_table_hash_op_hash’ {aka ‘long unsigned int (*)(void *, void *, unsigned int,  long unsi
gned int)’} to ‘uint32_t (*)(const void *, uint32_t,  uint32_t)’ {aka ‘unsigned int (*)(const void *, unsigned int,  unsigned int)’} [-Werror=cast-function-type]
   .hash_func = (rte_hash_function)(p->f_hash),   
                ^  
cc1: all warnings being treated as errors
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

