### PR TITLE
qa/tasks: improvements in vstart_runner.py and mount.py

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -155,10 +155,11 @@ class CephFSMount(object):
         p.wait()
         return p.stdout.getvalue().strip()
 
-    def run_shell(self, args, wait=True):
+    def run_shell(self, args, wait=True, check_status=True):
         args = ["cd", self.mountpoint, run.Raw('&&'), "sudo"] + args
         return self.client_remote.run(args=args, stdout=StringIO(),
-                                      stderr=StringIO(), wait=wait)
+                                      stderr=StringIO(), wait=wait,
+                                      check_status=check_status)
 
     def open_no_data(self, basename):
         """

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -155,11 +155,12 @@ class CephFSMount(object):
         p.wait()
         return p.stdout.getvalue().strip()
 
-    def run_shell(self, args, wait=True, check_status=True):
+    def run_shell(self, args, wait=True, check_status=True, omit_sudo=True):
         args = ["cd", self.mountpoint, run.Raw('&&'), "sudo"] + args
         return self.client_remote.run(args=args, stdout=StringIO(),
                                       stderr=StringIO(), wait=wait,
-                                      check_status=check_status)
+                                      check_status=check_status,
+                                      omit_sudo=omit_sudo)
 
     def open_no_data(self, basename):
         """

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -142,6 +142,11 @@ class CephFSMount(object):
                 'sudo', 'touch', os.path.join(self.mountpoint, suffix)
             ])
 
+    def test_create_file(self, filename='testfile', dirname=None, user=None,
+                         check_status=True):
+        return self.create_file(filename=filename, dirname=dirname, user=user,
+                                check_status=False)
+
     def check_files(self):
         assert(self.is_mounted())
 

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -155,11 +155,12 @@ class CephFSMount(object):
         p.wait()
         return p.stdout.getvalue().strip()
 
-    def run_shell(self, args, wait=True, check_status=True, omit_sudo=True):
+    def run_shell(self, args, wait=True, stdin=None, check_status=True,
+                  omit_sudo=True):
         args = ["cd", self.mountpoint, run.Raw('&&'), "sudo"] + args
         return self.client_remote.run(args=args, stdout=StringIO(),
                                       stderr=StringIO(), wait=wait,
-                                      check_status=check_status,
+                                      stdin=stdin, check_status=check_status,
                                       omit_sudo=omit_sudo)
 
     def open_no_data(self, basename):

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -111,6 +111,28 @@ class CephFSMount(object):
                 return True
         return False
 
+    def create_file(self, filename='testfile', dirname=None, user=None,
+                    check_status=True):
+        assert(self.is_mounted())
+
+        if not os.path.isabs(filename):
+            if dirname:
+                if os.path.isabs(dirname):
+                    path = os.path.join(dirname, filename)
+                else:
+                    path = os.path.join(self.mountpoint, dirname, filename)
+            else:
+                path = os.path.join(self.mountpoint, filename)
+        else:
+            path = filename
+
+        if user:
+            args = ['sudo', '-u', user, '-s', '/bin/bash', '-c', 'touch ' + path]
+        else:
+            args = 'touch ' + path
+
+        return self.client_remote.run(args=args, check_status=check_status)
+
     def create_files(self):
         assert(self.is_mounted())
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -418,13 +418,12 @@ class LocalFuseMount(FuseMount):
         # to avoid assumptions about daemons' pwd
         return os.path.abspath("./client.{0}.keyring".format(self.client_id))
 
-    def run_shell(self, args, wait=True):
+    def run_shell(self, args, wait=True, check_status=True):
         # FIXME maybe should add a pwd arg to teuthology.orchestra so that
         # the "cd foo && bar" shenanigans isn't needed to begin with and
         # then we wouldn't have to special case this
-        return self.client_remote.run(
-            args, wait=wait, cwd=self.mountpoint
-        )
+        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+                                      check_status=check_status)
 
     def setupfs(self, name=None):
         if name is None and self.fs is not None:

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -248,6 +248,21 @@ class LocalRemote(object):
         except ValueError:
             pass
 
+        # Quotes don't work in Python's shell simulation as a bash user would
+        # expect. However, it works fine it has special meaning for the given
+        # command (writing a small python program on the command line).
+        if 'sudo' in args and 'python' not in args and \
+           'python2' not in args and 'python3' not in args:
+            if '-c' in args:
+                args_to_check = args[args.index('-c') + 1 : ]
+            else:
+                args_to_check = args
+
+            for arg in args_to_check:
+                if arg.find("'") != -1 or arg.find('"') != -1:
+                    raise RuntimeError("Don't surround commands by "
+                                       "single/double quotes")
+
         if omit_sudo:
             args = [a for a in args if a != "sudo"]
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -432,6 +432,24 @@ class LocalFuseMount(FuseMount):
                                       check_status=check_status,
                                       omit_sudo=omit_sudo)
 
