### PR TITLE
rgw: sync counters: drop spaces from counter names

### DIFF
--- a/src/rgw/rgw_sync_counters.cc
+++ b/src/rgw/rgw_sync_counters.cc
@@ -13,12 +13,12 @@ PerfCountersRef build(CephContext *cct, const std::string& name)
   // share these counters with ceph-mgr
   b.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
 
-  b.add_u64_avg(l_fetch, "fetch bytes", "Number of object bytes replicated");
-  b.add_u64_counter(l_fetch_not_modified, "fetch not modified", "Number of objects already replicated");
-  b.add_u64_counter(l_fetch_err, "fetch errors", "Number of object replication errors");
+  b.add_u64_avg(l_fetch, "fetch_bytes", "Number of object bytes replicated");
+  b.add_u64_counter(l_fetch_not_modified, "fetch_not_modified", "Number of objects already replicated");
+  b.add_u64_counter(l_fetch_err, "fetch_errors", "Number of object replication errors");
 
-  b.add_time_avg(l_poll, "poll latency", "Average latency of replication log requests");
-  b.add_u64_counter(l_poll_err, "poll errors", "Number of replication log request errors");
+  b.add_time_avg(l_poll, "poll_latency", "Average latency of replication log requests");
+  b.add_u64_counter(l_poll_err, "poll_errors", "Number of replication log request errors");
 
   auto logger = PerfCountersRef{ b.create_perf_counters(), cct };
   cct->get_perfcounters_collection()->add(logger.get());


### PR DESCRIPTION
Since this might break modules like prometheus and general json processing tools
aren't too happy with spaces.

Fixes: https://tracker.ceph.com/issues/39434
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

