### PR TITLE
common: Add rdtsc() support for s390x

### DIFF
--- a/src/common/Cycles.h
+++ b/src/common/Cycles.h
@@ -78,6 +78,12 @@ class Cycles {
     uint32_t lo = 0, hi = 0;
     asm volatile("mftbu %0; mftb %1" : "=r" (hi), "=r" (lo));
     return (((uint64_t)hi << 32) | lo);
+#elif defined(__s390__)
+    uint64_t tod;
+
+    asm volatile("	stck %0\n"
+		 : "=Q" (tod) : : "cc");
+    return (tod);
 #else
 #warning No high-precision counter available for your OS/arch
     return 0;


### PR DESCRIPTION
Cycles: Add rdtsc() for s390x 

z Systems (aka s390/s390x) supports a time-of-day clock of 64-bits.

Fixes: #39491

Signed-off-by: Neale Ferguson <neale@sinenomine.net>

- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug