### PR TITLE
qa/workunits/rbd: wait for rbd-nbd unmap to complete

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -101,6 +101,19 @@ function get_pid()
     ps -p ${PID} -o cmd | grep rbd-nbd
 }
 
+unmap_device()
+{
+    local unmap_dev=$1
+    local list_dev=$2
+    _sudo rbd-nbd unmap ${unmap_dev}
+
+    for s in 0.5 1 2 4 8 16 32; do
+	sleep ${s}
+        rbd-nbd list-mapped | expect_false grep "${list_dev} $" && return 0
+    done
+    return 1
+}
+
 #
 # main
 #
@@ -128,8 +141,7 @@ get_pid
 # map test specifying the device
 expect_false _sudo rbd-nbd --device ${DEV} map ${POOL}/${IMAGE}
 dev1=${DEV}
-_sudo rbd-nbd unmap ${DEV}
-rbd-nbd list-mapped | expect_false grep "${DEV} $"
+unmap_device ${DEV} ${DEV}
 DEV=
 # XXX: race possible when the device is reused by other process
 DEV=`_sudo rbd-nbd --device ${dev1} map ${POOL}/${IMAGE}`
@@ -208,8 +220,7 @@ ps -p ${PID} -o cmd | expect_false grep rbd-nbd
 rbd snap create ${POOL}/${IMAGE}@snap
 DEV=`_sudo rbd-nbd map ${POOL}/${IMAGE}@snap`
 get_pid
-_sudo rbd-nbd unmap "${IMAGE}@snap"
-rbd-nbd list-mapped | expect_false grep "${DEV} $"
+unmap_device "${IMAGE}@snap" ${DEV}
 DEV=
 ps -p ${PID} -o cmd | expect_false grep rbd-nbd
 
@@ -217,8 +228,7 @@ ps -p ${PID} -o cmd | expect_false grep rbd-nbd
 rbd snap create ${POOL}/${NS}/${IMAGE}@snap
 DEV=`_sudo rbd-nbd map ${POOL}/${NS}/${IMAGE}@snap`
 get_pid ${NS}
-_sudo rbd-nbd unmap "${POOL}/${NS}/${IMAGE}@snap"
-rbd-nbd list-mapped | expect_false grep "${DEV} $"
+unmap_device "${POOL}/${NS}/${IMAGE}@snap" ${DEV}
 DEV=
 ps -p ${PID} -o cmd | expect_false grep rbd-nbd
 


### PR DESCRIPTION
The "unmap" request is asynchronous, so wait for a short amount
of time for the "rbd-nbd" daemon process to exit.

Fixes: http://tracker.ceph.com/issues/39598
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

