### PR TITLE
rgw: bucket stats report mtime in UTC

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1452,7 +1452,7 @@ static int bucket_stats(RGWRados *store, const std::string& tenant_name, std::st
   ::encode_json("owner", bucket_info.owner, formatter);
   formatter->dump_string("ver", bucket_ver);
   formatter->dump_string("master_ver", master_ver);
-  formatter->dump_stream("mtime") << ut;
+  ut.gmtime(formatter->dump_stream("mtime"));
   formatter->dump_string("max_marker", max_marker);
   dump_bucket_usage(stats, formatter);
   encode_json("bucket_quota", bucket_info.quota, formatter);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/39295