### PR TITLE
docs: fix rgw_ldap_dnattr username token

### DIFF
--- a/doc/radosgw/ldap-auth.rst
+++ b/doc/radosgw/ldap-auth.rst
@@ -64,7 +64,8 @@ authentication:
   more specific Organizational Unit (OU).
 - ``rgw_ldap_dnattr``: The attribute being used in the constructed search
   filter to match a username. Depending on your Directory Information Tree
-  (DIT) this would probably be ``uid`` or ``cn``.
+  (DIT) this would probably be ``uid`` or ``cn``. The generated filter string
+  will be, e.g., ``cn=some_username``.
 - ``rgw_ldap_searchfilter``: If not specified, the Ceph Object Gateway
   automatically constructs the search filter with the ``rgw_ldap_dnattr``
   setting. Use this parameter to narrow the list of allowed users in very
@@ -102,14 +103,14 @@ password.
 Specifying a complete filter
 ----------------------------
 
-A complete filter must contain a ``USERNAME`` token which will be substituted
+A complete filter must contain a ``@USERNAME@`` token which will be substituted
 with the user name during the authentication attempt. The ``rgw_ldap_dnattr``
 parameter is not used anymore in this case. For example, to limit valid users
 to a specific group, use the following filter:
 
 ::
 
-  "(&(uid=USERNAME)(memberOf=cn=ceph-users,ou=groups,dc=mycompany,dc=com))"
+  "(&(uid=@USERNAME@)(memberOf=cn=ceph-users,ou=groups,dc=mycompany,dc=com))"
 
 .. note:: Using the ``memberOf`` attribute in LDAP searches requires server side
           support from you specific LDAP server implementation.


### PR DESCRIPTION
The RGW documentation on LDAP authentication currently states to use a `USERNAME` token within the `rgw_ldap_searchfilter` option, which is replaced with the user-submitted user name. Unfortunately the docs do not mention that this token needs to be surrounded by `@` characters.

See https://github.com/ceph/ceph/blob/ba970314fe22fdd59793a16ff87245e448e5de4e/src/rgw/rgw_ldap.cc#L61-L64

This PR fixes the documentation by mentioning the correct token.
This PR adds a simple example of how `rgw_ldap_dnattr` is supposed to be used - as I was struggeling to understand the meaning of it without looking at the code.

This is a simple documentation fix, I did not create a ticket beforehand.
There are no code changes, and therefore no new tests.

This docs fix should be backported to (at least) the nautilius, mimic, and luminous branches.