### PR TITLE
mgr/dashboard: All RBD features are supported by 'tcmu:runner'

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -431,9 +431,9 @@ class IscsiTarget(RESTController):
             image = disk['image']
             backstore = disk['backstore']
             required_rbd_features = settings['required_rbd_features'][backstore]
-            supported_rbd_features = settings['supported_rbd_features'][backstore]
+            unsupported_rbd_features = settings['unsupported_rbd_features'][backstore]
             IscsiTarget._validate_image(pool, image, backstore, required_rbd_features,
-                                        supported_rbd_features)
+                                        unsupported_rbd_features)
 
         initiators = []
         for group in groups:
@@ -444,7 +444,7 @@ class IscsiTarget(RESTController):
                                      component='iscsi')
 
     @staticmethod
-    def _validate_image(pool, image, backstore, required_rbd_features, supported_rbd_features):
+    def _validate_image(pool, image, backstore, required_rbd_features, unsupported_rbd_features):
         try:
             ioctx = mgr.rados.open_ioctx(pool)
             try:
@@ -459,14 +459,14 @@ class IscsiTarget(RESTController):
                                                                       required_rbd_features)),
                                                  code='image_missing_required_features',
                                                  component='iscsi')
-                    if img.features() & supported_rbd_features != img.features():
+                    if img.features() & unsupported_rbd_features != 0:
                         raise DashboardException(msg='Image {} cannot be exported using {} '
                                                      'backstore because it contains unsupported '
-                                                     'features (supported features are '
+                                                     'features ('
                                                      '{})'.format(image,
                                                                   backstore,
                                                                   format_bitmask(
-                                                                      supported_rbd_features)),
+                                                                      unsupported_rbd_features)),
                                                  code='image_contains_unsupported_features',
                                                  component='iscsi')
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
@@ -37,9 +37,9 @@ describe('IscsiTargetFormComponent', () => {
       'backstore:1': 0,
       'backstore:2': 0
     },
-    supported_rbd_features: {
-      'backstore:1': 61,
-      'backstore:2': 61
+    unsupported_rbd_features: {
+      'backstore:1': 0,
+      'backstore:2': 0
     },
     backstores: ['backstore:1', 'backstore:2'],
     default_backstore: 'backstore:1'

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -32,7 +32,7 @@ export class IscsiTargetFormComponent implements OnInit {
   disk_default_controls: any;
   backstores: string[];
   default_backstore: string;
-  supported_rbd_features: any;
+  unsupported_rbd_features: any;
   required_rbd_features: any;
 
   isEdit = false;
@@ -124,7 +124,7 @@ export class IscsiTargetFormComponent implements OnInit {
       this.disk_default_controls = data[3].disk_default_controls;
       this.backstores = data[3].backstores;
       this.default_backstore = data[3].default_backstore;
-      this.supported_rbd_features = data[3].supported_rbd_features;
+      this.unsupported_rbd_features = data[3].unsupported_rbd_features;
       this.required_rbd_features = data[3].required_rbd_features;
 
       // rbdService.list()
@@ -685,11 +685,11 @@ export class IscsiTargetFormComponent implements OnInit {
   validFeatures(image, backstore) {
     const imageFeatures = image.features;
     const requiredFeatures = this.required_rbd_features[backstore];
-    const supportedFeatures = this.supported_rbd_features[backstore];
+    const unsupportedFeatures = this.unsupported_rbd_features[backstore];
     // tslint:disable-next-line:no-bitwise
     const validRequiredFeatures = (imageFeatures & requiredFeatures) === requiredFeatures;
     // tslint:disable-next-line:no-bitwise
-    const validSupportedFeatures = (imageFeatures & supportedFeatures) === imageFeatures;
+    const validSupportedFeatures = (imageFeatures & unsupportedFeatures) === 0;
     return validRequiredFeatures && validSupportedFeatures;
   }
 

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -503,9 +503,9 @@ class IscsiClientMock(object):
                 "rbd": 0,
                 "user:rbd": 4,
             },
-            "supported_rbd_features": {
-                "rbd": 135,
-                "user:rbd": 61,
+            "unsupported_rbd_features": {
+                "rbd": 88,
+                "user:rbd": 0,
             },
             "disk_default_controls": {
                 "user:rbd": {


### PR DESCRIPTION
This PR adapts the Ceph Dashboard acording to https://github.com/ceph/ceph-iscsi/pull/79
(use the `unsupported` features instead of `supported` features).

Fixes: https://tracker.ceph.com/issues/39607

Signed-off-by: Ricardo Marques <rimarques@suse.com>
