### PR TITLE
[RFC] os/BlueStore: avoid double caching bluestore onodes in rocksdb block_cache

### DIFF
--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -38,11 +38,11 @@ namespace PriorityCache
     // shrink it to 1/256 of the rounded up cache size
     chunk /= 256;
 
-    // bound the chunk size to be between 4MB and 32MB
+    // bound the chunk size to be between 4MB and 64MB
     chunk = (chunk > 4ul*1024*1024) ? chunk : 4ul*1024*1024;
-    chunk = (chunk < 16ul*1024*1024) ? chunk : 16ul*1024*1024;
+    chunk = (chunk < 64ul*1024*1024) ? chunk : 64ul*1024*1024;
 
-    /* Add 16 chunks of headroom and round up to the near chunk.  Note that
+    /* FIXME: Hardcoded to force get_chunk to never drop below 64MB. 
      * if RocksDB is used, it's a good idea to have N MB of headroom where
      * N is the target_file_size_base value.  RocksDB will read SST files
      * into the block cache during compaction which potentially can force out
@@ -51,7 +51,7 @@ namespace PriorityCache
      * compaction reads allows the kv cache grow even during extremely heavy
      * compaction workloads.
      */
-    uint64_t val = usage + (16 * chunk);
+    uint64_t val = usage + 64*1024*1024;
     uint64_t r = (val) % chunk;
     if (r > 0)
       val = val + chunk - r;

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4478,14 +4478,19 @@ std::vector<Option> get_global_options() {
     .add_see_also("bluestore_cache_size"),
 
     Option("bluestore_cache_meta_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
-    .set_default(.4)
+    .set_default(.45)
     .add_see_also("bluestore_cache_size")
     .set_description("Ratio of bluestore cache to devote to metadata"),
 
     Option("bluestore_cache_kv_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
-    .set_default(.4)
+    .set_default(.45)
     .add_see_also("bluestore_cache_size")
     .set_description("Ratio of bluestore cache to devote to kv database (rocksdb)"),
+
+    Option("bluestore_cache_kv_onode_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(.04)
+    .add_see_also("bluestore_cache_size")
+    .set_description("Ratio of bluestore cache to devote to kv onode column family (rocksdb)"),
 
     Option("bluestore_cache_autotune", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
@@ -4530,11 +4535,11 @@ std::vector<Option> get_global_options() {
     .set_description("Rocksdb options"),
 
     Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("M= P= L=")
+    .set_default("O=")
     .set_description("List of whitespace-separate key/value pairs where key is CF name and value is CF options"),
 
     Option("bluestore_fsck_on_mount", Option::TYPE_BOOL, Option::LEVEL_DEV)

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -31,8 +31,12 @@ public:
   struct ColumnFamily {
     string name;      //< name of this individual column family
     string option;    //< configure option string for this CF
+    bool share_cache = true; //< should this column family share the default block_cache?
+
     ColumnFamily(const string &name, const string &option)
       : name(name), option(option) {}
+    ColumnFamily(const string &name, const string &option, bool share_cache)
+      : name(name), option(option), share_cache(share_cache) {}
   };
 
   class TransactionImpl {
@@ -357,9 +361,19 @@ public:
     return -EOPNOTSUPP;
   }
 
+  virtual int64_t get_cache_usage(std::string prefix) const {
+    return -EOPNOTSUPP;
+  }
+
   virtual std::shared_ptr<PriorityCache::PriCache> get_priority_cache() const {
     return nullptr;
   }
+
+  virtual std::shared_ptr<PriorityCache::PriCache> get_priority_cache(std::string prefix) const {
+    return nullptr;
+  }
+
+
 
   virtual ~KeyValueDB() {}
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -79,6 +79,8 @@ class RocksDBStore : public KeyValueDB {
   rocksdb::Env *env;
   std::shared_ptr<rocksdb::Statistics> dbstats;
   rocksdb::BlockBasedTableOptions bbt_opts;
+  std::unordered_map<string, rocksdb::BlockBasedTableOptions> cf_bbt_opts;
+
   string options_str;
 
   uint64_t cache_size = 0;
@@ -93,6 +95,7 @@ class RocksDBStore : public KeyValueDB {
   int do_open(ostream &out, bool create_if_missing, bool open_readonly,
 	      const vector<ColumnFamily>* cfs = nullptr);
   int load_rocksdb_options(bool create_if_missing, rocksdb::Options& opt);
+  int init_block_cache(uint64_t size, rocksdb::BlockBasedTableOptions& bbto);
 
   // manage async compactions
   Mutex compact_queue_lock;
@@ -487,6 +490,14 @@ err:
     return static_cast<int64_t>(bbt_opts.block_cache->GetUsage());
   }
 
+  virtual int64_t get_cache_usage(string prefix) const override {
+    auto it = cf_bbt_opts.find(prefix);
+    if (it != cf_bbt_opts.end()) {
+      return static_cast<int64_t>(it->second.block_cache->GetUsage());
+    }
+    return -EINVAL;
+  }
+
   int set_cache_size(uint64_t s) override {
     cache_size = s;
     set_cache_flag = true;
@@ -496,11 +507,22 @@ err:
   int set_cache_capacity(int64_t capacity);
   int64_t get_cache_capacity();
 
-  virtual std::shared_ptr<PriorityCache::PriCache> get_priority_cache() 
-      const override {
+  virtual std::shared_ptr<PriorityCache::PriCache>
+      get_priority_cache() const override {
     return dynamic_pointer_cast<PriorityCache::PriCache>(
         bbt_opts.block_cache);
   }
+
+  virtual std::shared_ptr<PriorityCache::PriCache>
+      get_priority_cache(string prefix) const override {
+    auto it = cf_bbt_opts.find(prefix);
+    if (it != cf_bbt_opts.end()) {
+      return dynamic_pointer_cast<PriorityCache::PriCache>(
+          it->second.block_cache);
+    }
+    return nullptr;
+  }
+  
 
   WholeSpaceIterator get_wholespace_iterator() override;
 };

--- a/src/kv/rocksdb_cache/BinnedLRUCache.cc
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.cc
@@ -101,9 +101,10 @@ void BinnedLRUHandleTable::Resize() {
   length_ = new_length;
 }
 
-BinnedLRUCacheShard::BinnedLRUCacheShard(size_t capacity, bool strict_capacity_limit,
+BinnedLRUCacheShard::BinnedLRUCacheShard(CephContext *c, size_t capacity, bool strict_capacity_limit,
                              double high_pri_pool_ratio)
-    : capacity_(0),
+    : cct(c),
+      capacity_(0),
       high_pri_pool_usage_(0),
       strict_capacity_limit_(strict_capacity_limit),
       high_pri_pool_ratio_(high_pri_pool_ratio),
@@ -480,7 +481,7 @@ BinnedLRUCache::BinnedLRUCache(CephContext *c,
   size_t per_shard = (capacity + (num_shards_ - 1)) / num_shards_;
   for (int i = 0; i < num_shards_; i++) {
     new (&shards_[i])
-        BinnedLRUCacheShard(per_shard, strict_capacity_limit, high_pri_pool_ratio);
+        BinnedLRUCacheShard(c, per_shard, strict_capacity_limit, high_pri_pool_ratio);
   }
 }
 

--- a/src/kv/rocksdb_cache/BinnedLRUCache.h
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.h
@@ -171,7 +171,7 @@ class BinnedLRUHandleTable {
 // A single shard of sharded cache.
 class alignas(CACHE_LINE_SIZE) BinnedLRUCacheShard : public CacheShard {
  public:
-  BinnedLRUCacheShard(size_t capacity, bool strict_capacity_limit,
+  BinnedLRUCacheShard(CephContext *c, size_t capacity, bool strict_capacity_limit,
                 double high_pri_pool_ratio);
   virtual ~BinnedLRUCacheShard();
 
@@ -225,6 +225,7 @@ class alignas(CACHE_LINE_SIZE) BinnedLRUCacheShard : public CacheShard {
   size_t GetHighPriPoolUsage() const;
 
  private:
+  CephContext *cct;
   void LRU_Remove(BinnedLRUHandle* e);
   void LRU_Insert(BinnedLRUHandle* e);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1997,6 +1997,7 @@ private:
   uint64_t cache_size = 0;       ///< total cache size
   double cache_meta_ratio = 0;   ///< cache ratio dedicated to metadata
   double cache_kv_ratio = 0;     ///< cache ratio dedicated to kv (e.g., rocksdb)
+  double cache_kv_onode_ratio = 0; ///< cache ratio dedicated to kv onodes (e.g., rocksdb onode CF)
   double cache_data_ratio = 0;   ///< cache ratio dedicated to object data
   bool cache_autotune = false;   ///< cache autotune setting
   double cache_autotune_interval = 0; ///< time to wait between cache rebalancing
@@ -2023,6 +2024,7 @@ private:
     bool stop = false;
     uint64_t autotune_cache_size = 0;
     std::shared_ptr<PriorityCache::PriCache> binned_kv_cache = nullptr;
+    std::shared_ptr<PriorityCache::PriCache> binned_kv_onode_cache = nullptr;
     std::shared_ptr<PriorityCache::Manager> pcm = nullptr;
 
     struct MempoolCache : public PriorityCache::PriCache {


### PR DESCRIPTION
This PR reduces the occurrence of double caching bluestore onodes in the bluestore onode cache and rocksdb block cache.  This is done by introducing the ability to create per-column family block caches and by default creating a separate column family for bluestore onodes.  The onode-specific block cache competes independently of the rest of the rocksdb block cache for memory at a lower priority.  This PR also slightly changes the priority cache chunking algorithm to avoid waste when caches are small.

4KB fio+librbd randwrite performance results are available here:

https://docs.google.com/spreadsheets/d/1oLNNtQ8Y3fhPPcMdrIeOulbvJoZhrVYNIRYAkXfJl64/edit?usp=sharing

Signed-off-by: Mark Nelson <mnelson@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

