### PR TITLE
nautilus: mds: there is an assertion when calling Beacon::shutdown()

### DIFF
--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -56,7 +56,8 @@ void Beacon::shutdown()
   if (!finished) {
     finished = true;
     lock.unlock();
-    sender.join();
+    if (sender.joinable())
+      sender.join();
   }
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/39214