### PR TITLE
luminous: doc: osd_recovery_priority is not documented (but osd_recovery_op_priority is)

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -410,8 +410,7 @@ recovery operations to ensure optimal performance during recovery.
 
 ``osd recovery op priority``
 
-:Description: The priority set for recovery operations. It is relative to
-              ``osd client op priority``.
+:Description: The priority set for recovery operations, if not specified by the pool's ``recovery_op_priority``.
 
 :Type: 32-bit Integer
 :Default: ``3``
@@ -938,6 +937,16 @@ perform well in a degraded state.
 
 :Type: Float
 :Default: ``0.025``
+
+
+``osd recovery priority``
+
+:Description: The default priority set for recovery work queue.  Not
+              related to a pool's ``recovery_priority``.
+
+:Type: 32-bit Integer
+:Default: ``5``
+
 
 Tiering
 =======

--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -401,8 +401,7 @@ recovery operations to ensure optimal performance during recovery.
 
 ``osd client op priority``
 
-:Description: The priority set for client operations. It is relative to
-              ``osd recovery op priority``.
+:Description: The priority set for client operations.
 
 :Type: 32-bit Integer
 :Default: ``63``
@@ -421,18 +420,30 @@ recovery operations to ensure optimal performance during recovery.
 
 ``osd scrub priority``
 
-:Description: The priority set for scrub operations. It is relative to
-              ``osd client op priority``.
+:Description: The default priority set for a scheduled scrub work queue when the
+              pool doesn't specify a value of ``scrub_priority``.  This can be
+              boosted to the value of ``osd client op priority`` when scrub is
+              blocking client operations.
 
 :Type: 32-bit Integer
 :Default: ``5``
 :Valid Range: 1-63
 
 
+``osd requested scrub priority``
+
+:Description: The priority set for user requested scrub on the work queue.  If
+              this value were to be smaller than ``osd client op priority`` it
+              can be boosted to the value of ``osd client op priority`` when
+              scrub is blocking client operations.
+
+:Type: 32-bit Integer
+:Default: ``120``
+
+
 ``osd snap trim priority``
 
-:Description: The priority set for snap trim operations. It is relative to
-              ``osd client op priority``.
+:Description: The priority set for the snap trim work queue.
 
 :Type: 32-bit Integer
 :Default: ``5``

--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -455,49 +455,6 @@ recovery operations to ensure optimal performance during recovery.
 :Default: ``30``
 
 
-``osd disk threads``
-
-:Description: The number of disk threads, which are used to perform background
-              disk intensive OSD operations such as scrubbing and snap
-              trimming.
-
-:Type: 32-bit Integer
-:Default: ``1``
-
-``osd disk thread ioprio class``
-
-:Description: Warning: it will only be used if both ``osd disk thread
-	      ioprio class`` and ``osd disk thread ioprio priority`` are
-	      set to a non default value.  Sets the ioprio_set(2) I/O
-	      scheduling ``class`` for the disk thread. Acceptable
-	      values are ``idle``, ``be`` or ``rt``. The ``idle``
-	      class means the disk thread will have lower priority
-	      than any other thread in the OSD. This is useful to slow
-	      down scrubbing on an OSD that is busy handling client
-	      operations. ``be`` is the default and is the same
-	      priority as all other threads in the OSD. ``rt`` means
-	      the disk thread will have precendence over all other
-	      threads in the OSD. Note: Only works with the Linux Kernel
-	      CFQ scheduler. Since Jewel scrubbing is no longer carried
-	      out by the disk iothread, see osd priority options instead.
-:Type: String
-:Default: the empty string
-
-``osd disk thread ioprio priority``
-
-:Description: Warning: it will only be used if both ``osd disk thread
-	      ioprio class`` and ``osd disk thread ioprio priority`` are
-	      set to a non default value. It sets the ioprio_set(2)
-	      I/O scheduling ``priority`` of the disk thread ranging
-	      from 0 (highest) to 7 (lowest). If all OSDs on a given
-	      host were in class ``idle`` and compete for I/O
-	      (i.e. due to controller congestion), it can be used to
-	      lower the disk thread priority of one OSD to 7 so that
-	      another OSD with priority 0 can have priority.
-	      Note: Only works with the Linux Kernel CFQ scheduler.
-:Type: Integer in the range of 0 to 7 or -1 if not to be used.
-:Default: ``-1``
-
 ``osd op history size``
 
 :Description: The maximum number of completed operations to track.

--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -264,6 +264,20 @@ Ceph configuration file.
 :Type: Float
 :Default: ``2``
 
+``osd recovery priority``
+
+:Description: Priority of recovery in the work queue.
+
+:Type: Integer
+:Default: ``5``
+
+``osd recovery op priority``
+
+:Description: Default priority used for recovery operations if pool doesn't override.
+
+:Type: Integer
+:Default: ``3``
+
 .. _pool: ../../operations/pools
 .. _Monitoring OSDs and PGs: ../../operations/monitoring-osd-pg#peering
 .. _Weighting Bucket Items: ../../operations/crush-map#weightingbucketitems

--- a/doc/rados/operations/monitoring-osd-pg.rst
+++ b/doc/rados/operations/monitoring-osd-pg.rst
@@ -230,15 +230,15 @@ few cases:
    Placement group IDs consist of the pool number (not pool name) followed 
    by a period (.) and the placement group ID--a hexadecimal number. You
    can view pool numbers and their names from the output of ``ceph osd 
