### PR TITLE
pybind/mgr: convert str to int using "int()"

### DIFF
--- a/src/pybind/mgr/insights/module.py
+++ b/src/pybind/mgr/insights/module.py
@@ -307,7 +307,10 @@ class Module(MgrModule):
         the selftest module to manage testing scenarios related to tracking
         health history.
         """
-        hours = long(hours)
+        try:
+            hours = long(hours)
+        except NameError:
+            hours = int(hours)
         health_util.NOW_OFFSET = datetime.timedelta(hours = hours)
         self.log.warning("Setting now time offset {}".format(health_util.NOW_OFFSET))
 


### PR DESCRIPTION
on python3, integers are of unlimited size. while on python2, "long"
integers have unlimited size.

Fixes: https://tracker.ceph.com/issues/38627
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

