### PR TITLE
doc/dev/corpus.rst: correct instructions

### DIFF
--- a/doc/dev/corpus.rst
+++ b/doc/dev/corpus.rst
@@ -36,14 +36,15 @@ We can generate an object corpus for a particular version of ceph like so.
 #. Start via vstart::
 
 	cd build
-	MON=3 OSD=3 MDS=3 RGW=1 ../src/vstart.sh -n -x
+	MON=3 MGR=2 OSD=3 MDS=3 RGW=1 ../src/vstart.sh -n -x
 
 #. Use as much functionality of the cluster as you can, to exercise as many object encoder methods as possible::
 
 	bin/ceph osd pool create mypool 8
 	bin/rados -p mypool bench 10 write -b 123
 	bin/ceph osd out 0
-	bin/init-ceph stop osd.1
+	bin/ceph osd in 0
+	bin/init-ceph restart osd.1
 	for f in ../qa/workunits/cls/*.sh ; do PATH="bin:$PATH" $f ; done
 	PATH="bin:$PATH" ../qa/workunits/rados/test.sh
 	bin/ceph_test_librbd


### PR DESCRIPTION
* should keep all OSD up and running, otherwise some tests will wait for
  healthy cluster for ever.
* should start 2 MGR for an active-standby setting -- better coverage
this way

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

