### PR TITLE
rgw/pubsub: handle subscription conf errors better

### DIFF
--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -42,6 +42,7 @@ int rgw_perf_start(CephContext *cct)
   plb.add_u64_counter(l_rgw_pubsub_push_ok, "pubsub_push_ok", "Pubsub events pushed to an endpoint");
   plb.add_u64_counter(l_rgw_pubsub_push_failed, "pubsub_push_failed", "Pubsub events failed to be pushed to an endpoint");
   plb.add_u64(l_rgw_pubsub_push_pending, "pubsub_push_pending", "Pubsub events pending reply from endpoint");
+  plb.add_u64_counter(l_rgw_pubsub_missing_conf, "pubsub_missing_conf", "Pubsub events could not be handled because of missing configuration");
   
   perfcounter = plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(perfcounter);

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -41,6 +41,7 @@ enum {
   l_rgw_pubsub_push_ok,
   l_rgw_pubsub_push_failed,
   l_rgw_pubsub_push_pending,
+  l_rgw_pubsub_missing_conf,
 
   l_rgw_last,
 };

--- a/src/test/rgw/rgw_multi/zone_ps.py
+++ b/src/test/rgw/rgw_multi/zone_ps.py
@@ -34,6 +34,13 @@ class PSZone(Zone):  # pylint: disable=too-many-ancestors
 NO_HTTP_BODY = ''
 
 
+def print_connection_info(conn):
+    """print connection details"""
+    print('Endpoint: ' + conn.host + ':' + str(conn.port))
+    print('AWS Access Key:: ' + conn.aws_access_key_id)
+    print('AWS Secret Key:: ' + conn.aws_secret_access_key)
+
+
 def make_request(conn, method, resource, parameters=None, sign_parameters=False, extra_parameters=None):
     """generic request sending to pubsub radogw
     should cover: topics, notificatios and subscriptions


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

this PR is replacing PR #26912.
it avoids returning ENOENT to the sync module, when subscription configuration is not found.
also unifies error logging in the pubsub sync module.
> note: this does not fix all duplicate pubsub events, as some of them are due to the use of full-sync. this will be handled in a different PR

