### PR TITLE
rgw: fix default_placement containing "/" when storage_class is standard

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -695,7 +695,7 @@ struct rgw_placement_rule {
 
   void encode(bufferlist& bl) const {
     /* no ENCODE_START/END due to backward compatibility */
-    std::string s = to_str_explicit();
+    std::string s = to_str();
     ceph::encode(s, bl);
   }
 
@@ -720,12 +720,11 @@ struct rgw_placement_rule {
     size_t pos = s.find("/");
     if (pos == std::string::npos) {
       name = s;
+      storage_class.clear();
       return;
     }
     name = s.substr(0, pos);
-    if (pos < s.size() - 1) {
-      storage_class = s.substr(pos + 1);
-    }
+    storage_class = s.substr(pos + 1);
   }
 
   bool standard_storage_class() const {


### PR DESCRIPTION
The user default placement contains an extraneous slash:
`"default_placement": "/" `
and the zonegroup defaut placement contains a trailing slash
` "default_placement": "default-placement/",`

```
radosgw-admin --keyring=/etc/ceph/keyring-store/keyring --mon-host=$ROOK_CEPH_MON_HOST --name=client.radosgw.gateway  metadata get user:cosbench
"default_placement": "/" 
-------------------->^^^

radosgw-admin --keyring=/etc/ceph/keyring-store/keyring --mon-host=$ROOK_CEPH_MON_HOST --name=client.radosgw.gateway  zonegroup get
{
    "placement_targets": [
        {
            "name": "default-placement",
            "tags": []
        }
    ],
    "default_placement": "default-placement/",
------------------------------------------>^
    "realm_id": "52539210-99bc-449b-9bae-00e60bd5064a" 
}
```

fixes: http://tracker.ceph.com/issues/39380

Signed-off-by: mkogan1 <mkogan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

