### PR TITLE
mgr/telemetry: exclude hostname field in crash reports

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -70,8 +70,8 @@ class Module(MgrModule):
         {
             'name': 'interval',
             'type': 'int',
-            'default': 72,
-            'min': 24
+            'default': 24,
+            'min': 8
         }
     ]
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -180,7 +180,9 @@ class Module(MgrModule):
             errno, crashinfo, err = self.remote('crash', 'do_info', cmd, '')
             if errno:
                 continue
-            crashlist.append(json.loads(crashinfo))
+            c = json.loads(crashinfo)
+            del c['utsname_hostname']
+            crashlist.append(c)
         return crashlist
 
     def compile_report(self):


### PR DESCRIPTION
On some systems the hostname is a fully-qualified domain name and
(even when not a fqdn) may inadvertantly allow the cluster to be
identified.

Signed-off-by: Sage Weil <sage@redhat.com>