### PR TITLE
osd: revamp {noup,nodown,noin,noout} related commands

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -201,7 +201,7 @@ ____________
 
 One or more cluster flags of interest has been set.  These flags include:
 
-* *full* - the cluster is flagged as full and cannot service writes
+* *full* - the cluster is flagged as full and cannot serve writes
 * *pauserd*, *pausewr* - paused reads or writes
 * *noup* - OSDs are not allowed to start
 * *nodown* - OSD failure reports are being ignored, such that the
@@ -223,7 +223,8 @@ With the exception of *full*, these flags can be set or cleared with::
 OSD_FLAGS
 _________
 
-One or more OSDs or CRUSH nodes has a flag of interest set.  These flags include:
+One or more OSDs or CRUSH {nodes,device classes} has a flag of interest set.
+These flags include:
 
 * *noup*: these OSDs are not allowed to start
 * *nodown*: failure reports for these OSDs will be ignored
@@ -232,15 +233,19 @@ One or more OSDs or CRUSH nodes has a flag of interest set.  These flags include
 * *noout*: if these OSDs are down they will not automatically be marked
   `out` after the configured interval
 
-These flags can be set and cleared with::
+These flags can be set and cleared in batch with::
 
-  ceph osd add-<flag> <osd-id-or-crush-node-name>
-  ceph osd rm-<flag> <osd-id-or-crush-node-name>
+  ceph osd set-group <flags> <who>
+  ceph osd unset-group <flags> <who>
 
 For example, ::
 
-  ceph osd rm-nodown osd.123
-  ceph osd rm-noout hostfoo
+  ceph osd set-group noup,noout osd.0 osd.1
+  ceph osd unset-group noup,noout osd.0 osd.1
+  ceph osd set-group noup,noout host-foo
+  ceph osd unset-group noup,noout host-foo
+  ceph osd set-group noup,noout class-hdd
+  ceph osd unset-group noup,noout class-hdd
 
 OLD_CRUSH_TUNABLES
 __________________

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1602,6 +1602,99 @@ function test_mon_osd()
   ceph osd crush rm foo
   ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep foo
 
+  ceph osd set-group noup osd.0
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noup'
+  ceph osd set-group noup,nodown osd.0
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'nodown'
+  ceph osd set-group noup,nodown,noin osd.0
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noin'
+  ceph osd set-group noup,nodown,noin,noout osd.0
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noout'
+  ceph osd unset-group noup osd.0
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | expect_false grep 'noup'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noout'
+  ceph osd unset-group noup,nodown osd.0
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | expect_false grep 'noup\|nodown'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noout'
+  ceph osd unset-group noup,nodown,noin osd.0
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | expect_false grep 'noup\|nodown\|noin'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noout'
+  ceph osd unset-group noup,nodown,noin,noout osd.0
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | expect_false grep 'noup\|nodown\|noin\|noout'
+
+  ceph osd set-group noup,nodown,noin,noout osd.0 osd.1
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noout'
+  ceph osd dump -f json-pretty | jq ".osds[1].state" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".osds[1].state" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".osds[1].state" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".osds[1].state" | grep 'noout'
+  ceph osd unset-group noup,nodown,noin,noout osd.0 osd.1
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | expect_false grep 'noup\|nodown\|noin\|noout'
+  ceph osd dump -f json-pretty | jq ".osds[1].state" | expect_false grep 'noup\|nodown\|noin\|noout'
+
+  ceph osd set-group noup all
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | grep 'noup'
+  ceph osd unset-group noup all
+  ceph osd dump -f json-pretty | jq ".osds[0].state" | expect_false grep 'noup'
+
+  # crush node flags
+  ceph osd crush add-bucket foo host root=default
+  ceph osd set-group noup foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noup'
+  ceph osd set-group noup,nodown foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'nodown'
+  ceph osd set-group noup,nodown,noin foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noin'
+  ceph osd set-group noup,nodown,noin,noout foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noout'
+
+  ceph osd unset-group noup foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | expect_false grep 'noup'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noout'
+  ceph osd unset-group noup,nodown foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | expect_false grep 'noup\|nodown'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noout'
+  ceph osd unset-group noup,nodown,noin foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | expect_false grep 'noup\|nodown\|noin'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noout'
+  ceph osd unset-group noup,nodown,noin,noout foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | expect_false grep 'noup\|nodown\|noin\|noout'
+
+  ceph osd set-group noin,noout foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noout'
+  ceph osd unset-group noin,noout foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep 'foo'
+
+  ceph osd set-group noup,nodown,noin,noout foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".crush_node_flags.foo" | grep 'noout'
+  ceph osd crush rm foo
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep 'foo'
+
   # make sure mark out preserves weight
   ceph osd reweight osd.0 .5
   ceph osd dump | grep ^osd.0 | grep 'weight 0.5'

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1554,11 +1554,9 @@ function test_mon_osd()
   expect_false ceph osd add-noup 797er
   expect_false ceph osd add-nodown u9uwer
   expect_false ceph osd add-noin 78~15
