### PR TITLE
mimic: mon/OSDMonitor: further improve prepare_command_pool_set E2BIG error message

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6798,9 +6798,9 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     int64_t new_pgs = n - p.get_pg_num();
     if (new_pgs > g_conf->mon_osd_max_split_count * expected_osds) {
       ss << "specified pg_num " << n << " is too large (creating "
-	 << new_pgs << " new PGs on ~" << expected_osds
-	 << " OSDs exceeds per-OSD max with mon_osd_max_split_count of "
-         << g_conf->mon_osd_max_split_count << ')';
+         << new_pgs << " new PGs on ~" << expected_osds
+         << " OSDs would exceed the per-OSD max of " << g_conf->mon_osd_max_split_count
+         << " given by mon_osd_max_split_count); please increase the pg_num in smaller steps";
       return -E2BIG;
     }
     p.set_pg_num(n);


### PR DESCRIPTION
d2c0fe9b5319a4404965c40ec92e291802ef30f6 improved this error message,
but at least one user suggested it could be improved further by suggesting
that the pg_num be increased in smaller increments.

This commit is not cherry-picked from master because 4d3407ba93b2c15dd86aa7f97bd9f29c3508c60e
(merged for Nautilus) removed the error message in question.

Fixes: http://tracker.ceph.com/issues/39353
Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

