### PR TITLE
script/backport-create-issue: handle long Redmine issue names

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -189,7 +189,7 @@ def update_relations(r, issue, dry_run):
             logging.error(url(issue) + " requires backport to " +
                 "unknown release " + release)
             break
-        subject = release + ": " + issue['subject']
+        subject = (release + ": " + issue['subject'])[:255]
         if dry_run:
             logging.info(url(issue) + " add backport to " + release)
             continue


### PR DESCRIPTION
Redmine issue names have a maximum length of 255 characters. When we prepend,
e.g., "nautilus: " to a very long issue name, we can end up with a string that
is over 255 characters long. Such a string will be refused by Redmine:

ValidationError: Subject is too long (maximum is 255 characters)

This patch avoids such an eventuality by truncating the post-prepend string to
255 characters.

Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

