### PR TITLE
doc：Fixes a command error in manual deployment document

### DIFF
--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -196,11 +196,11 @@ The procedure is as follows:
 
 #. Populate the monitor daemon(s) with the monitor map and keyring. ::
 
-	sudo -u ceph ceph-mon [--cluster {cluster-name}] --mkfs -i {hostname} --monmap /tmp/monmap --keyring /tmp/ceph.mon.keyring
+	sudo -u ceph-mon [--cluster {cluster-name}] --mkfs -i {hostname} --monmap /tmp/monmap --keyring /tmp/ceph.mon.keyring
 
    For example::
 
-	sudo -u ceph ceph-mon --mkfs -i node1 --monmap /tmp/monmap --keyring /tmp/ceph.mon.keyring
+	sudo -u ceph-mon --mkfs -i node1 --monmap /tmp/monmap --keyring /tmp/ceph.mon.keyring
 
 
 #. Consider settings for a Ceph configuration file. Common settings include


### PR DESCRIPTION
doc：Fixes a command error in manual deployment document

If i execute `ceph ceph-mon --mkfs.....` there will be no response until timeout,but if i execute `ceph-mon --mkfs.....` the response is correct.My version is mimic v13.2.5

Signed-off-by: liuenqi <liuenqi01@inspur.com>