+    def run_as_user(self, args, user, wait=True, stdin=None, check_status=True):
+        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
+        # the "cd foo && bar" shenanigans isn't needed to begin with and
+        # then we wouldn't have to special case this
+        if isinstance(args, str):
+            args = 'sudo -u %s -s /bin/bash -c %s' % (user, args)
+        elif isinstance(args, list):
+            cmdlist = args
+            cmd = ''
+            for i in cmdlist:
+                cmd = cmd + i + ' '
+            args = ['sudo', '-u', user, '-s', '/bin/bash', '-c']
+            args.append(cmd)
+
+        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+                                      check_status=check_status, stdin=stdin,
+                                      omit_sudo=False)
+
     def setupfs(self, name=None):
         if name is None and self.fs is not None:
             # Previous mount existed, reuse the old name

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -237,6 +237,9 @@ class LocalRemote(object):
     def run(self, args, check_status=True, wait=True,
             stdout=None, stderr=None, cwd=None, stdin=None,
             logger=None, label=None, env=None, timeout=None, omit_sudo=True):
+        if str(type(args)).find('str') != -1:
+            args = args.split()
+
         try:
             if args[args.index('sudo') + 1] in ['-u', 'passwd', 'chown']:
                 omit_sudo = False

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -459,12 +459,12 @@ class LocalFuseMount(FuseMount):
         # to avoid assumptions about daemons' pwd
         return os.path.abspath("./client.{0}.keyring".format(self.client_id))
 
-    def run_shell(self, args, wait=True, check_status=True, omit_sudo=True):
+    def run_shell(self, args, wait=True, stdin=None, check_status=True, omit_sudo=True):
         # FIXME maybe should add a pwd arg to teuthology.orchestra so that
         # the "cd foo && bar" shenanigans isn't needed to begin with and
         # then we wouldn't have to special case this
         return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
-                                      check_status=check_status,
+                                      stdin=stdin, check_status=check_status,
                                       omit_sudo=omit_sudo)
 
     def run_as_user(self, args, user, wait=True, stdin=None, check_status=True):

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -498,6 +498,27 @@ class LocalFuseMount(FuseMount):
                                       check_status=check_status,
                                       omit_sudo=False)
 
+    def testcmd(self, args, wait=True, stdin=None, omit_sudo=True):
+        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
+        # the "cd foo && bar" shenanigans isn't needed to begin with and
+        # then we wouldn't have to special case this
+        return self.run_shell(args, wait=wait, stdin=stdin, check_status=False,
+                              omit_sudo=omit_sudo)
+
+    def testcmd_as_user(self, args, user, wait=True, stdin=None):
+        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
+        # the "cd foo && bar" shenanigans isn't needed to begin with and
+        # then we wouldn't have to special case this
+        return self.run_as_user(args, user=user, wait=wait, stdin=stdin,
+                                check_status=False)
+
+    def testcmd_as_root(self, args, wait=True, stdin=None):
+        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
+        # the "cd foo && bar" shenanigans isn't needed to begin with and
+        # then we wouldn't have to special case this
+        return self.run_as_root(args, wait=wait, stdin=stdin,
+                                check_status=False)
+
     def setupfs(self, name=None):
         if name is None and self.fs is not None:
             # Previous mount existed, reuse the old name

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -263,6 +263,15 @@ class LocalRemote(object):
                     raise RuntimeError("Don't surround commands by "
                                        "single/double quotes")
 
+        # ['sudo', '-u', 'user', '-s', 'path-to-shell', '-c', 'ls', 'a']
+        # and ['sudo', '-u', user, '-s', path_to_shell, '-c', 'ls a'] are
+        # treated differently by Python's shell simulation. Only latter has
+        # the desired effect.
+        if 'sudo' in args and '-c' in args:
+            if args.index('-c') != len(args) - 2:
+                raise RuntimeError("All args after '-c' should be a single "
+                                   "string")
+
         if omit_sudo:
             args = [a for a in args if a != "sudo"]
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -450,6 +450,19 @@ class LocalFuseMount(FuseMount):
                                       check_status=check_status, stdin=stdin,
                                       omit_sudo=False)
 
+    def run_as_root(self, args, wait=True, stdin=None, check_status=True):
+        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
+        # the "cd foo && bar" shenanigans isn't needed to begin with and
+        # then we wouldn't have to special case this
+        if isinstance(args, str):
+            args = 'sudo ' + args
+        if isinstance(args, list):
+            args.insert(0, 'sudo')
+
+        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+                                      check_status=check_status,
+                                      omit_sudo=False)
+
     def setupfs(self, name=None):
         if name is None and self.fs is not None:
             # Previous mount existed, reuse the old name


### PR DESCRIPTION
Brief summary for this PR:
* makes crashing optional (but default) for `run_shell()`
* adds methods that can run a command with a user other than
  the current user (including as the root user)
* allows running commands with `sudo` (right now `run_shell` elides `sudo`s
  from command arguments)
* makes `run_shell()` accept command arguments as string (right now it only
  accepts a list of args)
* allows passing stdin to `run_shell()`
* adds a method to create an empty file as any user
* adds wrappers for `vstart_runner.py`'s `run()` that is tuned to *test*
  a command rather than executing a command with the hope for success.

These modifications were originally made while I was writing PR #26477.