### PR TITLE
rgw: delete_obj_index() takes mtime for bilog

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2015,7 +2015,7 @@ public:
   int delete_raw_obj(const rgw_raw_obj& obj);
 
   /** Remove an object from the bucket index */
-  int delete_obj_index(const rgw_obj& obj);
+  int delete_obj_index(const rgw_obj& obj, ceph::real_time mtime);
 
   /**
    * Set an attr on an object.


### PR DESCRIPTION
writing an empty timestamp to the bilog prevents other zones from applying the delete. this means that the --bypass-gc flag for 'radosgw-admin bucket rm' doesn't work in multisite

Fixes: http://tracker.ceph.com/issues/24991