### PR TITLE
mgr/dashboard: Fix iSCSI form when using IPv6

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -577,10 +577,10 @@ export class IscsiTargetFormComponent implements OnInit {
 
     // Portals
     formValue.portals.forEach((portal) => {
-      const portalSplit = portal.split(':');
+      const index = portal.indexOf(':');
       request.portals.push({
-        host: portalSplit[0],
-        ip: portalSplit[1]
+        host: portal.substring(0, index),
+        ip: portal.substring(index + 1)
       });
     });
 


### PR DESCRIPTION
This PR fixes an error in iSCSI form when using IPv6 adresses.

Fixes: https://tracker.ceph.com/issues/39578

Signed-off-by: Ricardo Marques <rimarques@suse.com>

