### PR TITLE
mimic: core: ENOENT in collection_move_rename on EC backfill target

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4368,12 +4368,12 @@ void PG::_scan_rollback_obs(const vector<ghobject_t> &rollback_obs)
        i != rollback_obs.end();
        ++i) {
     if (i->generation < trimmed_to.version) {
-      osd->clog->error() << "osd." << osd->whoami
-			<< " pg " << info.pgid
-			<< " found obsolete rollback obj "
-			<< *i << " generation < trimmed_to "
-			<< trimmed_to
-			<< "...repaired";
+      dout(10) << __func__ << "osd." << osd->whoami
+	       << " pg " << info.pgid
+	       << " found obsolete rollback obj "
+	       << *i << " generation < trimmed_to "
+	       << trimmed_to
+	       << "...repaired" << dendl;
       t.remove(coll, *i);
     }
   }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3625,7 +3625,7 @@ void PG::append_log(
 
   PGLogEntryHandler handler{this, &t};
   if (!transaction_applied) {
-     /* We must be a backfill peer, so it's ok if we apply
+     /* We must be a backfill or async recovery peer, so it's ok if we apply
       * out-of-turn since we won't be considered when
       * determining a min possible last_update.
       *

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3628,8 +3628,13 @@ void PG::append_log(
      /* We must be a backfill peer, so it's ok if we apply
       * out-of-turn since we won't be considered when
       * determining a min possible last_update.
+      *
+      * We skip_rollforward() here, which advances the crt, without
+      * doing an actual rollforward. This avoids cleaning up entries
+      * from the backend and we do not end up in a situation, where the
+      * object is deleted before we can _merge_object_divergent_entries().
       */
-    pg_log.roll_forward(&handler);
+    pg_log.skip_rollforward();
   }
 
   for (vector<pg_log_entry_t>::const_iterator p = logv.begin();

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -726,6 +726,10 @@ public:
       h);
   }
 
+  void skip_rollforward() {
+    log.skip_can_rollback_to_to_head();
+  }
+
   //////////////////// get or set log & missing ////////////////////
 
   void reset_backfill_claim_log(const pg_log_t &o, LogEntryHandler *h) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/38879