### PR TITLE
common: Log report time in UTC

### DIFF
--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -267,7 +267,7 @@ void LogEntry::dump(Formatter *f) const
   f->dump_stream("name") << name;
   f->dump_stream("rank") << rank;
   f->dump_object("addrs", addrs);
-  f->dump_stream("stamp") << stamp;
+  stamp.gmtime(f->dump_stream("stamp"));
   f->dump_unsigned("seq", seq);
   f->dump_string("channel", channel);
   f->dump_stream("priority") << prio;
@@ -372,4 +372,3 @@ void LogSummary::generate_test_instances(list<LogSummary*>& o)
   o.push_back(new LogSummary);
   // more!
 }
-


### PR DESCRIPTION
Sending UTC time, instead of server time from backend

Fixes: https://tracker.ceph.com/issues/39297
Signed-off-by: Kanika Murarka <kmurarka@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

