### PR TITLE
Warn, Baby, Warn!

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2795,7 +2795,8 @@ void Client::send_reconnect(MetaSession *session)
     auto it = in->caps.find(mds);
     if (it != in->caps.end()) {
       if (allow_multi &&
-	  m->get_approx_size() >= (std::numeric_limits<int>::max() >> 1)) {
+	  m->get_approx_size() >=
+	  static_cast<size_t>((std::numeric_limits<int>::max() >> 1))) {
 	m->mark_more();
 	session->con->send_message2(std::move(m));
 

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -146,7 +146,7 @@ void SimpleSchedulerObjectDispatch<I>::ObjectRequests::dispatch_delayed_requests
     auto &merged_requests = it.second;
 
     auto ctx = new FunctionContext(
-        [this, requests=std::move(merged_requests.requests), latency_stats,
+        [requests=std::move(merged_requests.requests), latency_stats,
          latency_stats_lock, start_time=ceph_clock_now()](int r) {
           if (latency_stats) {
             Mutex::Locker locker(*latency_stats_lock);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2230,7 +2230,7 @@ namespace librbd {
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, discard_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, ofs, len);
-    if (len > std::numeric_limits<int32_t>::max()) {
+    if (len > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
         tracepoint(librbd, discard_exit, -EINVAL);
         return -EINVAL;
     }
@@ -2247,7 +2247,7 @@ namespace librbd {
                ictx->read_only, ofs, len, bl.length() <= 0 ? NULL : bl.c_str(), bl.length(),
                op_flags);
     if (bl.length() <= 0 || len % bl.length() ||
-        len > std::numeric_limits<int>::max()) {
+        len > static_cast<size_t>(std::numeric_limits<int>::max())) {
       tracepoint(librbd, writesame_exit, -EINVAL);
       return -EINVAL;
     }
@@ -5147,7 +5147,7 @@ extern "C" int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len)
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   tracepoint(librbd, discard_enter, ictx, ictx->name.c_str(),
              ictx->snap_name.c_str(), ictx->read_only, ofs, len);
-  if (len > std::numeric_limits<int>::max()) {
+  if (len > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
     tracepoint(librbd, discard_exit, -EINVAL);
     return -EINVAL;
   }
@@ -5166,7 +5166,7 @@ extern "C" ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
              ictx->read_only, ofs, len, data_len == 0 ? NULL : buf, data_len, op_flags);
 
   if (data_len == 0 || len % data_len ||
-      len > std::numeric_limits<int>::max()) {
+      len > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
     tracepoint(librbd, writesame_exit, -EINVAL);
     return -EINVAL;
   }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1192,7 +1192,8 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
       // which is obviously the hard part TBD..
       vector<pg_t> pgs_to_check;
       tmp.get_upmap_pgs(&pgs_to_check);
-      if (pgs_to_check.size() < g_conf()->mon_clean_pg_upmaps_per_chunk * 2) {
+      if (pgs_to_check.size() <
+	  static_cast<uint64_t>(g_conf()->mon_clean_pg_upmaps_per_chunk * 2)) {
         // not enough pgs, do it inline
         tmp.clean_pg_upmaps(cct, &pending_inc);
       } else {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -176,7 +176,7 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   coll(p),
   osd(o),
   cct(o->cct),
-  pool(recovery_state.get_pool()),
+  pool(_pool),
   osdriver(osd->store, coll_t(), OSD::make_snapmapper_oid()),
   snap_mapper(
     cct,

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -446,7 +446,7 @@ std::unique_ptr<BlockCrypt> AES_256_CBC_create(CephContext* cct, const uint8_t* 
 {
   auto cbc = std::unique_ptr<AES_256_CBC>(new AES_256_CBC(cct));
   cbc->set_key(key, AES_256_KEYSIZE);
-  return std::move(cbc);
+  return cbc;
 }
 
 

--- a/src/test/common/test_bit_vector.cc
+++ b/src/test/common/test_bit_vector.cc
@@ -28,7 +28,7 @@ public:
 };
 
 typedef ::testing::Types<TestParams<2> > BitVectorTypes;
-TYPED_TEST_CASE(BitVectorTest, BitVectorTypes);
+TYPED_TEST_SUITE(BitVectorTest, BitVectorTypes);
 
 TYPED_TEST(BitVectorTest, resize) {
   typename TestFixture::bit_vector_t bit_vector;

--- a/src/test/common/test_interval_map.cc
+++ b/src/test/common/test_interval_map.cc
@@ -72,7 +72,7 @@ struct bufferlist_test_type {
 
 using IntervalMapTypes = ::testing::Types< bufferlist_test_type<uint64_t> >;
 
-TYPED_TEST_CASE(IntervalMapTest, IntervalMapTypes);
+TYPED_TEST_SUITE(IntervalMapTest, IntervalMapTypes);
 
 #define USING(_can_merge)					 \
   using TT = typename TestFixture::TestType;                     \

--- a/src/test/common/test_interval_set.cc
+++ b/src/test/common/test_interval_set.cc
@@ -38,7 +38,7 @@ typedef ::testing::Types<
 	       boost::container::flat_map<IntervalValueType,IntervalValueType>>
   > IntervalSetTypes;
 
-TYPED_TEST_CASE(IntervalSetTest, IntervalSetTypes);
+TYPED_TEST_SUITE(IntervalSetTest, IntervalSetTypes);
 
 TYPED_TEST(IntervalSetTest, compare) {
   typedef typename TestFixture::ISet ISet;

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -40,7 +40,7 @@ typedef ::testing::Types<
   ErasureCodeJerasureBlaumRoth,
   ErasureCodeJerasureLiber8tion
 > JerasureTypes;
-TYPED_TEST_CASE(ErasureCodeTest, JerasureTypes);
+TYPED_TEST_SUITE(ErasureCodeTest, JerasureTypes);
 
 TYPED_TEST(ErasureCodeTest, sanity_check_k)
 {

--- a/src/test/immutable_object_cache/test_DomainSocket.cc
+++ b/src/test/immutable_object_cache/test_DomainSocket.cc
@@ -58,7 +58,7 @@ public:
       }
     }
 
-    auto ctx = new FunctionContext([this](bool reg) {
+    auto ctx = new FunctionContext([](bool reg) {
       ASSERT_TRUE(reg);
     });
     m_cache_client->register_client(ctx);

--- a/src/test/journal/test_JournalPlayer.cc
+++ b/src/test/journal/test_JournalPlayer.cc
@@ -143,7 +143,7 @@ public:
 
 typedef ::testing::Types<TestJournalPlayerParams<0>,
                          TestJournalPlayerParams<16> > TestJournalPlayerTypes;
-TYPED_TEST_CASE(TestJournalPlayer, TestJournalPlayerTypes);
+TYPED_TEST_SUITE(TestJournalPlayer, TestJournalPlayerTypes);
 
 TYPED_TEST(TestJournalPlayer, Prefetch) {
   std::string oid = this->get_temp_oid();

--- a/src/test/journal/test_ObjectPlayer.cc
+++ b/src/test/journal/test_ObjectPlayer.cc
@@ -69,7 +69,7 @@ struct TestObjectPlayerParams {
 
 typedef ::testing::Types<TestObjectPlayerParams<0>,
                          TestObjectPlayerParams<10> > TestObjectPlayerTypes;
-TYPED_TEST_CASE(TestObjectPlayer, TestObjectPlayerTypes);
+TYPED_TEST_SUITE(TestObjectPlayer, TestObjectPlayerTypes);
 
 TYPED_TEST(TestObjectPlayer, Fetch) {
   std::string oid = this->get_temp_oid();

--- a/src/test/librados/misc_cxx.cc
+++ b/src/test/librados/misc_cxx.cc
@@ -714,7 +714,7 @@ typedef ::testing::Types<
 			   Checksummer::crc32c, uint32_t>
   > LibRadosChecksumTypes;
 
-TYPED_TEST_CASE(LibRadosChecksum, LibRadosChecksumTypes);
+TYPED_TEST_SUITE(LibRadosChecksum, LibRadosChecksumTypes);
 
 TYPED_TEST(LibRadosChecksum, Subset) {
   uint32_t chunk_size = 1024;

--- a/src/test/test_str_list.cc
+++ b/src/test/test_str_list.cc
@@ -26,7 +26,7 @@ struct SplitTest : ::testing::Test {
   }
 };
 
-TYPED_TEST_CASE(SplitTest, Types);
+TYPED_TEST_SUITE(SplitTest, Types);
 
 TYPED_TEST(SplitTest, Get)
 {

--- a/src/tools/immutable_object_cache/CacheClient.cc
+++ b/src/tools/immutable_object_cache/CacheClient.cc
@@ -244,7 +244,7 @@ namespace immutable_obj_cache {
     }
 
     ceph_assert(current_request != nullptr);
-    auto process_reply = new FunctionContext([this, current_request, reply]
+    auto process_reply = new FunctionContext([current_request, reply]
       (bool dedicated) {
        if (dedicated) {
          // dedicated thrad to execute this context.

--- a/src/tools/immutable_object_cache/ObjectCacheStore.cc
+++ b/src/tools/immutable_object_cache/ObjectCacheStore.cc
@@ -100,8 +100,7 @@ int ObjectCacheStore::do_promote(std::string pool_nspace,
                    << " snapshot: " << snap_id << dendl;
 
   int ret = 0;
-  std::string cache_file_name = std::move(get_cache_file_name(pool_nspace,
-                                          pool_id, snap_id, object_name));
+  std::string cache_file_name = get_cache_file_name(pool_nspace, pool_id, snap_id, object_name);
   librados::IoCtx ioctx;
   {
     Mutex::Locker _locker(m_ioctx_map_lock);
@@ -147,8 +146,7 @@ int ObjectCacheStore::handle_promote_callback(int ret, bufferlist* read_buf,
     ret = 0;
   }
 
-  std::string cache_file_path = std::move(
-    get_cache_file_path(cache_file_name, true));
+  std::string cache_file_path = get_cache_file_path(cache_file_name, true);
 
   if (cache_file_path == "") {
     lderr(m_cct) << "fail to write cache file" << dendl;
@@ -186,8 +184,7 @@ int ObjectCacheStore::lookup_object(std::string pool_nspace,
                    << " in pool ID : " << pool_id << dendl;
 
   int pret = -1;
-  std::string cache_file_name = std::move(get_cache_file_name(pool_nspace,
-                                            pool_id, snap_id, object_name));
+  std::string cache_file_name = get_cache_file_name(pool_nspace, pool_id, snap_id, object_name);
 
   cache_status_t ret = m_policy->lookup_object(cache_file_name);
 
@@ -245,7 +242,7 @@ int ObjectCacheStore::do_evict(std::string cache_file) {
     return 0;
   }
 
-  std::string cache_file_path = std::move(get_cache_file_path(cache_file));
+  std::string cache_file_path = get_cache_file_path(cache_file);
 
   ldout(m_cct, 20) << "evict cache: " << cache_file_path << dendl;
 


### PR DESCRIPTION
Get rid of the Fun, New Compiler warnings from  GCC 9 and Clang 8.

Since the main cause are in software we include as submodules, specifically RocksDB and Google Test, just disable the relevant warning.

This does not fix the build failure of DPDK. I made an attempt to fix it but for some reason passing in flags to disable the warning made it unable to find its headers.