### PR TITLE
rgw: silence a -Wunused-function warning in pubsub

### DIFF
--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -771,7 +771,7 @@ std::string topic_to_unique(const std::string& topic, const std::string& notific
 }
 
 // extract the topic from a unique topic of the form: <notification>_<topic>
-std::string unique_to_topic(const std::string& unique_topic, const std::string& notification) {
+[[maybe_unused]] std::string unique_to_topic(const std::string& unique_topic, const std::string& notification) {
   if (unique_topic.find(notification + "_") == string::npos) {
     return "";
   }


### PR DESCRIPTION
> src/rgw/rgw_sync_module_pubsub_rest.cc:774:13: warning: ‘std::__cxx11::string {anonymous}::unique_to_topic(const string&, const string&)’ d
efined but not used [-Wunused-function]
 std::string unique_to_topic(const std::string& unique_topic, const std::string& notification) {                                                             
             ^~~~~~~~~~~~~~~