### PR TITLE
rgw: multisite log trimming only checks peers that sync from us

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3569,7 +3569,7 @@ class DataLogTrimCR : public RGWCoroutine {
     : RGWCoroutine(store->ctx()), store(store), http(http),
       num_shards(num_shards),
       zone_id(store->svc.zone->get_zone().id),
-      peer_status(store->svc.zone->get_zone_conn_map().size()),
+      peer_status(store->svc.zone->get_zone_data_notify_to_map().size()),
       min_shard_markers(num_shards),
       last_trim(last_trim)
   {}
@@ -3592,7 +3592,7 @@ int DataLogTrimCR::operate()
       };
 
       auto p = peer_status.begin();
-      for (auto& c : store->svc.zone->get_zone_conn_map()) {
+      for (auto& c : store->svc.zone->get_zone_data_notify_to_map()) {
         ldout(cct, 20) << "query sync status from " << c.first << dendl;
         using StatusCR = RGWReadRESTResourceCR<rgw_data_sync_status>;
         spawn(new StatusCR(cct, c.second, http, "/admin/log/", params, &*p),

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -438,7 +438,7 @@ class BucketTrimInstanceCR : public RGWCoroutine {
       http(http), observer(observer),
       bucket_instance(bucket_instance),
       zone_id(store->svc.zone->get_zone().id),
-      peer_status(store->svc.zone->get_zone_conn_map().size())
+      peer_status(store->svc.zone->get_zone_data_notify_to_map().size())
   {}
 
   int operate() override;
@@ -462,7 +462,7 @@ int BucketTrimInstanceCR::operate()
       };
 
       auto p = peer_status.begin();
-      for (auto& c : store->svc.zone->get_zone_conn_map()) {
+      for (auto& c : store->svc.zone->get_zone_data_notify_to_map()) {
         using StatusCR = RGWReadRESTResourceCR<StatusShards>;
         spawn(new StatusCR(cct, c.second, http, "/admin/log/", params, &*p),
               false);

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -354,9 +354,7 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
                     std::vector<std::string> *status)
 {
   status->clear();
-  // The initialisation below is required to silence a false positive
-  // -Wmaybe-uninitialized warning
-  boost::optional<uint64_t> num_shards = boost::make_optional(false, uint64_t());
+  std::optional<uint64_t> num_shards;
   for (auto peer = first; peer != last; ++peer) {
     const size_t peer_shards = peer->size();
     if (!num_shards) {


### PR DESCRIPTION
if there are peer zones in our zonegroup that do not sync from us, they won't have any sync status that corresponds to our logs. fetching their status will give us empty markers, so we'll never make progress with log trimming

the get_zone_data_notify_to_map() contains only the zones that are configured to sync from us, so use that instead of get_zone_conn_map()

Fixes: http://tracker.ceph.com/issues/39283