### PR TITLE
qa/tasks: add positive test for ceph_volume_client method

### DIFF
--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -983,7 +983,9 @@ vc.disconnect()
             obj_data = obj_data
         )))
 
-    def test_put_object_versioned(self):
+    # test that put_object_versioned() matches the object version with
+    # supplied version number before writing to the object.
+    def test_version_check_for_put_object_versioned(self):
         vc_mount = self.mounts[1]
         vc_mount.umount_wait()
         self._configure_vc_auth(vc_mount, "manila")


### PR DESCRIPTION
`ceph_volume_client.py's` `put_object_versioned()` has only one test. Since
this only test is a negative test it fails to assure that
`put_object_versioned()` works as expected with positive inputs even when
it completes successfully. Therefore, write a positive test for better
coverage.