### PR TITLE
msg/async: fix a deadlock on Processor::start

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -154,17 +154,18 @@ void Processor::start()
   ldout(msgr->cct, 1) << __func__ << dendl;
 
   // start thread
-  worker->center.submit_to(worker->center.get_id(), [this]() {
-      for (auto& listen_socket : listen_sockets) {
-	if (listen_socket) {
-          if (listen_socket.fd() == -1) {
-            ldout(msgr->cct, 1) << __func__ << " Erro: processor restart after listen_socket.fd closed. " << this << dendl;
-            return;
-          }
-	  worker->center.create_file_event(listen_socket.fd(), EVENT_READABLE,
-					   listen_handler); }
+  if (listen_sockets.size()) {
+    worker->center.submit_to(worker->center.get_id(), [this]() {
+        for (auto& listen_socket : listen_sockets) {
+	  if (listen_socket) {
+	    if (listen_socket.fd() == -1) {
+	      ldout(msgr->cct, 1) << __func__ << " Erro: processor restart after listen_socket.fd closed. " << this << dendl;
+	      return;
+	    }
+	    worker->center.create_file_event(listen_socket.fd(), EVENT_READABLE, listen_handler); }
       }
     }, false);
+  }
 }
 
 void Processor::accept()

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -329,7 +329,6 @@ void AsyncMessenger::ready()
     }
   }
 
-  std::lock_guard l{lock};
   for (auto &&p : processors)
     p->start();
   dispatch_queue.start();


### PR DESCRIPTION
suppose a client do the following:
      main thread			async-work
  Messenger::create
  msgr->start()
  msgr->connect_to_osd
  msgr->add_dispatch_header
        msgr->ready
				  ProtocolV1::handle_server_banner_and_identify
				    msgr->learned_addr
				        msgr->lock.lock()
        msgr->lock.lock()
           Processor::start
                submit_to(async-work, false)

Main thread get msgr->lock and wait the extern-evetn complete. But
extern-work only complte handle_server_banner_and_identify and then do.
So the deadlock is occur.
For client, Processor::start in a no-op extern events. So skip this
extern-events can avoid deadlock.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

