### PR TITLE
dencoder: include some missed types

### DIFF
--- a/src/include/utime.cc
+++ b/src/include/utime.cc
@@ -17,10 +17,8 @@
 
 void utime_t::dump(ceph::Formatter *f) const
 {
-  f->open_object_section("utime");
   f->dump_int("seconds", tv.tv_sec);
   f->dump_int("nanoseconds", tv.tv_nsec);
-  f->close_section();
 }
 
 void utime_t::generate_test_instances(std::list<utime_t*>& o)

--- a/src/include/utime.cc
+++ b/src/include/utime.cc
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "utime.h"
+#include "common/Formatter.h"
+
+void utime_t::dump(ceph::Formatter *f) const
+{
+  f->open_object_section("utime");
+  f->dump_int("seconds", tv.tv_sec);
+  f->dump_int("nanoseconds", tv.tv_nsec);
+  f->close_section();
+}
+
+void utime_t::generate_test_instances(std::list<utime_t*>& o)
+{
+  o.push_back(new utime_t());
+  o.push_back(new utime_t());
+  o.back()->tv.tv_sec = static_cast<__u32>((1L << 32) - 1);
+  o.push_back(new utime_t());
+  o.back()->tv.tv_nsec = static_cast<__u32>((1L << 32) - 1);
+}

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -172,7 +172,9 @@ public:
     denc(v.tv.tv_nsec, p);
   }
 
-
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<utime_t*>& o);
+  
   void encode_timeval(struct ceph_timespec *t) const {
     t->tv_sec = tv.tv_sec;
     t->tv_nsec = tv.tv_nsec;

--- a/src/include/uuid.cc
+++ b/src/include/uuid.cc
@@ -17,11 +17,7 @@
 
 void uuid_d::dump(ceph::Formatter *f) const
 {
-  f->open_object_section("uuid_d");
-  {
-    f->dump_stream("uuid") << to_string();
-  }
-  f->close_section();
+  f->dump_stream("uuid") << to_string();
 }
 
 void uuid_d::generate_test_instances(std::list<uuid_d*>& o)

--- a/src/include/uuid.cc
+++ b/src/include/uuid.cc
@@ -1,0 +1,40 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "uuid.h"
+#include "common/Formatter.h"
+
+void uuid_d::dump(ceph::Formatter *f) const
+{
+  f->open_object_section("uuid_d");
+  {
+    f->dump_stream("uuid") << to_string();
+  }
+  f->close_section();
+}
+
+void uuid_d::generate_test_instances(std::list<uuid_d*>& o)
+{
+  // these are sourced from examples at
+  // https://www.boost.org/doc/libs/1_62_0/libs/uuid/uuid.html#Synopsis_generators
+  boost::uuids::string_generator gen;
+  o.push_back(new uuid_d());
+  o.back()->uuid = gen("{01234567-89ab-cdef-0123-456789abcdef}");
+  o.push_back(new uuid_d());
+  o.back()->uuid = gen(L"01234567-89ab-cdef-0123-456789abcdef");
+  o.push_back(new uuid_d());
+  o.back()->uuid = gen(std::string("0123456789abcdef0123456789abcdef"));
+  o.push_back(new uuid_d());
+  o.back()->uuid = gen(std::wstring(L"01234567-89ab-cdef-0123-456789abcdef"));
+}

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -15,6 +15,10 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+namespace ceph {
+  class Formatter;
+}
+
 struct uuid_d {
   boost::uuids::uuid uuid;
 
@@ -61,6 +65,9 @@ struct uuid_d {
   void decode(ceph::buffer::list::const_iterator& p) const {
     ceph::decode_raw(uuid, p);
   }
+
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<uuid_d*>& o);
 };
 WRITE_CLASS_ENCODER(uuid_d)
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5624,17 +5624,12 @@ struct watch_item_t {
     }
     DECODE_FINISH(bl);
   }
