### PR TITLE
test/crimson: fix a compiler error.

### DIFF
--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -161,7 +161,7 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
             server.msgr.set_default_policy(ceph::net::SocketPolicy::stateless_server(0));
             server.msgr.set_policy_throttler(entity_name_t::TYPE_OSD,
                                              &server.byte_throttler);
-            client.msgr->set_require_authorizer(false);
+            server.msgr.set_require_authorizer(false);
             server.msgr.set_auth_client(&server.dummy_auth);
             server.msgr.set_auth_server(&server.dummy_auth);
             return server.msgr.bind(entity_addrvec_t{addr})
@@ -187,7 +187,7 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
             client.msgr.set_default_policy(ceph::net::SocketPolicy::lossy_client(0));
             client.msgr.set_policy_throttler(entity_name_t::TYPE_OSD,
                                              &client.byte_throttler);
-            client.msgr->set_require_authorizer(false);
+            client.msgr.set_require_authorizer(false);
             client.msgr.set_auth_client(&client.dummy_auth);
             client.msgr.set_auth_server(&client.dummy_auth);
             return client.msgr.start(&client.dispatcher)


### PR DESCRIPTION
When with -DWITH_SEASTAR=ON, met the following bug:
/home/ceph/src/test/crimson/test_alien_echo.cc:164:13: error: ‘client’ was not declared in this scope
             client.msgr->set_require_authorizer(false);
             ^~~~~~
/home/ceph/src/test/crimson/test_alien_echo.cc:164:13: note: suggested alternative: ‘client_t’
             client.msgr->set_require_authorizer(false);
             ^~~~~~
             client_t
/home/ceph/src/test/crimson/test_alien_echo.cc: In instantiation of ‘seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)>::<lambda(auto:48&)> [with auto:48 = seastar_pingpong::Client; auto:47 = ceph::net::Messenger*]’:
/usr/include/c++/7/type_traits:2428:26:   required by substitution of ‘template<class _Fn, class ... _Args> static std::__result_of_success<decltype (declval<_Fn>()((declval<_Args>)()...)), std::__invoke_other> std::__result_of_other_impl::_S_test(int) [with _Fn = seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)> [with auto:47 = ceph::net::Messenger*]::<lambda(auto:48&)>; _Args = {seastar_pingpong::Client&}]’
/usr/include/c++/7/type_traits:2439:55:   required from ‘struct std::__result_of_impl<false, false, seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)> [with auto:47 = ceph::net::Messenger*]::<lambda(auto:48&)>, seastar_pingpong::Client&>’
/usr/include/c++/7/type_traits:2444:12:   required from ‘struct std::__invoke_result<seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)> [with auto:47 = ceph::net::Messenger*]::<lambda(auto:48&)>, seastar_pingpong::Client&>’
/usr/include/c++/7/type_traits:2457:12:   required from ‘class std::result_of<seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)> [with auto:47 = ceph::net::Messenger*]::<lambda(auto:48&)>(seastar_pingpong::Client&)>’
/home//ceph/src/seastar/include/seastar/core/do_with.hh:93:17:   required from ‘auto seastar::do_with(T&&, F&&) [with T = seastar_pingpong::Client; F = seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)> [with auto:47 = ceph::net::Messenger*]::<lambda(auto:48&)>]’
/home/ceph/src/test/crimson/test_alien_echo.cc:184:32:   required from ‘seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)> [with auto:47 = ceph::net::Messenger*]’
/usr/include/c++/7/type_traits:2428:26:   required by substitution of ‘template<class _Fn, class ... _Args> static std::__result_of_success<decltype (declval<_Fn>()((declval<_Args>)()...)), std::__invoke_other> std::__result_of_other_impl::_S_test(int) [with _Fn = seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)>; _Args = {ceph::net::Messenger*&&}]’
/usr/include/c++/7/type_traits:2439:55:   required from ‘struct std::__result_of_impl<false, false, seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)>, ceph::net::Messenger*&&>’
/usr/include/c++/7/type_traits:2444:12:   required from ‘struct std::__invoke_result<seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)>, ceph::net::Messenger*&&>’
/usr/include/c++/7/type_traits:2457:12:   required from ‘class std::result_of<seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)>(ceph::net::Messenger*&&)>’
/home//ceph/src/seastar/include/seastar/core/future.hh:980:30:   required by substitution of ‘template<class Func, class Result>  requires  CanApply<Func, ceph::net::Messenger*> Result seastar::future<ceph::net::Messenger*>::then<Func, Result>(Func&&) [with Func = seastar_echo(entity_addr_t, echo_role, unsigned int)::<lambda(auto:47)>; Result = <missing>]’
/home//ceph/src/test/crimson/test_alien_echo.cc:207:8:   required from here
/home/ceph/src/test/crimson/test_alien_echo.cc:190:13: error: base operand of ‘->’ has non-pointer type ‘ceph::net::Messenger’
             client.msgr->set_require_authorizer(false);
             ^~~~~~

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

