### PR TITLE
tests: mgr/tox: make run-tox.sh scripts more robust

### DIFF
--- a/src/pybind/mgr/ansible/run-tox.sh
+++ b/src/pybind/mgr/ansible/run-tox.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
+function dump_envvars {
+  echo "WITH_PYTHON2: ->$WITH_PYTHON2<-"
+  echo "WITH_PYTHON3: ->$WITH_PYTHON3<-"
+  echo "TOX_PATH: ->$TOX_PATH<-"
+  echo "ENV_LIST: ->$ENV_LIST<-"
+}
+
 # run from ./ or from ../
 : ${MGR_ANSIBLE_VIRTUALENV:=$CEPH_BUILD_DIR/mgr-ansible-virtualenv}
 : ${WITH_PYTHON2:=ON}
-: ${WITH_PYTHON3:=ON}
+: ${WITH_PYTHON3:=3}
 : ${CEPH_BUILD_DIR:=$PWD/.tox}
 test -d ansible && cd ansible
 
@@ -20,10 +27,15 @@ export CEPH_BUILD_DIR=$CEPH_BUILD_DIR
 source ${MGR_ANSIBLE_VIRTUALENV}/bin/activate
 
 if [ "$WITH_PYTHON2" = "ON" ]; then
-  ENV_LIST+="py27"
+  ENV_LIST+="py27,"
 fi
-if [ "$WITH_PYTHON3" = "ON" ]; then
-  ENV_LIST+="py3"
+if [ "$WITH_PYTHON3" = "3" ]; then
+  ENV_LIST+="py3,"
 fi
+# use bash string manipulation to strip off any trailing comma
+ENV_LIST=${ENV_LIST%,}
 
-tox -c ${TOX_PATH} -e ${ENV_LIST}
+tox -c "${TOX_PATH}" -e "${ENV_LIST}"
+TOX_STATUS="$?"
+test "$TOX_STATUS" -ne "0" && dump_envvars
+exit $TOX_STATUS

--- a/src/pybind/mgr/dashboard/run-tox.sh
+++ b/src/pybind/mgr/dashboard/run-tox.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
 
+function dump_envvars {
+  echo "WITH_PYTHON2: ->$WITH_PYTHON2<-"
+  echo "WITH_PYTHON3: ->$WITH_PYTHON3<-"
+  echo "TOX_PATH: ->$TOX_PATH<-"
+  echo "ENV_LIST: ->$ENV_LIST<-"
+}
+
 # run from ./ or from ../
 : ${CEPH_BUILD_DIR:=$PWD/.tox}
 : ${MGR_DASHBOARD_VIRTUALENV:=$CEPH_BUILD_DIR/mgr-dashboard-virtualenv}
 : ${WITH_PYTHON2:=ON}
-: ${WITH_PYTHON3:=ON}
+: ${WITH_PYTHON3:=3}
 test -d dashboard && cd dashboard
 
 if [ -e tox.ini ]; then
-    TOX_PATH=`readlink -f tox.ini`
+    TOX_PATH=$(readlink -f tox.ini)
 else
-    TOX_PATH=`readlink -f $(dirname $0)/tox.ini`
+    TOX_PATH=$(readlink -f $(dirname $0)/tox.ini)
 fi
 
 # tox.ini will take care of this.
@@ -26,12 +33,17 @@ if [ "$WITH_PYTHON2" = "ON" ]; then
     ENV_LIST+="py27-cov,py27-lint,"
   fi
 fi
-if [ "$WITH_PYTHON3" = "ON" ]; then
+if [ "$WITH_PYTHON3" = "3" ]; then
   if [[ -n "$@" ]]; then
-    ENV_LIST+="py3-run"
+    ENV_LIST+="py3-run,"
   else
     ENV_LIST+="py3-cov,py3-lint"
   fi
 fi
+# use bash string manipulation to strip off any trailing comma
+ENV_LIST=${ENV_LIST%,}
 
-tox -c ${TOX_PATH} -e "$ENV_LIST" "$@"
+tox -c "${TOX_PATH}" -e "${ENV_LIST}"
+TOX_STATUS="$?"
+test "$TOX_STATUS" -ne "0" && dump_envvars
+exit $TOX_STATUS

--- a/src/pybind/mgr/insights/run-tox.sh
+++ b/src/pybind/mgr/insights/run-tox.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
 
