### PR TITLE
mgr/dashboard: Allow viewing and setting pool quotas

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -423,6 +423,61 @@
             </div>
           </div>
 
+        <!-- Quotas -->
+        <div>
+          <legend i18n>Quotas</legend>
+
+          <!-- Max Bytes -->
+          <div class="form-group"
+               [ngClass]="{'has-error': form.showError('max_bytes', formDir)}">
+            <label class="control-label col-sm-3"
+                   for="max_bytes">
+              <ng-container i18n>Max bytes</ng-container>
+              <cd-helper>
+                <span i18n>Leave it blank or specify 0 to disable this quota.</span>
+                <br>
+                <span i18n>A valid quota should be greater than 0.</span>
+              </cd-helper>
+            </label>
+            <div class="col-sm-9">
+              <input class="form-control"
+                     id="max_bytes"
+                     name="max_bytes"
+                     type="text"
+                     formControlName="max_bytes"
+                     i18n-placeholder
+                     placeholder="e.g., 10GiB"
+                     defaultUnit="GiB"
+                     cdDimlessBinary>
+            </div>
+          </div>
+
+          <!-- Max Objects -->
+          <div class="form-group"
+               [ngClass]="{'has-error': form.showError('max_objects', formDir)}">
+            <label class="control-label col-sm-3"
+                   for="max_objects">
+              <ng-container i18n>Max objects</ng-container>
+              <cd-helper>
+                <span i18n>Leave it blank or specify 0 to disable this quota.</span>
+                <br>
+                <span i18n>A valid quota should be greater than 0.</span>
+              </cd-helper>
+            </label>
+            <div class="col-sm-9">
+              <input class="form-control"
+                     id="max_objects"
+                     min="0"
+                     name="max_objects"
+                     type="number"
+                     formControlName="max_objects">
+              <span class="help-block"
+                    *ngIf="form.showError('max_objects', formDir, 'min')"
+                    i18n>The value should be greater or equal to 0</span>
+            </div>
+          </div>
+        </div>
+
         <!-- Pool configuration -->
         <div [hidden]="form.get('poolType').value !== 'replicated' || data.applications.selected.indexOf('rbd') === -1">
           <cd-rbd-configuration-form [form]="form"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -136,7 +136,11 @@ export class PoolFormComponent implements OnInit {
           validators: [Validators.required, Validators.min(1)]
         }),
         ecOverwrites: new FormControl(false),
-        compression: compressionForm
+        compression: compressionForm,
+        max_bytes: new FormControl(''),
+        max_objects: new FormControl(0, {
+          validators: [Validators.min(0)]
+        })
       },
       [
         CdValidators.custom('form', () => null),
@@ -221,7 +225,9 @@ export class PoolFormComponent implements OnInit {
       algorithm: pool.options.compression_algorithm,
       minBlobSize: this.dimlessBinaryPipe.transform(pool.options.compression_min_blob_size),
       maxBlobSize: this.dimlessBinaryPipe.transform(pool.options.compression_max_blob_size),
-      ratio: pool.options.compression_required_ratio
+      ratio: pool.options.compression_required_ratio,
+      max_bytes: this.dimlessBinaryPipe.transform(pool.quota_max_bytes),
+      max_objects: pool.quota_max_objects
     };
 
     Object.keys(dataMap).forEach((controlName: string) => {
@@ -529,7 +535,20 @@ export class PoolFormComponent implements OnInit {
             formControlName: 'erasureProfile',
             attr: 'name'
           },
-      { externalFieldName: 'rule_name', formControlName: 'crushRule', attr: 'rule_name' }
+      { externalFieldName: 'rule_name', formControlName: 'crushRule', attr: 'rule_name' },
+      {
+        externalFieldName: 'quota_max_bytes',
+        formControlName: 'max_bytes',
+        replaceFn: this.formatter.toBytes,
+        editable: true,
+        resetValue: this.editing ? 0 : undefined
+      },
+      {
+        externalFieldName: 'quota_max_objects',
+        formControlName: 'max_objects',
+        editable: true,
+        resetValue: this.editing ? 0 : undefined
+      }
     ]);
 
     if (this.info.is_all_bluestore) {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
Allow managing pool quotas in both frontend and backend.

Fixes: https://tracker.ceph.com/issues/36559
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