-  expect_false ceph osd add-noout 0 all 1
 
   expect_false ceph osd rm-noup 1234567
   expect_false ceph osd rm-nodown fsadf7
-  expect_false ceph osd rm-noin 0 1 any
   expect_false ceph osd rm-noout 790-fd
 
   ids=`ceph osd ls-tree default`

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1695,6 +1695,44 @@ function test_mon_osd()
   ceph osd crush rm foo
   ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep 'foo'
 
+  # test device class flags
+  osd_0_device_class=$(ceph osd crush get-device-class osd.0)
+  ceph osd set-group noup $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noup'
+  ceph osd set-group noup,nodown $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'nodown'
+  ceph osd set-group noup,nodown,noin $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noin'
+  ceph osd set-group noup,nodown,noin,noout $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noup'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noout'
+
+  ceph osd unset-group noup $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | expect_false grep 'noup'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'nodown'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noout'
+  ceph osd unset-group noup,nodown $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | expect_false grep 'noup\|nodown'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noout'
+  ceph osd unset-group noup,nodown,noin $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | expect_false grep 'noup\|nodown\|noin'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noout'
+  ceph osd unset-group noup,nodown,noin,noout $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | expect_false grep 'noup\|nodown\|noin\|noout'
+
+  ceph osd set-group noin,noout $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noin'
+  ceph osd dump -f json-pretty | jq ".device_class_flags.$osd_0_device_class" | grep 'noout'
+  ceph osd unset-group noin,noout $osd_0_device_class
+  ceph osd dump -f json-pretty | jq ".crush_node_flags" | expect_false grep $osd_0_device_class
+
   # make sure mark out preserves weight
   ceph osd reweight osd.0 .5
   ceph osd dump | grep ^osd.0 | grep 'weight 0.5'

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -505,6 +505,12 @@ public:
       return 0;
     return get_class_name(p->second);
   }
