### PR TITLE
pybind/tox: pass additional command line arguments through to tox

### DIFF
--- a/src/pybind/mgr/ansible/run-tox.sh
+++ b/src/pybind/mgr/ansible/run-tox.sh
@@ -35,7 +35,7 @@ fi
 # use bash string manipulation to strip off any trailing comma
 ENV_LIST=${ENV_LIST%,}
 
-tox -c "${TOX_PATH}" -e "${ENV_LIST}"
+tox -c "${TOX_PATH}" -e "${ENV_LIST}" "$@"
 TOX_STATUS="$?"
 test "$TOX_STATUS" -ne "0" && dump_envvars
 exit $TOX_STATUS

--- a/src/pybind/mgr/dashboard/run-tox.sh
+++ b/src/pybind/mgr/dashboard/run-tox.sh
@@ -43,7 +43,7 @@ fi
 # use bash string manipulation to strip off any trailing comma
 ENV_LIST=${ENV_LIST%,}
 
-tox -c "${TOX_PATH}" -e "${ENV_LIST}"
+tox -c "${TOX_PATH}" -e "${ENV_LIST}" "$@"
 TOX_STATUS="$?"
 test "$TOX_STATUS" -ne "0" && dump_envvars
 exit $TOX_STATUS

--- a/src/pybind/mgr/insights/run-tox.sh
+++ b/src/pybind/mgr/insights/run-tox.sh
@@ -35,7 +35,7 @@ fi
 # use bash string manipulation to strip off any trailing comma
 ENV_LIST=${ENV_LIST%,}
 
-tox -c "${TOX_PATH}" -e "${ENV_LIST}"
+tox -c "${TOX_PATH}" -e "${ENV_LIST}" "$@"
 TOX_STATUS="$?"
 test "$TOX_STATUS" -ne "0" && dump_envvars
 exit $TOX_STATUS

--- a/src/pybind/mgr/orchestrator_cli/run-tox.sh
+++ b/src/pybind/mgr/orchestrator_cli/run-tox.sh
@@ -40,7 +40,7 @@ ENV_LIST=$(echo "$ENV_LIST" | sed -e 's/,$//')
 # use bash string manipulation to strip off any trailing comma
 ENV_LIST=${ENV_LIST%,}
 
-tox -c "${TOX_PATH}" -e "${ENV_LIST}"
+tox -c "${TOX_PATH}" -e "${ENV_LIST}" "$@"
 TOX_STATUS="$?"
 test "$TOX_STATUS" -ne "0" && dump_envvars
 exit $TOX_STATUS


### PR DESCRIPTION
Fixes: 9426f1f2045d0ae0f319530c3dc3a9240d838d07
Fixes: https://tracker.ceph.com/issues/39579
Signed-off-by: Nathan Cutler <ncutler@suse.com>