### PR TITLE
mds: async dir operation support

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1004,7 +1004,7 @@ void Client::update_dentry_lease(Dentry *dn, LeaseStat *dlease, utime_t from, Me
   
   ceph_assert(dn);
 
-  if (dlease->mask & CEPH_LOCK_DN) {
+  if (dlease->mask & CEPH_LEASE_VALID) {
     if (dttl > dn->lease_ttl) {
       ldout(cct, 10) << "got dentry lease on " << dn->name
 	       << " dur " << dlease->duration_ms << "ms ttl " << dttl << dendl;
@@ -2991,7 +2991,7 @@ void Client::handle_lease(const MConstRef<MClientLease>& m)
   }
   in = inode_map[vino];
 
-  if (m->get_mask() & CEPH_LOCK_DN) {
+  if (m->get_mask() & CEPH_LEASE_VALID) {
     if (!in->dir || in->dir->dentries.count(m->dname) == 0) {
       ldout(cct, 10) << " don't have dir|dentry " << m->get_ino() << "/" << m->dname <<dendl;
       goto revoke;

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -318,19 +318,21 @@ extern const char *ceph_mds_state_name(int s);
  *  - they also define the lock ordering by the MDS
  *  - a few of these are internal to the mds
  */
-#define CEPH_LOCK_DVERSION    1
-#define CEPH_LOCK_DN          2
-#define CEPH_LOCK_IVERSION    16    /* mds internal */
-#define CEPH_LOCK_ISNAP       32
-#define CEPH_LOCK_IFILE       64
-#define CEPH_LOCK_IAUTH       128
-#define CEPH_LOCK_ILINK       256
-#define CEPH_LOCK_IDFT        512   /* dir frag tree */
-#define CEPH_LOCK_INEST       1024  /* mds internal */
-#define CEPH_LOCK_IXATTR      2048
-#define CEPH_LOCK_IFLOCK      4096  /* advisory file locks */
-#define CEPH_LOCK_INO         8192  /* immutable inode bits; not a lock */
-#define CEPH_LOCK_IPOLICY     16384 /* policy lock on dirs. MDS internal */
+#define CEPH_LOCK_DN          (1 << 0)
+#define CEPH_LOCK_DVERSION    (1 << 1)
+#define CEPH_LOCK_ISNAP       (1 << 4)  /* snapshot lock. MDS internal */
+#define CEPH_LOCK_IPOLICY     (1 << 5)  /* policy lock on dirs. MDS internal */
+#define CEPH_LOCK_IFILE       (1 << 6)
+#define CEPH_LOCK_INEST       (1 << 7)  /* mds internal */
+#define CEPH_LOCK_IDFT        (1 << 8)  /* dir frag tree */
+#define CEPH_LOCK_IAUTH       (1 << 9)
+#define CEPH_LOCK_ILINK       (1 << 10)
+#define CEPH_LOCK_IXATTR      (1 << 11)
+#define CEPH_LOCK_IFLOCK      (1 << 12)  /* advisory file locks */
+#define CEPH_LOCK_IVERSION    (1 << 13)  /* mds internal */
+
+#define CEPH_LOCK_IFIRST      CEPH_LOCK_ISNAP
+
 
 /* client_session ops */
 enum {

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -763,7 +763,7 @@ int ceph_flags_to_mode(int flags);
 #define CEPH_CAP_LINK_EXCL     (CEPH_CAP_GEXCL     << CEPH_CAP_SLINK)
 #define CEPH_CAP_XATTR_SHARED (CEPH_CAP_GSHARED  << CEPH_CAP_SXATTR)
 #define CEPH_CAP_XATTR_EXCL    (CEPH_CAP_GEXCL     << CEPH_CAP_SXATTR)
-#define CEPH_CAP_FILE(x)    (x << CEPH_CAP_SFILE)
+#define CEPH_CAP_FILE(x)       ((x) << CEPH_CAP_SFILE)
 #define CEPH_CAP_FILE_SHARED   (CEPH_CAP_GSHARED   << CEPH_CAP_SFILE)
 #define CEPH_CAP_FILE_EXCL     (CEPH_CAP_GEXCL     << CEPH_CAP_SFILE)
 #define CEPH_CAP_FILE_CACHE    (CEPH_CAP_GCACHE    << CEPH_CAP_SFILE)
@@ -817,6 +817,13 @@ int ceph_flags_to_mode(int flags);
 
 #define CEPH_CAP_LOCKS (CEPH_LOCK_IFILE | CEPH_LOCK_IAUTH | CEPH_LOCK_ILINK | \
 			CEPH_LOCK_IXATTR)
+
+/* cap masks async dir operations */
+#define CEPH_CAP_DIR_CREATE    CEPH_CAP_FILE_CACHE
+#define CEPH_CAP_DIR_UNLINK    CEPH_CAP_FILE_RD
+#define CEPH_CAP_ANY_DIR_OPS   (CEPH_CAP_FILE_CACHE | CEPH_CAP_FILE_RD | \
+				CEPH_CAP_FILE_WREXTEND | CEPH_CAP_FILE_LAZYIO)
+
 
 int ceph_caps_for_mode(int mode);
 

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -694,6 +694,7 @@ struct ceph_mds_reply_lease {
 } __attribute__ ((packed));
 
 #define CEPH_LEASE_VALID	(1 | 2) /* old and new bit values */
+#define CEPH_LEASE_PRIMARY_LINK	4	/* primary linkage */
 
 struct ceph_mds_reply_dirfrag {
 	__le32 frag;            /* fragment */

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -693,6 +693,8 @@ struct ceph_mds_reply_lease {
 	__le32 seq;
 } __attribute__ ((packed));
 
+#define CEPH_LEASE_VALID	(1 | 2) /* old and new bit values */
+
 struct ceph_mds_reply_dirfrag {
 	__le32 frag;            /* fragment */
 	__le32 auth;            /* auth mds, if this is a delegation point */

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -196,6 +196,7 @@ CDir::CDir(CInode *in, frag_t fg, MDCache *mdcache, bool auth) :
   dirty_dentries(member_offset(CDentry, item_dir_dirty)),
   item_dirty(this), item_new(this),
   lock_caches_with_auth_pins(member_offset(MDLockCache::DirItem, item_dir)),
+  freezing_inodes(member_offset(CInode, item_freezing_inode)),
   dir_rep(REP_NONE),
   pop_me(mdcache->decayrate),
   pop_nested(mdcache->decayrate),
@@ -591,6 +592,11 @@ void CDir::link_inode_work( CDentry *dn, CInode *in)
   if (in->auth_pins)
     dn->adjust_nested_auth_pins(in->auth_pins, NULL);
 
+  if (in->is_freezing_inode())
+    freezing_inodes.push_back(&in->item_freezing_inode);
+  else if (in->is_frozen_inode() || in->is_frozen_auth_pin())
+    num_frozen_inodes++;
+
   // verify open snaprealm parent
   if (in->snaprealm)
     in->snaprealm->adjust_parent();
@@ -671,6 +677,11 @@ void CDir::unlink_inode_work(CDentry *dn)
     // unlink auth_pin count
     if (in->auth_pins)
       dn->adjust_nested_auth_pins(-in->auth_pins, nullptr);
+
+    if (in->is_freezing_inode())
+      in->item_freezing_inode.remove_myself();
+    else if (in->is_frozen_inode() || in->is_frozen_auth_pin())
+      num_frozen_inodes--;
 
     // detach inode
     in->remove_primary_parent(dn);
@@ -3168,6 +3179,19 @@ void CDir::unfreeze_dir()
     auth_unpin(this);
     
     finish_waiting(WAIT_UNFREEZE);
+  }
+}
+
+void CDir::enable_frozen_inode()
+{
+  ceph_assert(frozen_inode_suppressed > 0);
+  if (--frozen_inode_suppressed == 0) {
+    for (auto p = freezing_inodes.begin(); !p.end(); ) {
+      CInode *in = *p;
+      ++p;
+      ceph_assert(in->is_freezing_inode());
+      in->maybe_finish_freeze_inode();
+    }
   }
 }
 

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -599,6 +599,9 @@ public:
   elist<CDentry*> dirty_dentries;
   elist<CDir*>::item item_dirty, item_new;
 
+  // lock caches that auth-pin me
+  elist<MDLockCache::DirItem*> lock_caches_with_auth_pins;
+
   // all dirfrags within freezing/frozen tree reference the 'state'
   std::shared_ptr<freeze_tree_state_t> freeze_tree_state;
 

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -578,6 +578,15 @@ public:
     return true;
   }
 
+  bool is_any_freezing_or_frozen_inode() const {
+    return num_frozen_inodes || !freezing_inodes.empty();
+  }
+  void disable_frozen_inode() {
+    ceph_assert(num_frozen_inodes == 0);
+    frozen_inode_suppressed++;
+  }
+  void enable_frozen_inode();
+
   ostream& print_db_line_prefix(ostream& out) override;
   void print(ostream& out) override;
   void dump(Formatter *f, int flags = DUMP_DEFAULT) const;
@@ -682,6 +691,11 @@ protected:
   // lock nesting, freeze
   static int num_frozen_trees;
   static int num_freezing_trees;
+
+  // freezing/frozen inodes in this dirfrag
+  int num_frozen_inodes = 0;
+  int frozen_inode_suppressed = 0;
+  elist<CInode*> freezing_inodes;
 
   int dir_auth_pins = 0;
 

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -581,6 +581,9 @@ public:
   bool is_any_freezing_or_frozen_inode() const {
     return num_frozen_inodes || !freezing_inodes.empty();
   }
+  bool is_auth_pinned_by_lock_cache() const {
+    return frozen_inode_suppressed;
+  }
   void disable_frozen_inode() {
     ceph_assert(num_frozen_inodes == 0);
     frozen_inode_suppressed++;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3442,7 +3442,11 @@ int CInode::get_caps_allowed_for_client(Session *session, Capability *cap,
     allowed = get_caps_allowed_by_type(CAP_ANY);
   }
 
-  if (!is_dir()) {
+  if (is_dir()) {
+    allowed &= ~CEPH_CAP_ANY_DIR_OPS;
+    if (cap && (allowed & CEPH_CAP_FILE_EXCL))
+      allowed |= cap->get_lock_cache_allowed();
+  } else {
     if (file_i->inline_data.version == CEPH_INLINE_NONE &&
 	file_i->layout.pool_ns.empty()) {
       // noop

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1587,6 +1587,7 @@ void CInode::decode_store(bufferlist::const_iterator& bl)
 SimpleLock* CInode::get_lock(int type)
 {
   switch (type) {
+    case CEPH_LOCK_IVERSION: return &versionlock;
     case CEPH_LOCK_IFILE: return &filelock;
     case CEPH_LOCK_IAUTH: return &authlock;
     case CEPH_LOCK_ILINK: return &linklock;
@@ -2680,25 +2681,64 @@ void CInode::take_waiting(uint64_t mask, MDSContext::vec& ls)
   MDSCacheObject::take_waiting(mask, ls);
 }
 
+void CInode::maybe_finish_freeze_inode()
+{
+  CDir *dir = get_parent_dir();
+  if (auth_pins > auth_pin_freeze_allowance || dir->frozen_inode_suppressed)
+    return;
+
+  dout(10) << "maybe_finish_freeze_inode - frozen" << dendl;
+  ceph_assert(auth_pins == auth_pin_freeze_allowance);
+  get(PIN_FROZEN);
+  put(PIN_FREEZING);
+  state_clear(STATE_FREEZING);
+  state_set(STATE_FROZEN);
+
+  item_freezing_inode.remove_myself();
+  dir->num_frozen_inodes++;
+
+  finish_waiting(WAIT_FROZEN);
+}
+
 bool CInode::freeze_inode(int auth_pin_allowance)
 {
+  CDir *dir = get_parent_dir();
+  ceph_assert(dir);
+
   ceph_assert(auth_pin_allowance > 0);  // otherwise we need to adjust parent's nested_auth_pins
   ceph_assert(auth_pins >= auth_pin_allowance);
-  if (auth_pins > auth_pin_allowance) {
-    dout(10) << "freeze_inode - waiting for auth_pins to drop to " << auth_pin_allowance << dendl;
-    auth_pin_freeze_allowance = auth_pin_allowance;
-    get(PIN_FREEZING);
-    state_set(STATE_FREEZING);
-    return false;
+  if (auth_pins == auth_pin_allowance && !dir->frozen_inode_suppressed) {
+    dout(10) << "freeze_inode - frozen" << dendl;
+    if (!state_test(STATE_FROZEN)) {
+      get(PIN_FROZEN);
+      state_set(STATE_FROZEN);
+      dir->num_frozen_inodes++;
+    }
+    return true;
   }
 
-  dout(10) << "freeze_inode - frozen" << dendl;
-  ceph_assert(auth_pins == auth_pin_allowance);
-  if (!state_test(STATE_FROZEN)) {
-    get(PIN_FROZEN);
-    state_set(STATE_FROZEN);
+  dout(10) << "freeze_inode - waiting for auth_pins to drop to " << auth_pin_allowance << dendl;
+  auth_pin_freeze_allowance = auth_pin_allowance;
+  dir->freezing_inodes.push_back(&item_freezing_inode);
+
+  get(PIN_FREEZING);
+  state_set(STATE_FREEZING);
+
+  if (!dir->lock_caches_with_auth_pins.empty())
+    mdcache->mds->locker->invalidate_lock_caches(dir);
+
+  const static int lock_types[] = {
+    CEPH_LOCK_IVERSION, CEPH_LOCK_IFILE, CEPH_LOCK_IAUTH, CEPH_LOCK_ILINK, CEPH_LOCK_IDFT,
+    CEPH_LOCK_IXATTR, CEPH_LOCK_ISNAP, CEPH_LOCK_INEST, CEPH_LOCK_IFLOCK, CEPH_LOCK_IPOLICY, 0
+  };
+  for (int i = 0; lock_types[i]; ++i) {
+    auto lock = get_lock(lock_types[i]);
+    if (lock->is_cached())
+      mdcache->mds->locker->invalidate_lock_caches(lock);
   }
-  return true;
+  // invalidate_lock_caches() may decrease dir->frozen_inode_suppressed
+  // and finish freezing the inode
+  return state_test(STATE_FROZEN);
 }
 
 void CInode::unfreeze_inode(MDSContext::vec& finished) 
@@ -2707,9 +2747,11 @@ void CInode::unfreeze_inode(MDSContext::vec& finished)
   if (state_test(STATE_FREEZING)) {
     state_clear(STATE_FREEZING);
     put(PIN_FREEZING);
+    item_freezing_inode.remove_myself();
   } else if (state_test(STATE_FROZEN)) {
     state_clear(STATE_FROZEN);
     put(PIN_FROZEN);
+    get_parent_dir()->num_frozen_inodes--;
   } else 
     ceph_abort();
   take_waiting(WAIT_UNFREEZE, finished);
@@ -2726,12 +2768,14 @@ void CInode::freeze_auth_pin()
 {
   ceph_assert(state_test(CInode::STATE_FROZEN));
   state_set(CInode::STATE_FROZENAUTHPIN);
+  get_parent_dir()->num_frozen_inodes++;
 }
 
 void CInode::unfreeze_auth_pin()
 {
   ceph_assert(state_test(CInode::STATE_FROZENAUTHPIN));
   state_clear(CInode::STATE_FROZENAUTHPIN);
+  get_parent_dir()->num_frozen_inodes--;
   if (!state_test(STATE_FREEZING|STATE_FROZEN)) {
     MDSContext::vec finished;
     take_waiting(WAIT_UNFREEZE, finished);
@@ -2808,15 +2852,8 @@ void CInode::auth_unpin(void *by)
   if (parent)
     parent->adjust_nested_auth_pins(-1, by);
 
-  if (is_freezing_inode() &&
-      auth_pins == auth_pin_freeze_allowance) {
-    dout(10) << "auth_unpin freezing!" << dendl;
-    get(PIN_FROZEN);
-    put(PIN_FREEZING);
-    state_clear(STATE_FREEZING);
-    state_set(STATE_FROZEN);
-    finish_waiting(WAIT_FROZEN);
-  }  
+  if (is_freezing_inode())
+    maybe_finish_freeze_inode();
 }
 
 // authority

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -513,7 +513,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   bool has_snap_data(snapid_t s);
   void purge_stale_snap_data(const std::set<snapid_t>& snaps);
 
-  bool has_dirfrags() { return !dirfrags.empty(); }
+  size_t get_num_dirfrags() const { return dirfrags.size(); }
   CDir* get_dirfrag(frag_t fg) {
     auto pi = dirfrags.find(fg);
     if (pi != dirfrags.end()) {

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -197,7 +197,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   friend class MDCache;
   friend class StrayManager;
   friend class CDir;
-  friend class CInodeExport;
+  friend ostream& operator<<(ostream&, const CInode&);
 
   class scrub_stamp_info_t {
   public:
@@ -957,8 +957,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   elist<CInode*>::item& item_recover_queue = item_dirty_dirfrag_dir;
   elist<CInode*>::item& item_recover_queue_front = item_dirty_dirfrag_nest;
 
-  int auth_pin_freeze_allowance = 0;
-
   inode_load_vec_t pop;
   elist<CInode*>::item item_pop_lru;
 
@@ -1069,6 +1067,11 @@ protected:
   // -- waiting --
   mempool::mds_co::compact_map<frag_t, MDSContext::vec > waiting_on_dir;
 
+
+  // -- freezing inode --
+  int auth_pin_freeze_allowance = 0;
+  elist<CInode*>::item item_freezing_inode;
+  void maybe_finish_freeze_inode();
 private:
 
   friend class ValidationContinuation;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -893,6 +893,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     parent = projected_parent.front();
     projected_parent.pop_front();
   }
+  bool is_parent_projected() const {
+    return !projected_parent.empty();
+  }
 
   void maybe_export_pin(bool update=false);
   void set_export_pin(mds_rank_t rank);

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -148,6 +148,7 @@ void Capability::revoke_info::generate_test_instances(std::list<Capability::revo
 Capability::Capability(CInode *i, Session *s, uint64_t id) :
   item_session_caps(this), item_snaprealm_caps(this),
   item_revoking_caps(this), item_client_revoking_caps(this),
+  lock_caches(member_offset(MDLockCache, item_cap_lock_cache)),
   inode(i), session(s), cap_id(id)
 {
   if (session) {

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -20,6 +20,7 @@
 #include "include/counter.h"
 #include "include/mempool.h"
 #include "include/xlist.h"
+#include "include/elist.h"
 
 #include "common/config.h"
 
@@ -62,6 +63,7 @@
 
 class CInode;
 class Session;
+class MDLockCache;
 
 namespace ceph {
   class Formatter;
@@ -361,6 +363,7 @@ public:
   xlist<Capability*>::item item_revoking_caps;
   xlist<Capability*>::item item_client_revoking_caps;
 
+  elist<MDLockCache*> lock_caches;
 private:
   void calc_issued() {
     _issued = _pending;

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1741,6 +1741,22 @@ void Locker::xlock_import(SimpleLock *lock)
   lock->get_parent()->auth_pin(lock);
 }
 
+void Locker::xlock_downgrade(SimpleLock *lock, MutationImpl *mut)
+{
+  dout(10) << "xlock_downgrade on " << *lock << " " << *lock->get_parent() << dendl;
+  auto it = mut->locks.find(lock);
+  if (it->is_rdlock())
+    return; // already downgraded
+
+  ceph_assert(lock->get_parent()->is_auth());
+  ceph_assert(it != mut->locks.end());
+  ceph_assert(it->is_xlock());
+
+  lock->set_xlock_done();
+  lock->get_rdlock();
+  xlock_finish(it, mut, nullptr);
+  mut->emplace_lock(lock, MutationImpl::LockOp::RDLOCK);
+}
 
 
 // file i/o -----------------------------------------

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -4130,7 +4130,7 @@ void Locker::issue_client_lease(CDentry *dn, client_t client,
     mdcache->touch_client_lease(l, pool, now);
 
     LeaseStat lstat;
-    lstat.mask = 1 | CEPH_LOCK_DN;  // old and new bit values
+    lstat.mask = CEPH_LEASE_VALID;
     lstat.duration_ms = (uint32_t)(1000 * mdcache->client_lease_durations[pool]);
     lstat.seq = ++l->seq;
     encode_lease(bl, session->info, lstat);

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -69,6 +69,7 @@ public:
 
   void create_lock_cache(MDRequestRef& mdr, CInode *diri);
   bool find_and_attach_lock_cache(MDRequestRef& mdr, CInode *diri);
+  void invalidate_lock_caches(SimpleLock *lock);
   void invalidate_lock_cache(MDLockCache *lock_cache);
   void put_lock_cache(MDLockCache* lock_cache);
 

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -85,11 +85,11 @@ public:
   void try_eval(SimpleLock *lock, bool *pneed_issue);
 
   bool _rdlock_kick(SimpleLock *lock, bool as_anon);
-  bool rdlock_try(SimpleLock *lock, client_t client, MDSContext *c);
+  bool rdlock_try(SimpleLock *lock, client_t client);
   bool rdlock_start(SimpleLock *lock, MDRequestRef& mut, bool as_anon=false);
   void rdlock_finish(const MutationImpl::lock_iterator& it, MutationImpl *mut, bool *pneed_issue);
-  bool can_rdlock_set(MutationImpl::LockOpVec& lov);
-  void rdlock_take_set(MutationImpl::LockOpVec& lov, MutationRef& mut);
+  bool rdlock_try_set(MutationImpl::LockOpVec& lov, MDRequestRef& mdr);
+  bool rdlock_try_set(MutationImpl::LockOpVec& lov, MutationRef& mut);
 
   void wrlock_force(SimpleLock *lock, MutationRef& mut);
   bool wrlock_try(SimpleLock *lock, MutationRef& mut);

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -105,6 +105,7 @@ public:
 
   void xlock_export(const MutationImpl::lock_iterator& it, MutationImpl *mut);
   void xlock_import(SimpleLock *lock);
+  void xlock_downgrade(SimpleLock *lock, MutationImpl *mut);
 
   void try_simple_eval(SimpleLock *lock);
   bool simple_rdlock_try(SimpleLock *lock, MDSContext *con);

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -67,6 +67,11 @@ public:
   void drop_rdlocks_for_early_reply(MutationImpl *mut);
   void drop_locks_for_fragment_unfreeze(MutationImpl *mut);
 
+  void create_lock_cache(MDRequestRef& mdr, CInode *diri);
+  bool find_and_attach_lock_cache(MDRequestRef& mdr, CInode *diri);
+  void invalidate_lock_cache(MDLockCache *lock_cache);
+  void put_lock_cache(MDLockCache* lock_cache);
+
   void eval_gather(SimpleLock *lock, bool first=false, bool *need_issue=0, MDSContext::vec *pfinishers=0);
   void eval(SimpleLock *lock, bool *need_issue);
   void eval_any(SimpleLock *lock, bool *need_issue, MDSContext::vec *pfinishers=0, bool first=false) {

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -51,14 +51,13 @@ public:
 
   void nudge_log(SimpleLock *lock);
 
-  void include_snap_rdlocks(CInode *in, MutationImpl::LockOpVec& lov);
-  void include_snap_rdlocks_wlayout(CInode *in, MutationImpl::LockOpVec& lov,
-				    file_layout_t **layout);
-
   bool acquire_locks(MDRequestRef& mdr,
 		     MutationImpl::LockOpVec& lov,
 		     CInode *auth_pin_freeze=NULL,
 		     bool auth_pin_nonblocking=false);
+
+  bool try_rdlock_snap_layout(CInode *in, MDRequestRef& mdr,
+			      int n=0, bool want_layout=false);
 
   void notify_freeze_waiter(MDSCacheObject *o);
   void cancel_locking(MutationImpl *mut, std::set<CInode*> *pneed_issue);

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -185,7 +185,7 @@ public:
   // -- client leases --
   void handle_client_lease(const cref_t<MClientLease> &m);
 
-  void issue_client_lease(CDentry *dn, client_t client, bufferlist &bl, utime_t now, Session *session);
+  void issue_client_lease(CDentry *dn, MDRequestRef &mdr, int mask, utime_t now, bufferlist &bl);
   void revoke_client_leases(SimpleLock *lock);
   static void encode_lease(bufferlist& bl, const session_info_t& info, const LeaseStat& ls);
 

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -68,7 +68,7 @@ public:
   void drop_locks_for_fragment_unfreeze(MutationImpl *mut);
 
   int get_cap_bit_for_lock_cache(int op);
-  void create_lock_cache(MDRequestRef& mdr, CInode *diri);
+  void create_lock_cache(MDRequestRef& mdr, CInode *diri, file_layout_t *dir_layout=nullptr);
   bool find_and_attach_lock_cache(MDRequestRef& mdr, CInode *diri);
   void invalidate_lock_caches(CDir *dir);
   void invalidate_lock_caches(SimpleLock *lock);

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -67,11 +67,13 @@ public:
   void drop_rdlocks_for_early_reply(MutationImpl *mut);
   void drop_locks_for_fragment_unfreeze(MutationImpl *mut);
 
+  int get_cap_bit_for_lock_cache(int op);
   void create_lock_cache(MDRequestRef& mdr, CInode *diri);
   bool find_and_attach_lock_cache(MDRequestRef& mdr, CInode *diri);
   void invalidate_lock_caches(CDir *dir);
   void invalidate_lock_caches(SimpleLock *lock);
   void invalidate_lock_cache(MDLockCache *lock_cache);
+  void eval_lock_caches(Capability *cap);
   void put_lock_cache(MDLockCache* lock_cache);
 
   void eval_gather(SimpleLock *lock, bool first=false, bool *need_issue=0, MDSContext::vec *pfinishers=0);

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -69,6 +69,7 @@ public:
 
   void create_lock_cache(MDRequestRef& mdr, CInode *diri);
   bool find_and_attach_lock_cache(MDRequestRef& mdr, CInode *diri);
+  void invalidate_lock_caches(CDir *dir);
   void invalidate_lock_caches(SimpleLock *lock);
   void invalidate_lock_cache(MDLockCache *lock_cache);
   void put_lock_cache(MDLockCache* lock_cache);

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -58,7 +58,7 @@ public:
   bool acquire_locks(MDRequestRef& mdr,
 		     MutationImpl::LockOpVec& lov,
 		     CInode *auth_pin_freeze=NULL,
-		     bool auth_pin_nonblock=false);
+		     bool auth_pin_nonblocking=false);
 
   void notify_freeze_waiter(MDSCacheObject *o);
   void cancel_locking(MutationImpl *mut, std::set<CInode*> *pneed_issue);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5969,7 +5969,7 @@ void MDCache::opened_undef_inode(CInode *in) {
   if (in->is_dir()) {
     // FIXME: re-hash dentries if necessary
     ceph_assert(in->inode.dir_layout.dl_dir_hash == g_conf()->mds_default_dir_hash);
-    if (in->has_dirfrags() && !in->dirfragtree.is_leaf(frag_t())) {
+    if (in->get_num_dirfrags() && !in->dirfragtree.is_leaf(frag_t())) {
       CDir *dir = in->get_dirfrag(frag_t());
       ceph_assert(dir);
       rejoin_undef_dirfrags.erase(dir);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6912,7 +6912,7 @@ bool MDCache::trim_inode(CDentry *dn, CInode *in, CDir *con, expiremap& expirema
     // This is because that unconnected replicas are problematic for
     // subtree migration.
     //
-    if (!in->is_auth() && !mds->locker->rdlock_try(&in->dirfragtreelock, -1, nullptr)) {
+    if (!in->is_auth() && !mds->locker->rdlock_try(&in->dirfragtreelock, -1)) {
       return true;
     }
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -119,6 +119,8 @@ static const int MDS_TRAVERSE_RDLOCK_SNAP	= (1 << 4);
 static const int MDS_TRAVERSE_RDLOCK_SNAP2	= (1 << 5);
 static const int MDS_TRAVERSE_WANT_DIRLAYOUT	= (1 << 6);
 static const int MDS_TRAVERSE_RDLOCK_PATH	= (1 << 7);
+static const int MDS_TRAVERSE_XLOCK_DENTRY	= (1 << 8);
+static const int MDS_TRAVERSE_RDLOCK_AUTHLOCK	= (1 << 9);
 
 
 // flags for predirty_journal_parents()

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -115,7 +115,9 @@ static const int MDS_TRAVERSE_DISCOVER		= (1 << 0);
 static const int MDS_TRAVERSE_LAST_XLOCKED	= (1 << 1);
 static const int MDS_TRAVERSE_WANT_DENTRY	= (1 << 2);
 static const int MDS_TRAVERSE_WANT_AUTH		= (1 << 3);
-
+static const int MDS_TRAVERSE_RDLOCK_SNAP	= (1 << 4);
+static const int MDS_TRAVERSE_RDLOCK_SNAP2	= (1 << 5);
+static const int MDS_TRAVERSE_WANT_DIRLAYOUT	= (1 << 6);
 
 // flags for predirty_journal_parents()
 static const int PREDIRTY_PRIMARY = 1; // primary dn, adjust nested accounting

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -173,6 +173,7 @@ class MDCache {
     inodeno_t ino;
     ceph_tid_t tid = 0;
     MDSContext *fin = nullptr;
+    bool path_locked = false;
     mds_rank_t hint = MDS_RANK_NONE;
     mds_rank_t checking = MDS_RANK_NONE;
     set<mds_rank_t> checked;
@@ -822,7 +823,8 @@ class MDCache {
   void open_ino(inodeno_t ino, int64_t pool, MDSContext *fin,
 		bool want_replica=true, bool want_xlocked=false);
 
-  void find_ino_peers(inodeno_t ino, MDSContext *c, mds_rank_t hint=MDS_RANK_NONE);
+  void find_ino_peers(inodeno_t ino, MDSContext *c,
+		      mds_rank_t hint=MDS_RANK_NONE, bool path_locked=false);
   void _do_find_ino_peer(find_ino_peer_info_t& fip);
   void handle_find_ino(const cref_t<MMDSFindIno> &m);
   void handle_find_ino_reply(const cref_t<MMDSFindInoReply> &m);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -118,6 +118,8 @@ static const int MDS_TRAVERSE_WANT_AUTH		= (1 << 3);
 static const int MDS_TRAVERSE_RDLOCK_SNAP	= (1 << 4);
 static const int MDS_TRAVERSE_RDLOCK_SNAP2	= (1 << 5);
 static const int MDS_TRAVERSE_WANT_DIRLAYOUT	= (1 << 6);
+static const int MDS_TRAVERSE_RDLOCK_PATH	= (1 << 7);
+
 
 // flags for predirty_journal_parents()
 static const int PREDIRTY_PRIMARY = 1; // primary dn, adjust nested accounting

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -112,7 +112,7 @@ enum {
 
 // flags for path_traverse();
 static const int MDS_TRAVERSE_DISCOVER		= (1 << 0);
-static const int MDS_TRAVERSE_LAST_XLOCKED	= (1 << 1);
+static const int MDS_TRAVERSE_PATH_LOCKED	= (1 << 1);
 static const int MDS_TRAVERSE_WANT_DENTRY	= (1 << 2);
 static const int MDS_TRAVERSE_WANT_AUTH		= (1 << 3);
 static const int MDS_TRAVERSE_RDLOCK_SNAP	= (1 << 4);
@@ -155,7 +155,7 @@ class MDCache {
     filepath want_path;
     CInode *basei = nullptr;
     bool want_base_dir = false;
-    bool want_xlocked = false;
+    bool path_locked = false;
   };
 
   // [reconnect/rejoin caps]
@@ -273,9 +273,9 @@ class MDCache {
   void discover_dir_frag(CInode *base, frag_t approx_fg, MDSContext *onfinish,
 			 mds_rank_t from=MDS_RANK_NONE);
   void discover_path(CInode *base, snapid_t snap, filepath want_path, MDSContext *onfinish,
-		     bool want_xlocked=false, mds_rank_t from=MDS_RANK_NONE);
+		     bool path_locked=false, mds_rank_t from=MDS_RANK_NONE);
   void discover_path(CDir *base, snapid_t snap, filepath want_path, MDSContext *onfinish,
-		     bool want_xlocked=false);
+		     bool path_locked=false);
   void kick_discovers(mds_rank_t who);  // after a failure.
 
   // adjust subtree auth specification
@@ -778,7 +778,7 @@ class MDCache {
    * MDS_TRAVERSE_DISCOVER: Instead of forwarding request, path_traverse()
    * attempts to look up the path from a different MDS (and bring them into
    * its cache as replicas).
-   * MDS_TRAVERSE_LAST_XLOCKED: path_traverse() will procceed when xlocked tail
+   * MDS_TRAVERSE_PATH_LOCKED: path_traverse() will procceed when xlocked
    * dentry is encountered.
    * MDS_TRAVERSE_WANT_DENTRY: Caller wants tail dentry. Add a null dentry if
    * tail dentry does not exist. return 0 even tail dentry is null.

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -121,6 +121,7 @@ static const int MDS_TRAVERSE_WANT_DIRLAYOUT	= (1 << 6);
 static const int MDS_TRAVERSE_RDLOCK_PATH	= (1 << 7);
 static const int MDS_TRAVERSE_XLOCK_DENTRY	= (1 << 8);
 static const int MDS_TRAVERSE_RDLOCK_AUTHLOCK	= (1 << 9);
+static const int MDS_TRAVERSE_CHECK_LOCKCACHE	= (1 << 10);
 
 
 // flags for predirty_journal_parents()

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -737,37 +737,42 @@ public:
 };
 
 
-void Migrator::get_export_lock_set(CDir *dir, MutationImpl::LockOpVec& lov)
+bool Migrator::export_try_grab_locks(CDir *dir, MutationRef& mut)
 {
-  // path
-  vector<CDentry*> trace;
-  cache->make_trace(trace, dir->inode);
+  CInode *diri = dir->get_inode();
+
+  if (!diri->filelock.can_wrlock(diri->get_loner()) ||
+      !diri->nestlock.can_wrlock(diri->get_loner()))
+    return false;
+
+  MutationImpl::LockOpVec lov;
 
   set<CDir*> wouldbe_bounds;
+  set<CInode*> bound_inodes;
   cache->get_wouldbe_subtree_bounds(dir, wouldbe_bounds);
+  for (auto& bound : wouldbe_bounds)
+    bound_inodes.insert(bound->get_inode());
+  for (auto& in : bound_inodes)
+    lov.add_rdlock(&in->dirfragtreelock);
 
-  lov.reserve(trace.size() + wouldbe_bounds.size() + 8);
+  lov.add_rdlock(&diri->dirfragtreelock);
 
-  for (auto& dn : trace)
-    lov.add_rdlock(&dn->lock);
+  CInode* in = diri;
+  while (true) {
+    lov.add_rdlock(&in->snaplock);
+    CDentry* pdn = in->get_projected_parent_dn();
+    if (!pdn)
+      break;
+    in = pdn->get_dir()->get_inode();
+  }
 
-  // prevent scatter gather race
-  lov.add_rdlock(&dir->get_inode()->dirfragtreelock);
+  if (!mds->locker->rdlock_try_set(lov, mut))
+    return false;
 
-  // bound dftlocks:
-  // NOTE: We need to take an rdlock on bounding dirfrags during
-  //  migration for a rather irritating reason: when we export the
-  //  bound inode, we need to send scatterlock state for the dirfrags
-  //  as well, so that the new auth also gets the correct info.  If we
-  //  race with a refragment, this info is useless, as we can't
-  //  redivvy it up.  And it's needed for the scatterlocks to work
-  //  properly: when the auth is in a sync/lock state it keeps each
-  //  dirfrag's portion in the local (auth OR replica) dirfrag.
-  for (auto& dir : wouldbe_bounds)
-    lov.add_rdlock(&dir->get_inode()->dirfragtreelock);
+  mds->locker->wrlock_force(&diri->filelock, mut);
+  mds->locker->wrlock_force(&diri->nestlock, mut);
 
-  // above code may add duplicated locks
-  lov.sort_and_merge();
+  return true;
 }
 
 
@@ -1067,26 +1072,54 @@ void Migrator::dispatch_export_dir(MDRequestRef& mdr, int count)
   }
 
   // locks?
-  MutationImpl::LockOpVec lov;
-  get_export_lock_set(dir, lov);
-  // If auth MDS of the subtree root inode is neither the exporter MDS
-  // nor the importer MDS and it gathers subtree root's fragstat/neststat
-  // while the subtree is exporting. It's possible that the exporter MDS
-  // and the importer MDS both are auth MDS of the subtree root or both
-  // are not auth MDS of the subtree root at the time they receive the
-  // lock messages. So the auth MDS of the subtree root inode may get no
-  // or duplicated fragstat/neststat for the subtree root dirfrag.
-  lov.lock_scatter_gather(&dir->get_inode()->filelock);
-  lov.lock_scatter_gather(&dir->get_inode()->nestlock);
-  if (dir->get_inode()->is_auth()) {
-    dir->get_inode()->filelock.set_scatter_wanted();
-    dir->get_inode()->nestlock.set_scatter_wanted();
-  }
+  if (!(mdr->locking_state & MutationImpl::ALL_LOCKED)) {
+    MutationImpl::LockOpVec lov;
+    // If auth MDS of the subtree root inode is neither the exporter MDS
+    // nor the importer MDS and it gathers subtree root's fragstat/neststat
+    // while the subtree is exporting. It's possible that the exporter MDS
+    // and the importer MDS both are auth MDS of the subtree root or both
+    // are not auth MDS of the subtree root at the time they receive the
+    // lock messages. So the auth MDS of the subtree root inode may get no
+    // or duplicated fragstat/neststat for the subtree root dirfrag.
+    lov.lock_scatter_gather(&dir->get_inode()->filelock);
+    lov.lock_scatter_gather(&dir->get_inode()->nestlock);
+    if (dir->get_inode()->is_auth()) {
+      dir->get_inode()->filelock.set_scatter_wanted();
+      dir->get_inode()->nestlock.set_scatter_wanted();
+    }
+    lov.add_rdlock(&dir->get_inode()->dirfragtreelock);
 
-  if (!mds->locker->acquire_locks(mdr, lov, NULL, true)) {
-    if (mdr->aborted)
-      export_try_cancel(dir);
-    return;
+    if (!mds->locker->acquire_locks(mdr, lov, nullptr, true)) {
+      if (mdr->aborted)
+	export_try_cancel(dir);
+      return;
+    }
+
+    lov.clear();
+    // bound dftlocks:
+    // NOTE: We need to take an rdlock on bounding dirfrags during
+    //  migration for a rather irritating reason: when we export the
+    //  bound inode, we need to send scatterlock state for the dirfrags
+    //  as well, so that the new auth also gets the correct info.  If we
+    //  race with a refragment, this info is useless, as we can't
+    //  redivvy it up.  And it's needed for the scatterlocks to work
+    //  properly: when the auth is in a sync/lock state it keeps each
+    //  dirfrag's portion in the local (auth OR replica) dirfrag.
+    set<CDir*> wouldbe_bounds;
+    set<CInode*> bound_inodes;
+    cache->get_wouldbe_subtree_bounds(dir, wouldbe_bounds);
+    for (auto& bound : wouldbe_bounds)
+      bound_inodes.insert(bound->get_inode());
+    for (auto& in : bound_inodes)
+      lov.add_rdlock(&in->dirfragtreelock);
+
+    if (!mds->locker->rdlock_try_set(lov, mdr))
+      return;
+
+    if (!mds->locker->try_rdlock_snap_layout(dir->get_inode(), mdr))
+      return;
+
+    mdr->locking_state |= MutationImpl::ALL_LOCKED;
   }
 
   ceph_assert(g_conf()->mds_kill_export_at != 1);
@@ -1314,28 +1347,20 @@ void Migrator::export_frozen(CDir *dir, uint64_t tid)
   ceph_assert(it->second.state == EXPORT_FREEZING);
   ceph_assert(dir->is_frozen_tree_root());
 
-  CInode *diri = dir->get_inode();
+  it->second.mut = new MutationImpl();
 
   // ok, try to grab all my locks.
-  MutationImpl::LockOpVec lov;
-  get_export_lock_set(dir, lov);
+  CInode *diri = dir->get_inode();
   if ((diri->is_auth() && diri->is_frozen()) ||
-      !mds->locker->can_rdlock_set(lov) ||
-      // for pinning scatter gather. loner has a higher chance to get wrlock
-      !diri->filelock.can_wrlock(diri->get_loner()) ||
-      !diri->nestlock.can_wrlock(diri->get_loner())) {
+      !export_try_grab_locks(dir, it->second.mut)) {
     dout(7) << "export_dir couldn't acquire all needed locks, failing. "
 	    << *dir << dendl;
     export_try_cancel(dir);
     return;
   }
 
-  it->second.mut = new MutationImpl();
   if (diri->is_auth())
     it->second.mut->auth_pin(diri);
-  mds->locker->rdlock_take_set(lov, it->second.mut);
-  mds->locker->wrlock_force(&diri->filelock, it->second.mut);
-  mds->locker->wrlock_force(&diri->nestlock, it->second.mut);
 
   cache->show_subtrees();
 
@@ -2301,7 +2326,9 @@ void Migrator::handle_export_discover(const cref_t<MExportDirDiscover> &m, bool 
     filepath fpath(m->get_path());
     vector<CDentry*> trace;
     MDRequestRef null_ref;
-    int r = cache->path_traverse(null_ref, cf, fpath, MDS_TRAVERSE_DISCOVER, &trace);
+    int r = cache->path_traverse(null_ref, cf, fpath,
+				 MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_PATH_LOCKED,
+				 &trace);
     if (r > 0) return;
     if (r < 0) {
       dout(7) << "handle_export_discover failed to discover or not dir " << m->get_path() << ", NAK" << dendl;

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -318,7 +318,7 @@ public:
 			  vector<pair<CDir*, size_t> >& results);
   void child_export_finish(std::shared_ptr<export_base_t>& parent, bool success);
 
-  void get_export_lock_set(CDir *dir, MutationImpl::LockOpVec& lov);
+  bool export_try_grab_locks(CDir *dir, MutationRef& mut);
   void get_export_client_set(CDir *dir, std::set<client_t> &client_set);
   void get_export_client_set(CInode *in, std::set<client_t> &client_set);
 

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -82,6 +82,24 @@ void MutationImpl::finish_locking(SimpleLock *lock)
   locking_target_mds = -1;
 }
 
+bool MutationImpl::is_rdlocked(SimpleLock *lock) const {
+  auto it = locks.find(lock);
+  if (it != locks.end() && it->is_rdlock())
+    return true;
+  if (lock_cache)
+    return static_cast<const MutationImpl*>(lock_cache)->is_rdlocked(lock);
+  return false;
+}
+
+bool MutationImpl::is_wrlocked(SimpleLock *lock) const {
+  auto it = locks.find(lock);
+  if (it != locks.end() && it->is_wrlock())
+    return true;
+  if (lock_cache)
+    return static_cast<const MutationImpl*>(lock_cache)->is_wrlocked(lock);
+  return false;
+}
+
 void MutationImpl::LockOpVec::erase_rdlock(SimpleLock* lock)
 {
   for (int i = size() - 1; i >= 0; --i) {

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -413,6 +413,19 @@ bool MDRequestImpl::is_batch_op()
      client_request->get_filepath().depth() == 0);
 }
 
+int MDRequestImpl::compare_paths()
+{
+  if (dir_root[0] < dir_root[1])
+    return -1;
+  if (dir_root[0] > dir_root[1])
+    return 1;
+  if (dir_depth[0] < dir_depth[1])
+    return -1;
+  if (dir_depth[0] > dir_depth[1])
+    return 1;
+  return 0;
+}
+
 cref_t<MClientRequest> MDRequestImpl::release_client_request()
 {
   msg_lock.lock();

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -285,7 +285,11 @@ struct MDRequestImpl : public MutationImpl {
   // -- i am a client (master) request
   cref_t<MClientRequest> client_request; // client request (if any)
 
+  // tree and depth info of path1 and path2
+  inodeno_t dir_root[2] = {0, 0};
+  int dir_depth[2] = {-1, -1};
   file_layout_t dir_layout;
+
   // store up to two sets of dn vectors, inode pointers, for request path1 and path2.
   vector<CDentry*> dn[2];
   CInode *in[2];
@@ -441,6 +445,7 @@ struct MDRequestImpl : public MutationImpl {
   void set_filepath2(const filepath& fp);
   bool is_queued_for_replay() const;
   bool is_batch_op();
+  int compare_paths();
 
   void print(ostream &out) const override;
   void dump(Formatter *f) const override;

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -484,12 +484,21 @@ struct MDSlaveUpdate {
   }
 };
 
+struct MDLockCacheItem {
+  MDLockCache *parent = nullptr;
+  elist<MDLockCacheItem*>::item item_lock;
+};
+
 struct MDLockCache : public MutationImpl {
   CInode *diri;
   Capability *client_cap;
   int opcode;
 
   elist<MDLockCache*>::item item_cap_lock_cache;
+
+  using LockItem = MDLockCacheItem;
+  // link myself to locked locks
+  std::unique_ptr<LockItem[]> items_lock;
 
   int ref = 1;
   bool invalidating = false;
@@ -500,6 +509,9 @@ struct MDLockCache : public MutationImpl {
   }
 
   CInode *get_dir_inode() { return diri; }
+  void attach_locks();
+  void attach_dirfrags(std::vector<CDir*>&& dfv);
+  void detach_all();
 };
 
 #endif

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -170,7 +170,14 @@ public:
 
   // if this flag is set, do not attempt to acquire further locks.
   //  (useful for wrlock, which may be a moving auth target)
-  bool done_locking = false;
+  enum {
+    SNAP_LOCKED		= 1,
+    SNAP2_LOCKED	= 2,
+    PATH_LOCKED		= 4,
+    ALL_LOCKED		= 8,
+  };
+  int locking_state = 0;
+
   bool committing = false;
   bool aborted = false;
   bool killed = false;
@@ -278,10 +285,11 @@ struct MDRequestImpl : public MutationImpl {
   // -- i am a client (master) request
   cref_t<MClientRequest> client_request; // client request (if any)
 
+  file_layout_t dir_layout;
   // store up to two sets of dn vectors, inode pointers, for request path1 and path2.
   vector<CDentry*> dn[2];
-  CDentry *straydn;
   CInode *in[2];
+  CDentry *straydn;
   snapid_t snapid;
 
   CInode *tracei;

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -500,6 +500,14 @@ struct MDLockCache : public MutationImpl {
   // link myself to locked locks
   std::unique_ptr<LockItem[]> items_lock;
 
+  struct DirItem {
+    MDLockCache *parent = nullptr;
+    elist<DirItem*>::item item_dir;
+  };
+  // link myself to auth-pinned dirfrags
+  std::unique_ptr<DirItem[]> items_dir;
+  std::vector<CDir*> auth_pinned_dirfrags;
+
   int ref = 1;
   bool invalidating = false;
 

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -138,6 +138,11 @@ public:
   lock_set locks;  // full ordering
 
   MDLockCache* lock_cache = nullptr;
+  bool lock_cache_disabled = false;
+
+  void disable_lock_cache() {
+    lock_cache_disabled = true;
+  }
 
   lock_iterator emplace_lock(SimpleLock *l, unsigned f=0, mds_rank_t t=MDS_RANK_NONE) {
     last_locked = l;
@@ -493,6 +498,7 @@ struct MDLockCache : public MutationImpl {
   CInode *diri;
   Capability *client_cap;
   int opcode;
+  file_layout_t dir_layout;
 
   elist<MDLockCache*>::item item_cap_lock_cache;
 
@@ -517,6 +523,13 @@ struct MDLockCache : public MutationImpl {
   }
 
   CInode *get_dir_inode() { return diri; }
+  void set_dir_layout(file_layout_t& layout) {
+    dir_layout = layout;
+  }
+  const file_layout_t& get_dir_layout() const {
+    return dir_layout;
+  }
+
   void attach_locks();
   void attach_dirfrags(std::vector<CDir*>&& dfv);
   void detach_all();

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2605,7 +2605,7 @@ void Server::handle_slave_request(const cref_t<MMDSSlaveRequest> &m)
       return;
     }
 
-    // may get these requests while mdr->slave_request is non-null
+    // may get these while mdr->slave_request is non-null
     if (m->get_op() == MMDSSlaveRequest::OP_DROPLOCKS) {
       mds->locker->drop_locks(mdr.get());
       return;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7072,7 +7072,7 @@ void Server::handle_slave_rmdir_prep(MDRequestRef& mdr)
   if (r > 0) return;
   if (r == -ESTALE) {
     mdcache->find_ino_peers(srcpath.get_ino(), new C_MDS_RetryRequest(mdcache, mdr),
-	mdr->slave_to_mds);
+			    mdr->slave_to_mds, true);
     return;
   }
   ceph_assert(r == 0);
@@ -8593,7 +8593,7 @@ void Server::handle_slave_rename_prep(MDRequestRef& mdr)
   if (r > 0) return;
   if (r == -ESTALE) {
     mdcache->find_ino_peers(destpath.get_ino(), new C_MDS_RetryRequest(mdcache, mdr),
-			    mdr->slave_to_mds);
+			    mdr->slave_to_mds, true);
     return;
   }
   ceph_assert(r == 0);  // we shouldn't get an error here!

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -9577,7 +9577,7 @@ void Server::handle_client_lssnap(MDRequestRef& mdr)
 
     encode(snap_name, dnbl);
     //infinite lease
-    LeaseStat e(-1, -1, 0);
+    LeaseStat e(CEPH_LEASE_VALID, -1, 0);
     mds->locker->encode_lease(dnbl, mdr->session->info, e);
     dout(20) << "encode_infinite_lease" << dendl;
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7067,7 +7067,7 @@ void Server::handle_slave_rmdir_prep(MDRequestRef& mdr)
   CInode *in;
   CF_MDS_MDRContextFactory cf(mdcache, mdr, false);
   int r = mdcache->path_traverse(mdr, cf, srcpath,
-				 MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_LAST_XLOCKED,
+				 MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_PATH_LOCKED,
 				 &trace, &in);
   if (r > 0) return;
   if (r == -ESTALE) {
@@ -8588,7 +8588,7 @@ void Server::handle_slave_rename_prep(MDRequestRef& mdr)
   vector<CDentry*> trace;
   CF_MDS_MDRContextFactory cf(mdcache, mdr, false);
   int r = mdcache->path_traverse(mdr, cf, destpath,
-				 MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_LAST_XLOCKED | MDS_TRAVERSE_WANT_DENTRY,
+				 MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_PATH_LOCKED | MDS_TRAVERSE_WANT_DENTRY,
 				 &trace);
   if (r > 0) return;
   if (r == -ESTALE) {
@@ -8608,7 +8608,7 @@ void Server::handle_slave_rename_prep(MDRequestRef& mdr)
   dout(10) << " src " << srcpath << dendl;
   CInode *srci = nullptr;
   r = mdcache->path_traverse(mdr, cf, srcpath,
-			     MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_LAST_XLOCKED,
+			     MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_PATH_LOCKED,
 			     &trace, &srci);
   if (r > 0) return;
   ceph_assert(r == 0);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -216,12 +216,11 @@ public:
 
   CInode* rdlock_path_pin_ref(MDRequestRef& mdr, int n, MutationImpl::LockOpVec& lov,
 			      bool want_auth, bool no_want_auth=false,
-			      file_layout_t **layout=nullptr,
-			      bool no_lookup=false);
+			      bool want_layout=false, bool no_lookup=false);
   CDentry* rdlock_path_xlock_dentry(MDRequestRef& mdr, int n,
 				    MutationImpl::LockOpVec& lov,
 				    bool okexist, bool alwaysxlock,
-				    file_layout_t **layout=nullptr);
+				    bool want_layout=false);
 
   CDir* try_open_auth_dirfrag(CInode *diri, frag_t fg, MDRequestRef& mdr);
 
@@ -249,10 +248,8 @@ public:
                           string value,
                           file_layout_t *layout);
   void handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
-			 file_layout_t *dir_layout,
 			 MutationImpl::LockOpVec& lov);
   void handle_remove_vxattr(MDRequestRef& mdr, CInode *cur,
-			    file_layout_t *dir_layout,
 			    MutationImpl::LockOpVec& lov);
   void handle_client_setxattr(MDRequestRef& mdr);
   void handle_client_removexattr(MDRequestRef& mdr);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -214,9 +214,9 @@ public:
   void journal_allocated_inos(MDRequestRef& mdr, EMetaBlob *blob);
   void apply_allocated_inos(MDRequestRef& mdr, Session *session);
 
-  CInode* rdlock_path_pin_ref(MDRequestRef& mdr, int n, MutationImpl::LockOpVec& lov,
-			      bool want_auth, bool no_want_auth=false,
-			      bool want_layout=false, bool no_lookup=false);
+  CInode* rdlock_path_pin_ref(MDRequestRef& mdr, bool want_auth,
+			      bool no_want_auth=false,
+			      bool want_layout=false);
   CDentry* rdlock_path_xlock_dentry(MDRequestRef& mdr, int n,
 				    MutationImpl::LockOpVec& lov,
 				    bool okexist, bool alwaysxlock,
@@ -247,10 +247,8 @@ public:
                           string name,
                           string value,
                           file_layout_t *layout);
-  void handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
-			 MutationImpl::LockOpVec& lov);
-  void handle_remove_vxattr(MDRequestRef& mdr, CInode *cur,
-			    MutationImpl::LockOpVec& lov);
+  void handle_set_vxattr(MDRequestRef& mdr, CInode *cur);
+  void handle_remove_vxattr(MDRequestRef& mdr, CInode *cur);
   void handle_client_setxattr(MDRequestRef& mdr);
   void handle_client_removexattr(MDRequestRef& mdr);
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -215,12 +215,9 @@ public:
   void apply_allocated_inos(MDRequestRef& mdr, Session *session);
 
   CInode* rdlock_path_pin_ref(MDRequestRef& mdr, bool want_auth,
-			      bool no_want_auth=false,
-			      bool want_layout=false);
-  CDentry* rdlock_path_xlock_dentry(MDRequestRef& mdr, int n,
-				    MutationImpl::LockOpVec& lov,
-				    bool okexist, bool alwaysxlock,
-				    bool want_layout=false);
+			      bool no_want_auth=false, bool want_layout=false);
+  CDentry* rdlock_path_xlock_dentry(MDRequestRef& mdr, bool create,
+				    bool okexist=false, bool want_layout=false);
 
   CDir* try_open_auth_dirfrag(CInode *diri, frag_t fg, MDRequestRef& mdr);
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -218,6 +218,8 @@ public:
 			      bool no_want_auth=false, bool want_layout=false);
   CDentry* rdlock_path_xlock_dentry(MDRequestRef& mdr, bool create,
 				    bool okexist=false, bool want_layout=false);
+  std::pair<CDentry*, CDentry*>
+	    rdlock_two_paths_xlock_destdn(MDRequestRef& mdr, bool xlock_srcdn);
 
   CDir* try_open_auth_dirfrag(CInode *diri, frag_t fg, MDRequestRef& mdr);
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -213,7 +213,7 @@ public:
   void apply_allocated_inos(MDRequestRef& mdr, Session *session);
 
   CInode* rdlock_path_pin_ref(MDRequestRef& mdr, bool want_auth,
-			      bool no_want_auth=false, bool want_layout=false);
+			      bool no_want_auth=false);
   CDentry* rdlock_path_xlock_dentry(MDRequestRef& mdr, bool create,
 				    bool okexist=false, bool want_layout=false);
   std::pair<CDentry*, CDentry*>
@@ -232,6 +232,9 @@ public:
   void handle_client_file_setlock(MDRequestRef& mdr);
   void handle_client_file_readlock(MDRequestRef& mdr);
 
+  bool xlock_policylock(MDRequestRef& mdr, CInode *in,
+			bool want_layout=false, bool xlock_snaplock=false);
+  CInode* try_get_auth_inode(MDRequestRef& mdr, inodeno_t ino);
   void handle_client_setattr(MDRequestRef& mdr);
   void handle_client_setlayout(MDRequestRef& mdr);
   void handle_client_setdirlayout(MDRequestRef& mdr);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -192,9 +192,7 @@ public:
   void perf_gather_op_latency(const cref_t<MClientRequest> &req, utime_t lat);
   void early_reply(MDRequestRef& mdr, CInode *tracei, CDentry *tracedn);
   void respond_to_request(MDRequestRef& mdr, int r = 0);
-  void set_trace_dist(Session *session, const ref_t<MClientReply> &reply, CInode *in, CDentry *dn,
-		      snapid_t snapid,
-		      int num_dentries_wanted,
+  void set_trace_dist(const ref_t<MClientReply> &reply, CInode *in, CDentry *dn,
 		      MDRequestRef& mdr);
 
 

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -142,10 +142,9 @@ public:
       case CEPH_LOCK_INEST: return "inest";
       case CEPH_LOCK_IXATTR: return "ixattr";
       case CEPH_LOCK_ISNAP: return "isnap";
-      case CEPH_LOCK_INO: return "ino";
       case CEPH_LOCK_IFLOCK: return "iflock";
       case CEPH_LOCK_IPOLICY: return "ipolicy";
-      default: ceph_abort(); return std::string_view();
+      default: return "unknown";
     }
   }
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -531,7 +531,7 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
 	       << dirfragtree << " on " << *in << dendl;
       in->dirfragtree = dirfragtree;
       in->force_dirfrags();
-      if (in->has_dirfrags() && in->authority() == CDIR_AUTH_UNDEF) {
+      if (in->get_num_dirfrags() && in->authority() == CDIR_AUTH_UNDEF) {
 	auto&& ls = in->get_nested_dirfrags();
 	for (const auto& dir : ls) {
 	  if (dir->get_num_any() == 0 &&

--- a/src/messages/MDiscover.h
+++ b/src/messages/MDiscover.h
@@ -34,7 +34,7 @@ private:
   filepath        want;   // ... [/]need/this/stuff
 
   bool want_base_dir = true;
-  bool want_xlocked = false;
+  bool path_locked = false;
 
  public:
   inodeno_t get_base_ino() const { return base_ino; }
@@ -45,7 +45,7 @@ private:
   const std::string& get_dentry(int n) const { return want[n]; }
 
   bool wants_base_dir() const { return want_base_dir; }
-  bool wants_xlocked() const { return want_xlocked; }
+  bool is_path_locked() const { return path_locked; }
   
   void set_base_dir_frag(frag_t f) { base_dir_frag = f; }
 
@@ -56,14 +56,14 @@ protected:
 	    snapid_t s,
             filepath& want_path_,
             bool want_base_dir_ = true,
-	    bool discover_xlocks_ = false) :
+	    bool path_locked_ = false) :
     SafeMessage{MSG_MDS_DISCOVER},
     base_ino(base_ino_),
     base_dir_frag(base_frag_),
     snapid(s),
     want(want_path_),
     want_base_dir(want_base_dir_),
-    want_xlocked(discover_xlocks_) { }
+    path_locked(path_locked_) { }
   ~MDiscover() override {}
 
 public:
@@ -80,7 +80,7 @@ public:
     decode(snapid, p);
     decode(want, p);
     decode(want_base_dir, p);
-    decode(want_xlocked, p);
+    decode(path_locked, p);
   }
   void encode_payload(uint64_t features) override {
     using ceph::encode;
@@ -89,7 +89,7 @@ public:
     encode(snapid, payload);
     encode(want, payload);
     encode(want_base_dir, payload);
-    encode(want_xlocked, payload);
+    encode(path_locked, payload);
   }
 private:
   template<class T, typename... Args>

--- a/src/messages/MDiscoverReply.h
+++ b/src/messages/MDiscoverReply.h
@@ -72,7 +72,7 @@ private:
   inodeno_t base_ino;
   frag_t base_dir_frag;  
   bool wanted_base_dir = false;
-  bool wanted_xlocked = false;
+  bool path_locked = false;
   snapid_t wanted_snapid;
 
   // and the response
@@ -93,7 +93,7 @@ private:
   inodeno_t get_base_ino() const { return base_ino; }
   frag_t get_base_dir_frag() const { return base_dir_frag; }
   bool get_wanted_base_dir() const { return wanted_base_dir; }
-  bool get_wanted_xlocked() const { return wanted_xlocked; }
+  bool is_path_locked() const { return path_locked; }
   snapid_t get_wanted_snapid() const { return wanted_snapid; }
 
   bool is_flag_error_dn() const { return flag_error_dn; }
@@ -116,7 +116,7 @@ protected:
     base_ino(dis.get_base_ino()),
     base_dir_frag(dis.get_base_dir_frag()),
     wanted_base_dir(dis.wants_base_dir()),
-    wanted_xlocked(dis.wants_xlocked()),
+    path_locked(dis.is_path_locked()),
     wanted_snapid(dis.get_snapid()),
     flag_error_dn(false),
     flag_error_dir(false),
@@ -131,7 +131,7 @@ protected:
     base_ino(df.ino),
     base_dir_frag(df.frag),
     wanted_base_dir(false),
-    wanted_xlocked(false),
+    path_locked(false),
     wanted_snapid(CEPH_NOSNAP),
     flag_error_dn(false),
     flag_error_dir(false),
@@ -179,7 +179,7 @@ public:
     decode(base_ino, p);
     decode(base_dir_frag, p);
     decode(wanted_base_dir, p);
-    decode(wanted_xlocked, p);
+    decode(path_locked, p);
     decode(wanted_snapid, p);
     decode(flag_error_dn, p);
     decode(flag_error_dir, p);
@@ -195,7 +195,7 @@ public:
     encode(base_ino, payload);
     encode(base_dir_frag, payload);
     encode(wanted_base_dir, payload);
-    encode(wanted_xlocked, payload);
+    encode(path_locked, payload);
     encode(wanted_snapid, payload);
     encode(flag_error_dn, payload);
     encode(flag_error_dir, payload);

--- a/src/messages/MMDSSlaveRequest.h
+++ b/src/messages/MMDSSlaveRequest.h
@@ -98,12 +98,14 @@ public:
   __s16 op;
   mutable __u16 flags; /* XXX HACK for mark_interrupted */
 
-  static constexpr unsigned FLAG_NONBLOCK       =	1<<0;
-  static constexpr unsigned FLAG_WOULDBLOCK     =	1<<1;
-  static constexpr unsigned FLAG_NOTJOURNALED   =	1<<2;
-  static constexpr unsigned FLAG_EROFS          =	1<<3;
-  static constexpr unsigned FLAG_ABORT          =	1<<4;
-  static constexpr unsigned FLAG_INTERRUPTED    =	1<<5;
+  static constexpr unsigned FLAG_NONBLOCKING	= 1<<0;
+  static constexpr unsigned FLAG_WOULDBLOCK	= 1<<1;
+  static constexpr unsigned FLAG_NOTJOURNALED	= 1<<2;
+  static constexpr unsigned FLAG_EROFS		= 1<<3;
+  static constexpr unsigned FLAG_ABORT		= 1<<4;
+  static constexpr unsigned FLAG_INTERRUPTED	= 1<<5;
+  static constexpr unsigned FLAG_NOTIFYBLOCKING	= 1<<6;
+  static constexpr unsigned FLAG_REQBLOCKED	= 1<<7;
 
   // for locking
   __u16 lock_type;  // lock object type
@@ -140,8 +142,8 @@ public:
 
   const vector<MDSCacheObjectInfo>& get_authpins() const { return authpins; }
   vector<MDSCacheObjectInfo>& get_authpins() { return authpins; }
-  void mark_nonblock() { flags |= FLAG_NONBLOCK; }
-  bool is_nonblock() const { return (flags & FLAG_NONBLOCK); }
+  void mark_nonblocking() { flags |= FLAG_NONBLOCKING; }
+  bool is_nonblocking() const { return (flags & FLAG_NONBLOCKING); }
   void mark_error_wouldblock() { flags |= FLAG_WOULDBLOCK; }
   bool is_error_wouldblock() const { return (flags & FLAG_WOULDBLOCK); }
   void mark_not_journaled() { flags |= FLAG_NOTJOURNALED; }
@@ -152,6 +154,11 @@ public:
   void mark_abort() { flags |= FLAG_ABORT; }
   bool is_interrupted() const { return (flags & FLAG_INTERRUPTED); }
   void mark_interrupted() const { flags |= FLAG_INTERRUPTED; }
+  bool should_notify_blocking() const { return (flags & FLAG_NOTIFYBLOCKING); }
+  void mark_notify_blocking() { flags |= FLAG_NOTIFYBLOCKING; }
+  void clear_notify_blocking() const { flags &= ~FLAG_NOTIFYBLOCKING; }
+  bool is_req_blocked() const { return (flags & FLAG_REQBLOCKED); }
+  void mark_req_blocked() { flags |= FLAG_REQBLOCKED; }
 
   void set_lock_type(int t) { lock_type = t; }
   const bufferlist& get_lock_data() const { return inode_export; }


### PR DESCRIPTION
Change the order of taking locks to:

1. Lock objects in fs tree first, then lock objects in mdsdir
2. Lock objects according to their depth, in ascending order.
3. Lock objects according to inodes' numbers or dentries' parent
   inode numbers, in ascending order.



- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

