### PR TITLE
cephfs-shell: add quota management

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1108,6 +1108,78 @@ sub-directories, files')
                 self.poutput('{:10s} {}'.format(humansize(int(cephfs.getxattr(to_bytes(
                     dir_), 'ceph.dir.rbytes').decode('utf-8'))), '.' + dir_))
 
+    quota_parser = argparse.ArgumentParser(
+        description='Quota management for a Directory')
+    quota_parser.add_argument('op', choices=['get', 'set'],
+                              help='Quota operation type.')
+    quota_parser.add_argument('dir', type=str, help='Name of the directory.')
+    quota_parser.add_argument('--max_bytes', type=int, default=-1, nargs='?',
+                              help='Max cumulative size of the data under '
+                                   'this directory.')
+    quota_parser.add_argument('--max_files', type=int, default=-1, nargs='?',
+                              help='Total number of files under this '
+                                   'directory tree.')
+
+    @with_argparser(quota_parser)
+    def do_quota(self, args):
+        """
+        Quota management.
+        """
+        if not is_dir_exists(args.dir):
+            self.poutput("error: no such directory '%s'" % args.dir)
+            return
+
+        if args.op == 'set':
+            if (args.max_bytes == -1) and (args.max_files == -1):
+                self.poutput('please specify either --max_bytes or '
+                             '--max_files or both')
+                return
+
+            if args.max_bytes >= 0:
+                max_bytes = to_bytes(str(args.max_bytes))
+                try:
+                    cephfs.setxattr(to_bytes(args.dir), 'ceph.quota.max_bytes',
+                                    max_bytes, len(max_bytes),
+                                    os.XATTR_CREATE)
+                    self.poutput('max_bytes set to %d' % args.max_bytes)
+                except:
+                    cephfs.setxattr(to_bytes(args.dir), 'ceph.quota.max_bytes',
+                                    max_bytes, len(max_bytes),
+                                    os.XATTR_REPLACE)
+                    self.poutput('max_bytes reset to %d' % args.max_bytes)
+
+            if args.max_files >= 0:
+                max_files = to_bytes(str(args.max_files))
+                try:
+                    cephfs.setxattr(to_bytes(args.dir), 'ceph.quota.max_files',
+                                    max_files, len(max_files),
+                                    os.XATTR_CREATE)
+                    self.poutput('max_files set to %d' % args.max_files)
+                except:
+                    cephfs.setxattr(to_bytes(args.dir), 'ceph.quota.max_files',
+                                    max_files, len(max_files),
+                                    os.XATTR_REPLACE)
+                    self.poutput('max_files reset to %d' % args.max_files)
+        elif args.op == 'get':
+            max_bytes = '0'
+            max_files = '0'
+            try:
+                max_bytes = cephfs.getxattr(to_bytes(args.dir),
+                                            'ceph.quota.max_bytes')
+                self.poutput('max_bytes: %s' % max_bytes)
+            except:
+                self.poutput('max_bytes is not set')
+                pass
+
+            try:
+                max_files = cephfs.getxattr(to_bytes(args.dir),
+                                            'ceph.quota.max_files')
+                self.poutput('max_files: %s' % max_files)
+            except:
+                self.poutput('max_files is not set')
+                pass
+
+
     def do_help(self, line):
         """
         Get details about a command.


### PR DESCRIPTION
Quotas can be managed by:
$ quota get dir
$ quota set {--max_files MAX_FILES} {--max_bytes MAX_BYTES} dir

Fixes: http://tracker.ceph.com/issues/39165
Signed-off-by: Milind Changire <mchangir@redhat.com>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug