### PR TITLE
mgr/restful: do not use filter() for list

### DIFF
--- a/src/pybind/mgr/restful/api/mon.py
+++ b/src/pybind/mgr/restful/api/mon.py
@@ -16,15 +16,11 @@ class MonName(RestController):
         """
         Show the information for the monitor name
         """
-        mon = filter(
-            lambda x: x['name'] == self.name,
-            context.instance.get_mons()
-        )
-
+        mon = [x for x in context.instance.get_mons()
+               if x['name'] == self.name]
         if len(mon) != 1:
             response.status = 500
             return {'message': 'Failed to identify the monitor node "{}"'.format(self.name)}
-
         return mon[0]
 
 

--- a/src/pybind/mgr/restful/api/request.py
+++ b/src/pybind/mgr/restful/api/request.py
@@ -16,17 +16,12 @@ class RequestId(RestController):
         """
         Show the information for the request id
         """
-        request = filter(
-            lambda x: x.id == self.request_id,
-            context.instance.requests
-        )
-
+        request = [x for x in context.instance.requests
+                   if x.id == self.request_id]
         if len(request) != 1:
             response.status = 500
             return {'message': 'Unknown request id "{}"'.format(self.request_id)}
-
-        request = request[0]
-        return request
+        return request[0]
 
 
     @expose(template='json')
@@ -66,15 +61,13 @@ class Request(RestController):
         """
         num_requests = len(context.instance.requests)
 
-        context.instance.requests = filter(
-            lambda x: not x.is_finished(),
-            context.instance.requests
-        )
-
+        context.instance.requests = [x for x in context.instance.requests
+                                     if not x.is_finished()]
+        remaining = len(context.instance.requests)
         # Return the job statistics
         return {
-            'cleaned': num_requests - len(context.instance.requests),
-            'remaining': len(context.instance.requests),
+            'cleaned': num_requests - remaining,
+            'remaining': remaining,
         }
 
 

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -79,16 +79,16 @@ class CommandsRequest(object):
 
         # Gather the results (in parallel)
         results = []
-        for index in range(len(commands)):
+        for index, command in enumerate(commands):
             tag = '%s:%s:%d' % (__name__, self.id, index)
 
             # Store the result
             result = CommandResult(tag)
-            result.command = common.humanify_command(commands[index])
+            result.command = common.humanify_command(command)
             results.append(result)
 
             # Run the command
-            context.instance.send_command(result, 'mon', '', json.dumps(commands[index]), tag)
+            context.instance.send_command(result, 'mon', '', json.dumps(command), tag)
 
         return results
 


### PR DESCRIPTION
unlike python2, python3 returns an iterator instead of a list, so
construct a list using list comprehension directly.

Fixes: https://tracker.ceph.com/issues/38628