### PR TITLE
luminous: mds/server: check directory split after rename.

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7183,6 +7183,7 @@ void Server::handle_client_rename(MDRequestRef& mdr)
   C_MDS_rename_finish *fin = new C_MDS_rename_finish(this, mdr, srcdn, destdn, straydn);
 
   journal_and_reply(mdr, srci, destdn, le, fin);
+  mds->balancer->maybe_fragment(destdn->get_dir(), false);
 }
 
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/39198