### PR TITLE
mon,msg/async: fix mon to mon authentication

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6188,9 +6188,11 @@ int Monitor::handle_auth_request(
 	   << " payload " << payload.length()
 	   << dendl;
   if (!payload.length()) {
-    if (!con->is_msgr2()) {
-      // for v1 connections, we tolerate no authorizer, because authentication
-      // happens via MAuth messages.
+    if (!con->is_msgr2() &&
+	con->get_peer_type() != CEPH_ENTITY_TYPE_MON) {
+      // for v1 connections, we tolerate no authorizer (from
+      // non-monitors), because authentication happens via MAuth
+      // messages.
       return 1;
     }
     return -EACCES;

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1444,7 +1444,8 @@ CtPtr ProtocolV1::send_connect_message()
   bufferlist auth_bl;
   vector<uint32_t> preferred_modes;
 
-  if (connection->peer_type != CEPH_ENTITY_TYPE_MON) {
+  if (connection->peer_type != CEPH_ENTITY_TYPE_MON ||
+      messenger->get_myname().type() == CEPH_ENTITY_TYPE_MON) {
     if (authorizer_more.length()) {
       ldout(cct,10) << __func__ << " using augmented (challenge) auth payload"
 		    << dendl;
@@ -1575,7 +1576,8 @@ CtPtr ProtocolV1::handle_connect_reply_auth(char *buffer, int r) {
   bufferlist authorizer_reply;
   authorizer_reply.append(buffer, connect_reply.authorizer_len);
 
-  if (connection->peer_type != CEPH_ENTITY_TYPE_MON) {
+  if (connection->peer_type != CEPH_ENTITY_TYPE_MON ||
+      messenger->get_myname().type() == CEPH_ENTITY_TYPE_MON) {
     auto am = auth_meta;
     bool more = (connect_reply.tag == CEPH_MSGR_TAG_CHALLENGE_AUTHORIZER);
     bufferlist auth_retry_bl;


### PR DESCRIPTION
The refactor in #27566 broke mon to mon connections by skipping authentication for any mon connection.