### PR TITLE
mon/OSDMonitor: feature of custom subtree down out interval

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1360,6 +1360,15 @@ std::vector<Option> get_global_options() {
     .set_description("do not automatically mark OSDs 'out' if an entire subtree of this size is down")
     .add_see_also("mon_osd_down_out_interval"),
 
+    Option("mon_custom_subtree_down_out_type", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description("the subtree type down out interval independently timing"),
+
+    Option("mon_custom_subtree_down_out_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("mark all OSDs of subree 'out' that has been 'down' for this long (seconds)")
+    .add_see_also("mon_custom_subtree_down_out_type"),
+
     Option("mon_osd_min_up_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(.3)
     .add_service("mon")

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -220,6 +220,7 @@ public:
   set<int>             pending_metadata_rm;
   map<int, failure_info_t> failure_info;
   map<int,utime_t>    down_pending_out;  // osd down -> out
+  map<int,utime_t>    down_pending_out_subtree; // custom subtree down -> out
 
   map<int,double> osd_weight;
 


### PR DESCRIPTION
The motivation of the feature is:
Sometimes we want down host could have higher interval to out.
We defaultly set the osd down out interval to 10min, but host
reboot may longer than 10min, so it's be bettre if we could
have a custom subtree with custom down out interval.
although we already have mon_osd_down_out_subtree_limit option,
but seems can not totally replace the option here we try to introduce.

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

