### PR TITLE
EventEpoll: poll epoll events from userspace

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1145,6 +1145,10 @@ std::vector<Option> get_global_options() {
     .set_default(8192)
     .set_description(""),
 
+    Option("ms_uepoll", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Uses polling from userspace"),
+
     Option("inject_early_sigterm", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description("send ourselves a SIGTERM early during startup"),

--- a/src/msg/async/EventEpoll.cc
+++ b/src/msg/async/EventEpoll.cc
@@ -7,6 +7,9 @@
  *
  * Author: Haomai Wang <haomaiwang@gmail.com>
  *
+ * Polling from userspace support by Roman Penyaev <rpenyaev@suse.de>
+ * Copyright (C) 2019 SUSE.
+ *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License version 2.1, as published by the Free Software
@@ -23,8 +26,73 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "EpollDriver."
 
+#define BUILD_BUG_ON(condition) ((void )sizeof(char [1 - 2*!!(condition)]))
+#define READ_ONCE(v) (*(volatile decltype(v)*)&(v))
+
+#ifdef __x86_64__
+#ifndef __NR_sys_epoll_create2
+#define __NR_sys_epoll_create2  428
+#endif
+#endif
+
+static inline long epoll_create2(int flags, size_t size)
+{
+#ifdef __NR_sys_epoll_create2
+  return syscall(__NR_sys_epoll_create2, flags, size);
+#else
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+int EpollDriver::uepoll_mmap(int epfd,
+			     struct epoll_uheader **_header,
+			     unsigned int **_index)
+{
+  struct epoll_uheader *header;
+  unsigned int *index, len;
+  int rc;
+
+  len = sysconf(_SC_PAGESIZE);
+again:
+  header = (decltype(header))mmap(NULL, len, PROT_WRITE|PROT_READ,
+				  MAP_SHARED, epfd, 0);
+  if (header == MAP_FAILED) {
+    rc = -errno;
+    lderr(cct) << "mmap(header): " << cpp_strerror(errno) << dendl;
+    return rc;
+  }
+
+  if (header->header_length != len) {
+    unsigned int tmp_len = len;
+
+    len = header->header_length;
+    munmap(header, tmp_len);
+    goto again;
+  }
+  ceph_assert(header->magic == EPOLL_USERPOLL_HEADER_MAGIC);
+
+  index = (decltype(index))mmap(NULL, header->index_length,
+				PROT_WRITE|PROT_READ, MAP_SHARED,
+				epfd, header->header_length);
+  if (index == MAP_FAILED) {
+    rc = -errno;
+    lderr(cct) << "mmap(index): " << cpp_strerror(errno) << dendl;
+    return rc;
+  }
+
+  BUILD_BUG_ON(sizeof(*header) != EPOLL_USERPOLL_HEADER_SIZE);
+  BUILD_BUG_ON(sizeof(header->items[0]) != 16);
+
+  *_header = header;
+  *_index = index;
+
+  return 0;
+}
+
 int EpollDriver::init(EventCenter *c, int nevent)
 {
+  use_uepoll = g_ceph_context->_conf.get_val<bool>("ms_uepoll");
   events = (struct epoll_event*)malloc(sizeof(struct epoll_event)*nevent);
   if (!events) {
     lderr(cct) << __func__ << " unable to malloc memory. " << dendl;
@@ -32,7 +100,16 @@ int EpollDriver::init(EventCenter *c, int nevent)
   }
   memset(events, 0, sizeof(struct epoll_event)*nevent);
 
-  epfd = epoll_create(1024); /* 1024 is just an hint for the kernel */
+  if (use_uepoll) {
+    epfd = epoll_create2(EPOLL_USERPOLL, 1024);
+    if (epfd >= 0) {
+      /* Mmap all pointers */
+      uepoll_mmap(epfd, &uheader, &uindex);
+      lderr(cct) << "UEPOLL enabled!" << dendl;
+    }
+  } else {
+    epfd = epoll_create1(0);
+  }
   if (epfd == -1) {
     lderr(cct) << __func__ << " unable to do epoll_create: "
                        << cpp_strerror(errno) << dendl;
@@ -117,12 +194,114 @@ int EpollDriver::resize_events(int newsize)
   return 0;
 }
 
+static inline unsigned int max_index_nr(struct epoll_uheader *header)
+{
+  return header->index_length >> 2;
+}
+
+static inline bool read_event(struct epoll_uheader *header, unsigned int *index,
+			      unsigned int idx, struct epoll_event *event)
+{
+  struct epoll_uitem *item;
+  unsigned int *item_idx_ptr;
+  unsigned int indeces_mask;
+
+  indeces_mask = max_index_nr(header) - 1;
+  if (indeces_mask & max_index_nr(header)) {
+    /* Should be pow2, corrupted header? */
+    return false;
+  }
+
+  item_idx_ptr = &index[idx & indeces_mask];
+
+  /*
+   * Spin here till we see valid index
+   */
+  while (!(idx = __atomic_load_n(item_idx_ptr, __ATOMIC_ACQUIRE)))
+    ;
+
+  if (idx > header->max_items_nr) {
+    /* Corrupted index? */
+    return false;
+  }
+
+  item = &header->items[idx - 1];
+
+  /*
+   * Mark index as invalid, that is for userspace only, kernel does not care
+   * and will refill this pointer only when observes that event is cleared,
+   * which happens below.
+   */
+  *item_idx_ptr = 0;
+
+  /*
+   * Fetch data first, if event is cleared by the kernel we drop the data
+   * returning false.
+   */
+  event->data.u64 = item->data;
+  event->events = __atomic_exchange_n(&item->ready_events, 0,
+				      __ATOMIC_RELEASE);
+
+  return (event->events & ~EPOLLREMOVED);
+}
+
+int EpollDriver::uepoll_wait(int ep, struct epoll_event *events,
+			     int maxevents, int timeout)
+
+{
+  unsigned int spins = 1000000;
+  unsigned int tail;
+  int i;
+
+  ceph_assert(maxevents > 0);
+
+again:
+  /*
+   * Cache the tail because we don't want refetch it on each iteration
+   * and then catch live events updates, i.e. we don't want user @events
+   * array consist of events from the same fds.
+   */
+  tail = READ_ONCE(uheader->tail);
+
+  if (uheader->head == tail && timeout != 0) {
+    if (spins--)
+      /* Busy loop a bit */
+      goto again;
+
+    i = epoll_wait(ep, NULL, 0, timeout);
+    ceph_assert(i <= 0);
+    if (i == 0 || (i < 0 && errno != ESTALE))
+      return i;
+
+    tail = READ_ONCE(uheader->tail);
+    ceph_assert(uheader->head != tail);
+  }
+
+  for (i = 0; uheader->head != tail && i < maxevents; uheader->head++) {
+    if (read_event(uheader, uindex, uheader->head, &events[i]))
+      i++;
+    else {
+      /*
+       * Event cleared by kernel because EPOLL_CTL_DEL was called,
+       * nothing interesting, continue.
+       */
+    }
+  }
+
+  return i;
+}
+
 int EpollDriver::event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tvp)
 {
   int retval, numevents = 0;
 
-  retval = epoll_wait(epfd, events, size,
-                      tvp ? (tvp->tv_sec*1000 + tvp->tv_usec/1000) : -1);
+  if (use_uepoll) {
+    retval = uepoll_wait(epfd, events, size,
+			 tvp ? (tvp->tv_sec*1000 + tvp->tv_usec/1000) : -1);
+  } else {
+    retval = epoll_wait(epfd, events, size,
+			tvp ? (tvp->tv_sec*1000 + tvp->tv_usec/1000) : -1);
+  }
   if (retval > 0) {
     int j;
 

--- a/src/msg/async/EventEpoll.h
+++ b/src/msg/async/EventEpoll.h
@@ -22,14 +22,59 @@
 
 #include "Event.h"
 
+#define EPOLL_USERPOLL_HEADER_MAGIC 0xeb01eb01
+#define EPOLL_USERPOLL_HEADER_SIZE  128
+#define EPOLL_USERPOLL 1
+
+/* User item marked as removed for EPOLL_USERPOLL */
+#define EPOLLREMOVED	(1U << 27)
+
+/*
+ * Item, shared with userspace.  Unfortunately we can't embed epoll_event
+ * structure, because it is badly aligned on all 64-bit archs, except
+ * x86-64 (see EPOLL_PACKED).  sizeof(epoll_uitem) == 16
+ */
+struct epoll_uitem {
+  uint32_t ready_events;
+  uint32_t events;
+  uint64_t data;
+};
+
+/*
+ * Header, shared with userspace. sizeof(epoll_uheader) == 128
+ */
+struct epoll_uheader {
+  uint32_t magic;          /* epoll user header magic */
+  uint32_t header_length;  /* length of the header + items */
+  uint32_t index_length;   /* length of the index ring, always pow2 */
+  uint32_t max_items_nr;   /* max number of items */
+  uint32_t head;           /* updated by userland */
+  uint32_t tail;           /* updated by kernel */
+
+  struct epoll_uitem items[]
+	__attribute__((aligned(EPOLL_USERPOLL_HEADER_SIZE)));
+};
+
 class EpollDriver : public EventDriver {
   int epfd;
+  struct epoll_uheader *uheader;
+  unsigned int         *uindex;
+  bool use_uepoll;
+
   struct epoll_event *events;
   CephContext *cct;
   int size;
 
  public:
-  explicit EpollDriver(CephContext *c): epfd(-1), events(NULL), cct(c), size(0) {}
+  explicit EpollDriver(CephContext *c):
+    epfd(-1),
+    uheader(NULL),
+    uindex(NULL),
+    use_uepoll(false),
+    events(NULL),
+    cct(c),
+    size(0)
+  {}
   ~EpollDriver() override {
     if (epfd != -1)
       close(epfd);
@@ -44,6 +89,13 @@ class EpollDriver : public EventDriver {
   int resize_events(int newsize) override;
   int event_wait(vector<FiredFileEvent> &fired_events,
 		 struct timeval *tp) override;
+
+private:
+  int uepoll_mmap(int epfd,
+		  struct epoll_uheader **_header,
+		  unsigned int **_index);
+  int uepoll_wait(int ep, struct epoll_event *events,
+		  int maxevents, int timeout);
 };
 
 #endif


### PR DESCRIPTION
With the following patch EventEpoll engine polls user events
from userspace, avoiding any costs of transition to kernel.
Patch utilizes RFC epoll kernel interface [1] and demonstrates
possible IOPS performance gain on small block sizes.

All measurements are done using fio messenger engine, which
tests transport stack only.  Polling events from userspace is
optional: ms_uepoll should be set to true in order to enable
the feature.

Fio config and generic config is the following:

    localhost, async+posix
    iodepth=128

```
master, ms_uepoll=false

   1k  IOPS=110k,  BW=107MiB/s,  Lat=1.164ms
   2k  IOPS=118k,  BW=231MiB/s,  Lat=1.080ms
   4k  IOPS=111k,  BW=433MiB/s,  Lat=1.153ms
   8k  IOPS=100k,  BW=784MiB/s,  Lat=1.274ms
  16k  IOPS=94.2k, BW=1472MiB/s, Lat=1.357ms
  32k  IOPS=85.4k, BW=2669MiB/s, Lat=1.497ms
  64k  IOPS=63.3k, BW=3956MiB/s, Lat=2.021ms
 128k  IOPS=32.0k, BW=4001MiB/s, Lat=3.996ms
 256k  IOPS=17.0k, BW=4256MiB/s, Lat=7.516ms

master, ms_uepoll=true

   1k  IOPS=136k,  BW=132MiB/s,  Lat=0.944ms
   2k  IOPS=132k,  BW=258MiB/s,  Lat=0.968ms
   4k  IOPS=124k,  BW=484MiB/s,  Lat=1.032ms
   8k  IOPS=109k,  BW=853MiB/s,  Lat=1.171ms
  16k  IOPS=96.8k, BW=1513MiB/s, Lat=1.321ms
  32k  IOPS=91.0k, BW=2844MiB/s, Lat=1.405ms
  64k  IOPS=62.3k, BW=3894MiB/s, Lat=2.054ms
 128k  IOPS=32.4k, BW=4044MiB/s, Lat=3.953ms
 256k  IOPS=17.2k, BW=4289MiB/s, Lat=7.459ms
```

So avoiding transition from userspace to kernel gives IOPS
for block sizes up to 32k:

```
   1k  +23%
   2k  +11%
   4k  +11%
   8k  +9%
  16k  +2%
  32k  +7%
  64k  -1%
 128k  +1%
 256k  +1%
```

[1] https://lwn.net/Articles/777263/

Signed-off-by: Roman Penyaev <rpenyaev@suse.de>
