### PR TITLE
client: fix fuse client hang because its bad session PipeConnection to mds

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2733,23 +2733,25 @@ void Client::handle_mds_map(const MConstRef<MMDSMap>& m)
       continue;  // no change
     
     session->mds_state = newstate;
-    if (old_inc != new_inc && newstate > MDSMap::STATE_RECONNECT) {
-      // missed reconnect close the session so that it can be reopened
-      _closed_mds_session(session);
-      continue;
-    }
     if (newstate == MDSMap::STATE_RECONNECT) {
       session->con = messenger->connect_to_mds(session->addrs);
       send_reconnect(session);
-    } else if (newstate >= MDSMap::STATE_ACTIVE) {
-      if (oldstate < MDSMap::STATE_ACTIVE) {
-	// kick new requests
-	kick_requests(session);
-	kick_flushing_caps(session);
-	signal_context_list(session->waiting_for_open);
-	wake_up_session_caps(session, true);
+    } else if (newstate > MDSMap::STATE_RECONNECT) {
+      if (oldstate < MDSMap::STATE_RECONNECT) {
+	ldout(cct, 1) << "we may miss the MDSMap::RECONNECT, close mds session ... " << dendl;
+	_closed_mds_session(session);
+	continue;
       }
-      connect_mds_targets(mds);
+      if (newstate >= MDSMap::STATE_ACTIVE) {
+	if (oldstate < MDSMap::STATE_ACTIVE) {
+	  // kick new requests
+	  kick_requests(session);
+	  kick_flushing_caps(session);
+	  signal_context_list(session->waiting_for_open);
+	  wake_up_session_caps(session, true);
+	}
+	connect_mds_targets(mds);
+      }
     } else if (newstate == MDSMap::STATE_NULL &&
 	       mds >= mdsmap->get_max_mds()) {
       _closed_mds_session(session);


### PR DESCRIPTION
There still has a risk client will hang all the time and which
happened in my enviroment a few days ago. Well konw, the start
of mds will go through four stages at least(replay, reconnect,
rejoin, active). According to current logic, we recived
replay mdsmap and marked down pipe will return directly and if
we miss the next reconnect mdsmap the client may hang all the
time becuase we lost the opportunity due to old_inc equal to
new_inc. So we shuold judge if we have lost MDSMap::reconnect
by comparing newstate and oldstate.


Fixes: http://tracker.ceph.com/issues/39305
Signed-off-by: Guan yunfei <yunfei.guan@xtaotech.com>