### PR TITLE
osd: add 'ceph osd stop <osd.nnn>' command

### DIFF
--- a/qa/standalone/osd/osd-markdown.sh
+++ b/qa/standalone/osd/osd-markdown.sh
@@ -124,8 +124,23 @@ function TEST_markdown_boot_exceed_time() {
     ceph osd tree | grep up | grep osd.0 || return 1
 }
 
-main osd-markdown "$@"
+function TEST_osd_stop() {
 
-# Local Variables:
-# compile-command: "cd ../.. ; make -j4 && test/osd/osd-bench.sh"
-# End:
+    local dir=$1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+    osd_0_pid=$(cat $dir/osd.0.pid)
+    ps -p $osd_0_pid || return 1
+
+    ceph osd tree | grep osd.0 | grep up || return 1
+    ceph osd stop osd.0
+    sleep 15 # give osd plenty of time to notice and exit
+    ceph osd tree | grep down | grep osd.0 || return 1
+    ! ps -p $osd_0_pid || return 1
+}
+
+main osd-markdown "$@"

--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -65,6 +65,8 @@ const char *ceph_osd_state_name(int s)
                 return "noin";
         case CEPH_OSD_NOOUT:
                 return "noout";
+        case CEPH_OSD_STOP:
+                return "stop";
 	default:
 		return "???";
 	}

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -124,6 +124,7 @@ struct ceph_eversion {
 #define CEPH_OSD_NODOWN       (1<<9)  /* osd can not be marked down */
 #define CEPH_OSD_NOIN         (1<<10) /* osd can not be marked in */
 #define CEPH_OSD_NOOUT        (1<<11) /* osd can not be marked out */
+#define CEPH_OSD_STOP         (1<<12) /* osd has been stopped by admin */
 
 extern const char *ceph_osd_state_name(int s);
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -817,6 +817,10 @@ COMMAND("osd down " \
 	"set osd(s) <id> [<id>...] down, " \
         "or use <any|all> to set all osds down", \
         "osd", "rw")
+COMMAND("osd stop " \
+        "type=CephString,name=ids,n=N", \
+        "stop the corresponding osd daemons and mark them as down", \
+        "osd", "rw")
 COMMAND("osd out " \
 	"name=ids,type=CephString,n=N", \
 	"set osd(s) <id> [<id>...] out, " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10397,9 +10397,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     pending_inc.new_require_osd_release = rel;
     goto update;
   } else if (prefix == "osd down" ||
-	     prefix == "osd out" ||
-	     prefix == "osd in" ||
-	     prefix == "osd rm") {
+             prefix == "osd out" ||
+             prefix == "osd in" ||
+             prefix == "osd rm" ||
+             prefix == "osd stop") {
 
     bool any = false;
     bool stop = false;
@@ -10505,6 +10506,19 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
             }
 	    any = true;
 	  }
+        } else if (prefix == "osd stop") {
+          if (osdmap.is_stop(osd)) {
+            if (verbose)
+              ss << "osd." << osd << " is already stopped. ";
+          } else if (osdmap.is_down(osd)) {
+            pending_inc.pending_osd_state_set(osd, CEPH_OSD_STOP);
+            ss << "stop down osd." << osd << ". ";
+            any = true;
+          } else {
+            pending_inc.pending_osd_state_set(osd, CEPH_OSD_UP | CEPH_OSD_STOP);
+            ss << "stop osd." << osd << ". ";
+            any = true;
+          }
         }
       }
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8241,6 +8241,9 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
       dout(0) << "map says i do not exist.  shutting down." << dendl;
       do_shutdown = true;   // don't call shutdown() while we have
 			    // everything paused
+    } else if (osdmap->is_stop(whoami)) {
+      dout(0) << "map says i am stopped by admin. shutting down." << dendl;
+      do_shutdown = true;
     } else if (!osdmap->is_up(whoami) ||
 	       !osdmap->get_addrs(whoami).legacy_equals(
 		 client_messenger->get_myaddrs()) ||

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2030,6 +2030,7 @@ int OSDMap::apply_incremental(const Incremental &inc)
 
   for (const auto &client : inc.new_up_client) {
     osd_state[client.first] |= CEPH_OSD_EXISTS | CEPH_OSD_UP;
+    osd_state[client.first] &= ~CEPH_OSD_STOP; // if any
     osd_addrs->client_addrs[client.first].reset(
       new entity_addrvec_t(client.second));
     osd_addrs->hb_back_addrs[client.first].reset(

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -815,6 +815,11 @@ public:
     return !is_up(osd);
   }
 
+  bool is_stop(int osd) const {
+    return exists(osd) && is_down(osd) &&
+           (osd_state[osd] & CEPH_OSD_STOP);
+  }
+
   bool is_out(int osd) const {
     return !exists(osd) || get_weight(osd) == CEPH_OSD_OUT;
   }


### PR DESCRIPTION
- admin-down command can be used to force stopping a specified osd daemon, e.g.,
  you don't have to pre-figure out where it located.
- admin-down osd(s) won't be automatically marked out by Ceph.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

