### PR TITLE
nautilus: os/bluestore: fix out-of-bound access in bmap allocator.

### DIFF
--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -286,20 +286,22 @@ void AllocatorLevel01Loose::_mark_alloc_l0(int64_t l0_pos_start,
 
   int64_t pos = l0_pos_start;
   slot_t bits = (slot_t)1 << (l0_pos_start % d0);
-
-  while (pos < std::min(l0_pos_end, p2roundup<int64_t>(l0_pos_start, d0))) {
-    l0[pos / d0] &= ~bits;
+  slot_t* val_s = &l0[pos / d0];
+  int64_t pos_e = std::min(l0_pos_end, p2roundup<int64_t>(l0_pos_start + 1, d0));
+  while (pos < pos_e) {
+    (*val_s) &= ~bits;
     bits <<= 1;
     pos++;
   }
-
-  while (pos < std::min(l0_pos_end, p2align<int64_t>(l0_pos_end, d0))) {
-    l0[pos / d0] = all_slot_clear;
+  pos_e = std::min(l0_pos_end, p2align<int64_t>(l0_pos_end, d0));
+  while (pos < pos_e) {
+    *(++val_s) = all_slot_clear;
     pos += d0;
   }
   bits = 1;
+  ++val_s;
   while (pos < l0_pos_end) {
-    l0[pos / d0] &= ~bits;
+    (*val_s) &= ~bits;
     bits <<= 1;
     pos++;
   }

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -337,24 +337,23 @@ protected:
 
     auto pos = l0_pos_start;
     slot_t bits = (slot_t)1 << (l0_pos_start % d0);
-    slot_t& val_s = l0[pos / d0];
+    slot_t* val_s = &l0[pos / d0];
     int64_t pos_e = std::min(l0_pos_end,
                              p2roundup<int64_t>(l0_pos_start + 1, d0));
     while (pos < pos_e) {
-      val_s |= bits;
+      *val_s |=  bits;
       bits <<= 1;
       pos++;
     }
     pos_e = std::min(l0_pos_end, p2align<int64_t>(l0_pos_end, d0));
-    auto idx = pos / d0;
     while (pos < pos_e) {
-      l0[idx++] = all_slot_set;
+      *(++val_s) = all_slot_set;
       pos += d0;
     }
     bits = 1;
-    uint64_t& val_e = l0[pos / d0];
+    ++val_s;
     while (pos < l0_pos_end) {
-      val_e |= bits;
+      *val_s |= bits;
       bits <<= 1;
       pos++;
     }


### PR DESCRIPTION
https://tracker.ceph.com/issues/39446
