### PR TITLE
nautilus: rgw: remove rgw_num_rados_handles; set autoscale parameters or rgw metadata pools

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,12 +1,13 @@
->=14.2.1
+>=14.2.2
 --------
 
-* Ceph now packages python bindings for python3.6 instead of
-  python3.4, because EPEL7 recently switched from python3.4 to
-  python3.6 as the native python3. see the `announcement <https://lists.fedoraproject.org/archives/list/epel-announce@lists.fedoraproject.org/message/EGUMKAIMPK2UD5VSHXM53BH2MBDGDWMO/>_`
-  for more details on the background of this change.
-
 * Nautilus-based librbd clients can now open images on Jewel clusters.
+
+* The RGW "num_rados_handles" has been removed.
+  If you were using a value of "num_rados_handles" greater than 1
+  multiply your current "objecter_inflight_ops" and
+  "objecter_inflight_op_bytes" paramaeters by the old
+  "num_rados_handles" to get the same throttle behavior.
 
 14.2.2
 ------

--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -157,18 +157,6 @@ instances or all radosgw-admin commands can be put into the ``[global]`` or the
 :Default: 100 threads.
 
 
-``rgw num rados handles``
-
-:Description: The number of `RADOS cluster handles`_ for Ceph Object Gateway.
-              Having a configurable number of RADOS handles is resulting in
-              significant performance boost for all types of workloads. Each RGW
-              worker thread would now get to pick a RADOS handle for its lifetime,
-              from the available bunch.
-
-:Type: Integer
-:Default: ``1``
-
-
 ``rgw num control oids``
 
 :Description: The number of notification objects used for cache synchronization

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1376,7 +1376,6 @@ OPTION(rgw_op_thread_timeout, OPT_INT)
 OPTION(rgw_op_thread_suicide_timeout, OPT_INT)
 OPTION(rgw_thread_pool_size, OPT_INT)
 OPTION(rgw_num_control_oids, OPT_INT)
