### PR TITLE
mgr/telemetry: change crash dict to a list

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -171,7 +171,7 @@ class Module(MgrModule):
         return metadata
 
     def gather_crashinfo(self):
-        crashdict = dict()
+        crashlist = list()
         errno, crashids, err = self.remote('crash', 'do_ls', '', '')
         if errno:
             return ''
@@ -180,8 +180,8 @@ class Module(MgrModule):
             errno, crashinfo, err = self.remote('crash', 'do_info', cmd, '')
             if errno:
                 continue
-            crashdict[crashid] = json.loads(crashinfo)
-        return crashdict
+            crashlist.append(json.loads(crashinfo))
+        return crashlist
 
     def compile_report(self):
         report = {


### PR DESCRIPTION
For ease of indexing.  There's no value in timestamp keys.

Signed-off-by: Dan Mick <dan.mick@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

