### PR TITLE
[RFC] crimson/osd: introduce execution stage at PG::do_osd_ops().

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -127,10 +127,13 @@ private:
 			    int new_up_primary,
 			    const std::vector<int>& new_acting,
 			    int new_acting_primary);
+public:
+  // public because of execution stage
   seastar::future<Ref<MOSDOpReply>> do_osd_ops(Ref<MOSDOp> m);
-  seastar::future<> do_osd_op(const object_info_t& oi, OSDOp* op);
 
 private:
+  seastar::future<> do_osd_op(const object_info_t& oi, OSDOp* op);
+
   const spg_t pgid;
   pg_shard_t whoami;
   pg_pool_t pool;


### PR DESCRIPTION
This appears to be a trade-off between latency and throughput. Performance comparison is available [here](https://gist.github.com/rzarzynski/d6cd261d7d54e8fda377725fdc15e592).

CC: @cyx1231st.