### PR TITLE
osd: Don't include user changeable flag in snaptrim related assert

### DIFF
--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1580,11 +1580,15 @@ private:
     explicit SnapTrimmer(PrimaryLogPG *pg) : pg(pg) {}
     void log_enter(const char *state_name);
     void log_exit(const char *state_name, utime_t duration);
-    bool can_trim() {
+    bool permit_trim() {
       return
 	pg->is_clean() &&
 	!pg->scrubber.active &&
-	!pg->snap_trimq.empty() &&
+	!pg->snap_trimq.empty();
+    }
+    bool can_trim() {
+      return
+	permit_trim() &&
 	!pg->get_osdmap()->test_flag(CEPH_OSDMAP_NOSNAPTRIM);
     }
   } snap_trimmer_machine;
@@ -1603,7 +1607,7 @@ private:
       : my_base(ctx),
 	NamedState(context< SnapTrimmer >().pg, "Trimming") {
       context< SnapTrimmer >().log_enter(state_name);
-      ceph_assert(context< SnapTrimmer >().can_trim());
+      ceph_assert(context< SnapTrimmer >().permit_trim());
       ceph_assert(in_flight.empty());
     }
     void exit() {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/38124

Signed-off-by: David Zafman <dzafman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] ~Updates documentation if necessary~
- [ ] ~Includes tests for new functionality or reproducer for bug~

