### PR TITLE
luminous:  rgw: multisite log trimming only checks peers that sync from us

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3388,7 +3388,7 @@ class DataLogTrimCR : public RGWCoroutine {
     : RGWCoroutine(store->ctx()), store(store), http(http),
       num_shards(num_shards),
       zone_id(store->get_zone().id),
-      peer_status(store->zone_conn_map.size()),
+      peer_status(store->get_zone_data_notify_to_map().size()),
       min_shard_markers(num_shards),
       last_trim(last_trim)
   {}
@@ -3411,7 +3411,7 @@ int DataLogTrimCR::operate()
       };
 
       auto p = peer_status.begin();
-      for (auto& c : store->zone_conn_map) {
+      for (auto& c : store->get_zone_data_notify_to_map()) {
         ldout(cct, 20) << "query sync status from " << c.first << dendl;
         using StatusCR = RGWReadRESTResourceCR<rgw_data_sync_status>;
         spawn(new StatusCR(cct, c.second, http, "/admin/log/", params, &*p),

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -348,7 +348,7 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
                     std::vector<std::string> *status)
 {
   status->clear();
-  boost::optional<size_t> num_shards;
+  std::optional<uint64_t> num_shards;
   for (auto peer = first; peer != last; ++peer) {
     const size_t peer_shards = peer->size();
     if (!num_shards) {

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -431,7 +431,7 @@ class BucketTrimInstanceCR : public RGWCoroutine {
       http(http), observer(observer),
       bucket_instance(bucket_instance),
       zone_id(store->get_zone().id),
-      peer_status(store->zone_conn_map.size())
+      peer_status(store->get_zone_data_notify_to_map().size())
   {}
 
   int operate() override;
@@ -455,7 +455,7 @@ int BucketTrimInstanceCR::operate()
       };
 
       auto p = peer_status.begin();
-      for (auto& c : store->zone_conn_map) {
+      for (auto& c : store->get_zone_data_notify_to_map()) {
         using StatusCR = RGWReadRESTResourceCR<StatusShards>;
         spawn(new StatusCR(cct, c.second, http, "/admin/log/", params, &*p),
               false);


### PR DESCRIPTION
https://tracker.ceph.com/issues/39416