### PR TITLE
pybind/mgr: add cephfs subvolumes module

### DIFF
--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -1,0 +1,232 @@
+"""
+Copyright (C) 2019 Red Hat, Inc.
+
+LGPL2.1.  See file COPYING.
+"""
+
+import errno
+import logging
+import os
+
+import cephfs
+import rados
+
+
+log = logging.getLogger(__name__)
+
+# Reserved subvolume group name which we use in paths for subvolumes
+# that are not assigned to a group (i.e. created with group=None)
+NO_GROUP_NAME = "_nogroup"
+
+
+class SubvolumePath(object):
+    """
+    Identify a subvolume's path as group->subvolume
+    The Subvolume ID is a unique identifier, but this is a much more
+    helpful thing to pass around.
+    """
+    def __init__(self, group_id, subvolume_id):
+        self.group_id = group_id
+        self.subvolume_id = subvolume_id
+        assert self.group_id != NO_GROUP_NAME
+        assert self.subvolume_id != "" and self.subvolume_id is not None
+
+    def __str__(self):
+        return "{0}/{1}".format(self.group_id, self.subvolume_id)
+
+
+class SubvolumeClient(object):
+    """
+    Combine libcephfs and librados interfaces to implement a
+    'Subvolume' concept implemented as a cephfs directory.
+
+    Additionally, subvolumes may be in a 'Group'.  Conveniently,
+    subvolumes are a lot like manila shares, and groups are a lot
+    like manila consistency groups.
+
+    Refer to subvolumes with SubvolumePath, which specifies the
+    subvolume and group IDs (both strings).  The group ID may
+    be None.
+
+    In general, functions in this class are allowed raise rados.Error
+    or cephfs.Error exceptions in unexpected situations.
+    """
+
+    # Where shall we create our subvolumes?
+    DEFAULT_SUBVOL_PREFIX = "/volumes"
+    DEFAULT_NS_PREFIX = "fsvolumens_"
+
+    def __init__(self, mgr, subvolume_prefix=None, pool_ns_prefix=None, fs_name=None):
+        self.fs = None
+        self.fs_name = fs_name
+        self.connected = False
+
+        self.rados = mgr.rados
+
+        self.subvolume_prefix = subvolume_prefix if subvolume_prefix else self.DEFAULT_SUBVOL_PREFIX
+        self.pool_ns_prefix = pool_ns_prefix if pool_ns_prefix else self.DEFAULT_NS_PREFIX
+
+    def _subvolume_path(self, subvolume_path):
+        """
+        Determine the path within CephFS where this subvolume will live
+        :return: absolute path (string)
+        """
+        return os.path.join(
+            self.subvolume_prefix,
+            subvolume_path.group_id if subvolume_path.group_id is not None else NO_GROUP_NAME,
+            subvolume_path.subvolume_id)
+
+    def connect(self):
+        log.debug("Connecting to cephfs...")
+        self.fs = cephfs.LibCephFS(rados_inst=self.rados)
+        log.debug("CephFS initializing...")
+        self.fs.init()
+        log.debug("CephFS mounting...")
+        self.fs.mount(filesystem_name=self.fs_name)
+        log.debug("Connection to cephfs complete")
+
+    def disconnect(self):
+        log.info("disconnect")
+        if self.fs:
+            log.debug("Disconnecting cephfs...")
+            self.fs.shutdown()
+            self.fs = None
+            log.debug("Disconnecting cephfs complete")
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+
+    def __del__(self):
+        self.disconnect()
+
+    def _mkdir_p(self, path, mode=0o755):
+        try:
+            self.fs.stat(path)
+        except cephfs.ObjectNotFound:
+            pass
+        else:
+            return
+
+        parts = path.split(os.path.sep)
+
+        for i in range(1, len(parts) + 1):
+            subpath = os.path.join(*parts[0:i])
+            try:
+                self.fs.stat(subpath)
+            except cephfs.ObjectNotFound:
+                self.fs.mkdir(subpath, mode)
+
+    def create_subvolume(self, subvolume_path, size=None, namespace_isolated=True, mode=0o755):
+        """
+        Set up metadata, pools and auth for a subvolume.
+
+        This function is idempotent.  It is safe to call this again
+        for an already-created subvolume, even if it is in use.
+
+        :param subvolume_path: SubvolumePath instance
+        :param size: In bytes, or None for no size limit
+        :param namespace_isolated: If true, use separate RADOS namespace for this subvolume
+        :return: None
+        """
+        path = self._subvolume_path(subvolume_path)
+        log.info("creating subvolume with path: {0}".format(path))
+
+        self._mkdir_p(path, mode)
+
+        if size is not None:
+            self.fs.setxattr(path, 'ceph.quota.max_bytes', size.encode('utf-8'), 0)
+
+        # enforce security isolation, use separate namespace for this subvolume
+        if namespace_isolated:
+            namespace = "{0}{1}".format(self.pool_ns_prefix, subvolume_path.subvolume_id)
+            log.info("creating subvolume with path: {0}, using rados namespace {1} to isolate data.".format(subvolume_path, namespace))
+            self.fs.setxattr(path, 'ceph.dir.layout.pool_namespace',
+                             namespace.encode('utf-8'), 0)
+        else:
+            # If subvolume's namespace layout is not set, then the subvolume's pool
+            # layout remains unset and will undesirably change with ancestor's
+            # pool layout changes.
+            pool_name = self._get_ancestor_xattr(path, "ceph.dir.layout.pool")
+            self.fs.setxattr(path, 'ceph.dir.layout.pool',
+                             pool_name.encode('utf-8'), 0)
+
+    def delete_subvolume(self, subvolume_path):
+        """
+        Make a subvolume inaccessible to guests.  This function is idempotent.
+        This is the fast part of tearing down a subvolume: you must also later
+        call purge_subvolume, which is the slow part.
+
+        :param subvolume_path: Same identifier used in create_subvolume
+        :return: None
+        """
+
+        path = self._subvolume_path(subvolume_path)
+        log.info("deleting subvolume with path: {0}".format(path))
+
+        # Create the trash folder if it doesn't already exist
+        trash = os.path.join(self.subvolume_prefix, "_deleting")
+        self._mkdir_p(trash)
+
+        # We'll move it to here
+        trashed_subvolume = os.path.join(trash, subvolume_path.subvolume_id)
+
+        # Move the subvolume to the trash folder
+        self.fs.rename(path, trashed_subvolume)
+
+    def purge_subvolume(self, subvolume_path):
+        """
+        Finish clearing up a subvolume that was previously passed to delete_subvolume.  This
+        function is idempotent.
+        """
+
+        trash = os.path.join(self.subvolume_prefix, "_deleting")
+        trashed_subvolume = os.path.join(trash, subvolume_path.subvolume_id)
+
+        def rmtree(root_path):
+            log.debug("rmtree {0}".format(root_path))
+            try:
+                dir_handle = self.fs.opendir(root_path)
+            except cephfs.ObjectNotFound:
+                return
+            d = self.fs.readdir(dir_handle)
+            while d:
+                d_name = d.d_name.decode('utf-8')
+                if d_name not in [".", ".."]:
+                    # Do not use os.path.join because it is sensitive
+                    # to string encoding, we just pass through dnames
+                    # as byte arrays
+                    d_full = "{0}/{1}".format(root_path, d_name)
+                    if d.is_dir():
+                        rmtree(d_full)
+                    else:
+                        self.fs.unlink(d_full)
+
+                d = self.fs.readdir(dir_handle)
+            self.fs.closedir(dir_handle)
+
+            self.fs.rmdir(root_path)
+
+        rmtree(trashed_subvolume)
+
+
+    def _get_ancestor_xattr(self, path, attr):
+        """
+        Helper for reading layout information: if this xattr is missing
+        on the requested path, keep checking parents until we find it.
+        """
+        try:
+            result = self.fs.getxattr(path, attr).decode('utf-8')
+            if result == "":
+                # Annoying!  cephfs gives us empty instead of an error when attr not found
+                raise cephfs.NoData()
+            else:
+                return result
+        except cephfs.NoData:
+            if path == "/":
+                raise
+            else:
+                return self._get_ancestor_xattr(os.path.split(path)[0], attr)

