### PR TITLE
admin/doc-requirements.txt: workaround: revert/pin breathe to v4.12.0

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,6 +1,6 @@
 Sphinx == 1.8.3
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
-git+https://github.com/michaeljones/breathe#egg=breathe
+git+https://github.com/michaeljones/breathe@v4.12.0#egg=breathe
 # 4.2 is not yet release at the time of writing, to address CVE-2017-18342,
 # we have to use its beta release.
 pyyaml>=4.2b1


### PR DESCRIPTION
doc builds are failing because of a recent release to breathe; pin to
month-old version until it can be sorted

Signed-off-by: Dan Mick <dan.mick@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

