### PR TITLE
crush/CrushCompiler: Fix __replacement_assert

### DIFF
--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -751,7 +751,7 @@ int CrushCompiler::parse_bucket(iter_t const& i)
   ceph_assert(id != 0);
   int idout;
   int r = crush.add_bucket(id, alg, hash, type, size,
-                           &items[0], &weights[0], &idout);
+                           items.data(), weights.data(), &idout);
   if (r < 0) {
     if (r == -EEXIST)
       err << "Duplicate bucket id " << id << std::endl;

--- a/src/test/cli/crushtool/empty-default.cushmap.txt
+++ b/src/test/cli/crushtool/empty-default.cushmap.txt
@@ -1,0 +1,42 @@
+# begin crush map
+tunable choose_local_tries 0
+tunable choose_local_fallback_tries 0
+tunable choose_total_tries 50
+tunable chooseleaf_descend_once 1
+tunable chooseleaf_vary_r 1
+tunable chooseleaf_stable 0
+tunable straw_calc_version 1
+tunable allowed_bucket_algs 22
+
+# types
+type 0 osd
+type 1 host
+type 2 chassis
+type 3 rack
+type 4 row
+type 5 pdu
+type 6 pod
+type 7 room
+type 8 datacenter
+type 9 region
+type 10 root
+
+# default bucket
+root default {
+    id -1   # do not change unnecessarily
+    alg straw
+    hash 0  # rjenkins1
+}
+
+# rules
+rule replicated_ruleset {
+    ruleset 0
+    type replicated
+    min_size 1
+    max_size 10
+    step take default
+    step chooseleaf firstn 0 type host
+    step emit
+}
+
+# end crush map

--- a/src/test/cli/crushtool/empty-default.t
+++ b/src/test/cli/crushtool/empty-default.t
@@ -1,0 +1,2 @@
+  $ crushtool -c "$TESTDIR/empty-default.cushmap.txt"
+  crushtool successfully built or modified map.  Use '-o <file>' to write it out.


### PR DESCRIPTION
When compiled with _GLIBCXX_ASSERTIONS we see an assert due to UB of
passing the address of an empty vector. Use vector's data member
function instead of address of array syntax.

Fixes: http://tracker.ceph.com/issues/39174

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