--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -230,3 +230,11 @@ class SubvolumeClient(object):
                 raise
             else:
                 return self._get_ancestor_xattr(os.path.split(path)[0], attr)
+
+    def get_subvolume_path(self, subvolume_path):
+        path = self._subvolume_path(subvolume_path)
+        try:
+            self.fs.stat(path)
+        except cephfs.ObjectNotFound:
+            return None
+        return path

--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -299,3 +299,9 @@ class SubvolumeClient(object):
 
     def delete_subvolume_snapshot(self, subvolume_path, snapshot_name):
         return self._snapshot_delete(self._subvolume_path(subvolume_path), snapshot_name)
+
+    def create_group_snapshot(self, group_id, snapshot_name, mode=0o755):
+        return self._snapshot_create(self._group_path(group_id), snapshot_name, mode)
+
+    def delete_group_snapshot(self, group_id, snapshot_name):
+        return self._snapshot_delete(self._group_path(group_id), snapshot_name)

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -61,6 +61,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'desc': "Delete a CephFS subvolume in a volume",
             'perm': 'rw'
         },
+        {
+            'cmd': 'fs subvolume getpath '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString ',
+            'desc': "Get the mountpath of a CephFS subvolume in a volume",
+            'perm': 'rw'
+        },
 
         # volume ls [recursive]
         # subvolume ls <volume>
