### PR TITLE
crimson: add support for basic write path

### DIFF
--- a/src/crimson/common/shared_lru.h
+++ b/src/crimson/common/shared_lru.h
@@ -29,11 +29,11 @@ class SharedLRU {
     SharedLRU<K,V>* cache;
     const K key;
     void operator()(V* ptr) {
-      cache->_erase(key);
+      cache->_erase_weak(key);
       delete ptr;
     }
   };
-  void _erase(const K& key) {
+  void _erase_weak(const K& key) {
     weak_refs.erase(key);
   }
 public:
@@ -85,6 +85,11 @@ public:
   shared_ptr_t lower_bound(const K& key);
   // return the first element that is greater than key
   std::optional<value_type> upper_bound(const K& key);
+
+  void erase(const K& key) {
+    cache.erase(key);
+    _erase_weak(key);
+  }
 };
 
 template<class K, class V>

--- a/src/crimson/common/simple_lru.h
+++ b/src/crimson/common/simple_lru.h
@@ -113,7 +113,7 @@ template <class Key, class Value, bool Ordered>
 void SimpleLRU<Key,Value,Ordered>::erase(const Key& key)
 {
   if (auto found = cache.find(key); found != cache.end()) {
-    lru.erase(found->second->second);
+    lru.erase(found->second.second);
     cache.erase(found);
   }
 }

--- a/src/crimson/os/Transaction.h
+++ b/src/crimson/os/Transaction.h
@@ -867,7 +867,7 @@ public:
   /// Set an xattr of an object
   void setattr(const coll_t& cid, const ghobject_t& oid,
 	       const char* name,
-	       bufferlist& val) {
+	       bufferlist&& val) {
     string n(name);
     setattr(cid, oid, n, val);
   }

--- a/src/crimson/os/Transaction.h
+++ b/src/crimson/os/Transaction.h
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
 // vim: ts=8 sw=2 smarttab
 
+#pragma once
+
 #include <map>
 
 #include "include/int_types.h"

--- a/src/crimson/os/cyan_store.cc
+++ b/src/crimson/os/cyan_store.cc
@@ -164,7 +164,8 @@ seastar::future<ceph::bufferptr> CyanStore::get_attr(CollectionRef c,
                 __func__, c->cid, oid);
   auto o = c->get_object(oid);
   if (!o) {
-    throw std::runtime_error(fmt::format("object does not exist: {}", oid));
+    return seastar::make_exception_future<ceph::bufferptr>(
+      EnoentException(fmt::format("object does not exist: {}", oid)));
   }
   if (auto found = o->xattr.find(name); found != o->xattr.end()) {
     return seastar::make_ready_future<ceph::bufferptr>(found->second);

--- a/src/crimson/os/cyan_store.cc
+++ b/src/crimson/os/cyan_store.cc
@@ -170,8 +170,8 @@ seastar::future<ceph::bufferptr> CyanStore::get_attr(CollectionRef c,
   if (auto found = o->xattr.find(name); found != o->xattr.end()) {
     return seastar::make_ready_future<ceph::bufferptr>(found->second);
   } else {
-    throw std::runtime_error(fmt::format("attr does not exist: {}/{}",
-                                         oid, name));
+    return seastar::make_exception_future<ceph::bufferptr>(
+      EnoentException(fmt::format("attr does not exist: {}/{}", oid, name)));
   }
 }
 

--- a/src/crimson/os/cyan_store.cc
+++ b/src/crimson/os/cyan_store.cc
@@ -217,6 +217,13 @@ seastar::future<> CyanStore::do_transaction(CollectionRef ch,
     switch (op->op) {
     case Transaction::OP_NOP:
       break;
+    case Transaction::OP_TOUCH:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        r = _touch(cid, oid);
+      }
+      break;
     case Transaction::OP_WRITE:
       {
         coll_t cid = i.get_cid(op->cid);
@@ -227,6 +234,26 @@ seastar::future<> CyanStore::do_transaction(CollectionRef ch,
         bufferlist bl;
         i.decode_bl(bl);
         r = _write(cid, oid, off, len, bl, fadvise_flags);
+      }
+      break;
+    case Transaction::OP_TRUNCATE:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        uint64_t off = op->off;
+        r = _truncate(cid, oid, off);
+      }
+      break;
+    case Transaction::OP_SETATTR:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        string name = i.decode_string();
+        bufferlist bl;
+        i.decode_bl(bl);
+        map<string, bufferptr> to_set;
+        to_set[name] = bufferptr(bl.c_str(), bl.length());
+        r = _setattrs(cid, oid, to_set);
       }
       break;
     case Transaction::OP_MKCOLL:
@@ -246,9 +273,21 @@ seastar::future<> CyanStore::do_transaction(CollectionRef ch,
   return seastar::now();
 }
 
+int CyanStore::_touch(const coll_t& cid, const ghobject_t& oid)
+{
+  logger().debug("{} cid={} oid={}",
+                __func__, cid, oid);
+  auto c = open_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  c->get_or_create_object(oid);
+  return 0;
+}
+
 int CyanStore::_write(const coll_t& cid, const ghobject_t& oid,
-                       uint64_t offset, size_t len, const bufferlist& bl,
-                       uint32_t fadvise_flags)
+                      uint64_t offset, size_t len, const bufferlist& bl,
+                      uint32_t fadvise_flags)
 {
   logger().debug("{} {} {} {} ~ {}",
                 __func__, cid, oid, offset, len);
@@ -265,6 +304,40 @@ int CyanStore::_write(const coll_t& cid, const ghobject_t& oid,
     used_bytes += (o->get_size() - old_size);
   }
 
+  return 0;
+}
+
+int CyanStore::_truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size)
+{
+  logger().debug("{} cid={} oid={} size={}",
+                __func__, cid, oid, size);
+  auto c = open_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  const ssize_t old_size = o->get_size();
+  int r = o->truncate(size);
+  used_bytes += (o->get_size() - old_size);
+  return r;
+}
+
+int CyanStore::_setattrs(const coll_t& cid, const ghobject_t& oid,
+                         map<string,bufferptr>& aset)
+{
+  logger().debug("{} cid={} oid={}",
+                __func__, cid, oid);
+  auto c = open_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  for (map<string,bufferptr>::const_iterator p = aset.begin(); p != aset.end(); ++p)
+    o->xattr[p->first] = p->second;
   return 0;
 }
 

--- a/src/crimson/os/cyan_store.h
+++ b/src/crimson/os/cyan_store.h
@@ -91,9 +91,13 @@ public:
   uuid_d get_fsid() const;
 
 private:
+  int _touch(const coll_t& cid, const ghobject_t& oid);
   int _write(const coll_t& cid, const ghobject_t& oid,
 	     uint64_t offset, size_t len, const bufferlist& bl,
 	     uint32_t fadvise_flags);
+  int _truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size);
+  int _setattrs(const coll_t& cid, const ghobject_t& oid,
+                map<string,bufferptr>& aset);
   int _create_collection(const coll_t& cid, int bits);
 };
 

--- a/src/crimson/osd/exceptions.h
+++ b/src/crimson/osd/exceptions.h
@@ -11,3 +11,5 @@ class object_not_found : public std::exception {
 class object_corrupted : public std::exception {
 };
 
+class invalid_argument : public std::exception {
+};

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -969,13 +969,13 @@ seastar::future<> PG::wait_for_active()
 }
 
 seastar::future<>
-PG::do_osd_op(const object_info_t& oi, OSDOp& osd_op)
+PG::do_osd_op(const ObjectState& os, OSDOp& osd_op)
 {
   switch (const auto& op = osd_op.op; op.op) {
   case CEPH_OSD_OP_SYNC_READ:
     [[fallthrough]];
   case CEPH_OSD_OP_READ:
-    return backend->read(oi,
+    return backend->read(os.oi,
                          op.extent.offset,
                          op.extent.length,
                          op.extent.truncate_size,
@@ -1001,8 +1001,8 @@ seastar::future<Ref<MOSDOpReply>> PG::do_osd_ops(Ref<MOSDOp> m)
       const auto oid = (m->get_snapid() == CEPH_SNAPDIR ?
                         m->get_hobj().get_head() :
                         m->get_hobj());
-      return backend->get_object(oid).then([&osd_op,this](auto oi) {
-        return do_osd_op(*oi, osd_op);
+      return backend->get_object_state(oid).then([&osd_op,this](auto os) {
+        return do_osd_op(*os, osd_op);
       }).handle_exception_type([&osd_op](const object_not_found&) {
         osd_op.rval = -ENOENT;
         throw;

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -12,6 +12,9 @@
 #include <boost/range/algorithm/max_element.hpp>
 #include <boost/range/numeric.hpp>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
 #include "messages/MOSDPGInfo.h"
@@ -983,7 +986,8 @@ PG::do_osd_op(const object_info_t& oi, OSDOp* osd_op)
       return seastar::now();
     });
   default:
-    return seastar::now();
+    throw std::runtime_error(
+      fmt::format("op '{}' not supported", ceph_osd_op_name(op.op)));
   }
 }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -13,6 +13,7 @@
 
 #include "crimson/net/Fwd.h"
 #include "osd/osd_types.h"
+#include "osd/osd_internal_types.h"
 #include "recovery_state.h"
 
 template<typename T> using Ref = boost::intrusive_ptr<T>;
@@ -128,7 +129,7 @@ private:
 			    const std::vector<int>& new_acting,
 			    int new_acting_primary);
   seastar::future<Ref<MOSDOpReply>> do_osd_ops(Ref<MOSDOp> m);
-  seastar::future<> do_osd_op(const object_info_t& oi, OSDOp& op);
+  seastar::future<> do_osd_op(const ObjectState& os, OSDOp& op);
 
 private:
   const spg_t pgid;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -131,7 +131,7 @@ private:
 			    int new_acting_primary);
   seastar::future<Ref<MOSDOpReply>> do_osd_ops(Ref<MOSDOp> m);
   seastar::future<> do_osd_op(
-    const ObjectState& os,
+    ObjectState& os,
     OSDOp& op,
     ceph::os::Transaction& txn);
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -128,7 +128,7 @@ private:
 			    const std::vector<int>& new_acting,
 			    int new_acting_primary);
   seastar::future<Ref<MOSDOpReply>> do_osd_ops(Ref<MOSDOp> m);
-  seastar::future<> do_osd_op(const object_info_t& oi, OSDOp* op);
+  seastar::future<> do_osd_op(const object_info_t& oi, OSDOp& op);
 
 private:
   const spg_t pgid;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -12,6 +12,7 @@
 #include <seastar/core/shared_future.hh>
 
 #include "crimson/net/Fwd.h"
+#include "crimson/os/Transaction.h"
 #include "osd/osd_types.h"
 #include "osd/osd_internal_types.h"
 #include "recovery_state.h"
@@ -129,7 +130,10 @@ private:
 			    const std::vector<int>& new_acting,
 			    int new_acting_primary);
   seastar::future<Ref<MOSDOpReply>> do_osd_ops(Ref<MOSDOp> m);
-  seastar::future<> do_osd_op(const ObjectState& os, OSDOp& op);
+  seastar::future<> do_osd_op(
+    const ObjectState& os,
+    OSDOp& op,
+    ceph::os::Transaction& txn);
 
 private:
   const spg_t pgid;

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -149,6 +149,13 @@ PGBackend::_load_ss(const hobject_t& oid)
   });
 }
 
+seastar::future<>
+PGBackend::evict_object_state(const hobject_t& oid)
+{
+  os_cache.erase(oid);
+  return seastar::now();
+}
+
 seastar::future<bufferlist> PGBackend::read(const object_info_t& oi,
                                             size_t offset,
                                             size_t length,

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -199,7 +199,7 @@ seastar::future<bufferlist> PGBackend::read(const object_info_t& oi,
 }
 
 seastar::future<> PGBackend::writefull(
-  const ObjectState& os,
+  ObjectState& os,
   const OSDOp& osd_op,
   ceph::os::Transaction& txn)
 {

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -34,6 +34,7 @@ public:
 					   const ec_profile_t& ec_profile);
   using cached_os_t = boost::local_shared_ptr<ObjectState>;
   seastar::future<cached_os_t> get_object_state(const hobject_t& oid);
+  seastar::future<> evict_object_state(const hobject_t& oid);
   seastar::future<bufferlist> read(const object_info_t& oi,
 				   uint64_t off,
 				   uint64_t len,

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -42,7 +42,7 @@ public:
 				   uint32_t truncate_seq,
 				   uint32_t flags);
   seastar::future<> writefull(
-    const ObjectState& os,
+    ObjectState& os,
     const OSDOp& osd_op,
     ceph::os::Transaction& trans);
   seastar::future<> submit_transaction(ceph::os::Transaction&& txn);

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -33,6 +33,9 @@ public:
 					   ceph::os::CyanStore* store,
 					   const ec_profile_t& ec_profile);
   using cached_os_t = boost::local_shared_ptr<ObjectState>;
