### PR TITLE
rbd_replay: call the member decode() explicitly

### DIFF
--- a/src/rbd_replay/ActionTypes.cc
+++ b/src/rbd_replay/ActionTypes.cc
@@ -276,15 +276,15 @@ void ActionEntry::encode(bufferlist &bl) const {
 
 void ActionEntry::decode(bufferlist::const_iterator &it) {
   DECODE_START(1, it);
-  decode(struct_v, it);
+  decode_versioned(struct_v, it);
   DECODE_FINISH(it);
 }
 
 void ActionEntry::decode_unversioned(bufferlist::const_iterator &it) {
-  decode(0, it);
+  decode_versioned(0, it);
 }
 
-void ActionEntry::decode(__u8 version, bufferlist::const_iterator &it) {
+void ActionEntry::decode_versioned(__u8 version, bufferlist::const_iterator &it) {
   using ceph::decode;
   uint8_t action_type;
   decode(action_type, it);

--- a/src/rbd_replay/ActionTypes.h
+++ b/src/rbd_replay/ActionTypes.h
@@ -325,7 +325,7 @@ public:
   static void generate_test_instances(std::list<ActionEntry *> &o);
 
 private:
-  void decode(__u8 version, bufferlist::const_iterator &it);
+  void decode_versioned(__u8 version, bufferlist::const_iterator &it);
 };
 
 WRITE_CLASS_ENCODER(ActionEntry);


### PR DESCRIPTION
it's found that at least on GCC-9.0.1, the one defined using
WRITE_RAW_ENCODER is called instead. so call the member function
explicitly.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

