### PR TITLE
luminous: backport recent messenger fixes

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -137,7 +137,7 @@ OPTION(ms_bind_retry_delay, OPT_INT) // Delay between attemps to bind
 OPTION(ms_bind_before_connect, OPT_BOOL)
 OPTION(ms_tcp_listen_backlog, OPT_INT)
 OPTION(ms_rwthread_stack_bytes, OPT_U64)
-OPTION(ms_tcp_read_timeout, OPT_U64)
+OPTION(ms_connection_idle_timeout, OPT_U64)
 OPTION(ms_pq_max_tokens_per_priority, OPT_U64)
 OPTION(ms_pq_min_cost, OPT_U64)
 OPTION(ms_inject_socket_failures, OPT_U64)

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -137,6 +137,7 @@ OPTION(ms_bind_retry_delay, OPT_INT) // Delay between attemps to bind
 OPTION(ms_bind_before_connect, OPT_BOOL)
 OPTION(ms_tcp_listen_backlog, OPT_INT)
 OPTION(ms_rwthread_stack_bytes, OPT_U64)
+OPTION(ms_connection_ready_timeout, OPT_U64)
 OPTION(ms_connection_idle_timeout, OPT_U64)
 OPTION(ms_pq_max_tokens_per_priority, OPT_U64)
 OPTION(ms_pq_min_cost, OPT_U64)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -707,6 +707,10 @@ std::vector<Option> get_global_options() {
     .set_default(1_M)
     .set_description(""),
 
+    Option("ms_connection_ready_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(10)
+    .set_description("Time before we declare a not yet ready connection as dead (seconds)"),
+
     Option("ms_connection_idle_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(900)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -707,7 +707,7 @@ std::vector<Option> get_global_options() {
     .set_default(1_M)
     .set_description(""),
 
-    Option("ms_tcp_read_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    Option("ms_connection_idle_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(900)
     .set_description(""),
 

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2608,7 +2608,7 @@ void AsyncConnection::tick(uint64_t id)
     if (connect_timeout_us <=
         (uint64_t)std::chrono::duration_cast<std::chrono::microseconds>
           (now - last_connect_started).count()) {
-      ldout(async_msgr->cct, 0) << __func__ << " see no progress in more than "
+      ldout(async_msgr->cct, 1) << __func__ << " see no progress in more than "
                                 << connect_timeout_us
                                 << " us during connecting, fault."
                                 << dendl;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -128,6 +128,7 @@ AsyncConnection::AsyncConnection(CephContext *cct, AsyncMessenger *m, DispatchQu
     recv_max_prefetch(MAX(msgr->cct->_conf->ms_tcp_prefetch_max_size, TCP_PREFETCH_MIN_SIZE)),
     recv_start(0), recv_end(0),
     last_active(ceph::coarse_mono_clock::now()),
+    connect_timeout_us(cct->_conf->ms_connection_ready_timeout*1000*1000),
     inactive_timeout_us(cct->_conf->ms_connection_idle_timeout*1000*1000),
     authorizer(NULL), replacing(false),
     is_reset_from_peer(false), once_ready(false), state_buffer(NULL), state_offset(0),
@@ -878,6 +879,12 @@ ssize_t AsyncConnection::_process_connection()
       {
         assert(!policy.server);
 
+        // clear timer (if any) since we are connecting/re-connecting
+        if (last_tick_id) {
+          center->delete_time_event(last_tick_id);
+          last_tick_id = 0;
+        }
+
         // reset connect state variables
         delete authorizer;
         authorizer = NULL;
@@ -923,6 +930,12 @@ ssize_t AsyncConnection::_process_connection()
 
         center->delete_file_event(cs.fd(), EVENT_WRITABLE);
         ldout(async_msgr->cct, 10) << __func__ << " connect successfully, ready to send banner" << dendl;
+
+        ceph_assert(last_tick_id == 0);
+        // exclude TCP nonblock connect time
+        last_connect_started = ceph::coarse_mono_clock::now();
+        last_tick_id = center->create_time_event(
+          connect_timeout_us, tick_handler);
 
         bufferlist bl;
         bl.append(CEPH_BANNER, strlen(CEPH_BANNER));
@@ -1797,8 +1810,14 @@ ssize_t AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlis
         if (existing->state == STATE_CLOSED)
           return ;
         assert(existing->state == STATE_NONE);
-  
         existing->state = STATE_ACCEPTING_WAIT_CONNECT_MSG;
+
+        // we have called shutdown_socket above
+        ceph_assert(existing->last_tick_id == 0);
+        // restart timer since we are going to re-build connection
+        existing->last_connect_started = ceph::coarse_mono_clock::now();
+        existing->last_tick_id = existing->center->create_time_event(
+          existing->connect_timeout_us, existing->tick_handler);
         existing->center->create_file_event(existing->cs.fd(), EVENT_READABLE, existing->read_handler);
         reply.global_seq = existing->peer_global_seq;
         if (existing->_reply_accept(CEPH_MSGR_TAG_RETRY_GLOBAL, connect, reply, authorizer_reply) < 0) {
@@ -2585,13 +2604,29 @@ void AsyncConnection::tick(uint64_t id)
                              << " last_active" << last_active << dendl;
   std::lock_guard<std::mutex> l(lock);
   last_tick_id = 0;
-  auto idle_period = std::chrono::duration_cast<std::chrono::microseconds>(now - last_active).count();
-  if (inactive_timeout_us < (uint64_t)idle_period) {
-    ldout(async_msgr->cct, 1) << __func__ << " idle(" << idle_period << ") more than "
-                              << inactive_timeout_us
-                              << " us, mark self fault." << dendl;
-    fault();
-  } else if (is_connected()) {
-    last_tick_id = center->create_time_event(inactive_timeout_us, tick_handler);
+  if (!is_connected()) {
+    if (connect_timeout_us <=
+        (uint64_t)std::chrono::duration_cast<std::chrono::microseconds>
+          (now - last_connect_started).count()) {
+      ldout(async_msgr->cct, 0) << __func__ << " see no progress in more than "
+                                << connect_timeout_us
+                                << " us during connecting, fault."
+                                << dendl;
+      fault();
+    } else {
+      last_tick_id = center->create_time_event(connect_timeout_us, tick_handler);
+    }
+  } else {
+    auto idle_period = std::chrono::duration_cast<std::chrono::microseconds>
+      (now - last_active).count();
+    if (inactive_timeout_us < (uint64_t)idle_period) {
+      ldout(async_msgr->cct, 1) << __func__ << " idle (" << idle_period
+                                << ") for more than " << inactive_timeout_us
+                                << " us, fault."
+                                << dendl;
+      fault();
+    } else {
+      last_tick_id = center->create_time_event(inactive_timeout_us, tick_handler);
+    }
   }
 }

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -128,7 +128,7 @@ AsyncConnection::AsyncConnection(CephContext *cct, AsyncMessenger *m, DispatchQu
     recv_max_prefetch(MAX(msgr->cct->_conf->ms_tcp_prefetch_max_size, TCP_PREFETCH_MIN_SIZE)),
     recv_start(0), recv_end(0),
     last_active(ceph::coarse_mono_clock::now()),
-    inactive_timeout_us(cct->_conf->ms_tcp_read_timeout*1000*1000),
+    inactive_timeout_us(cct->_conf->ms_connection_idle_timeout*1000*1000),
     authorizer(NULL), replacing(false),
     is_reset_from_peer(false), once_ready(false), state_buffer(NULL), state_offset(0),
     worker(w), center(&w->center)

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -331,8 +331,10 @@ class AsyncConnection : public Connection {
   uint32_t recv_start;
   uint32_t recv_end;
   set<uint64_t> register_time_events; // need to delete it if stop
+  ceph::coarse_mono_clock::time_point last_connect_started;
   ceph::coarse_mono_clock::time_point last_active;
   uint64_t last_tick_id = 0;
+  const uint64_t connect_timeout_us;
   const uint64_t inactive_timeout_us;
 
   // Tis section are temp variables used by state transition

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -166,7 +166,7 @@ Pipe::Pipe(SimpleMessenger *r, int st, PipeConnection *con)
   }
     
 
-  msgr->timeout = msgr->cct->_conf->ms_tcp_read_timeout * 1000; //convert to ms
+  msgr->timeout = msgr->cct->_conf->ms_connection_idle_timeout * 1000; //convert to ms
   if (msgr->timeout == 0)
     msgr->timeout = -1;
 

--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -794,10 +794,10 @@ TEST_F(LibRadosWatchNotify, Watch3Timeout) {
     // timer of timeout on OSD side will be reset by the new request.
     char conf[128];
     ASSERT_EQ(0, rados_conf_get(cluster,
-                                "ms_tcp_read_timeout",
+                                "ms_connection_idle_timeout",
                                 conf, sizeof(conf)));
-    auto tcp_read_timeout = std::stoll(conf);
-    ASSERT_LT(timeout, tcp_read_timeout);
+    auto connection_idle_timeout = std::stoll(conf);
+    ASSERT_LT(timeout, connection_idle_timeout);
   }
   ASSERT_EQ(0,
 	    rados_watch3(ioctx, notify_oid, &handle,

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -382,7 +382,7 @@ TEST_P(MessengerTest, FeatureTest) {
 }
 
 TEST_P(MessengerTest, TimeoutTest) {
-  g_ceph_context->_conf->set_val("ms_tcp_read_timeout", "1");
+  g_ceph_context->_conf->set_val("ms_connection_idle_timeout", "1");
   FakeDispatcher cli_dispatcher(false), srv_dispatcher(true);
   entity_addr_t bind_addr;
   bind_addr.parse("127.0.0.1");
@@ -416,7 +416,7 @@ TEST_P(MessengerTest, TimeoutTest) {
 
   client_msgr->shutdown();
   client_msgr->wait();
-  g_ceph_context->_conf->set_val("ms_tcp_read_timeout", "900");
+  g_ceph_context->_conf->set_val("ms_connection_idle_timeout", "900");
 }
 
 TEST_P(MessengerTest, StatefulTest) {


### PR DESCRIPTION
This backports recent identified messenger fixes:
https://github.com/ceph/ceph/pull/25754
https://github.com/ceph/ceph/pull/27337

This does not follow the normal backport process because the protocol of transport layer of Ceph has been greatly changed for Nautilus.

Related backport tickets:
http://tracker.ceph.com/issues/38242
http://tracker.ceph.com/issues/39243


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

