### PR TITLE
osd/osd_types: fix object_stat_sum_t fast-path decode

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2325,7 +2325,7 @@ void object_stat_sum_t::decode(ceph::buffer::list::const_iterator& bl)
   bool decode_finish = false;
   DECODE_START(20, bl);  // make sure to also update fast decode below
 #if defined(CEPH_LITTLE_ENDIAN)
-  if (struct_v >= 19) {  // this must match newest decode version
+  if (struct_v >= 20) {  // this must match newest decode version
     bl.copy(sizeof(object_stat_sum_t), (char*)(&num_bytes));
     decode_finish = true;
   }


### PR DESCRIPTION
This needs to match the latest object version number.

Fixes d2ca3d2feb442f97ca89023c7d01178d96f517a6

Signed-off-by: Sage Weil <sage@redhat.com>