### PR TITLE
nautilus: doc: Backported dashboard documentation changes

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -280,8 +280,10 @@ Finally, provide the credentials to the dashboard::
   $ ceph dashboard set-rgw-api-access-key <access_key>
   $ ceph dashboard set-rgw-api-secret-key <secret_key>
 
-This is all you have to do to get the Object Gateway management functionality
-working. The host and port of the Object Gateway are determined automatically.
+In a typical default configuration with a single RGW endpoint, this is all you
+have to do to get the Object Gateway management functionality working. The
+dashboard will try to automatically determine the host and port of the Object
+Gateway by obtaining this information from the Ceph Manager's service map.
 
 If multiple zones are used, it will automatically determine the host within the
 master zone group and master zone. This should be sufficient for most setups,

--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -326,7 +326,7 @@ installed and enabled on the iSCSI gateways.
   The iSCSI management functionality of Ceph Dashboard depends on the latest
   version 3 of the `ceph-iscsi <https://github.com/ceph/ceph-iscsi>`_ project.
   Make sure that your operating system provides the correct version, otherwise
-  the dashboard won't enable the managemement features.
+  the dashboard won't enable the management features.
 
 If ceph-iscsi REST API is configured in HTTPS mode and its using a self-signed
 certificate, then you need to configure the dashboard to avoid SSL certificate

--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -316,12 +316,18 @@ The default value is 45 seconds.
 Enabling iSCSI Management
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Ceph Dashboard can manage iSCSI targets using the REST API provided
-by the `rbd-target-api` service of the `ceph-iscsi <https://github.com/ceph/ceph-iscsi>`_
-project. Please make sure that it's installed and enabled on the iSCSI gateways.
+The Ceph Dashboard can manage iSCSI targets using the REST API provided by the
+`rbd-target-api` service of the :ref:`ceph-iscsi`. Please make sure that it's
+installed and enabled on the iSCSI gateways.
+
+.. note::
+  The iSCSI management functionality of Ceph Dashboard depends on the latest
+  version 3 of the `ceph-iscsi <https://github.com/ceph/ceph-iscsi>`_ project.
+  Make sure that your operating system provides the correct version, otherwise
+  the dashboard won't enable the managemement features.
 
 If ceph-iscsi REST API is configured in HTTPS mode and its using a self-signed
-certificate, then we need to configure the dashboard to avoid SSL certificate
+certificate, then you need to configure the dashboard to avoid SSL certificate
 verification when accessing ceph-iscsi API.
 
 To disable API SSL verification run the following commmand::

--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -551,7 +551,7 @@ twice if you use both sources.
    should not disturb each other through annoying duplicated notifications
    popping up.
 
-Accessing the dashboard
+Accessing the Dashboard
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 You can now access the dashboard using your (JavaScript-enabled) web browser, by
@@ -734,11 +734,33 @@ view and create Ceph pools, and have read-only access to any other scopes.
    $ ceph dashboard ac-user-set-roles bob rbd/pool-manager read-only
 
 
-Reverse Proxies
----------------
+Proxy Configuration
+-------------------
+
+In a Ceph cluster with multiple ceph-mgr instances, only the dashboard running
+on the currently active ceph-mgr daemon will serve incoming requests. Accessing
+the dashboard's TCP port on any of the other ceph-mgr instances that are
+currently on standby will perform a HTTP redirect (303) to the currently active
+manager's dashboard URL. This way, you can point your browser to any of the
+ceph-mgr instances in order to access the dashboard.
+
+If you want to establish a fixed URL to reach the dashboard or if you don't want
+to allow direct connections to the manager nodes, you could set up a proxy that
+automatically forwards incoming requests to the currently active ceph-mgr
+instance.
+
+.. note::
+  Note that putting the dashboard behind a load-balancing proxy like `HAProxy
+  <https://www.haproxy.org/>`_ currently has some limitations, particularly if
+  you require the traffic between the proxy and the dashboard to be encrypted
+  via SSL/TLS. See `BUG#24662 <https://tracker.ceph.com/issues/24662>`_ for
+  details.
+
+Configuring a URL Prefix
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you are accessing the dashboard via a reverse proxy configuration,
-you may wish to service it under a URL prefix.  To get the dashboard
+you may wish to service it under a URL prefix. To get the dashboard
 to use hyperlinks that include your prefix, you can set the
 ``url_prefix`` setting:
 
@@ -747,6 +769,7 @@ to use hyperlinks that include your prefix, you can set the
   ceph config set mgr mgr/dashboard/url_prefix $PREFIX
 
 so you can access the dashboard at ``http://$IP:$PORT/$PREFIX/``.
+
 
 .. _dashboard-auditing:
 

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -1,3 +1,5 @@
+.. _configuring-ceph:
+
 ==================
  Configuring Ceph
 ==================

--- a/doc/rbd/iscsi-overview.rst
+++ b/doc/rbd/iscsi-overview.rst
@@ -1,3 +1,5 @@
+.. _ceph-iscsi:
+
 ==================
 Ceph iSCSI Gateway
 ==================

--- a/doc/rbd/iscsi-requirements.rst
+++ b/doc/rbd/iscsi-requirements.rst
@@ -6,8 +6,8 @@ To implement the Ceph iSCSI gateway there are a few requirements. It is recommen
 to use two to four iSCSI gateway nodes for a highly available Ceph iSCSI gateway
 solution.
 
-For hardware recommendations, see the `Hardware Recommendation page <http://docs.ceph.com/docs/master/start/hardware-recommendations/>`_
-for more details.
+For hardware recommendations, see :ref:`hardware-recommendations` for more
+details.
 
 .. note::
     On the iSCSI gateway nodes, the memory footprint of the RBD images
@@ -46,4 +46,5 @@ cluster::
        ceph daemon osd.0 config set osd_heartbeat_grace 20
        ceph daemon osd.0 config set osd_heartbeat_interval 5
 
-For more details on setting Ceph's configuration options, see the `Configuration page <http://docs.ceph.com/docs/master/rados/configuration/>`_.
+For more details on setting Ceph's configuration options, see
+:ref:`configuring-ceph`.

--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -13,7 +13,7 @@ Major Changes from Mimic
 
 - *Dashboard*:
 
-  The Ceph Dashboard has gained a lot of new functionality:
+  The :ref:`mgr-dashboard` has gained a lot of new functionality:
 
   * Support for multiple users / roles
   * SSO (SAMLv2) for user authentication
@@ -32,7 +32,7 @@ Major Changes from Mimic
   * Embedded Grafana Dashboards (derived from Ceph Metrics)
   * CRUSH map viewer
   * NFS Ganesha management
-  * iSCSI target management (via ceph-iscsi)
+  * iSCSI target management (via :ref:`ceph-iscsi`)
   * RBD QoS configuration
   * Ceph Manager (ceph-mgr) module management
   * Prometheus alert Management

--- a/doc/start/hardware-recommendations.rst
+++ b/doc/start/hardware-recommendations.rst
@@ -1,3 +1,5 @@
+.. _hardware-recommendations:
+
 ==========================
  Hardware Recommendations
 ==========================


### PR DESCRIPTION
Backport of some dashboard-related documentation updates:

* doc: Updated dashboard iSCSI configuration, added labels #27074
* doc: dashboard: refined object gateway configuration #27581
* doc: Improved the dashboard proxy config section #27581
* doc: Fix small typo in dashboard documentation #27850