### PR TITLE
qa/suites/upgrade/*-x-singleton: enable bluestore debugging settings

### DIFF
--- a/qa/suites/upgrade/mimic-x-singleton/bluestore-bitmap.yaml
+++ b/qa/suites/upgrade/mimic-x-singleton/bluestore-bitmap.yaml
@@ -1,0 +1,1 @@
+.qa/objectstore/bluestore-bitmap.yaml

--- a/qa/suites/upgrade/nautilus-x-singleton/bluestore-bitmap.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/bluestore-bitmap.yaml
@@ -1,0 +1,1 @@
+.qa/objectstore/bluestore-bitmap.yaml


### PR DESCRIPTION
We default to bluestore already; use the yaml explicitly so that we get debugging turned up.