### PR TITLE
nautilus: mgr/telemetry: add report_timestamp to sent reports

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -186,7 +186,8 @@ class Module(MgrModule):
     def compile_report(self):
         report = {
             'leaderboard': False,
-            'report_version': 1
+            'report_version': 1,
+            'report_timestamp': datetime.utcnow().isoformat()
         }
 
         if self.leaderboard:


### PR DESCRIPTION
Received time may differ from report time, and correlating
to local cluster state events might be useful.

Signed-off-by: Dan Mick <dan.mick@redhat.com>
(cherry picked from commit a42c8e327c9f7d53b8c13cf51837c294bc4c643d)