### PR TITLE
mds: judge "was_revoking" correctly

### DIFF
--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -183,8 +183,10 @@ public:
       while (!_revokes.empty() && _revokes.front().seq < seq)
 	_revokes.pop_front();
       if (!_revokes.empty()) {
-	if (_revokes.front().seq == seq)
+	if (_revokes.front().seq == seq) {
+	  was_revoking = true;
 	  _revokes.begin()->before = caps;
+	}
 	calc_issued();
       } else {
 	// seq < last_sent


### PR DESCRIPTION
_revokes not empty means there was a revoke

Fixes: http://tracker.ceph.com/issues/39349
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

