### PR TITLE
import-generated.sh: use PATH to get ceph-dencoder

### DIFF
--- a/src/test/encoding/import-generated.sh
+++ b/src/test/encoding/import-generated.sh
@@ -4,7 +4,7 @@ archive=$1
 
 [ -d "$archive" ] || echo "usage: $0 <archive>"
 
-ver=`./ceph-dencoder version`
+ver=`bin/ceph-dencoder version`
 echo "version $ver"
 
 [ -d "$archive/$ver" ] || mkdir "$archive/$ver"
@@ -12,15 +12,15 @@ echo "version $ver"
 tmp1=`mktemp /tmp/typ-XXXXXXXXX`
 
 echo "numgen\ttype"
-for type in `./ceph-dencoder list_types`; do
+for type in `bin/ceph-dencoder list_types`; do
 
     [ -d "$archive/$ver/objects/$type" ] || mkdir -p "$archive/$ver/objects/$type"
 
-    num=`./ceph-dencoder type $type count_tests`
+    num=`bin/ceph-dencoder type $type count_tests`
     echo "$num\t$type"
     max=$(($num - 1))
     for n in `seq 0 $max`; do
-	./ceph-dencoder type $type select_test $n encode export $tmp1
+	bin/ceph-dencoder type $type select_test $n encode export $tmp1
 	md=`md5sum $tmp1 | awk '{print $1}'`
 	echo "\t$md"
 	[ -e "$archive/$ver/objects/$type/$md" ] || cp $tmp1 $archive/$ver/objects/$type/$md


### PR DESCRIPTION
align with instructions in doc/dev/corpus.rst.
doc/dev/corpus.rst is under change by kchai@redhat.com
in PR #27552.

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

