### PR TITLE
rgw:RGWGetBucketVersioning on non-existing bucket does not return NoSuchBucket (http=404)

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2388,7 +2388,11 @@ void RGWStatAccount::execute()
 
 int RGWGetBucketVersioning::verify_permission()
 {
-  return verify_bucket_owner_or_policy(s, rgw::IAM::s3GetBucketVersioning);
+  if (!s->bucket_exists) {
+    return -ERR_NO_SUCH_BUCKET;
+  } else {
+    return verify_bucket_owner_or_policy(s, rgw::IAM::s3GetBucketVersioning);
+  }
 }
 
 void RGWGetBucketVersioning::pre_exec()


### PR DESCRIPTION
Fix incorrect result when attempting to fetch bucket version for a
bucket that does not exist.
    
This change leads to a NoSuchBucket error result when version is
requested from a non-existent bucket.
    
Fixes: https://tracker.ceph.com/issues/39622
    
Signed-off-by: Prashant D pdhange@redhat.com