+  int get_item_class_id(int t) const {
+    auto p = class_map.find(t);
+    if (p == class_map.end())
+      return -ENOENT;
+    return p->second;
+  }
   int set_item_class(int i, const std::string& name) {
     if (!is_valid_crush_name(name))
       return -EINVAL;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -837,50 +837,58 @@ COMMAND_WITH_FLAG("osd rm " \
         "or use <any|all> to remove all osds", \
 	"osd", "rw",
 	FLAG(DEPRECATED))
-COMMAND("osd add-noup " \
+COMMAND_WITH_FLAG("osd add-noup " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noup, " \
         "or use <all|any> to mark all osds as noup", \
-        "osd", "rw")
-COMMAND("osd add-nodown " \
+        "osd", "rw",
+        FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd add-nodown " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as nodown, " \
         "or use <all|any> to mark all osds as nodown", \
-        "osd", "rw")
-COMMAND("osd add-noin " \
+        "osd", "rw",
+        FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd add-noin " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noin, " \
         "or use <all|any> to mark all osds as noin", \
-        "osd", "rw")
-COMMAND("osd add-noout " \
+        "osd", "rw",
+        FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd add-noout " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noout, " \
         "or use <all|any> to mark all osds as noout", \
-        "osd", "rw")
-COMMAND("osd rm-noup " \
+        "osd", "rw",
+        FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd rm-noup " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked up " \
         "(if they are currently marked as noup), " \
         "can use <all|any> to automatically filter out all noup osds", \
-        "osd", "rw")
-COMMAND("osd rm-nodown " \
+        "osd", "rw",
+        FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd rm-nodown " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked down " \
         "(if they are currently marked as nodown), " \
         "can use <all|any> to automatically filter out all nodown osds", \
-        "osd", "rw")
-COMMAND("osd rm-noin " \
+        "osd", "rw",
+        FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd rm-noin " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked in " \
         "(if they are currently marked as noin), " \
         "can use <all|any> to automatically filter out all noin osds", \
-        "osd", "rw")
-COMMAND("osd rm-noout " \
+        "osd", "rw",
+        FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd rm-noout " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked out " \
         "(if they are currently marked as noout), " \
         "can use <all|any> to automatically filter out all noout osds", \
-        "osd", "rw")
+        "osd", "rw",
+        FLAG(DEPRECATED))
 COMMAND("osd set-group " \
         "name=flags,type=CephString "
         "name=who,type=CephString,n=N", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -881,6 +881,18 @@ COMMAND("osd rm-noout " \
         "(if they are currently marked as noout), " \
         "can use <all|any> to automatically filter out all noout osds", \
         "osd", "rw")
+COMMAND("osd set-group " \
+        "name=flags,type=CephString "
+        "name=who,type=CephString,n=N", \
+        "set <flags> for batch osds or crush nodes, " \
+        "<flags> must be a comma-separated subset of {noup,nodown,noin,noout}", \
+        "osd", "rw")
+COMMAND("osd unset-group " \
+        "name=flags,type=CephString "
+        "name=who,type=CephString,n=N", \
+        "unset <flags> for batch osds or crush nodes, " \
+        "<flags> must be a comma-separated subset of {noup,nodown,noin,noout}", \
+        "osd", "rw")
 COMMAND("osd reweight " \
 	"name=id,type=CephOsdName " \
 	"type=CephFloat,name=weight,range=0.0|1.0", \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10722,30 +10722,53 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       return true;
     }
   } else if (prefix == "osd set-group" ||
-             prefix == "osd unset-group") {
-    bool do_set = prefix == "osd set-group";
+             prefix == "osd unset-group" ||
+             prefix == "osd add-noup" ||
+             prefix == "osd add-nodown" ||
+             prefix == "osd add-noin" ||
+             prefix == "osd add-noout" ||
+             prefix == "osd rm-noup" ||
+             prefix == "osd rm-nodown" ||
+             prefix == "osd rm-noin" ||
+             prefix == "osd rm-noout") {
+    bool do_set = prefix == "osd set-group" ||
+                  prefix.find("add") != string::npos;
     string flag_str;
-    vector<string> who;
-    cmd_getval(cct, cmdmap, "flags", flag_str);
-    cmd_getval(cct, cmdmap, "who", who);
-    vector<string> raw_flags;
-    boost::split(raw_flags, flag_str, boost::is_any_of(","));
     unsigned flags = 0;
-    for (auto& f : raw_flags) {
-      if (f == "noup")
-        flags |= CEPH_OSD_NOUP;
-      else if (f == "nodown")
-        flags |= CEPH_OSD_NODOWN;
-      else if (f == "noin")
-        flags |= CEPH_OSD_NOIN;
-      else if (f == "noout")
-        flags |= CEPH_OSD_NOOUT;
-      else {
-        ss << "unrecognized flag '" << f << "', must be one of "
-           << "{noup,nodown,noin,noout}";
-        err = -EINVAL;
-        goto reply;
+    vector<string> who;
+    if (prefix == "osd set-group" || prefix == "osd unset-group") {
+      cmd_getval(cct, cmdmap, "flags", flag_str);
+      cmd_getval(cct, cmdmap, "who", who);
+      vector<string> raw_flags;
+      boost::split(raw_flags, flag_str, boost::is_any_of(","));
+      for (auto& f : raw_flags) {
+        if (f == "noup")
+          flags |= CEPH_OSD_NOUP;
+        else if (f == "nodown")
+          flags |= CEPH_OSD_NODOWN;
+        else if (f == "noin")
+          flags |= CEPH_OSD_NOIN;
+        else if (f == "noout")
+          flags |= CEPH_OSD_NOOUT;
+        else {
+          ss << "unrecognized flag '" << f << "', must be one of "
+             << "{noup,nodown,noin,noout}";
+          err = -EINVAL;
+          goto reply;
+        }
       }
+    } else {
+      cmd_getval(cct, cmdmap, "ids", who);
+      if (prefix.find("noup") != string::npos)
+        flags = CEPH_OSD_NOUP;
+      else if (prefix.find("nodown") != string::npos)
+        flags = CEPH_OSD_NODOWN;
+      else if (prefix.find("noin") != string::npos)
+        flags = CEPH_OSD_NOIN;
+      else if (prefix.find("noout") != string::npos)
+        flags = CEPH_OSD_NOOUT;
+      else
+        ceph_assert(0 == "Unreachable!");
     }
     if (flags == 0) {
       ss << "must specify flag(s) {noup,nodwon,noin,noout} to set/unset";
@@ -10854,332 +10877,6 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       }
       any = true;
     }
-    if (any) {
-      getline(ss, rs);
-      wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, err, rs,
-                                 get_last_committed() + 1));
-      return true;
-    }
-  } else if (prefix == "osd add-noup" ||
-             prefix == "osd add-nodown" ||
-             prefix == "osd add-noin" ||
-             prefix == "osd add-noout") {
-
-    enum {
-      OP_NOUP,
-      OP_NODOWN,
-      OP_NOIN,
-      OP_NOOUT,
-    } option;
-
-    if (prefix == "osd add-noup") {
-      option = OP_NOUP;
-    } else if (prefix == "osd add-nodown") {
-      option = OP_NODOWN;
-    } else if (prefix == "osd add-noin") {
-      option = OP_NOIN;
-    } else {
-      option = OP_NOOUT;
-    }
-
-    bool any = false;
-    bool stop = false;
-
-    vector<string> idvec;
-    cmd_getval(cct, cmdmap, "ids", idvec);
-    for (unsigned j = 0; j < idvec.size() && !stop; j++) {
-      set<int> osds;
-      set<int> crush_nodes;
-
-      // wildcard?
-      if (j == 0 &&
-          (idvec[0] == "any" || idvec[0] == "all" || idvec[0] == "*")) {
-        osdmap.get_all_osds(osds);
-        stop = true;
-      } else {
-        if (long osd = parse_osd_id(idvec[j].c_str(), &ss); osd >= 0) {
-          osds.insert(osd);
-	} else if (osdmap.crush->name_exists(idvec[j])) {
-          std::stringstream().swap(ss);
-	  crush_nodes.insert(osdmap.crush->get_item_id(idvec[j]));
-	} else {
-	  // ss has reason for failure
-	  ss << ", unable to parse osd id or crush node:\"" << idvec[j]
-	     << "\". ";
-	  err = -EINVAL;
-	  continue;
-	}
-      }
-
-      for (auto &i : crush_nodes) {
-	auto q = osdmap.crush_node_flags.find(i);
-	if (pending_inc.new_crush_node_flags.count(i) == 0 &&
-	    q != osdmap.crush_node_flags.end()) {
-	  pending_inc.new_crush_node_flags[i] = q->second;
-	}
-	switch (option) {
-	case OP_NOUP:
-	  pending_inc.new_crush_node_flags[i] |= CEPH_OSD_NOUP;
-	  break;
-	case OP_NODOWN:
-	  pending_inc.new_crush_node_flags[i] |= CEPH_OSD_NODOWN;
-	  break;
-	case OP_NOIN:
-	  pending_inc.new_crush_node_flags[i] |= CEPH_OSD_NOIN;
-	  break;
-	case OP_NOOUT:
-	  pending_inc.new_crush_node_flags[i] |= CEPH_OSD_NOOUT;
-	  break;
-	}
-	any = true;
-      }
-      for (auto &osd : osds) {
-        if (!osdmap.exists(osd)) {
-          ss << "osd." << osd << " does not exist. ";
-          continue;
-        }
-
-        switch (option) {
-        case OP_NOUP:
-          if (osdmap.is_noup(osd)) {
-            if (pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOUP))
-              any = true;
-          } else {
-            pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOUP);
-            any = true;
-          }
-
-          break;
-
-        case OP_NODOWN:
-          if (osdmap.is_nodown(osd)) {
-            if (pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NODOWN))
-              any = true;
-          } else {
-            pending_inc.pending_osd_state_set(osd, CEPH_OSD_NODOWN);
-            any = true;
-          }
-
-          break;
-
-        case OP_NOIN:
-          if (osdmap.is_noin(osd)) {
-            if (pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOIN))
-              any = true;
-          } else {
-            pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOIN);
-            any = true;
-          }
-
-          break;
-
-        case OP_NOOUT:
-          if (osdmap.is_noout(osd)) {
-            if (pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOOUT))
-              any = true;
-          } else {
-            pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOOUT);
-            any = true;
-          }
-
-          break;
-
-        default:
-	  ceph_abort_msg("invalid option");
-        }
-      }
-    }
-
-    if (any) {
-      getline(ss, rs);
-      wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, err, rs,
-                                 get_last_committed() + 1));
-      return true;
-    }
-  } else if (prefix == "osd rm-noup" ||
-             prefix == "osd rm-nodown" ||
-             prefix == "osd rm-noin" ||
-             prefix == "osd rm-noout") {
-
-    enum {
-      OP_NOUP,
-      OP_NODOWN,
-      OP_NOIN,
-      OP_NOOUT,
-    } option;
-
-    if (prefix == "osd rm-noup") {
-      option = OP_NOUP;
-    } else if (prefix == "osd rm-nodown") {
-      option = OP_NODOWN;
-    } else if (prefix == "osd rm-noin") {
-      option = OP_NOIN;
-    } else {
-      option = OP_NOOUT;
-    }
-
-    bool any = false;
-    bool stop = false;
-
-    vector<string> idvec;
-    cmd_getval(cct, cmdmap, "ids", idvec);
-
-    for (unsigned j = 0; j < idvec.size() && !stop; j++) {
-      vector<int> osds;
-      set<int> crush_nodes;
-
-      // wildcard?
-      if (j == 0 &&
-          (idvec[0] == "any" || idvec[0] == "all" || idvec[0] == "*")) {
-
-        // touch previous noup/nodown/noin/noout osds only
-        switch (option) {
-        case OP_NOUP:
-          osdmap.get_noup_osds(&osds);
-          break;
-        case OP_NODOWN:
-          osdmap.get_nodown_osds(&osds);
-          break;
-        case OP_NOIN:
-          osdmap.get_noin_osds(&osds);
-          break;
-        case OP_NOOUT:
-          osdmap.get_noout_osds(&osds);
-          break;
-        default:
-          ceph_abort_msg("invalid option");
-        }
-
-        // cancel any pending noup/nodown/noin/noout requests too
-        vector<int> pending_state_osds;
-        (void) pending_inc.get_pending_state_osds(&pending_state_osds);
-        for (auto &p : pending_state_osds) {
-
-          switch (option) {
-          case OP_NOUP:
-            if (!osdmap.is_noup(p) &&
-                pending_inc.pending_osd_state_clear(p, CEPH_OSD_NOUP)) {
-              any = true;
-            }
-            break;
-
-          case OP_NODOWN:
-            if (!osdmap.is_nodown(p) &&
-                pending_inc.pending_osd_state_clear(p, CEPH_OSD_NODOWN)) {
-              any = true;
-            }
-            break;
-
-          case OP_NOIN:
-            if (!osdmap.is_noin(p) &&
-                pending_inc.pending_osd_state_clear(p, CEPH_OSD_NOIN)) {
-              any = true;
-            }
-            break;
-
-          case OP_NOOUT:
-            if (!osdmap.is_noout(p) &&
-                pending_inc.pending_osd_state_clear(p, CEPH_OSD_NOOUT)) {
-              any = true;
-            }
-            break;
-
-          default:
-            ceph_abort_msg("invalid option");
-          }
-        }
-
-        stop = true;
-      } else {
-	if (long osd = parse_osd_id(idvec[j].c_str(), &ss); osd >= 0) {
-	  osds.push_back(osd);
-        } else if (osdmap.crush->name_exists(idvec[j])) {
-          std::stringstream().swap(ss);
-          crush_nodes.insert(osdmap.crush->get_item_id(idvec[j]));
-	} else {
-	  // ss has reason for failure
-	  ss << ", unable to parse osd id or crush node:\"" << idvec[j]
-	     << "\". ";
-	  err = -EINVAL;
-	  continue;
-	}
-      }
-
-      for (auto &i : crush_nodes) {
-	auto q = osdmap.crush_node_flags.find(i);
-	if (pending_inc.new_crush_node_flags.count(i) == 0 &&
-	    q != osdmap.crush_node_flags.end()) {
-	  pending_inc.new_crush_node_flags[i] = q->second;
-	}
-	switch (option) {
-	case OP_NOUP:
-	  pending_inc.new_crush_node_flags[i] &= ~CEPH_OSD_NOUP;
-	  break;
-	case OP_NODOWN:
-	  pending_inc.new_crush_node_flags[i] &= ~CEPH_OSD_NODOWN;
-	  break;
-	case OP_NOIN:
-	  pending_inc.new_crush_node_flags[i] &= ~CEPH_OSD_NOIN;
-	  break;
-	case OP_NOOUT:
-	  pending_inc.new_crush_node_flags[i] &= ~CEPH_OSD_NOOUT;
-	  break;
-	}
-	any = true;
-      }
-      for (auto &osd : osds) {
-        if (!osdmap.exists(osd)) {
-          ss << "osd." << osd << " does not exist. ";
-          continue;
-        }
-
-        switch (option) {
-          case OP_NOUP:
-            if (osdmap.is_noup(osd)) {
-              pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOUP);
-              any = true;
-            } else if (pending_inc.pending_osd_state_clear(
-              osd, CEPH_OSD_NOUP)) {
-              any = true;
-            }
-            break;
-
-          case OP_NODOWN:
-            if (osdmap.is_nodown(osd)) {
-              pending_inc.pending_osd_state_set(osd, CEPH_OSD_NODOWN);
-              any = true;
-            } else if (pending_inc.pending_osd_state_clear(
-              osd, CEPH_OSD_NODOWN)) {
-              any = true;
-            }
-            break;
-
-          case OP_NOIN:
-            if (osdmap.is_noin(osd)) {
-              pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOIN);
-              any = true;
-            } else if (pending_inc.pending_osd_state_clear(
-              osd, CEPH_OSD_NOIN)) {
-              any = true;
-            }
-            break;
-
-          case OP_NOOUT:
-            if (osdmap.is_noout(osd)) {
-              pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOOUT);
-              any = true;
-            } else if (pending_inc.pending_osd_state_clear(
-              osd, CEPH_OSD_NOOUT)) {
-              any = true;
-            }
-            break;
-
-          default:
-            ceph_abort_msg("invalid option");
-        }
-      }
-    }
-
     if (any) {
       getline(ss, rs);
       wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, err, rs,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -598,7 +598,7 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
   }
 
   {
-    uint8_t target_v = 8;
+    uint8_t target_v = 9;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       target_v = 2;
     } else if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