-  void dump_bare(ceph::Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_stream("watcher") << name;
     f->dump_int("cookie", cookie);
     f->dump_int("timeout", timeout_seconds);
     f->open_object_section("addr");
     addr.dump(f);
-    f->close_section();
-  }
-  void dump(ceph::Formatter *f) const {
-    f->open_object_section("watch_item_t");
-    dump_bare(f);
     f->close_section();
   }
   static void generate_test_instances(std::list<watch_item_t*>& o) {
@@ -5682,7 +5677,7 @@ struct obj_list_watch_response_t {
     f->open_array_section("entries");
     for (std::list<watch_item_t>::const_iterator p = entries.begin(); p != entries.end(); ++p) {
       f->open_object_section("watch");
-      p->dump_bare(f);
+      p->dump(f);
       f->close_section();
     }
     f->close_section();

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5624,6 +5624,35 @@ struct watch_item_t {
     }
     DECODE_FINISH(bl);
   }
+  void dump_bare(ceph::Formatter *f) const {
+    f->dump_stream("watcher") << name;
+    f->dump_int("cookie", cookie);
+    f->dump_int("timeout", timeout_seconds);
+    f->open_object_section("addr");
+    addr.dump(f);
+    f->close_section();
+  }
+  void dump(ceph::Formatter *f) const {
+    f->open_object_section("watch_item_t");
+    dump_bare(f);
+    f->close_section();
+  }
+  static void generate_test_instances(std::list<watch_item_t*>& o) {
+    entity_addr_t ea;
+    ea.set_type(entity_addr_t::TYPE_LEGACY);
+    ea.set_nonce(1000);
+    ea.set_family(AF_INET);
+    ea.set_in4_quad(0, 127);
+    ea.set_in4_quad(1, 0);
+    ea.set_in4_quad(2, 0);
+    ea.set_in4_quad(3, 1);
+    ea.set_port(1024);
+    o.push_back(new watch_item_t(entity_name_t(entity_name_t::TYPE_CLIENT, 1), 10, 30, ea));
+    ea.set_nonce(1001);
+    ea.set_in4_quad(3, 2);
+    ea.set_port(1025);
+    o.push_back(new watch_item_t(entity_name_t(entity_name_t::TYPE_CLIENT, 2), 20, 60, ea));
+  }
 };
 WRITE_CLASS_ENCODER_FEATURES(watch_item_t)
 
@@ -5653,12 +5682,7 @@ struct obj_list_watch_response_t {
     f->open_array_section("entries");
     for (std::list<watch_item_t>::const_iterator p = entries.begin(); p != entries.end(); ++p) {
       f->open_object_section("watch");
-      f->dump_stream("watcher") << p->name;
-      f->dump_int("cookie", p->cookie);
-      f->dump_int("timeout", p->timeout_seconds);
-      f->open_object_section("addr");
-      p->addr.dump(f);
-      f->close_section();
+      p->dump_bare(f);
       f->close_section();
     }
     f->close_section();
@@ -5667,19 +5691,12 @@ struct obj_list_watch_response_t {
     entity_addr_t ea;
     o.push_back(new obj_list_watch_response_t);
     o.push_back(new obj_list_watch_response_t);
-    ea.set_type(entity_addr_t::TYPE_LEGACY);
-    ea.set_nonce(1000);
-    ea.set_family(AF_INET);
-    ea.set_in4_quad(0, 127);
-    ea.set_in4_quad(1, 0);
-    ea.set_in4_quad(2, 0);
-    ea.set_in4_quad(3, 1);
-    ea.set_port(1024);
-    o.back()->entries.push_back(watch_item_t(entity_name_t(entity_name_t::TYPE_CLIENT, 1), 10, 30, ea));
-    ea.set_nonce(1001);
-    ea.set_in4_quad(3, 2);
-    ea.set_port(1025);
-    o.back()->entries.push_back(watch_item_t(entity_name_t(entity_name_t::TYPE_CLIENT, 2), 20, 60, ea));
+    std::list<watch_item_t*> test_watchers;
+    watch_item_t::generate_test_instances(test_watchers);
+    for (auto &e : test_watchers) {
+      o.back()->entries.push_back(*e);
+      delete e;
+    }
   }
 };
 WRITE_CLASS_ENCODER_FEATURES(obj_list_watch_response_t)

--- a/src/tools/ceph-dencoder/CMakeLists.txt
+++ b/src/tools/ceph-dencoder/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 set(dencoder_srcs
   ceph_dencoder.cc
   ../../include/uuid.cc
+  ../../include/utime.cc
   $<TARGET_OBJECTS:common_texttable_obj>)
 if(WITH_RADOSGW)
   list(APPEND dencoder_srcs

--- a/src/tools/ceph-dencoder/CMakeLists.txt
+++ b/src/tools/ceph-dencoder/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 set(dencoder_srcs
   ceph_dencoder.cc
+  ../../include/uuid.cc
   $<TARGET_OBJECTS:common_texttable_obj>)
 if(WITH_RADOSGW)
   list(APPEND dencoder_srcs

--- a/src/tools/ceph-dencoder/types.h
+++ b/src/tools/ceph-dencoder/types.h
@@ -5,6 +5,12 @@ TYPE(real_time_wrapper)
 TYPE(coarse_real_time_wrapper)
 TYPE(timespan_wrapper)
 
+#include "include/utime.h"
+TYPE(utime_t)
+
+#include "include/uuid.h"
+TYPE(uuid_d)
+
 #include "sstring.h"
 TYPE(sstring_wrapper)
 
@@ -98,6 +104,7 @@ TYPE(pg_create_t)
 TYPE(OSDSuperblock)
 TYPE(SnapSet)
 TYPE_FEATUREFUL(watch_info_t)
+TYPE_FEATUREFUL(watch_item_t)
 TYPE(object_manifest_t)
 TYPE_FEATUREFUL(object_info_t)
 TYPE(SnapSet)


### PR DESCRIPTION
Add utime_t, uuid_d, and watch_item_t to the list of types for ceph-dencoder, so they get tested.