### PR TITLE
[DNM] nautilus: src/tools: Workaround for gcc7 ICE bug

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -65,6 +65,10 @@ endif(WITH_LIBCEPHFS)
 add_executable(ceph-kvstore-tool
   kvstore_tool.cc
   ceph_kvstore_tool.cc)
+# Temporary workaround to get past a compiler bug in gcc7
+# https://bugzilla.redhat.com/show_bug.cgi?id=1531154
+set_source_files_properties(kvstore_tool.cc PROPERTIES COMPILE_FLAGS
+  "${CMAKE_CXX_FLAGS} --param ggc-min-expand=1 --param ggc-min-heapsize=0")
 target_link_libraries(ceph-kvstore-tool os global)
 install(TARGETS ceph-kvstore-tool DESTINATION bin)
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1531154

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>

Adding this as DNM as the preferred solution seems to be update gcc on Bionic to version 8. Nevertheless adding this here so people have access to the workaround.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

