### PR TITLE
rgw: use explicit to_string() overload for boost::string_ref

### DIFF
--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1528,10 +1528,10 @@ void rgw::keystone::AdminTokenRequestVer2::dump(Formatter* const f) const
   f->open_object_section("token_request");
     f->open_object_section("auth");
       f->open_object_section("passwordCredentials");
-        encode_json("username", to_string(conf.get_admin_user()), f);
+        encode_json("username", ::to_string(conf.get_admin_user()), f);
         encode_json("password", ::to_string(conf.get_admin_password()), f);
       f->close_section();
-      encode_json("tenantName", to_string(conf.get_admin_tenant()), f);
+      encode_json("tenantName", ::to_string(conf.get_admin_tenant()), f);
     f->close_section();
   f->close_section();
 }
@@ -1547,9 +1547,9 @@ void rgw::keystone::AdminTokenRequestVer3::dump(Formatter* const f) const
         f->open_object_section("password");
           f->open_object_section("user");
             f->open_object_section("domain");
-              encode_json("name", to_string(conf.get_admin_domain()), f);
+              encode_json("name", ::to_string(conf.get_admin_domain()), f);
             f->close_section();
-            encode_json("name", to_string(conf.get_admin_user()), f);
+            encode_json("name", ::to_string(conf.get_admin_user()), f);
             encode_json("password", ::to_string(conf.get_admin_password()), f);
           f->close_section();
         f->close_section();
@@ -1557,12 +1557,12 @@ void rgw::keystone::AdminTokenRequestVer3::dump(Formatter* const f) const
       f->open_object_section("scope");
         f->open_object_section("project");
           if (! conf.get_admin_project().empty()) {
-            encode_json("name", to_string(conf.get_admin_project()), f);
+            encode_json("name", ::to_string(conf.get_admin_project()), f);
           } else {
-            encode_json("name", to_string(conf.get_admin_tenant()), f);
+            encode_json("name", ::to_string(conf.get_admin_tenant()), f);
           }
           f->open_object_section("domain");
-            encode_json("name", to_string(conf.get_admin_domain()), f);
+            encode_json("name", ::to_string(conf.get_admin_domain()), f);
           f->close_section();
         f->close_section();
       f->close_section();


### PR DESCRIPTION
fix the build on s390x

Fixes: http://tracker.ceph.com/issues/39611