### PR TITLE
mon: paxos: empty pending_finishers before retrying any of committing…

### DIFF
--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -597,6 +597,15 @@ private:
    * this list.  When it commits, these finishers are notified.
    */
   list<Context*> committing_finishers;
+  /**
+   * This function re-triggers pending_ and committing_finishers
+   * safely, so as to maintain existing system invariants. In particular
+   * we maintain ordering by triggering committing before pending, and
+   * we clear out pending_finishers prior to any triggers so that
+   * we don't trigger asserts on them being empty. You should
+   * use it instead of sending -EAGAIN to them with finish_contexts.
+   */
+  void reset_pending_committing_finishers();
 
   /**
    * @defgroup Paxos_h_sync_warns Synchronization warnings


### PR DESCRIPTION
…_finishers

There are asserts about the state of the system and pending_finishers which can
be triggered by running arbitrary commands through again. They are correct
when not restarting, but when we do restart we need to take care to preserve
the same invariants as appropriate.

Fixes: http://tracker.ceph.com/issues/39484

Signed-off-by: Greg Farnum <gfarnum@redhat.com>