### PR TITLE
rgw: add editor directive comments to rgw services source files

### DIFF
--- a/src/rgw/services/svc_finisher.cc
+++ b/src/rgw/services/svc_finisher.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "common/Finisher.h"
 
 #include "svc_finisher.h"

--- a/src/rgw/services/svc_finisher.h
+++ b/src/rgw/services/svc_finisher.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_FINISHER_H
-#define CEPH_RGW_SERVICES_FINISHER_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -41,5 +42,3 @@ public:
 
   void schedule_context(Context *c);
 };
-
-#endif

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "include/random.h"
 #include "common/errno.h"
 

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_NOTIFY_H
-#define CEPH_RGW_SERVICES_NOTIFY_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -96,6 +97,3 @@ public:
 
   void register_watch_cb(CB *cb);
 };
-
-#endif
-

--- a/src/rgw/services/svc_quota.cc
+++ b/src/rgw/services/svc_quota.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "svc_quota.h"
 #include "svc_zone.h"
 

--- a/src/rgw/services/svc_quota.h
+++ b/src/rgw/services/svc_quota.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_QUOTA_H
-#define CEPH_RGW_SERVICES_QUOTA_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -19,5 +20,3 @@ public:
   const RGWQuotaInfo& get_bucket_quota() const;
   const RGWQuotaInfo& get_user_quota() const;
 };
-
-#endif

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "svc_rados.h"
 
 #include "include/rados/librados.hpp"

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_RADOS_H
-#define CEPH_RGW_SERVICES_RADOS_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -173,5 +174,3 @@ public:
   friend Pool;
   friend Pool::List;
 };
-
-#endif

--- a/src/rgw/services/svc_sync_modules.cc
+++ b/src/rgw/services/svc_sync_modules.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "svc_sync_modules.h"
 
 #include "rgw/rgw_sync_module.h"

--- a/src/rgw/services/svc_sync_modules.h
+++ b/src/rgw/services/svc_sync_modules.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_SYNC_MODULES_H
-#define CEPH_RGW_SERVICES_SYNC_MODULES_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -21,6 +22,3 @@ public:
 
   void init();
 };
-
-#endif
-

--- a/src/rgw/services/svc_sys_obj.cc
+++ b/src/rgw/services/svc_sys_obj.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "svc_sys_obj.h"
 #include "svc_sys_obj_core.h"
 #include "svc_rados.h"

--- a/src/rgw/services/svc_sys_obj.h
+++ b/src/rgw/services/svc_sys_obj.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_SYS_OBJ_H
-#define CEPH_RGW_SERVICES_SYS_OBJ_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -269,6 +270,3 @@ public:
     return sysobj_svc->get_obj(*this, obj);
   }
 };
-
-#endif
-

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "svc_sys_obj_cache.h"
 #include "svc_zone.h"
 #include "svc_notify.h"

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -1,7 +1,7 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
-#ifndef CEPH_RGW_SERVICES_SYS_OBJ_CACHE_H
-#define CEPH_RGW_SERVICES_SYS_OBJ_CACHE_H
-
+#pragma once
 
 #include "rgw/rgw_service.h"
 #include "rgw/rgw_cache.h"
@@ -181,5 +181,3 @@ public:
     entries.clear();
   }
 }; /* RGWChainedCacheImpl */
-
-#endif

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "svc_sys_obj_core.h"
 #include "svc_rados.h"
 #include "svc_zone.h"

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_SYS_OBJ_CORE_H
-#define CEPH_RGW_SERVICES_SYS_OBJ_CORE_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -217,5 +218,3 @@ public:
     return zone_svc;
   }
 };
-
-#endif

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "svc_zone.h"
 #include "svc_rados.h"
 #include "svc_sys_obj.h"

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_ZONE_H
-#define CEPH_RGW_SERVICES_ZONE_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -130,5 +131,3 @@ public:
   int list_periods(list<string>& periods);
   int list_periods(const string& current_period, list<string>& periods);
 };
-
-#endif

--- a/src/rgw/services/svc_zone_utils.cc
+++ b/src/rgw/services/svc_zone_utils.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "svc_zone_utils.h"
 #include "svc_rados.h"
 #include "svc_zone.h"

--- a/src/rgw/services/svc_zone_utils.h
+++ b/src/rgw/services/svc_zone_utils.h
@@ -1,6 +1,7 @@
-#ifndef CEPH_RGW_SERVICES_ZONEUTILS_H
-#define CEPH_RGW_SERVICES_ZONEUTILS_H
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
+#pragma once
 
 #include "rgw/rgw_service.h"
 
@@ -35,5 +36,3 @@ public:
 
   string unique_trans_id(const uint64_t unique_num);
 };
-
-#endif


### PR DESCRIPTION
So that both vi and emacs help to correctly format the source files, add the directives to each of the source files in src/rgw/services. In addition, use `#pragma once` in the header files instead of the macro kludge.