### PR TITLE
luminous: build/ops: python-cephfs should depend on python-rados

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -655,9 +655,7 @@ Summary:	Python 2 libraries for Ceph distributed file system
 Group:		Development/Languages/Python
 %endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
-%if 0%{?suse_version}
-Recommends: python-rados = %{_epoch_prefix}%{version}-%{release}
-%endif
+Requires:	python-rados = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-ceph < %{_epoch_prefix}%{version}-%{release}
 %description -n python-cephfs
 This package contains Python 2 libraries for interacting with Cephs distributed

--- a/debian/control
+++ b/debian/control
@@ -886,6 +886,7 @@ Package: python-rgw
 Architecture: linux-any
 Section: python
 Depends: librgw2 (>= ${binary:Version}),
+         python-rados (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
@@ -920,6 +921,7 @@ Package: python3-rgw
 Architecture: linux-any
 Section: python
 Depends: librgw2 (>= ${binary:Version}),
+         python3-rados (= ${binary:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
@@ -952,6 +954,7 @@ Package: python-cephfs
 Architecture: linux-any
 Section: python
 Depends: libcephfs2 (= ${binary:Version}),
+         python-rados (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
@@ -986,6 +989,7 @@ Package: python3-cephfs
 Architecture: linux-any
 Section: python
 Depends: libcephfs2 (= ${binary:Version}),
+         python3-rados (= ${binary:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},


### PR DESCRIPTION
http://tracker.ceph.com/issues/37612