### PR TITLE
cephfs-shell: Add stat command

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1141,6 +1141,38 @@ sub-directories, files')
         else:
             super().do_help(line)
 
+    def complete_stat(self, text, line, begidx, endidx):
+        """
+        auto complete of file name.
+        """
+        return self.complete_filenames(text, line, begidx, endidx)
+
+    stat_parser = argparse.ArgumentParser(
+                  description='Display file or file system status')
+    stat_parser.add_argument('name', type=str, help='Name of the file', nargs='+')
+
+    @with_argparser(stat_parser)
+    def do_stat(self, args):
+        """
+        Display file or file system status
+        """
+        for files in args.name:
+            try:
+                stat = cephfs.stat(files)
+                atime = stat.st_atime.isoformat(' ')
+                mtime = stat.st_mtime.isoformat(' ')
+                ctime = stat.st_mtime.isoformat(' ')
+
+                self.poutput("File: {}\nSize: {:d}\nBlocks: {:d}\nIO Block: {:d}\n\
+Device: {:d}\tInode: {:d}\tLinks: {:d}\nPermission: {:o}/{}\tUid: {:d}\tGid: {:d}\n\
+Access: {}\nModify: {}\nChange: {}".format(files, stat.st_size, stat.st_blocks,
+                             stat.st_blksize, stat.st_dev, stat.st_ino,
+                             stat.st_nlink, stat.st_mode,
+                             mode_notation(stat.st_mode), stat.st_uid,
+                             stat.st_gid, atime, mtime, ctime))
+            except libcephfs.Error:
+                self.poutput("{}: no such file or directory".format(files))
+
 
 if __name__ == '__main__':
     config_file = ''


### PR DESCRIPTION
This patch adds stat command to cephfs-shell.

Fixes: https://tracker.ceph.com/issues/38829
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->