### PR TITLE
global/pidfile: pass string_view instead of ConfigProxy to pidfile_wr…

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -393,7 +393,7 @@ int global_init_prefork(CephContext *cct)
   const auto& conf = cct->_conf;
   if (!conf->daemonize) {
 
-    if (pidfile_write(conf) < 0)
+    if (pidfile_write(conf->pid_file) < 0)
       exit(1);
 
     if ((cct->get_init_flags() & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
@@ -474,7 +474,7 @@ void global_init_postfork_start(CephContext *cct)
   reopen_as_null(cct, STDIN_FILENO);
 
   const auto& conf = cct->_conf;
-  if (pidfile_write(conf) < 0)
+  if (pidfile_write(conf->pid_file) < 0)
     exit(1);
 
   if ((cct->get_init_flags() & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&

--- a/src/global/pidfile.h
+++ b/src/global/pidfile.h
@@ -15,11 +15,11 @@
 #ifndef CEPH_COMMON_PIDFILE_H
 #define CEPH_COMMON_PIDFILE_H
 
-#include "common/config_fwd.h"
+#include <string_view>
 
 // Write a pidfile with the current pid, using the configuration in the
 // provided conf structure.
-int pidfile_write(const ConfigProxy& conf);
+int pidfile_write(std::string_view pid_file);
 
 // Remove the pid file that was previously written by pidfile_write.
 // This is safe to call in a signal handler context.


### PR DESCRIPTION
…ite()

there is no need to pass ConfigProxy to this function. and passing a
string_view also make it easier to reuse this function.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

