### PR TITLE
rgw: RGWPeriodPusher uses zone system key for inter-zonegroup messages

### DIFF
--- a/src/rgw/rgw_period_pusher.cc
+++ b/src/rgw/rgw_period_pusher.cc
@@ -250,7 +250,7 @@ void RGWPeriodPusher::handle_notify(RGWZonesNeedPeriod&& period)
       hint = conns.emplace_hint(
           hint, std::piecewise_construct,
           std::forward_as_tuple(zonegroup.get_id()),
-          std::forward_as_tuple(cct, store->svc.zone, zonegroup.get_id(), zonegroup.endpoints, RGWAccessKey()));
+          std::forward_as_tuple(cct, store->svc.zone, zonegroup.get_id(), zonegroup.endpoints));
     }
   }
 


### PR DESCRIPTION
RGWPeriodPusher was using an empty RGWAccessKey for inter-zonegroup messages, which were rejected as an anonymous user with 403 Forbidden. this prevented multi-zonegroup configurations from converging on the same period configuration

Fixes: http://tracker.ceph.com/issues/39287

the empty access key was added in https://github.com/ceph/ceph/commit/e1ecd2bb607b87e030efe622f39ec753f7731255