### PR TITLE
luminous: rgw: unable to cancel reshard operations for buckets with tenants

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6093,7 +6093,7 @@ next:
     RGWReshard reshard(store);
 
     cls_rgw_reshard_entry entry;
-    //entry.tenant = tenant;
+    entry.tenant = tenant;
     entry.bucket_name = bucket_name;
     //entry.bucket_id = bucket_id;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/39016