### PR TITLE
mgr/dashboard: Do not default to 'admin' as Admin Resource

### DIFF
--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -273,7 +273,7 @@ class RgwClient(RestClient):
                  secret_key,
                  host=None,
                  port=None,
-                 admin_path='admin',
+                 admin_path=None,
                  ssl=False):
 
         if not host and not RgwClient._host:


### PR DESCRIPTION
The current if-statement would always default to 'admin' as the admin
resource regardless of what 'mgr/dashboard/RGW_API_ADMIN_RESOURCE' is set
to.

In some cases users change this setting in the RGW for various reasons.

The dashboard currently does not support this and will cause the RGW management
not to work.

Fixes: http://tracker.ceph.com/issues/39338

Signed-off-by: Wido den Hollander <wido@42on.com>