### PR TITLE
test/rgw: fix test-rgw-multisite.sh script for creating multisite clusters

### DIFF
--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -61,6 +61,8 @@ mstop=$root_path/mstop.sh
 mrun=$root_path/mrun
 mrgw=$root_path/mrgw.sh
 
+url=http://localhost
+
 function start_ceph_cluster {
   [ $# -ne 1 ] && echo "start_ceph_cluster() needs 1 param" && exit 1
 
@@ -115,10 +117,10 @@ function init_zone_in_existing_zg {
   access_key=$7
   secret=$8
 
-  x $(rgw_admin $cid) realm pull --url=http://localhost:$master_zg_zone1_port --access-key=${access_key} --secret=${secret} --default
+  x $(rgw_admin $cid) realm pull --url=$url:$master_zg_zone1_port --access-key=${access_key} --secret=${secret} --default
   x $(rgw_admin $cid) zonegroup default --rgw-zonegroup=$zg
   x $(rgw_admin $cid) zone create --rgw-zonegroup=$zg --rgw-zone=$zone --access-key=${access_key} --secret=${secret} --endpoints=$endpoints
-  x $(rgw_admin $cid) period update --commit --url=http://localhost:$master_zg_zone1_port --access-key=${access_key} --secret=${secret}
+  x $(rgw_admin $cid) period update --commit --url=$url:$master_zg_zone1_port --access-key=${access_key} --secret=${secret}
 }
 
 function init_first_zone_in_slave_zg {
@@ -135,7 +137,7 @@ function init_first_zone_in_slave_zg {
   secret=$8
 
 # create zonegroup, zone
-  x $(rgw_admin $cid) realm pull --url=http://localhost:$master_zg_zone1_port --access-key=${access_key} --secret=${secret}
+  x $(rgw_admin $cid) realm pull --url=$url:$master_zg_zone1_port --access-key=${access_key} --secret=${secret}
   x $(rgw_admin $cid) realm default --rgw-realm=$realm
   x $(rgw_admin $cid) zonegroup create --rgw-realm=$realm --rgw-zonegroup=$zg --endpoints=$endpoints --default
   x $(rgw_admin $cid) zonegroup default --rgw-zonegroup=$zg

--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -88,7 +88,7 @@ function init_first_zone {
   realm=$2
   zg=$3
   zone=$4
-  endpoints=$5
+  endpoints=$url:$5
 
   access_key=$6
   secret=$7
@@ -112,7 +112,7 @@ function init_zone_in_existing_zg {
   zg=$3
   zone=$4
   master_zg_zone1_port=$5
-  endpoints=$6
+  endpoints=$url:$6
 
   access_key=$7
   secret=$8
@@ -131,7 +131,7 @@ function init_first_zone_in_slave_zg {
   zg=$3
   zone=$4
   master_zg_zone1_port=$5
-  endpoints=$6
+  endpoints=$url:$6
 
   access_key=$7
   secret=$8


### PR DESCRIPTION
to bring up two vstart.sh clusters and configure for multisite:
```
~/ceph/build $ MON=1 OSD=1 MGR=0 MDS=0 ../src/test/rgw/test-rgw-multisite.sh 2
```
without these fixes, the zones failed to communicate with each other due to incomplete http endpoints