+  seastar::future<> store_object_state(const cached_os_t os,
+				       const MOSDOp& m,
+				       ceph::os::Transaction& txn);
   seastar::future<cached_os_t> get_object_state(const hobject_t& oid);
   seastar::future<> evict_object_state(const hobject_t& oid);
   seastar::future<bufferlist> read(const object_info_t& oi,
@@ -62,4 +65,5 @@ private:
 					    size_t offset,
 					    size_t length,
 					    uint32_t flags) = 0;
+  bool maybe_create_new_object(ObjectState& os, ceph::os::Transaction& txn);
 };

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -10,6 +10,7 @@
 
 #include "crimson/common/shared_lru.h"
 #include "osd/osd_types.h"
+#include "osd/osd_internal_types.h"
 
 struct hobject_t;
 namespace ceph::os {
@@ -30,8 +31,8 @@ public:
 					   const pg_pool_t& pool,
 					   ceph::os::CyanStore* store,
 					   const ec_profile_t& ec_profile);
-  using cached_oi_t = boost::local_shared_ptr<object_info_t>;
-  seastar::future<cached_oi_t> get_object(const hobject_t& oid);
+  using cached_os_t = boost::local_shared_ptr<ObjectState>;
+  seastar::future<cached_os_t> get_object_state(const hobject_t& oid);
   seastar::future<bufferlist> read(const object_info_t& oi,
 				   uint64_t off,
 				   uint64_t len,
@@ -47,8 +48,8 @@ private:
   using cached_ss_t = boost::local_shared_ptr<SnapSet>;
   SharedLRU<hobject_t, SnapSet> ss_cache;
   seastar::future<cached_ss_t> _load_ss(const hobject_t& oid);
-  SharedLRU<hobject_t, object_info_t> oi_cache;
-  seastar::future<cached_oi_t> _load_oi(const hobject_t& oid);
+  SharedLRU<hobject_t, ObjectState> os_cache;
+  seastar::future<cached_os_t> _load_os(const hobject_t& oid);
   virtual seastar::future<bufferlist> _read(const hobject_t& hoid,
 					    size_t offset,
 					    size_t length,

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -9,6 +9,7 @@
 #include <boost/smart_ptr/local_shared_ptr.hpp>
 
 #include "crimson/common/shared_lru.h"
+#include "crimson/os/Transaction.h"
 #include "osd/osd_types.h"
 #include "osd/osd_internal_types.h"
 
@@ -39,6 +40,12 @@ public:
 				   size_t truncate_size,
 				   uint32_t truncate_seq,
 				   uint32_t flags);
+  seastar::future<> write(
+    const ObjectState& os,
+    const OSDOp& osd_op,
+    ceph::os::Transaction& trans);
+  seastar::future<> submit_transaction(ceph::os::Transaction&& txn);
+
 protected:
   const shard_id_t shard;
   CollectionRef coll;

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -41,7 +41,7 @@ public:
 				   size_t truncate_size,
 				   uint32_t truncate_seq,
 				   uint32_t flags);
-  seastar::future<> write(
+  seastar::future<> writefull(
     const ObjectState& os,
     const OSDOp& osd_op,
     ceph::os::Transaction& trans);

--- a/src/crimson/thread/Throttle.h
+++ b/src/crimson/thread/Throttle.h
@@ -4,6 +4,9 @@
 #pragma once
 
 #include <seastar/core/condition-variable.hh>
+// pull seastar::timer<...>::timer definitions. FIX SEASTAR or reactor.hh
+// is obligatory and should be included everywhere?
+#include <seastar/core/reactor.hh>
 
 #include "common/ThrottleInterface.h"
 


### PR DESCRIPTION
This is still work in progress. At the moment `crimson-osd` can be bootstrapped with `bin/rados bench -p test-pool 2 write -b 4096 --no-cleanup` to serve read requests for `bin/rados bench -p test-pool 30 rand`. Creating collection isn't supported yet and `ceph-osd` must be used for that.