### PR TITLE
crimson/net: prefer <fmt/chrono.h> over <fmt/time.h>

### DIFF
--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -5,8 +5,11 @@
 
 #include <seastar/core/lowres_clock.hh>
 #include <fmt/format.h>
+#if __has_include(<fmt/chrono.h>)
+#include <fmt/chrono.h>
+#else
 #include <fmt/time.h>
-
+#endif
 #include "include/msgr.h"
 #include "include/random.h"
 


### PR DESCRIPTION
in latest libfmt, <fmt/time.h> is deprecated.

to silence warnings like

/home/kchai/ceph/src/fmt/include/fmt/time.h:13:2: warning: #warning
fmt/time.h is deprecated, use fmt/chrono.h instead [-Wcpp]
 #warning fmt/time.h is deprecated, use fmt/chrono.h instead
  ^~~~~~~
In file included from
/home/kchai/ceph/src/seastar/include/seastar/core/reactor.hh:72:0,
                 from
/home/kchai/ceph/src/seastar/include/seastar/core/sharded.hh:24,
                 from /home/kchai/ceph/src/crimson/net/Fwd.h:18,
                 from /home/kchai/ceph/src/crimson/net/Protocol.h:9,
                 from /home/kchai/ceph/src/crimson/net/ProtocolV2.h:6,
                 from /home/kchai/ceph/src/crimson/net/ProtocolV2.cc:4:

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

