### PR TITLE
doc/corpus: update to adapt the change from autotools to cmake

### DIFF
--- a/doc/dev/corpus.rst
+++ b/doc/dev/corpus.rst
@@ -29,7 +29,8 @@ We can generate an object corpus for a particular version of ceph like so.
 #. Build with flag to dump objects to /tmp/foo::
 
 	rm -rf /tmp/foo ; mkdir /tmp/foo
-	./do_autogen.sh -e /tmp/foo
+	do_cmake.sh -DCMAKE_CXX_FLAGS="-DENCODE_DUMP_PATH=/tmp/foo"
+	cd build
 	make
 
 #. Start via vstart::
@@ -57,8 +58,8 @@ Do some more stuff with rgw if you know how.
 
 #. Import the corpus (this will take a few minutes)::
 
-	test/encoding/import.sh /tmp/foo `./ceph-dencoder version` ../ceph-object-corpus/archive
-	test/encoding/import-generated.sh ../ceph-object-corpus/archive
+	../src/test/encoding/import.sh /tmp/foo `bin/ceph-dencoder version` ../ceph-object-corpus/archive
+	../src/test/encoding/import-generated.sh ../ceph-object-corpus/archive
 
 #. Prune it!  There will be a bazillion copies of various objects, and we only want a representative sample.::
 
@@ -68,7 +69,7 @@ Do some more stuff with rgw if you know how.
 
 #. Verify the tests pass::
 
-	make check-local
+	ctest -R readable.sh
 
 #. Commit it to the corpus repo and push::
 
@@ -86,8 +87,8 @@ Do some more stuff with rgw if you know how.
 	cd ceph-object-corpus
 	git fetch origin
 	git checkout wip-new
-	cd ../src
-	make check-local
+	cd ../build
+	ctest -R readable.sh
 
 #. If everything looks good, update the submodule master branch, and commit the submodule in ceph.git.
 


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

