### PR TITLE
common/options: update mon_crush_min_required_version=hammer

### DIFF
--- a/doc/rados/operations/balancer.rst
+++ b/doc/rados/operations/balancer.rst
@@ -1,3 +1,6 @@
+
+.. _balancer:
+
 Balancer
 ========
 

--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -319,6 +319,28 @@ Instructions
 
 #. Verify the cluster is healthy with ``ceph health``.
 
+   If your CRUSH tunables are older than Hammer, Ceph will now issue a
+   health warning.  If you see a health alert to that effect, you can
+   revert this change with::
+
+     ceph config set mon mon_crush_min_required_version firefly
+
+   If Ceph does not complain, however, then we recommend you also
+   switch any existing CRUSH buckets to straw2, which was added back
+   in the Hammer release.  If you have any 'straw' buckets, this will
+   result in a modest amount of data movement, but generally nothing
+   too severe.::
+
+     ceph osd getcrushmap -o backup-crushmap
+     ceph osd crush set-all-straw-buckets-to-straw2
+
+   If there are problems, you can easily revert with::
+
+     ceph osd setcrushmap -i backup-crushmap
+
+   Moving to 'straw2' buckets will unlock a few recent features, like
+   the `crush-compat` :ref:`balancer <balancer>` mode added back in Luminous.
+
 #. To enable the new :ref:`v2 network protocol <msgr2>`, issue the
    following command::
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1572,7 +1572,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("mon_crush_min_required_version"),
 
     Option("mon_crush_min_required_version", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("firefly")
+    .set_default("hammer")
     .add_service("mgr")
     .set_description("minimum ceph release to use for mon_warn_on_legacy_crush_tunables")
     .add_see_also("mon_warn_on_legacy_crush_tunables"),


### PR DESCRIPTION
- change min to hammer
- update nautilus upgrade docs to migrate to all buckets to straw2

The intention here is to backport this to nautilus for 14.2.2.  I think the timing is right, notwithstanding the fact that we didn't do this for 14.2.0.  We could wait for Octopus instead...