### PR TITLE
rgw: object expirer: handle resharded buckets

### DIFF
--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -52,11 +52,14 @@ int RGWObjectExpirer::init_bucket_info(const string& tenant_name,
    * punching the tenant through the objexp_hint_entry, but now we
    * find that our instances do not actually have tenants. They are
    * unique thanks to IDs. So the tenant string is not needed...
+
+   * XXX reloaded: it turns out tenants were needed after all since bucket ids
+   * are ephemeral, good call encoding tenant info!
    */
-  const string bucket_instance_id = bucket_name + ":" + bucket_id;
-  int ret = store->get_bucket_instance_info(obj_ctx, bucket_instance_id,
-          bucket_info, NULL, NULL);
-  return ret;
+
+  return store->get_bucket_info(obj_ctx, tenant_name, bucket_name,
+				bucket_info, nullptr, nullptr);
+
 }
 
 int RGWObjectExpirer::garbage_single_object(objexp_hint_entry& hint)


### PR DESCRIPTION
Previously we fetched the bucket instance info which changes during a reshard
causing the bucket info to fail, since the subsequent checks will assume that
would mean a deleted bucket, the expiry hint is purged as well, leaving a non
deleted object as well as a deleted hint. This should fix newer runs of object
expiry processes. Finding out stale expired objects will require more complex
rgw-admin tooling support

Fixes: https://tracker.ceph.com/issues/39495
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