@@ -641,6 +641,9 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
     }
     if (target_v >= 8) {
       encode(new_crush_node_flags, bl);
+    }
+    if (target_v >= 9) {
+      encode(new_device_class_flags, bl);
     }
     ENCODE_FINISH(bl); // osd-only data
   }
@@ -851,7 +854,7 @@ void OSDMap::Incremental::decode(ceph::buffer::list::const_iterator& bl)
   }
 
   {
-    DECODE_START(8, bl); // extended, osd-only data
+    DECODE_START(9, bl); // extended, osd-only data
     decode(new_hb_back_up, bl);
     decode(new_up_thru, bl);
     decode(new_last_clean_interval, bl);
@@ -904,6 +907,9 @@ void OSDMap::Incremental::decode(ceph::buffer::list::const_iterator& bl)
     }
     if (struct_v >= 8) {
       decode(new_crush_node_flags, bl);
+    }
+    if (struct_v >= 9) {
+      decode(new_device_class_flags, bl);
     }
     DECODE_FINISH(bl); // osd-only data
   }
@@ -1211,6 +1217,18 @@ void OSDMap::Incremental::dump(Formatter *f) const
   f->open_array_section("new_crush_node_flags");
   for (auto& i : new_crush_node_flags) {
     f->open_object_section("node");
+    f->dump_int("id", i.first);
+    set<string> st;
+    calc_state_set(i.second, st);
+    for (auto& j : st) {
+      f->dump_string("flag", j);
+    }
+    f->close_section();
+  }
+  f->close_section();
+  f->open_array_section("new_device_class_flags");
+  for (auto& i : new_device_class_flags) {
+    f->open_object_section("device_class");
     f->dump_int("id", i.first);
     set<string> st;
     calc_state_set(i.second, st);
@@ -2131,6 +2149,14 @@ int OSDMap::apply_incremental(const Incremental &inc)
     }
   }
 
