### PR TITLE
mon/OSDMonitor: osd add-no{up,down,in,out} - remove state checker

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10573,11 +10573,6 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
         switch (option) {
         case OP_NOUP:
-          if (osdmap.is_up(osd)) {
-            ss << "osd." << osd << " is already up. ";
-            continue;
-          }
-
           if (osdmap.is_noup(osd)) {
             if (pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOUP))
               any = true;
@@ -10589,11 +10584,6 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
           break;
 
         case OP_NODOWN:
-          if (osdmap.is_down(osd)) {
-            ss << "osd." << osd << " is already down. ";
-            continue;
-          }
-
           if (osdmap.is_nodown(osd)) {
             if (pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NODOWN))
               any = true;
@@ -10605,11 +10595,6 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
           break;
 
         case OP_NOIN:
-          if (osdmap.is_in(osd)) {
-            ss << "osd." << osd << " is already in. ";
-            continue;
-          }
-
           if (osdmap.is_noin(osd)) {
             if (pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOIN))
               any = true;
@@ -10621,11 +10606,6 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
           break;
 
         case OP_NOOUT:
-          if (osdmap.is_out(osd)) {
-            ss << "osd." << osd << " is already out. ";
-            continue;
-          }
-
           if (osdmap.is_noout(osd)) {
             if (pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOOUT))
               any = true;


### PR DESCRIPTION
The existing sanity checkers are total unnecessary, e.g, noup indicates
we should not allow the corresponding osd to boot (marked as up)
later on, which has nothing to do with the current existing osd states.

By removing these checkers, we can:
$ ceph osd add-noup osd.nnn
$ ceph osd down osd.nnn

this way we can manually mark a specific osd as down and then ensure it
will not be automatically marked as up until the specific restrictions
has been resolved.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

