### PR TITLE
os/bluestore: create the tail when first set FLAG_OMAP

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3877,7 +3877,7 @@ bool BlueStore::OmapIteratorImpl::valid()
 {
   RWLock::RLocker l(c->lock);
   bool r = o->onode.has_omap() && it && it->valid() &&
-    it->raw_key().second <= tail;
+    it->raw_key().second < tail;
   if (it && it->valid()) {
     ldout(c->store->cct,20) << __func__ << " is at "
 			    << pretty_binary_string(it->raw_key().second)
@@ -12907,6 +12907,7 @@ void BlueStore::_do_omap_clear(TransContext *txc, const string& omap_prefix,
   get_omap_header(id, &prefix);
   get_omap_tail(id, &tail);
   txc->t->rm_range_keys(omap_prefix, prefix, tail);
+  txc->t->rmkey(omap_prefix, tail);
   dout(20) << __func__ << " remove range start: "
            << pretty_binary_string(prefix) << " end: "
            << pretty_binary_string(tail) << dendl;
@@ -12945,6 +12946,13 @@ int BlueStore::_omap_setkeys(TransContext *txc,
       o->onode.flags |= bluestore_onode_t::FLAG_PGMETA_OMAP;
     }
     txc->write_onode(o);
+
+    const string& prefix =
+      o->onode.is_pgmeta_omap() ? PREFIX_PGMETA_OMAP : PREFIX_OMAP;
+    string key_tail;
+    bufferlist tail;
+    get_omap_tail(o->onode.nid, &key_tail);
+    txc->t->set(prefix, key_tail, tail);
   } else {
     txc->note_modified_object(o);
   }
@@ -12984,6 +12992,13 @@ int BlueStore::_omap_setheader(TransContext *txc,
       o->onode.flags |= bluestore_onode_t::FLAG_PGMETA_OMAP;
     }
     txc->write_onode(o);
+
+    const string& prefix =
+      o->onode.is_pgmeta_omap() ? PREFIX_PGMETA_OMAP : PREFIX_OMAP;
+    string key_tail;
+    bufferlist tail;
+    get_omap_tail(o->onode.nid, &key_tail);
+    txc->t->set(prefix, key_tail, tail);
   } else {
     txc->note_modified_object(o);
   }
@@ -13130,14 +13145,13 @@ int BlueStore::_clone(TransContext *txc,
 		   newo->onode.is_pgmeta_omap() ? PREFIX_PGMETA_OMAP
 		   : PREFIX_OMAP,
 		   newo->onode.nid);
+    newo->onode.clear_omap_flag();
   }
   if (oldo->onode.has_omap()) {
     dout(20) << __func__ << " copying omap data" << dendl;
-    if (!newo->onode.has_omap()) {
-      newo->onode.set_omap_flag();
-      if (newo->oid.is_pgmeta()) {
-	newo->onode.flags |= bluestore_onode_t::FLAG_PGMETA_OMAP;
-      }
+    newo->onode.set_omap_flag();
+    if (newo->oid.is_pgmeta()) {
+      newo->onode.flags |= bluestore_onode_t::FLAG_PGMETA_OMAP;
     }
     const string& prefix =
       newo->onode.is_pgmeta_omap() ? PREFIX_PGMETA_OMAP : PREFIX_OMAP;
@@ -13159,8 +13173,10 @@ int BlueStore::_clone(TransContext *txc,
       }
       it->next();
     }
-  } else {
-    newo->onode.clear_omap_flag();
+    string new_tail;
+    bufferlist new_tail_value;
+    get_omap_tail(newo->onode.nid, &new_tail);
+    txc->t->set(prefix, new_tail, new_tail_value);
   }
 
   txc->write_onode(newo);


### PR DESCRIPTION
the omap iterator when listing omap use the tail of '~', when the iterator moved to the last key of the omapswe wanted, we will try to call extra next(), usually this will be another object's omap header(with '-'). *IF* there are some deleted key or tombstones, rocksdb will fall in the loop of `FindNextUserEntryInternal` until find a valid key, so it will travels all dead key in mid and read the sst file heavily.

Signed-off-by: ningtao <ningtao@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

