### PR TITLE
nautilus: mgr/dashboard: Can't login with a bigger time difference between user and server or make auth token work with UTC times only

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -183,7 +183,7 @@ class User(object):
             self.lastUpdate = lastUpdate
 
     def refreshLastUpdate(self):
-        self.lastUpdate = int(time.mktime(time.gmtime()))
+        self.lastUpdate = int(time.time())
 
     def set_password(self, password):
         self.password = password_hash(password)


### PR DESCRIPTION
http://tracker.ceph.com/issues/39524