### PR TITLE
rgw: protect removing bucket w radosgw-admin under multisite & w --bypass-gc

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -967,7 +967,9 @@ int RGWBucket::remove(RGWBucketAdminOpState& op_state, bool bypass_gc,
     if (delete_children) {
       ret = rgw_remove_bucket_bypass_gc(store, bucket, op_state.get_max_aio(), keep_index_consistent);
     } else {
-      set_err_msg(err_msg, "purge objects should be set for gc to be bypassed");
+      set_err_msg(err_msg,
+		  "option --purge-objects must be used for gc to be bypassed "
+		  "during bucket removal");
       return -EINVAL;
     }
   } else {

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -904,10 +904,10 @@ bool RGWSI_Zone::need_to_log_metadata() const
     (zonegroup->zones.size() > 1 || current_period->is_multi_zonegroups_with_zones());
 }
 
-bool RGWSI_Zone::can_reshard() const
+bool RGWSI_Zone::is_multisite() const
 {
-  return current_period->get_id().empty() ||
-    (zonegroup->zones.size() == 1 && current_period->is_single_zonegroup());
+  return ! current_period->get_id().empty() &&
+    (zonegroup->zones.size() != 1 || ! current_period->is_single_zonegroup());
 }
 
 /**

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -120,7 +120,10 @@ public:
 
   bool need_to_log_data() const;
   bool need_to_log_metadata() const;
-  bool can_reshard() const;
+  bool is_multisite() const;
+  bool can_reshard() const {
+    return ! is_multisite();
+  }
   bool is_syncing_bucket_meta(const rgw_bucket& bucket);
 
   int list_zonegroups(list<string>& zonegroups);


### PR DESCRIPTION
rgw: protect removing bucket w radosgw-admin under multisite & w --bypass-gc

Under multisite we depend on the clean-up done by gc to add the
metadata information to remove tail objects across sites. When
radosgw-admin is used to remove a bucket and the --bypass-gc option is
used, this process is circumvented, thereby leaving orphan tail
objects across synced sites.

Rather than prevent the user from doing this, we instead warn them and
require them to provide the --yes-i-really-mean-it option to carry out
the operation.