### PR TITLE
luminous: mds: drop reconnect message from non-existent session

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1008,7 +1008,8 @@ void Server::handle_client_reconnect(MClientReconnect *m)
   dout(7) << "handle_client_reconnect " << m->get_source() << dendl;
   client_t from = m->get_source().num();
   Session *session = mds->get_session(m);
-  assert(session);
+  if (!session)
+    return;
 
   if (!mds->is_reconnect() && mds->get_want_state() == CEPH_MDS_STATE_RECONNECT) {
     dout(10) << " we're almost in reconnect state (mdsmap delivery race?); waiting" << dendl;


### PR DESCRIPTION
http://tracker.ceph.com/issues/39191