### PR TITLE
common/assert: include ceph_abort_msg(arg) arg in log output

### DIFF
--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -172,8 +172,10 @@ namespace ceph {
     BackTrace *bt = new BackTrace(1);
     snprintf(g_assert_msg, sizeof(g_assert_msg),
              "%s: In function '%s' thread %llx time %s\n"
-	     "%s: %d: abort()\n", file, func, (unsigned long long)pthread_self(),
-	     tss.str().c_str(), file, line);
+	     "%s: %d: ceph_abort_msg(\"%s\")\n", file, func,
+	     (unsigned long long)pthread_self(),
+	     tss.str().c_str(), file, line,
+	     msg.c_str());
     dout_emergency(g_assert_msg);
 
     // TODO: get rid of this memory allocation.


### PR DESCRIPTION
This will also be part of the "assert_msg" field in the crash dump.

Signed-off-by: Sage Weil <sage@redhat.com>