### PR TITLE
mon,osd: add no{out,down,in,out} flags on CRUSH nodes

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -223,23 +223,24 @@ With the exception of *full*, these flags can be set or cleared with::
 OSD_FLAGS
 _________
 
-One or more OSDs has a per-OSD flag of interest set.  These flags include:
+One or more OSDs or CRUSH nodes has a flag of interest set.  These flags include:
 
-* *noup*: OSD is not allowed to start
-* *nodown*: failure reports for this OSD will be ignored
-* *noin*: if this OSD was previously marked `out` automatically
-  after a failure, it will not be marked in when it stats
-* *noout*: if this OSD is down it will not automatically be marked
+* *noup*: these OSDs are not allowed to start
+* *nodown*: failure reports for these OSDs will be ignored
+* *noin*: if these OSDs were previously marked `out` automatically
+  after a failure, they will not be marked in when they start
+* *noout*: if these OSDs are down they will not automatically be marked
   `out` after the configured interval
 
-Per-OSD flags can be set and cleared with::
+These flags can be set and cleared with::
 
-  ceph osd add-<flag> <osd-id>
-  ceph osd rm-<flag> <osd-id>
+  ceph osd add-<flag> <osd-id-or-crush-node-name>
+  ceph osd rm-<flag> <osd-id-or-crush-node-name>
 
 For example, ::
 
   ceph osd rm-nodown osd.123
+  ceph osd rm-noout hostfoo
 
 OLD_CRUSH_TUNABLES
 __________________

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2454,6 +2454,13 @@ bool OSDMonitor::can_mark_down(int i)
     return false;
   }
 
+  if (osdmap.get_crush_node_flags(i) & CEPH_OSD_NODOWN) {
+    dout(5) << __func__ << " osd." << i
+	    << " is marked as nodown via a crush node flag, "
+            << "will not mark it down" << dendl;
+    return false;
+  }
+
   int num_osds = osdmap.get_num_osds();
   if (num_osds == 0) {
     dout(5) << __func__ << " no osds" << dendl;
@@ -2484,6 +2491,13 @@ bool OSDMonitor::can_mark_up(int i)
     return false;
   }
 
+  if (osdmap.get_crush_node_flags(i) & CEPH_OSD_NOUP) {
+    dout(5) << __func__ << " osd." << i
+	    << " is marked as noup via a crush node flag, "
+            << "will not mark it up" << dendl;
+    return false;
+  }
+
   return true;
 }
 
@@ -2500,6 +2514,13 @@ bool OSDMonitor::can_mark_out(int i)
 
   if (osdmap.is_noout(i)) {
     dout(5) << __func__ << " osd." << i << " is marked as noout, "
+            << "will not mark it out" << dendl;
+    return false;
+  }
+
+  if (osdmap.get_crush_node_flags(i) & CEPH_OSD_NOOUT) {
+    dout(5) << __func__ << " osd." << i
+	    << " is marked as noout via a crush node flag, "
             << "will not mark it out" << dendl;
     return false;
   }
@@ -2536,6 +2557,13 @@ bool OSDMonitor::can_mark_in(int i)
 
   if (osdmap.is_noin(i)) {
     dout(5) << __func__ << " osd." << i << " is marked as noin, "
+            << "will not mark it in" << dendl;
+    return false;
+  }
+
+  if (osdmap.get_crush_node_flags(i) & CEPH_OSD_NOIN) {
+    dout(5) << __func__ << " osd." << i
+	    << " is marked as noin via a crush node flag, "
             << "will not mark it in" << dendl;
     return false;
   }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5632,9 +5632,21 @@ void OSDMap::check_health(health_check_map_t *checks) const
 	detail.push_back(ss.str());
       }
     }
