### PR TITLE
test/fio: fix a compiler error.

### DIFF
--- a/src/test/fio/fio_ceph_messenger.cc
+++ b/src/test/fio/fio_ceph_messenger.cc
@@ -214,7 +214,6 @@ public:
   FioDispatcher(struct ceph_msgr_data *data):
     Dispatcher(g_ceph_context),
     m_data(data) {
-    require_authorizer = false;
   }
   bool ms_can_fast_dispatch_any() const override {
     return true;
@@ -311,6 +310,7 @@ static Messenger *create_messenger(struct ceph_msgr_options *o)
   }
   msgr->set_auth_client(g_dummy_auth);
   msgr->set_auth_server(g_dummy_auth);
+  msgr->set_require_authorizer(false);
   msgr->start();
 
   return msgr;


### PR DESCRIPTION
Met the following bug when -DWITH_FIO=ON:
/home/src/test/fio/fio_ceph_messenger.cc:217:5: error: ‘require_authorizer’ was not declared in this scope
     require_authorizer = false;
This bug introduce by f10660e84f85116b9 which omit this.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

