### PR TITLE
nautilus: mgr/dashboard: iSCSI GET requests should not be logged

### DIFF
--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -212,5 +212,5 @@ class IscsiClient(RestClient):
 
     @RestClient.api_get('/api/targetinfo/{target_iqn}')
     def get_targetinfo(self, target_iqn, request=None):
-        logger.debug("iSCSI: Getting targetinfo: %s", target_iqn)
+        # pylint: disable=unused-argument
         return request()


### PR DESCRIPTION
https://tracker.ceph.com/issues/39630