### PR TITLE
ceph-volume: batch ensure device lists are disjoint

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -254,7 +254,7 @@ class Batch(object):
         self.args = parser.parse_args(argv)
         self.parser = parser
         for dev_list in ['', 'db_', 'wal_', 'journal_']:
-            setattr(self, '{}usable'.format(dev_list), [])
+            setattr(self, '{}usable'.format(dev_list), set())
 
     def get_devices(self):
         # remove devices with partitions
@@ -327,6 +327,7 @@ class Batch(object):
     def _get_explicit_strategy(self):
         # TODO assert that none of the device lists overlap?
         self._filter_devices()
+        self._ensure_disjoint_device_lists()
         if self.args.bluestore:
             if self.db_usable or self.wal_usable:
                 self.strategy = strategies.bluestore.MixedType(
@@ -360,8 +361,17 @@ class Batch(object):
             dev_list_prop = '{}devices'.format(dev_list)
             if hasattr(self.args, dev_list_prop):
                 usable_dev_list_prop = '{}usable'.format(dev_list)
-                usable = [d for d in getattr(self.args, dev_list_prop) if d.available]
+                usable = set([d for d in getattr(self.args, dev_list_prop) if
+                              d.available])
                 setattr(self, usable_dev_list_prop, usable)
                 self.filtered_devices.update({d: used_reason for d in
                                               getattr(self.args, dev_list_prop)
                                               if d.used_by_ceph})
+
+    def _ensure_disjoint_device_lists(self):
+        # check that all device lists are disjoint with each other
+        if not(self.usable.isdisjoint(self.db_usable) and
+               self.usable.isdisjoint(self.wal_usable) and
+               self.usable.isdisjoint(self.journal_usable) and
+               self.db_usable.isdisjoint(self.wal_usable)):
+            raise Exception('Device lists are not disjoint')

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -1,3 +1,4 @@
+import pytest
 from ceph_volume.devices.lvm import batch
 
 
@@ -54,6 +55,16 @@ class TestBatch(object):
         b = batch.Batch([])
         result = b.get_devices().strip()
         assert result == '* /dev/vdf                  20.00 GB   rotational'
+
+    def test_disjoint_device_lists(self, factory):
+        device1 = factory(used_by_ceph=False, available=True, abspath="/dev/sda")
+        device2 = factory(used_by_ceph=False, available=True, abspath="/dev/sdb")
+        b = batch.Batch([])
+        b.args.devices = [device1, device2]
+        b.args.db_devices = [device2]
+        b._filter_devices()
+        with pytest.raises(Exception):
+            b._ensure_disjoint_device_lists()
 
 
 class TestFilterDevices(object):


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>


Adds a simple validation to ceph-volume lvm batch to ensure the device lists passed are disjoint. Overlapping device lists would fail at a later stage anyway and potentially leave behind an half configured setup.
