### PR TITLE
restful: Expose perf counters

### DIFF
--- a/qa/workunits/rest/test_mgr_rest_api.py
+++ b/qa/workunits/rest/test_mgr_rest_api.py
@@ -72,8 +72,9 @@ screenplay = [
     ('get',    '/request?page=0', {}),
     ('delete', '/request', {}),
     ('get',    '/request', {}),
-    ('patch', '/pool/1', {'pg_num': 128}),
-    ('patch', '/pool/1', {'pgp_num': 128}),
+    ('patch',  '/pool/1', {'pg_num': 128}),
+    ('patch',  '/pool/1', {'pgp_num': 128}),
+    ('get',    '/perf?daemon=.*', {}),
 ]
 
 for method, endpoint, args in screenplay:

--- a/src/pybind/mgr/restful/api/__init__.py
+++ b/src/pybind/mgr/restful/api/__init__.py
@@ -7,6 +7,7 @@ from .doc import Doc
 from .mon import Mon
 from .osd import Osd
 from .pool import Pool
+from .perf import Perf
 from .request import Request
 from .server import Server
 
@@ -17,6 +18,7 @@ class Root(RestController):
     doc = Doc()
     mon = Mon()
     osd = Osd()
+    perf = Perf()
     pool = Pool()
     request = Request()
     server = Server()

--- a/src/pybind/mgr/restful/api/perf.py
+++ b/src/pybind/mgr/restful/api/perf.py
@@ -1,0 +1,27 @@
+from pecan import expose, request, response
+from pecan.rest import RestController
+
+from restful import context
+from restful.decorators import auth, lock, paginate
+
+import re
+
+class Perf(RestController):
+    @expose(template='json')
+    @paginate
+    @auth
+    def get(self, **kwargs):
+        """
+        List all the available performance counters
+
+        Options:
+         - 'daemon' -- filter by daemon, accepts Python regexp
+        """
+
+        counters = context.instance.get_all_perf_counters()
+
+        if 'daemon' in kwargs:
+            _re = re.compile(kwargs['daemon'])
+            counters = {k: v for k, v in counters.items() if _re.match(k)}
+
+        return counters


### PR DESCRIPTION
We currently do not expose perf counters in the restful module but this
is a useful piece of information to be exposed by the restful module.

Since we already have a function to gather all the information about the
perf counters, we can make this easily accessible through the restful
API.

This also supports filtering by daemons through regexps.

Signed-off-by: Boris Ranto <branto@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

