### PR TITLE
luminous: mon: Error message displayed when mon_osd_max_split_count would be exceeded is not as user-friendly as it could be

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6588,9 +6588,9 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
     int64_t new_pgs = n - p.get_pg_num();
     if (new_pgs > g_conf->mon_osd_max_split_count * expected_osds) {
       ss << "specified pg_num " << n << " is too large (creating "
-	 << new_pgs << " new PGs on ~" << expected_osds
-	 << " OSDs exceeds per-OSD max with mon_osd_max_split_count of "
-         << g_conf->mon_osd_max_split_count << ')';
+         << new_pgs << " new PGs on ~" << expected_osds
+         << " OSDs would exceed the per-OSD max of " << g_conf->mon_osd_max_split_count
+         << " given by mon_osd_max_split_count); please increase the pg_num in smaller steps";
       return -E2BIG;
     }
     p.set_pg_num(n);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6589,8 +6589,8 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
     if (new_pgs > g_conf->mon_osd_max_split_count * expected_osds) {
       ss << "specified pg_num " << n << " is too large (creating "
 	 << new_pgs << " new PGs on ~" << expected_osds
-	 << " OSDs exceeds per-OSD max of " << g_conf->mon_osd_max_split_count
-	 << ')';
+	 << " OSDs exceeds per-OSD max with mon_osd_max_split_count of "
+         << g_conf->mon_osd_max_split_count << ')';
       return -E2BIG;
     }
     p.set_pg_num(n);


### PR DESCRIPTION
http://tracker.ceph.com/issues/39563