### PR TITLE
rbd-nbd: sscanf return 0 mean not-match.

### DIFF
--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -89,7 +89,7 @@ static void usage()
             << "               unmap <device|image-or-snap-spec>   Unmap nbd device\n"
             << "               [options] list-mapped               List mapped nbd devices\n"
             << "Map options:\n"
-            << "  --device <device path>  Specify nbd device path\n"
+            << "  --device <device path>  Specify nbd device path (/dev/nbd{num})\n"
             << "  --read-only             Map read-only\n"
             << "  --nbds_max <limit>      Override for module param nbds_max\n"
             << "  --max_part <limit>      Override for module param max_part\n"
@@ -782,7 +782,10 @@ static int do_map(int argc, const char *argv[], Config *cfg)
     }
   } else {
     r = sscanf(cfg->devpath.c_str(), "/dev/nbd%d", &index);
-    if (r < 0) {
+    if (r <= 0) {
+      // mean an early matching failure. But some cases need a negative value.
+      if (r == 0)
+	r = -EINVAL;
       cerr << "rbd-nbd: invalid device path: " << cfg->devpath
            << " (expected /dev/nbd{num})" << std::endl;
       goto close_fd;


### PR DESCRIPTION
When exec:  rbd-nbd map rbd/image --device /dev/image
The error message is:
rbd-nbd: failed to open device: /dev/image.

In fact, it should print:
rbd-nbd: invalid device path: /dev/image (expected /dev/nbd{num})

Meantime change help which make more understand.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

