### PR TITLE
mgr/dashboard: Watch for pool pg's increase and decrease

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import time
 import cherrypy
 
 from . import ApiController, RESTController, Endpoint, ReadPermission, Task
@@ -9,7 +10,7 @@ from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.rbd import RbdConfiguration
 from ..services.exception import handle_send_command_error
-from ..tools import str_to_bool
+from ..tools import str_to_bool, TaskManager
 
 
 def pool_task(name, metadata, wait_for=2.0):
@@ -81,6 +82,7 @@ class Pool(RESTController):
     def set(self, pool_name, flags=None, application_metadata=None, configuration=None, **kwargs):
         self._set_pool_values(pool_name, application_metadata, flags, True, kwargs)
         RbdConfiguration(pool_name).set_configuration(configuration)
+        self._wait_for_pgs(pool_name)
 
     @pool_task('create', {'pool_name': '{pool}'})
     @handle_send_command_error('pool')
@@ -92,6 +94,7 @@ class Pool(RESTController):
                                  rule=rule_name)
         self._set_pool_values(pool, application_metadata, flags, False, kwargs)
         RbdConfiguration(pool).set_configuration(configuration)
+        self._wait_for_pgs(pool)
 
     def _set_pool_values(self, pool, application_metadata, flags, update_existing, kwargs):
         update_name = False
@@ -150,6 +153,36 @@ class Pool(RESTController):
                         'compression_required_ratio']:
                 reset_arg(arg, '0')
             reset_arg('compression_algorithm', 'unset')
+
+    def _wait_for_pgs(self, pool_name):
+        """
+        Keep the task waiting for until all pg changes are complete
+        :param pool_name: The name of the pool.
+        :type pool_name: string
+        """
+        current_pool = self._get(pool_name)
+        initial_pgs = int(current_pool['pg_placement_num']) + int(current_pool['pg_num'])
+        self._pg_wait_loop(current_pool, initial_pgs)
+
+    def _pg_wait_loop(self, pool, initial_pgs):
+        """
+        Compares if all pg changes are completed, if not it will call itself
+        until all changes are completed.
+        :param pool: The dict that represents a pool.
+        :type pool: dict
+        :param initial_pgs: The pg and pg_num count before any change happened.
+        :type initial_pgs: int
+        """
+        if 'pg_num_target' in pool:
+            target = int(pool['pg_num_target']) + int(pool['pg_placement_num_target'])
+            current = int(pool['pg_placement_num']) + int(pool['pg_num'])
+            if current != target:
+                max_diff = abs(target - initial_pgs)
+                diff = max_diff - abs(target - current)
+                percentage = int(round(diff / float(max_diff) * 100))
+                TaskManager.current_task().set_progress(percentage)
+                time.sleep(4)
+                self._pg_wait_loop(self._get(pool['pool_name']), initial_pgs)
 
     @RESTController.Resource()
     @ReadPermission

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -44,7 +44,8 @@ class Pool(RESTController):
         res['pool_name'] = pool['pool_name']
         return res
 
-    def _pool_list(self, attrs=None, stats=False):
+    @classmethod
+    def _pool_list(cls, attrs=None, stats=False):
         if attrs:
             attrs = attrs.split(',')
 
@@ -53,14 +54,15 @@ class Pool(RESTController):
         else:
             pools = CephService.get_pool_list()
 
-        return [self._serialize_pool(pool, attrs) for pool in pools]
+        return [cls._serialize_pool(pool, attrs) for pool in pools]
 
     def list(self, attrs=None, stats=False):
         return self._pool_list(attrs, stats)
 
-    def _get(self, pool_name, attrs=None, stats=False):
+    @classmethod
+    def _get(cls, pool_name, attrs=None, stats=False):
         # type: (str, str, bool) -> dict
-        pools = self._pool_list(attrs, stats)
+        pools = cls._pool_list(attrs, stats)
         pool = [pool for pool in pools if pool['pool_name'] == pool_name]
         if not pool:
             raise cherrypy.NotFound('No such pool')
@@ -154,17 +156,19 @@ class Pool(RESTController):
                 reset_arg(arg, '0')
             reset_arg('compression_algorithm', 'unset')
 
-    def _wait_for_pgs(self, pool_name):
+    @classmethod
+    def _wait_for_pgs(cls, pool_name):
         """
         Keep the task waiting for until all pg changes are complete
         :param pool_name: The name of the pool.
         :type pool_name: string
         """
-        current_pool = self._get(pool_name)
+        current_pool = cls._get(pool_name)
         initial_pgs = int(current_pool['pg_placement_num']) + int(current_pool['pg_num'])
-        self._pg_wait_loop(current_pool, initial_pgs)
+        cls._pg_wait_loop(current_pool, initial_pgs)
 
