### PR TITLE
tools: pin the version of breathe that works with Python2

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,6 +1,7 @@
 Sphinx == 1.8.3
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
-git+https://github.com/michaeljones/breathe#egg=breathe
+# newer versions of breathe will require Sphinx >= 2.0.0 and are Python3 only
+breathe==4.12.0
 # 4.2 is not yet release at the time of writing, to address CVE-2017-18342,
 # we have to use its beta release.
 pyyaml>=4.2b1


### PR DESCRIPTION
The breathe package was being installed directly from master and it recently changed to support Python3 and Sphinx2 only which the Ceph builds don't work with.

See: https://github.com/michaeljones/breathe/issues/433

Pinning for now should help prevent the breakage:

    reading sources... [ 56%] rados/api/librados
    
    Exception occurred:
      File "/home/jenkins-build/build/workspace/ceph-pr-docs/build-doc/virtualenv/local/lib/python2.7/site-packages/breathe/renderer/filter.py", line 320, in __call__
        raise e
    AttributeError: 'str' object has no attribute 'node_type'