### PR TITLE
pybind/tox: handle possible WITH_PYTHON3 values other than "3"

### DIFF
--- a/src/pybind/mgr/ansible/run-tox.sh
+++ b/src/pybind/mgr/ansible/run-tox.sh
@@ -29,7 +29,9 @@ source ${MGR_ANSIBLE_VIRTUALENV}/bin/activate
 if [ "$WITH_PYTHON2" = "ON" ]; then
   ENV_LIST+="py27,"
 fi
-if [ "$WITH_PYTHON3" = "3" ]; then
+# WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
+# prevailing on the system - e.g. "3", "36"
+if [[ "$WITH_PYTHON3" =~ (^3|^ON) ]]; then
   ENV_LIST+="py3,"
 fi
 # use bash string manipulation to strip off any trailing comma

--- a/src/pybind/mgr/dashboard/run-tox.sh
+++ b/src/pybind/mgr/dashboard/run-tox.sh
@@ -33,7 +33,9 @@ if [ "$WITH_PYTHON2" = "ON" ]; then
     ENV_LIST+="py27-cov,py27-lint,"
   fi
 fi
-if [ "$WITH_PYTHON3" = "3" ]; then
+# WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
+# prevailing on the system - e.g. "3", "36"
+if [[ "$WITH_PYTHON3" =~ (^3|^ON) ]]; then
   if [[ -n "$@" ]]; then
     ENV_LIST+="py3-run,"
   else

--- a/src/pybind/mgr/insights/run-tox.sh
+++ b/src/pybind/mgr/insights/run-tox.sh
@@ -29,7 +29,9 @@ source ${MGR_INSIGHTS_VIRTUALENV}/bin/activate
 if [ "$WITH_PYTHON2" = "ON" ]; then
   ENV_LIST+="py27,"
 fi
-if [ "$WITH_PYTHON3" = "3" ]; then
+# WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
+# prevailing on the system - e.g. "3", "36"
+if [[ "$WITH_PYTHON3" =~ (^3|^ON) ]]; then
   ENV_LIST+="py3,"
 fi
 # use bash string manipulation to strip off any trailing comma

--- a/src/pybind/mgr/orchestrator_cli/run-tox.sh
+++ b/src/pybind/mgr/orchestrator_cli/run-tox.sh
@@ -32,11 +32,11 @@ fi
 if [ "$WITH_PYTHON2" = "ON" ]; then
   ENV_LIST+="py27,"
 fi
-if [ "$WITH_PYTHON3" = "3" ]; then
+# WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
+# prevailing on the system - e.g. "3", "36"
+if [[ "$WITH_PYTHON3" =~ (^3|^ON) ]]; then
   ENV_LIST+="py3,"
 fi
-ENV_LIST=$(echo "$ENV_LIST" | sed -e 's/,$//')
-
 # use bash string manipulation to strip off any trailing comma
 ENV_LIST=${ENV_LIST%,}
 


### PR DESCRIPTION
WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
prevailing on the system - e.g. "3", "36"

Fixes: 9426f1f2045d0ae0f319530c3dc3a9240d838d07
Signed-off-by: Nathan Cutler <ncutler@suse.com>
