### PR TITLE
Mgr subvolumes

### DIFF
--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -19,6 +19,9 @@ class Context;
 class RWLock;
 
 namespace librbd {
+
+namespace io { class AsyncOperation; }
+
 namespace deep_copy {
 
 template <typename ImageCtxT = librbd::ImageCtx>
@@ -160,6 +163,8 @@ private:
   std::map<librados::snap_t, uint8_t> m_dst_object_state;
   std::map<librados::snap_t, bool> m_dst_object_may_exist;
   bufferlist m_read_from_parent_data;
+
+  io::AsyncOperation* m_src_async_op = nullptr;
 
   void send_list_snaps();
   void handle_list_snaps(int r);

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -6,7 +6,7 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "common/Mutex.h"
-
+#include "common/WorkQueue.h"
 #include "librbd/AsyncObjectThrottle.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
@@ -32,41 +32,61 @@ namespace io {
 
 namespace {
 
-class UpdateObjectMap : public C_AsyncObjectThrottle<> {
+template <typename I>
+class C_UpdateObjectMap : public C_AsyncObjectThrottle<I> {
 public:
-  UpdateObjectMap(AsyncObjectThrottle<> &throttle, ImageCtx *image_ctx,
-                  uint64_t object_no, const std::vector<uint64_t> *snap_ids,
-                  const ZTracer::Trace &trace, size_t snap_id_idx)
-    : C_AsyncObjectThrottle(throttle, *image_ctx), m_object_no(object_no),
-      m_snap_ids(*snap_ids), m_trace(trace), m_snap_id_idx(snap_id_idx)
+  C_UpdateObjectMap(AsyncObjectThrottle<I> &throttle, I *image_ctx,
+                    uint64_t object_no, uint8_t head_object_map_state,
+                    const std::vector<uint64_t> *snap_ids,
+                    const ZTracer::Trace &trace, size_t snap_id_idx)
+    : C_AsyncObjectThrottle<I>(throttle, *image_ctx), m_object_no(object_no),
+      m_head_object_map_state(head_object_map_state), m_snap_ids(*snap_ids),
+      m_trace(trace), m_snap_id_idx(snap_id_idx)
   {
   }
 
   int send() override {
-    uint64_t snap_id = m_snap_ids[m_snap_id_idx];
-    if (snap_id == CEPH_NOSNAP) {
-      RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
-      RWLock::WLocker object_map_locker(m_image_ctx.object_map_lock);
-      ceph_assert(m_image_ctx.exclusive_lock->is_lock_owner());
-      ceph_assert(m_image_ctx.object_map != nullptr);
-      bool sent = m_image_ctx.object_map->aio_update<Context>(
-        CEPH_NOSNAP, m_object_no, OBJECT_EXISTS, {}, m_trace, false, this);
-      return (sent ? 0 : 1);
+    auto& image_ctx = this->m_image_ctx;
+    ceph_assert(image_ctx.owner_lock.is_locked());
+    if (image_ctx.exclusive_lock == nullptr) {
+      return 1;
     }
+    ceph_assert(image_ctx.exclusive_lock->is_lock_owner());
 
-    uint8_t state = OBJECT_EXISTS;
-    if (m_image_ctx.test_features(RBD_FEATURE_FAST_DIFF) &&
-        m_snap_id_idx + 1 < m_snap_ids.size()) {
-      state = OBJECT_EXISTS_CLEAN;
-    }
-
-    RWLock::RLocker snap_locker(m_image_ctx.snap_lock);
-    RWLock::RLocker object_map_locker(m_image_ctx.object_map_lock);
-    if (m_image_ctx.object_map == nullptr) {
+    RWLock::RLocker snap_locker(image_ctx.snap_lock);
+    if (image_ctx.object_map == nullptr) {
       return 1;
     }
 
-    bool sent = m_image_ctx.object_map->aio_update<Context>(
+    uint64_t snap_id = m_snap_ids[m_snap_id_idx];
+    if (snap_id == CEPH_NOSNAP) {
+      return update_head();
+    } else {
+      return update_snapshot(snap_id);
+    }
+  }
+
+  int update_head() {
+    auto& image_ctx = this->m_image_ctx;
+    RWLock::WLocker object_map_locker(image_ctx.object_map_lock);
+    bool sent = image_ctx.object_map->template aio_update<Context>(
+      CEPH_NOSNAP, m_object_no, m_head_object_map_state, {}, m_trace, false,
+      this);
+    return (sent ? 0 : 1);
+  }
+
+  int update_snapshot(uint64_t snap_id) {
+    auto& image_ctx = this->m_image_ctx;
+    uint8_t state = OBJECT_EXISTS;
+    if (image_ctx.test_features(RBD_FEATURE_FAST_DIFF, image_ctx.snap_lock) &&
+        m_snap_id_idx > 0) {
+      // first snapshot should be exists+dirty since it contains
+      // the copyup data -- later snapshots inherit the data.
+      state = OBJECT_EXISTS_CLEAN;
+    }
+
+    RWLock::RLocker object_map_locker(image_ctx.object_map_lock);
+    bool sent = image_ctx.object_map->template aio_update<Context>(
       snap_id, m_object_no, state, {}, m_trace, true, this);
     ceph_assert(sent);
     return 0;
@@ -74,6 +94,7 @@ public:
 
 private:
   uint64_t m_object_no;
+  uint8_t m_head_object_map_state;
   const std::vector<uint64_t> &m_snap_ids;
   const ZTracer::Trace &m_trace;
   size_t m_snap_id_idx;
@@ -85,12 +106,12 @@ template <typename I>
 CopyupRequest<I>::CopyupRequest(I *ictx, const std::string &oid,
                                 uint64_t objectno, Extents &&image_extents,
                                 const ZTracer::Trace &parent_trace)
-  : m_ictx(util::get_image_ctx(ictx)), m_oid(oid), m_object_no(objectno),
+  : m_image_ctx(ictx), m_oid(oid), m_object_no(objectno),
     m_image_extents(image_extents),
-    m_trace(util::create_trace(*m_ictx, "copy-up", parent_trace)),
-    m_state(STATE_READ_FROM_PARENT), m_lock("CopyupRequest", false, false)
+    m_trace(util::create_trace(*m_image_ctx, "copy-up", parent_trace)),
+    m_lock("CopyupRequest", false, false)
 {
-  m_async_op.start_op(*m_ictx);
+  m_async_op.start_op(*util::get_image_ctx(m_image_ctx));
 }
 
 template <typename I>
@@ -101,31 +122,251 @@ CopyupRequest<I>::~CopyupRequest() {
 
 template <typename I>
 void CopyupRequest<I>::append_request(AbstractObjectWriteRequest<I> *req) {
-  ldout(m_ictx->cct, 20) << req << dendl;
-  m_pending_requests.push_back(req);
-}
+  Mutex::Locker locker(m_lock);
 
-template <typename I>
-void CopyupRequest<I>::complete_requests(int r) {
-  while (!m_pending_requests.empty()) {
-    auto it = m_pending_requests.begin();
-    auto req = *it;
-    ldout(m_ictx->cct, 20) << "completing request " << req << dendl;
-    req->handle_copyup(r);
-    m_pending_requests.erase(it);
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "oid=" << m_oid << ", "
+                 << "object_request=" << req << ", "
+                 << "append=" << m_append_request_permitted << dendl;
+  if (m_append_request_permitted) {
+    m_pending_requests.push_back(req);
+  } else {
+    m_restart_requests.push_back(req);
   }
 }
 
 template <typename I>
-bool CopyupRequest<I>::send_copyup() {
-  ldout(m_ictx->cct, 20) << "oid " << m_oid << dendl;
-  m_state = STATE_COPYUP;
+void CopyupRequest<I>::send() {
+  read_from_parent();
+}
 
-  m_ictx->snap_lock.get_read();
-  ::SnapContext snapc = m_ictx->snapc;
-  m_ictx->snap_lock.put_read();
+template <typename I>
+void CopyupRequest<I>::read_from_parent() {
+  auto cct = m_image_ctx->cct;
+  RWLock::RLocker snap_locker(m_image_ctx->snap_lock);
+  RWLock::RLocker parent_locker(m_image_ctx->parent_lock);
 
-  std::vector<librados::snap_t> snaps;
+  if (m_image_ctx->parent == nullptr) {
+    ldout(cct, 5) << "parent detached" << dendl;
+
+    m_image_ctx->op_work_queue->queue(
+      util::create_context_callback<
+        CopyupRequest<I>, &CopyupRequest<I>::handle_read_from_parent>(this),
+      -ENOENT);
+    return;
+  } else if (is_deep_copy()) {
+    deep_copy();
+    return;
+  }
+
+  m_deep_copy = false;
+  auto comp = AioCompletion::create_and_start<
+    CopyupRequest<I>,
+    &CopyupRequest<I>::handle_read_from_parent>(
+      this, util::get_image_ctx(m_image_ctx), AIO_TYPE_READ);
+
+  ldout(cct, 20) << "oid=" << m_oid << ", "
+                 << "completion=" << comp << ", "
+                 << "extents=" << m_image_extents
+                 << dendl;
+  ImageRequest<I>::aio_read(m_image_ctx->parent, comp,
+                            std::move(m_image_extents),
+                            ReadResult{&m_copyup_data}, 0, m_trace);
+}
+
+template <typename I>
+void CopyupRequest<I>::handle_read_from_parent(int r) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "oid=" << m_oid << ", r=" << r << dendl;
+
+  m_lock.Lock();
+  m_copyup_required = is_copyup_required();
+  disable_append_requests();
+
+  if (r < 0 && r != -ENOENT) {
+    m_lock.Unlock();
+
+    lderr(cct) << "error reading from parent: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  if (!m_copyup_required) {
+    m_lock.Unlock();
+
+    ldout(cct, 20) << "no-op, skipping" << dendl;
+    finish(0);
+    return;
+  }
+  m_lock.Unlock();
+
+  update_object_maps();
+}
+
+template <typename I>
+void CopyupRequest<I>::deep_copy() {
+  auto cct = m_image_ctx->cct;
+  ceph_assert(m_image_ctx->snap_lock.is_locked());
+  ceph_assert(m_image_ctx->parent_lock.is_locked());
+  ceph_assert(m_image_ctx->parent != nullptr);
+
+  m_lock.Lock();
+  m_flatten = is_copyup_required() ? true : m_image_ctx->migration_info.flatten;
+  m_lock.Unlock();
+
+  ldout(cct, 20) << "oid=" << m_oid << ", flatten=" << m_flatten << dendl;
+
+  m_deep_copy = true;
+  auto ctx = util::create_context_callback<
+    CopyupRequest<I>, &CopyupRequest<I>::handle_deep_copy>(this);
+  auto req = deep_copy::ObjectCopyRequest<I>::create(
+    m_image_ctx->parent, m_image_ctx, m_image_ctx->migration_info.snap_map,
+    m_object_no, m_flatten, ctx);
+
+  req->send();
+}
+
+template <typename I>
+void CopyupRequest<I>::handle_deep_copy(int r) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "oid=" << m_oid << ", r=" << r << dendl;
+
+  m_image_ctx->snap_lock.get_read();
+  m_lock.Lock();
+  m_copyup_required = is_copyup_required();
+  if (r == -ENOENT && !m_flatten && m_copyup_required) {
+    m_lock.Unlock();
+    m_image_ctx->snap_lock.put_read();
+
+    ldout(cct, 10) << "restart deep-copy with flatten" << dendl;
+    send();
+    return;
+  }
+
+  disable_append_requests();
+
+  if (r < 0 && r != -ENOENT) {
+    m_lock.Unlock();
+    m_image_ctx->snap_lock.put_read();
+
+    lderr(cct) << "error encountered during deep-copy: " << cpp_strerror(r)
+               << dendl;
+    finish(r);
+    return;
+  }
+
+  if (!m_copyup_required && !is_update_object_map_required(r)) {
+    m_lock.Unlock();
+    m_image_ctx->snap_lock.put_read();
+
+    if (r == -ENOENT) {
+      r = 0;
+    }
+
+    ldout(cct, 20) << "skipping" << dendl;
+    finish(r);
+    return;
+  }
+
+  m_lock.Unlock();
+  m_image_ctx->snap_lock.put_read();
+
+  update_object_maps();
+}
+
+template <typename I>
+void CopyupRequest<I>::update_object_maps() {
+  RWLock::RLocker owner_locker(m_image_ctx->owner_lock);
+  RWLock::RLocker snap_locker(m_image_ctx->snap_lock);
+  if (m_image_ctx->object_map == nullptr) {
+    snap_locker.unlock();
+    owner_locker.unlock();
+
+    copyup();
+    return;
+  }
+
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "oid=" << m_oid << dendl;
+
+  if (!m_image_ctx->snaps.empty()) {
+    if (m_deep_copy) {
+      compute_deep_copy_snap_ids();
+    } else {
+      m_snap_ids.insert(m_snap_ids.end(), m_image_ctx->snaps.rbegin(),
+                        m_image_ctx->snaps.rend());
+    }
+  }
+
+  bool copy_on_read = m_pending_requests.empty();
+  uint8_t head_object_map_state = OBJECT_EXISTS;
+  if (copy_on_read && !m_snap_ids.empty() &&
+      m_image_ctx->test_features(RBD_FEATURE_FAST_DIFF,
+                                 m_image_ctx->snap_lock)) {
+    // HEAD is non-dirty since data is tied to first snapshot
+    head_object_map_state = OBJECT_EXISTS_CLEAN;
+  }
+
+  auto r_it = m_pending_requests.rbegin();
+  if (r_it != m_pending_requests.rend()) {
+    // last write-op determines the final object map state
+    head_object_map_state = (*r_it)->get_pre_write_object_map_state();
+  }
+
+  RWLock::WLocker object_map_locker(m_image_ctx->object_map_lock);
+  if ((*m_image_ctx->object_map)[m_object_no] != head_object_map_state) {
+    // (maybe) need to update the HEAD object map state
+    m_snap_ids.push_back(CEPH_NOSNAP);
+  }
+  object_map_locker.unlock();
+  snap_locker.unlock();
+
+  ceph_assert(m_image_ctx->exclusive_lock->is_lock_owner());
+  typename AsyncObjectThrottle<I>::ContextFactory context_factory(
+    boost::lambda::bind(boost::lambda::new_ptr<C_UpdateObjectMap<I>>(),
+    boost::lambda::_1, m_image_ctx, m_object_no, head_object_map_state,
+    &m_snap_ids, m_trace, boost::lambda::_2));
+  auto ctx = util::create_context_callback<
+    CopyupRequest<I>, &CopyupRequest<I>::handle_update_object_maps>(this);
+  auto throttle = new AsyncObjectThrottle<I>(
+    nullptr, *m_image_ctx, context_factory, ctx, nullptr, 0, m_snap_ids.size());
+  throttle->start_ops(
+    m_image_ctx->config.template get_val<uint64_t>("rbd_concurrent_management_ops"));
+}
+
+template <typename I>
+void CopyupRequest<I>::handle_update_object_maps(int r) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "oid=" << m_oid << ", r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_image_ctx->cct) << "failed to update object map: "
+                            << cpp_strerror(r) << dendl;
+
+    finish(r);
+    return;
+  }
+
+  copyup();
+}
+
+template <typename I>
+void CopyupRequest<I>::copyup() {
+  auto cct = m_image_ctx->cct;
+  m_image_ctx->snap_lock.get_read();
+  auto snapc = m_image_ctx->snapc;
+  m_image_ctx->snap_lock.put_read();
+
+  m_lock.Lock();
+  if (!m_copyup_required) {
+    m_lock.Unlock();
+
+    ldout(cct, 20) << "skipping copyup" << dendl;
+    finish(0);
+    return;
+  }
+
+  ldout(cct, 20) << "oid=" << m_oid << dendl;
 
   bool copy_on_read = m_pending_requests.empty();
   bool deep_copyup = !snapc.snaps.empty() && !m_copyup_data.is_zero();
@@ -133,67 +374,148 @@ bool CopyupRequest<I>::send_copyup() {
     m_copyup_data.clear();
   }
 
-  Mutex::Locker locker(m_lock);
   int r;
+  librados::ObjectWriteOperation copyup_op;
   if (copy_on_read || deep_copyup) {
-    librados::ObjectWriteOperation copyup_op;
     copyup_op.exec("rbd", "copyup", m_copyup_data);
-    ObjectRequest<I>::add_write_hint(*m_ictx, &copyup_op);
+    ObjectRequest<I>::add_write_hint(*m_image_ctx, &copyup_op);
+    ++m_pending_copyups;
+  }
 
+  librados::ObjectWriteOperation write_op;
+  if (!copy_on_read) {
+    if (!deep_copyup) {
+      write_op.exec("rbd", "copyup", m_copyup_data);
+      ObjectRequest<I>::add_write_hint(*m_image_ctx, &write_op);
+    }
+
+    // merge all pending write ops into this single RADOS op
+    for (auto req : m_pending_requests) {
+      ldout(cct, 20) << "add_copyup_ops " << req << dendl;
+      req->add_copyup_ops(&write_op);
+    }
+
+    if (write_op.size() > 0) {
+      ++m_pending_copyups;
+    }
+  }
+  m_lock.Unlock();
+
+  // issue librados ops at the end to simplify test cases
+  std::vector<librados::snap_t> snaps;
+  if (copyup_op.size() > 0) {
     // send only the copyup request with a blank snapshot context so that
     // all snapshots are detected from the parent for this object.  If
     // this is a CoW request, a second request will be created for the
     // actual modification.
-    m_pending_copyups++;
-    ldout(m_ictx->cct, 20) << "copyup with empty snapshot context" << dendl;
+    ldout(cct, 20) << "copyup with empty snapshot context" << dendl;
 
-    librados::AioCompletion *comp = util::create_rados_callback(this);
-    r = m_ictx->data_ctx.aio_operate(
+    auto comp = util::create_rados_callback<
+      CopyupRequest<I>, &CopyupRequest<I>::handle_copyup>(this);
+    r = m_image_ctx->data_ctx.aio_operate(
       m_oid, comp, &copyup_op, 0, snaps,
       (m_trace.valid() ? m_trace.get_info() : nullptr));
     ceph_assert(r == 0);
     comp->release();
   }
 
-  if (!copy_on_read) {
-    librados::ObjectWriteOperation write_op;
-    if (!deep_copyup) {
-      write_op.exec("rbd", "copyup", m_copyup_data);
-      ObjectRequest<I>::add_write_hint(*m_ictx, &write_op);
-    }
-
-    // merge all pending write ops into this single RADOS op
-    for (auto req : m_pending_requests) {
-      ldout(m_ictx->cct, 20) << "add_copyup_ops " << req << dendl;
-      req->add_copyup_ops(&write_op);
-    }
-
+  if (write_op.size() > 0) {
     // compare-and-write doesn't add any write ops (copyup+cmpext+write
     // can't be executed in the same RADOS op because, unless the object
     // was already present in the clone, cmpext wouldn't see it)
-    if (!write_op.size()) {
-      return false;
-    }
-
-    m_pending_copyups++;
-    ldout(m_ictx->cct, 20) << (!deep_copyup && write_op.size() > 2 ?
-                               "copyup + ops" : !deep_copyup ?
-                                                "copyup" : "ops")
-                           << " with current snapshot context" << dendl;
+    ldout(cct, 20) << (!deep_copyup && write_op.size() > 2 ?
+                        "copyup + ops" : !deep_copyup ? "copyup" : "ops")
+                   << " with current snapshot context" << dendl;
 
     snaps.insert(snaps.end(), snapc.snaps.begin(), snapc.snaps.end());
-    librados::AioCompletion *comp = util::create_rados_callback(this);
-    r = m_ictx->data_ctx.aio_operate(
+    auto comp = util::create_rados_callback<
+      CopyupRequest<I>, &CopyupRequest<I>::handle_copyup>(this);
+    r = m_image_ctx->data_ctx.aio_operate(
       m_oid, comp, &write_op, snapc.seq, snaps,
       (m_trace.valid() ? m_trace.get_info() : nullptr));
     ceph_assert(r == 0);
     comp->release();
   }
-  return false;
+}
+
+template <typename I>
+void CopyupRequest<I>::handle_copyup(int r) {
+  auto cct = m_image_ctx->cct;
+  unsigned pending_copyups;
+  {
+    Mutex::Locker locker(m_lock);
+    ceph_assert(m_pending_copyups > 0);
+    pending_copyups = --m_pending_copyups;
+  }
+
+  ldout(cct, 20) << "oid=" << m_oid << ", " << "r=" << r << ", "
+                 << "pending=" << pending_copyups << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    lderr(cct) << "failed to copyup object: " << cpp_strerror(r) << dendl;
+    complete_requests(false, r);
+  }
+
+  if (pending_copyups == 0) {
+    finish(0);
+  }
+}
+
+template <typename I>
+void CopyupRequest<I>::finish(int r) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "oid=" << m_oid << ", r=" << r << dendl;
+
+  complete_requests(true, r);
+  delete this;
+}
+
+template <typename I>
+void CopyupRequest<I>::complete_requests(bool override_restart_retval, int r) {
+  auto cct = m_image_ctx->cct;
+  remove_from_list();
+
+  while (!m_pending_requests.empty()) {
+    auto it = m_pending_requests.begin();
+    auto req = *it;
+    ldout(cct, 20) << "completing request " << req << dendl;
+    req->handle_copyup(r);
+    m_pending_requests.erase(it);
+  }
+
+  if (override_restart_retval) {
+    r = -ERESTART;
+  }
+
+  while (!m_restart_requests.empty()) {
+    auto it = m_restart_requests.begin();
+    auto req = *it;
+    ldout(cct, 20) << "restarting request " << req << dendl;
+    req->handle_copyup(r);
+    m_restart_requests.erase(it);
+  }
+}
+
+template <typename I>
+void CopyupRequest<I>::disable_append_requests() {
+  ceph_assert(m_lock.is_locked());
+  m_append_request_permitted = false;
+}
+
+template <typename I>
+void CopyupRequest<I>::remove_from_list() {
+  Mutex::Locker copyup_list_locker(m_image_ctx->copyup_list_lock);
+
+  auto it = m_image_ctx->copyup_list.find(m_object_no);
+  if (it != m_image_ctx->copyup_list.end()) {
+    m_image_ctx->copyup_list.erase(it);
+  }
 }
 
 template <typename I>
 bool CopyupRequest<I>::is_copyup_required() {
+  ceph_assert(m_lock.is_locked());
+
   bool copy_on_read = m_pending_requests.empty();
   if (copy_on_read) {
     // always force a copyup if CoR enabled
@@ -213,287 +535,73 @@ bool CopyupRequest<I>::is_copyup_required() {
 }
 
 template <typename I>
+bool CopyupRequest<I>::is_deep_copy() const {
+  ceph_assert(m_image_ctx->snap_lock.is_locked());
+  return !m_image_ctx->migration_info.empty();
+}
+
+template <typename I>
 bool CopyupRequest<I>::is_update_object_map_required(int r) {
+  ceph_assert(m_image_ctx->snap_lock.is_locked());
+
   if (r < 0) {
     return false;
   }
 
-  RWLock::RLocker owner_locker(m_ictx->owner_lock);
-  RWLock::RLocker snap_locker(m_ictx->snap_lock);
-  if (m_ictx->object_map == nullptr) {
+  if (m_image_ctx->object_map == nullptr) {
     return false;
   }
 
-  if (!is_deep_copy()) {
-    return false;
+  if (m_image_ctx->migration_info.empty()) {
+    // migration might have completed while IO was in-flight,
+    // assume worst-case and perform an object map update
+    return true;
   }
 
-  auto it = m_ictx->migration_info.snap_map.find(CEPH_NOSNAP);
-  ceph_assert(it != m_ictx->migration_info.snap_map.end());
+  auto it = m_image_ctx->migration_info.snap_map.find(CEPH_NOSNAP);
+  ceph_assert(it != m_image_ctx->migration_info.snap_map.end());
   return it->second[0] != CEPH_NOSNAP;
 }
 
 template <typename I>
-bool CopyupRequest<I>::is_deep_copy() const {
-  return !m_ictx->migration_info.empty();
-}
+void CopyupRequest<I>::compute_deep_copy_snap_ids() {
+  ceph_assert(m_image_ctx->snap_lock.is_locked());
 
-template <typename I>
-void CopyupRequest<I>::send()
-{
-  m_state = STATE_READ_FROM_PARENT;
-
-  if (is_deep_copy()) {
-    m_flatten = is_copyup_required() ? true : m_ictx->migration_info.flatten;
-    auto req = deep_copy::ObjectCopyRequest<I>::create(
-        m_ictx->parent, m_ictx, m_ictx->migration_info.snap_map, m_object_no,
-        m_flatten, util::create_context_callback(this));
-    ldout(m_ictx->cct, 20) << "deep copy object req " << req
-                           << ", object_no " << m_object_no
-                           << ", flatten " << m_flatten
-                           << dendl;
-    req->send();
-    return;
+  // don't copy ids for the snaps updated by object deep copy or
+  // that don't overlap
+  std::set<uint64_t> deep_copied;
+  for (auto &it : m_image_ctx->migration_info.snap_map) {
+    if (it.first != CEPH_NOSNAP) {
+      deep_copied.insert(it.second.front());
+    }
   }
 
-  AioCompletion *comp = AioCompletion::create_and_start(
-    this, m_ictx, AIO_TYPE_READ);
-
-  ldout(m_ictx->cct, 20) << "completion " << comp
-                         << ", oid " << m_oid
-                         << ", extents " << m_image_extents
-                         << dendl;
-  ImageRequest<>::aio_read(m_ictx->parent, comp, std::move(m_image_extents),
-                           ReadResult{&m_copyup_data}, 0, m_trace);
-}
-
-template <typename I>
-void CopyupRequest<I>::complete(int r)
-{
-  if (should_complete(&r)) {
-    complete_requests(r);
-    delete this;
-  }
-}
-
-template <typename I>
-bool CopyupRequest<I>::should_complete(int *r) {
-  CephContext *cct = m_ictx->cct;
-  ldout(cct, 20) << "oid " << m_oid
-                 << ", r " << *r << dendl;
-
-  unsigned pending_copyups;
-  switch (m_state) {
-  case STATE_READ_FROM_PARENT:
-    ldout(cct, 20) << "READ_FROM_PARENT" << dendl;
-    m_ictx->copyup_list_lock.Lock();
-    if (*r == -ENOENT && is_deep_copy() && !m_flatten && is_copyup_required()) {
-      ldout(cct, 5) << "restart deep copy with flatten" << dendl;
-      m_ictx->copyup_list_lock.Unlock();
-      send();
-      return false;
-    }
-    remove_from_list(m_ictx->copyup_list_lock);
-    m_ictx->copyup_list_lock.Unlock();
-    if (*r >= 0 || *r == -ENOENT) {
-      if (!is_copyup_required() && !is_update_object_map_required(*r)) {
-        if (*r == -ENOENT && is_deep_copy()) {
-          *r = 0;
-        }
-        ldout(cct, 20) << "skipping" << dendl;
-        return true;
-      }
-
-      return send_object_map_head();
-    }
-    break;
-
-  case STATE_OBJECT_MAP_HEAD:
-    ldout(cct, 20) << "OBJECT_MAP_HEAD" << dendl;
-    if (*r < 0) {
-      lderr(cct) << "failed to update head object map: " << cpp_strerror(*r)
-                 << dendl;
-      break;
-    }
-
-    return send_object_map();
-
-  case STATE_OBJECT_MAP:
-    ldout(cct, 20) << "OBJECT_MAP" << dendl;
-    if (*r < 0) {
-      lderr(cct) << "failed to update object map: " << cpp_strerror(*r)
-                 << dendl;
-      break;
-    }
-
-    if (!is_copyup_required()) {
-      ldout(cct, 20) << "skipping copyup" << dendl;
-      return true;
-    }
-    return send_copyup();
-
-  case STATE_COPYUP:
-    {
-      Mutex::Locker locker(m_lock);
-      ceph_assert(m_pending_copyups > 0);
-      pending_copyups = --m_pending_copyups;
-    }
-    ldout(cct, 20) << "COPYUP (" << pending_copyups << " pending)"
-                   << dendl;
-    if (*r == -ENOENT) {
-      // hide the -ENOENT error if this is the last op
-      if (pending_copyups == 0) {
-        *r = 0;
-        complete_requests(0);
-      }
-    } else if (*r < 0) {
-      complete_requests(*r);
-    }
-    return (pending_copyups == 0);
-
-  default:
-    lderr(cct) << "invalid state: " << m_state << dendl;
-    ceph_abort();
-    break;
-  }
-  return (*r < 0);
-}
-
-template <typename I>
-void CopyupRequest<I>::remove_from_list() {
-  Mutex::Locker l(m_ictx->copyup_list_lock);
-
-  remove_from_list(m_ictx->copyup_list_lock);
-}
-
-template <typename I>
-void CopyupRequest<I>::remove_from_list(Mutex &lock) {
-  ceph_assert(m_ictx->copyup_list_lock.is_locked());
-
-  auto it = m_ictx->copyup_list.find(m_object_no);
-  ceph_assert(it != m_ictx->copyup_list.end());
-  m_ictx->copyup_list.erase(it);
-}
-
-template <typename I>
-bool CopyupRequest<I>::send_object_map_head() {
-  CephContext *cct = m_ictx->cct;
-  ldout(cct, 20) << dendl;
-
-  m_state = STATE_OBJECT_MAP_HEAD;
-
-  {
-    RWLock::RLocker owner_locker(m_ictx->owner_lock);
-    RWLock::RLocker snap_locker(m_ictx->snap_lock);
-    if (m_ictx->object_map != nullptr) {
-      bool copy_on_read = m_pending_requests.empty();
-      ceph_assert(m_ictx->exclusive_lock->is_lock_owner());
-
-      RWLock::WLocker object_map_locker(m_ictx->object_map_lock);
-
-      if (!m_ictx->snaps.empty()) {
-        if (is_deep_copy()) {
-          // don't copy ids for the snaps updated by object deep copy or
-          // that don't overlap
-          std::set<uint64_t> deep_copied;
-          for (auto &it : m_ictx->migration_info.snap_map) {
-            if (it.first != CEPH_NOSNAP) {
-              deep_copied.insert(it.second.front());
-            }
-          }
-          std::copy_if(m_ictx->snaps.begin(), m_ictx->snaps.end(),
-                       std::back_inserter(m_snap_ids),
-                       [this, cct, &deep_copied](uint64_t snap_id) {
-                         if (deep_copied.count(snap_id)) {
-                           return false;
-                         }
-                         RWLock::RLocker parent_locker(m_ictx->parent_lock);
-                         uint64_t parent_overlap = 0;
-                         int r = m_ictx->get_parent_overlap(snap_id,
-                                                            &parent_overlap);
-                         if (r < 0) {
-                           ldout(cct, 5) << "failed getting parent overlap for "
-                                         << "snap_id: " << snap_id << ": "
-                                         << cpp_strerror(r) << dendl;
-                         }
-                         if (parent_overlap == 0) {
-                           return false;
-                         }
-                         std::vector<std::pair<uint64_t, uint64_t>> extents;
-                         Striper::extent_to_file(cct, &m_ictx->layout,
-                                                 m_object_no, 0,
-                                                 m_ictx->layout.object_size,
-                                                 extents);
-                         auto overlap = m_ictx->prune_parent_extents(
-                             extents, parent_overlap);
-                         return overlap > 0;
-                       });
-        } else {
-          m_snap_ids.insert(m_snap_ids.end(), m_ictx->snaps.begin(),
-                            m_ictx->snaps.end());
-        }
-      }
-      if (copy_on_read &&
-          (*m_ictx->object_map)[m_object_no] != OBJECT_EXISTS) {
-        m_snap_ids.insert(m_snap_ids.begin(), CEPH_NOSNAP);
-        object_map_locker.unlock();
-        snap_locker.unlock();
-        owner_locker.unlock();
-        return send_object_map();
-      }
-
-      bool may_update = false;
-      uint8_t new_state;
-      uint8_t current_state = (*m_ictx->object_map)[m_object_no];
-
-      auto r_it = m_pending_requests.rbegin();
-      if (r_it != m_pending_requests.rend()) {
-        auto req = *r_it;
-        new_state = req->get_pre_write_object_map_state();
-
-        ldout(cct, 20) << req->get_op_type() << " object no "
-                       << m_object_no << " current state "
-                       << stringify(static_cast<uint32_t>(current_state))
-                       << " new state " << stringify(static_cast<uint32_t>(new_state))
-                       << dendl;
-        may_update = true;
-      }
-
-      if (may_update && (new_state != current_state) &&
-          m_ictx->object_map->aio_update<CopyupRequest>(
-            CEPH_NOSNAP, m_object_no, new_state, current_state, m_trace,
-            false, this)) {
+  RWLock::RLocker parent_locker(m_image_ctx->parent_lock);
+  std::copy_if(m_image_ctx->snaps.rbegin(), m_image_ctx->snaps.rend(),
+               std::back_inserter(m_snap_ids),
+               [this, cct=m_image_ctx->cct, &deep_copied](uint64_t snap_id) {
+      if (deep_copied.count(snap_id)) {
         return false;
       }
-    }
-  }
 
-  return send_object_map();
-}
-
-template <typename I>
-bool CopyupRequest<I>::send_object_map() {
-  // avoid possible recursive lock attempts
-  if (m_snap_ids.empty()) {
-    // no object map update required
-    return send_copyup();
-  } else {
-    // update object maps for HEAD and all existing snapshots
-    ldout(m_ictx->cct, 20) << "oid " << m_oid << dendl;
-    m_state = STATE_OBJECT_MAP;
-
-    RWLock::RLocker owner_locker(m_ictx->owner_lock);
-    AsyncObjectThrottle<>::ContextFactory context_factory(
-      boost::lambda::bind(boost::lambda::new_ptr<UpdateObjectMap>(),
-      boost::lambda::_1, m_ictx, m_object_no, &m_snap_ids, m_trace,
-      boost::lambda::_2));
-    AsyncObjectThrottle<> *throttle = new AsyncObjectThrottle<>(
-      NULL, *m_ictx, context_factory, util::create_context_callback(this),
-      NULL, 0, m_snap_ids.size());
-    throttle->start_ops(
-      m_ictx->config.template get_val<uint64_t>("rbd_concurrent_management_ops"));
-  }
-  return false;
+      uint64_t parent_overlap = 0;
+      int r = m_image_ctx->get_parent_overlap(snap_id, &parent_overlap);
+      if (r < 0) {
+        ldout(cct, 5) << "failed getting parent overlap for snap_id: "
+                      << snap_id << ": " << cpp_strerror(r) << dendl;
+      }
+      if (parent_overlap == 0) {
+        return false;
+      }
+      std::vector<std::pair<uint64_t, uint64_t>> extents;
+      Striper::extent_to_file(cct, &m_image_ctx->layout,
+                              m_object_no, 0,
+                              m_image_ctx->layout.object_size,
+                              extents);
+      auto overlap = m_image_ctx->prune_parent_extents(
+          extents, parent_overlap);
+      return overlap > 0;
+    });
 }
 
 } // namespace io

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -395,7 +395,7 @@ void AbstractImageWriteRequest<I>::send_request() {
     send_object_requests(object_extents, snapc, journal_tid);
   } else {
     // no IO to perform -- fire completion
-    aio_comp->unblock();
+    aio_comp->set_request_count(0);
   }
 
   update_stats(clip_len);

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -266,33 +266,34 @@ template <typename I>
 void ObjectReadRequest<I>::read_parent() {
   I *image_ctx = this->m_ictx;
 
-  uint64_t object_overlap = 0;
+  RWLock::RLocker snap_locker(image_ctx->snap_lock);
+  RWLock::RLocker parent_locker(image_ctx->parent_lock);
+
+  // calculate reverse mapping onto the image
   Extents parent_extents;
-  {
-    RWLock::RLocker snap_locker(image_ctx->snap_lock);
-    RWLock::RLocker parent_locker(image_ctx->parent_lock);
+  Striper::extent_to_file(image_ctx->cct, &image_ctx->layout,
+                          this->m_object_no, this->m_object_off,
+                          this->m_object_len, parent_extents);
 
-    // calculate reverse mapping onto the image
-    Striper::extent_to_file(image_ctx->cct, &image_ctx->layout,
-                            this->m_object_no, this->m_object_off,
-                            this->m_object_len, parent_extents);
-
-    uint64_t parent_overlap = 0;
-    int r = image_ctx->get_parent_overlap(this->m_snap_id, &parent_overlap);
-    if (r == 0) {
-      object_overlap = image_ctx->prune_parent_extents(parent_extents,
-                                                       parent_overlap);
-    }
+  uint64_t parent_overlap = 0;
+  uint64_t object_overlap = 0;
+  int r = image_ctx->get_parent_overlap(this->m_snap_id, &parent_overlap);
+  if (r == 0) {
+    object_overlap = image_ctx->prune_parent_extents(parent_extents,
+                                                     parent_overlap);
   }
 
   if (object_overlap == 0) {
+    parent_locker.unlock();
+    snap_locker.unlock();
+
     this->finish(-ENOENT);
     return;
   }
 
   ldout(image_ctx->cct, 20) << dendl;
 
-  AioCompletion *parent_completion = AioCompletion::create_and_start<
+  auto parent_completion = AioCompletion::create_and_start<
     ObjectReadRequest<I>, &ObjectReadRequest<I>::handle_read_parent>(
       this, util::get_image_ctx(image_ctx->parent), AIO_TYPE_READ);
   ImageRequest<I>::aio_read(image_ctx->parent, parent_completion,
@@ -384,6 +385,12 @@ AbstractObjectWriteRequest<I>::AbstractObjectWriteRequest(
   }
 
   compute_parent_info();
+
+  ictx->snap_lock.get_read();
+  if (!ictx->migration_info.empty()) {
+    m_guarding_migration_write = true;
+  }
+  ictx->snap_lock.put_read();
 }
 
 template <typename I>
@@ -498,8 +505,7 @@ void AbstractObjectWriteRequest<I>::write_object() {
   librados::ObjectWriteOperation write;
   if (m_copyup_enabled) {
     ldout(image_ctx->cct, 20) << "guarding write" << dendl;
-    if (!image_ctx->migration_info.empty()) {
-      m_guarding_migration_write = true;
+    if (m_guarding_migration_write) {
       cls_client::assert_snapc_seq(
         &write, m_snap_seq, cls::rbd::ASSERT_SNAPC_SEQ_LE_SNAPSET_SEQ);
     } else {
@@ -533,11 +539,14 @@ void AbstractObjectWriteRequest<I>::handle_write_object(int r) {
       return;
     }
   } else if (r == -ERANGE && m_guarding_migration_write) {
-    if (!image_ctx->migration_info.empty()) {
+    image_ctx->snap_lock.get_read();
+    m_guarding_migration_write = !image_ctx->migration_info.empty();
+    image_ctx->snap_lock.put_read();
+
+    if (m_guarding_migration_write) {
       copyup();
     } else {
       ldout(image_ctx->cct, 10) << "migration parent gone, restart io" << dendl;
-      m_guarding_migration_write = false;
       compute_parent_info();
       write_object();
     }
@@ -592,14 +601,14 @@ void AbstractObjectWriteRequest<I>::handle_copyup(int r) {
   ceph_assert(m_copyup_in_progress);
   m_copyup_in_progress = false;
 
-  if (r < 0) {
+  if (r < 0 && r != -ERESTART) {
     lderr(image_ctx->cct) << "failed to copyup object: " << cpp_strerror(r)
                           << dendl;
     this->finish(r);
     return;
   }
 
-  if (is_post_copyup_write_required()) {
+  if (r == -ERESTART || is_post_copyup_write_required()) {
     write_object();
     return;
   }

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -1176,7 +1176,7 @@ bool Replay<I>::clipped_io(uint64_t image_offset, io::AioCompletion *aio_comp) {
     // it wouldn't have been recorded in the journal
     ldout(cct, 5) << ": no-op IO event beyond image size" << dendl;
     aio_comp->get();
-    aio_comp->unblock();
+    aio_comp->set_request_count(0);
     aio_comp->put();
     return true;
   }

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -9,7 +9,7 @@ except ImportError:
 from mgr_module import MgrModule
 import orchestrator
 
-from ceph_volume_client import CephFSVolumeClient, VolumePath
+from .subvolume import SubvolumePath, SubvolumeClient
 
 class PurgeJob(object):
     def __init__(self, volume_fscid, subvolume_path):
@@ -222,12 +222,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
         # TODO: validate that subvol size fits in volume size
 
-        with CephFSVolumeClient(rados=self.rados, fs_name=vol_name) as vc:
+        with SubvolumeClient(rados=self.rados, fs_name=vol_name) as svc:
             # TODO: support real subvolume groups rather than just
             # always having them 1:1 with subvolumes.
-            vp = VolumePath(sub_name, sub_name)
+            svp = SubvolumePath(sub_name, sub_name)
 
-            vc.create_volume(vp, size)
+            svc.create_subvolume(svp, size)
 
         return 0, "", ""
 
@@ -241,15 +241,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
         vol_fscid = fs['id']
 
-        with CephFSVolumeClient(rados=self.rados, fs_name=vol_name) as vc:
+        with SubvolumeClient(rados=self.rados, fs_name=vol_name) as svc:
             # TODO: support real subvolume groups rather than just
             # always having them 1:1 with subvolumes.
-            vp = VolumePath(sub_name, sub_name)
+            svp = SubvolumePath(sub_name, sub_name)
 
-            vc.delete_volume(vp)
+            vc.delete_volume(svp)
 
         # TODO: create a progress event
-        self._background_jobs.put(PurgeJob(vol_fscid, vp))
+        self._background_jobs.put(PurgeJob(vol_fscid, svp))
 
         return 0, "", ""
 

--- a/src/pybind/mgr/volumes/subvolume.py
+++ b/src/pybind/mgr/volumes/subvolume.py
@@ -1,0 +1,561 @@
+
+"""
+Copyright (C) 2019 Red Hat, Inc.
+
+LGPL2.1.  See file COPYING.
+"""
+
+import errno
+import json
+import logging
+import os
+
+from ceph_argparse import json_command
+
+import cephfs
+import rados
+
+def to_bytes(param):
+    '''
+    Helper method that returns byte representation of the given parameter.
+    '''
+    if isinstance(param, str):
+        return param.encode()
+    else:
+        return str(param).encode()
+
+class RadosError(Exception):
+    """
+    Something went wrong talking to Ceph with librados
+    """
+    pass
+
+
+RADOS_TIMEOUT = 10
+
+log = logging.getLogger(__name__)
+
+# Reserved subvolume group name which we use in paths for subvolumes
+# that are not assigned to a group (i.e. created with group=None)
+NO_GROUP_NAME = "_nogroup"
+
+
+class SubvolumePath(object):
+    """
+    Identify a subvolume's path as group->subvolume
+    The Subvolume ID is a unique identifier, but this is a much more
+    helpful thing to pass around.
+    """
+    def __init__(self, group_id, subvolume_id):
+        self.group_id = group_id
+        self.subvolume_id = subvolume_id
+        assert self.group_id != NO_GROUP_NAME
+        assert self.subvolume_id != "" and self.subvolume_id is not None
+
+    def __str__(self):
+        return "{0}/{1}".format(self.group_id, self.subvolume_id)
+
+
+class SubvolumeClient(object):
+    """
+    Combine libcephfs and librados interfaces to implement a
+    'Subvolume' concept implemented as a cephfs directory and
+    client capabilities which restrict mount access to this
+    directory.
+
+    Additionally, subvolumes may be in a 'Group'.  Conveniently,
+    subvolumes are a lot like manila shares, and groups are a lot
+    like manila consistency groups.
+
+    Refer to subvolumes with SubvolumePath, which specifies the
+    subvolume and group IDs (both strings).  The group ID may
+    be None.
+
+    In general, functions in this class are allowed raise rados.Error
+    or cephfs.Error exceptions in unexpected situations.
+    """
+
+    # Where shall we create our volumes?
+    DEFAULT_SUBVOL_PREFIX = "/subvolumes"
+    DEFAULT_NS_PREFIX = "fssubvolumens_"
+
+    def __init__(self, subvolume_prefix=None, pool_ns_prefix=None, rados=None,
+                 fs_name=None):
+        self.fs = None
+        self.fs_name = fs_name
+        self.connected = False
+
+        self.rados = rados
+
+        self.subvolume_prefix = subvolume_prefix if subvolume_prefix else self.DEFAULT_SUBVOL_PREFIX
+        self.pool_ns_prefix = pool_ns_prefix if pool_ns_prefix else self.DEFAULT_NS_PREFIX
+
+    def get_mds_map(self):
+        fs_map = self._rados_command("fs dump", {})
+        return fs_map['filesystems'][0]['mdsmap']
+
+    def _get_path(self, subvolume_path):
+        """
+        Determine the path within CephFS where this subvolume will live
+        :return: absolute path (string)
+        """
+        return os.path.join(
+            self.subvolume_prefix,
+            subvolume_path.group_id if subvolume_path.group_id is not None else NO_GROUP_NAME,
+            subvolume_path.subvolume_id)
+
+    def _get_group_path(self, group_id):
+        if group_id is None:
+            raise ValueError("group_id may not be None")
+
+        return os.path.join(
+            self.subvolume_prefix,
+            group_id
+        )
+
+    def connect(self):
+        log.debug("Connecting to cephfs...")
+        self.fs = cephfs.LibCephFS(rados_inst=self.rados)
+        log.debug("CephFS initializing...")
+        self.fs.init()
+        log.debug("CephFS mounting...")
+        self.fs.mount(filesystem_name=self.fs_name)
+        log.debug("Connection to cephfs complete")
+
+    def get_mon_addrs(self):
+        log.info("get_mon_addrs")
+        result = []
+        mon_map = self._rados_command("mon dump")
+        for mon in mon_map['mons']:
+            ip_port = mon['addr'].split("/")[0]
+            result.append(ip_port)
+
+        return result
+
+    def disconnect(self):
+        log.info("disconnect")
+        if self.fs:
+            log.debug("Disconnecting cephfs...")
+            self.fs.shutdown()
+            self.fs = None
+            log.debug("Disconnecting cephfs complete")
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+
+    def __del__(self):
+        self.disconnect()
+
+    def _mkdir_p(self, path, mode=0o755):
+        try:
+            self.fs.stat(path)
+        except cephfs.ObjectNotFound:
+            pass
+        else:
+            return
+
+        parts = path.split(os.path.sep)
+
+        for i in range(1, len(parts) + 1):
+            subpath = os.path.join(*parts[0:i])
+            try:
+                self.fs.stat(subpath)
+            except cephfs.ObjectNotFound:
+                self.fs.mkdir(subpath, mode)
+
+    def create_subvolume(self, subvolume_path, size=None, namespace_isolated=True, mode=0o755):
+        """
+        Set up metadata, pools and auth for a subvolume.
+
+        This function is idempotent.  It is safe to call this again
+        for an already-created subvolume, even if it is in use.
+
+        :param subvolume_path: SubvolumePath instance
+        :param size: In bytes, or None for no size limit
+        :param namespace_isolated: If true, use separate RADOS namespace for this volume
+        :return:
+        """
+        path = self._get_path(subvolume_path)
+        log.info("create_subvolume: {0}".format(path))
+
+        self._mkdir_p(path, mode)
+
+        if size is not None:
+            self.fs.setxattr(path, 'ceph.quota.max_bytes', to_bytes(size), 0)
+
+        # enforce security isolation, use separate namespace for this subvolume
+        if namespace_isolated:
+            namespace = "{0}{1}".format(self.pool_ns_prefix, subvolume_path.subvolume_id)
+            log.info("create_subvolume: {0}, using rados namespace {1} to isolate data.".format(subvolume_path, namespace))
+            self.fs.setxattr(path, 'ceph.dir.layout.pool_namespace',
+                             to_bytes(namespace), 0)
+        else:
+            # If subvolume's namespace layout is not set, then the subvolume's pool
+            # layout remains unset and will undesirably change with ancestor's
+            # pool layout changes.
+            pool_name = self._get_ancestor_xattr(path, "ceph.dir.layout.pool")
+            self.fs.setxattr(path, 'ceph.dir.layout.pool',
+                             to_bytes(pool_name), 0)
+
+        return {
+            'mount_path': path
+        }
+
+    def delete_subvolume(self, subvolume_path, data_isolated=False):
+        """
+        Make a subvolume inaccessible to guests.  This function is
+        idempotent.  This is the fast part of tearing down a subvolume: you must
+        also later call purge_subvolume, which is the slow part.
+
+        :param subvolume_path: Same identifier used in create_subvolume
+        :return:
+        """
+
+        path = self._get_path(subvolume_path)
+        log.info("delete_subvolume: {0}".format(path))
+
+        # Create the trash folder if it doesn't already exist
+        trash = os.path.join(self.subvolume_prefix, "_deleting")
+        self._mkdir_p(trash)
+
+        # We'll move it to here
+        trashed_subvolume = os.path.join(trash, subvolume_path.subvolume_id)
+
+        # Move the subvolume's data to the trash folder
+        try:
+            self.fs.stat(path)
+        except cephfs.ObjectNotFound:
+            log.warning("Trying to delete subvolume '{0}' but it's already gone".format(
+                path))
+        else:
+            self.fs.rename(path, trashed_subvolume)
+
+    def purge_subvolume(self, subvolume_path, data_isolated=False):
+        """
+        Finish clearing up a subvolume that was previously passed to delete_subvolume.  This
+        function is idempotent.
+        """
+
+        trash = os.path.join(self.subvolume_prefix, "_deleting")
+        trashed_subvolume = os.path.join(trash, subvolume_path.subvolume_id)
+
+        try:
+            self.fs.stat(trashed_subvolume)
+        except cephfs.ObjectNotFound:
+            log.warning("Trying to purge subvolume '{0}' but it's already been purged".format(
+                trashed_subvolume))
+            return
+
+        def rmtree(root_path):
+            log.debug("rmtree {0}".format(root_path))
+            dir_handle = self.fs.opendir(root_path)
+            d = self.fs.readdir(dir_handle)
+            while d:
+                if d.d_name not in [".", ".."]:
+                    # Do not use os.path.join because it is sensitive
+                    # to string encoding, we just pass through dnames
+                    # as byte arrays
+                    d_full = "{0}/{1}".format(root_path, d.d_name)
+                    if d.is_dir():
+                        rmtree(d_full)
+                    else:
+                        self.fs.unlink(d_full)
+
+                d = self.fs.readdir(dir_handle)
+            self.fs.closedir(dir_handle)
+
+            self.fs.rmdir(root_path)
+
+        rmtree(trashed_subvolume)
+
+    def _get_ancestor_xattr(self, path, attr):
+        """
+        Helper for reading layout information: if this xattr is missing
+        on the requested path, keep checking parents until we find it.
+        """
+        try:
+            result = self.fs.getxattr(path, attr).decode()
+            if result == "":
+                # Annoying!  cephfs gives us empty instead of an error when attr not found
+                raise cephfs.NoData()
+            else:
+                return result
+        except cephfs.NoData:
+            if path == "/":
+                raise
+            else:
+                return self._get_ancestor_xattr(os.path.split(path)[0], attr)
+
+    def authorize(self, subvolume_path, auth_id, readonly=False):
+        """
+        Get-or-create a Ceph auth identity for `auth_id` and grant them access
+        to
+        :param volume_path:
+        :param auth_id:
+        :param readonly:
+        :return:
+        """
+        path = self._get_path(subvolume_path)
+        log.debug("Authorizing Ceph id '{0}' for path '{1}'".format(
+            auth_id, path
+        ))
+
+        # First I need to work out what the data pool is for this share:
+        # read the layout
+        pool_name = self._get_ancestor_xattr(path, "ceph.dir.layout.pool")
+
+        try:
+            namespace = self.fs.getxattr(path, "ceph.dir.layout.pool_"
+                                         "namespace").decode()
+        except cephfs.NoData:
+            namespace = None
+
+        # Now construct auth capabilities that give the guest just enough
+        # permissions to access the share
+        client_entity = "client.{0}".format(auth_id)
+        want_access_level = 'r' if readonly else 'rw'
+        want_mds_cap = 'allow {0} path={1}'.format(want_access_level, path)
+        if namespace:
+            want_osd_cap = 'allow {0} pool={1} namespace={2}'.format(
+                want_access_level, pool_name, namespace)
+        else:
+            want_osd_cap = 'allow {0} pool={1}'.format(want_access_level,
+                                                       pool_name)
+
+        try:
+            existing = self._rados_command(
+                'auth get',
+                {
+                    'entity': client_entity
+                }
+            )
+            # FIXME: rados raising Error instead of ObjectNotFound in auth get failure
+        except rados.Error:
+            caps = self._rados_command(
+                'auth get-or-create',
+                {
+                    'entity': client_entity,
+                    'caps': [
+                        'mds', want_mds_cap,
+                        'osd', want_osd_cap,
+                        'mon', 'allow r']
+                })
+        else:
+            # entity exists, update it
+            cap = existing[0]
+
+            # Construct auth caps that if present might conflict with the desired
+            # auth caps.
+            unwanted_access_level = 'r' if want_access_level is 'rw' else 'rw'
+            unwanted_mds_cap = 'allow {0} path={1}'.format(unwanted_access_level, path)
+            if namespace:
+                unwanted_osd_cap = 'allow {0} pool={1} namespace={2}'.format(
+                    unwanted_access_level, pool_name, namespace)
+            else:
+                unwanted_osd_cap = 'allow {0} pool={1}'.format(
+                    unwanted_access_level, pool_name)
+
+            def cap_update(
+                    orig_mds_caps, orig_osd_caps, want_mds_cap,
+                    want_osd_cap, unwanted_mds_cap, unwanted_osd_cap):
+
+                if not orig_mds_caps:
+                    return want_mds_cap, want_osd_cap
+
+                mds_cap_tokens = orig_mds_caps.split(",")
+                osd_cap_tokens = orig_osd_caps.split(",")
+
+                if want_mds_cap in mds_cap_tokens:
+                    return orig_mds_caps, orig_osd_caps
+
+                if unwanted_mds_cap in mds_cap_tokens:
+                    mds_cap_tokens.remove(unwanted_mds_cap)
+                    osd_cap_tokens.remove(unwanted_osd_cap)
+
+                mds_cap_tokens.append(want_mds_cap)
+                osd_cap_tokens.append(want_osd_cap)
+
+                return ",".join(mds_cap_tokens), ",".join(osd_cap_tokens)
+
+            orig_mds_caps = cap['caps'].get('mds', "")
+            orig_osd_caps = cap['caps'].get('osd', "")
+
+            mds_cap_str, osd_cap_str = cap_update(
+                orig_mds_caps, orig_osd_caps, want_mds_cap, want_osd_cap,
+                unwanted_mds_cap, unwanted_osd_cap)
+
+            caps = self._rados_command(
+                'auth caps',
+                {
+                    'entity': client_entity,
+                    'caps': [
+                        'mds', mds_cap_str,
+                        'osd', osd_cap_str,
+                        'mon', cap['caps'].get('mon', 'allow r')]
+                })
+            caps = self._rados_command(
+                'auth get',
+                {
+                    'entity': client_entity
+                }
+            )
+
+        # Result expected like this:
+        # [
+        #     {
+        #         "entity": "client.foobar",
+        #         "key": "AQBY0\/pViX\/wBBAAUpPs9swy7rey1qPhzmDVGQ==",
+        #         "caps": {
+        #             "mds": "allow *",
+        #             "mon": "allow *"
+        #         }
+        #     }
+        # ]
+        assert len(caps) == 1
+        assert caps[0]['entity'] == client_entity
+        return caps[0]['key']
+
+    def deauthorize(self, subvolume_path, auth_id):
+        """
+        The volume must still exist.
+        """
+        client_entity = "client.{0}".format(auth_id)
+        path = self._get_path(subvolume_path)
+        pool_name = self._get_ancestor_xattr(path, "ceph.dir.layout.pool")
+        try:
+            namespace = self.fs.getxattr(path, "ceph.dir.layout.pool_"
+                                         "namespace").decode()
+        except cephfs.NoData:
+            namespace = None
+
+        # The auth_id might have read-only or read-write mount access for the
+        # volume path.
+        access_levels = ('r', 'rw')
+        want_mds_caps = ['allow {0} path={1}'.format(access_level, path)
+                         for access_level in access_levels]
+        if namespace:
+            want_osd_caps = ['allow {0} pool={1} namespace={2}'.format(access_level, pool_name, namespace)
+                             for access_level in access_levels]
+        else:
+            want_osd_caps = ['allow {0} pool={1}'.format(access_level, pool_name)
+                             for access_level in access_levels]
+
+
+        try:
+            existing = self._rados_command(
+                'auth get',
+                {
+                    'entity': client_entity
+                }
+            )
+
+            def cap_remove(orig_mds_caps, orig_osd_caps, want_mds_caps, want_osd_caps):
+                mds_cap_tokens = orig_mds_caps.split(",")
+                osd_cap_tokens = orig_osd_caps.split(",")
+
+                for want_mds_cap, want_osd_cap in zip(want_mds_caps, want_osd_caps):
+                    if want_mds_cap in mds_cap_tokens:
+                        mds_cap_tokens.remove(want_mds_cap)
+                        osd_cap_tokens.remove(want_osd_cap)
+                        break
+
+                return ",".join(mds_cap_tokens), ",".join(osd_cap_tokens)
+
+            cap = existing[0]
+            orig_mds_caps = cap['caps'].get('mds', "")
+            orig_osd_caps = cap['caps'].get('osd', "")
+            mds_cap_str, osd_cap_str = cap_remove(orig_mds_caps, orig_osd_caps,
+                                                  want_mds_caps, want_osd_caps)
+
+            if not mds_cap_str:
+                self._rados_command('auth del', {'entity': client_entity}, decode=False)
+            else:
+                self._rados_command(
+                    'auth caps',
+                    {
+                        'entity': client_entity,
+                        'caps': [
+                            'mds', mds_cap_str,
+                            'osd', osd_cap_str,
+                            'mon', cap['caps'].get('mon', 'allow r')]
+                    })
+
+        # FIXME: rados raising Error instead of ObjectNotFound in auth get failure
+        except rados.Error:
+            # Already gone, great.
+            return
+
+    def _rados_command(self, prefix, args=None, decode=True):
+        """
+        Safer wrapper for ceph_argparse.json_command, which raises
+        Error exception instead of relying on caller to check return
+        codes.
+
+        Error exception can result from:
+        * Timeout
+        * Actual legitimate errors
+        * Malformed JSON output
+
+        return: Decoded object from ceph, or None if empty string returned.
+                If decode is False, return a string (the data returned by
+                ceph command)
+        """
+        if args is None:
+            args = {}
+
+        argdict = args.copy()
+        argdict['format'] = 'json'
+
+        ret, outbuf, outs = json_command(self.rados,
+                                         prefix=prefix,
+                                         argdict=argdict,
+                                         timeout=RADOS_TIMEOUT)
+        if ret != 0:
+            raise rados.Error(outs)
+        else:
+            if decode:
+                if outbuf:
+                    try:
+                        return json.loads(outbuf.decode())
+                    except (ValueError, TypeError):
+                        raise RadosError("Invalid JSON output for command {0}".format(argdict))
+                else:
+                    return None
+            else:
+                return outbuf
+
+    def get_used_bytes(self, subvolume_path):
+        return int(self.fs.getxattr(self._get_path(subvolume_path), "ceph.dir."
+                                    "rbytes").decode())
+
+    def set_max_bytes(self, subvolume_path, max_bytes):
+        self.fs.setxattr(self._get_path(subvolume_path), 'ceph.quota.max_bytes',
+                         to_bytes(max_bytes if max_bytes else 0), 0)
+
+    def _snapshot_path(self, dir_path, snapshot_name):
+        return os.path.join(
+            dir_path, self.rados.conf_get('client_snapdir'), snapshot_name
+        )
+
+    def _snapshot_create(self, dir_path, snapshot_name, mode=0o755):
+        # TODO: raise intelligible exception for clusters where snaps are disabled
+        self.fs.mkdir(self._snapshot_path(dir_path, snapshot_name), mode)
+
+    def _snapshot_destroy(self, dir_path, snapshot_name):
+        """
+        Remove a snapshot, or do nothing if it already doesn't exist.
+        """
+        try:
+            self.fs.rmdir(self._snapshot_path(dir_path, snapshot_name))
+        except cephfs.ObjectNotFound:
+            log.warn("Snapshot was already gone: {0}".format(snapshot_name))
+
+    def create_snapshot_subvolume(self, subvolume_path, snapshot_name, mode=0o755):
+        self._snapshot_create(self._get_path(subvolume_path), snapshot_name, mode)
+
+    def destroy_snapshot_subvolume(self, subvolume_path, snapshot_name):
+        self._snapshot_destroy(self._get_path(subvolume_path), snapshot_name)

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -69,6 +69,7 @@ set(unittest_librbd_srcs
   image/test_mock_RefreshRequest.cc
   image/test_mock_RemoveRequest.cc
   image/test_mock_ValidatePoolRequest.cc
+  io/test_mock_CopyupRequest.cc
   io/test_mock_ImageRequest.cc
   io/test_mock_ImageRequestWQ.cc
   io/test_mock_ObjectRequest.cc

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -64,7 +64,7 @@ ImageRequest<MockTestImageCtx> *ImageRequest<MockTestImageCtx>::s_instance = nul
 #include "librbd/deep_copy/ObjectCopyRequest.cc"
 template class librbd::deep_copy::ObjectCopyRequest<librbd::MockTestImageCtx>;
 
-bool operator==(const SnapContext& rhs, const SnapContext& lhs) {
+static bool operator==(const SnapContext& rhs, const SnapContext& lhs) {
   return (rhs.seq == lhs.seq && rhs.snaps == lhs.snaps);
 }
 
@@ -207,7 +207,6 @@ public:
       librbd::MockTestImageCtx &mock_src_image_ctx,
       librbd::MockTestImageCtx &mock_dst_image_ctx, Context *on_finish) {
     expect_get_object_name(mock_dst_image_ctx);
-    expect_get_object_count(mock_dst_image_ctx);
     return new MockObjectCopyRequest(&mock_src_image_ctx, &mock_dst_image_ctx,
                                      m_snap_map, 0, false, on_finish);
   }
@@ -453,6 +452,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, DNE) {
   librbd::MockObjectMap mock_object_map;
   mock_dst_image_ctx.object_map = &mock_object_map;
   expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
@@ -484,6 +484,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Write) {
   mock_dst_image_ctx.object_map = &mock_object_map;
 
   expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
@@ -529,6 +530,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, ReadMissingStaleSnapSet) {
   mock_dst_image_ctx.object_map = &mock_object_map;
 
   expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
@@ -661,6 +663,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteError) {
   mock_dst_image_ctx.object_map = &mock_object_map;
 
   expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
@@ -709,6 +712,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnaps) {
   mock_dst_image_ctx.object_map = &mock_object_map;
 
   expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
@@ -773,6 +777,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Trim) {
   mock_dst_image_ctx.object_map = &mock_object_map;
 
   expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
@@ -825,6 +830,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Remove) {
   mock_dst_image_ctx.object_map = &mock_object_map;
 
   expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
@@ -875,6 +881,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, ObjectMapUpdateError) {
   mock_dst_image_ctx.object_map = &mock_object_map;
 
   expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -1,0 +1,987 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockExclusiveLock.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockJournal.h"
+#include "test/librbd/mock/MockObjectMap.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/deep_copy/ObjectCopyRequest.h"
+#include "librbd/io/CopyupRequest.h"
+#include "librbd/io/ImageRequest.h"
+#include "librbd/io/ObjectRequest.h"
+#include "librbd/io/ReadResult.h"
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public MockImageCtx {
+  MockTestImageCtx(ImageCtx &image_ctx,
+                   MockTestImageCtx* mock_parent_image_ctx = nullptr)
+    : MockImageCtx(image_ctx) {
+    parent = mock_parent_image_ctx;
+  }
+
+  std::map<uint64_t, librbd::io::CopyupRequest<librbd::MockTestImageCtx>*> copyup_list;
+};
+
+} // anonymous namespace
+
+namespace util {
+
+inline ImageCtx *get_image_ctx(MockImageCtx *image_ctx) {
+  return image_ctx->image_ctx;
+}
+
+} // namespace util
+
+namespace deep_copy {
+
+template <>
+struct ObjectCopyRequest<librbd::MockTestImageCtx> {
+  static ObjectCopyRequest* s_instance;
+  static ObjectCopyRequest* create(librbd::MockImageCtx* parent_image_ctx,
+                                   librbd::MockTestImageCtx* image_ctx,
+                                   const SnapMap &snap_map,
+                                   uint64_t object_number, bool flatten,
+                                   Context *on_finish) {
+    ceph_assert(s_instance != nullptr);
+    s_instance->object_number = object_number;
+    s_instance->flatten = flatten;
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  uint64_t object_number;
+  bool flatten;
+  Context *on_finish;
+
+  ObjectCopyRequest() {
+    s_instance = this;
+  }
+
+  MOCK_METHOD0(send, void());
+};
+
+ObjectCopyRequest<librbd::MockTestImageCtx>* ObjectCopyRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
+
+} // namespace deep_copy
+
+namespace io {
+
+template <>
+struct ObjectRequest<librbd::MockTestImageCtx> {
+  static void add_write_hint(librbd::MockTestImageCtx&,
+                             librados::ObjectWriteOperation*) {
+  }
+};
+
+template <>
+struct AbstractObjectWriteRequest<librbd::MockTestImageCtx> {
+  C_SaferCond ctx;
+  void handle_copyup(int r) {
+    ctx.complete(r);
+  }
+
+  MOCK_CONST_METHOD0(get_pre_write_object_map_state, uint8_t());
+  MOCK_CONST_METHOD0(is_empty_write_op, bool());
+
+  MOCK_METHOD1(add_copyup_ops, void(librados::ObjectWriteOperation*));
+};
+
+template <>
+struct ImageRequest<librbd::MockTestImageCtx> {
+  static ImageRequest *s_instance;
+  static void aio_read(librbd::MockImageCtx *ictx, AioCompletion *c,
+                       Extents &&image_extents, ReadResult &&read_result,
+                       int op_flags, const ZTracer::Trace &parent_trace) {
+    s_instance->aio_read(c, image_extents, &read_result);
+  }
+
+  MOCK_METHOD3(aio_read, void(AioCompletion *, const Extents&, ReadResult*));
+
+  ImageRequest() {
+    s_instance = this;
+  }
+};
+
+ImageRequest<librbd::MockTestImageCtx>* ImageRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
+
+} // namespace io
+} // namespace librbd
+
+static bool operator==(const SnapContext& rhs, const SnapContext& lhs) {
+  return (rhs.seq == lhs.seq && rhs.snaps == lhs.snaps);
+}
+
+#include "librbd/AsyncObjectThrottle.cc"
+#include "librbd/io/CopyupRequest.cc"
+
+namespace librbd {
+namespace io {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::WithArg;
+using ::testing::WithArgs;
+using ::testing::WithoutArgs;
+
+struct TestMockIoCopyupRequest : public TestMockFixture {
+  typedef CopyupRequest<librbd::MockTestImageCtx> MockCopyupRequest;
+  typedef ImageRequest<librbd::MockTestImageCtx> MockImageRequest;
+  typedef ObjectRequest<librbd::MockTestImageCtx> MockObjectRequest;
+  typedef AbstractObjectWriteRequest<librbd::MockTestImageCtx> MockAbstractObjectWriteRequest;
+  typedef deep_copy::ObjectCopyRequest<librbd::MockTestImageCtx> MockObjectCopyRequest;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+    if (!is_feature_enabled(RBD_FEATURE_LAYERING)) {
+      return;
+    }
+
+    m_parent_image_name = m_image_name;
+    m_image_name = get_temp_image_name();
+
+    librbd::Image image;
+    librbd::RBD rbd;
+    ASSERT_EQ(0, rbd.open(m_ioctx, image, m_parent_image_name.c_str(),
+                          nullptr));
+    ASSERT_EQ(0, image.snap_create("one"));
+    ASSERT_EQ(0, image.snap_protect("one"));
+
+    uint64_t features;
+    ASSERT_EQ(0, image.features(&features));
+    image.close();
+
+    int order = 0;
+    ASSERT_EQ(0, rbd.clone(m_ioctx, m_parent_image_name.c_str(), "one", m_ioctx,
+                           m_image_name.c_str(), features, &order));
+  }
+
+  void expect_get_parent_overlap(MockTestImageCtx& mock_image_ctx,
+                                 librados::snap_t snap_id, uint64_t overlap,
+                                 int r) {
+    if (mock_image_ctx.object_map != nullptr) {
+      EXPECT_CALL(mock_image_ctx, get_parent_overlap(snap_id, _))
+        .WillOnce(WithArg<1>(Invoke([overlap, r](uint64_t *o) {
+                               *o = overlap;
+                               return r;
+                             })));
+    }
+  }
+
+  void expect_prune_parent_extents(MockTestImageCtx& mock_image_ctx,
+                                   uint64_t overlap, uint64_t object_overlap) {
+    if (mock_image_ctx.object_map != nullptr) {
+      EXPECT_CALL(mock_image_ctx, prune_parent_extents(_, overlap))
+        .WillOnce(WithoutArgs(Invoke([object_overlap]() {
+                                return object_overlap;
+                              })));
+    }
+  }
+
+  void expect_read_parent(MockTestImageCtx& mock_image_ctx,
+                          MockImageRequest& mock_image_request,
+                          const Extents& image_extents,
+                          const std::string& data, int r) {
+    EXPECT_CALL(mock_image_request, aio_read(_, image_extents, _))
+      .WillOnce(WithArgs<0, 2>(Invoke(
+        [&mock_image_ctx, image_extents, data, r](
+            AioCompletion* aio_comp, ReadResult* read_result) {
+          aio_comp->read_result = std::move(*read_result);
+          aio_comp->set_request_count(1);
+          auto ctx = new ReadResult::C_ImageReadRequest(aio_comp,
+                                                        image_extents);
+          ctx->bl.append(data);
+          mock_image_ctx.image_ctx->op_work_queue->queue(ctx, r);
+        })));
+  }
+
+  void expect_copyup(MockTestImageCtx& mock_image_ctx, uint64_t snap_id,
+                     const std::string& oid, const std::string& data, int r) {
+    bufferlist in_bl;
+    in_bl.append(data);
+
+    SnapContext snapc;
+    if (snap_id == CEPH_NOSNAP) {
+      snapc = mock_image_ctx.snapc;
+    }
+
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
+                exec(oid, _, StrEq("rbd"), StrEq("copyup"),
+                     ContentsEqual(in_bl), _, snapc))
+      .WillOnce(Return(r));
+  }
+
+  void expect_write(MockTestImageCtx& mock_image_ctx, uint64_t snap_id,
+                    const std::string& oid, int r) {
+    SnapContext snapc;
+    if (snap_id == CEPH_NOSNAP) {
+      snapc = mock_image_ctx.snapc;
+    }
+
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
+                write(oid, _, 0, 0, snapc))
+      .WillOnce(Return(r));
+  }
+
+  void expect_test_features(MockTestImageCtx& mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, test_features(_, _))
+      .WillRepeatedly(WithArg<0>(Invoke([&mock_image_ctx](uint64_t features) {
+              return (mock_image_ctx.features & features) != 0;
+            })));
+  }
+
+  void expect_is_lock_owner(MockTestImageCtx& mock_image_ctx) {
+    if (mock_image_ctx.exclusive_lock != nullptr) {
+      EXPECT_CALL(*mock_image_ctx.exclusive_lock,
+                  is_lock_owner()).WillRepeatedly(Return(true));
+    }
+  }
+
+  void expect_is_empty_write_op(MockAbstractObjectWriteRequest& mock_write_request,
+                                bool is_empty) {
+    EXPECT_CALL(mock_write_request, is_empty_write_op())
+      .WillOnce(Return(is_empty));
+  }
+
+  void expect_add_copyup_ops(MockAbstractObjectWriteRequest& mock_write_request) {
+    EXPECT_CALL(mock_write_request, add_copyup_ops(_))
+      .WillOnce(Invoke([](librados::ObjectWriteOperation* op) {
+                  op->write(0, bufferlist{});
+                }));
+  }
+
+  void expect_get_pre_write_object_map_state(MockTestImageCtx& mock_image_ctx,
+                                             MockAbstractObjectWriteRequest& mock_write_request,
+                                             uint8_t state) {
+    if (mock_image_ctx.object_map != nullptr) {
+      EXPECT_CALL(mock_write_request, get_pre_write_object_map_state())
+        .WillOnce(Return(state));
+    }
+  }
+
+  void expect_object_map_at(MockTestImageCtx& mock_image_ctx,
+                            uint64_t object_no, uint8_t state) {
+    if (mock_image_ctx.object_map != nullptr) {
+      EXPECT_CALL(*mock_image_ctx.object_map, at(object_no))
+        .WillOnce(Return(state));
+    }
+  }
+
+  void expect_object_map_update(MockTestImageCtx& mock_image_ctx,
+                                uint64_t snap_id, uint64_t object_no,
+                                uint8_t state, bool updated, int ret_val) {
+    if (mock_image_ctx.object_map != nullptr) {
+      if (!mock_image_ctx.image_ctx->test_features(RBD_FEATURE_FAST_DIFF) &&
+          state == OBJECT_EXISTS_CLEAN) {
+        state = OBJECT_EXISTS;
+      }
+
+      EXPECT_CALL(*mock_image_ctx.object_map,
+                  aio_update(snap_id, object_no, object_no + 1, state,
+                             boost::optional<uint8_t>(), _,
+                             (snap_id != CEPH_NOSNAP), _))
+        .WillOnce(WithArg<7>(Invoke([&mock_image_ctx, updated, ret_val](Context *ctx) {
+                               if (updated) {
+                                 mock_image_ctx.op_work_queue->queue(ctx, ret_val);
+                               }
+                               return updated;
+                             })));
+    }
+  }
+
+  void expect_object_copy(MockTestImageCtx& mock_image_ctx,
+                          MockObjectCopyRequest& mock_object_copy_request,
+                          bool flatten, int r) {
+    EXPECT_CALL(mock_object_copy_request, send())
+      .WillOnce(Invoke(
+        [&mock_image_ctx, &mock_object_copy_request, flatten, r]() {
+          ASSERT_EQ(flatten, mock_object_copy_request.flatten);
+          mock_image_ctx.op_work_queue->queue(
+            mock_object_copy_request.on_finish, r);
+        }));
+  }
+
+  std::string m_parent_image_name;
+};
+
+TEST_F(TestMockIoCopyupRequest, Standard) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_add_copyup_ops(mock_write_request);
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", data, 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, StandardWithSnaps) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ictx->snap_lock.get_write();
+  ictx->add_snap(cls::rbd::UserSnapshotNamespace(), "2", 2, ictx->size,
+                 ictx->parent_md, RBD_PROTECTION_STATUS_UNPROTECTED,
+                 0, {});
+  ictx->add_snap(cls::rbd::UserSnapshotNamespace(), "1", 1, ictx->size,
+                 ictx->parent_md, RBD_PROTECTION_STATUS_UNPROTECTED,
+                 0, {});
+  ictx->snapc = {2, {2, 1}};
+  ictx->snap_lock.put_write();
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_test_features(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, 1, 0, OBJECT_EXISTS, true, 0);
+  expect_object_map_update(mock_image_ctx, 2, 0, OBJECT_EXISTS_CLEAN, true, 0);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_add_copyup_ops(mock_write_request);
+  expect_copyup(mock_image_ctx, 0, "oid", data, 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, CopyOnRead) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", data, 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->send();
+  ictx->flush_async_operations();
+}
+
+TEST_F(TestMockIoCopyupRequest, CopyOnReadWithSnaps) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ictx->snap_lock.get_write();
+  ictx->add_snap(cls::rbd::UserSnapshotNamespace(), "1", 1, ictx->size,
+                 ictx->parent_md, RBD_PROTECTION_STATUS_UNPROTECTED,
+                 0, {});
+  ictx->snapc = {1, {1}};
+  ictx->snap_lock.put_write();
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_test_features(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, 1, 0, OBJECT_EXISTS, true, 0);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS_CLEAN,
+                           true, 0);
+
+  expect_copyup(mock_image_ctx, 0, "oid", data, 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->send();
+  ictx->flush_async_operations();
+}
+
+TEST_F(TestMockIoCopyupRequest, DeepCopy) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  MockObjectCopyRequest mock_object_copy_request;
+  mock_image_ctx.migration_info = {1, "", "", "image id", {}, ictx->size, true};
+  expect_is_empty_write_op(mock_write_request, false);
+  expect_object_copy(mock_image_ctx, mock_object_copy_request, true, 0);
+
+  expect_is_empty_write_op(mock_write_request, false);
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_add_copyup_ops(mock_write_request);
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", "", 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, DeepCopyOnRead) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockObjectCopyRequest mock_object_copy_request;
+  mock_image_ctx.migration_info = {1, "", "", "image id", {}, ictx->size,
+                                   false};
+  expect_object_copy(mock_image_ctx, mock_object_copy_request, true, 0);
+
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", "", 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->send();
+  ictx->flush_async_operations();
+}
+
+TEST_F(TestMockIoCopyupRequest, DeepCopyWithSnaps) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ictx->snap_lock.get_write();
+  ictx->add_snap(cls::rbd::UserSnapshotNamespace(), "3", 3, ictx->size,
+                 ictx->parent_md, RBD_PROTECTION_STATUS_UNPROTECTED,
+                 0, {});
+  ictx->add_snap(cls::rbd::UserSnapshotNamespace(), "2", 2, ictx->size,
+                 ictx->parent_md, RBD_PROTECTION_STATUS_UNPROTECTED,
+                 0, {});
+  ictx->add_snap(cls::rbd::UserSnapshotNamespace(), "1", 1, ictx->size,
+                 ictx->parent_md, RBD_PROTECTION_STATUS_UNPROTECTED,
+                 0, {});
+  ictx->snapc = {3, {3, 2, 1}};
+  ictx->snap_lock.put_write();
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_test_features(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  MockObjectCopyRequest mock_object_copy_request;
+  mock_image_ctx.migration_info = {1, "", "", "image id",
+                                   {{CEPH_NOSNAP, {2, 1}}, {10, {1}}},
+                                   ictx->size, true};
+  expect_is_empty_write_op(mock_write_request, false);
+  expect_object_copy(mock_image_ctx, mock_object_copy_request, true, 0);
+
+  expect_is_empty_write_op(mock_write_request, false);
+  expect_get_parent_overlap(mock_image_ctx, 2, 0, 0);
+  expect_get_parent_overlap(mock_image_ctx, 3, 1, 0);
+  expect_prune_parent_extents(mock_image_ctx, 1, 1);
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, 3, 0, OBJECT_EXISTS, true, 0);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_add_copyup_ops(mock_write_request);
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", "", 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, ZeroedCopyup) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_is_empty_write_op(mock_write_request, false);
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_add_copyup_ops(mock_write_request);
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", "", 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, ZeroedCopyOnRead) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '\0');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", "", 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->send();
+  ictx->flush_async_operations();
+}
+
+TEST_F(TestMockIoCopyupRequest, NoOpCopyup) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     "", -ENOENT);
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_is_empty_write_op(mock_write_request, true);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, RestartWrite) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  MockAbstractObjectWriteRequest mock_write_request1;
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request1,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  expect_add_copyup_ops(mock_write_request1);
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", data, 0);
+
+  MockAbstractObjectWriteRequest mock_write_request2;
+  EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
+              write("oid", _, 0, 0, _))
+    .WillOnce(WithoutArgs(Invoke([req, &mock_write_request2]() {
+                            req->append_request(&mock_write_request2);
+                            return 0;
+                          })));
+
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request1);
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request1.ctx.wait());
+  ASSERT_EQ(-ERESTART, mock_write_request2.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, ReadFromParentError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     "", -EPERM);
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_is_empty_write_op(mock_write_request, false);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(-EPERM, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, DeepCopyError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  MockObjectCopyRequest mock_object_copy_request;
+  mock_image_ctx.migration_info = {1, "", "", "image id", {}, ictx->size, true};
+  expect_is_empty_write_op(mock_write_request, false);
+  expect_object_copy(mock_image_ctx, mock_object_copy_request, true, -EPERM);
+
+  expect_is_empty_write_op(mock_write_request, false);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(-EPERM, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, UpdateObjectMapError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_OBJECT_MAP);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           -EINVAL);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(-EINVAL, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, CopyupError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ictx->snap_lock.get_write();
+  ictx->add_snap(cls::rbd::UserSnapshotNamespace(), "1", 1, ictx->size,
+                 ictx->parent_md, RBD_PROTECTION_STATUS_UNPROTECTED,
+                 0, {});
+  ictx->snapc = {1, {1}};
+  ictx->snap_lock.put_write();
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_test_features(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, 1, 0, OBJECT_EXISTS, true, 0);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_add_copyup_ops(mock_write_request);
+  expect_copyup(mock_image_ctx, 0, "oid", data, -EPERM);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request);
+  req->send();
+
+  ASSERT_EQ(-EPERM, mock_write_request.ctx.wait());
+  ictx->flush_async_operations();
+}
+
+} // namespace io
+} // namespace librbd

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -11,6 +11,11 @@
 namespace librbd {
 
 struct MockObjectMap {
+  MOCK_METHOD1(at, uint8_t(uint64_t));
+  uint8_t operator[](uint64_t object_no) {
+    return at(object_no);
+  }
+
   MOCK_CONST_METHOD1(enabled, bool(const RWLock &object_map_lock));
 
   MOCK_CONST_METHOD0(size, uint64_t());


### PR DESCRIPTION
Subvolume module allows managing CephFS subvolumes, which are CephFS subdirectories with a desired layout and quota. It's code is heavily borrowed from,
    src/pybind/ceph_volume_client.py

Initially, the CephFS CSI driver will use this module to manage subvolumes. Later, OpenStack Manila's CephFS drivers will also make use of this module instead of ceph_volume_client module.
