### PR TITLE
crimson/net: improve batching in the write path

### DIFF
--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -72,7 +72,7 @@ seastar::future<> Protocol::close()
 seastar::future<> Protocol::send(MessageRef msg)
 {
   if (write_state != write_state_t::drop) {
-    conn.out_q.push(std::move(msg));
+    conn.out_q.push_back(std::move(msg));
     write_event();
   }
   return seastar::now();
@@ -98,46 +98,49 @@ void Protocol::notify_keepalive_ack()
 seastar::future<stop_t> Protocol::do_write_dispatch_sweep()
 {
   switch (write_state) {
-   case write_state_t::open:
-    return seastar::futurize_apply([this] {
-      if (need_keepalive) {
-        return do_keepalive()
-        .then([this] { need_keepalive = false; });
+   case write_state_t::open: {
+    size_t num_msgs = conn.out_q.size();
+    // we must have something to write...
+    ceph_assert(num_msgs || need_keepalive || need_keepalive_ack);
+    Message* msg_ptr = nullptr;
+    if (likely(num_msgs)) {
+      msg_ptr = conn.out_q.front().get();
+    }
+    // sweep all pending writes with the concrete Protocol
+    return socket->write(do_sweep_messages(
+        conn.out_q, num_msgs, need_keepalive, need_keepalive_ack))
+    .then([this, msg_ptr, num_msgs] {
+      need_keepalive = false;
+      need_keepalive_ack = false;
+      if (likely(num_msgs && msg_ptr == conn.out_q.front().get())) {
+        // we have sent some messages successfully
+        // and the out_q was not reset during socket write
+        conn.out_q.erase(conn.out_q.begin(), conn.out_q.begin()+num_msgs);
       }
-      return seastar::now();
-    }).then([this] {
-      if (need_keepalive_ack) {
-        return do_keepalive_ack()
-        .then([this] { need_keepalive_ack = false; });
-      }
-      return seastar::now();
-    }).then([this] {
-      if (!conn.out_q.empty()){
-        MessageRef msg = conn.out_q.front();
-        return write_message(msg)
-        .then([this, msg] {
-          if (msg == conn.out_q.front()) {
-            conn.out_q.pop();
-          }
-          return stop_t::no;
-        });
-      } else {
+      if (conn.out_q.empty()) {
+        // good, we have nothing pending to send now.
         return socket->flush().then([this] {
-          if (!conn.out_q.empty()) {
-            return stop_t::no;
-          } else {
-            // the dispatching can only stop when out_q is empty
+          if (conn.out_q.empty() && !need_keepalive && !need_keepalive_ack) {
+            // still nothing pending to send after flush,
+            // the dispatching can ONLY stop now
             ceph_assert(write_dispatching);
             write_dispatching = false;
-            return stop_t::yes;
+            return seastar::make_ready_future<stop_t>(stop_t::yes);
+          } else {
+            // something is pending to send during flushing
+            return seastar::make_ready_future<stop_t>(stop_t::no);
           }
         });
+      } else {
+        // messages were enqueued during socket write
+        return seastar::make_ready_future<stop_t>(stop_t::no);
       }
     }).handle_exception([this] (std::exception_ptr eptr) {
       logger().warn("{} do_write_dispatch_sweep() fault: {}", conn, eptr);
       close();
-      return stop_t::no;
+      return seastar::make_ready_future<stop_t>(stop_t::no);
     });
+   }
    case write_state_t::delay: {
     // delay dispatching writes until open
     return state_changed.get_shared_future()

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -44,12 +44,11 @@ class Protocol {
 
   virtual void trigger_close() = 0;
 
-  // encode/write a message
-  virtual seastar::future<> write_message(MessageRef msg) = 0;
-
-  virtual seastar::future<> do_keepalive() = 0;
-
-  virtual seastar::future<> do_keepalive_ack() = 0;
+  virtual ceph::bufferlist do_sweep_messages(
+      const std::deque<MessageRef>& msgs,
+      size_t num_msgs,
+      bool require_keepalive,
+      bool require_keepalive_ack) = 0;
 
  public:
   const proto_t proto_type;

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -48,7 +48,7 @@ class Protocol {
       const std::deque<MessageRef>& msgs,
       size_t num_msgs,
       bool require_keepalive,
-      bool require_keepalive_ack) = 0;
+      std::optional<utime_t> keepalive_ack) = 0;
 
  public:
   const proto_t proto_type;
@@ -75,7 +75,7 @@ class Protocol {
     state_changed = seastar::shared_promise<>();
   }
 
-  void notify_keepalive_ack();
+  void notify_keepalive_ack(utime_t keepalive_ack);
 
  private:
   write_state_t write_state = write_state_t::none;
@@ -87,7 +87,7 @@ class Protocol {
   seastar::shared_future<> close_ready;
 
   bool need_keepalive = false;
-  bool need_keepalive_ack = false;
+  std::optional<utime_t> keepalive_ack = std::nullopt;
   bool write_dispatching = false;
   seastar::future<stop_t> do_write_dispatch_sweep();
   void write_event();

--- a/src/crimson/net/ProtocolV1.h
+++ b/src/crimson/net/ProtocolV1.h
@@ -26,11 +26,11 @@ class ProtocolV1 final : public Protocol {
 
   void trigger_close() override;
 
-  seastar::future<> write_message(MessageRef msg) override;
-
-  seastar::future<> do_keepalive() override;
-
-  seastar::future<> do_keepalive_ack() override;
+  ceph::bufferlist do_sweep_messages(
+      const std::deque<MessageRef>& msgs,
+      size_t num_msgs,
+      bool require_keepalive,
+      bool require_keepalive_ack) override;
 
  private:
   SocketMessenger &messenger;

--- a/src/crimson/net/ProtocolV1.h
+++ b/src/crimson/net/ProtocolV1.h
@@ -30,7 +30,7 @@ class ProtocolV1 final : public Protocol {
       const std::deque<MessageRef>& msgs,
       size_t num_msgs,
       bool require_keepalive,
-      bool require_keepalive_ack) override;
+      std::optional<utime_t> keepalive_ack) override;
 
  private:
   SocketMessenger &messenger;

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1342,46 +1342,54 @@ seastar::future<> ProtocolV2::send_reconnect_ok()
 
 // READY state
 
-seastar::future<> ProtocolV2::write_message(MessageRef msg)
+ceph::bufferlist ProtocolV2::do_sweep_messages(
+    const std::deque<MessageRef>& msgs,
+    size_t num_msgs,
+    bool require_keepalive,
+    bool require_keepalive_ack)
 {
-  // TODO: move to common code
-  // set priority
-  msg->get_header().src = messenger.get_myname();
+  ceph::bufferlist bl;
 
-  msg->encode(conn.features, 0);
+  if (unlikely(require_keepalive)) {
+    auto keepalive_frame = KeepAliveFrame::Encode();
+    bl.append(keepalive_frame.get_buffer(session_stream_handlers));
+  }
 
-  msg->set_seq(++conn.out_seq);
-  uint64_t ack_seq = conn.in_seq;
-  // ack_left = 0;
+  if (unlikely(require_keepalive_ack)) {
+    auto keepalive_ack_frame = KeepAliveFrameAck::Encode(last_keepalive_ack_to_send);
+    bl.append(keepalive_ack_frame.get_buffer(session_stream_handlers));
+  }
 
-  ceph_msg_header &header = msg->get_header();
-  ceph_msg_footer &footer = msg->get_footer();
+  std::for_each(msgs.begin(), msgs.begin()+num_msgs, [this, &bl](const MessageRef& msg) {
+    // TODO: move to common code
+    // set priority
+    msg->get_header().src = messenger.get_myname();
 
-  ceph_msg_header2 header2{header.seq,        header.tid,
-                           header.type,       header.priority,
-                           header.version,
-                           0,                 header.data_off,
-                           ack_seq,
-                           footer.flags,      header.compat_version,
-                           header.reserved};
+    msg->encode(conn.features, 0);
 
-  auto message = MessageFrame::Encode(header2,
-      msg->get_payload(), msg->get_middle(), msg->get_data());
-  logger().debug("{} write msg type={} off={} seq={}",
-                 conn, header2.type, header2.data_off, header2.seq);
-  return write_frame(message, false);
-}
+    msg->set_seq(++conn.out_seq);
+    uint64_t ack_seq = conn.in_seq;
+    // ack_left = 0;
 
-seastar::future<> ProtocolV2::do_keepalive()
-{
-  auto keepalive_frame = KeepAliveFrame::Encode();
-  return write_frame(keepalive_frame, false);
-}
+    ceph_msg_header &header = msg->get_header();
+    ceph_msg_footer &footer = msg->get_footer();
 
-seastar::future<> ProtocolV2::do_keepalive_ack()
-{
-  auto keepalive_ack_frame = KeepAliveFrameAck::Encode(last_keepalive_ack_to_send);
-  return write_frame(keepalive_ack_frame, false);
+    ceph_msg_header2 header2{header.seq,        header.tid,
+                             header.type,       header.priority,
+                             header.version,
+                             0,                 header.data_off,
+                             ack_seq,
+                             footer.flags,      header.compat_version,
+                             header.reserved};
+
+    auto message = MessageFrame::Encode(header2,
+        msg->get_payload(), msg->get_middle(), msg->get_data());
+    logger().debug("{} write msg type={} off={} seq={}",
+                   conn, header2.type, header2.data_off, header2.seq);
+    bl.append(message.get_buffer(session_stream_handlers));
+  });
+
+  return bl;
 }
 
 void ProtocolV2::handle_message_ack(seq_num_t seq) {

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -29,7 +29,7 @@ class ProtocolV2 final : public Protocol {
       const std::deque<MessageRef>& msgs,
       size_t num_msgs,
       bool require_keepalive,
-      bool require_keepalive_ack) override;
+      std::optional<utime_t> keepalive_ack) override;
 
  private:
   SocketMessenger &messenger;
@@ -71,8 +71,6 @@ class ProtocolV2 final : public Protocol {
   uint64_t global_seq = 0;
   uint64_t peer_global_seq = 0;
   uint64_t connect_seq = 0;
-
-  utime_t last_keepalive_ack_to_send;
 
  // TODO: Frame related implementations, probably to a separate class.
  private:

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -25,11 +25,11 @@ class ProtocolV2 final : public Protocol {
 
   void trigger_close() override;
 
-  seastar::future<> write_message(MessageRef msg) override;
-
-  seastar::future<> do_keepalive() override;
-
-  seastar::future<> do_keepalive_ack() override;
+  ceph::bufferlist do_sweep_messages(
+      const std::deque<MessageRef>& msgs,
+      size_t num_msgs,
+      bool require_keepalive,
+      bool require_keepalive_ack) override;
 
  private:
   SocketMessenger &messenger;

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -35,7 +35,9 @@ class Socket
     : sid{seastar::engine().cpu_id()},
       socket(std::move(_socket)),
       in(socket.input()),
-      out(socket.output()) {}
+      // the default buffer size 8192 is too small that may impact our write
+      // performance. see seastar::net::connected_socket::output()
+      out(socket.output(65536)) {}
 
   Socket(Socket&& o) = delete;
 

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -81,8 +81,8 @@ void SocketConnection::requeue_sent()
   out_seq -= sent.size();
   while (!sent.empty()) {
     auto m = sent.front();
-    sent.pop();
-    out_q.push(std::move(m));
+    sent.pop_front();
+    out_q.push_back(std::move(m));
   }
 }
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -58,9 +58,9 @@ class SocketConnection : public Connection {
   bool update_rx_seq(seq_num_t seq);
 
   // messages to be resent after connection gets reset
-  std::queue<MessageRef> out_q;
+  std::deque<MessageRef> out_q;
   // messages sent, but not yet acked by peer
-  std::queue<MessageRef> sent;
+  std::deque<MessageRef> sent;
 
   // which of the peer_addrs we're connecting to (as client)
   // or should reconnect to (as peer)
@@ -115,7 +115,7 @@ class SocketConnection : public Connection {
   /// move all messages in the sent list back into the queue
   void requeue_sent();
 
-  std::tuple<seq_num_t, std::queue<MessageRef>> get_out_queue() {
+  std::tuple<seq_num_t, std::deque<MessageRef>> get_out_queue() {
     return {out_seq, std::move(out_q)};
   }
 


### PR DESCRIPTION
Implements [A] and [C] in https://github.com/ceph/ceph/pull/27430

2-way 4K read/write
----

saturated connection (throughput):
`$perf_crimson_msgr --round=4194304 --cbs=4096 --sbs=4096 --depth=512 -c 3`

 run | 1st | 2nd | 3rd 
---|---|---|---
base line | 21.3406s | 21.4988s | 21.3055s
+gather buffer | 19.7826s | 19.7931s | 19.7753s
+increase out buffer size | 18.4555s | 18.5185s | 18.4318s

depth=1 (latency):
`$perf_crimson_msgr --round=1048576 --cbs=4096 --sbs=4096 --depth=1 -c 3`

 run | 1st | 2nd | 3rd 
---|---|---|---
reference point | 20.5859s | 20.5712s | 20.3843s
+gather buffer | 21.0238s | 21.0726s | 21.0982s
+increase out buffer size | 20.8363s | 20.9622s | 21.1441s

2-way 1M read/write
----

saturated connection (throughput):
`$perf_crimson_msgr --round=65536 --cbs=1048576 --sbs=1048576 --depth=512 -c 3`

 run | 1st | 2nd | 3rd 
---|---|---|---
reference point | 25.1085s | 24.8107s | 25.0559s
+gather buffer | 24.6698s | 24.7343s | 24.5978s
+increase out buffer size | 24.7577s | 24.8432s | 24.8043s

depth=1 (latency):
`$perf_crimson_msgr --round=65536 --cbs=1048576 --sbs=1048576 --depth=1 -c 3 `

 run | 1st | 2nd | 3rd 
---|---|---|---
 reference point | 30.9145s | 30.8507s | 30.8499
 +gather buffer | 30.907s | 30.8757s | 30.8697s
 +increase out buffer size | 31.0175s | 30.9355s | 30.8921s