### PR TITLE
RFC common/Formatter: dump_timestamp

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -17,6 +17,7 @@
 #include "HTMLFormatter.h"
 #include "common/escape.h"
 #include "include/buffer.h"
+#include "include/utime.h"
 
 #include <set>
 #include <limits>
@@ -89,6 +90,26 @@ void Formatter::flush(bufferlist &bl)
   std::stringstream os;
   flush(os);
   bl.append(os.str());
+}
+
+void Formatter::dump_timestamp(const char *name, const utime_t& t)
+{
+  open_object_section(name);
+  dump_unsigned("unix_seconds", t.sec());
+  dump_unsigned("unix_nanoseconds", t.nsec());
+  t.gmtime(dump_stream("iso8601"));
+  close_section();
+}
+
+void Formatter::dump_timestamp(const char *name, unsigned long long seconds,
+			       unsigned long nsec)
+{
+  utime_t t(seconds, nsec);
+  open_object_section(name);
+  dump_unsigned("unix_seconds", t.sec());
+  dump_unsigned("unix_nanoseconds", t.nsec());
+  t.gmtime(dump_stream("iso8601"));
+  close_section();
 }
 
 void Formatter::dump_format(const char *name, const char *fmt, ...)

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -6,12 +6,15 @@
 #include "include/int_types.h"
 #include "include/buffer_fwd.h"
 
+#include <chrono>
 #include <deque>
 #include <list>
 #include <vector>
 #include <stdarg.h>
 #include <sstream>
 #include <map>
+
+class utime_t;
 
 namespace ceph {
 
@@ -94,6 +97,21 @@ namespace ceph {
       foo.dump(this);
       close_section();
     }
+    void dump_timestamp(const char *name, const utime_t& t);
+    void dump_timestamp(const char *name, unsigned long long seconds,
+			unsigned long nsec);
+
+    template<typename Clock, typename Duration>
+    void dump_timestamp(const char *name,
+			const std::chrono::time_point<Clock, Duration>& t) {
+      auto a = t.time_since_epoch();
+      dump_timestamp(
+	name,
+	std::chrono::duration_cast<std::chrono::seconds>(a).count(),
+	std::chrono::duration_cast<std::chrono::nanoseconds>(
+	  (a % std::chrono::seconds(1))).count());
+    }
+
     virtual std::ostream& dump_stream(const char *name) = 0;
     virtual void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) = 0;
     virtual void dump_format(const char *name, const char *fmt, ...);

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -2303,11 +2303,11 @@ void rename_rollback::drec::decode(bufferlist::const_iterator &bl)
 
 void rename_rollback::drec::dump(Formatter *f) const
 {
-  f->dump_stream("directory fragment") << dirfrag;
-  f->dump_stream("directory old mtime") << dirfrag_old_mtime;
-  f->dump_stream("directory old rctime") << dirfrag_old_rctime;
+  f->dump_stream("directory_fragment") << dirfrag;
+  f->dump_stream("directory_old_mtime") << dirfrag_old_mtime;
+  f->dump_stream("directory_old_rctime") << dirfrag_old_rctime;
   f->dump_int("ino", ino);
-  f->dump_int("remote ino", remote_ino);
+  f->dump_int("remote_ino", remote_ino);
   f->dump_string("dname", dname);
   uint32_t type = DTTOIF(remote_d_type) & S_IFMT; // convert to type entries
   string type_string;
@@ -2321,8 +2321,8 @@ void rename_rollback::drec::dump(Formatter *f) const
   default:
     type_string = "UNKNOWN-" + stringify((int)type); break;
   }
-  f->dump_string("remote dtype", type_string);
-  f->dump_stream("old ctime") << old_ctime;
+  f->dump_string("remote_dtype", type_string);
+  f->dump_stream("old_ctime") << old_ctime;
 }
 
 void rename_rollback::drec::generate_test_instances(std::list<drec*>& ls)
