### PR TITLE
mgr/test_orchestrator: Fix 'TestWriteCompletion' object has no attribute 'id'

### DIFF
--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -23,6 +23,7 @@ class TestCompletionMixin(object):
         self._complete = False
 
         self.message = message
+        self.id = str(uuid.uuid4())
 
         TestCompletionMixin.all_completions.append(self)
 
@@ -52,7 +53,6 @@ class TestReadCompletion(TestCompletionMixin, orchestrator.ReadCompletion):
 class TestWriteCompletion(TestCompletionMixin, orchestrator.WriteCompletion):
     def __init__(self, cb, message):
         super(TestWriteCompletion, self).__init__(cb, message)
-        self.id = str(uuid.uuid4())
 
     @property
     def is_persistent(self):


### PR DESCRIPTION
Caused by a race between `TestWriteCompletion.__init__() and
  `TestOrchestrator.serve()`

Fixes: https://tracker.ceph.com/issues/39259

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

