### PR TITLE
nautilus: qa/tasks/rbd_fio: fixed missing delimiter between 'cd' and 'configure' 

### DIFF
--- a/qa/suites/rbd/librbd/supported-random-distro$
+++ b/qa/suites/rbd/librbd/supported-random-distro$
@@ -1,0 +1,1 @@
+.qa/distros/supported-random-distro$

--- a/qa/tasks/rbd_fio.py
+++ b/qa/tasks/rbd_fio.py
@@ -207,8 +207,8 @@ def run_fio(remote, config, rbd_test_dir):
         fio = "https://github.com/axboe/fio/archive/fio-" + fio_version + ".tar.gz"
         remote.run(args=['mkdir', run.Raw(rbd_test_dir),])
         remote.run(args=['cd' , run.Raw(rbd_test_dir),
-                         run.Raw(';'), 'wget' , fio , run.Raw(';'), run.Raw('tar -xvf fio*tar.gz'), run.Raw(';'),
-                         run.Raw('cd fio-fio*'), 'configure', run.Raw(';') ,'make'])
+                         run.Raw(';'), 'wget', fio, run.Raw(';'), run.Raw('tar -xvf fio*tar.gz'), run.Raw(';'),
+                         run.Raw('cd fio-fio*'), run.Raw(';'), './configure', run.Raw(';'), 'make'])
         remote.run(args=['ceph', '-s'])
         remote.run(args=[run.Raw('{tdir}/fio-fio-{v}/fio --showcmd {f}'.format(tdir=rbd_test_dir,v=fio_version,f=fio_config.name))])
         remote.run(args=['sudo', run.Raw('{tdir}/fio-fio-{v}/fio {f}'.format(tdir=rbd_test_dir,v=fio_version,f=fio_config.name))])


### PR DESCRIPTION
http://tracker.ceph.com/issues/39590