### PR TITLE
osd: fast_info need update when pglog rewind

### DIFF
--- a/qa/standalone/osd/osd-peering.sh
+++ b/qa/standalone/osd/osd-peering.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7155" # git grep '\<7155\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON"
+
+     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        $func $dir || return 1
+    done
+}
+
+ function TEST_fast_info() {
+    local dir=$1
+
+    setup $dir || return 1
+    run_mon $dir a --osd_pool_default_size=3 || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+
+    ceph osd primary-affinity 1 10	# let osd.1 be primary
+    ceph osd primary-affinity 0 0
+
+    wait_for_clean || return 1
+
+    ceph osd pool create rep 1 || return 1
+    ceph osd pool set rep min_size 1 || return 1
+    ceph osd set norecover || return 1
+
+    rados -p rep put test /etc/hosts || return 1
+    ceph daemon osd.1 config set objectstore_blackhole true || return 1
+
+    timeout 10 rados -p rep put test /etc/hosts || return 1
+
+    # let osd.0 & osd.1 shutdown 
+    kill_daemons $dir STOP osd.0 || return 1
+    kill_daemons $dir STOP osd.1 || return 1
+    kill_daemons $dir KILL osd.0 || return 1
+    kill_daemons $dir KILL osd.1 || return 1
+
+    activate_osd $dir 1 || return 1
+    sleep 10 # wait for pgs to go active
+
+    activate_osd $dir 0 || return 1
+    sleep 10 # wait for pgs to go active
+
+    # let osd.0 & osd.1 shutdown 
+    kill_daemons $dir STOP osd.0 || return 1
+    kill_daemons $dir STOP osd.1 || return 1
+    kill_daemons $dir KILL osd.0 || return 1
+    kill_daemons $dir KILL osd.1 || return 1
+
+    
+    activate_osd $dir 0 || return 1
+    sleep 10 # wait for pgs to go active
+    activate_osd $dir 1 --osd-debug-im-sure-no-pg-ever-split || return 1
+    sleep 10 # wait for pgs to go active
+
+    ceph osd unset norecover || return 1
+    wait_for_clean || return 1
+}
+
+
+
+ main osd-peering "$@"
+
+ # Local Variables:
+# compile-command: "cd ../.. ; make -j4 && test/osd/pg-split-merge.sh"
+# End:

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -755,6 +755,7 @@ OPTION(osd_verify_sparse_read_holes, OPT_BOOL)  // read fiemap-reported holes an
 OPTION(osd_backoff_on_unfound, OPT_BOOL)   // object unfound
 OPTION(osd_backoff_on_degraded, OPT_BOOL) // [mainly for debug?] object unreadable/writeable
 OPTION(osd_backoff_on_peering, OPT_BOOL)  // [debug] pg peering
+OPTION(osd_debug_im_sure_no_pg_ever_split, OPT_BOOL)
 OPTION(osd_debug_crash_on_ignored_backoff, OPT_BOOL) // crash osd if client ignores a backoff; useful for debugging
 OPTION(osd_debug_inject_dispatch_delay_probability, OPT_DOUBLE)
 OPTION(osd_debug_inject_dispatch_delay_duration, OPT_DOUBLE)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3686,6 +3686,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description("Turn up debug levels during shutdown"),
 
+    Option("osd_debug_im_sure_no_pg_ever_split", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("debug on the circumstance pg never split"),
+
     Option("osd_debug_crash_on_ignored_backoff", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description(""),

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -2090,6 +2090,8 @@ void PeeringState::activate(
 
   // init complete pointer
   if (missing.num_missing() == 0) {
+    if (cct->_conf->osd_debug_im_sure_no_pg_ever_split)
+      ceph_assert(info.last_complete == info.last_update);
     psdout(10) << "activate - no missing, moving last_complete " << info.last_complete
 	     << " -> " << info.last_update << dendl;
     info.last_complete = info.last_update;


### PR DESCRIPTION
When the pglog need rewind, the info.last_update will need to change to
older value, current impl of PG::_prepare_write_info() will keep
fast_info.last_update remain newer value, if osd crash after info be
persisted, next reboot fast_info will cover the info with inconsistent
last_update!

Fixes: https://tracker.ceph.com/issues/39398

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

