### PR TITLE
mgr/dashboard: commands to set SSL certificate and key

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -173,15 +173,15 @@ For example, a key pair can be generated with a command similar to::
 The ``dashboard.crt`` file should then be signed by a CA. Once that is done, you
 can enable it for all Ceph manager instances by running the following commands::
 
-  $ ceph config-key set mgr/dashboard/crt -i dashboard.crt
-  $ ceph config-key set mgr/dashboard/key -i dashboard.key
+  $ ceph dashboard set-ssl-certificate -i dashboard.crt
+  $ ceph dashboard set-ssl-certificate-key -i dashboard.key
 
 If different certificates are desired for each manager instance for some reason,
 the name of the instance can be included as follows (where ``$name`` is the name
 of the ``ceph-mgr`` instance, usually the hostname)::
 
-  $ ceph config-key set mgr/dashboard/$name/crt -i dashboard.crt
-  $ ceph config-key set mgr/dashboard/$name/key -i dashboard.key
+  $ ceph dashboard set-ssl-certificate $name -i dashboard.crt
+  $ ceph dashboard set-ssl-certificate-key $name -i dashboard.key
 
 SSL can also be disabled by setting this configuration value::
 

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -14,7 +14,7 @@ import threading
 import time
 from uuid import uuid4
 from OpenSSL import crypto, SSL
-from mgr_module import MgrModule, MgrStandbyModule, Option
+from mgr_module import MgrModule, MgrStandbyModule, Option, CLIWriteCommand
 from mgr_util import get_default_addr
 
 try:
@@ -404,6 +404,30 @@ class Module(MgrModule, CherryPyConfig):
         CherryPyConfig.shutdown(self)
         logger.info('Stopping engine...')
         self.shutdown_event.set()
+
+    @CLIWriteCommand("dashboard set-ssl-certificate",
+                     "name=mgr_id,type=CephString,req=false")
+    def set_ssl_certificate(self, mgr_id=None, inbuf=None):
+        if inbuf is None:
+            return -errno.EINVAL, '',\
+                   'Please specify the certificate file with "-i" option'
+        if mgr_id is not None:
+            self.set_store('{}/crt'.format(mgr_id), inbuf)
+        else:
+            self.set_store('crt', inbuf)
+        return 0, 'SSL certificate updated', ''
+
+    @CLIWriteCommand("dashboard set-ssl-certificate-key",
+                     "name=mgr_id,type=CephString,req=false")
+    def set_ssl_certificate_key(self, mgr_id=None, inbuf=None):
+        if inbuf is None:
+            return -errno.EINVAL, '',\
+                   'Please specify the certificate key file with "-i" option'
+        if mgr_id is not None:
+            self.set_store('{}/key'.format(mgr_id), inbuf)
+        else:
+            self.set_store('key', inbuf)
+        return 0, 'SSL certificate key updated', ''
 
     def handle_command(self, inbuf, cmd):
         # pylint: disable=too-many-return-statements


### PR DESCRIPTION
Adds two new commands to ceph-dashboard to set the SSL certificate and key:
* `ceph dashboard set-ssl-certificate [mgr_id] -i <cert_filename>`
* `ceph dashboard set-ssl-certificate-key [mgr_id] -i <key_filename>`

Fixes: https://tracker.ceph.com/issues/39123
Signed-off-by: Ricardo Dias <rdias@suse.com>

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

