### PR TITLE
common/util: handle long lines in /proc/cpuinfo

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -268,7 +268,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   // processor
   f = fopen(PROCPREFIX "/proc/cpuinfo", "r");
   if (f) {
-    char buf[100];
+    char buf[1024];
     while (!feof(f)) {
       char *line = fgets(buf, sizeof(buf), f);
       if (!line)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/38296
Signed-off-by: Sage Weil <sage@redhat.com>