### PR TITLE
rgw/pubsub: fix topic arn. tenant support to multisite tests

### DIFF
--- a/doc/radosgw/pubsub-module.rst
+++ b/doc/radosgw/pubsub-module.rst
@@ -157,13 +157,11 @@ Request parameters:
  - "none" - message is considered "delivered" if sent to broker
  - "broker" message is considered "delivered" if acked by broker
 
-Response:
-The ARN will have one of the following format (depending with whether a push-endpoint was defined):
+The topic ARN in the response will have the following format:
 
 ::
 
    arn:aws:sns:<zone-group>:<tenant>:<topic>
-   arn:aws:sns:<zone-group>:<tenant>:<webhook|amqp>:<push-endpoint-url>:<topic>
 
 Get Topic Information
 `````````````````````
@@ -522,7 +520,7 @@ the events will have an S3-compatible record format (JSON):
 - s3.object.version: object version in case of versioned bucket
 - s3.object.sequencer: monotonically increasing identifier of the change per object (hexadecimal format)
 
-In case that the subscription was not created via an S3-compatible notification, 
+In case that the subscription was not created via a non S3-compatible notification, 
 the events will have the following event format (JSON):
 
 ::
@@ -549,7 +547,7 @@ the events will have the following event format (JSON):
        }
    ]}
 
-- id: unique ID of the event, that could be used for acking (an extension to the S3 notification API)
+- id: unique ID of the event, that could be used for acking
 - event: either ``OBJECT_CREATE``, or ``OBJECT_DELETE``
 - timestamp: timestamp indicating when the event was sent
 - info.attrs.mtime: timestamp indicating when the event was triggered

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -160,40 +160,6 @@ void rgw_pubsub_sub_config::dump(Formatter *f) const
   encode_json("s3_id", s3_id, f);
 }
 
-std::string dest_to_topic_arn(const rgw_pubsub_sub_dest& dest, 
-    const std::string& topic_name, 
-    const std::string& zonegroup_name,
-    const std::string& user_name) {
-  rgw::ARN arn(rgw::Partition::aws, rgw::Service::sns, zonegroup_name, user_name, "");
-  rgw::ARNResource arn_resource;
-  const auto endpoint_type = RGWPubSubEndpoint::get_schema(dest.push_endpoint);
-  if (endpoint_type.empty()) {
-    arn_resource.resource = topic_name;
-  } else {
-    // add endpoint info as resource
-    arn_resource.resource_type = endpoint_type;
-    arn_resource.resource = dest.push_endpoint;
-    arn_resource.qualifier = topic_name;
-  }
-  arn.resource = arn_resource.to_string();
-  return arn.to_string();
-}
-
-std::string topic_name_from_arn(const std::string& topic_arn) {
-  const auto arn = rgw::ARN::parse(topic_arn);
-  if (!arn || arn->resource.empty()) {
-    return "";
-  }
-  const auto arn_resource = rgw::ARNResource::parse(arn->resource);
-  if (!arn_resource) {
-    return "";
-  }
-  if (arn_resource->resource_type.empty()) {
-    return arn_resource->resource;
-  }
-  return arn_resource->qualifier;
-}
-
 int RGWUserPubSub::remove(const rgw_raw_obj& obj, RGWObjVersionTracker *objv_tracker)
 {
   int ret = rgw_delete_system_obj(store, obj.pool, obj.oid, objv_tracker);

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -23,7 +23,7 @@ class XMLObj;
       </S3Key>
     </Filter>
     <Id>notification1</Id>
-    <Topic>arn:aws:sns:<region>:<account>:[<endpoint-type>:<endpoint-name>]:<topic></Topic>
+    <Topic>arn:aws:sns:<region>:<account>:<topic></Topic>
     <Event>s3:ObjectCreated:*</Event>
     <Event>s3:ObjectRemoved:*</Event>
   </TopicConfiguration>
@@ -410,17 +410,6 @@ struct rgw_pubsub_user_topics {
 WRITE_CLASS_ENCODER(rgw_pubsub_user_topics)
 
 static std::string pubsub_user_oid_prefix = "pubsub.user.";
-
-// generate a topic ARN string
-// no endpoint (pull mode only): arn:s3:sns:<region>:<account>:<topic>
-// with endpoint               : arn:s3:sns:<region>:<account>:<endpoint-type>:<endpoint>:<topic>
-std::string dest_to_topic_arn(const rgw_pubsub_sub_dest& dest, 
-    const std::string& topic_name, 
-    const std::string& zonegroup_name,
-    const std::string& user_name);
-
-// extract the name of the topic from the string representation of the topic ARN
-std::string topic_name_from_arn(const std::string& topic_arn);
 
 class RGWUserPubSub
 {

--- a/src/rgw/rgw_pubsub_push.cc
+++ b/src/rgw/rgw_pubsub_push.cc
@@ -312,7 +312,7 @@ static const std::string WEBHOOK_SCHEMA("webhook");
 static const std::string UNKNOWN_SCHEMA("unknown");
 static const std::string NO_SCHEMA("");
 
-const std::string& RGWPubSubEndpoint::get_schema(const std::string& endpoint) {
+const std::string& get_schema(const std::string& endpoint) {
   if (endpoint.empty()) {
     return NO_SCHEMA; 
   }

--- a/src/rgw/rgw_pubsub_push.h
+++ b/src/rgw/rgw_pubsub_push.h
@@ -25,8 +25,6 @@ public:
 
   typedef std::unique_ptr<RGWPubSubEndpoint> Ptr;
 
-  static const std::string& get_schema(const std::string& endpoint);
-
   // factory method for the actual notification endpoint
   // derived class specific arguments are passed in http args format
   // may throw a configuration_error if creation fails

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -35,6 +35,7 @@ class Config:
         self.checkpoint_delay = kwargs.get('checkpoint_delay', 5)
         # allow some time for realm reconfiguration after changing master zone
         self.reconfigure_delay = kwargs.get('reconfigure_delay', 5)
+        self.tenant = kwargs.get('tenant', '')
 
 # rgw multisite tests, written against the interfaces provided in rgw_multi.
 # these tests must be initialized and run by another module that provides
@@ -50,6 +51,12 @@ def init_multi(_realm, _user, _config=None):
     global config
     config = _config or Config()
     realm_meta_checkpoint(realm)
+
+def get_user():
+    return user.id if user is not None else ''
+
+def get_tenant():
+    return config.tenant if config is not None and config.tenant is not None else ''
 
 def get_realm():
     return realm
@@ -108,6 +115,7 @@ def datalog_autotrim(zone):
 
 def bilog_list(zone, bucket, args = None):
     cmd = ['bilog', 'list', '--bucket', bucket] + (args or [])
+    cmd += ['--tenant', config.tenant, '--uid', user.name] if config.tenant else []
     bilog, _ = zone.cluster.admin(cmd, read_only=True)
     bilog = bilog.decode('utf-8')
     return json.loads(bilog)
@@ -265,6 +273,7 @@ def bucket_sync_status(target_zone, source_zone, bucket_name):
     cmd = ['bucket', 'sync', 'markers'] + target_zone.zone_args()
     cmd += ['--source-zone', source_zone.name]
     cmd += ['--bucket', bucket_name]
+    cmd += ['--tenant', config.tenant, '--uid', user.name] if config.tenant else []
     while True:
         bucket_sync_status_json, retcode = target_zone.cluster.admin(cmd, check_retcode=False, read_only=True)
         if retcode == 0:
@@ -300,6 +309,7 @@ def data_source_log_status(source_zone):
 def bucket_source_log_status(source_zone, bucket_name):
     cmd = ['bilog', 'status'] + source_zone.zone_args()
     cmd += ['--bucket', bucket_name]
+    cmd += ['--tenant', config.tenant, '--uid', user.name] if config.tenant else []
     source_cluster = source_zone.cluster
     bilog_status_json, retcode = source_cluster.admin(cmd, read_only=True)
     bilog_status = json.loads(bilog_status_json.decode('utf-8'))

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -347,13 +347,16 @@ def init(parse_args):
                     arg = ['--display-name', '"Test User"']
                     arg += user_creds.credential_args()
                     if args.tenant:
-                        cmd += ['--tenant', args.tenant]
+                        arg += ['--tenant', args.tenant]
                     user.create(zone, arg)
                 else:
                     # read users and update keys
                     admin_user.info(zone)
                     admin_creds = admin_user.credentials[0]
-                    user.info(zone)
+                    arg = []
+                    if args.tenant:
+                        arg += ['--tenant', args.tenant]
+                    user.info(zone, arg)
                     user_creds = user.credentials[0]
 
     if not bootstrap:
@@ -361,7 +364,8 @@ def init(parse_args):
 
     config = Config(checkpoint_retries=args.checkpoint_retries,
                     checkpoint_delay=args.checkpoint_delay,
-                    reconfigure_delay=args.reconfigure_delay)
+                    reconfigure_delay=args.reconfigure_delay,
+                    tenant=args.tenant)
     init_multi(realm, user, config)
 
 def setup_module():


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

This PR handling several issues:
- Topic ARN should not include the endpoint definition, just the topic name. Information on the endpoint and its parameters could be fetched from the topic **[small API change]**
  - There is a 1-1 relationship between an endpoint and a topic this does not create any limitation
  - ARN resources cannot contain ":" while endpoint (URLs) need them
  - This is more compatible with how topic ARNs look in S3
- Topic ARNs now include zonegroup and tenant info that was previously missing **[bug fix]**
- To tests tenant value, fixes were made to the multisite testing framework (not only for pubsub) **[bug fix in the test]**
