### PR TITLE
test/librbd: drop 'ceph_test_librbd_api' target

### DIFF
--- a/qa/workunits/rbd/test_librbd_api.sh
+++ b/qa/workunits/rbd/test_librbd_api.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -e
-
-ceph_test_librbd_api
-exit 0

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -148,19 +148,6 @@ target_link_libraries(ceph_test_librbd
   radostest)
 target_compile_definitions(ceph_test_librbd PRIVATE "TEST_LIBRBD_INTERNALS")
 
-add_executable(ceph_test_librbd_api
-  test_support.cc
-  test_librbd.cc
-  test_main.cc
-  $<TARGET_OBJECTS:common_texttable_obj>)
-target_link_libraries(ceph_test_librbd_api
-  ceph-common
-  radostest
-  radostest-cxx
-  librbd
-  librados
-  ${UNITTEST_LIBS})
-
 add_executable(ceph_test_librbd_fsx
   fsx.cc
   $<TARGET_OBJECTS:common_texttable_obj>
@@ -185,5 +172,4 @@ install(TARGETS
 
 install(TARGETS
   ceph_test_librbd
-  ceph_test_librbd_api
   DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This was used for API backwards compatibility testing, but now that
the C++ API will not remain stable, it serves no purpose.

Fixes: http://tracker.ceph.com/issues/39072
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

