### PR TITLE
include/utime: do not cast sec to time_t

### DIFF
--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -83,8 +83,8 @@ public:
 
 #if defined(WITH_SEASTAR)
   explicit utime_t(const seastar::lowres_system_clock::time_point& t) {
-    tv.tv_sec = std::time_t(std::chrono::duration_cast<std::chrono::seconds>(
-        t.time_since_epoch()).count());
+    tv.tv_sec = std::chrono::duration_cast<std::chrono::seconds>(
+        t.time_since_epoch()).count();
     tv.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(
         t.time_since_epoch() % std::chrono::seconds(1)).count();
   }


### PR DESCRIPTION
strictly speaking, time_t is an opaque time, and in this context, we
need a uint32_t, so it is not necessary and wrong. let's remove it.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

