### PR TITLE
rgw: rest client fixes for cloud sync XML outputs

### DIFF
--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -15,12 +15,11 @@ class CephContext;
 class RGWSI_Zone;
 
 template <class T>
-static int parse_decode_json(CephContext *cct, T& t, bufferlist& bl)
+static int parse_decode_json(T& t, bufferlist& bl)
 {
   JSONParser p;
-  int ret = p.parse(bl.c_str(), bl.length());
-  if (ret < 0) {
-    return ret;
+  if (!p.parse(bl.c_str(), bl.length())) {
+    return -EINVAL;
   }
 
   try {
@@ -216,7 +215,7 @@ int RGWRESTConn::get_json_resource(const string& resource, param_vec_t *params, 
     return ret;
   }
 
-  ret = parse_decode_json(cct, t, bl);
+  ret = parse_decode_json(t, bl);
   if (ret < 0) {
     return ret;
   }
@@ -330,7 +329,7 @@ int RGWRESTReadResource::decode_resource(T *dest)
   if (ret < 0) {
     return ret;
   }
-  ret = parse_decode_json(cct, *dest, bl);
+  ret = parse_decode_json(*dest, bl);
   if (ret < 0) {
     return ret;
   }
@@ -449,7 +448,7 @@ int RGWRESTSendResource::decode_resource(T *dest, E *err_result)
   int ret = req.get_status();
   if (ret < 0) {
     if (err_result) {
-      parse_decode_json(cct, *err_result, bl);
+      parse_decode_json(*err_result, bl);
     }
     return ret;
   }
@@ -458,7 +457,7 @@ int RGWRESTSendResource::decode_resource(T *dest, E *err_result)
     return 0;
   }
 
-  ret = parse_decode_json(cct, *dest, bl);
+  ret = parse_decode_json(*dest, bl);
   if (ret < 0) {
     return ret;
   }
@@ -471,7 +470,7 @@ int RGWRESTSendResource::wait(T *dest, optional_yield y, E *err_result)
   int ret = req.wait(y);
   if (ret < 0) {
     if (err_result) {
-      parse_decode_json(cct, *err_result, bl);
+      parse_decode_json(*err_result, bl);
     }
     return ret;
   }

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -410,9 +410,6 @@ public:
     return req.get_io_user_info();
   }
 
-  template <class T, class E>
-  int decode_resource(T *dest, E *err_result);
-
   int send(bufferlist& bl);
 
   int aio_send(bufferlist& bl);
@@ -425,36 +422,46 @@ public:
     return req.get_http_status();
   }
 
-  int wait(bufferlist *pbl, optional_yield y) {
+  template <class E = std::nullptr_t>
+  int wait(bufferlist *pbl, optional_yield y, E *err_result = nullptr) {
     int ret = req.wait(y);
     *pbl = bl;
-    if (ret < 0) {
-      return ret;
+
+    if (ret >=0) {
+      ret = req.get_status();
     }
 
-    if (req.get_status() < 0) {
-      return req.get_status();
+    if (ret < 0) {
+      if constexpr (!std::is_same_v<E, std::nullptr_t>) {
+        if (err_result) {
+          ret = parse_decode_json(*err_result, bl);
+        }
+      }
     }
-    return 0;
+
+    return ret;
   }
 
-  template <class T, class E = int>
+  template <class T, class E = std::nullptr_t>
   int wait(T *dest, optional_yield y, E *err_result = nullptr);
 };
 
 template <class T, class E>
-int RGWRESTSendResource::decode_resource(T *dest, E *err_result)
+int RGWRESTSendResource::wait(T *dest, optional_yield y, E *err_result)
 {
-  int ret = req.get_status();
-  if (ret < 0) {
-    if (err_result) {
-      parse_decode_json(*err_result, bl);
-    }
-    return ret;
+  int ret = req.wait(y);
+  if (ret >=0) {
+    ret = req.get_status();
   }
 
-  if (!dest) {
-    return 0;
+  if constexpr (!std::is_same_v<E, std::nullptr_t>) {
+    if (ret <0 && err_result) {
+      ret = parse_decode_json(*err_result, bl);
+    }
+  }
+
+  if (ret < 0){
+    return ret;
   }
 
   ret = parse_decode_json(*dest, bl);
@@ -462,24 +469,7 @@ int RGWRESTSendResource::decode_resource(T *dest, E *err_result)
     return ret;
   }
   return 0;
-}
 
-template <class T, class E>
-int RGWRESTSendResource::wait(T *dest, optional_yield y, E *err_result)
-{
-  int ret = req.wait(y);
-  if (ret < 0) {
-    if (err_result) {
-      parse_decode_json(*err_result, bl);
-    }
-    return ret;
-  }
-
-  ret = decode_resource(dest, err_result);
-  if (ret < 0) {
-    return ret;
-  }
-  return 0;
 }
 
 class RGWRESTPostResource : public RGWRESTSendResource {


### PR DESCRIPTION
Currently the cloud sync module was passing the XML bufferlist to `parse_decode_json` which actually used to fail the parser, but the error code was ignored due to an int -bool conversion the upper layer just saw an empty bufferlist which would later fail the  XML parsing in the client. 
Currently allowed the `wait(bufferlist)` function to take up an optional error code argument as well so that this overload is chosen. 

Verified this in actual testing and a static_assert in parse_decode_json to verify that a bufferlist codepath never reaches here, which I haven't here added yet as technically a possibly single item json could be a bufferlist since decode_json_obj is technically compileable, though very likely something wrong.

I also see that most calls to SendResource ignore the err_result, so all of these can possibly benefit from a nullptr override?
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

