### PR TITLE
common/PriorityCache: fix over-aggressive assert when mem limited

### DIFF
--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -262,7 +262,13 @@ namespace PriorityCache
     // Each cache is going to get a little extra from get_chunk, so shrink the
     // available memory here to compensate.
     mem_avail -= get_chunk(1, tuned_mem) * caches.size();
-    ceph_assert(mem_avail >= 0);
+
+    if (mem_avail < 0) {
+      // There's so little memory available that just assigning a chunk per
+      // cache pushes us over the limit. Set mem_avail to 0 and continue to
+      // ensure each priority's byte counts are zeroed in balance_priority.
+      mem_avail = 0;
+    }
 
     // Assign memory for each priority level
     for (int i = 0; i < Priority::LAST+1; i++) {


### PR DESCRIPTION
This PR fixes tracker bug 39437.  In memory limited scenarios, the priority cache manager will currently assert when there isn't enough memory to assign a single minimum-sized chunk of memory to each cache.  This PR loosens the constraints to allow a single chunk to be assigned to each cache and sets mem_avail to 0 if doing so would cause overage.  The primary difference is that in this specific case the priority cache manager will favor using extra memory over asserting.  The new behavior looks like this where the *_alloc is allowed to exceed the cache_size when extremely memory limited and only a single memory chunk is assigned to each cache:

`2019-04-24 13:13:15.730 7f4e83de4700  5 prioritycache tune_memory target: 1073741824 mapped: 493912064 unmapped: 5234688 heap: 499146752 old mem: 134217728 new mem: 134217728`

`2019-04-24 13:13:16.306 7f4e83de4700  5 bluestore.MempoolThread(0x55ffd9401b60) _trim_shards cache_size: 134217728 kv_alloc: 67108864 kv_used: 1249 meta_alloc: 67108864 meta_used: 67074810 data_alloc: 67108864 data_used: 87752704`

Alternately, we could increase the default osd_memory_cache_min, though that would not guarantee that the assert isn't hit in the future (the minimum required memory depends on the chunk size and number of registered caches).  Another possibility is reducing the minimum chunk size, though generally for rocksdb we want the chunk_size to be at least target_file_size + headroom otherwise it won't be able to have new SST files added and may fail to grow properly in some situations.

Fixes: https://tracker.ceph.com/issues/39437
Signed-off-by: Mark Nelson <mnelson@redhat.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

