### PR TITLE
luminous: osd: Avoid OSD::consume_map() race with the sub_read op

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -310,6 +310,7 @@ protected:
    * unlock() when done with the current pointer (_most common_).
    */  
   mutable Mutex _lock;
+  mutable Mutex _peering_lock;
   std::atomic_uint ref{0};
 
 #ifdef PG_DEBUG_REFS
@@ -335,6 +336,10 @@ public:
 
   bool is_locked() const {
     return _lock.is_locked();
+  }
+  void peering_lock() const;
+  void peering_unlock() const {
+    _peering_lock.Unlock();
   }
 
 #ifdef PG_DEBUG_REFS


### PR DESCRIPTION
1. When osd is doing backfill, a single read op may carry multiple objects. At this time, handle_sub_read may take a long time (it is more obvious when the disk is loaded), and pg.lock will be held until the read op is completed.
2. osd'epoch will be updated frequently during backfill, OSD::consume_map() will scan all PGS, then it will compete with read op and cause pg's epoch to delay advance,l eading to pg peering consumption for a long time.

Signed-off-by: ningtao <ningtao@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

