### PR TITLE
doc/releases/nautilus: Correct a systemctl command in an upgrade guide

### DIFF
--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -306,7 +306,7 @@ Instructions
 #. Upgrade all radosgw daemons by upgrading packages and restarting
    daemons on all hosts::
 
-     # systemctl restart radosgw.target
+     # systemctl restart ceph-radosgw.target
 
 #. Complete the upgrade by disallowing pre-Nautilus OSDs and enabling
    all new Nautilus-only functionality::


### PR DESCRIPTION
Correct a systemctl command in an upgrade guide from radosgw.target to ceph-radosgw.target
Signed-off-by: Teeranai Kormongkolkul <istudko@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

