### PR TITLE
rgw: don't write mdlog entries in RGWMetadataManager::pre_modify()

### DIFF
--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -475,6 +475,11 @@ void decode_json_obj(utime_t& val, JSONObj *obj)
   }
 }
 
+void encode_json(const char *name, std::string_view val, Formatter *f)
+{
+  f->dump_string(name, val);
+}
+
 void encode_json(const char *name, const string& val, Formatter *f)
 {
   f->dump_string(name, val);

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -377,6 +377,7 @@ static void encode_json(const char *name, const T& val, ceph::Formatter *f)
 
 class utime_t;
 
+void encode_json(const char *name, std::string_view val, ceph::Formatter *f);
 void encode_json(const char *name, const std::string& val, ceph::Formatter *f);
 void encode_json(const char *name, const char *val, ceph::Formatter *f);
 void encode_json(const char *name, bool val, ceph::Formatter *f);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7665,7 +7665,7 @@ next:
     string oid = store->get_mfa_oid(user_id);
 
     int ret = store->meta_mgr->mutate(rgw_otp_get_handler(), oid, mtime, &objv_tracker,
-                                      MDLOG_STATUS_WRITE, RGWMetadataHandler::APPLY_ALWAYS,
+                                      RGWMDLogStatus::Write, RGWMetadataHandler::APPLY_ALWAYS,
                                       [&] {
       return store->create_mfa(user_id, config, &objv_tracker, mtime);
     });
@@ -7700,7 +7700,7 @@ next:
     string oid = store->get_mfa_oid(user_id);
 
     int ret = store->meta_mgr->mutate(rgw_otp_get_handler(), oid, mtime, &objv_tracker,
-                                      MDLOG_STATUS_WRITE, RGWMetadataHandler::APPLY_ALWAYS,
+                                      RGWMDLogStatus::Write, RGWMetadataHandler::APPLY_ALWAYS,
                                       [&] {
       return store->remove_mfa(user_id, totp_serial, &objv_tracker, mtime);
     });
@@ -7843,7 +7843,7 @@ next:
     string oid = store->get_mfa_oid(user_id);
 
     ret = store->meta_mgr->mutate(rgw_otp_get_handler(), oid, mtime, &objv_tracker,
-                                  MDLOG_STATUS_WRITE, RGWMetadataHandler::APPLY_ALWAYS,
+                                  RGWMDLogStatus::Write, RGWMetadataHandler::APPLY_ALWAYS,
                                   [&] {
       return store->create_mfa(user_id, config, &objv_tracker, mtime);
     });

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7665,7 +7665,7 @@ next:
     string oid = store->get_mfa_oid(user_id);
 
     int ret = store->meta_mgr->mutate(rgw_otp_get_handler(), oid, mtime, &objv_tracker,
-                                      RGWMDLogStatus::Write, RGWMetadataHandler::APPLY_ALWAYS,
+                                      RGWMDLogOp::Write, RGWMetadataHandler::APPLY_ALWAYS,
                                       [&] {
       return store->create_mfa(user_id, config, &objv_tracker, mtime);
     });
@@ -7700,7 +7700,7 @@ next:
     string oid = store->get_mfa_oid(user_id);
 
     int ret = store->meta_mgr->mutate(rgw_otp_get_handler(), oid, mtime, &objv_tracker,
-                                      RGWMDLogStatus::Write, RGWMetadataHandler::APPLY_ALWAYS,
+                                      RGWMDLogOp::Write, RGWMetadataHandler::APPLY_ALWAYS,
                                       [&] {
       return store->remove_mfa(user_id, totp_serial, &objv_tracker, mtime);
     });
@@ -7843,7 +7843,7 @@ next:
     string oid = store->get_mfa_oid(user_id);
 
     ret = store->meta_mgr->mutate(rgw_otp_get_handler(), oid, mtime, &objv_tracker,
-                                  RGWMDLogStatus::Write, RGWMetadataHandler::APPLY_ALWAYS,
+                                  RGWMDLogOp::Write, RGWMetadataHandler::APPLY_ALWAYS,
                                   [&] {
       return store->create_mfa(user_id, config, &objv_tracker, mtime);
     });

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3240,7 +3240,7 @@ int RGWRunBucketSyncCoroutine::operate()
 
         call(new RGWMetaSyncSingleEntryCR(&meta_sync_env, raw_key,
                                           string() /* no marker */,
-                                          MDLOG_STATUS_COMPLETE,
+                                          RGWMDLogStatus::Complete,
                                           NULL /* no marker tracker */,
                                           tn));
       }

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -25,14 +25,13 @@ struct RGWObjVersionTracker;
 
 struct obj_version;
 