+    for (auto& i : crush_node_flags) {
+      if (i.second && crush->item_exists(i.first)) {
+	ostringstream ss;
+	set<string> states;
+	OSDMap::calc_state_set(i.second, states);
+	int t = i.first >= 0 ? 0 : crush->get_bucket_type(i.first);
+	const char *tn = crush->get_type_name(t);
+	ss << (tn ? tn : "node") << " "
+	   << crush->get_item_name(i.first) << " has flags " << states;
+	detail.push_back(ss.str());
+      }
+    }
     if (!detail.empty()) {
       ostringstream ss;
-      ss << detail.size() << " osd(s) have {NOUP,NODOWN,NOIN,NOOUT} flags set";
+      ss << detail.size() << " OSDs or CRUSH nodes have {NOUP,NODOWN,NOIN,NOOUT} flags set";
       auto& d = checks->add("OSD_FLAGS", HEALTH_WARN, ss.str());
       d.detail.swap(detail);
     }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5843,3 +5843,20 @@ float OSDMap::pool_raw_used_rate(int64_t poolid) const
     ceph_abort_msg("unrecognized pool type");
   }
 }
+
+unsigned OSDMap::get_crush_node_flags(int osd) const
+{
+  unsigned flags = 0;
+  if (!crush_node_flags.empty()) {
+    // the map will contain type -> name
+    std::map<std::string,std::string> ploc = crush->get_full_location(osd);
+    for (auto& i : ploc) {
+      int id = crush->get_item_id(i.second);
+      auto p = crush_node_flags.find(id);
+      if (p != crush_node_flags.end()) {
+	flags |= p->second;
+      }
+    }
+  }
+  return flags;
+}

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -827,6 +827,8 @@ public:
     return !is_out(osd);
   }
 
+  unsigned get_crush_node_flags(int osd) const;
+
   bool is_noup(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_NOUP);
   }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -399,6 +399,8 @@ public:
     mempool::osdmap::map<int64_t, snap_interval_set_t> new_removed_snaps;
     mempool::osdmap::map<int64_t, snap_interval_set_t> new_purged_snaps;
 
+    mempool::osdmap::map<int32_t,uint32_t> new_crush_node_flags;
+
     std::string cluster_snapshot;
 
     float new_nearfull_ratio = -1;
@@ -510,6 +512,8 @@ private:
 
   int32_t max_osd;
   std::vector<uint32_t> osd_state;
+
+  mempool::osdmap::map<int32_t,uint32_t> crush_node_flags; // crush node -> CEPH_OSD_* flags
 
   utime_t last_up_change, last_in_change;
 

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -509,6 +509,37 @@ TEST_F(OSDMapTest, PrimaryAffinity) {
   }
 }
 
+TEST_F(OSDMapTest, get_crush_node_flags) {
+  set_up_map();
+
+  for (unsigned i=0; i<get_num_osds(); ++i) {
+    ASSERT_EQ(0u, osdmap.get_crush_node_flags(i));
+  }
+
+  OSDMap::Incremental inc(osdmap.get_epoch() + 1);
+  inc.new_crush_node_flags[-1] = 123u;
+  osdmap.apply_incremental(inc);
+  for (unsigned i=0; i<get_num_osds(); ++i) {
+    ASSERT_EQ(123u, osdmap.get_crush_node_flags(i));
+  }
+  ASSERT_EQ(0u, osdmap.get_crush_node_flags(1000));
+
+  OSDMap::Incremental inc3(osdmap.get_epoch() + 1);
+  inc3.new_crush_node_flags[-1] = 456u;
+  osdmap.apply_incremental(inc3);
+  for (unsigned i=0; i<get_num_osds(); ++i) {
+    ASSERT_EQ(456u, osdmap.get_crush_node_flags(i));
+  }
+  ASSERT_EQ(0u, osdmap.get_crush_node_flags(1000));
+
+  OSDMap::Incremental inc2(osdmap.get_epoch() + 1);
+  inc2.new_crush_node_flags[-1] = 0;
+  osdmap.apply_incremental(inc2);
+  for (unsigned i=0; i<get_num_osds(); ++i) {
+    ASSERT_EQ(0u, osdmap.get_crush_node_flags(i));
+  }
+}
+
 TEST_F(OSDMapTest, parse_osd_id_list) {
   set_up_map();
   set<int> out;


### PR DESCRIPTION
- put these in a new OSDMap crush_node_flags map that can take CEPH_OSD_*
- in practice, only the no* flags are used here
- re-use the existing 'ceph osd add-no*' and 'ceph osd rm-no*' commands
- re-use the existing OSD_FLAGS health warning, but update the docs to make it generalize to crush nodes (not just OSDs)