+  for (auto& i : inc.new_device_class_flags) {
+    if (i.second) {
+      device_class_flags[i.first] = i.second;
+    } else {
+      device_class_flags.erase(i.first);
+    }
+  }
+
   // cluster snapshot?
   if (inc.cluster_snapshot.length()) {
     cluster_snapshot = inc.cluster_snapshot;
@@ -2178,6 +2204,14 @@ int OSDMap::apply_incremental(const Incremental &inc)
       // are decoding and applying on their end.  if we won't encode
       // it in the canonical version, don't change it.
       ++crush_version;
+    }
+    for (auto it = device_class_flags.begin();
+         it != device_class_flags.end();) {
+      const char* class_name = crush->get_class_name(it->first);
+      if (!class_name) // device class is gone
+        it = device_class_flags.erase(it);
+      else
+        it++;
     }
   }
 
@@ -2832,7 +2866,7 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
   {
     // NOTE: any new encoding dependencies must be reflected by
     // SIGNIFICANT_FEATURES
-    uint8_t target_v = 8;
+    uint8_t target_v = 9;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       target_v = 1;
     } else if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
@@ -2884,6 +2918,9 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
     }
     if (target_v >= 8) {
       encode(crush_node_flags, bl);
+    }
+    if (target_v >= 9) {
+      encode(device_class_flags, bl);
     }
     ENCODE_FINISH(bl); // osd-only data
   }
