### PR TITLE
osd/PG: the warning seems more serious than what it wanna transmit

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -826,10 +826,13 @@ protected:
 	if (j == needs_recovery_map.end()) {
 	  needs_recovery_map.insert(*i);
 	} else {
-	  lgeneric_dout(pg->cct, 0) << this << " " << pg->info.pgid << " unexpected need for "
-				    << i->first << " have " << j->second
-				    << " tried to add " << i->second << dendl;
-	  ceph_assert(i->second.need == j->second.need);
+	  if (i->second.need != j->second.need) {
+	    lgeneric_dout(pg->cct, 0) << this << " " << pg->info.pgid << " unexpected need for "
+				      << i->first << " have " << j->second
+				      << " tried to add " << i->second << dendl;
+	    ceph_assert(0 == "unexpected need for missing item");
+
+	  }
 	}
       }
     }


### PR DESCRIPTION
The missing items is picked from primary and peers, so it is normal if
some guys missing the same version, assertion on the next line will check
wrong circumstances.

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

