### PR TITLE
rgw: add tenant as parameter to User in multisite tests

### DIFF
--- a/src/test/rgw/rgw_multi/multisite.py
+++ b/src/test/rgw/rgw_multi/multisite.py
@@ -344,14 +344,18 @@ class Credentials:
         return ['--access-key', self.access_key, '--secret', self.secret]
 
 class User(SystemObject):
-    def __init__(self, uid, data = None, name = None, credentials = None):
+    def __init__(self, uid, data = None, name = None, credentials = None, tenant = None):
         self.name = name
         self.credentials = credentials or []
+        self.tenant = tenant
         super(User, self).__init__(data, uid)
 
     def user_arg(self):
         """ command-line argument to specify this user """
-        return ['--uid', self.id]
+        args = ['--uid', self.id]
+        if self.tenant:
+            args += ['--tenant', self.tenant]
+        return args
 
     def build_command(self, command):
         """ build a command line for the given command and args """

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -232,7 +232,7 @@ def init(parse_args):
     admin_user = multisite.User('zone.user')
 
     user_creds = gen_credentials()
-    user = multisite.User('tester')
+    user = multisite.User('tester', tenant=args.tenant)
 
     realm = multisite.Realm('r')
     if bootstrap:
@@ -346,16 +346,12 @@ def init(parse_args):
                     # create test user
                     arg = ['--display-name', '"Test User"']
                     arg += user_creds.credential_args()
-                    if args.tenant:
-                        arg += ['--tenant', args.tenant]
                     user.create(zone, arg)
                 else:
                     # read users and update keys
                     admin_user.info(zone)
                     admin_creds = admin_user.credentials[0]
                     arg = []
-                    if args.tenant:
-                        arg += ['--tenant', args.tenant]
                     user.info(zone, arg)
                     user_creds = user.credentials[0]
 


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

Implementing comments from: https://github.com/ceph/ceph/pull/27838
Adding tenant as parameter to User.

Test results here: http://pulpito.front.sepia.ceph.com/yuvalif-2019-05-05_21:10:22-rgw:multisite-wip-yuval-add-tenant-to-user-distro-basic-smithi/
No multisite tests failed (only valgrind).