@@ -3145,7 +3182,7 @@ void OSDMap::decode(ceph::buffer::list::const_iterator& bl)
   }
 
   {
-    DECODE_START(8, bl); // extended, osd-only data
+    DECODE_START(9, bl); // extended, osd-only data
     decode(osd_addrs->hb_back_addrs, bl);
     decode(osd_info, bl);
     decode(blacklist, bl);
@@ -3205,6 +3242,11 @@ void OSDMap::decode(ceph::buffer::list::const_iterator& bl)
       decode(crush_node_flags, bl);
     } else {
       crush_node_flags.clear();
+    }
+    if (struct_v >= 9) {
+      decode(device_class_flags, bl);
+    } else {
+      device_class_flags.clear();
     }
     DECODE_FINISH(bl); // osd-only data
   }
@@ -3454,6 +3496,19 @@ void OSDMap::dump(Formatter *f) const
   for (auto& i : crush_node_flags) {
     string s = crush->item_exists(i.first) ? crush->get_item_name(i.first)
       : stringify(i.first);
+    f->open_array_section(s.c_str());
+    set<string> st;
+    calc_state_set(i.second, st);
+    for (auto& j : st) {
+      f->dump_string("flag", j);
+    }
+    f->close_section();
+  }
+  f->close_section();
+  f->open_object_section("device_class_flags");
+  for (auto& i : device_class_flags) {
+    const char* class_name = crush->get_class_name(i.first);
+    string s = class_name ? class_name : stringify(i.first);
     f->open_array_section(s.c_str());
     set<string> st;
     calc_state_set(i.second, st);
@@ -5670,9 +5725,19 @@ void OSDMap::check_health(health_check_map_t *checks) const
 	detail.push_back(ss.str());
       }
     }
