### PR TITLE
luminous: rgw: update civetweb submodule to match version in mimic

### DIFF
--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -228,10 +228,8 @@ def run_tests(ctx, config):
     """
     assert isinstance(config, dict)
     testdir = teuthology.get_testdir(ctx)
-    attrs = ["!fails_on_rgw", "!lifecycle"]
-    # beast parser is strict about unreadable headers
-    if ctx.rgw.frontend == 'beast':
-        attrs.append("!fails_strict_rfc2616")
+    # civetweb > 1.8 && beast parsers are strict on rfc2616
+    attrs = ["!fails_on_rgw", "!lifecycle_expiration", "!fails_strict_rfc2616"]
     for client, client_config in config.iteritems():
         args = [
             'S3TEST_CONF={tdir}/archive/s3-tests.{client}.conf'.format(tdir=testdir, client=client),

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -89,7 +89,7 @@ int RGWCivetWeb::init_env(CephContext *cct)
   }
 
   for (int i = 0; i < info->num_headers; i++) {
-    const struct mg_request_info::mg_header* header = &info->http_headers[i];
+    const auto header = &info->http_headers[i];
 
     if (header->name == nullptr || header->value==nullptr) {
       lderr(cct) << "client supplied malformatted headers" << dendl;
@@ -132,7 +132,7 @@ int RGWCivetWeb::init_env(CephContext *cct)
   env.set("REQUEST_METHOD", info->request_method);
   env.set("HTTP_VERSION", info->http_version);
   env.set("REQUEST_URI", info->request_uri); // get the full uri, we anyway handle abs uris later
-  env.set("SCRIPT_URI", info->uri); /* FIXME */
+  env.set("SCRIPT_URI", info->local_uri);
   if (info->query_string) {
     env.set("QUERY_STRING", info->query_string);
   }

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -58,6 +58,7 @@ int RGWCivetWebFrontend::run()
   set_conf_default(conf_map, "validate_http_method", "no");
   set_conf_default(conf_map, "canonicalize_url_path", "no");
   set_conf_default(conf_map, "enable_auth_domain_check", "no");
+  set_conf_default(conf_map, "allow_unicode_in_urls", "yes");
 
   std::string listening_ports;
   // support multiple port= entries


### PR DESCRIPTION
cherry-picks several updates to the civetweb submodule to fix a keepalive bug that only reproduces against luminous

Fixes: https://tracker.ceph.com/issues/23237