### PR TITLE
luminous: pybind: Rados.get_fsid() returning bytes in python3

### DIFF
--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -9,6 +9,7 @@ import time
 import threading
 import json
 import errno
+import re
 import sys
 
 # Are we running Python 2.x
@@ -244,7 +245,7 @@ class TestRados(object):
 
     def test_get_fsid(self):
         fsid = self.rados.get_fsid()
-        eq(len(fsid), 36)
+        assert re.match('[0-9a-f\-]{36}', fsid, re.I)
 
     def test_blacklist_add(self):
         self.rados.blacklist_add("1.2.3.4/123", 1)


### PR DESCRIPTION
http://tracker.ceph.com/issues/38873