### PR TITLE
osd/Peer: an exceptional case when request log in GetMissing Stage

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -6474,9 +6474,11 @@ PeeringState::GetMissing::GetMissing(my_context ctx)
       continue;
     }
 
-    // We pull the log from the peer's last_epoch_started to ensure we
-    // get enough log to detect divergent updates.
-    since.epoch = pi.last_epoch_started;
+    // We pull the log from the minimum of peer's last_epoch_started and last_update.epoch 
+    // to ensure we get enough log to detect divergent updates.
+    // That's because we can't ensure there is no divergent entries before last_epoch_started
+    since.epoch = std::min(pi.last_epoch_started, pi.last_update.epoch);
+
     ceph_assert(pi.last_update >= ps->info.log_tail);  // or else choose_acting() did a bad thing
     if (pi.log_tail <= since) {
       psdout(10) << " requesting log+missing since " << since << " from osd." << *i << dendl;


### PR DESCRIPTION
conside such circumstance:

osd.0 last_update=1'2 les=2
osd.1 last_update=1'1 les=3

When they go peering, osd.1's log will be the auth log,
when osd.1 request log from osd.0, current logic use
pi.last_epoch_started as *since*, then osd.0 will reply
with log((1'2,1'2] empty entries), osd.1 can't rewind
the osd.0's divergent log(1'2) in proc_replica_log().This
will cause the primary think peer has no missing , but peer
may delete the object when rewind and mark it as missing..

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

