### PR TITLE
crimson: pass `Connection*` to Dispatch::ms_dispatch()

### DIFF
--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -49,7 +49,7 @@ seastar::future<> Client::stop()
   });
 }
 
-seastar::future<> Client::ms_dispatch(ceph::net::ConnectionRef conn,
+seastar::future<> Client::ms_dispatch(ceph::net::Connection* conn,
                                       MessageRef m)
 {
   switch(m->get_type()) {
@@ -90,7 +90,7 @@ seastar::future<> Client::reconnect()
   });
 }
 
-seastar::future<> Client::handle_mgr_map(ceph::net::ConnectionRef,
+seastar::future<> Client::handle_mgr_map(ceph::net::Connection*,
                                          Ref<MMgrMap> m)
 {
   mgrmap = m->get_map();
@@ -104,7 +104,7 @@ seastar::future<> Client::handle_mgr_map(ceph::net::ConnectionRef,
   }
 }
 
-seastar::future<> Client::handle_mgr_conf(ceph::net::ConnectionRef conn,
+seastar::future<> Client::handle_mgr_conf(ceph::net::Connection* conn,
                                           Ref<MMgrConfigure> m)
 {
   logger().info("{} {}", __func__, *m);

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -37,12 +37,12 @@ public:
   seastar::future<> start();
   seastar::future<> stop();
 private:
-  seastar::future<> ms_dispatch(ceph::net::ConnectionRef conn,
+  seastar::future<> ms_dispatch(ceph::net::Connection* conn,
 				Ref<Message> m) override;
   seastar::future<> ms_handle_reset(ceph::net::ConnectionRef conn) override;
-  seastar::future<> handle_mgr_map(ceph::net::ConnectionRef conn,
+  seastar::future<> handle_mgr_map(ceph::net::Connection* conn,
 				   Ref<MMgrMap> m);
-  seastar::future<> handle_mgr_conf(ceph::net::ConnectionRef conn,
+  seastar::future<> handle_mgr_conf(ceph::net::Connection* conn,
 				    Ref<MMgrConfigure> m);
   seastar::future<> reconnect();
   void report();

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -433,7 +433,7 @@ bool Client::is_hunting() const {
 }
 
 seastar::future<>
-Client::ms_dispatch(ceph::net::ConnectionRef conn, MessageRef m)
+Client::ms_dispatch(ceph::net::Connection* conn, MessageRef m)
 {
   // we only care about these message types
   switch (m->get_type()) {
@@ -689,7 +689,7 @@ int Client::handle_auth_bad_method(ceph::net::ConnectionRef conn,
   }
 }
 
-seastar::future<> Client::handle_monmap(ceph::net::ConnectionRef conn,
+seastar::future<> Client::handle_monmap(ceph::net::Connection* conn,
                                         Ref<MMonMap> m)
 {
   monmap.decode(m->monmapbl);
@@ -707,7 +707,7 @@ seastar::future<> Client::handle_monmap(ceph::net::ConnectionRef conn,
   }
 }
 
-seastar::future<> Client::handle_auth_reply(ceph::net::ConnectionRef conn,
+seastar::future<> Client::handle_auth_reply(ceph::net::Connection* conn,
                                                Ref<MAuthReply> m)
 {
   logger().info("mon {} => {} returns {}: {}",

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -143,14 +143,14 @@ private:
 private:
   void tick();
 
-  seastar::future<> ms_dispatch(ceph::net::ConnectionRef conn,
+  seastar::future<> ms_dispatch(ceph::net::Connection* conn,
 				MessageRef m) override;
   seastar::future<> ms_handle_reset(ceph::net::ConnectionRef conn) override;
   AuthAuthorizer* ms_get_authorizer(peer_type_t peer) const override;
 
-  seastar::future<> handle_monmap(ceph::net::ConnectionRef conn,
+  seastar::future<> handle_monmap(ceph::net::Connection* conn,
 				  Ref<MMonMap> m);
-  seastar::future<> handle_auth_reply(ceph::net::ConnectionRef conn,
+  seastar::future<> handle_auth_reply(ceph::net::Connection* conn,
 				      Ref<MAuthReply> m);
   seastar::future<> handle_subscribe_ack(Ref<MMonSubscribeAck> m);
   seastar::future<> handle_get_version_reply(Ref<MMonGetVersionReply> m);

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -27,7 +27,7 @@ class Dispatcher {
  public:
   virtual ~Dispatcher() {}
 
-  virtual seastar::future<> ms_dispatch(ConnectionRef conn, MessageRef m) {
+  virtual seastar::future<> ms_dispatch(Connection* conn, MessageRef m) {
     return seastar::make_ready_future<>();
   }
 

--- a/src/crimson/net/ProtocolV1.cc
+++ b/src/crimson/net/ProtocolV1.cc
@@ -733,10 +733,7 @@ seastar::future<> ProtocolV1::read_message()
       seastar::with_gate(pending_dispatch, [this, msg = std::move(msg_ref)] {
           logger().debug("{} <= {}@{} === {}", messenger,
                 msg->get_source(), conn.peer_addr, *msg);
-          return dispatcher.ms_dispatch(
-              seastar::static_pointer_cast<SocketConnection>(
-                conn.shared_from_this()),
-              std::move(msg))
+          return dispatcher.ms_dispatch(&conn, std::move(msg))
             .handle_exception([this] (std::exception_ptr eptr) {
               logger().error("{} ms_dispatch caught exception: {}", conn, eptr);
               ceph_assert(false);

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1466,11 +1466,8 @@ seastar::future<> ProtocolV2::read_message(utime_t throttle_stamp)
     // TODO: change MessageRef with seastar::shared_ptr
     auto msg_ref = MessageRef{message, false};
     seastar::with_gate(pending_dispatch, [this, msg = std::move(msg_ref)] {
-      return dispatcher.ms_dispatch(
-          seastar::static_pointer_cast<SocketConnection>(
-            conn.shared_from_this()),
-          std::move(msg))
-      .handle_exception([this] (std::exception_ptr eptr) {
+      return dispatcher.ms_dispatch(&conn, std::move(msg))
+	.handle_exception([this] (std::exception_ptr eptr) {
         logger().error("{} ms_dispatch caught exception: {}", conn, eptr);
         ceph_assert(false);
       });

--- a/src/crimson/osd/chained_dispatchers.cc
+++ b/src/crimson/osd/chained_dispatchers.cc
@@ -3,7 +3,7 @@
 
 
 seastar::future<>
-ChainedDispatchers::ms_dispatch(ceph::net::ConnectionRef conn,
+ChainedDispatchers::ms_dispatch(ceph::net::Connection* conn,
                                 MessageRef m) {
   return seastar::do_for_each(dispatchers, [conn, m](Dispatcher* dispatcher) {
     return dispatcher->ms_dispatch(conn, m);

--- a/src/crimson/osd/chained_dispatchers.h
+++ b/src/crimson/osd/chained_dispatchers.h
@@ -22,7 +22,7 @@ public:
   void push_back(Dispatcher* dispatcher) {
     dispatchers.push_back(dispatcher);
   }
-  seastar::future<> ms_dispatch(ceph::net::ConnectionRef conn, MessageRef m) override;
+  seastar::future<> ms_dispatch(ceph::net::Connection* conn, MessageRef m) override;
   seastar::future<> ms_handle_accept(ceph::net::ConnectionRef conn) override;
   seastar::future<> ms_handle_connect(ceph::net::ConnectionRef conn) override;
   seastar::future<> ms_handle_reset(ceph::net::ConnectionRef conn) override;

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -201,7 +201,7 @@ seastar::future<> Heartbeat::remove_peer(osd_id_t peer)
     });
 }
 
-seastar::future<> Heartbeat::ms_dispatch(ceph::net::ConnectionRef conn,
+seastar::future<> Heartbeat::ms_dispatch(ceph::net::Connection* conn,
                                          MessageRef m)
 {
   switch (m->get_type()) {
@@ -229,7 +229,7 @@ seastar::future<> Heartbeat::ms_handle_reset(ceph::net::ConnectionRef conn)
   });
 }
 
-seastar::future<> Heartbeat::handle_osd_ping(ceph::net::ConnectionRef conn,
+seastar::future<> Heartbeat::handle_osd_ping(ceph::net::Connection* conn,
                                              Ref<MOSDPing> m)
 {
   switch (m->op) {
@@ -244,7 +244,7 @@ seastar::future<> Heartbeat::handle_osd_ping(ceph::net::ConnectionRef conn,
   }
 }
 
-seastar::future<> Heartbeat::handle_ping(ceph::net::ConnectionRef conn,
+seastar::future<> Heartbeat::handle_ping(ceph::net::Connection* conn,
                                          Ref<MOSDPing> m)
 {
   auto min_message = static_cast<uint32_t>(
@@ -258,7 +258,7 @@ seastar::future<> Heartbeat::handle_ping(ceph::net::ConnectionRef conn,
   return conn->send(reply);
 }
 
-seastar::future<> Heartbeat::handle_reply(ceph::net::ConnectionRef conn,
+seastar::future<> Heartbeat::handle_reply(ceph::net::Connection* conn,
                                           Ref<MOSDPing> m)
 {
   const osd_id_t from = m->get_source().num();

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -42,17 +42,17 @@ public:
   const entity_addrvec_t& get_back_addrs() const;
 
   // Dispatcher methods
-  seastar::future<> ms_dispatch(ceph::net::ConnectionRef conn,
+  seastar::future<> ms_dispatch(ceph::net::Connection* conn,
 				MessageRef m) override;
   seastar::future<> ms_handle_reset(ceph::net::ConnectionRef conn) override;
   AuthAuthorizer* ms_get_authorizer(peer_type_t peer) const override;
 
 private:
-  seastar::future<> handle_osd_ping(ceph::net::ConnectionRef conn,
+  seastar::future<> handle_osd_ping(ceph::net::Connection* conn,
 				    Ref<MOSDPing> m);
-  seastar::future<> handle_ping(ceph::net::ConnectionRef conn,
+  seastar::future<> handle_ping(ceph::net::Connection* conn,
 				Ref<MOSDPing> m);
-  seastar::future<> handle_reply(ceph::net::ConnectionRef conn,
+  seastar::future<> handle_reply(ceph::net::Connection* conn,
 				 Ref<MOSDPing> m);
   seastar::future<> handle_you_died();
 

--- a/src/test/crimson/perf_crimson_msgr.cc
+++ b/src/test/crimson/perf_crimson_msgr.cc
@@ -128,7 +128,7 @@ static seastar::future<> run(
       seastar::future<> stop() {
         return seastar::make_ready_future<>();
       }
-      seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
+      seastar::future<> ms_dispatch(ceph::net::Connection* c,
                                     MessageRef m) override {
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
 
@@ -224,7 +224,7 @@ static seastar::future<> run(
         active_session->connected_time = mono_clock::now();
         return seastar::now();
       }
-      seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
+      seastar::future<> ms_dispatch(ceph::net::Connection* c,
                                     MessageRef m) override {
         // server replies with MOSDOp to generate server-side write workload
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -42,7 +42,7 @@ struct Server {
   struct ServerDispatcher : ceph::net::Dispatcher {
     unsigned count = 0;
     seastar::condition_variable on_reply;
-    seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
+    seastar::future<> ms_dispatch(ceph::net::Connection* c,
                                   MessageRef m) override {
       std::cout << "server got ping " << *m << std::endl;
       // reply with a pong
@@ -79,7 +79,7 @@ struct Client {
   struct ClientDispatcher : ceph::net::Dispatcher {
     unsigned count = 0;
     seastar::condition_variable on_reply;
-    seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
+    seastar::future<> ms_dispatch(ceph::net::Connection* c,
                                   MessageRef m) override {
       std::cout << "client got pong " << *m << std::endl;
       ++count;


### PR DESCRIPTION
currently, we use a `with_gate()` in `ProtocolV2::read_message()` for
ensuring that `this` (or `Connection` holding this protocol instance)
will outlive the continuation of `dispatcher.ms_dispatch()` which
references `this->dispatcher`. but we also pass a strong reference of
connection to dispatcher. in short, we have *two* safeguards for the
same purpose.

in this change, one of these safeguards is removed -- to pass the raw
pointer of `Connection` to `Dispatch::ms_dispatch()`. the reason why
the `with_gate()` is kept is that, if we have removed `with_gate()` in
Protocol, we need to

1. let `Dispatcher::ms_dispatch()` return `void`, as it should not block
any succeeding calls.
2. add a `with_gate()` in `Dispatcher::ms_dispatch()` to ensure that
`this` is alive during the lifecycle of the continuation(s) in
`Dispatcher::ms_dispatch()`.

Signed-off-by: Yingxin Cheng <yingxincheng@gmail.com>
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