-    def _pg_wait_loop(self, pool, initial_pgs):
+    @classmethod
+    def _pg_wait_loop(cls, pool, initial_pgs):
         """
         Compares if all pg changes are completed, if not it will call itself
         until all changes are completed.
@@ -182,7 +186,7 @@ class Pool(RESTController):
                 percentage = int(round(diff / float(max_diff) * 100))
                 TaskManager.current_task().set_progress(percentage)
                 time.sleep(4)
-                self._pg_wait_loop(self._get(pool['pool_name']), initial_pgs)
+                cls._pg_wait_loop(cls._get(pool['pool_name']), initial_pgs)
 
     @RESTController.Resource()
     @ReadPermission

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
@@ -10,6 +10,7 @@ import { BehaviorSubject, of } from 'rxjs';
 
 import {
   configureTestBed,
+  expectItemTasks,
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
@@ -136,10 +137,6 @@ describe('IscsiTargetListComponent', () => {
       summaryService.addRunningTask(task);
     };
 
-    const expectTargetTasks = (target: any, executing: string) => {
-      expect(target.cdExecuting).toEqual(executing);
-    };
-
     beforeEach(() => {
       targets = [];
       addTarget('iqn.a');
@@ -160,16 +157,16 @@ describe('IscsiTargetListComponent', () => {
     it('should add a new target from a task', () => {
       addTask('iscsi/target/create', 'iqn.d');
       expect(component.targets.length).toBe(4);
-      expectTargetTasks(component.targets[0], undefined);
-      expectTargetTasks(component.targets[1], undefined);
-      expectTargetTasks(component.targets[2], undefined);
-      expectTargetTasks(component.targets[3], 'Creating');
+      expectItemTasks(component.targets[0], undefined);
+      expectItemTasks(component.targets[1], undefined);
+      expectItemTasks(component.targets[2], undefined);
+      expectItemTasks(component.targets[3], 'Creating');
     });
 
     it('should show when an existing target is being modified', () => {
       addTask('iscsi/target/delete', 'iqn.b');
       expect(component.targets.length).toBe(3);
-      expectTargetTasks(component.targets[1], 'Deleting');
+      expectItemTasks(component.targets[1], 'Deleting');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -13,6 +13,7 @@ import { BehaviorSubject, of } from 'rxjs';
 
 import {
   configureTestBed,
+  expectItemTasks,
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
@@ -137,10 +138,6 @@ describe('RbdListComponent', () => {
       summaryService.addRunningTask(task);
     };
 
-    const expectImageTasks = (image: RbdModel, executing: string) => {
-      expect(image.cdExecuting).toEqual(executing);
-    };
-
     beforeEach(() => {
       images = [];
       addImage('a');
@@ -162,28 +159,28 @@ describe('RbdListComponent', () => {
     it('should add a new image from a task', () => {
       addTask('rbd/create', 'd');
       expect(component.images.length).toBe(4);
-      expectImageTasks(component.images[0], undefined);
-      expectImageTasks(component.images[1], undefined);
-      expectImageTasks(component.images[2], undefined);
-      expectImageTasks(component.images[3], 'Creating');
+      expectItemTasks(component.images[0], undefined);
+      expectItemTasks(component.images[1], undefined);
+      expectItemTasks(component.images[2], undefined);
+      expectItemTasks(component.images[3], 'Creating');
     });
 
     it('should show when a image is being cloned', () => {
       addTask('rbd/clone', 'd');
       expect(component.images.length).toBe(4);
-      expectImageTasks(component.images[0], undefined);
-      expectImageTasks(component.images[1], undefined);
-      expectImageTasks(component.images[2], undefined);
-      expectImageTasks(component.images[3], 'Cloning');
+      expectItemTasks(component.images[0], undefined);
+      expectItemTasks(component.images[1], undefined);
+      expectItemTasks(component.images[2], undefined);
+      expectItemTasks(component.images[3], 'Cloning');
     });
 
     it('should show when a image is being copied', () => {
       addTask('rbd/copy', 'd');
       expect(component.images.length).toBe(4);
-      expectImageTasks(component.images[0], undefined);
-      expectImageTasks(component.images[1], undefined);
-      expectImageTasks(component.images[2], undefined);
-      expectImageTasks(component.images[3], 'Copying');
+      expectItemTasks(component.images[0], undefined);
+      expectItemTasks(component.images[1], undefined);
+      expectItemTasks(component.images[2], undefined);
+      expectItemTasks(component.images[3], 'Copying');
     });
 
     it('should show when an existing image is being modified', () => {
@@ -191,9 +188,9 @@ describe('RbdListComponent', () => {
       addTask('rbd/delete', 'b');
       addTask('rbd/flatten', 'c');
       expect(component.images.length).toBe(3);
-      expectImageTasks(component.images[0], 'Updating');
-      expectImageTasks(component.images[1], 'Deleting');
-      expectImageTasks(component.images[2], 'Flattening');
+      expectItemTasks(component.images[0], 'Updating');
+      expectItemTasks(component.images[1], 'Deleting');
+      expectItemTasks(component.images[2], 'Flattening');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -10,6 +10,7 @@ import { Subject, throwError as observableThrowError } from 'rxjs';
 
 import {
   configureTestBed,
+  expectItemTasks,
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
@@ -137,10 +138,6 @@ describe('RbdSnapshotListComponent', () => {
       summaryService.addRunningTask(task);
     };
 
-    const expectImageTasks = (snapshot: RbdSnapshotModel, executing: string) => {
-      expect(snapshot.cdExecuting).toEqual(executing);
-    };
-
     const refresh = (data) => {
       summaryService['summaryDataSource'].next(data);
     };
@@ -167,10 +164,10 @@ describe('RbdSnapshotListComponent', () => {
     it('should add a new image from a task', () => {
       addTask('rbd/snap/create', 'd');
       expect(component.snapshots.length).toBe(4);
-      expectImageTasks(component.snapshots[0], undefined);
-      expectImageTasks(component.snapshots[1], undefined);
-      expectImageTasks(component.snapshots[2], undefined);
-      expectImageTasks(component.snapshots[3], 'Creating');
+      expectItemTasks(component.snapshots[0], undefined);
+      expectItemTasks(component.snapshots[1], undefined);
+      expectItemTasks(component.snapshots[2], undefined);
+      expectItemTasks(component.snapshots[3], 'Creating');
     });
 
     it('should show when an existing image is being modified', () => {
@@ -178,9 +175,9 @@ describe('RbdSnapshotListComponent', () => {
       addTask('rbd/snap/delete', 'b');
       addTask('rbd/snap/rollback', 'c');
       expect(component.snapshots.length).toBe(3);
-      expectImageTasks(component.snapshots[0], 'Updating');
-      expectImageTasks(component.snapshots[1], 'Deleting');
-      expectImageTasks(component.snapshots[2], 'Rolling back');
+      expectItemTasks(component.snapshots[0], 'Updating');
+      expectItemTasks(component.snapshots[1], 'Deleting');
+      expectItemTasks(component.snapshots[2], 'Rolling back');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
@@ -6,7 +6,11 @@ import { ToastModule } from 'ng2-toastr';
 import { of } from 'rxjs';
 
 import { By } from '@angular/platform-browser';
-import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import {
+  configureTestBed,
+  expectItemTasks,
+  i18nProviders
+} from '../../../../testing/unit-test-helper';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { ExecutingTask } from '../../../shared/models/executing-task';
@@ -74,10 +78,6 @@ describe('RbdTrashListComponent', () => {
       summaryService.addRunningTask(task);
     };
 
-    const expectImageTasks = (image: any, executing: string) => {
-      expect(image.cdExecuting).toEqual(executing);
-    };
-
     beforeEach(() => {
       images = [];
       addImage('1');
@@ -99,8 +99,8 @@ describe('RbdTrashListComponent', () => {
       addTask('rbd/trash/remove', '1');
       addTask('rbd/trash/restore', '2');
       expect(component.images.length).toBe(2);
-      expectImageTasks(component.images[0], 'Deleting');
-      expectImageTasks(component.images[1], 'Restoring');
+      expectItemTasks(component.images[0], 'Deleting');
+      expectItemTasks(component.images[1], 'Restoring');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
@@ -9,6 +9,7 @@ import { BehaviorSubject, of } from 'rxjs';
 
 import {
   configureTestBed,
+  expectItemTasks,
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
@@ -127,10 +128,6 @@ describe('NfsListComponent', () => {
       summaryService.addRunningTask(task);
     };
 
-    const expectExportTasks = (expo: any, executing: string) => {
-      expect(expo.cdExecuting).toEqual(executing);
-    };
-
     beforeEach(() => {
       exports = [];
       addExport('a');
@@ -154,18 +151,18 @@ describe('NfsListComponent', () => {
       addTask('nfs/create', 'd');
       tick();
       expect(component.exports.length).toBe(4);
-      expectExportTasks(component.exports[0], undefined);
-      expectExportTasks(component.exports[1], undefined);
-      expectExportTasks(component.exports[2], undefined);
-      expectExportTasks(component.exports[3], 'Creating');
+      expectItemTasks(component.exports[0], undefined);
+      expectItemTasks(component.exports[1], undefined);
+      expectItemTasks(component.exports[2], undefined);
+      expectItemTasks(component.exports[3], 'Creating');
     }));
 
     it('should show when an existing export is being modified', () => {
       addTask('nfs/edit', 'a');
       addTask('nfs/delete', 'b');
       expect(component.exports.length).toBe(3);
-      expectExportTasks(component.exports[0], 'Updating');
-      expectExportTasks(component.exports[1], 'Deleting');
+      expectItemTasks(component.exports[0], 'Updating');
+      expectItemTasks(component.exports[1], 'Deleting');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -8,7 +8,11 @@ import { BsModalService } from 'ngx-bootstrap/modal';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { of } from 'rxjs';
 
-import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import {
+  configureTestBed,
+  expectItemTasks,
+  i18nProviders
+} from '../../../../testing/unit-test-helper';
 import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { PoolService } from '../../../shared/api/pool.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
@@ -195,13 +199,13 @@ describe('PoolListComponent', () => {
     it('gets a pool from a task during creation', () => {
       addTask('pool/create', 'd');
       expect(component.pools.length).toBe(4);
-      expect(component.pools[3].cdExecuting).toBe('Creating');
+      expectItemTasks(component.pools[3], 'Creating');
     });
 
     it('gets all pools with one executing pools', () => {
       addTask('pool/create', 'a');
       expect(component.pools.length).toBe(3);
-      expect(component.pools[0].cdExecuting).toBe('Creating');
+      expectItemTasks(component.pools[0], 'Creating');
       expect(component.pools[1].cdExecuting).toBeFalsy();
       expect(component.pools[2].cdExecuting).toBeFalsy();
     });
@@ -214,9 +218,9 @@ describe('PoolListComponent', () => {
       addTask('pool/delete', 'b');
       addTask('pool/delete', 'c');
       expect(component.pools.length).toBe(3);
-      expect(component.pools[0].cdExecuting).toBe('Creating, Updating, Deleting');
-      expect(component.pools[1].cdExecuting).toBe('Updating, Deleting');
-      expect(component.pools[2].cdExecuting).toBe('Deleting');
+      expectItemTasks(component.pools[0], 'Creating..., Updating..., Deleting');
+      expectItemTasks(component.pools[1], 'Updating..., Deleting');
+      expectItemTasks(component.pools[2], 'Deleting');
     });
 
     it('gets all pools with multiple executing tasks (not only pool tasks)', () => {
@@ -227,8 +231,8 @@ describe('PoolListComponent', () => {
       addTask('rbd/delete', 'b');
       addTask('rbd/delete', 'c');
       expect(component.pools.length).toBe(3);
-      expect(component.pools[0].cdExecuting).toBe('Deleting');
-      expect(component.pools[1].cdExecuting).toBe('Updating');
+      expectItemTasks(component.pools[0], 'Deleting');
+      expectItemTasks(component.pools[1], 'Updating');
       expect(component.pools[2].cdExecuting).toBeFalsy();
     });
   });
@@ -364,12 +368,12 @@ describe('PoolListComponent', () => {
           pg_num_target: 16,
           pg_placement_num: 32,
           pg_placement_num_target: 16,
-          cdExecuting: 'Updating 50%'
+          cdExecuting: 'Updating... 50%'
         })
       ];
       expect(component.transformPoolsData(pools)).toEqual(
         getPoolData({
-          cdExecuting: 'Updating 50%',
+          cdExecuting: 'Updating... 50%',
           pg_num: 32,
           pg_num_target: 16,
           pg_placement_num: 32,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -27,18 +27,18 @@ describe('PoolListComponent', () => {
   let fixture: ComponentFixture<PoolListComponent>;
   let poolService: PoolService;
 
-  const addPool = (pools, name, id) => {
-    const pool = new Pool(name);
-    pool.pool = id;
-    pool.pg_num = 256;
-    pools.push(pool);
+  const createPool = (name, id): Pool => {
+    return _.merge(new Pool(name), {
+      pool: id,
+      pg_num: 256,
+      pg_placement_num: 256,
+      pg_num_target: 256,
+      pg_placement_num_target: 256
+    });
   };
 
-  const setUpPools = (pools) => {
-    addPool(pools, 'a', 0);
-    addPool(pools, 'b', 1);
-    addPool(pools, 'c', 2);
-    component.pools = pools;
+  const getPoolList = (): Pool[] => {
+    return [createPool('a', 0), createPool('b', 1), createPool('c', 2)];
   };
 
   configureTestBed({
@@ -58,6 +58,7 @@ describe('PoolListComponent', () => {
     component = fixture.componentInstance;
     component.permissions.pool.read = true;
     poolService = TestBed.get(PoolService);
+    spyOn(poolService, 'getList').and.callFake(() => of(getPoolList()));
     fixture.detectChanges();
   });
 
@@ -67,6 +68,12 @@ describe('PoolListComponent', () => {
 
   it('should have columns that are sortable', () => {
     expect(component.columns.every((column) => Boolean(column.prop))).toBeTruthy();
+  });
+
+  it('returns pool details correctly', () => {
+    const pool = { prop1: 1, cdIsBinary: true, prop2: 2, cdExecuting: true, prop3: 3 };
+    const expected = { prop1: 1, prop2: 2, prop3: 3 };
+    expect(component.getPoolDetails(pool)).toEqual(expected);
   });
 
   describe('monAllowPoolDelete', () => {
@@ -166,7 +173,6 @@ describe('PoolListComponent', () => {
   });
 
   describe('handling of executing tasks', () => {
-    let pools: Pool[];
     let summaryService: SummaryService;
 
     const addTask = (name: string, pool: string) => {
@@ -179,10 +185,6 @@ describe('PoolListComponent', () => {
     beforeEach(() => {
       summaryService = TestBed.get(SummaryService);
       summaryService['summaryDataSource'].next({ executing_tasks: [], finished_tasks: [] });
-      pools = [];
-      setUpPools(pools);
-      spyOn(poolService, 'getList').and.callFake(() => of(pools));
-      fixture.detectChanges();
     });
 
     it('gets all pools without executing pools', () => {
@@ -279,39 +281,11 @@ describe('PoolListComponent', () => {
   });
 
   describe('transformPoolsData', () => {
-    it('transforms pools data correctly', () => {
-      const pools = [
-        {
-          stats: {
-            bytes_used: { latest: 5, rate: 0, rates: [] },
-            max_avail: { latest: 15, rate: 0, rates: [] },
-            rd_bytes: { latest: 6, rate: 4, rates: [[0, 2], [1, 6]] }
-          },
-          pg_status: { 'active+clean': 8, down: 2 }
-        }
-      ];
-      const expected = [
-        {
-          cdIsBinary: true,
-          pg_status: '8 active+clean, 2 down',
-          stats: {
-            bytes_used: { latest: 5, rate: 0, rates: [] },
-            max_avail: { latest: 15, rate: 0, rates: [] },
-            rd: { latest: 0, rate: 0, rates: [] },
-            rd_bytes: { latest: 6, rate: 4, rates: [2, 6] },
-            wr: { latest: 0, rate: 0, rates: [] },
-            wr_bytes: { latest: 0, rate: 0, rates: [] }
-          },
-          usage: 0.25
-        }
-      ];
-      expect(component.transformPoolsData(pools)).toEqual(expected);
-    });
+    let pool: Pool;
 
-    it('transforms pools data correctly if stats are missing', () => {
-      const pools = [{}];
-      const expected = [
-        {
+    const getPoolData = (o) => [
+      _.merge(
+        _.merge(createPool('a', 0), {
           cdIsBinary: true,
           pg_status: '',
           stats: {
@@ -323,15 +297,85 @@ describe('PoolListComponent', () => {
             wr_bytes: { latest: 0, rate: 0, rates: [] }
           },
           usage: 0
-        }
-      ];
-      expect(component.transformPoolsData(pools)).toEqual(expected);
+        }),
+        o
+      )
+    ];
+
+    beforeEach(() => {
+      pool = createPool('a', 0);
+    });
+
+    it('transforms pools data correctly', () => {
+      pool = _.merge(pool, {
+        stats: {
+          bytes_used: { latest: 5, rate: 0, rates: [] },
+          max_avail: { latest: 15, rate: 0, rates: [] },
+          rd_bytes: { latest: 6, rate: 4, rates: [[0, 2], [1, 6]] }
+        },
+        pg_status: { 'active+clean': 8, down: 2 }
+      });
+      expect(component.transformPoolsData([pool])).toEqual(
+        getPoolData({
+          pg_status: '8 active+clean, 2 down',
+          stats: {
+            bytes_used: { latest: 5, rate: 0, rates: [] },
+            max_avail: { latest: 15, rate: 0, rates: [] },
+            rd_bytes: { latest: 6, rate: 4, rates: [2, 6] }
+          },
+          usage: 0.25
+        })
+      );
+    });
+
+    it('transforms pools data correctly if stats are missing', () => {
+      expect(component.transformPoolsData([pool])).toEqual(getPoolData({}));
     });
 
     it('transforms empty pools data correctly', () => {
-      const pools = undefined;
-      const expected = undefined;
-      expect(component.transformPoolsData(pools)).toEqual(expected);
+      expect(component.transformPoolsData(undefined)).toEqual(undefined);
+      expect(component.transformPoolsData([])).toEqual([]);
+    });
+
+    it('shows not marked pools in progress if pg_num does not match pg_num_target', () => {
+      const pools = [
+        _.merge(pool, {
+          pg_num: 32,
+          pg_num_target: 16,
+          pg_placement_num: 32,
+          pg_placement_num_target: 16
+        })
+      ];
+      expect(component.transformPoolsData(pools)).toEqual(
+        getPoolData({
+          cdExecuting: 'Updating',
+          pg_num: 32,
+          pg_num_target: 16,
+          pg_placement_num: 32,
+          pg_placement_num_target: 16
+        })
+      );
+    });
+
+    it('shows marked pools in progress as defined by task', () => {
+      const pools = [
+        _.merge(pool, {
+          pg_num: 32,
+          pg_num_target: 16,
+          pg_placement_num: 32,
+          pg_placement_num_target: 16,
+          cdExecuting: 'Updating 50%'
+        })
+      ];
+      expect(component.transformPoolsData(pools)).toEqual(
+        getPoolData({
+          cdExecuting: 'Updating 50%',
+          pg_num: 32,
+          pg_num_target: 16,
+          pg_placement_num: 32,
+          pg_placement_num_target: 16
+        })
+      );
     });
   });
 
@@ -365,17 +409,7 @@ describe('PoolListComponent', () => {
     });
   });
 
-  describe('getPoolDetails', () => {
-    it('returns pool details corretly', () => {
-      const pool = { prop1: 1, cdIsBinary: true, prop2: 2, cdExecuting: true, prop3: 3 };
-      const expected = { prop1: 1, prop2: 2, prop3: 3 };
-
-      expect(component.getPoolDetails(pool)).toEqual(expected);
-    });
-  });
-
   describe('getSelectionTiers', () => {
-    let pools: Pool[];
     const setSelectionTiers = (tiers: number[]) => {
       component.selection.selected = [
         {
@@ -387,18 +421,17 @@ describe('PoolListComponent', () => {
     };
 
     beforeEach(() => {
-      pools = [];
-      setUpPools(pools);
+      component.pools = getPoolList();
     });
 
     it('should select multiple existing cache tiers', () => {
       setSelectionTiers([0, 1, 2]);
-      expect(component.selectionCacheTiers).toEqual(pools);
+      expect(component.selectionCacheTiers).toEqual(getPoolList());
     });
 
     it('should select correct existing cache tier', () => {
       setSelectionTiers([0]);
-      expect(component.selectionCacheTiers).toEqual([{ pg_num: 256, pool: 0, pool_name: 'a' }]);
+      expect(component.selectionCacheTiers).toEqual([createPool('a', 0)]);
     });
 
     it('should not select cache tier if id is invalid', () => {
@@ -413,9 +446,9 @@ describe('PoolListComponent', () => {
 
     it('should be able to selected one pool with multiple tiers, than with a single tier, than with no tiers', () => {
       setSelectionTiers([0, 1, 2]);
-      expect(component.selectionCacheTiers).toEqual(pools);
+      expect(component.selectionCacheTiers).toEqual(getPoolList());
       setSelectionTiers([0]);
-      expect(component.selectionCacheTiers).toEqual([{ pg_num: 256, pool: 0, pool_name: 'a' }]);
+      expect(component.selectionCacheTiers).toEqual([createPool('a', 0)]);
       setSelectionTiers([]);
       expect(component.selectionCacheTiers).toEqual([]);
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -248,6 +248,13 @@ export class PoolListComponent implements OnInit {
       const avail = stats.bytes_used.latest + stats.max_avail.latest;
       pool['usage'] = avail > 0 ? stats.bytes_used.latest / avail : avail;
 
+      if (
+        !pool.cdExecuting &&
+        pool.pg_num + pool.pg_placement_num !== pool.pg_num_target + pool.pg_placement_num_target
+      ) {
+        pool['cdExecuting'] = 'Updating';
+      }
+
       ['rd_bytes', 'wr_bytes'].forEach((stat) => {
         pool.stats[stat].rates = pool.stats[stat].rates.map((point) => point[1]);
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.ts
@@ -21,6 +21,12 @@ export class Pool {
   min_read_recency_for_promote: number;
   target_max_objects: number;
   pg_num: number;
+  pg_num_target: number;
+  pg_num_pending: number;
+  pg_placement_num: number;
+  pg_placement_num_target: number;
+  pg_autoscale_mode: string;
+  pg_status: string;
   type: string;
   pool_name: string;
   cache_min_evict_age: number;
@@ -57,7 +63,6 @@ export class Pool {
   last_change: string;
   min_write_recency_for_promote: number;
   read_tier: number;
-  pg_status: string;
   stats?: PoolStats;
   cdIsBinary?: boolean;
   configuration: { source: number; name: string; value: string }[];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -175,7 +175,7 @@
      *ngIf="row.cdExecuting"></i>
   {{ value }}
   <span *ngIf="row.cdExecuting"
-        class="text-muted italic">({{ row.cdExecuting }}... )</span>
+        class="text-muted italic">({{ row.cdExecuting }})</span>
 </ng-template>
 
 <ng-template #classAddingTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
@@ -4,7 +4,11 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { of } from 'rxjs';
 
-import { configureTestBed, i18nProviders } from '../../../testing/unit-test-helper';
+import {
+  configureTestBed,
+  expectItemTasks,
+  i18nProviders
+} from '../../../testing/unit-test-helper';
 import { ExecutingTask } from '../models/executing-task';
 import { SummaryService } from './summary.service';
 import { TaskListService } from './task-list.service';
@@ -71,10 +75,6 @@ describe('TaskListService', () => {
     summaryService.addRunningTask(task);
   };
 
-  const expectItemTasks = (item: any, executing: string) => {
-    expect(item.cdExecuting).toBe(executing);
-  };
-
   it('gets all items without any executing items', () => {
     expect(list.length).toBe(3);
     expect(list.every((item) => !item.cdExecuting)).toBeTruthy();
@@ -90,7 +90,7 @@ describe('TaskListService', () => {
     addTask('test/edit', 'd', 97);
     addTask('test/edit', 'e', 0);
     expect(list.length).toBe(5);
-    expectItemTasks(list[3], 'Updating 97%');
+    expectItemTasks(list[3], 'Updating', 97);
     expectItemTasks(list[4], 'Updating');
   });
 
@@ -110,8 +110,8 @@ describe('TaskListService', () => {
     addTask('test/delete', 'b');
     addTask('test/delete', 'c');
     expect(list.length).toBe(3);
-    expectItemTasks(list[0], 'Creating, Updating, Deleting');
-    expectItemTasks(list[1], 'Updating, Deleting');
+    expectItemTasks(list[0], 'Creating..., Updating..., Deleting');
+    expectItemTasks(list[1], 'Updating..., Deleting');
     expectItemTasks(list[2], 'Deleting');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
@@ -62,9 +62,10 @@ describe('TaskListService', () => {
     expect(service).toBeTruthy();
   });
 
-  const addTask = (name: string, itemName: string) => {
+  const addTask = (name: string, itemName: string, progress?: number) => {
     const task = new ExecutingTask();
     task.name = name;
+    task.progress = progress;
     task.metadata = { name: itemName };
     tasks.push(task);
     summaryService.addRunningTask(task);
@@ -83,6 +84,14 @@ describe('TaskListService', () => {
     addTask('test/create', 'd');
     expect(list.length).toBe(4);
     expectItemTasks(list[3], 'Creating');
+  });
+
+  it('shows progress of current task if any above 0', () => {
+    addTask('test/edit', 'd', 97);
+    addTask('test/edit', 'e', 0);
+    expect(list.length).toBe(5);
+    expectItemTasks(list[3], 'Updating 97%');
+    expectItemTasks(list[4], 'Updating');
   });
 
   it('gets all items with one executing items', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
@@ -93,7 +93,7 @@ export class TaskListService implements OnDestroy {
     return tasks
       .map((task) => {
         const progress = task.progress ? ` ${task.progress}%` : '';
-        return this.taskMessageService.getRunningText(task) + progress;
+        return this.taskMessageService.getRunningText(task) + '...' + progress;
       })
       .join(', ');
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
@@ -90,7 +90,12 @@ export class TaskListService implements OnDestroy {
     if (tasks.length === 0) {
       return;
     }
-    return tasks.map((task) => this.taskMessageService.getRunningText(task)).join(', ');
+    return tasks
+      .map((task) => {
+        const progress = task.progress ? ` ${task.progress}%` : '';
+        return this.taskMessageService.getRunningText(task) + progress;
+      })
+      .join(', ');
   }
 
   ngOnDestroy() {

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -275,3 +275,13 @@ const i18nProviders = [
 ];
 
 export { i18nProviders };
+
+export function expectItemTasks(item: any, executing: string, percentage?: number) {
+  if (executing) {
+    executing = executing + '...';
+    if (percentage) {
+      executing = `${executing} ${percentage}%`;
+    }
+  }
+  expect(item.cdExecuting).toBe(executing);
+}

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -78,6 +78,8 @@ class CLICommandTestMixin(KVStoreMockMixin):
 
 
 class ControllerTestCase(helper.CPWebCase):
+    _endpoints_cache = {}
+
     @classmethod
     def setup_controllers(cls, ctrl_classes, base_url=''):
         if not isinstance(ctrl_classes, list):
@@ -86,7 +88,17 @@ class ControllerTestCase(helper.CPWebCase):
         endpoint_list = []
         for ctrl in ctrl_classes:
             inst = ctrl()
-            for endpoint in ctrl.endpoints():
+
+            # We need to cache the controller endpoints because
+            # BaseController#endpoints method is not idempontent
+            # and a controller might be needed by more than one
+            # unit test.
+            if ctrl not in cls._endpoints_cache:
+                ctrl_endpoints = ctrl.endpoints()
+                cls._endpoints_cache[ctrl] = ctrl_endpoints
+
+            ctrl_endpoints = cls._endpoints_cache[ctrl]
+            for endpoint in ctrl_endpoints:
                 endpoint.inst = inst
                 endpoint_list.append(endpoint)
         endpoint_list = sorted(endpoint_list, key=lambda e: e.url)

--- a/src/pybind/mgr/dashboard/tests/test_pool.py
+++ b/src/pybind/mgr/dashboard/tests/test_pool.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+import mock
+
+from . import ControllerTestCase
+from ..controllers.pool import Pool
+
+
+class MockTask(object):
+    percentages = []
+
+    def set_progress(self, percentage):
+        self.percentages.append(percentage)
+
+
+class PoolControllerTest(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        Pool._cp_config['tools.authenticate.on'] = False
+        cls.setup_controllers([Pool])
+
+    def test_creation(self):
+        self._post('/api/pool', {
+            'pool': 'test-pool',
+            'pool_type': 1,
+            'pg_num': 64
+        })
+        self.assertStatus(202)
+        self.assertJsonBody({'name': 'pool/create', 'metadata': {'pool_name': 'test-pool'}})
+
+    @mock.patch('dashboard.controllers.pool.Pool._get')
+    def test_wait_for_pgs_without_waiting(self, _get):
+        _get.side_effect = [{
+            'pool_name': 'test-pool',
+            'pg_num': 32,
+            'pg_num_target': 32,
+            'pg_placement_num': 32,
+            'pg_placement_num_target': 32
+        }]
+        pool = Pool()
+        pool._wait_for_pgs('test-pool')
+        self.assertEqual(_get.call_count, 1)
+
+    @mock.patch('dashboard.controllers.pool.Pool._get')
+    @mock.patch('dashboard.tools.TaskManager.current_task')
+    def test_wait_for_pgs_with_waiting(self, taskMock, _get):
+        task = MockTask()
+        taskMock.return_value = task
+        _get.side_effect = [{
+            'pool_name': 'test-pool',
+            'pg_num': 64,
+            'pg_num_target': 32,
+            'pg_placement_num': 64,
+            'pg_placement_num_target': 64
+        }, {
+            'pool_name': 'test-pool',
+            'pg_num': 63,
+            'pg_num_target': 32,
+            'pg_placement_num': 62,
+            'pg_placement_num_target': 32
+        }, {
+            'pool_name': 'test-pool',
+            'pg_num': 48,
+            'pg_num_target': 32,
+            'pg_placement_num': 48,
+            'pg_placement_num_target': 32
+        }, {
+            'pool_name': 'test-pool',
+            'pg_num': 48,
+            'pg_num_target': 32,
+            'pg_placement_num': 33,
+            'pg_placement_num_target': 32
+        }, {
+            'pool_name': 'test-pool',
+            'pg_num': 33,
+            'pg_num_target': 32,
+            'pg_placement_num': 32,
+            'pg_placement_num_target': 32
+        }, {
+            'pool_name': 'test-pool',
+            'pg_num': 32,
+            'pg_num_target': 32,
+            'pg_placement_num': 32,
+            'pg_placement_num_target': 32
+        }]
+        pool = Pool()
+        pool._wait_for_pgs('test-pool')
+        self.assertEqual(_get.call_count, 6)
+        self.assertEqual(task.percentages, [0, 5, 50, 73, 98])

--- a/src/pybind/mgr/dashboard/tests/test_pool.py
+++ b/src/pybind/mgr/dashboard/tests/test_pool.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
+import time
 import mock
 
 from . import ControllerTestCase
 from ..controllers.pool import Pool
+from ..controllers.task import Task
+from ..tools import NotificationQueue, TaskManager
 
 
 class MockTask(object):
@@ -16,17 +19,42 @@ class MockTask(object):
 class PoolControllerTest(ControllerTestCase):
     @classmethod
     def setup_server(cls):
+        Task._cp_config['tools.authenticate.on'] = False
         Pool._cp_config['tools.authenticate.on'] = False
-        cls.setup_controllers([Pool])
+        cls.setup_controllers([Pool, Task])
 
-    def test_creation(self):
-        self._post('/api/pool', {
+    @mock.patch('dashboard.controllers.pool.Pool._get')
+    @mock.patch('dashboard.services.ceph_service.CephService.send_command')
+    def test_creation(self, send_command, _get):
+        _get.side_effect = [{
+            'pool_name': 'test-pool',
+            'pg_num': 64,
+            'pg_num_target': 63,
+            'pg_placement_num': 64,
+            'pg_placement_num_target': 63
+        }, {
+            'pool_name': 'test-pool',
+            'pg_num': 64,
+            'pg_num_target': 64,
+            'pg_placement_num': 64,
+            'pg_placement_num_target': 64
+        }]
+        NotificationQueue.start_queue()
+        TaskManager.init()
+
+        def _send_cmd(*args, **kwargs):  # pylint: disable=unused-argument
+            time.sleep(3)
+
+        send_command.side_effect = _send_cmd
+
+        self._task_post('/api/pool', {
             'pool': 'test-pool',
             'pool_type': 1,
             'pg_num': 64
-        })
-        self.assertStatus(202)
-        self.assertJsonBody({'name': 'pool/create', 'metadata': {'pool_name': 'test-pool'}})
+        }, 10)
+        self.assertStatus(201)
+        self.assertEqual(_get.call_count, 2)
+        NotificationQueue.stop()
 
     @mock.patch('dashboard.controllers.pool.Pool._get')
     def test_wait_for_pgs_without_waiting(self, _get):
@@ -37,15 +65,15 @@ class PoolControllerTest(ControllerTestCase):
             'pg_placement_num': 32,
             'pg_placement_num_target': 32
         }]
-        pool = Pool()
-        pool._wait_for_pgs('test-pool')
+        Pool._wait_for_pgs('test-pool')
         self.assertEqual(_get.call_count, 1)
 
     @mock.patch('dashboard.controllers.pool.Pool._get')
-    @mock.patch('dashboard.tools.TaskManager.current_task')
-    def test_wait_for_pgs_with_waiting(self, taskMock, _get):
+    def test_wait_for_pgs_with_waiting(self, _get):
         task = MockTask()
-        taskMock.return_value = task
+        orig_method = TaskManager.current_task
+        TaskManager.current_task = mock.MagicMock()
+        TaskManager.current_task.return_value = task
         _get.side_effect = [{
             'pool_name': 'test-pool',
             'pg_num': 64,
@@ -83,7 +111,7 @@ class PoolControllerTest(ControllerTestCase):
             'pg_placement_num': 32,
             'pg_placement_num_target': 32
         }]
-        pool = Pool()
-        pool._wait_for_pgs('test-pool')
+        Pool._wait_for_pgs('test-pool')
         self.assertEqual(_get.call_count, 6)
         self.assertEqual(task.percentages, [0, 5, 50, 73, 98])
+        TaskManager.current_task = orig_method


### PR DESCRIPTION
Now when creating or editing a pool the background task will watch
increasing and decreasing pg's. The executing task will also use a
progress to show the progress.

If the change was not executed through the dashboard, there is no task
to show, but the frontend will make sure to inform the user about the
change that is going on in order to stop the user from doing actions on
the changing pool.

Fixes: https://tracker.ceph.com/issues/39482
Signed-off-by: Stephan Müller <smueller@suse.com>

![pg_progress_2019-05-07 16-27](https://user-images.githubusercontent.com/16167865/57311700-6fb16400-70ec-11e9-9cf2-31d7733efc00.gif)