@@ -360,3 +367,18 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             })
 
         return 0, json.dumps(result, indent=2), ""
+
+    def _cmd_fs_subvolume_getpath(self, inbuf, cmd):
+        vol_name = cmd['vol_name']
+        sub_name = cmd['sub_name']
+
+        if not self._volume_exists(vol_name):
+            return -errno.ENOENT, "", "Volume '{0}' not found".format(vol_name)
+
+        with SubvolumeClient(self, fs_name=vol_name) as svc:
+            svp = SubvolumePath(sub_name, sub_name)
+            path = svc.get_subvolume_path(svp)
+            if not path:
+                return -errno.ENOENT, "", \
+                       "Subvolume '{0}' not found".format(sub_name)
+        return 0, path, ""

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -45,35 +45,58 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'rw'
         },
         {
+            'cmd': 'fs subvolumegroup create '
+                   'name=vol_name,type=CephString '
+                   'name=group_name,type=CephString ',
+            'desc': "Create a CephFS subvolume group in a volume",
+            'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolumegroup rm '
+                   'name=vol_name,type=CephString '
+                   'name=group_name,type=CephString '
+                   'name=force,type=CephBool,req=false ',
+            'desc': "Delete a CephFS subvolume group in a volume",
+            'perm': 'rw'
+        },
+        {
             'cmd': 'fs subvolume create '
                    'name=vol_name,type=CephString '
                    'name=sub_name,type=CephString '
-                   'name=size,type=CephInt,req=false ',
-            'desc': "Create a CephFS subvolume in a volume, and "
-                    "optionally with a specific size(in bytes)",
+                   'name=size,type=CephInt,req=false '
+                   'name=group_name,type=CephString,req=false ',
+            'desc': "Create a CephFS subvolume in a volume, and optionally, "
+                    "with a specific size (in bytes) and in a specific "
+                    "subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume rm '
                    'name=vol_name,type=CephString '
                    'name=sub_name,type=CephString '
+                   'name=group_name,type=CephString,req=false '
                    'name=force,type=CephBool,req=false ',
-            'desc': "Delete a CephFS subvolume in a volume",
+            'desc': "Delete a CephFS subvolume in a volume, and optionally, "
+                    "in a specific subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume getpath '
                    'name=vol_name,type=CephString '
-                   'name=sub_name,type=CephString ',
-            'desc': "Get the mountpath of a CephFS subvolume in a volume",
+                   'name=sub_name,type=CephString '
+                   'name=group_name,type=CephString,req=false ',
+            'desc': "Get the mountpath of a CephFS subvolume in a volume, "
+                    "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
         {
             'cmd': 'fs subvolume snapshot create '
                    'name=vol_name,type=CephString '
                    'name=sub_name,type=CephString '
-                   'name=snap_name,type=CephString ',
-            'desc': "Create a snapshot of a CephFS subvolume in a volume",
+                   'name=snap_name,type=CephString '
+                   'name=group_name,type=CephString,req=false ',
+            'desc': "Create a snapshot of a CephFS subvolume in a volume, "
+                    "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
         {
@@ -81,8 +104,10 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=vol_name,type=CephString '
                    'name=sub_name,type=CephString '
                    'name=snap_name,type=CephString '
+                   'name=group_name,type=CephString,req=false '
                    'name=force,type=CephBool,req=false ',
-            'desc': "Delete a snapshot of a CephFS subvolume in a volume",
+            'desc': "Delete a snapshot of a CephFS subvolume in a volume, "
+                    "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
 
@@ -236,6 +261,55 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _volume_exists(self, vol_name):
         return self._volume_get_fs(vol_name) is not None
 
+    def _cmd_fs_subvolumegroup_create(self, inbuf, cmd):
+        """
+        :return: a 3-tuple of return code(int), empty string(str), error message (str)
+        """
+        vol_name = cmd['vol_name']
+        group_name = cmd['group_name']
+
+        if not self._volume_exists(vol_name):
+            return -errno.ENOENT, "", \
+                   "Volume '{0}' not found, create it with `ceph fs volume create` " \
+                   "before trying to create subvolume groups".format(vol_name)
+
+        # TODO: validate that subvol size fits in volume size
+
+        with SubvolumeClient(self, fs_name=vol_name) as svc:
+            svc.create_group(group_name)
+
+        return 0, "", ""
+
+    def _cmd_fs_subvolumegroup_rm(self, inbuf, cmd):
+        """
+        :return: a 3-tuple of return code(int), empty string(str), error message (str)
+        """
+        vol_name = cmd['vol_name']
+        group_name = cmd['group_name']
+
+        force = cmd.get('force', False)
+
+        if not self._volume_exists(vol_name):
+            if force:
+                return 0, "", ""
+            else:
+                return -errno.ENOENT, "", \
+                       "Volume '{0}' not found, cannot remove subvolume group '{0}'".format(vol_name, group_name)
+
+        with SubvolumeClient(self, fs_name=vol_name) as svc:
+            # TODO: check whether there are no subvolumes in the group
+            try:
+                svc.delete_group(group_name)
+            except cephfs.ObjectNotFound:
+                if force:
+                    return 0, "", ""
+                else:
+                    return -errno.ENOENT, "", \
+                           "Subvolume group '{0}' not found, cannot remove it".format(group_name)
+
+
+        return 0, "", ""
+
     def _cmd_fs_subvolume_create(self, inbuf, cmd):
         """
         :return: a 3-tuple of return code(int), empty string(str), error message (str)
@@ -244,6 +318,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         sub_name = cmd['sub_name']
 
         size = cmd.get('size', None)
+        group_name = cmd.get('group_name', None)
 
         if not self._volume_exists(vol_name):
             return -errno.ENOENT, "", \
@@ -253,9 +328,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         # TODO: validate that subvol size fits in volume size
 
         with SubvolumeClient(self, fs_name=vol_name) as svc:
-            # TODO: support real subvolume groups rather than just
-            # always having them 1:1 with subvolumes.
-            svp = SubvolumePath(sub_name, sub_name)
+            if group_name and not svc.get_group_path(group_name):
+                return -errno.ENOENT, "", \
+                    "Subvolume group '{0}' not found, create it with `ceph fs subvolumegroup create` " \
+                    "before trying to create subvolumes".format(group_name)
+            svp = SubvolumePath(group_name, sub_name)
             svc.create_subvolume(svp, size)
 
         return 0, "", ""
@@ -268,6 +345,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         sub_name = cmd['sub_name']
 
         force = cmd.get('force', False)
+        group_name = cmd.get('group_name', None)
 
         fs = self._volume_get_fs(vol_name)
         if fs is None:
@@ -280,9 +358,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         vol_fscid = fs['id']
 
         with SubvolumeClient(self, fs_name=vol_name) as svc:
-            # TODO: support real subvolume groups rather than just
-            # always having them 1:1 with subvolumes.
-            svp = SubvolumePath(sub_name, sub_name)
+            if group_name and not svc.get_group_path(group_name):
+                if force:
+                    return 0, "", ""
+                else:
+                    return -errno.ENOENT, "", \
+                           "Subvolume group '{0}' not found, cannot remove subvolume '{1}'".format(group_name, sub_name)
+            svp = SubvolumePath(group_name, sub_name)
             try:
                 svc.delete_subvolume(svp)
             except cephfs.ObjectNotFound:
@@ -389,11 +471,16 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         vol_name = cmd['vol_name']
         sub_name = cmd['sub_name']
 
+        group_name = cmd.get('group_name', None)
+
         if not self._volume_exists(vol_name):
             return -errno.ENOENT, "", "Volume '{0}' not found".format(vol_name)
 
         with SubvolumeClient(self, fs_name=vol_name) as svc:
-            svp = SubvolumePath(sub_name, sub_name)
+            if group_name and not svc.get_group_path(group_name):
+                return -errno.ENOENT, "", \
+                    "Subvolume group '{0}' not found".format(group_name)
+            svp = SubvolumePath(group_name, sub_name)
             path = svc.get_subvolume_path(svp)
             if not path:
                 return -errno.ENOENT, "", \
@@ -405,12 +492,17 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         sub_name = cmd['sub_name']
         snap_name = cmd['snap_name']
 
+        group_name = cmd.get('group_name', None)
+
         if not self._volume_exists(vol_name):
             return -errno.ENOENT, "", \
                    "Volume '{0}' not found, cannot create snapshot '{1}'".format(vol_name, snap_name)
 
         with SubvolumeClient(self, fs_name=vol_name) as svc:
-            svp = SubvolumePath(sub_name, sub_name)
+            if group_name and not svc.get_group_path(group_name):
+                return -errno.ENOENT, "", \
+                    "Subvolume group '{0}' not found, cannot create snapshot '{1}'".format(group_name, snap_name)
+            svp = SubvolumePath(group_name, sub_name)
             if not svc.get_subvolume_path(svp):
                 return -errno.ENOENT, "", \
                        "Subvolume '{0}' not found, cannot create snapshot '{1}'".format(sub_name, snap_name)
@@ -424,6 +516,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         snap_name = cmd['snap_name']
 
         force = cmd.get('force', False)
+        group_name = cmd.get('group_name', None)
 
         if not self._volume_exists(vol_name):
             if force:
@@ -433,7 +526,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                        "Volume '{0}' not found, cannot remove subvolume snapshot '{1}'".format(vol_name, snap_name)
 
         with SubvolumeClient(self, fs_name=vol_name) as svc:
-            svp = SubvolumePath(sub_name, sub_name)
+            if group_name and not svc.get_group_path(group_name):
+                if force:
+                    return 0, "", ""
+                else:
+                    return -errno.ENOENT, "", \
+                           "Subvolume group '{0}' not found, cannot remove subvolume snapshot '{1}'".format(group_name, snap_name)
+            svp = SubvolumePath(group_name, sub_name)
             if not svc.get_subvolume_path(svp):
                 if force:
                     return 0, "", ""

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -68,6 +68,23 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'desc': "Get the mountpath of a CephFS subvolume in a volume",
             'perm': 'rw'
         },
+        {
+            'cmd': 'fs subvolume snapshot create '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=snap_name,type=CephString ',
+            'desc': "Create a snapshot of a CephFS subvolume in a volume",
+            'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolume snapshot rm '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=snap_name,type=CephString '
+                   'name=force,type=CephBool,req=false ',
+            'desc': "Delete a snapshot of a CephFS subvolume in a volume",
+            'perm': 'rw'
+        },
 
         # volume ls [recursive]
         # subvolume ls <volume>
@@ -382,3 +399,54 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                 return -errno.ENOENT, "", \
                        "Subvolume '{0}' not found".format(sub_name)
         return 0, path, ""
+
+    def _cmd_fs_subvolume_snapshot_create(self, inbuf, cmd):
+        vol_name = cmd['vol_name']
+        sub_name = cmd['sub_name']
+        snap_name = cmd['snap_name']
+
+        if not self._volume_exists(vol_name):
+            return -errno.ENOENT, "", \
+                   "Volume '{0}' not found, cannot create snapshot '{1}'".format(vol_name, snap_name)
+
+        with SubvolumeClient(self, fs_name=vol_name) as svc:
+            svp = SubvolumePath(sub_name, sub_name)
+            if not svc.get_subvolume_path(svp):
+                return -errno.ENOENT, "", \
+                       "Subvolume '{0}' not found, cannot create snapshot '{1}'".format(sub_name, snap_name)
+            svc.create_subvolume_snapshot(svp, snap_name)
+
+        return 0, "", ""
+
+    def _cmd_fs_subvolume_snapshot_rm(self, inbuf, cmd):
+        vol_name = cmd['vol_name']
+        sub_name = cmd['sub_name']
+        snap_name = cmd['snap_name']
+
+        force = cmd.get('force', False)
+
+        if not self._volume_exists(vol_name):
+            if force:
+                return 0, "", ""
+            else:
+                return -errno.ENOENT, "", \
+                       "Volume '{0}' not found, cannot remove subvolume snapshot '{1}'".format(vol_name, snap_name)
+
+        with SubvolumeClient(self, fs_name=vol_name) as svc:
+            svp = SubvolumePath(sub_name, sub_name)
+            if not svc.get_subvolume_path(svp):
+                if force:
+                    return 0, "", ""
+                else:
+                    return -errno.ENOENT, "", \
+                           "Subvolume '{0}' not found, cannot remove subvolume snapshot '{1}'".format(sub_name, snap_name)
+            try:
+                svc.delete_subvolume_snapshot(svp, snap_name)
+            except cephfs.ObjectNotFound:
+                if force:
+                    return 0, "", ""
+                else:
+                    return -errno.ENOENT, "", \
+                           "Subvolume snapshot '{0}' not found, cannot remove it".format(snap_name)
+
+        return 0, "", ""


### PR DESCRIPTION
Subvolume module allows managing CephFS subvolumes, which are CephFS subdirectories with a desired layout and quota. It's code is heavily borrowed from,
src/pybind/ceph_volume_client.py

Fixes: http://tracker.ceph.com/issues/39610