### PR TITLE
filestore: assure sufficient leaves in pre-split

### DIFF
--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -703,10 +703,11 @@ int HashIndex::pre_split_folder(uint32_t pg_num, uint64_t expected_num_objs)
   const uint32_t subs = (1 << split_bits);
   // Calculate how many levels we create starting from here
   int level  = 0;
-  leavies /= subs;
-  while (leavies > 1) {
+  int level_limit = MAX_HASH_LEVEL - dump_num - 1;
+  uint64_t actual_leaves = subs;
+  while (actual_leaves < leavies && level < level_limit) {
     ++level;
-    leavies = leavies >> 4;
+    actual_leaves <<= 4;
   }
   for (uint32_t i = 0; i < subs; ++i) {
     ceph_assert(split_bits <= 4); // otherwise BAD_SHIFT


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/39390
Signed-off-by: Jeegn Chen <jeegnchen@tencent.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

