### PR TITLE
osd/ECBackend: Avoid handle_sub_read holding pg.lock for a long time

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -810,7 +810,9 @@ bool ECBackend::_handle_message(
     reply->pgid = get_parent()->primary_spg_t();
     reply->map_epoch = get_osdmap_epoch();
     reply->min_epoch = get_parent()->get_interval_start_epoch();
+    get_parent()->pg_unlock();
     handle_sub_read(op->op.from, op->op, &(reply->op), _op->pg_trace);
+    get_parent()->pg_lock();
     reply->trace = _op->pg_trace;
     get_parent()->send_message_osd_cluster(
       op->op.from.osd, reply, get_osdmap_epoch());

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -304,6 +304,8 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
      virtual void pg_add_num_bytes(int64_t num_bytes) = 0;
      virtual void pg_sub_num_bytes(int64_t num_bytes) = 0;
      virtual bool maybe_preempt_replica_scrub(const hobject_t& oid) = 0;
+     virtual void pg_lock() = 0;
+     virtual void pg_unlock() = 0;    
      virtual ~Listener() {}
    };
    Listener *parent;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15511,6 +15511,16 @@ bool PrimaryLogPG::check_failsafe_full() {
     return osd->check_failsafe_full(get_dpp());
 }
 
+void PrimaryLogPG::pg_lock()
+{
+  lock();
+}
+
+ void PrimaryLogPG::pg_unlock()
+{
+  unlock();
+}
+
 void intrusive_ptr_add_ref(PrimaryLogPG *pg) { pg->get("intptr"); }
 void intrusive_ptr_release(PrimaryLogPG *pg) { pg->put("intptr"); }
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1895,7 +1895,8 @@ public:
   int getattrs_maybe_cache(
     ObjectContextRef obc,
     map<string, bufferlist> *out);
-
+  void pg_lock();
+  void pg_unlock();
 public:
   void set_dynamic_perf_stats_queries(
       const std::list<OSDPerfMetricQuery> &queries)  override;


### PR DESCRIPTION
When the disk load is very heavy,  IO may appear larger delay,  we test 64k read op may use up 200-400 ms, handle_sub_read hold pg.lock so long time (Recovery in OSD will grow up to 5-10 s), the pg cannot do other operations, such as: Peering（This is even worse when peering_wq and sharded_wq are separated）, so release before handle_sub_read pg. Lock, or change the handle_sub_read to asynchronous might better

Signed-off-by: ningtao <ningtao@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