+function dump_envvars {
+  echo "WITH_PYTHON2: ->$WITH_PYTHON2<-"
+  echo "WITH_PYTHON3: ->$WITH_PYTHON3<-"
+  echo "TOX_PATH: ->$TOX_PATH<-"
+  echo "ENV_LIST: ->$ENV_LIST<-"
+}
+
 # run from ./ or from ../
 : ${MGR_INSIGHTS_VIRTUALENV:=$CEPH_BUILD_DIR/mgr-insights-virtualenv}
 : ${WITH_PYTHON2:=ON}
-: ${WITH_PYTHON3:=ON}
+: ${WITH_PYTHON3:=3}
 : ${CEPH_BUILD_DIR:=$PWD/.tox}
 test -d insights && cd insights
 
 if [ -e tox.ini ]; then
-    TOX_PATH=`readlink -f tox.ini`
+    TOX_PATH=$(readlink -f tox.ini)
 else
-    TOX_PATH=`readlink -f $(dirname $0)/tox.ini`
+    TOX_PATH=$(readlink -f $(dirname $0)/tox.ini)
 fi
 
 # tox.ini will take care of this.
@@ -20,10 +27,15 @@ export CEPH_BUILD_DIR=$CEPH_BUILD_DIR
 source ${MGR_INSIGHTS_VIRTUALENV}/bin/activate
 
 if [ "$WITH_PYTHON2" = "ON" ]; then
-  ENV_LIST+="py27"
+  ENV_LIST+="py27,"
 fi
-if [ "$WITH_PYTHON3" = "ON" ]; then
-  ENV_LIST+="py3"
+if [ "$WITH_PYTHON3" = "3" ]; then
+  ENV_LIST+="py3,"
 fi
+# use bash string manipulation to strip off any trailing comma
+ENV_LIST=${ENV_LIST%,}
 
-tox -c ${TOX_PATH} -e ${ENV_LIST}
+tox -c "${TOX_PATH}" -e "${ENV_LIST}"
+TOX_STATUS="$?"
+test "$TOX_STATUS" -ne "0" && dump_envvars
+exit $TOX_STATUS

--- a/src/pybind/mgr/orchestrator_cli/run-tox.sh
+++ b/src/pybind/mgr/orchestrator_cli/run-tox.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
+function dump_envvars {
+  echo "WITH_PYTHON2: ->$WITH_PYTHON2<-"
+  echo "WITH_PYTHON3: ->$WITH_PYTHON3<-"
+  echo "TOX_PATH: ->$TOX_PATH<-"
+  echo "ENV_LIST: ->$ENV_LIST<-"
+}
+
 # run from ./ or from ../
 : ${MGR_ORCHESTRATOR_CLI_VIRTUALENV:=$CEPH_BUILD_DIR/mgr-orchestrator_cli-virtualenv}
 : ${WITH_PYTHON2:=ON}
-: ${WITH_PYTHON3:=ON}
+: ${WITH_PYTHON3:=3}
 : ${CEPH_BUILD_DIR:=$PWD/.tox}
 test -d orchestrator_cli && cd orchestrator_cli
 
@@ -23,10 +30,17 @@ then
 fi
 
 if [ "$WITH_PYTHON2" = "ON" ]; then
-  ENV_LIST+="py27"
+  ENV_LIST+="py27,"
 fi
-if [ "$WITH_PYTHON3" = "ON" ]; then
-  ENV_LIST+=",py3"
+if [ "$WITH_PYTHON3" = "3" ]; then
+  ENV_LIST+="py3,"
 fi
+ENV_LIST=$(echo "$ENV_LIST" | sed -e 's/,$//')
 
-tox -c ${TOX_PATH} -e ${ENV_LIST}
+# use bash string manipulation to strip off any trailing comma
+ENV_LIST=${ENV_LIST%,}
+
+tox -c "${TOX_PATH}" -e "${ENV_LIST}"
+TOX_STATUS="$?"
+test "$TOX_STATUS" -ne "0" && dump_envvars
+exit $TOX_STATUS


### PR DESCRIPTION
The following tests fail on systems with only Python 3 installed (no Python 2):

```
          6 - run-tox-mgr-insights (Failed)
          7 - run-tox-mgr-ansible (Failed)
          8 - run-tox-mgr-orchestrator_cli (Failed)
```

With this commit, they no longer fail.

(Note that, following a recent code change, WITH_PYTHON3 now gets set to "3" instead of "ON".)

Fixes: http://tracker.ceph.com/issues/39323
Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