+    for (auto& i : device_class_flags) {
+      const char* class_name = crush->get_class_name(i.first);
+      if (i.second && class_name) {
+        ostringstream ss;
+        set<string> states;
+        OSDMap::calc_state_set(i.second, states);
+        ss << "device class '" << class_name << "' has flags " << states;
+        detail.push_back(ss.str());
+      }
+    }
     if (!detail.empty()) {
       ostringstream ss;
-      ss << detail.size() << " OSDs or CRUSH nodes have {NOUP,NODOWN,NOIN,NOOUT} flags set";
+      ss << detail.size() << " OSDs or CRUSH {nodes, device-classes} have {NOUP,NODOWN,NOIN,NOOUT} flags set";
       auto& d = checks->add("OSD_FLAGS", HEALTH_WARN, ss.str());
       d.detail.swap(detail);
     }
@@ -5892,6 +5957,15 @@ unsigned OSDMap::get_crush_node_flags(int id) const
   unsigned flags = 0;
   auto it = crush_node_flags.find(id);
   if (it != crush_node_flags.end())
+    flags = it->second;
+  return flags;
+}
+
+unsigned OSDMap::get_device_class_flags(int id) const
+{
+  unsigned flags = 0;
+  auto it = device_class_flags.find(id);
+  if (it != device_class_flags.end())
     flags = it->second;
   return flags;
 }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5870,7 +5870,7 @@ float OSDMap::pool_raw_used_rate(int64_t poolid) const
   }
 }
 
