### PR TITLE
rbd-mirror: periodically flush IO and commit positions

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -396,6 +396,18 @@ public:
         }));
   }
 
+  void expect_flush_repeatedly(MockReplay& mock_replay,
+                               journal::MockJournaler& mock_journal) {
+    EXPECT_CALL(mock_replay, flush(_))
+      .WillRepeatedly(Invoke([this](Context* ctx) {
+                        m_threads->work_queue->queue(ctx, 0);
+                      }));
+    EXPECT_CALL(mock_journal, flush_commit_position(_))
+      .WillRepeatedly(Invoke([this](Context* ctx) {
+                        m_threads->work_queue->queue(ctx, 0);
+                      }));
+  }
+
   void expect_trash_move(MockImageDeleter& mock_image_deleter,
                          const std::string& global_image_id,
                          bool ignore_orphan, int r) {
@@ -624,6 +636,7 @@ TEST_F(TestMockImageReplayer, StartStop) {
   MockEventPreprocessor mock_event_preprocessor;
   MockReplayStatusFormatter mock_replay_status_formatter;
 
+  expect_flush_repeatedly(mock_local_replay, mock_remote_journaler);
   expect_get_or_send_update(mock_replay_status_formatter);
 
   InSequence seq;
@@ -999,6 +1012,7 @@ TEST_F(TestMockImageReplayer, StopError) {
   MockEventPreprocessor mock_event_preprocessor;
   MockReplayStatusFormatter mock_replay_status_formatter;
 
+  expect_flush_repeatedly(mock_local_replay, mock_remote_journaler);
   expect_get_or_send_update(mock_replay_status_formatter);
 
   InSequence seq;
@@ -1067,6 +1081,7 @@ TEST_F(TestMockImageReplayer, Replay) {
   MockReplayStatusFormatter mock_replay_status_formatter;
   ::journal::MockReplayEntry mock_replay_entry;
 
+  expect_flush_repeatedly(mock_local_replay, mock_remote_journaler);
   expect_get_or_send_update(mock_replay_status_formatter);
   expect_get_commit_tid_in_debug(mock_replay_entry);
   expect_get_tag_tid_in_debug(mock_local_journal);
@@ -1176,6 +1191,7 @@ TEST_F(TestMockImageReplayer, DecodeError) {
   MockReplayStatusFormatter mock_replay_status_formatter;
   ::journal::MockReplayEntry mock_replay_entry;
 
+  expect_flush_repeatedly(mock_local_replay, mock_remote_journaler);
   expect_get_or_send_update(mock_replay_status_formatter);
   expect_get_commit_tid_in_debug(mock_replay_entry);
   expect_get_tag_tid_in_debug(mock_local_journal);
@@ -1277,6 +1293,7 @@ TEST_F(TestMockImageReplayer, DelayedReplay) {
   MockReplayStatusFormatter mock_replay_status_formatter;
   ::journal::MockReplayEntry mock_replay_entry;
 
+  expect_flush_repeatedly(mock_local_replay, mock_remote_journaler);
   expect_get_or_send_update(mock_replay_status_formatter);
   expect_get_commit_tid_in_debug(mock_replay_entry);
   expect_get_tag_tid_in_debug(mock_local_journal);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -853,80 +853,76 @@ void ImageReplayer<I>::restart(Context *on_finish)
 }
 
 template <typename I>
-void ImageReplayer<I>::flush(Context *on_finish)
+void ImageReplayer<I>::flush()
 {
   dout(10) << dendl;
+  C_SaferCond ctx;
+  flush_local_replay(&ctx);
+  ctx.wait();
 
-  {
-    Mutex::Locker locker(m_lock);
-    if (m_state == STATE_REPLAYING) {
-      Context *ctx = new FunctionContext(
-        [on_finish](int r) {
-          if (on_finish != nullptr) {
-            on_finish->complete(r);
-          }
-        });
-      on_flush_local_replay_flush_start(ctx);
-      return;
-    }
-  }
-
-  if (on_finish) {
-    on_finish->complete(0);
-  }
+  update_mirror_image_status(false, boost::none);
 }
 
 template <typename I>
-void ImageReplayer<I>::on_flush_local_replay_flush_start(Context *on_flush)
+void ImageReplayer<I>::flush_local_replay(Context* on_flush)
 {
-  dout(10) << dendl;
-  FunctionContext *ctx = new FunctionContext(
+  m_lock.Lock();
+  if (m_state != STATE_REPLAYING) {
+    m_lock.Unlock();
+    on_flush->complete(0);
+    return;
+  }
+
+  dout(15) << dendl;
+  auto ctx = new FunctionContext(
     [this, on_flush](int r) {
-      on_flush_local_replay_flush_finish(on_flush, r);
+      handle_flush_local_replay(on_flush, r);
     });
-
-  ceph_assert(m_lock.is_locked());
-  ceph_assert(m_state == STATE_REPLAYING);
   m_local_replay->flush(ctx);
+  m_lock.Unlock();
 }
 
 template <typename I>
-void ImageReplayer<I>::on_flush_local_replay_flush_finish(Context *on_flush,
-                                                          int r)
+void ImageReplayer<I>::handle_flush_local_replay(Context* on_flush, int r)
 {
-  dout(10) << "r=" << r << dendl;
+  dout(15) << "r=" << r << dendl;
   if (r < 0) {
     derr << "error flushing local replay: " << cpp_strerror(r) << dendl;
     on_flush->complete(r);
     return;
   }
 
-  on_flush_flush_commit_position_start(on_flush);
+  flush_commit_position(on_flush);
 }
 
 template <typename I>
-void ImageReplayer<I>::on_flush_flush_commit_position_start(Context *on_flush)
+void ImageReplayer<I>::flush_commit_position(Context* on_flush)
 {
-  FunctionContext *ctx = new FunctionContext(
+  m_lock.Lock();
+  if (m_state != STATE_REPLAYING) {
+    m_lock.Unlock();
+    on_flush->complete(0);
+    return;
+  }
+
+  dout(15) << dendl;
+  auto ctx = new FunctionContext(
     [this, on_flush](int r) {
-      on_flush_flush_commit_position_finish(on_flush, r);
+      handle_flush_commit_position(on_flush, r);
     });
-
   m_remote_journaler->flush_commit_position(ctx);
+  m_lock.Unlock();
 }
 
 template <typename I>
-void ImageReplayer<I>::on_flush_flush_commit_position_finish(Context *on_flush,
-                                                             int r)
+void ImageReplayer<I>::handle_flush_commit_position(Context* on_flush, int r)
 {
+  dout(15) << "r=" << r << dendl;
   if (r < 0) {
     derr << "error flushing remote journal commit position: "
 	 << cpp_strerror(r) << dendl;
   }
 
-  update_mirror_image_status(false, boost::none);
-
-  dout(20) << "flush complete, r=" << r << dendl;
   on_flush->complete(r);
 }
 

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -117,7 +117,7 @@ public:
   void stop(Context *on_finish = nullptr, bool manual = false,
 	    int r = 0, const std::string& desc = "");
   void restart(Context *on_finish = nullptr);
-  void flush(Context *on_finish = nullptr);
+  void flush();
 
   void resync_image(Context *on_finish=nullptr);
 
@@ -202,11 +202,6 @@ protected:
   virtual bool on_start_interrupted(Mutex& lock);
 
   virtual void on_stop_journal_replay(int r = 0, const std::string &desc = "");
-
-  virtual void on_flush_local_replay_flush_start(Context *on_flush);
-  virtual void on_flush_local_replay_flush_finish(Context *on_flush, int r);
-  virtual void on_flush_flush_commit_position_start(Context *on_flush);
-  virtual void on_flush_flush_commit_position_finish(Context *on_flush, int r);
 
   bool on_replay_interrupted();
 
@@ -378,6 +373,12 @@ private:
     return (m_state == STATE_REPLAYING ||
             m_state == STATE_REPLAY_FLUSHING);
   }
+
+  void flush_local_replay(Context* on_flush);
+  void handle_flush_local_replay(Context* on_flush, int r);
+
+  void flush_commit_position(Context* on_flush);
+  void handle_flush_commit_position(Context* on_flush, int r);
 
   bool update_mirror_image_status(bool force, const OptionalState &state);
   bool start_mirror_image_status_update(bool force, bool restarting);


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

