### PR TITLE
mgr/dashboard: bucket modification time to local time

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
@@ -51,7 +51,7 @@
           <tr>
             <td i18n
                 class="bold col-sm-1">Modification time</td>
-            <td>{{ bucket.mtime }}</td>
+            <td>{{ bucket.mtime | cdDate }}</td>
           </tr>
           <tr>
             <td i18n


### PR DESCRIPTION
* After backend PR https://github.com/ceph/ceph/pull/27617
  bucket modification time is UTC, so date pipe is applied
  in order to show it as local time.

Fixes: https://tracker.ceph.com/issues/39295

Signed-off-by: Alfonso Martínez <almartin@redhat.com>

Before backend PR https://github.com/ceph/ceph/pull/27617

![39295-rgw-bucket-mtime-before](https://user-images.githubusercontent.com/6780162/56341803-808a4c00-61b6-11e9-9d38-1e6efef5dfd7.png)

After backend PR https://github.com/ceph/ceph/pull/27617

![39295-rgw-bucket-mtime-after](https://user-images.githubusercontent.com/6780162/56341816-897b1d80-61b6-11e9-8f97-ce8c44ec378f.png)

After backend + frontend PR:

![39295-rgw-bucket-mtime-after-pipe](https://user-images.githubusercontent.com/6780162/56341834-97c93980-61b6-11e9-96ae-fae8e8dc53e4.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

