### PR TITLE
mgr/dashboard: Fix iSCSI target form warning

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -244,7 +244,7 @@
                            for="user"
                            i18n>User</label>
                     <div class="col-sm-9">
-                      <input id="user"
+                      <input [id]="'user' + ii"
                              class="form-control"
                              formControlName="user"
                              type="text">
@@ -267,7 +267,7 @@
                            i18n>Password</label>
                     <div class="col-sm-9">
                       <div class="input-group">
-                        <input id="password"
+                        <input [id]="'password' + ii"
                                class="form-control"
                                formControlName="password"
                                type="password">
@@ -275,11 +275,11 @@
                         <span class="input-group-btn">
                           <button type="button"
                                   class="btn btn-default"
-                                  cdPasswordButton="password">
+                                  [cdPasswordButton]="'password' + ii">
                           </button>
                           <button type="button"
                                   class="btn btn-default"
-                                  cdCopy2ClipboardButton="password">
+                                  [cdCopy2ClipboardButton]="'password' + ii">
                           </button>
                         </span>
                       </div>
@@ -303,7 +303,7 @@
                       <ng-container i18n>Mutual User</ng-container>
                     </label>
                     <div class="col-sm-9">
-                      <input id="mutual_user"
+                      <input [id]="'mutual_user' + ii"
                              class="form-control"
                              formControlName="mutual_user"
                              type="text">
@@ -327,7 +327,7 @@
                            i18n>Mutual Password</label>
                     <div class="col-sm-9">
                       <div class="input-group">
-                        <input id="mutual_password"
+                        <input [id]="'mutual_password' + ii"
                                class="form-control"
                                formControlName="mutual_password"
                                type="password">
@@ -335,11 +335,11 @@
                         <span class="input-group-btn">
                           <button type="button"
                                   class="btn btn-default"
-                                  cdPasswordButton="mutual_password">
+                                  [cdPasswordButton]="'mutual_password' + ii">
                           </button>
                           <button type="button"
                                   class="btn btn-default"
-                                  cdCopy2ClipboardButton="mutual_password">
+                                  [cdCopy2ClipboardButton]="'mutual_password' + ii">
                           </button>
                         </span>
                       </div>


### PR DESCRIPTION
Chrome was throwing an warning because we had multiple inputs with the same id.

Fixes: http://tracker.ceph.com/issues/39324

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

