### PR TITLE
mgr/dashboard: RBD snapshot name suggestion with local time suffix

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -206,7 +206,7 @@ describe('RbdSnapshotListComponent', () => {
     it('should display suggested snapshot name', () => {
       component.openCreateSnapshotModal();
       expect(component.modalRef.content.snapName).toMatch(
-        RegExp(`^${component.rbdName}-\\d+T\\d+Z\$`)
+        RegExp(`^${component.rbdName}_[\\d-]+T[\\d.:]+\\+[\\d:]+\$`)
       );
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -167,9 +167,7 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
     } else {
       // Auto-create a name for the snapshot: <image_name>_<timestamp_ISO_8601>
       // https://en.wikipedia.org/wiki/ISO_8601
-      snapName = `${this.rbdName}-${moment()
-        .utc()
-        .format('YYYYMMDD[T]HHmmss[Z]')}`;
+      snapName = `${this.rbdName}_${moment().toISOString(true)}`;
     }
     this.modalRef.content.setSnapName(snapName);
     this.modalRef.content.onSubmit.subscribe((snapshotName: string) => {


### PR DESCRIPTION
The new suffix is still a time that follows the ISO standard as it can
be converted into any other time zone through the time zone prefix of
itself.

Signed-off-by: Stephan Müller <smueller@suse.com>