### PR TITLE
osd: Output Base64 encoding of CRC header if binary data present

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -329,7 +329,7 @@ void dump_services(Formatter* f, const map<string, list<string> >& services, con
 
 // If non-printable characters found then convert bufferlist to
 // base64 encoded string indicating whether it did.
-string cleanbin(bufferlist &bl, bool &base64)
+string cleanbin(bufferlist &bl, bool &base64, bool show)
 {
   bufferlist::iterator it;
   for (it = bl.begin(); it != bl.end(); ++it) {
@@ -345,6 +345,8 @@ string cleanbin(bufferlist &bl, bool &base64)
   bufferlist b64;
   bl.encode_base64(b64);
   string encoded(b64.c_str(), b64.length());
+  if (show)
+    encoded = "Base64:" + encoded;
   base64 = true;
   return encoded;
 }
@@ -356,9 +358,7 @@ string cleanbin(string &str)
   bool base64;
   bufferlist bl;
   bl.append(str);
-  string result = cleanbin(bl, base64);
-  if (base64)
-    result = "Base64:" + result;
+  string result = cleanbin(bl, base64, true);
   return result;
 }
 

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -93,7 +93,7 @@ void dump_services(ceph::Formatter* f,
 void dump_services(ceph::Formatter* f, const std::map<std::string,
 		   std::list<std::string> >& services, const char* type);
 
-std::string cleanbin(ceph::buffer::list &bl, bool &b64);
+std::string cleanbin(ceph::buffer::list &bl, bool &b64, bool show = false);
 std::string cleanbin(std::string &str);
 
 namespace ceph::util {

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -21,6 +21,7 @@
 #include "messages/MOSDPGPushReply.h"
 #include "common/EventTrace.h"
 #include "include/random.h"
+#include "include/util.h"
 #include "OSD.h"
 
 #define dout_context cct
@@ -659,8 +660,8 @@ int ReplicatedBackend::be_deep_scrub(
       return 0;
     }
     if (r == 0 && hdrbl.length()) {
-      dout(25) << "CRC header " << string(hdrbl.c_str(), hdrbl.length())
-	       << dendl;
+      bool encoded = false;
+      dout(25) << "CRC header " << cleanbin(hdrbl, encoded, true) << dendl;
       pos.omap_hash << hdrbl;
     }
   }


### PR DESCRIPTION

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] ~Updates documentation if necessary~
- [ ] ~Includes tests for new functionality or reproducer for bug~

