### PR TITLE
nautilus: mgr/prometheus: replace whitespaces in metrics' names

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -121,7 +121,7 @@ class Metric(object):
         def promethize(path):
             ''' replace illegal metric name characters '''
             result = path.replace('.', '_').replace(
-                '+', '_plus').replace('::', '_')
+                '+', '_plus').replace('::', '_').replace(' ', '_')
 
             # Hyphens usually turn into underscores, unless they are
             # trailing


### PR DESCRIPTION
https://tracker.ceph.com/issues/39459