### PR TITLE
kv/Rocksdb: avoid update merge operator name after db opened

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -68,20 +68,21 @@ public:
     // do this in a way that doesn't constrain the ordering of calls
     // to set_merge_operator, so sort the merge operators and then
     // construct a name from all of those parts.
-    store.assoc_name.clear();
-    map<std::string,std::string> names;
+    if (store.assoc_name.empty()) {
+      map<std::string,std::string> names;
 
-    for (auto& p : store.merge_ops) {
-      names[p.first] = p.second->name();
-    }
-    for (auto& p : store.cf_handles) {
-      names.erase(p.first);
-    }
-    for (auto& p : names) {
-      store.assoc_name += '.';
-      store.assoc_name += p.first;
-      store.assoc_name += ':';
-      store.assoc_name += p.second;
+      for (auto& p : store.merge_ops) {
+        names[p.first] = p.second->name();
+      }
+      for (auto& p : store.cf_handles) {
+        names.erase(p.first);
+      }
+      for (auto& p : names) {
+        store.assoc_name += '.';
+        store.assoc_name += p.first;
+        store.assoc_name += ':';
+        store.assoc_name += p.second;
+      }
     }
     return store.assoc_name.c_str();
   }


### PR DESCRIPTION
the merge operator Name() will be invoked when compacion job gen sst,
becaue rocksdb will save it into blockbasedtable meta block properties
field. Disregarding the performance issue, I think it is unsafe
when we have *max_backgroud_compations* more than 1.

Fixe: https://tracker.ceph.com/issues/39509

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

