### PR TITLE
mon/OSDMonitor: crush node flags - two fixes; add tests

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1569,6 +1569,34 @@ function test_mon_osd()
   ! ceph -s | grep 'NODOWN'
   ! ceph -s | grep 'NOOUT'
 
+  # test crush node flags
+  ceph osd add-noup osd.0
+  ceph osd add-nodown osd.0
+  ceph osd add-noin osd.0
+  ceph osd add-noout osd.0
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep "osd.0"
+  ceph osd rm-noup osd.0
+  ceph osd rm-nodown osd.0
+  ceph osd rm-noin osd.0
+  ceph osd rm-noout osd.0
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep "osd.0"
+
+  ceph osd crush add-bucket foo host root=default
+  ceph osd add-noup foo
+  ceph osd add-nodown foo
+  ceph osd add-noin foo
+  ceph osd add-noout foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | grep foo
+  ceph osd rm-noup foo
+  ceph osd rm-nodown foo
+  ceph osd rm-noin foo
+  ceph osd rm-noout foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep foo
+  ceph osd add-noup foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | grep foo
+  ceph osd crush rm foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep foo
+
   # make sure mark out preserves weight
   ceph osd reweight osd.0 .5
   ceph osd dump | grep ^osd.0 | grep 'weight 0.5'

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9635,6 +9635,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 	break;
       }
       if (err == 0) {
+        if (!unlink_only)
+          pending_inc.new_crush_node_flags[id] = 0;
 	ss << "removed item id " << id << " name '" << name << "' from crush map";
 	getline(ss, rs);
 	wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10582,11 +10582,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
         osdmap.get_all_osds(osds);
         stop = true;
       } else {
-	if (osdmap.crush->name_exists(idvec[j])) {
+        if (long osd = parse_osd_id(idvec[j].c_str(), &ss); osd >= 0) {
+          osds.insert(osd);
+	} else if (osdmap.crush->name_exists(idvec[j])) {
+          std::stringstream().swap(ss);
 	  crush_nodes.insert(osdmap.crush->get_item_id(idvec[j]));
-	} else if (long osd = parse_osd_id(idvec[j].c_str(), &ss);
-		   osd >= 0) {
-	  osds.insert(osd);
 	} else {
 	  // ss has reason for failure
 	  ss << ", unable to parse osd id or crush node:\"" << idvec[j]
@@ -10796,11 +10796,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
         stop = true;
       } else {
-	if (osdmap.crush->name_exists(idvec[j])) {
-	  crush_nodes.insert(osdmap.crush->get_item_id(idvec[j]));
-	} else if (long osd = parse_osd_id(idvec[j].c_str(), &ss);
-		   osd >= 0) {
+	if (long osd = parse_osd_id(idvec[j].c_str(), &ss); osd >= 0) {
 	  osds.push_back(osd);
+        } else if (osdmap.crush->name_exists(idvec[j])) {
+          std::stringstream().swap(ss);
+          crush_nodes.insert(osdmap.crush->get_item_id(idvec[j]));
 	} else {
 	  // ss has reason for failure
 	  ss << ", unable to parse osd id or crush node:\"" << idvec[j]


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

