### PR TITLE
common: Clang requires a default constructor, but it can be empty

### DIFF
--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -224,6 +224,7 @@ public:
   static void generate_test_instances(std::list<BitVector *> &o);
 private:
   struct NoInitAllocator : public std::allocator<__u32> {
+    NoInitAllocator() {}
     NoInitAllocator(const std::allocator<__u32>& alloc)
       : std::allocator<__u32>(alloc) {
     }


### PR DESCRIPTION
Just do what the error messages ask for.

Error from Clang:
```
In file included from /home/jenkins/workspace/ceph-master/src/cls/rbd/cls_rbd.cc:28:
In file included from /home/jenkins/workspace/ceph-master/src/objclass/../include/types.h:21:
In file included from /home/jenkins/workspace/ceph-master/src/include/uuid.h:9:
In file included from /home/jenkins/workspace/ceph-master/src/include/encoding.h:17:
In file included from /usr/include/c++/v1/set:426:
In file included from /usr/include/c++/v1/__tree:16:
/usr/include/c++/v1/memory:2241:41: error: call to implicitly-deleted default constructor of '__compressed_pair_elem<ceph::BitVector<'\x02'>::NoInitAllocator, 1>'
      : _Base1(std::forward<_Tp>(__t)), _Base2() {}
                                        ^
/usr/include/c++/v1/vector:437:7: note: in instantiation of function template specialization 'std::__1::__compressed_pair<unsigned int *, ceph::BitVector<'\x02'>::NoInitAllocator>::__compressed_pair<nullptr_t, true>' requested here
      __end_cap_(nullptr)
      ^
/usr/include/c++/v1/vector:496:5: note: in instantiation of member function 'std::__1::__vector_base<unsigned int, ceph::BitVector<'\x02'>::NoInitAllocator>::__vector_base' requested here
    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
    ^
/home/jenkins/workspace/ceph-master/src/common/bit_vector.hpp:163:3: note: in instantiation of member function 'std::__1::vector<unsigned int, ceph::BitVector<'\x02'>::NoInitAllocator>::vector' requested here
  BitVector();
  ^
/home/jenkins/workspace/ceph-master/src/cls/rbd/cls_rbd.cc:3289:16: note: in instantiation of member function 'ceph::BitVector<'\x02'>::BitVector' requested here
  BitVector<2> object_map;
               ^
/usr/include/c++/v1/memory:2179:39: note: explicitly defaulted function was implicitly deleted here
  _LIBCPP_INLINE_VISIBILITY constexpr __compressed_pair_elem() = default;
                                      ^
/usr/include/c++/v1/memory:2172:50: note: default constructor of '__compressed_pair_elem<ceph::BitVector<'\x02'>::NoInitAllocator, 1, true>' is implicitly deleted because base class 'ceph::BitVector<'\x02'>::NoInitAllocator' has no default constructor
struct __compressed_pair_elem<_Tp, _Idx, true> : private _Tp {
                                                 ^
1 error generated.

```




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug