### PR TITLE
 rgw: cls_bucket_list_unordered lists a single shard

### DIFF
--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -422,6 +422,13 @@ public:
   start_obj(_start_obj), filter_prefix(_filter_prefix), num_entries(_num_entries), list_versions(_list_versions), result(list_results) {}
 };
 
+void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
+                            const cls_rgw_obj_key& start_obj,
+                            const std::string& filter_prefix,
+                            uint32_t num_entries,
+                            bool list_versions,
+                            rgw_cls_list_ret* result);
+
 class CLSRGWIssueBILogList : public CLSRGWConcurrentIO {
   map<int, cls_rgw_bi_log_list_ret>& result;
   BucketIndexShardsManager& marker_mgr;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9242,19 +9242,16 @@ int RGWRados::cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
   while (count <= num_entries &&
 	 ((shard_id >= 0 && current_shard == uint32_t(shard_id)) ||
 	  current_shard < num_shards)) {
-    // key   - oid (for different shards if there is any)
-    // value - list result for the corresponding oid (shard), it is filled by
-    //         the AIO callback
-    map<int, struct rgw_cls_list_ret> list_results;
-    r = CLSRGWIssueBucketList(index_ctx, marker, prefix, num_entries,
-			      list_versions, oids, list_results,
-			      cct->_conf->rgw_bucket_index_max_aio)();
+    const std::string& oid = oids[current_shard];
+    rgw_cls_list_ret result;
+
+    librados::ObjectReadOperation op;
+    cls_rgw_bucket_list_op(op, marker, prefix, num_entries,
+                           list_versions, &result);
+    r = index_ctx.operate(oid, &op, nullptr);
     if (r < 0)
       return r;
 
-    const std::string& oid = oids[current_shard];
-    ceph_assert(list_results.find(current_shard) != list_results.end());
-    auto& result = list_results[current_shard];
     for (auto& entry : result.dir.m) {
       rgw_bucket_dir_entry& dirent = entry.second;
 


### PR DESCRIPTION
`RGWRados::cls_bucket_list_unordered()` loops over bucket index shards, but each loop uses `CLSRGWIssueBucketList` to send a `[call rgw.bucket_list]` osd op to every shard of the bucket index. this change exposes a new `cls_rgw_bucket_list()` in cls_rgw_client.h, and `RGWRados::cls_bucket_list_unordered()` uses that to list a single shard object by oid


before/after logs of an unordered list_bucket request from s3tests_boto3.functional.test_s3.test_bucket_list_unordered with rgw_override_bucket_index_max_shards=8:

- [unordered-8-shard-bucket-list-before.log](https://gist.github.com/cbodley/7783ebc0ba850c1fc679edc19d495e38)
- [unordered-8-shard-bucket-list-after.log](https://gist.github.com/cbodley/fd472e22180f331c3101f6864387dfee)

the difference is clear after counting the number of `[call rgw.bucket_list]` osd ops:
> $ grep 'call rgw.bucket_list' unordered-8-shard-bucket-list-before.log | wc -l                                                        
64
$ grep 'call rgw.bucket_list' unordered-8-shard-bucket-list-after.log | wc -l                                                        
8

Fixes: http://tracker.ceph.com/issues/39393