@@ -2361,14 +2361,14 @@ void rename_rollback::decode(bufferlist::const_iterator &bl)
 
 void rename_rollback::dump(Formatter *f) const
 {
-  f->dump_stream("request id") << reqid;
-  f->open_object_section("original src drec");
+  f->dump_stream("request_id") << reqid;
+  f->open_object_section("original_src_drec");
   orig_src.dump(f);
   f->close_section(); // original src drec
-  f->open_object_section("original dest drec");
+  f->open_object_section("original_dest_drec");
   orig_dest.dump(f);
   f->close_section(); // original dest drec
-  f->open_object_section("stray drec");
+  f->open_object_section("stray_drec");
   stray.dump(f);
   f->close_section(); // stray drec
   f->dump_stream("ctime") << ctime;

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -332,7 +332,9 @@ void MonMap::dump(Formatter *f) const
   f->dump_unsigned("epoch", epoch);
   f->dump_stream("fsid") <<  fsid;
   f->dump_stream("modified") << last_changed;
+  f->dump_timestamp("modified_time", last_changed);
   f->dump_stream("created") << created;
+  f->dump_timestamp("created_time", created);
   f->dump_unsigned("min_mon_release", min_mon_release);
   f->dump_string("min_mon_release_name", ceph_release_name(min_mon_release));
   f->open_object_section("features");

--- a/src/test/formatter.cc
+++ b/src/test/formatter.cc
@@ -15,6 +15,9 @@
 #include "gtest/gtest.h"
 #include "common/Formatter.h"
 #include "common/HTMLFormatter.h"
+#include "common/Clock.h"
+#include "common/ceph_time.h"
+#include "include/utime.h"
 
 #include <sstream>
 #include <string>
@@ -67,6 +70,25 @@ TEST(JsonFormatter, Empty) {
   JSONFormatter fmt(false);
   fmt.flush(oss);
   ASSERT_EQ(oss.str(), "");
+}
+
+TEST(JsonFormatter, utime) {
+  utime_t t(1556122013, 839991182);
+  ostringstream oss;
+  JSONFormatter fmt(false);
+  fmt.dump_timestamp("time", t);
+  fmt.flush(oss);
+  ASSERT_EQ(oss.str(), "{\"unix_seconds\":1556122013,\"unix_nanoseconds\":839991182,\"iso8601\":\"2019-04-24 16:06:53.839991Z\"}");
+}
+
+TEST(JsonFormatter, time) {
+  ceph::real_clock::time_point t =
+    ceph::real_clock::from_time_t(1556122013);
+  ostringstream oss;
+  JSONFormatter fmt(false);
+  fmt.dump_timestamp("time", t);
+  fmt.flush(oss);
+  ASSERT_EQ(oss.str(), "{\"unix_seconds\":1556122013,\"unix_nanoseconds\":0,\"iso8601\":\"2019-04-24 16:06:53.000000Z\"}");
 }
 
 TEST(XmlFormatter, Simple1) {


### PR DESCRIPTION
This is what it looks like:

```
{
    "epoch": 1,
    "fsid": "40ee807d-704b-4d3e-a94b-e60161c19cbb",
    "modified": "2019-04-25 12:10:01.488223",
    "modified_time": {
        "unix_seconds": 1556212201,
        "unix_nanoseconds": 488223994,
        "iso8601": "2019-04-25 17:10:01.488223Z"
    },
    "created": "2019-04-25 12:10:01.488223",
    "created_time": {
        "unix_seconds": 1556212201,
        "unix_nanoseconds": 488223994,
        "iso8601": "2019-04-25 17:10:01.488223Z"
    },
    "min_mon_release": 15,
    "min_mon_release_name": "octopus",
```
Questions
- Is the format okay?
- In places where we want to maintain schema compatibility, I suggest appending ``_time``.  It's a bit crufty, though.  In order places (e.g., mds/journal.cc), we dump things that nobody ever looks at, and it probably makes more sense to just replace the durring dump_stream calls with dump_timestamp.  Thoughts?
