### PR TITLE
denc: fix build error by calling global snprintf

### DIFF
--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -94,7 +94,7 @@ inline constexpr bool denc_supported = denc_traits<T>::supported;
     if (bits > 2)							\
       break;								\
     char fn[PATH_MAX];							\
-    snprintf(fn, sizeof(fn),						\
+    ::snprintf(fn, sizeof(fn),						\
 	     ENCODE_STRINGIFY(ENCODE_DUMP_PATH) "/%s__%d.%x", #Type,		\
 	     getpid(), i++);						\
     int fd = ::open(fn, O_WRONLY|O_TRUNC|O_CREAT|O_CLOEXEC, 0644);		\


### PR DESCRIPTION
The snprintf in local namespace only need 3 parameters which
doesn't match the call function protertype here.
Fix the build error by calling global snprintf.

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

