### PR TITLE
rgw: set object ACLS to reflect bucket owner supporting bucket unlink/link.

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -52,7 +52,20 @@ void RGWAccessControlList::add_grant(ACLGrant *grant)
   _add_grant(grant);
 }
 
-uint32_t RGWAccessControlList::get_perm(const DoutPrefixProvider* dpp, 
+void RGWAccessControlList::remove_canon_user_grant(rgw_user& user_id)
+{
+  auto multi_map_iter = grant_map.find(user_id.to_str());
+  if(multi_map_iter != grant_map.end()) {
+    grant_map.erase(multi_map_iter);
+  }
+
+  auto map_iter = acl_user_map.find(user_id.to_str());
+  if (map_iter != acl_user_map.end()){
+    acl_user_map.erase(map_iter);
+  }
+}
+
+uint32_t RGWAccessControlList::get_perm(const DoutPrefixProvider* dpp,
                                         const rgw::auth::Identity& auth_identity,
                                         const uint32_t perm_mask)
 {

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -344,6 +344,7 @@ public:
   static void generate_test_instances(list<RGWAccessControlList*>& o);
 
   void add_grant(ACLGrant *grant);
+  void remove_canon_user_grant(rgw_user& user_id);
 
   multimap<string, ACLGrant>& get_grant_map() { return grant_map; }
   const multimap<string, ACLGrant>& get_grant_map() const { return grant_map; }
@@ -460,6 +461,10 @@ public:
   }
   const RGWAccessControlList& get_acl() const {
     return acl;
+  }
+
+  void set_acl(RGWAccessControlList& acl) {
+    this->acl = acl;
   }
 
   virtual bool compare_group_name(string& id, ACLGroupTypeEnum group) { return false; }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -102,6 +102,7 @@ void usage()
   cout << "  bucket stats               returns bucket statistics\n";
   cout << "  bucket rm                  remove bucket\n";
   cout << "  bucket check               check bucket index\n";
+  cout << "  bucket chown               update object owner ACL after bucket link\n";
   cout << "  bucket reshard             reshard bucket\n";
   cout << "  bucket rewrite             rewrite all objects in the specified bucket\n";
   cout << "  bucket sync disable        disable bucket sync\n";
@@ -407,6 +408,7 @@ enum {
   OPT_BUCKET_RM,
   OPT_BUCKET_REWRITE,
   OPT_BUCKET_RESHARD,
+  OPT_BUCKET_CHOWN,
   OPT_POLICY,
   OPT_POOL_ADD,
   OPT_POOL_RM,
@@ -669,6 +671,8 @@ static int get_cmd(const char *cmd, const char *prev_cmd, const char *prev_prev_
       return OPT_BUCKET_STATS;
     if (strcmp(cmd, "rm") == 0)
       return OPT_BUCKET_RM;
+    if (strcmp(cmd, "chown") == 0)
+      return OPT_BUCKET_CHOWN;
     if (strcmp(cmd, "rewrite") == 0)
       return OPT_BUCKET_REWRITE;
     if (strcmp(cmd, "reshard") == 0)
@@ -5503,6 +5507,86 @@ int main(int argc, const char **argv)
       return -r;
     }
   }
+
+  if (opt_cmd == OPT_BUCKET_CHOWN) {
+    int ret = 0;
+    std::string tenant;
+    std::vector<rgw_bucket_dir_entry> objs;
+    map<string, bool> common_prefixes;
+    RGWObjectCtx obj_ctx(store);
+
+    //Get bucket info
+    RGWBucketInfo bucket_info;
+    RGWSysObjectCtx sys_ctx = store->svc.sysobj->init_obj_ctx();
+    map<string, bufferlist> attrs;
+
+    //split tenant/bucket
+    auto pos = bucket_name.find('/');
+    if (pos != boost::string_ref::npos) {
+      tenant = bucket_name.substr(0, pos);
+      bucket_name = bucket_name.substr(pos + 1);
+    }
+
+    ret = store->get_bucket_info(sys_ctx, tenant, bucket_name, bucket_info, NULL, &attrs);
+    if (ret < 0) {
+      cerr << " Bucket info failed: tenant: "<< tenant << "bucket_name: " << bucket_name << " " << ret << std::endl;
+      return ret;
+    }
+
+    //Get User info - for display name
+    RGWUserInfo user_info;
+    ret = rgw_get_user_info_by_uid(store, bucket_info.owner, user_info);
+    if (ret < 0) {
+      cerr << " User info failed: "<< ret << std::endl;
+      return ret;
+    }
+
+    RGWRados::Bucket target(store, bucket_info);
+    RGWRados::Bucket::List list_op(&target);
+    int max = 1000;
+
+    list_op.params.list_versions = true;
+    list_op.params.allow_unordered = true;
+
+    bool is_truncated = false;
+
+    do {
+      objs.clear();
+      ret = list_op.list_objects(max, &objs, &common_prefixes, &is_truncated);
+      if (ret < 0) {
+        cerr << " List objects failed: "<< ret << std::endl;
+        return ret;
+      }
+      //Loop through the results
+      for (const auto& obj : objs) {
+        const auto& aiter = attrs.find(RGW_ATTR_ACL);
+        bufferlist& bl = aiter->second;
+        RGWAccessControlPolicy policy;
+        ACLOwner owner;
+        try {
+          decode(policy, bl);
+          owner = policy.get_owner();
+        } catch (buffer::error& err) {
+          cerr << " Decode policy failed: " << std::endl;
+          return -EIO;
+        }
+
+        owner.set_id(bucket_info.owner);
+        owner.set_name(user_info.display_name);
+        policy.set_owner(owner);
+
+        bl.clear();
+        encode(policy, bl);
+
+        const rgw_obj r_obj(bucket_info.bucket, obj.key);
+        ret = modify_obj_attr(store, obj_ctx, bucket_info, r_obj, RGW_ATTR_ACL, bl);
+        if (ret < 0) {
+          cerr << " Modify attr failed: "<< ret << std::endl;
+          return ret;
+        }
+      }// for loop
+    } while(is_truncated);
+  } // if
 
   if (opt_cmd == OPT_LOG_LIST) {
     // filter by date?

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -439,6 +439,23 @@ static int get_multipart_info(RGWRados *store, struct req_state *s,
   return get_multipart_info(store, s, meta_obj, policy, attrs, upload_info);
 }
 
+int modify_obj_attr(RGWRados *store, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, const char* attr_name, bufferlist& attr_val)
+{
+  map<string, bufferlist> attrs;
+  RGWRados::Object op_target(store, bucket_info, obj_ctx, obj);
+  RGWRados::Object::Read read_op(&op_target);
+
+  read_op.params.attrs = &attrs;
+
+  int r = read_op.prepare();
+  if (r < 0) {
+    return r;
+  }
+  store->set_atomic(&obj_ctx, read_op.state.obj);
+  attrs[attr_name] = attr_val;
+  return store->set_attrs(&obj_ctx, bucket_info, read_op.state.obj, attrs, NULL);
+}
+
 static int modify_obj_attr(RGWRados *store, struct req_state *s, const rgw_obj& obj, const char* attr_name, bufferlist& attr_val)
 {
   map<string, bufferlist> attrs;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -320,9 +320,9 @@ vector<Policy> get_iam_user_policy_from_attr(CephContext* cct,
   return policies;
 }
 
-static int get_obj_attrs(RGWRados *store, struct req_state *s, const rgw_obj& obj, map<string, bufferlist>& attrs)
+int get_obj_attrs(RGWRados *store, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, map<string, bufferlist>& attrs)
 {
-  RGWRados::Object op_target(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), obj);
+  RGWRados::Object op_target(store, bucket_info, obj_ctx, obj);
   RGWRados::Object::Read read_op(&op_target);
 
   read_op.params.attrs = &attrs;
@@ -454,23 +454,6 @@ int modify_obj_attr(RGWRados *store, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucke
   store->set_atomic(&obj_ctx, read_op.state.obj);
   attrs[attr_name] = attr_val;
   return store->set_attrs(&obj_ctx, bucket_info, read_op.state.obj, attrs, NULL);
-}
-
-static int modify_obj_attr(RGWRados *store, struct req_state *s, const rgw_obj& obj, const char* attr_name, bufferlist& attr_val)
-{
-  map<string, bufferlist> attrs;
-  RGWRados::Object op_target(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), obj);
-  RGWRados::Object::Read read_op(&op_target);
-
-  read_op.params.attrs = &attrs;
-  
-  int r = read_op.prepare();
-  if (r < 0) {
-    return r;
-  }
-  store->set_atomic(s->obj_ctx, read_op.state.obj);
-  attrs[attr_name] = attr_val;
-  return store->set_attrs(s->obj_ctx, s->bucket_info, read_op.state.obj, attrs, NULL);
 }
 
 static int read_bucket_policy(RGWRados *store,
@@ -829,7 +812,7 @@ static int rgw_iam_add_tags_from_bl(struct req_state* s, bufferlist& bl){
 static int rgw_iam_add_existing_objtags(RGWRados* store, struct req_state* s, rgw_obj& obj, std::uint64_t action){
   map <string, bufferlist> attrs;
   store->set_atomic(s->obj_ctx, obj);
-  int op_ret = get_obj_attrs(store, s, obj, attrs);
+  int op_ret = get_obj_attrs(store, *(s->obj_ctx), s->bucket_info, obj, attrs);
   if (op_ret < 0)
     return op_ret;
   auto tags = attrs.find(RGW_ATTR_TAGS);
@@ -1056,7 +1039,7 @@ void RGWGetObjTags::execute()
 
   store->set_atomic(s->obj_ctx, obj);
 
-  op_ret = get_obj_attrs(store, s, obj, attrs);
+  op_ret = get_obj_attrs(store, *(s->obj_ctx), s->bucket_info, obj, attrs);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "ERROR: failed to get obj attrs, obj=" << obj
         << " ret=" << op_ret << dendl;
@@ -1108,7 +1091,7 @@ void RGWPutObjTags::execute()
   rgw_obj obj;
   obj = rgw_obj(s->bucket, s->object);
   store->set_atomic(s->obj_ctx, obj);
-  op_ret = modify_obj_attr(store, s, obj, RGW_ATTR_TAGS, tags_bl);
+  op_ret = modify_obj_attr(store, *(s->obj_ctx), s->bucket_info, obj, RGW_ATTR_TAGS, tags_bl);
   if (op_ret == -ECANCELED){
     op_ret = -ERR_TAG_CONFLICT;
   }
@@ -4405,7 +4388,7 @@ void RGWPutMetadataObject::execute()
   }
 
   /* check if obj exists, read orig attrs */
-  op_ret = get_obj_attrs(store, s, obj, orig_attrs);
+  op_ret = get_obj_attrs(store, *(s->obj_ctx), s->bucket_info, obj, orig_attrs);
   if (op_ret < 0) {
     return;
   }
@@ -4549,7 +4532,7 @@ void RGWDeleteObj::execute()
   if (!s->object.empty()) {
     if (need_object_expiration() || multipart_delete) {
       /* check if obj exists, read orig attrs */
-      op_ret = get_obj_attrs(store, s, obj, attrs);
+      op_ret = get_obj_attrs(store, *(s->obj_ctx), s->bucket_info, obj, attrs);
       if (op_ret < 0) {
         return;
       }
@@ -5164,7 +5147,7 @@ void RGWPutACLs::execute()
     obj = rgw_obj(s->bucket, s->object);
     store->set_atomic(s->obj_ctx, obj);
     //if instance is empty, we should modify the latest object
-    op_ret = modify_obj_attr(store, s, obj, RGW_ATTR_ACL, bl);
+    op_ret = modify_obj_attr(store, *(s->obj_ctx), s->bucket_info, obj, RGW_ATTR_ACL, bl);
   } else {
     attrs = s->bucket_attrs;
     attrs[RGW_ATTR_ACL] = bl;
@@ -5691,7 +5674,7 @@ void RGWCompleteMultipart::execute()
     return;
   }
 
-  op_ret = get_obj_attrs(store, s, meta_obj, attrs);
+  op_ret = get_obj_attrs(store, *(s->obj_ctx), s->bucket_info, meta_obj, attrs);
 
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "ERROR: failed to get obj attrs, obj=" << meta_obj

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2228,5 +2228,6 @@ static inline int parse_value_and_bound(
   return 0;
 }
 
+int modify_obj_attr(RGWRados *store, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, const char* attr_name, bufferlist& attr_val);
 
 #endif /* CEPH_RGW_OP_H */

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2228,6 +2228,7 @@ static inline int parse_value_and_bound(
   return 0;
 }
 
+int get_obj_attrs(RGWRados *store, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, map<string, bufferlist>& attrs);
 int modify_obj_attr(RGWRados *store, RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, const char* attr_name, bufferlist& attr_val);
 
 #endif /* CEPH_RGW_OP_H */

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -24,6 +24,7 @@
     bucket stats               returns bucket statistics
     bucket rm                  remove bucket
     bucket check               check bucket index
+    bucket chown               update object owner ACL after bucket link
     bucket reshard             reshard bucket
     bucket rewrite             rewrite all objects in the specified bucket
     bucket sync disable        disable bucket sync


### PR DESCRIPTION
Provides command line tool to update the acl on object of a bucket after bucket unlink/link.
"radosgw-admin bucket chown --bucket <bucket>"

Signed-off-by: Shilpa Jagannath <smanjara@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