-   lspools``. For example, the default pool ``rbd`` corresponds to
-   pool number ``0``. A fully qualified placement group ID has the
+   lspools``. For example, the first pool created corresponds to
+   pool number ``1``. A fully qualified placement group ID has the
    following form::
    
    	{pool-num}.{pg-id}
    
    And it typically looks like this:: 
    
-   	0.1f
+	1.1f
    
 
 To retrieve a list of placement groups, execute the following:: 
@@ -488,19 +488,19 @@ requests when it is ready.
 
 During the backfill operations, you may see one of several states:
 ``backfill_wait`` indicates that a backfill operation is pending, but is not
-underway yet; ``backfill`` indicates that a backfill operation is underway;
-and, ``backfill_too_full`` indicates that a backfill operation was requested,
+underway yet; ``backfilling`` indicates that a backfill operation is underway;
+and, ``backfill_toofull`` indicates that a backfill operation was requested,
 but couldn't be completed due to insufficient storage capacity. When a 
 placement group cannot be backfilled, it may be considered ``incomplete``.
 
 Ceph provides a number of settings to manage the load spike associated with
 reassigning placement groups to an OSD (especially a new OSD). By default,
-``osd_max_backfills`` sets the maximum number of concurrent backfills to or from
-an OSD to 10. The ``backfill full ratio`` enables an OSD to refuse a
+``osd_max_backfills`` sets the maximum number of concurrent backfills to and from
+an OSD to 1. The ``backfill full ratio`` enables an OSD to refuse a
 backfill request if the OSD is approaching its full ratio (90%, by default) and
 change with ``ceph osd set-backfillfull-ratio`` comand.
 If an OSD refuses a backfill request, the ``osd backfill retry interval``
-enables an OSD to retry the request (after 10 seconds, by default). OSDs can
+enables an OSD to retry the request (after 30 seconds, by default). OSDs can
 also set ``osd backfill scan min`` and ``osd backfill scan max`` to manage scan
 intervals (64 and 512, by default).
 
@@ -593,7 +593,7 @@ location, all you need is the object name and the pool name. For example::
    
 	Ceph should output the object's location. For example:: 
    
-		osdmap e537 pool 'data' (0) object 'test-object-1' -> pg 0.d1743484 (0.4) -> up [1,0] acting [1,0]
+		osdmap e537 pool 'data' (1) object 'test-object-1' -> pg 1.d1743484 (1.4) -> up [1,0] acting [1,0]
    
 	To remove the test object, simply delete it using the ``rados rm`` command.
 	For example:: 

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -603,6 +603,27 @@ You may set values for the following keys:
 :Default: ``0``
 
 
+.. _recovery_priority:
+
+``recovery_priority``
+
+:Description: When a value is set it will boost the computed reservation priority
+              by this amount. This value should be less than 30.
+
+:Type: Integer
+:Default: ``0``
+
+
+.. _recovery_op_priority:
+
+``recovery_op_priority``
+
+:Description: Specify the recovery operation priority for this pool instead of ``osd_recovery_op_priority``.
+
+:Type: Integer
+:Default: ``0``
+
+
 Get Pool Values
 ===============
 
@@ -755,6 +776,20 @@ You may get values for the following keys:
 :Description: see allow_ec_overwrites_
 
 :Type: Boolean
+
+
+``recovery_priority``
+
+:Description: see recovery_priority_
+
+:Type: Integer
+
+
+``recovery_op_priority``
+
+:Description: see recovery_op_priority_
+
+:Type: Integer
 
 
 Set the Number of Object Replicas

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1266,7 +1266,7 @@ std::vector<Option> get_global_options() {
 
     Option("mon_data_avail_warn", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(30)
-    .set_description(""),
+    .set_description("issue MON_DISK_LOW health warning when mon available space below this percentage"),
 
     Option("mon_data_size_warn", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(15_G)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1652,11 +1652,12 @@ std::vector<Option> get_global_options() {
 
     Option("osd_max_backfills", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1)
-    .set_description(""),
+    .set_description("Maximum number of concurrent local and remote backfills or recoveries per OSD ")
+    .set_long_description("There can be osd_max_backfills local reservations AND the same remote reservations per OSD. So a value of 1 lets this OSD participate as 1 PG primary in recovery and 1 shard of another recovering PG."),
 
     Option("osd_min_recovery_priority", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description(""),
+    .set_description("Minimum priority below which recovery is not performed"),
 
     Option("osd_backfill_retry_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(30.0)
@@ -3065,7 +3066,7 @@ std::vector<Option> get_global_options() {
 
     Option("osd_recovery_op_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(3)
-    .set_description(""),
+    .set_description("Priority to use for recovery operations if not specified for the pool"),
 
     Option("osd_snap_trim_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
@@ -3089,7 +3090,8 @@ std::vector<Option> get_global_options() {
 
     Option("osd_recovery_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
-    .set_description(""),
+    .set_description("Priority of recovery in the work queue")
+    .set_long_description("Not related to a pool's recovery_priority"),
 
     Option("osd_recovery_cost", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(20<<20)


### PR DESCRIPTION
Backport from mimic version which is closer to luminous

https://tracker.ceph.com/issues/38567