### PR TITLE
init-radosgw: use ceph-conf to get cluster configuration value

### DIFF
--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -86,7 +86,7 @@ case "$1" in
                 user="$DEFAULT_USER"
             fi
 
-            log_file=`$RADOSGW -n $name --show-config-value log_file`
+            log_file=`ceph-conf -n $name --show-config-value log_file`
             if [ -n "$log_file" ]; then
                 if [ ! -e "$log_file" ]; then
                     touch "$log_file"
@@ -123,7 +123,7 @@ case "$1" in
         timeout=0
         for name in $dlist
         do
-          t=`$RADOSGW -n $name --show-config-value rgw_exit_timeout_secs`
+          t=`ceph-conf -n $name --show-config-value rgw_exit_timeout_secs`
           if [ $t -gt $timeout ]; then timeout=$t; fi
         done
 


### PR DESCRIPTION
Sometimes, cluster isn't up and radosgw hang there for
getting configuration value. Use ceph-conf instead of
radosgw to get the value.

Signed-off-by: Daniel Badea <daniel.badea@windriver.com>
Tested-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

