### PR TITLE
Miscellaneous lost fixes

### DIFF
--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -280,6 +280,7 @@ public:
 				   boost::intrusive::list_member_hook<>,
 				   &Message::dispatch_q>> Queue;
 
+  ceph::mono_time queue_start;
 protected:
   CompletionHook* completion_hook = nullptr; // owned by Messenger
 

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -156,7 +156,11 @@ void Processor::start()
   // start thread
   worker->center.submit_to(worker->center.get_id(), [this]() {
       for (auto& l : listen_sockets) {
-	if (l) {
+	if (l) {   
+          if (l.fd() == -1) {
+            ldout(msgr->cct, 1) << __func__ << " Erro: processor restart after listen_socket.fd closed. " << this << dendl;
+            return;
+          }
 	  worker->center.create_file_event(l.fd(), EVENT_READABLE,
 					   listen_handler); }
       }

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -180,6 +180,7 @@ class PosixServerSocketImpl : public ServerSocketImpl {
   int accept(ConnectedSocket *sock, const SocketOptions &opts, entity_addr_t *out, Worker *w) override;
   void abort_accept() override {
     ::close(_fd);
+    _fd = -1;
   }
   int fd() const override {
     return _fd;

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -211,6 +211,9 @@ enum {
   l_msgr_running_recv_time,
   l_msgr_running_fast_dispatch_time,
 
+  l_msgr_send_messages_queue_lat,
+  l_msgr_handle_ack_lat,
+
   l_msgr_last,
 };
 
@@ -250,6 +253,9 @@ class Worker {
     plb.add_time(l_msgr_running_send_time, "msgr_running_send_time", "The total time of message sending");
     plb.add_time(l_msgr_running_recv_time, "msgr_running_recv_time", "The total time of message receiving");
     plb.add_time(l_msgr_running_fast_dispatch_time, "msgr_running_fast_dispatch_time", "The total time of fast dispatch");
+
+    plb.add_time_avg(l_msgr_send_messages_queue_lat, "msgr_send_messages_queue_lat", "Network sent messages lat");
+    plb.add_time_avg(l_msgr_handle_ack_lat, "msgr_handle_ack_lat", "Connection handle ack lat");
 
     perf_logger = plb.create_perf_counters();
     cct->get_perfcounters_collection()->add(perf_logger);

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -84,6 +84,8 @@
                            table, table-kv, html, html-pretty
      --dump                dump the crush map
      --tree                print map summary as a tree
+     --bucket-tree         print bucket map summary as a tree
+     --bucket-name         specify bucket bucket name for bucket-tree
      --check [max_id]      check if any item is referencing an unknown name/type
      -i mapfn --show-location id
                            show location for given device id

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -192,6 +192,8 @@ void usage()
   cout << "                         table, table-kv, html, html-pretty\n";
   cout << "   --dump                dump the crush map\n";
   cout << "   --tree                print map summary as a tree\n";
+  cout << "   --bucket-tree         print bucket map summary as a tree\n";
+  cout << "   --bucket-name         specify bucket bucket name for bucket-tree\n";
   cout << "   --check [max_id]      check if any item is referencing an unknown name/type\n";
   cout << "   -i mapfn --show-location id\n";
   cout << "                         show location for given device id\n";
@@ -374,7 +376,9 @@ int main(int argc, const char **argv)
   }
 
   const char *me = argv[0];
-  std::string infn, srcfn, outfn, add_name, add_type, remove_name, reweight_name;
+
+  std::string infn, srcfn, outfn, add_name, add_type, remove_name,
+    reweight_name, bucket_name;
   std::string move_name;
   bool compile = false;
   bool decompile = false;
@@ -383,6 +387,7 @@ int main(int argc, const char **argv)
   bool test = false;
   bool display = false;
   bool tree = false;
+  bool bucket_tree = false;
   string dump_format = "json-pretty";
   bool dump = false;
   int full_location = -1;
@@ -496,6 +501,10 @@ int main(int argc, const char **argv)
       i = args.erase(i);
     } else if (ceph_argparse_flag(args, i, "--tree", (char*)NULL)) {
       tree = true;
+    } else if (ceph_argparse_flag(args, i, "--bucket-tree", (char*)NULL)) {
+      bucket_tree = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "-b", "--bucket-name", (char*)NULL)) {
+      bucket_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-f", "--format", (char*)NULL)) {
       dump_format = val;
     } else if (ceph_argparse_flag(args, i, "--dump", (char*)NULL)) {
@@ -827,8 +836,10 @@ int main(int argc, const char **argv)
   }
   if (!check && !compile && !decompile && !build && !test && !reweight && !adjust && !tree && !dump &&
       add_item < 0 && !add_bucket && !move_item && !add_rule && !del_rule && full_location < 0 &&
+      !bucket_tree &&
       !reclassify && !rebuild_class_roots &&
       compare.empty() &&
+
       remove_name.empty() && reweight_name.empty()) {
     cerr << "no action specified; -h for help" << std::endl;
     return EXIT_FAILURE;
@@ -1208,6 +1219,19 @@ int main(int argc, const char **argv)
 
   if (tree) {
     crush.dump_tree(&cout, NULL, {}, true);
+  }
+
+  if (bucket_tree) {
+    if (bucket_name.empty()) {
+      cerr << ": error bucket_name is empty" << std::endl;
+    }
+    else {
+      set<int> osd_ids;
+      crush.get_leaves(bucket_name.c_str(), &osd_ids);
+      for (auto &id : osd_ids) {
+        cout << "osd." << id << std::endl;
+      }
+    }
   }
 
   if (dump) {


### PR DESCRIPTION
This PR includes several small fixes and improvements that had become stale.

In particular, it updates #21296 (msg/async: bug fix 23600 by setting _fd = 1),
#19607 (tools/crushtool: add new Option --bucket-tree to show bucket map tree), and
#16676 (msg/async: add async msg perf counter).