### PR TITLE
src/test: fix creating two different objects for testing chunked object

### DIFF
--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -157,6 +157,15 @@ public:
 	if ((_oid) % 2) {
 	  oid << " " << string(300, 'o');
 	}
+
+        if (context.oid_in_use.count(oid.str())) {
+          /* previous write is not finished */
+          op = NULL;
+          m_op--;
+          cout << m_op << " wait for completion of write op! " << std::endl;
+          return true;
+        }
+
 	int _oid2 = m_op - m_objects + 1;
 	if (_oid2 > copy_manifest_end - m_objects) {
 	  _oid2 -= (copy_manifest_end - m_objects);
@@ -584,7 +593,7 @@ int main(int argc, char **argv)
 
   if (set_redirect || set_chunk) {
     if (low_tier_pool_name == "") {
-      cerr << "low_tier_pool_name is needed" << std::endl;
+      cerr << "low_tier_pool is needed" << std::endl;
       exit(1);
     }
   }


### PR DESCRIPTION
Below is the test flow of ceph_test_rados (only for chunked object test)

1. WriteOp for create test objects
2. CopyOp (copy the object to the different pool)
3. Set-chunk (make the link between two objects that are created from WriteOp and CopyOp)
4. Run mixed ops

At a corner case, WriteOp could not be finished after CopyOp was started. So, CopyOp makes
incompleted objects, for example oid 1's size is 1MB (WriteOp) but oid 2's size is 500KB (CopyOp).
In this case, even through SetchunkOp set the chunk info (offset, length) based on
object 1's size (1MB), the object (oid 2) that exists on another pool has different contents.
As a result, oid 2 recevices a wrong read request from oid 1. So, EIO wil be returned.

This commit would make ceph_test_rados to wait for the completion of WriteOp before starting CopyOp.

Fixes: http://tracker.ceph.com/issues/39282
Signed-off-by: Myoungwon Oh <omwmw@sk.com>