-
-enum RGWMDLogStatus {
-  MDLOG_STATUS_UNKNOWN,
-  MDLOG_STATUS_WRITE,
-  MDLOG_STATUS_SETATTRS,
-  MDLOG_STATUS_REMOVE,
-  MDLOG_STATUS_COMPLETE,
-  MDLOG_STATUS_ABORT,
+enum class RGWMDLogStatus : uint32_t {
+  Unknown,
+  Write,
+  SetAttrs,
+  Remove,
+  Complete,
+  Abort,
 };
 
 class RGWMetadataObject {
@@ -259,9 +258,7 @@ struct LogStatusDump {
 struct RGWMetadataLogData {
   obj_version read_version;
   obj_version write_version;
-  RGWMDLogStatus status;
-  
-  RGWMetadataLogData() : status(MDLOG_STATUS_UNKNOWN) {}
+  RGWMDLogStatus status = RGWMDLogStatus::Unknown;
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);
@@ -407,7 +404,8 @@ int RGWMetadataManager::mutate(RGWMetadataHandler *handler, const string& key,
 
   string section;
   RGWMetadataLogData log_data;
-  ret = pre_modify(handler, section, key, log_data, objv_tracker, MDLOG_STATUS_WRITE);
+  ret = pre_modify(handler, section, key, log_data, objv_tracker,
+                   RGWMDLogStatus::Write);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_otp.cc
+++ b/src/rgw/rgw_otp.cc
@@ -71,7 +71,7 @@ public:
     }
 
     int ret = store->meta_mgr->mutate(this, entry, mtime, &objv_tracker,
-                                      MDLOG_STATUS_WRITE, sync_mode,
+                                      RGWMDLogStatus::Write, sync_mode,
                                       [&] {
          return store->set_mfa(entry, devices, true, &objv_tracker, mtime);
     });

--- a/src/rgw/rgw_otp.cc
+++ b/src/rgw/rgw_otp.cc
@@ -71,7 +71,7 @@ public:
     }
 
     int ret = store->meta_mgr->mutate(this, entry, mtime, &objv_tracker,
-                                      RGWMDLogStatus::Write, sync_mode,
+                                      RGWMDLogOp::Write, sync_mode,
                                       [&] {
          return store->set_mfa(entry, devices, true, &objv_tracker, mtime);
     });

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1246,7 +1246,7 @@ int RGWMetaSyncSingleEntryCR::operate() {
       return set_cr_error(-EIO);
     }
 
-    if (op_status != MDLOG_STATUS_COMPLETE) {
+    if (op_status != RGWMDLogStatus::Complete) {
       tn->log(20, "skipping pending operation");
       yield call(marker_tracker->finish(entry_marker));
       if (retcode < 0) {
@@ -1595,7 +1595,7 @@ public:
           } else {
             // fetch remote and write locally
             yield {
-              RGWCoroutinesStack *stack = spawn(new RGWMetaSyncSingleEntryCR(sync_env, marker, marker, MDLOG_STATUS_COMPLETE, marker_tracker, tn), false);
+              RGWCoroutinesStack *stack = spawn(new RGWMetaSyncSingleEntryCR(sync_env, marker, marker, RGWMDLogStatus::Complete, marker_tracker, tn), false);
               // stack_to_pos holds a reference to the stack
               stack_to_pos[stack] = marker;
               pos_to_prev[marker] = marker;

--- a/src/test/test_rgw_admin_log.cc
+++ b/src/test/test_rgw_admin_log.cc
@@ -1071,19 +1071,19 @@ TEST(TestRGWAdmin, mdlog_list) {
     list<cls_log_entry_json>::iterator it = entries.begin();
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_WRITE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Write);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_COMPLETE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Complete);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_WRITE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Write);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_COMPLETE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Complete);
   }
 
   sleep(1); /*To get a modified time*/
@@ -1105,19 +1105,19 @@ TEST(TestRGWAdmin, mdlog_list) {
     list<cls_log_entry_json>::iterator it = entries.begin();
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_WRITE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Write);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_COMPLETE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Complete);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_WRITE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Write);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_COMPLETE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Complete);
   }
 
   sleep(1);
@@ -1141,18 +1141,18 @@ TEST(TestRGWAdmin, mdlog_list) {
     list<cls_log_entry_json>::iterator it = entries.begin();
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_REMOVE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Remove);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_WRITE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Write);
     ++it;
     EXPECT_TRUE(it->section.compare("user") == 0);
     EXPECT_TRUE(it->name.compare(uid) == 0);
-    EXPECT_TRUE(it->log_data.status == MDLOG_STATUS_COMPLETE);
+    EXPECT_TRUE(it->log_data.status == RGWMDLogStatus::Complete);
   }
 
   sleep(1);


### PR DESCRIPTION
* only writes mdlog entries with status Complete (because metadata sync filters out everything else)
* changes enum RGWMDLogStatus to enum class
* adds a related enum class RGWMDLogOp to the mdlog entry