### PR TITLE
luminous: tests: krbd discard qa fixes

### DIFF
--- a/qa/workunits/rbd/krbd_data_pool.sh
+++ b/qa/workunits/rbd/krbd_data_pool.sh
@@ -61,7 +61,8 @@ function mkfs_and_mount() {
 
     local dev
     dev=$(sudo rbd map $spec)
-    mkfs.ext4 -q -E discard $dev
+    blkdiscard $dev
+    mkfs.ext4 -q -E nodiscard $dev
     sudo mount $dev /mnt
     sudo umount /mnt
     sudo rbd unmap $dev
@@ -187,7 +188,7 @@ for pool in rbd rbdnonzero; do
     done
 done
 
-# mkfs should discard some objects everywhere but in clonesonly
+# mkfs_and_mount should discard some objects everywhere but in clonesonly
 [[ $(list_HEADs rbd | wc -l) -lt $((NUM_META_RBDS + 5 * NUM_OBJECTS)) ]]
 [[ $(list_HEADs repdata | wc -l) -lt $((1 + 14 * NUM_OBJECTS)) ]]
 [[ $(list_HEADs ecdata | wc -l) -lt $((1 + 14 * NUM_OBJECTS)) ]]

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
-# This documents the state of things as of 4.12-rc4.
-#
 # - fallocate -z deallocates because BLKDEV_ZERO_NOUNMAP hint is ignored by
 # krbd
 #
-# - unaligned fallocate -z/-p appear to not deallocate -- see caveat #2 in
-# linux.git commit 6ac56951dc10 ("rbd: implement REQ_OP_WRITE_ZEROES")
+# - big unaligned blkdiscard and fallocate -z/-p leave the objects in place
 
 set -ex
 
@@ -107,7 +104,7 @@ assert_deallocated
 # unaligned blkdev_issue_discard
 allocate
 py_blkdiscard $((OBJECT_SIZE / 2))
-assert_deallocated_unaligned 1
+assert_deallocated_unaligned $NUM_OBJECTS
 
 # unaligned blkdev_issue_zeroout w/ BLKDEV_ZERO_NOUNMAP
 allocate

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -71,7 +71,7 @@ $(printf %x $IMAGE_SIZE)
 EOF
     [[ $(rados -p rbd ls | grep -c rbd_data.$IMAGE_ID) -eq $num_objects_expected ]]
     for ((i = 0; i < $num_objects_expected; i++)); do
-        rados -p rbd stat rbd_data.$IMAGE_ID.$(printf %016x $i) | grep "size $((OBJECT_SIZE / 2))"
+        rados -p rbd stat rbd_data.$IMAGE_ID.$(printf %016x $i) | egrep "(size $((OBJECT_SIZE / 2)))|(size 0)"
     done
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38954