### PR TITLE
[RFC] osd: new op queue

### DIFF
--- a/src/common/OpQueue.h
+++ b/src/common/OpQueue.h
@@ -24,6 +24,19 @@ namespace ceph {
   class Formatter;
 }
 
+struct BasePopGuard {
+  virtual bool is_inited() = 0;
+  virtual bool check() = 0;
+
+  virtual ~BasePopGuard() {};
+};
+
+struct BaseGuardBuilder {
+  virtual void init() = 0;
+
+  virtual ~BaseGuardBuilder() {};
+};
+
 /**
  * Abstract class for all Op Queues
  *

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1224,6 +1224,26 @@ struct OSDShard {
   void register_and_wake_split_child(PG *pg);
   void unprime_split_children(spg_t parent, unsigned old_pg_num);
 
+  struct PopGuard {
+    PGRef pg = nullptr;
+
+    bool is_inited() {
+      return !!pg;
+    }
+    bool check() {
+      if (!pg)
+        return true;
+      return !pg->is_locked();
+    }
+  };
+
+  struct GuardBuilder {
+    OSD* osd;
+    GuardBuilder(OSD* osd): osd(osd) { }
+
+    void init(PopGuard& guard, spg_t& pgid);
+  };
+
   OSDShard(
     int id,
     CephContext *cct,
@@ -1243,8 +1263,8 @@ struct OSDShard {
       context_queue(sdata_wait_lock, sdata_cond) {
     if (opqueue == io_queue::weightedpriority) {
       pqueue = std::make_unique<
-	WeightedPriorityQueue<OpQueueItem,uint64_t>>(
-	  max_tok_per_prio, min_cost);
+	WeightedPriorityQueue<uint64_t,PopGuard,GuardBuilder>>(
+	  max_tok_per_prio, min_cost, new GuardBuilder(osd));
     } else if (opqueue == io_queue::prioritized) {
       pqueue = std::make_unique<
 	PrioritizedQueue<OpQueueItem,uint64_t>>(
@@ -1738,6 +1758,8 @@ protected:
   {
     OSD *osd;
 
+
+
   public:
     ShardedOpWQ(OSD *o,
 		time_t ti,
@@ -1930,6 +1952,7 @@ protected:
 
   PGRef _lookup_pg(spg_t pgid);
   PGRef _lookup_lock_pg(spg_t pgid);
+  PGRef _lookup_pg_within_shardlock(spg_t pgid);
   void register_pg(PGRef pg);
   bool try_finish_pg_delete(PG *pg, unsigned old_pg_num);
 
@@ -1937,7 +1960,9 @@ protected:
   void _get_pgids(vector<spg_t> *v);
 
 public:
+  PGRef lookup_pg(spg_t pgid);
   PGRef lookup_lock_pg(spg_t pgid);
+  PGRef lookup_pg_within_shardlock(spg_t pgid);
 
   std::set<int64_t> get_mapped_pools();
 

--- a/src/osd/OpQueueItem.h
+++ b/src/osd/OpQueueItem.h
@@ -27,6 +27,7 @@ class OSDShard;
 
 class OpQueueItem {
 public:
+  typedef spg_t  orderkey_type;
   class OrderLocker {
   public:
     using Ref = unique_ptr<OrderLocker>;


### PR DESCRIPTION
the wpq queue is rbtree\<priority\>[rbtree\<client\>[list\<Opitem\>]]

I wish to change the queue to rbtree\<priority\>[rbtree\<client\>[rbtree\<spg_t\>[list\<Opitem\>]]]

the advantage:
* we can decrease the shards num, increase the threads num per shard
* reduce pg.lock contention within shard
* QOS will happy

the change:
* op will pop order in pg scope, not client scope
* if pg is locked, choose next pg's op
* if no unlocked pg, choose a locked pg

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

