### PR TITLE
nautilus: tools: pin the version of breathe that works with Python2

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,6 +1,7 @@
 Sphinx == 1.8.3
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
-git+https://github.com/michaeljones/breathe#egg=breathe
+# newer versions of breathe will require Sphinx >= 2.0.0 and are Python3 only
+breathe==4.12.0
 # 4.2 is not yet release at the time of writing, to address CVE-2017-18342,
 # we have to use its beta release.
 pyyaml>=4.2b1


### PR DESCRIPTION
http://tracker.ceph.com/issues/39480