### PR TITLE
cephfs-shell: Fix 'df' command errors

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -560,6 +560,47 @@ class TestDU(TestCephFSShell):
                         "expected_output -\n{}\ndu_output -\n{}\n".format(
                         expected_output, du_output)
 
+
+class TestDF(TestCephFSShell):
+    def validate_df(self, filename):
+        df_output = self.get_cephfs_shell_cmd_output('df '+filename)
+        log.info("cephfs-shell df output:\n{}".format(df_output))
+
+        shell_df = df_output.splitlines()[1].split()
+
+        block_size = int(self.mount_a.df()["total"]) // 1024
+        log.info("cephfs df block size output:{}\n".format(block_size))
+
+        st_size = int(self.mount_a.stat(filename)["st_size"])
+        log.info("cephfs stat used output:{}".format(st_size))
+        log.info("cephfs available:{}\n".format(block_size - st_size))
+
+        self.assertTupleEqual((block_size, st_size, block_size - st_size),
+            (int(shell_df[0]), int(shell_df[1]) , int(shell_df[2])))
+
+    def test_df_with_no_args(self):
+        expected_output = ''
+        df_output = self.get_cephfs_shell_cmd_output('df')
+        assert df_output == expected_output
+
+    def test_df_for_valid_directory(self):
+        dir_name = 'dir1'
+        mount_output = self.mount_a.run_shell('mkdir ' + dir_name)
+        log.info("cephfs-shell mount output:\n{}".format(mount_output))
+        self.validate_df(dir_name)
+
+    def test_df_for_invalid_directory(self):
+        dir_abspath = path.join(self.mount_a.mountpoint, 'non-existent-dir')
+        proc = self.run_cephfs_shell_cmd('df ' + dir_abspath)
+        assert proc.stderr.getvalue().find('error in stat') != -1
+
+    def test_df_for_valid_file(self):
+        s = 'df test' * 14145016
+        o = self.get_cephfs_shell_cmd_output("put - dumpfile", stdin=s)
+        log.info("cephfs-shell output:\n{}".format(o))
+        self.validate_df("dumpfile")
+
+
 #    def test_ls(self):
 #        """
 #        Test that ls passes

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1114,7 +1114,7 @@ sub-directories, files')
     df_parser = argparse.ArgumentParser(description='Show information about\
                 the amount of available disk space')
     df_parser.add_argument('file', help='Name of the file', nargs='*',
-                           action=path_to_bytes)
+                           default=['.'], action=path_to_bytes)
 
     @with_argparser(df_parser)
     def do_df(self, arglist):
@@ -1122,8 +1122,8 @@ sub-directories, files')
         Display the amount of available disk space for file systems
         """
         header = True    # Set to true for printing header only once
-        if not arglist.file:
-            arglist.file = ls(cephfs.getcwd())
+        if b'.' == arglist.file[0]:
+            arglist.file = ls(b'.')
 
         for file in arglist.file:
             if isinstance(file, libcephfs.DirEntry):

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1105,25 +1105,53 @@ sub-directories, files')
         """
         poutput(os.getcwd())
 
+    def complete_df(self, text, line, begidx, endidx):
+        """
+        auto complete of file name.
+        """
+        return self.complete_filenames(text, line, begidx, endidx)
+
+    df_parser = argparse.ArgumentParser(description='Show information about\
+                the amount of available disk space')
+    df_parser.add_argument('file', help='Name of the file', nargs='*',
+                           action=path_to_bytes)
+
+    @with_argparser(df_parser)
     def do_df(self, arglist):
         """
         Display the amount of available disk space for file systems
         """
-        for index, i in enumerate(ls(b".", opts='A')):
-            if index == 0:
-                poutput('{:25s}\t{:5s}\t{:15s}{:10s}{}'.format(
-                    "1K-blocks", "Used", "Available", "Use%", "Stored on"))
-            if not is_dir_exists(i.d_name):
-                statfs = cephfs.statfs(i.d_name)
-                stat = cephfs.stat(i.d_name)
-                block_size = statfs['f_blocks'] * statfs['f_bsize'] // 1024
+        header = True    # Set to true for printing header only once
+        if not arglist.file:
+            arglist.file = ls(cephfs.getcwd())
+
+        for file in arglist.file:
+            if isinstance(file, libcephfs.DirEntry):
+                file = file.d_name
+            if file == b'.' or file == b'..':
+                continue
+            try:
+                statfs = cephfs.statfs(file)
+                stat = cephfs.stat(file)
+                block_size = statfs['f_blocks']*statfs['f_bsize'] // 1024
                 available = block_size - stat.st_size
                 use = 0
+
                 if block_size > 0:
-                    use = (stat.st_size * 100 // block_size)
-                poutput('{:25d}\t{:5d}\t{:10d}\t{:5s} {}'.format(
-                    statfs['f_fsid'], stat.st_size, available,
-                    str(int(use)) + '%', i.d_name.decode('utf-8')))
+                    use = (stat.st_size*100 // block_size)
+
+                if header:
+                    header = False
+                    poutput('{:25s}\t{:5s}\t{:15s}{:10s}{}'.format(
+                            "1K-blocks", "Used", "Available", "Use%",
+                            "Stored on"))
+
+                poutput('{:d}\t{:18d}\t{:8d}\t{:10s} {}'.format(block_size,
+                        stat.st_size, available, str(int(use)) + '%',
+                        file.decode('utf-8')))
+            except libcephfs.OSError as e:
+                perror("could not statfs {}: {}".format(file.decode('utf-8'),
+                       e.strerror))
 
     locate_parser = argparse.ArgumentParser(
         description='Find file within file system')


### PR DESCRIPTION
In this patch following changes are made:
* When non-existing files or directories are used, print error message.
* Allow df on multiple file or directory.
* Add help option for df usage.

Fixes: https://tracker.ceph.com/issues/39543
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

