### PR TITLE
luminous: os/bluestore/BitmapFreelistManager: disable bluestore_debug_freelist

### DIFF
--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -505,8 +505,6 @@ void BitmapFreelistManager::allocate(
 {
   dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << std::dec << dendl;
-  if (cct->_conf->bluestore_debug_freelist)
-    _verify_range(offset, length, 0);
   _xor(offset, length, txn);
 }
 
@@ -516,8 +514,6 @@ void BitmapFreelistManager::release(
 {
   dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << std::dec << dendl;
-  if (cct->_conf->bluestore_debug_freelist)
-    _verify_range(offset, length, 1);
   _xor(offset, length, txn);
 }
 


### PR DESCRIPTION
This doesn't work as implemented.  We are doing _txc_finalize_kv() from
queue_transactions, which calls into the freelist and does this verify
code.  However, we have no assurance that a previous txc in the sequencer
has applied its changes to the kv store, which means that a simple sequence
like

 - write object
 - delete object

can trigger if the write is waiting for aio.  This currently happens
with ObjectStore/StoreTest.SimpleRemount/2.

Comment out the verify, but leave _verify_range() helper in place in case
we can use it in the future in some other context.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 354a6bab566a2f347937b2c3c787923bc5b5468e)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