-OPTION(rgw_num_rados_handles, OPT_U32)
 OPTION(rgw_verify_ssl, OPT_BOOL) // should http_client try to verify ssl when sent https request
 
 /* The following are tunables for caches of RGW NFS (and other file

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6079,6 +6079,16 @@ std::vector<Option> get_rgw_options() {
     .set_default(10)
     .set_description(""),
 
+    Option("rgw_rados_pool_autoscale_bias", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(4.0)
+    .set_min_max(0.01, 100000.0)
+    .set_description("pg_autoscale_bias value for RGW metadata (omap-heavy) pools"),
+
+    Option("rgw_rados_pool_pg_num_min", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(8)
+    .set_min_max(1, 1024)
+    .set_description("pg_num_min value for RGW metadata (omap-heavy) pools"),
+
     Option("rgw_zone", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description("Zone name")

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -4,6 +4,7 @@
 #include "rgw_gc.h"
 
 #include "include/scope_guard.h"
+#include "rgw_tools.h"
 #include "include/rados/librados.hpp"
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/refcount/cls_refcount_client.h"

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5703,7 +5703,7 @@ void RGWCompleteMultipart::execute()
   store->obj_to_raw((s->bucket_info).placement_rule, meta_obj, &raw_obj);
   store->get_obj_data_pool((s->bucket_info).placement_rule,
 			   meta_obj,&meta_pool);
-  store->open_pool_ctx(meta_pool, serializer.ioctx);
+  store->open_pool_ctx(meta_pool, serializer.ioctx, true);
 
   op_ret = serializer.try_lock(raw_obj.oid, dur);
   if (op_ret < 0) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1410,7 +1410,7 @@ int RGWRados::init_rados()
     }
   }
 
-  auto handles = std::vector<librados::Rados>{static_cast<size_t>(cct->_conf->rgw_num_rados_handles)};
+  auto handles = std::vector<librados::Rados>{static_cast<size_t>(1)};
 
   for (auto& r : handles) {
     ret = r.init_with_context(cct);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1270,10 +1270,7 @@ class RGWRados : public AdminSocketHook
 protected:
   CephContext *cct;
 
-  std::vector<librados::Rados> rados;
-  uint32_t next_rados_handle;
-  RWLock handle_lock;
-  std::map<pthread_t, int> rados_map;
+  librados::Rados rados;
 
   using RGWChainedCacheImpl_bucket_info_entry = RGWChainedCacheImpl<bucket_info_entry>;
   RGWChainedCacheImpl_bucket_info_entry *binfo_cache;
@@ -1307,8 +1304,6 @@ public:
                bucket_id_lock("rados_bucket_id"),
                bucket_index_max_shards(0),
                max_bucket_id(0), cct(NULL),
-               next_rados_handle(0),
-               handle_lock("rados_handle_lock"),
                binfo_cache(NULL), obj_tombstone_cache(nullptr),
                pools_initialized(false),
                quota_handler(NULL),

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1187,7 +1187,8 @@ class RGWRados : public AdminSocketHook
   int open_objexp_pool_ctx();
   int open_reshard_pool_ctx();
 
-  int open_pool_ctx(const rgw_pool& pool, librados::IoCtx&  io_ctx);
+  int open_pool_ctx(const rgw_pool& pool, librados::IoCtx&  io_ctx,
+		    bool mostly_omap);
   int open_bucket_index_ctx(const RGWBucketInfo& bucket_info, librados::IoCtx& index_ctx);
   int open_bucket_index(const RGWBucketInfo& bucket_info, librados::IoCtx&  index_ctx, string& bucket_oid);
   int open_bucket_index_base(const RGWBucketInfo& bucket_info, librados::IoCtx&  index_ctx,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -119,8 +119,6 @@ static inline void get_obj_bucket_and_oid_loc(const rgw_obj& obj, string& oid, s
   }
 }
 
-int rgw_init_ioctx(librados::Rados *rados, const rgw_pool& pool, librados::IoCtx& ioctx, bool create = false);
-
 int rgw_policy_from_attrset(CephContext *cct, map<string, bufferlist>& attrset, RGWAccessControlPolicy *policy);
 
 static inline bool rgw_raw_obj_to_obj(const rgw_bucket& bucket, const rgw_raw_obj& raw_obj, rgw_obj *obj)

--- a/src/rgw/rgw_realm_watcher.cc
+++ b/src/rgw/rgw_realm_watcher.cc
@@ -4,7 +4,7 @@
 #include "common/errno.h"
 
 #include "rgw_realm_watcher.h"
-#include "rgw_rados.h"
+#include "rgw_tools.h"
 #include "rgw_zone.h"
 
 #define dout_subsys ceph_subsys_rgw

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -19,6 +19,7 @@
 #include "rgw_aio_throttle.h"
 #include "rgw_compression.h"
 #include "rgw_zone.h"
+#include "osd/osd_types.h"
 
 #include "services/svc_sys_obj.h"
 #include "services/svc_zone_utils.h"
@@ -29,6 +30,42 @@
 #define READ_CHUNK_LEN (512 * 1024)
 
 static std::map<std::string, std::string>* ext_mime_map;
+
+int rgw_init_ioctx(librados::Rados *rados, const rgw_pool& pool,
+                   librados::IoCtx& ioctx, bool create)
+{
+  int r = rados->ioctx_create(pool.name.c_str(), ioctx);
+  if (r == -ENOENT && create) {
+    r = rados->pool_create(pool.name.c_str());
+    if (r == -ERANGE) {
+      dout(0)
+        << __func__
+        << " ERROR: librados::Rados::pool_create returned " << cpp_strerror(-r)
+        << " (this can be due to a pool or placement group misconfiguration, e.g."
+        << " pg_num < pgp_num or mon_max_pg_per_osd exceeded)"
+        << dendl;
+    }
+    if (r < 0 && r != -EEXIST) {
+      return r;
+    }
+
+    r = rados->ioctx_create(pool.name.c_str(), ioctx);
+    if (r < 0) {
+      return r;
+    }
+
+    r = ioctx.application_enable(pg_pool_t::APPLICATION_NAME_RGW, false);
+    if (r < 0 && r != -EOPNOTSUPP) {
+      return r;
+    }
+  } else if (r < 0) {
+    return r;
+  }
+  if (!pool.ns.empty()) {
+    ioctx.set_namespace(pool.ns);
+  }
+  return 0;
+}
 
 int rgw_put_system_obj(RGWRados *rgwstore, const rgw_pool& pool, const string& oid, bufferlist& data, bool exclusive,
                        RGWObjVersionTracker *objv_tracker, real_time set_mtime, map<string, bufferlist> *pattrs)

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -32,7 +32,8 @@
 static std::map<std::string, std::string>* ext_mime_map;
 
 int rgw_init_ioctx(librados::Rados *rados, const rgw_pool& pool,
-                   librados::IoCtx& ioctx, bool create)
+                   librados::IoCtx& ioctx, bool create,
+		   bool mostly_omap)
 {
   int r = rados->ioctx_create(pool.name.c_str(), ioctx);
   if (r == -ENOENT && create) {

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -18,7 +18,9 @@ class optional_yield;
 struct obj_version;
 
 int rgw_init_ioctx(librados::Rados *rados, const rgw_pool& pool,
-                   librados::IoCtx& ioctx, bool create = false);
+                   librados::IoCtx& ioctx,
+		   bool create = false,
+		   bool mostly_omap = false);
 
 int rgw_put_system_obj(RGWRados *rgwstore, const rgw_pool& pool, const string& oid, bufferlist& data, bool exclusive,
                        RGWObjVersionTracker *objv_tracker, real_time set_mtime, map<string, bufferlist> *pattrs = NULL);

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -17,6 +17,9 @@ class optional_yield;
 
 struct obj_version;
 
+int rgw_init_ioctx(librados::Rados *rados, const rgw_pool& pool,
+                   librados::IoCtx& ioctx, bool create = false);
+
 int rgw_put_system_obj(RGWRados *rgwstore, const rgw_pool& pool, const string& oid, bufferlist& data, bool exclusive,
                        RGWObjVersionTracker *objv_tracker, real_time set_mtime, map<string, bufferlist> *pattrs = NULL);
 int rgw_get_system_obj(RGWRados *rgwstore, RGWSysObjectCtx& obj_ctx, const rgw_pool& pool, const string& key, bufferlist& bl,

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -179,7 +179,7 @@ int RGWSI_Notify::init_watch()
       notify_oid = notify_oid_prefix;
     }
 
-    notify_objs[i] = rados_svc->handle(0).obj({control_pool, notify_oid});
+    notify_objs[i] = rados_svc->handle().obj({control_pool, notify_oid});
     auto& notify_obj = notify_objs[i];
 
     int r = notify_obj.open();
@@ -295,7 +295,7 @@ int RGWSI_Notify::unwatch(RGWSI_RADOS::Obj& obj, uint64_t watch_handle)
     ldout(cct, 0) << "ERROR: rados->unwatch2() returned r=" << r << dendl;
     return r;
   }
-  r = rados_svc->handle(0).watch_flush();
+  r = rados_svc->handle().watch_flush();
   if (r < 0) {
     ldout(cct, 0) << "ERROR: rados->watch_flush() returned r=" << r << dendl;
     return r;

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -44,7 +44,7 @@ static int init_ioctx(CephContext *cct, librados::Rados *rados, const rgw_pool& 
 
 int RGWSI_RADOS::do_start()
 {
-  auto handles = std::vector<librados::Rados>{static_cast<size_t>(cct->_conf->rgw_num_rados_handles)};
+  auto handles = std::vector<librados::Rados>{static_cast<size_t>(1)};
 
   for (auto& r : handles) {
     int ret = r.init_with_context(cct);

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -7,41 +7,6 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-static int init_ioctx(CephContext *cct, librados::Rados *rados, const rgw_pool& pool, librados::IoCtx& ioctx, bool create)
-{
-  int r = rados->ioctx_create(pool.name.c_str(), ioctx);
-  if (r == -ENOENT && create) {
-    r = rados->pool_create(pool.name.c_str());
-    if (r == -ERANGE) {
-      ldout(cct, 0)
-        << __func__
-        << " ERROR: librados::Rados::pool_create returned " << cpp_strerror(-r)
-        << " (this can be due to a pool or placement group misconfiguration, e.g."
-        << " pg_num < pgp_num or mon_max_pg_per_osd exceeded)"
-        << dendl;
-    }
-    if (r < 0 && r != -EEXIST) {
-      return r;
-    }
-
-    r = rados->ioctx_create(pool.name.c_str(), ioctx);
-    if (r < 0) {
-      return r;
-    }
-
-    r = ioctx.application_enable(pg_pool_t::APPLICATION_NAME_RGW, false);
-    if (r < 0 && r != -EOPNOTSUPP) {
-      return r;
-    }
-  } else if (r < 0) {
-    return r;
-  }
-  if (!pool.ns.empty()) {
-    ioctx.set_namespace(pool.ns);
-  }
-  return 0;
-}
-
 int RGWSI_RADOS::do_start()
 {
   int ret = rados.init_with_context(cct);
@@ -68,7 +33,7 @@ uint64_t RGWSI_RADOS::instance_id()
 int RGWSI_RADOS::open_pool_ctx(const rgw_pool& pool, librados::IoCtx& io_ctx)
 {
   constexpr bool create = true; // create the pool if it doesn't exist
-  return init_ioctx(cct, get_rados_handle(), pool, io_ctx, create);
+  return rgw_init_ioctx(get_rados_handle(), pool, io_ctx, create);
 }
 
 int RGWSI_RADOS::pool_iterate(librados::IoCtx& io_ctx,

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -44,63 +44,31 @@ static int init_ioctx(CephContext *cct, librados::Rados *rados, const rgw_pool& 
 
 int RGWSI_RADOS::do_start()
 {
-  auto handles = std::vector<librados::Rados>{static_cast<size_t>(1)};
-
-  for (auto& r : handles) {
-    int ret = r.init_with_context(cct);
-    if (ret < 0) {
-      return ret;
-    }
-    ret = r.connect();
-    if (ret < 0) {
-      return ret;
-    }
+  int ret = rados.init_with_context(cct);
+  if (ret < 0) {
+    return ret;
   }
-  std::swap(handles, rados);
+  ret = rados.connect();
+  if (ret < 0) {
+    return ret;
+  }
   return 0;
 }
 
-librados::Rados* RGWSI_RADOS::get_rados_handle(int rados_handle)
+librados::Rados* RGWSI_RADOS::get_rados_handle()
 {
-  if (rados.size() == 1) {
-    return &rados[0];
-  }
-
-  if (rados_handle >= 0) {
-    if (rados_handle >= (int)rados.size()) {
-      rados_handle = 0;
-    }
-    return &rados[rados_handle];
-  }
-
-  handle_lock.get_read();
-  pthread_t id = pthread_self();
-  std::map<pthread_t, int>:: iterator it = rados_map.find(id);
-
-  if (it != rados_map.end()) {
-    handle_lock.put_read();
-    return &rados[it->second];
-  }
-  handle_lock.put_read();
-  handle_lock.get_write();
-  const uint32_t handle = next_rados_handle;
-  rados_map[id] = handle;
-  if (++next_rados_handle == rados.size()) {
-    next_rados_handle = 0;
-  }
-  handle_lock.put_write();
-  return &rados[handle];
+  return &rados;
 }
 
 uint64_t RGWSI_RADOS::instance_id()
 {
-  return get_rados_handle(-1)->get_instance_id();
+  return get_rados_handle()->get_instance_id();
 }
 
-int RGWSI_RADOS::open_pool_ctx(const rgw_pool& pool, librados::IoCtx& io_ctx, int rados_handle)
+int RGWSI_RADOS::open_pool_ctx(const rgw_pool& pool, librados::IoCtx& io_ctx)
 {
   constexpr bool create = true; // create the pool if it doesn't exist
-  return init_ioctx(cct, get_rados_handle(rados_handle), pool, io_ctx, create);
+  return init_ioctx(cct, get_rados_handle(), pool, io_ctx, create);
 }
 
 int RGWSI_RADOS::pool_iterate(librados::IoCtx& io_ctx,
@@ -141,7 +109,7 @@ void RGWSI_RADOS::Obj::init(const rgw_raw_obj& obj)
 
 int RGWSI_RADOS::Obj::open()
 {
-  int r = rados_svc->open_pool_ctx(ref.obj.pool, ref.ioctx, rados_handle);
+  int r = rados_svc->open_pool_ctx(ref.obj.pool, ref.ioctx);
   if (r < 0) {
     return r;
   }
@@ -210,7 +178,7 @@ uint64_t RGWSI_RADOS::Obj::get_last_version()
 
 int RGWSI_RADOS::Pool::create()
 {
-  librados::Rados *rad = rados_svc->get_rados_handle(rados_handle);
+  librados::Rados *rad = rados_svc->get_rados_handle();
   int r = rad->pool_create(pool.name.c_str());
   if (r < 0) {
     ldout(rados_svc->cct, 0) << "WARNING: pool_create returned " << r << dendl;
@@ -235,7 +203,7 @@ int RGWSI_RADOS::Pool::create(const vector<rgw_pool>& pools, vector<int> *retcod
   vector<librados::PoolAsyncCompletion *> completions;
   vector<int> rets;
 
-  librados::Rados *rad = rados_svc->get_rados_handle(rados_handle);
+  librados::Rados *rad = rados_svc->get_rados_handle();
   for (auto iter = pools.begin(); iter != pools.end(); ++iter) {
     librados::PoolAsyncCompletion *c = librados::Rados::pool_async_create_completion();
     completions.push_back(c);
@@ -311,7 +279,7 @@ int RGWSI_RADOS::Pool::create(const vector<rgw_pool>& pools, vector<int> *retcod
 
 int RGWSI_RADOS::Pool::lookup()
 {
-  librados::Rados *rad = rados_svc->get_rados_handle(rados_handle);
+  librados::Rados *rad = rados_svc->get_rados_handle();
   int ret = rad->pool_lookup(pool.name.c_str());
   if (ret < 0) {
     return ret;
@@ -326,7 +294,7 @@ int RGWSI_RADOS::Pool::List::init(const string& marker, RGWAccessListFilter *fil
     return -EINVAL;
   }
 
-  int r = pool.rados_svc->open_pool_ctx(pool.pool, ctx.ioctx, pool.rados_handle);
+  int r = pool.rados_svc->open_pool_ctx(pool.pool, ctx.ioctx);
   if (r < 0) {
     return r;
   }
@@ -370,7 +338,6 @@ int RGWSI_RADOS::Pool::List::get_next(int max,
 
 int RGWSI_RADOS::Handle::watch_flush()
 {
-  librados::Rados *rad = rados_svc->get_rados_handle(rados_handle);
+  librados::Rados *rad = rados_svc->get_rados_handle();
   return rad->watch_flush();
 }
-

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -29,15 +29,12 @@ struct rgw_rados_ref {
 
 class RGWSI_RADOS : public RGWServiceInstance
 {
-  std::vector<librados::Rados> rados;
-  uint32_t next_rados_handle{0};
-  RWLock handle_lock;
-  std::map<pthread_t, int> rados_map;
+  librados::Rados rados;
 
   int do_start() override;
 
-  librados::Rados* get_rados_handle(int rados_handle);
-  int open_pool_ctx(const rgw_pool& pool, librados::IoCtx& io_ctx, int rados_handle);
+  librados::Rados* get_rados_handle();
+  int open_pool_ctx(const rgw_pool& pool, librados::IoCtx& io_ctx);
   int pool_iterate(librados::IoCtx& ioctx,
                    librados::NObjectIterator& iter,
                    uint32_t num, vector<rgw_bucket_dir_entry>& objs,
@@ -45,8 +42,7 @@ class RGWSI_RADOS : public RGWServiceInstance
                    bool *is_truncated);
 
 public:
-  RGWSI_RADOS(CephContext *cct): RGWServiceInstance(cct),
-                                 handle_lock("rados_handle_lock") {}
+  RGWSI_RADOS(CephContext *cct) : RGWServiceInstance(cct) {}
 
   void init() {}
 
@@ -56,15 +52,15 @@ public:
 
   class Obj {
     friend class RGWSI_RADOS;
-    friend class Handle;
+    friend Handle;
 
     RGWSI_RADOS *rados_svc{nullptr};
-    int rados_handle{-1};
     rgw_rados_ref ref;
 
     void init(const rgw_raw_obj& obj);
 
-    Obj(RGWSI_RADOS *_rados_svc, const rgw_raw_obj& _obj, int _rados_handle) : rados_svc(_rados_svc), rados_handle(_rados_handle) {
+    Obj(RGWSI_RADOS *_rados_svc, const rgw_raw_obj& _obj)
+      : rados_svc(_rados_svc) {
       init(_obj);
     }
 
@@ -98,17 +94,14 @@ public:
 
   class Pool {
     friend class RGWSI_RADOS;
-    friend class Handle;
+    friend Handle;
 
     RGWSI_RADOS *rados_svc{nullptr};
-    int rados_handle{-1};
     rgw_pool pool;
 
     Pool(RGWSI_RADOS *_rados_svc,
-         const rgw_pool& _pool,
-         int _rados_handle) : rados_svc(_rados_svc),
-                              rados_handle(_rados_handle),
-                              pool(_pool) {}
+         const rgw_pool& _pool) : rados_svc(_rados_svc),
+                                  pool(_pool) {}
 
     Pool(RGWSI_RADOS *_rados_svc) : rados_svc(_rados_svc) {}
   public:
@@ -140,35 +133,33 @@ public:
       return List(*this);
     }
 
-    friend class List;
+    friend List;
   };
 
   class Handle {
     friend class RGWSI_RADOS;
 
     RGWSI_RADOS *rados_svc{nullptr};
-    int rados_handle{-1};
 
-    Handle(RGWSI_RADOS *_rados_svc, int _rados_handle) : rados_svc(_rados_svc),
-                                                         rados_handle(_rados_handle) {}
+    Handle(RGWSI_RADOS *_rados_svc) : rados_svc(_rados_svc) {}
   public:
     Obj obj(const rgw_raw_obj& o) {
-      return Obj(rados_svc, o, rados_handle);
+      return Obj(rados_svc, o);
     }
 
     Pool pool(const rgw_pool& p) {
-      return Pool(rados_svc, p, rados_handle);
+      return Pool(rados_svc, p);
     }
 
     int watch_flush();
   };
 
-  Handle handle(int rados_handle) {
-    return Handle(this, rados_handle);
+  Handle handle() {
+    return Handle(this);
   }
 
   Obj obj(const rgw_raw_obj& o) {
-    return Obj(this, o, -1);
+    return Obj(this, o);
   }
 
   Pool pool() {
@@ -176,12 +167,12 @@ public:
   }
 
   Pool pool(const rgw_pool& p) {
-    return Pool(this, p, -1);
+    return Pool(this, p);
   }
 
-  friend class Obj;
-  friend class Pool;
-  friend class Pool::List;
+  friend Obj;
+  friend Pool;
+  friend Pool::List;
 };
 
 #endif


### PR DESCRIPTION
Backport of #27102 and #27375.  The rados handles removal got rid of conflicts with rgw_init_ioctx() in svc_rados.cc ... maybe there is an easier way?