-unsigned OSDMap::get_crush_node_flags(int osd) const
+unsigned OSDMap::get_osd_crush_node_flags(int osd) const
 {
   unsigned flags = 0;
   if (!crush_node_flags.empty()) {
@@ -5884,5 +5884,14 @@ unsigned OSDMap::get_crush_node_flags(int osd) const
       }
     }
   }
+  return flags;
+}
+
+unsigned OSDMap::get_crush_node_flags(int id) const
+{
+  unsigned flags = 0;
+  auto it = crush_node_flags.find(id);
+  if (it != crush_node_flags.end())
+    flags = it->second;
   return flags;
 }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -402,6 +402,7 @@ public:
     mempool::osdmap::map<int64_t, snap_interval_set_t> new_purged_snaps;
 
     mempool::osdmap::map<int32_t,uint32_t> new_crush_node_flags;
+    mempool::osdmap::map<int32_t,uint32_t> new_device_class_flags;
 
     std::string cluster_snapshot;
 
@@ -519,6 +520,7 @@ private:
   std::vector<uint32_t> osd_state;
 
   mempool::osdmap::map<int32_t,uint32_t> crush_node_flags; // crush node -> CEPH_OSD_* flags
+  mempool::osdmap::map<int32_t,uint32_t> device_class_flags; // device class -> CEPH_OSD_* flags
 
   utime_t last_up_change, last_in_change;
 
@@ -839,6 +841,7 @@ public:
 
   unsigned get_osd_crush_node_flags(int osd) const;
   unsigned get_crush_node_flags(int id) const;
+  unsigned get_device_class_flags(int id) const;
 
   bool is_noup(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_NOUP);

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -478,8 +478,11 @@ public:
       return new_state.count(osd) && (new_state[osd] & state) != 0;
     }
 
-    void pending_osd_state_set(int osd, unsigned state) {
+    bool pending_osd_state_set(int osd, unsigned state) {
+      if (pending_osd_has_state(osd, state))
+        return false;
       new_state[osd] |= state;
+      return true;
     }
 
     // cancel the specified pending osd state if there is any
@@ -834,7 +837,8 @@ public:
     return !is_out(osd);
   }
 
-  unsigned get_crush_node_flags(int osd) const;
+  unsigned get_osd_crush_node_flags(int osd) const;
+  unsigned get_crush_node_flags(int id) const;
 
   bool is_noup(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_NOUP);

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -509,28 +509,28 @@ TEST_F(OSDMapTest, PrimaryAffinity) {
   }
 }
 
-TEST_F(OSDMapTest, get_crush_node_flags) {
+TEST_F(OSDMapTest, get_osd_crush_node_flags) {
   set_up_map();
 
   for (unsigned i=0; i<get_num_osds(); ++i) {
-    ASSERT_EQ(0u, osdmap.get_crush_node_flags(i));
+    ASSERT_EQ(0u, osdmap.get_osd_crush_node_flags(i));
   }
 
   OSDMap::Incremental inc(osdmap.get_epoch() + 1);
   inc.new_crush_node_flags[-1] = 123u;
   osdmap.apply_incremental(inc);
   for (unsigned i=0; i<get_num_osds(); ++i) {
-    ASSERT_EQ(123u, osdmap.get_crush_node_flags(i));
+    ASSERT_EQ(123u, osdmap.get_osd_crush_node_flags(i));
   }
-  ASSERT_EQ(0u, osdmap.get_crush_node_flags(1000));
+  ASSERT_EQ(0u, osdmap.get_osd_crush_node_flags(1000));
 
   OSDMap::Incremental inc3(osdmap.get_epoch() + 1);
   inc3.new_crush_node_flags[-1] = 456u;
   osdmap.apply_incremental(inc3);
   for (unsigned i=0; i<get_num_osds(); ++i) {
-    ASSERT_EQ(456u, osdmap.get_crush_node_flags(i));
+    ASSERT_EQ(456u, osdmap.get_osd_crush_node_flags(i));
   }
-  ASSERT_EQ(0u, osdmap.get_crush_node_flags(1000));
+  ASSERT_EQ(0u, osdmap.get_osd_crush_node_flags(1000));
 
   OSDMap::Incremental inc2(osdmap.get_epoch() + 1);
   inc2.new_crush_node_flags[-1] = 0;


### PR DESCRIPTION
This works as a good supplement of https://github.com/ceph/ceph/pull/27563.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

