### PR TITLE
mon: take the mon lock in handle_conf_change

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -550,11 +550,19 @@ void Monitor::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("mon_health_to_clog") ||
       changed.count("mon_health_to_clog_interval") ||
       changed.count("mon_health_to_clog_tick_interval")) {
-    health_to_clog_update_conf(changed);
+    std::set<std::string> c2(changed);
+    finisher.queue(new C_MonContext(this, [this, c2](int) {
+      Mutex::Locker l(lock);
+      health_to_clog_update_conf(c2);
+    }));
   }
 
   if (changed.count("mon_scrub_interval")) {
-    scrub_update_interval(conf->mon_scrub_interval);
+    int scrub_interval = conf->mon_scrub_interval;
+    finisher.queue(new C_MonContext(this, [this, scrub_interval](int) {
+      Mutex::Locker l(lock);
+      scrub_update_interval(scrub_interval);
+    }));
   }
 }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/39625

Signed-off-by: huangjun <huangjun@xsky.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

