### PR TITLE
mgr/balancer: fix fudge

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1116,7 +1116,7 @@ class Module(MgrModule):
 
         # allow a small regression if we are phasing out osd weights
         fudge = 0
-        if next_ow != orig_osd_weight:
+        if best_ow != orig_osd_weight:
             fudge = .001
 
         if best_pe.score < pe.score + fudge:


### PR DESCRIPTION
next_* simply record some intermediate results when balancer tries
to find something to optimize, whereas best_* are used for the
final outputs.

Fix by comparing origin_ow with best_ow when determining if we
should use a valid fudge value.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

