### PR TITLE
luminous: mds: dont print subtrees if they are too big or too many 

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -188,6 +188,8 @@ void MDBalancer::tick()
     send_heartbeat();
     num_bal_times--;
   }
+
+  mds->mdcache->show_subtrees(10, true);
 }
 
 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -149,11 +149,24 @@ void MDBalancer::handle_export_pins(void)
 
   set<CDir *> authsubs;
   mds->mdcache->get_auth_subtrees(authsubs);
+  bool print_auth_subtrees = true;
+
+  if (authsubs.size() > AUTH_TREES_THRESHOLD &&
+      !g_conf->subsys.should_gather(ceph_subsys_mds, 25)) {
+    dout(15) << "number of auth trees = " << authsubs.size() << "; not "
+		"printing auth trees" << dendl;
+    print_auth_subtrees = false;
+  }
+
   for (auto &cd : authsubs) {
     mds_rank_t export_pin = cd->inode->get_export_pin();
-    dout(10) << "auth tree " << *cd << " export_pin=" << export_pin << dendl;
+
+    if (print_auth_subtrees) {
+      dout(25) << "auth tree " << *cd << " export_pin=" << export_pin <<
+		  dendl;
+    }
+
     if (export_pin >= 0 && export_pin != mds->get_nodeid()) {
-      dout(10) << "exporting auth subtree " << *cd->inode << " to " << export_pin << dendl;
       mds->mdcache->migrator->export_dir(cd, export_pin);
     }
   }

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -78,6 +78,7 @@ public:
 private:
   bool bal_fragment_dirs;
   int64_t bal_fragment_interval;
+  static const unsigned int AUTH_TREES_THRESHOLD = 5;
 
   typedef struct {
     std::map<mds_rank_t, double> targets;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -304,6 +304,9 @@ public:
 
 
   // -- subtrees --
+private:
+  static const unsigned int SUBTREES_COUNT_THRESHOLD = 5;
+  static const unsigned int SUBTREES_DEPTH_THRESHOLD = 5;
 protected:
   /* subtree keys and each tree's non-recursive nested subtrees (the "bounds") */
   map<CDir*,set<CDir*> > subtrees;
@@ -1204,7 +1207,7 @@ public:
   // == crap fns ==
  public:
   void show_cache();
-  void show_subtrees(int dbl=10);
+  void show_subtrees(int dbl=10, bool force_print=false);
 
   CInode *hack_pick_random_inode() {
     assert(!inode_map.empty());

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -796,6 +796,11 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
   assert(dir->is_auth());
   assert(dest != mds->get_nodeid());
    
+  if (!mds->is_stopping() && !dir->inode->is_exportable(dest)) {
+    dout(25) << "dir is export pinned" << dendl;
+    return;
+  }
+
   if (!(mds->is_active() || mds->is_stopping())) {
     dout(7) << "i'm not active, no exports for now" << dendl;
     return;
@@ -822,11 +827,6 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
   if (parent_dir && parent_dir->inode->is_stray()) {
     if (parent_dir->get_parent_dir()->ino() != MDS_INO_MDSDIR(dest)) {
       dout(7) << "i won't export anything in stray" << dendl;
-      return;
-    }
-  } else {
-    if (!mds->is_stopping() && !dir->inode->is_exportable(dest)) {
-      dout(7) << "dir is export pinned" << dendl;
       return;
     }
   }


### PR DESCRIPTION
https://tracker.ceph.com/issues/38877