### PR TITLE
librbd: tweaks to increase IOPS and reduce CPU usage

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -409,9 +409,7 @@ public:
   }
 
   string ImageCtx::get_object_name(uint64_t num) const {
-    char buf[object_prefix.length() + 32];
-    snprintf(buf, sizeof(buf), format_string, num);
-    return string(buf);
+    return util::data_object_name(this, num);
   }
 
   uint64_t ImageCtx::get_stripe_unit() const

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -6,11 +6,13 @@
 
 #include "include/rados/librados.hpp"
 #include "include/rbd_types.h"
+#include "include/ceph_assert.h"
 #include "include/Context.h"
 #include "common/zipkin_trace.h"
 
 #include <atomic>
 #include <type_traits>
+#include <stdio.h>
 
 namespace librbd {
 
@@ -106,6 +108,19 @@ const std::string id_obj_name(const std::string &name);
 const std::string header_name(const std::string &image_id);
 const std::string old_header_name(const std::string &image_name);
 std::string unique_lock_name(const std::string &name, void *address);
+
+template <typename I>
+std::string data_object_name(I* image_ctx, uint64_t object_no) {
+  char buf[RBD_MAX_OBJ_NAME_SIZE];
+  size_t length = snprintf(buf, RBD_MAX_OBJ_NAME_SIZE,
+                           image_ctx->format_string, object_no);
+  ceph_assert(length < RBD_MAX_OBJ_NAME_SIZE);
+
+  std::string oid;
+  oid.reserve(RBD_MAX_OBJ_NAME_SIZE);
+  oid.append(buf, length);
+  return oid;
+}
 
 librados::AioCompletion *create_rados_callback(Context *on_finish);
 

--- a/src/librbd/cache/ObjectCacherObjectDispatch.cc
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.cc
@@ -23,6 +23,8 @@
 namespace librbd {
 namespace cache {
 
+using librbd::util::data_object_name;
+
 namespace {
 
 typedef std::vector<ObjectExtent> ObjectExtents;
@@ -178,12 +180,11 @@ void ObjectCacherObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool ObjectCacherObjectDispatch<I>::read(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, librados::snap_t snap_id, int op_flags,
-    const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-    io::ExtentMap* extent_map, int* object_dispatch_flags,
-    io::DispatchResult* dispatch_result, Context** on_finish,
-    Context* on_dispatched) {
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
+    ceph::bufferlist* read_data, io::ExtentMap* extent_map,
+    int* object_dispatch_flags, io::DispatchResult* dispatch_result,
+    Context** on_finish, Context* on_dispatched) {
   // IO chained in reverse order
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "object_no=" << object_no << " " << object_off << "~"
@@ -197,7 +198,8 @@ bool ObjectCacherObjectDispatch<I>::read(
   auto rd = m_object_cacher->prepare_read(snap_id, read_data, op_flags);
   m_image_ctx->image_lock.put_read();
 
-  ObjectExtent extent(oid, object_no, object_off, object_len, 0);
+  ObjectExtent extent(data_object_name(m_image_ctx, object_no), object_no,
+                      object_off, object_len, 0);
   extent.oloc.pool = m_image_ctx->data_ctx.get_id();
   extent.buffer_extents.push_back({0, object_len});
   rd->extents.push_back(extent);
@@ -216,8 +218,8 @@ bool ObjectCacherObjectDispatch<I>::read(
 
 template <typename I>
 bool ObjectCacherObjectDispatch<I>::discard(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    const ::SnapContext &snapc, int discard_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -226,7 +228,8 @@ bool ObjectCacherObjectDispatch<I>::discard(
                  << object_len << dendl;
 
   ObjectExtents object_extents;
-  object_extents.emplace_back(oid, object_no, object_off, object_len, 0);
+  object_extents.emplace_back(data_object_name(m_image_ctx, object_no),
+                              object_no, object_off, object_len, 0);
 
   // discard the cache state after changes are committed to disk (and to
   // prevent races w/ readahead)
@@ -257,8 +260,8 @@ bool ObjectCacherObjectDispatch<I>::discard(
 
 template <typename I>
 bool ObjectCacherObjectDispatch<I>::write(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+    uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+    const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -275,7 +278,8 @@ bool ObjectCacherObjectDispatch<I>::write(
     snapc, data, ceph::real_time::min(), op_flags, *journal_tid);
   m_image_ctx->image_lock.put_read();
 
-  ObjectExtent extent(oid, 0, object_off, data.length(), 0);
+  ObjectExtent extent(data_object_name(m_image_ctx, object_no),
+                      object_no, object_off, data.length(), 0);
   extent.oloc.pool = m_image_ctx->data_ctx.get_id();
   extent.buffer_extents.push_back({0, data.length()});
   wr->extents.push_back(extent);
@@ -291,8 +295,8 @@ bool ObjectCacherObjectDispatch<I>::write(
 
 template <typename I>
 bool ObjectCacherObjectDispatch<I>::write_same(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, io::Extents&& buffer_extents, ceph::bufferlist&& data,
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    io::Extents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
@@ -302,22 +306,22 @@ bool ObjectCacherObjectDispatch<I>::write_same(
                  << object_len << dendl;
 
   // ObjectCacher doesn't support write-same so convert to regular write
-  ObjectExtent extent(oid, 0, object_off, object_len, 0);
+  ObjectExtent extent(data_object_name(m_image_ctx, object_no), object_no,
+                      object_off, object_len, 0);
   extent.buffer_extents = std::move(buffer_extents);
 
   bufferlist ws_data;
   io::util::assemble_write_same_extent(extent, data, &ws_data, true);
 
-  return write(oid, object_no, object_off, std::move(ws_data), snapc,
-               op_flags, parent_trace, object_dispatch_flags, journal_tid,
+  return write(object_no, object_off, std::move(ws_data), snapc, op_flags,
+               parent_trace, object_dispatch_flags, journal_tid,
                dispatch_result, on_finish, on_dispatched);
 }
 
 template <typename I>
 bool ObjectCacherObjectDispatch<I>::compare_and_write(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-    const ::SnapContext &snapc, int op_flags,
+    uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+    ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     io::DispatchResult* dispatch_result, Context** on_finish,
@@ -338,8 +342,8 @@ bool ObjectCacherObjectDispatch<I>::compare_and_write(
   *dispatch_result = io::DISPATCH_RESULT_CONTINUE;
 
   ObjectExtents object_extents;
-  object_extents.emplace_back(oid, object_no, object_off, cmp_data.length(),
-                              0);
+  object_extents.emplace_back(data_object_name(m_image_ctx, object_no),
+                              object_no, object_off, cmp_data.length(), 0);
 
   Mutex::Locker cache_locker(m_cache_lock);
   m_object_cacher->flush_set(m_object_set, object_extents, &trace,

--- a/src/librbd/cache/ObjectCacherObjectDispatch.cc
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.cc
@@ -10,6 +10,7 @@
 #include "librbd/cache/ObjectCacherWriteback.h"
 #include "librbd/io/ObjectDispatchSpec.h"
 #include "librbd/io/ObjectDispatcher.h"
+#include "librbd/io/Types.h"
 #include "librbd/io/Utils.h"
 #include "osd/osd_types.h"
 #include "osdc/WritebackHandler.h"
@@ -296,7 +297,7 @@ bool ObjectCacherObjectDispatch<I>::write(
 template <typename I>
 bool ObjectCacherObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
-    io::Extents&& buffer_extents, ceph::bufferlist&& data,
+    io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
@@ -306,8 +307,7 @@ bool ObjectCacherObjectDispatch<I>::write_same(
                  << object_len << dendl;
 
   // ObjectCacher doesn't support write-same so convert to regular write
-  ObjectExtent extent(data_object_name(m_image_ctx, object_no), object_no,
-                      object_off, object_len, 0);
+  io::LightweightObjectExtent extent(object_no, object_off, object_len, 0);
   extent.buffer_extents = std::move(buffer_extents);
 
   bufferlist ws_data;

--- a/src/librbd/cache/ObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.h
@@ -42,39 +42,38 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, librados::snap_t snap_id, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
       io::ExtentMap* extent_map, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool discard(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      const ::SnapContext &snapc, int discard_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write_same(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, io::Extents&& buffer_extents,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      io::Extents&& buffer_extents, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-      const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+      ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,

--- a/src/librbd/cache/ObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.h
@@ -65,7 +65,7 @@ public:
 
   bool write_same(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      io::Extents&& buffer_extents, ceph::bufferlist&& data,
+      io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,

--- a/src/librbd/cache/ObjectCacherWriteback.cc
+++ b/src/librbd/cache/ObjectCacherWriteback.cc
@@ -137,8 +137,8 @@ void ObjectCacherWriteback::read(const object_t& oid, uint64_t object_no,
     aio_comp, off, len, {{0, len}});
 
   auto req = io::ObjectDispatchSpec::create_read(
-    m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, oid.name, object_no, off, len,
-    snapid, op_flags, trace, &req_comp->bl, &req_comp->extent_map, req_comp);
+    m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, off, len, snapid,
+    op_flags, trace, &req_comp->bl, &req_comp->extent_map, req_comp);
   req->send();
 }
 
@@ -196,8 +196,8 @@ ceph_tid_t ObjectCacherWriteback::write(const object_t& oid,
   ctx = util::create_async_context_callback(*m_ictx, ctx);
 
   auto req = io::ObjectDispatchSpec::create_write(
-    m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, oid.name, object_no, off,
-    std::move(bl_copy), snapc, 0, journal_tid, trace, ctx);
+    m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, off, std::move(bl_copy),
+    snapc, 0, journal_tid, trace, ctx);
   req->object_dispatch_flags = (
     io::OBJECT_DISPATCH_FLAG_FLUSH |
     io::OBJECT_DISPATCH_FLAG_WILL_RETRY_ON_ERROR);

--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -99,7 +99,7 @@ bool WriteAroundObjectDispatch<I>::write(
 template <typename I>
 bool WriteAroundObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
-    io::Extents&& buffer_extents, ceph::bufferlist&& data,
+    io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,

--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -18,6 +18,8 @@
 namespace librbd {
 namespace cache {
 
+using librbd::util::data_object_name;
+
 template <typename I>
 WriteAroundObjectDispatch<I>::WriteAroundObjectDispatch(
     I* image_ctx, size_t max_dirty, bool writethrough_until_flush)
@@ -55,26 +57,25 @@ void WriteAroundObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool WriteAroundObjectDispatch<I>::read(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, librados::snap_t snap_id, int op_flags,
-    const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-    io::ExtentMap* extent_map, int* object_dispatch_flags,
-    io::DispatchResult* dispatch_result, Context** on_finish,
-    Context* on_dispatched) {
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
+    ceph::bufferlist* read_data, io::ExtentMap* extent_map,
+    int* object_dispatch_flags, io::DispatchResult* dispatch_result,
+    Context** on_finish, Context* on_dispatched) {
   return dispatch_unoptimized_io(object_no, object_off, object_len,
                                  dispatch_result, on_dispatched);
 }
 
 template <typename I>
 bool WriteAroundObjectDispatch<I>::discard(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    const ::SnapContext &snapc, int discard_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "object_no=" << object_no << " " << object_off << "~"
-                 << object_len << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << object_len << dendl;
 
   return dispatch_io(object_no, object_off, object_len, 0, dispatch_result,
                      on_finish, on_dispatched);
@@ -82,14 +83,14 @@ bool WriteAroundObjectDispatch<I>::discard(
 
 template <typename I>
 bool WriteAroundObjectDispatch<I>::write(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+    uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+    const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context**on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "object_no=" << object_no << " " << object_off << "~"
-                 << data.length() << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << data.length() << dendl;
 
   return dispatch_io(object_no, object_off, data.length(), op_flags,
                      dispatch_result, on_finish, on_dispatched);
@@ -97,15 +98,15 @@ bool WriteAroundObjectDispatch<I>::write(
 
 template <typename I>
 bool WriteAroundObjectDispatch<I>::write_same(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, io::Extents&& buffer_extents, ceph::bufferlist&& data,
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    io::Extents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context**on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "object_no=" << object_no << " " << object_off << "~"
-                 << object_len << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << object_len << dendl;
 
   return dispatch_io(object_no, object_off, object_len, 0, dispatch_result,
                      on_finish, on_dispatched);
@@ -113,9 +114,8 @@ bool WriteAroundObjectDispatch<I>::write_same(
 
 template <typename I>
 bool WriteAroundObjectDispatch<I>::compare_and_write(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-    const ::SnapContext &snapc, int op_flags,
+    uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+    ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     io::DispatchResult* dispatch_result, Context** on_finish,

--- a/src/librbd/cache/WriteAroundObjectDispatch.h
+++ b/src/librbd/cache/WriteAroundObjectDispatch.h
@@ -65,7 +65,7 @@ public:
 
   bool write_same(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      io::Extents&& buffer_extents, ceph::bufferlist&& data,
+      io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,

--- a/src/librbd/cache/WriteAroundObjectDispatch.h
+++ b/src/librbd/cache/WriteAroundObjectDispatch.h
@@ -42,39 +42,38 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, librados::snap_t snap_id, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
       io::ExtentMap* extent_map, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool discard(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      const ::SnapContext &snapc, int discard_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) override;
 
   bool write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) override;
 
   bool write_same(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, io::Extents&& buffer_extents,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      io::Extents&& buffer_extents, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-      const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+      ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -24,11 +24,14 @@
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
-#define dout_prefix *_dout << "librbd::io::CopyupRequest: " << this \
-                           << " " << __func__ << ": "
+#define dout_prefix *_dout << "librbd::io::CopyupRequest: " << this            \
+                           << " " << __func__ << ": "                          \
+                           << data_object_name(m_image_ctx, m_object_no) << " "
 
 namespace librbd {
 namespace io {
+
+using librbd::util::data_object_name;
 
 namespace {
 
@@ -108,11 +111,10 @@ private:
 } // anonymous namespace
 
 template <typename I>
-CopyupRequest<I>::CopyupRequest(I *ictx, const std::string &oid,
-                                uint64_t objectno, Extents &&image_extents,
+CopyupRequest<I>::CopyupRequest(I *ictx, uint64_t objectno,
+                                Extents &&image_extents,
                                 const ZTracer::Trace &parent_trace)
-  : m_image_ctx(ictx), m_oid(oid), m_object_no(objectno),
-    m_image_extents(image_extents),
+  : m_image_ctx(ictx), m_object_no(objectno), m_image_extents(image_extents),
     m_trace(util::create_trace(*m_image_ctx, "copy-up", parent_trace)),
     m_lock("CopyupRequest", false, false)
 {
@@ -130,8 +132,7 @@ void CopyupRequest<I>::append_request(AbstractObjectWriteRequest<I> *req) {
   Mutex::Locker locker(m_lock);
 
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "oid=" << m_oid << ", "
-                 << "object_request=" << req << ", "
+  ldout(cct, 20) << "object_request=" << req << ", "
                  << "append=" << m_append_request_permitted << dendl;
   if (m_append_request_permitted) {
     m_pending_requests.push_back(req);
@@ -168,8 +169,7 @@ void CopyupRequest<I>::read_from_parent() {
     &CopyupRequest<I>::handle_read_from_parent>(
       this, util::get_image_ctx(m_image_ctx->parent), AIO_TYPE_READ);
 
-  ldout(cct, 20) << "oid=" << m_oid << ", "
-                 << "completion=" << comp << ", "
+  ldout(cct, 20) << "completion=" << comp << ", "
                  << "extents=" << m_image_extents
                  << dendl;
   if (m_image_ctx->enable_sparse_copyup) {
@@ -186,7 +186,7 @@ void CopyupRequest<I>::read_from_parent() {
 template <typename I>
 void CopyupRequest<I>::handle_read_from_parent(int r) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "oid=" << m_oid << ", r=" << r << dendl;
+  ldout(cct, 20) << "r=" << r << dendl;
 
   m_image_ctx->image_lock.get_read();
   m_lock.Lock();
@@ -235,7 +235,7 @@ void CopyupRequest<I>::deep_copy() {
   m_flatten = is_copyup_required() ? true : m_image_ctx->migration_info.flatten;
   m_lock.Unlock();
 
-  ldout(cct, 20) << "oid=" << m_oid << ", flatten=" << m_flatten << dendl;
+  ldout(cct, 20) << "flatten=" << m_flatten << dendl;
 
   auto ctx = util::create_context_callback<
     CopyupRequest<I>, &CopyupRequest<I>::handle_deep_copy>(this);
@@ -249,7 +249,7 @@ void CopyupRequest<I>::deep_copy() {
 template <typename I>
 void CopyupRequest<I>::handle_deep_copy(int r) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "oid=" << m_oid << ", r=" << r << dendl;
+  ldout(cct, 20) << "r=" << r << dendl;
 
   m_image_ctx->image_lock.get_read();
   m_lock.Lock();
@@ -315,7 +315,7 @@ void CopyupRequest<I>::update_object_maps() {
   }
 
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "oid=" << m_oid << dendl;
+  ldout(cct, 20) << dendl;
 
   bool copy_on_read = m_pending_requests.empty();
   uint8_t head_object_map_state = OBJECT_EXISTS;
@@ -354,7 +354,7 @@ void CopyupRequest<I>::update_object_maps() {
 template <typename I>
 void CopyupRequest<I>::handle_update_object_maps(int r) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "oid=" << m_oid << ", r=" << r << dendl;
+  ldout(cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_image_ctx->cct) << "failed to update object map: "
@@ -383,7 +383,7 @@ void CopyupRequest<I>::copyup() {
     return;
   }
 
-  ldout(cct, 20) << "oid=" << m_oid << dendl;
+  ldout(cct, 20) << dendl;
 
   bool copy_on_read = m_pending_requests.empty();
   bool deep_copyup = !snapc.snaps.empty() && !m_copyup_is_zero;
@@ -429,6 +429,7 @@ void CopyupRequest<I>::copyup() {
   m_lock.Unlock();
 
   // issue librados ops at the end to simplify test cases
+  std::string oid(data_object_name(m_image_ctx, m_object_no));
   std::vector<librados::snap_t> snaps;
   if (copyup_op.size() > 0) {
     // send only the copyup request with a blank snapshot context so that
@@ -440,7 +441,7 @@ void CopyupRequest<I>::copyup() {
     auto comp = util::create_rados_callback<
       CopyupRequest<I>, &CopyupRequest<I>::handle_copyup>(this);
     r = m_image_ctx->data_ctx.aio_operate(
-      m_oid, comp, &copyup_op, 0, snaps,
+      oid, comp, &copyup_op, 0, snaps,
       (m_trace.valid() ? m_trace.get_info() : nullptr));
     ceph_assert(r == 0);
     comp->release();
@@ -458,7 +459,7 @@ void CopyupRequest<I>::copyup() {
     auto comp = util::create_rados_callback<
       CopyupRequest<I>, &CopyupRequest<I>::handle_copyup>(this);
     r = m_image_ctx->data_ctx.aio_operate(
-      m_oid, comp, &write_op, snapc.seq, snaps,
+      oid, comp, &write_op, snapc.seq, snaps,
       (m_trace.valid() ? m_trace.get_info() : nullptr));
     ceph_assert(r == 0);
     comp->release();
@@ -475,7 +476,7 @@ void CopyupRequest<I>::handle_copyup(int r) {
     pending_copyups = --m_pending_copyups;
   }
 
-  ldout(cct, 20) << "oid=" << m_oid << ", " << "r=" << r << ", "
+  ldout(cct, 20) << "r=" << r << ", "
                  << "pending=" << pending_copyups << dendl;
 
   if (r < 0 && r != -ENOENT) {
@@ -491,7 +492,7 @@ void CopyupRequest<I>::handle_copyup(int r) {
 template <typename I>
 void CopyupRequest<I>::finish(int r) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "oid=" << m_oid << ", r=" << r << dendl;
+  ldout(cct, 20) << "r=" << r << dendl;
 
   complete_requests(true, r);
   delete this;

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -29,15 +29,15 @@ template <typename I> class AbstractObjectWriteRequest;
 template <typename ImageCtxT = librbd::ImageCtx>
 class CopyupRequest {
 public:
-  static CopyupRequest* create(ImageCtxT *ictx, const std::string &oid,
-                               uint64_t objectno, Extents &&image_extents,
+  static CopyupRequest* create(ImageCtxT *ictx, uint64_t objectno,
+                               Extents &&image_extents,
                                const ZTracer::Trace &parent_trace) {
-    return new CopyupRequest(ictx, oid, objectno, std::move(image_extents),
+    return new CopyupRequest(ictx, objectno, std::move(image_extents),
                              parent_trace);
   }
 
-  CopyupRequest(ImageCtxT *ictx, const std::string &oid, uint64_t objectno,
-                Extents &&image_extents, const ZTracer::Trace &parent_trace);
+  CopyupRequest(ImageCtxT *ictx, uint64_t objectno, Extents &&image_extents,
+                const ZTracer::Trace &parent_trace);
   ~CopyupRequest();
 
   void append_request(AbstractObjectWriteRequest<ImageCtxT> *req);
@@ -80,7 +80,6 @@ private:
   typedef std::vector<AbstractObjectWriteRequest<ImageCtxT> *> WriteRequests;
 
   ImageCtxT *m_image_ctx;
-  std::string m_oid;
   uint64_t m_object_no;
   Extents m_image_extents;
   ZTracer::Trace m_trace;

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -29,6 +29,7 @@
 namespace librbd {
 namespace io {
 
+using librbd::util::data_object_name;
 using librbd::util::get_image_ctx;
 
 namespace {
@@ -36,20 +37,21 @@ namespace {
 template <typename I>
 struct C_RBD_Readahead : public Context {
   I *ictx;
-  object_t oid;
+  uint64_t object_no;
   uint64_t offset;
   uint64_t length;
 
   bufferlist read_data;
   io::ExtentMap extent_map;
 
-  C_RBD_Readahead(I *ictx, object_t oid, uint64_t offset, uint64_t length)
-    : ictx(ictx), oid(oid), offset(offset), length(length) {
+  C_RBD_Readahead(I *ictx, uint64_t object_no, uint64_t offset, uint64_t length)
+    : ictx(ictx), object_no(object_no), offset(offset), length(length) {
     ictx->readahead.inc_pending();
   }
 
   void finish(int r) override {
-    ldout(ictx->cct, 20) << "C_RBD_Readahead on " << oid << ": "
+    ldout(ictx->cct, 20) << "C_RBD_Readahead on "
+                         << data_object_name(ictx, object_no) << ": "
                          << offset << "~" << length << dendl;
     ictx->readahead.dec_pending();
   }
@@ -83,25 +85,25 @@ void readahead(I *ictx, const Extents& image_extents) {
   if (readahead_length > 0) {
     ldout(ictx->cct, 20) << "(readahead logical) " << readahead_offset << "~"
                          << readahead_length << dendl;
-    std::map<object_t, std::vector<ObjectExtent> > readahead_object_extents;
-    Striper::file_to_extents(ictx->cct, ictx->format_string, &ictx->layout,
-                             readahead_offset, readahead_length, 0,
-                             readahead_object_extents);
-    for (auto& readahead_object_extent : readahead_object_extents) {
-      for (auto& object_extent : readahead_object_extent.second) {
-        ldout(ictx->cct, 20) << "(readahead) oid " << object_extent.oid << " "
-                             << object_extent.offset << "~"
-                             << object_extent.length << dendl;
+    LightweightObjectExtents readahead_object_extents;
+    Striper::file_to_extents(ictx->cct, &ictx->layout,
+                             readahead_offset, readahead_length, 0, 0,
+                             &readahead_object_extents);
+    for (auto& object_extent : readahead_object_extents) {
+      ldout(ictx->cct, 20) << "(readahead) "
+                           << data_object_name(ictx,
+                                               object_extent.object_no) << " "
+                           << object_extent.offset << "~"
+                           << object_extent.length << dendl;
 
-        auto req_comp = new C_RBD_Readahead<I>(ictx, object_extent.oid,
-                                               object_extent.offset,
-                                               object_extent.length);
-        auto req = io::ObjectDispatchSpec::create_read(
-          ictx, io::OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
-          object_extent.offset, object_extent.length, snap_id, 0, {},
-          &req_comp->read_data, &req_comp->extent_map, req_comp);
-        req->send();
-      }
+      auto req_comp = new C_RBD_Readahead<I>(ictx, object_extent.object_no,
+                                             object_extent.offset,
+                                             object_extent.length);
+      auto req = io::ObjectDispatchSpec::create_read(
+        ictx, io::OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
+        object_extent.offset, object_extent.length, snap_id, 0, {},
+        &req_comp->read_data, &req_comp->extent_map, req_comp);
+      req->send();
     }
 
     ictx->perfcounter->inc(l_librbd_readahead);
@@ -348,52 +350,42 @@ void ImageReadRequest<I>::send_request() {
     readahead(get_image_ctx(&image_ctx), image_extents);
   }
 
-  AioCompletion *aio_comp = this->m_aio_comp;
   librados::snap_t snap_id;
-  map<object_t,vector<ObjectExtent> > object_extents;
   uint64_t buffer_ofs = 0;
   {
     // prevent image size from changing between computing clip and recording
     // pending async operation
     RWLock::RLocker image_locker(image_ctx.image_lock);
     snap_id = image_ctx.snap_id;
+  }
 
-    // map image extents to object extents
-    for (auto &extent : image_extents) {
-      if (extent.second == 0) {
-        continue;
-      }
-
-      Striper::file_to_extents(cct, image_ctx.format_string, &image_ctx.layout,
-                               extent.first, extent.second, 0, object_extents,
-                               buffer_ofs);
-      buffer_ofs += extent.second;
+  // map image extents to object extents
+  LightweightObjectExtents object_extents;
+  for (auto &extent : image_extents) {
+    if (extent.second == 0) {
+      continue;
     }
-  }
 
-  // pre-calculate the expected number of read requests
-  uint32_t request_count = 0;
-  for (auto &object_extent : object_extents) {
-    request_count += object_extent.second.size();
+    Striper::file_to_extents(cct, &image_ctx.layout, extent.first,
+                             extent.second, 0, buffer_ofs, &object_extents);
+    buffer_ofs += extent.second;
   }
-  aio_comp->set_request_count(request_count);
 
   // issue the requests
-  for (auto &object_extent : object_extents) {
-    for (auto &extent : object_extent.second) {
-      ldout(cct, 20) << "oid " << extent.oid << " " << extent.offset << "~"
-                     << extent.length << " from " << extent.buffer_extents
-                     << dendl;
+  AioCompletion *aio_comp = this->m_aio_comp;
+  aio_comp->set_request_count(object_extents.size());
+  for (auto &oe : object_extents) {
+    ldout(cct, 20) << data_object_name(&image_ctx, oe.object_no) << " "
+                   << oe.offset << "~" << oe.length << " from "
+                   << oe.buffer_extents << dendl;
 
-      auto req_comp = new io::ReadResult::C_ObjectReadRequest(
-        aio_comp, extent.offset, extent.length,
-        std::move(extent.buffer_extents));
-      auto req = ObjectDispatchSpec::create_read(
-        &image_ctx, OBJECT_DISPATCH_LAYER_NONE, extent.objectno, extent.offset,
-        extent.length, snap_id, m_op_flags, this->m_trace, &req_comp->bl,
-        &req_comp->extent_map, req_comp);
-      req->send();
-    }
+    auto req_comp = new io::ReadResult::C_ObjectReadRequest(
+      aio_comp, oe.offset, oe.length, std::move(oe.buffer_extents));
+    auto req = ObjectDispatchSpec::create_read(
+      &image_ctx, OBJECT_DISPATCH_LAYER_NONE, oe.object_no, oe.offset,
+      oe.length, snap_id, m_op_flags, this->m_trace, &req_comp->bl,
+      &req_comp->extent_map, req_comp);
+    req->send();
   }
 
   image_ctx.perfcounter->inc(l_librbd_rd);
@@ -423,8 +415,6 @@ void AbstractImageWriteRequest<I>::send_request() {
   bool journaling = false;
 
   AioCompletion *aio_comp = this->m_aio_comp;
-  uint64_t clip_len = 0;
-  ObjectExtents object_extents;
   ::SnapContext snapc;
   {
     // prevent image size from changing between computing clip and recording
@@ -435,20 +425,22 @@ void AbstractImageWriteRequest<I>::send_request() {
       return;
     }
 
-    for (auto &extent : this->m_image_extents) {
-      if (extent.second == 0) {
-        continue;
-      }
-
-      // map to object extents
-      Striper::file_to_extents(cct, image_ctx.format_string, &image_ctx.layout,
-                               extent.first, extent.second, 0, object_extents);
-      clip_len += extent.second;
-    }
-
     snapc = image_ctx.snapc;
     journaling = (image_ctx.journal != nullptr &&
                   image_ctx.journal->is_journal_appending());
+  }
+
+  uint64_t clip_len = 0;
+  LightweightObjectExtents object_extents;
+  for (auto &extent : this->m_image_extents) {
+    if (extent.second == 0) {
+      continue;
+    }
+
+    // map to object extents
+    Striper::file_to_extents(cct, &image_ctx.layout, extent.first,
+                             extent.second, 0, clip_len, &object_extents);
+    clip_len += extent.second;
   }
 
   int ret = prune_object_extents(&object_extents);
@@ -457,6 +449,7 @@ void AbstractImageWriteRequest<I>::send_request() {
     return;
   }
 
+  aio_comp->set_request_count(object_extents.size());
   if (!object_extents.empty()) {
     uint64_t journal_tid = 0;
     if (journaling) {
@@ -465,11 +458,7 @@ void AbstractImageWriteRequest<I>::send_request() {
       journal_tid = append_journal_event(m_synchronous);
     }
 
-    aio_comp->set_request_count(object_extents.size());
     send_object_requests(object_extents, snapc, journal_tid);
-  } else {
-    // no IO to perform -- fire completion
-    aio_comp->set_request_count(0);
   }
 
   update_stats(clip_len);
@@ -477,18 +466,18 @@ void AbstractImageWriteRequest<I>::send_request() {
 
 template <typename I>
 void AbstractImageWriteRequest<I>::send_object_requests(
-    const ObjectExtents &object_extents, const ::SnapContext &snapc,
+    const LightweightObjectExtents &object_extents, const ::SnapContext &snapc,
     uint64_t journal_tid) {
   I &image_ctx = this->m_image_ctx;
   CephContext *cct = image_ctx.cct;
 
   AioCompletion *aio_comp = this->m_aio_comp;
-  for (ObjectExtents::const_iterator p = object_extents.begin();
-       p != object_extents.end(); ++p) {
-    ldout(cct, 20) << "oid " << p->oid << " " << p->offset << "~" << p->length
-                   << " from " << p->buffer_extents << dendl;
+  for (auto& oe : object_extents) {
+    ldout(cct, 20) << data_object_name(&image_ctx, oe.object_no) << " "
+                   << oe.offset << "~" << oe.length << " from "
+                   << oe.buffer_extents << dendl;
     C_AioRequest *req_comp = new C_AioRequest(aio_comp);
-    auto request = create_object_request(*p, snapc, journal_tid, req_comp);
+    auto request = create_object_request(oe, snapc, journal_tid, req_comp);
 
     // if journaling, stash the request for later; otherwise send
     if (request != NULL) {
@@ -498,8 +487,8 @@ void AbstractImageWriteRequest<I>::send_object_requests(
 }
 
 template <typename I>
-void ImageWriteRequest<I>::assemble_extent(const ObjectExtent &object_extent,
-                                           bufferlist *bl) {
+void ImageWriteRequest<I>::assemble_extent(
+    const LightweightObjectExtent &object_extent, bufferlist *bl) {
   for (auto q = object_extent.buffer_extents.begin();
        q != object_extent.buffer_extents.end(); ++q) {
     bufferlist sub_bl;
@@ -541,14 +530,14 @@ void ImageWriteRequest<I>::send_image_cache_request() {
 
 template <typename I>
 ObjectDispatchSpec *ImageWriteRequest<I>::create_object_request(
-    const ObjectExtent &object_extent, const ::SnapContext &snapc,
+    const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
     uint64_t journal_tid, Context *on_finish) {
   I &image_ctx = this->m_image_ctx;
 
   bufferlist bl;
   assemble_extent(object_extent, &bl);
   auto req = ObjectDispatchSpec::create_write(
-    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
     object_extent.offset, std::move(bl), snapc, m_op_flags, journal_tid,
     this->m_trace, on_finish);
   return req;
@@ -597,11 +586,11 @@ void ImageDiscardRequest<I>::send_image_cache_request() {
 
 template <typename I>
 ObjectDispatchSpec *ImageDiscardRequest<I>::create_object_request(
-    const ObjectExtent &object_extent, const ::SnapContext &snapc,
+    const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
     uint64_t journal_tid, Context *on_finish) {
   I &image_ctx = this->m_image_ctx;
   auto req = ObjectDispatchSpec::create_discard(
-    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
     object_extent.offset, object_extent.length, snapc,
     OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE, journal_tid, this->m_trace,
     on_finish);
@@ -617,7 +606,7 @@ void ImageDiscardRequest<I>::update_stats(size_t length) {
 
 template <typename I>
 int ImageDiscardRequest<I>::prune_object_extents(
-    ObjectExtents* object_extents) const {
+    LightweightObjectExtents* object_extents) const {
   if (m_discard_granularity_bytes == 0) {
     return 0;
   }
@@ -633,7 +622,7 @@ int ImageDiscardRequest<I>::prune_object_extents(
                                             object_size);
   auto xform_lambda =
     [discard_granularity_bytes, object_size, &prune_required]
-    (ObjectExtent& object_extent) {
+    (LightweightObjectExtent& object_extent) {
       auto& offset = object_extent.offset;
       auto& length = object_extent.length;
       auto next_offset = offset + length;
@@ -656,7 +645,7 @@ int ImageDiscardRequest<I>::prune_object_extents(
   if (prune_required) {
     // one or more object extents were skipped
     auto remove_lambda =
-      [](const ObjectExtent& object_extent) {
+      [](const LightweightObjectExtent& object_extent) {
         return (object_extent.length == 0);
       };
     object_extents->erase(
@@ -757,7 +746,7 @@ void ImageWriteSameRequest<I>::send_image_cache_request() {
 
 template <typename I>
 ObjectDispatchSpec *ImageWriteSameRequest<I>::create_object_request(
-    const ObjectExtent &object_extent, const ::SnapContext &snapc,
+    const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
     uint64_t journal_tid, Context *on_finish) {
   I &image_ctx = this->m_image_ctx;
 
@@ -765,17 +754,17 @@ ObjectDispatchSpec *ImageWriteSameRequest<I>::create_object_request(
   ObjectDispatchSpec *req;
 
   if (util::assemble_write_same_extent(object_extent, m_data_bl, &bl, false)) {
-    Extents buffer_extents{object_extent.buffer_extents};
+    auto buffer_extents{object_extent.buffer_extents};
 
     req = ObjectDispatchSpec::create_write_same(
-      &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+      &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
       object_extent.offset, object_extent.length, std::move(buffer_extents),
       std::move(bl), snapc, m_op_flags, journal_tid,
       this->m_trace, on_finish);
     return req;
   }
   req = ObjectDispatchSpec::create_write(
-    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
     object_extent.offset, std::move(bl), snapc, m_op_flags, journal_tid,
     this->m_trace, on_finish);
   return req;
@@ -808,7 +797,7 @@ uint64_t ImageCompareAndWriteRequest<I>::append_journal_event(
 
 template <typename I>
 void ImageCompareAndWriteRequest<I>::assemble_extent(
-  const ObjectExtent &object_extent, bufferlist *bl) {
+  const LightweightObjectExtent &object_extent, bufferlist *bl) {
   for (auto q = object_extent.buffer_extents.begin();
        q != object_extent.buffer_extents.end(); ++q) {
     bufferlist sub_bl;
@@ -832,7 +821,7 @@ void ImageCompareAndWriteRequest<I>::send_image_cache_request() {
 
 template <typename I>
 ObjectDispatchSpec *ImageCompareAndWriteRequest<I>::create_object_request(
-    const ObjectExtent &object_extent,
+    const LightweightObjectExtent &object_extent,
     const ::SnapContext &snapc,
     uint64_t journal_tid, Context *on_finish) {
   I &image_ctx = this->m_image_ctx;
@@ -842,7 +831,7 @@ ObjectDispatchSpec *ImageCompareAndWriteRequest<I>::create_object_request(
   bufferlist bl;
   assemble_extent(object_extent, &bl);
   auto req = ObjectDispatchSpec::create_compare_and_write(
-    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
     object_extent.offset, std::move(m_cmp_bl), std::move(bl), snapc,
     m_mismatch_offset, m_op_flags, journal_tid, this->m_trace, on_finish);
   return req;
@@ -857,14 +846,14 @@ void ImageCompareAndWriteRequest<I>::update_stats(size_t length) {
 
 template <typename I>
 int ImageCompareAndWriteRequest<I>::prune_object_extents(
-    ObjectExtents* object_extents) const {
+    LightweightObjectExtents* object_extents) const {
   if (object_extents->size() > 1)
     return -EINVAL;
 
   I &image_ctx = this->m_image_ctx;
   uint64_t sector_size = 512ULL;
   uint64_t su = image_ctx.layout.stripe_unit;
-  ObjectExtent object_extent = object_extents->front();
+  auto& object_extent = object_extents->front();
   if (object_extent.offset % sector_size + object_extent.length > sector_size ||
       (su != 0 && (object_extent.offset % su + object_extent.length > su)))
     return -EINVAL;

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -97,10 +97,9 @@ void readahead(I *ictx, const Extents& image_extents) {
                                                object_extent.offset,
                                                object_extent.length);
         auto req = io::ObjectDispatchSpec::create_read(
-          ictx, io::OBJECT_DISPATCH_LAYER_NONE, object_extent.oid.name,
-          object_extent.objectno, object_extent.offset, object_extent.length,
-          snap_id, 0, {}, &req_comp->read_data, &req_comp->extent_map,
-          req_comp);
+          ictx, io::OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+          object_extent.offset, object_extent.length, snap_id, 0, {},
+          &req_comp->read_data, &req_comp->extent_map, req_comp);
         req->send();
       }
     }
@@ -390,9 +389,9 @@ void ImageReadRequest<I>::send_request() {
         aio_comp, extent.offset, extent.length,
         std::move(extent.buffer_extents));
       auto req = ObjectDispatchSpec::create_read(
-        &image_ctx, OBJECT_DISPATCH_LAYER_NONE, extent.oid.name,
-        extent.objectno, extent.offset, extent.length, snap_id, m_op_flags,
-        this->m_trace, &req_comp->bl, &req_comp->extent_map, req_comp);
+        &image_ctx, OBJECT_DISPATCH_LAYER_NONE, extent.objectno, extent.offset,
+        extent.length, snap_id, m_op_flags, this->m_trace, &req_comp->bl,
+        &req_comp->extent_map, req_comp);
       req->send();
     }
   }
@@ -549,9 +548,9 @@ ObjectDispatchSpec *ImageWriteRequest<I>::create_object_request(
   bufferlist bl;
   assemble_extent(object_extent, &bl);
   auto req = ObjectDispatchSpec::create_write(
-    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.oid.name,
-    object_extent.objectno, object_extent.offset, std::move(bl), snapc,
-    m_op_flags, journal_tid, this->m_trace, on_finish);
+    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+    object_extent.offset, std::move(bl), snapc, m_op_flags, journal_tid,
+    this->m_trace, on_finish);
   return req;
 }
 
@@ -602,8 +601,8 @@ ObjectDispatchSpec *ImageDiscardRequest<I>::create_object_request(
     uint64_t journal_tid, Context *on_finish) {
   I &image_ctx = this->m_image_ctx;
   auto req = ObjectDispatchSpec::create_discard(
-    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.oid.name,
-    object_extent.objectno, object_extent.offset, object_extent.length, snapc,
+    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+    object_extent.offset, object_extent.length, snapc,
     OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE, journal_tid, this->m_trace,
     on_finish);
   return req;
@@ -769,16 +768,16 @@ ObjectDispatchSpec *ImageWriteSameRequest<I>::create_object_request(
     Extents buffer_extents{object_extent.buffer_extents};
 
     req = ObjectDispatchSpec::create_write_same(
-      &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.oid.name,
-      object_extent.objectno, object_extent.offset, object_extent.length,
-      std::move(buffer_extents), std::move(bl), snapc, m_op_flags, journal_tid,
+      &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+      object_extent.offset, object_extent.length, std::move(buffer_extents),
+      std::move(bl), snapc, m_op_flags, journal_tid,
       this->m_trace, on_finish);
     return req;
   }
   req = ObjectDispatchSpec::create_write(
-    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.oid.name,
-    object_extent.objectno, object_extent.offset, std::move(bl), snapc,
-    m_op_flags, journal_tid, this->m_trace, on_finish);
+    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+    object_extent.offset, std::move(bl), snapc, m_op_flags, journal_tid,
+    this->m_trace, on_finish);
   return req;
 }
 
@@ -843,10 +842,9 @@ ObjectDispatchSpec *ImageCompareAndWriteRequest<I>::create_object_request(
   bufferlist bl;
   assemble_extent(object_extent, &bl);
   auto req = ObjectDispatchSpec::create_compare_and_write(
-    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.oid.name,
-    object_extent.objectno, object_extent.offset, std::move(m_cmp_bl),
-    std::move(bl), snapc, m_mismatch_offset, m_op_flags, journal_tid,
-    this->m_trace, on_finish);
+    &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.objectno,
+    object_extent.offset, std::move(m_cmp_bl), std::move(bl), snapc,
+    m_mismatch_offset, m_op_flags, journal_tid, this->m_trace, on_finish);
   return req;
 }
 

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -129,8 +129,6 @@ protected:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
   using typename ImageRequest<ImageCtxT>::Extents;
 
-  typedef std::vector<ObjectExtent> ObjectExtents;
-
   AbstractImageWriteRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                             Extents &&image_extents, const char *trace_name,
 			    const ZTracer::Trace &parent_trace)
@@ -141,14 +139,15 @@ protected:
 
   void send_request() override;
 
-  virtual int prune_object_extents(ObjectExtents* object_extents) const {
+  virtual int prune_object_extents(
+      LightweightObjectExtents* object_extents) const {
     return 0;
   }
 
-  void send_object_requests(const ObjectExtents &object_extents,
+  void send_object_requests(const LightweightObjectExtents &object_extents,
                             const ::SnapContext &snapc, uint64_t journal_tid);
   virtual ObjectDispatchSpec *create_object_request(
-      const ObjectExtent &object_extent, const ::SnapContext &snapc,
+      const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
       uint64_t journal_tid, Context *on_finish) = 0;
 
   virtual uint64_t append_journal_event(bool synchronous) = 0;
@@ -173,7 +172,6 @@ public:
 
 protected:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
-  using typename AbstractImageWriteRequest<ImageCtxT>::ObjectExtents;
 
   aio_type_t get_aio_type() const override {
     return AIO_TYPE_WRITE;
@@ -182,13 +180,14 @@ protected:
     return "aio_write";
   }
 
-  void assemble_extent(const ObjectExtent &object_extent, bufferlist *bl);
+  void assemble_extent(const LightweightObjectExtent &object_extent,
+                       bufferlist *bl);
 
   void send_image_cache_request() override;
 
 
   ObjectDispatchSpec *create_object_request(
-      const ObjectExtent &object_extent, const ::SnapContext &snapc,
+      const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
       uint64_t journal_tid, Context *on_finish) override;
 
   uint64_t append_journal_event(bool synchronous) override;
@@ -213,7 +212,6 @@ public:
 
 protected:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
-  using typename AbstractImageWriteRequest<ImageCtxT>::ObjectExtents;
 
   aio_type_t get_aio_type() const override {
     return AIO_TYPE_DISCARD;
@@ -225,13 +223,14 @@ protected:
   void send_image_cache_request() override;
 
   ObjectDispatchSpec *create_object_request(
-      const ObjectExtent &object_extent, const ::SnapContext &snapc,
+      const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
       uint64_t journal_tid, Context *on_finish) override;
 
   uint64_t append_journal_event(bool synchronous) override;
   void update_stats(size_t length) override;
 
-  int prune_object_extents(ObjectExtents* object_extents) const override;
+  int prune_object_extents(
+      LightweightObjectExtents* object_extents) const override;
 
 private:
   uint32_t m_discard_granularity_bytes;
@@ -284,7 +283,6 @@ public:
 
 protected:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
-  using typename AbstractImageWriteRequest<ImageCtxT>::ObjectExtents;
 
   aio_type_t get_aio_type() const override {
     return AIO_TYPE_WRITESAME;
@@ -296,7 +294,7 @@ protected:
   void send_image_cache_request() override;
 
   ObjectDispatchSpec *create_object_request(
-      const ObjectExtent &object_extent, const ::SnapContext &snapc,
+      const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
       uint64_t journal_tid, Context *on_finish) override;
 
   uint64_t append_journal_event(bool synchronous) override;
@@ -310,7 +308,6 @@ template <typename ImageCtxT = ImageCtx>
 class ImageCompareAndWriteRequest : public AbstractImageWriteRequest<ImageCtxT> {
 public:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
-  using typename AbstractImageWriteRequest<ImageCtxT>::ObjectExtents;
 
   ImageCompareAndWriteRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                               Extents &&image_extents, bufferlist &&cmp_bl,
@@ -325,10 +322,11 @@ public:
 protected:
   void send_image_cache_request() override;
 
-  void assemble_extent(const ObjectExtent &object_extent, bufferlist *bl);
+  void assemble_extent(const LightweightObjectExtent &object_extent,
+                       bufferlist *bl);
 
   ObjectDispatchSpec *create_object_request(
-      const ObjectExtent &object_extent, const ::SnapContext &snapc,
+      const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
       uint64_t journal_tid, Context *on_finish) override;
 
   uint64_t append_journal_event(bool synchronous) override;
@@ -341,7 +339,8 @@ protected:
     return "aio_compare_and_write";
   }
 
-  int prune_object_extents(ObjectExtents* object_extents) const override;
+  int prune_object_extents(
+      LightweightObjectExtents* object_extents) const override;
 
 private:
   bufferlist m_cmp_bl;

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -148,7 +148,7 @@ protected:
                             const ::SnapContext &snapc, uint64_t journal_tid);
   virtual ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
-      uint64_t journal_tid, Context *on_finish) = 0;
+      uint64_t journal_tid, bool single_extent, Context *on_finish) = 0;
 
   virtual uint64_t append_journal_event(bool synchronous) = 0;
   virtual void update_stats(size_t length) = 0;
@@ -188,7 +188,7 @@ protected:
 
   ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
-      uint64_t journal_tid, Context *on_finish) override;
+      uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
   uint64_t append_journal_event(bool synchronous) override;
   void update_stats(size_t length) override;
@@ -224,7 +224,7 @@ protected:
 
   ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
-      uint64_t journal_tid, Context *on_finish) override;
+      uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
   uint64_t append_journal_event(bool synchronous) override;
   void update_stats(size_t length) override;
@@ -295,7 +295,7 @@ protected:
 
   ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
-      uint64_t journal_tid, Context *on_finish) override;
+      uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
   uint64_t append_journal_event(bool synchronous) override;
   void update_stats(size_t length) override;
@@ -327,7 +327,7 @@ protected:
 
   ObjectDispatchSpec *create_object_request(
       const LightweightObjectExtent &object_extent, const ::SnapContext &snapc,
-      uint64_t journal_tid, Context *on_finish) override;
+      uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
   uint64_t append_journal_event(bool synchronous) override;
   void update_stats(size_t length) override;

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -92,7 +92,7 @@ bool ObjectDispatch<I>::write(
 template <typename I>
 bool ObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
-    Extents&& buffer_extents, ceph::bufferlist&& data,
+    LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -5,6 +5,7 @@
 #include "common/dout.h"
 #include "common/WorkQueue.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
 #include "librbd/io/ObjectRequest.h"
 
 #define dout_subsys ceph_subsys_rbd
@@ -14,6 +15,8 @@
 
 namespace librbd {
 namespace io {
+
+using librbd::util::data_object_name;
 
 template <typename I>
 ObjectDispatch<I>::ObjectDispatch(I* image_ctx)
@@ -30,17 +33,17 @@ void ObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool ObjectDispatch<I>::read(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, librados::snap_t snap_id, int op_flags,
-    const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-    ExtentMap* extent_map, int* object_dispatch_flags,
-    DispatchResult* dispatch_result, Context** on_finish,
-    Context* on_dispatched) {
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
+    ceph::bufferlist* read_data, ExtentMap* extent_map,
+    int* object_dispatch_flags, DispatchResult* dispatch_result,
+    Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << object_len << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << object_len << dendl;
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  auto req = new ObjectReadRequest<I>(m_image_ctx, oid, object_no, object_off,
+  auto req = new ObjectReadRequest<I>(m_image_ctx, object_no, object_off,
                                       object_len, snap_id, op_flags,
                                       parent_trace, read_data, extent_map,
                                       on_dispatched);
@@ -50,35 +53,36 @@ bool ObjectDispatch<I>::read(
 
 template <typename I>
 bool ObjectDispatch<I>::discard(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    const ::SnapContext &snapc, int discard_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << object_len << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << object_len << dendl;
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  auto req = new ObjectDiscardRequest<I>(m_image_ctx, oid, object_no,
-                                         object_off, object_len, snapc,
-                                         discard_flags, parent_trace,
-                                         on_dispatched);
+  auto req = new ObjectDiscardRequest<I>(m_image_ctx, object_no, object_off,
+                                         object_len, snapc, discard_flags,
+                                         parent_trace, on_dispatched);
   req->send();
   return true;
 }
 
 template <typename I>
 bool ObjectDispatch<I>::write(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+    uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+    const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << data.length() << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << data.length() << dendl;
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  auto req = new ObjectWriteRequest<I>(m_image_ctx, oid, object_no, object_off,
+  auto req = new ObjectWriteRequest<I>(m_image_ctx, object_no, object_off,
                                        std::move(data), snapc, op_flags,
                                        parent_trace, on_dispatched);
   req->send();
@@ -87,17 +91,18 @@ bool ObjectDispatch<I>::write(
 
 template <typename I>
 bool ObjectDispatch<I>::write_same(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, Extents&& buffer_extents, ceph::bufferlist&& data,
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    Extents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << object_len << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << object_len << dendl;
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  auto req = new ObjectWriteSameRequest<I>(m_image_ctx, oid, object_no,
+  auto req = new ObjectWriteSameRequest<I>(m_image_ctx, object_no,
                                            object_off, object_len,
                                            std::move(data), snapc, op_flags,
                                            parent_trace, on_dispatched);
@@ -107,19 +112,18 @@ bool ObjectDispatch<I>::write_same(
 
 template <typename I>
 bool ObjectDispatch<I>::compare_and_write(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-    const ::SnapContext &snapc, int op_flags,
+    uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+    ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << write_data.length()
-                 << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << write_data.length() << dendl;
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  auto req = new ObjectCompareAndWriteRequest<I>(m_image_ctx, oid, object_no,
+  auto req = new ObjectCompareAndWriteRequest<I>(m_image_ctx, object_no,
                                                  object_off,
                                                  std::move(cmp_data),
                                                  std::move(write_data), snapc,

--- a/src/librbd/io/ObjectDispatch.h
+++ b/src/librbd/io/ObjectDispatch.h
@@ -57,7 +57,7 @@ public:
 
   bool write_same(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      Extents&& buffer_extents, ceph::bufferlist&& data,
+      LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,

--- a/src/librbd/io/ObjectDispatch.h
+++ b/src/librbd/io/ObjectDispatch.h
@@ -34,39 +34,38 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, librados::snap_t snap_id, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
       ExtentMap* extent_map, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool discard(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      const ::SnapContext &snapc, int discard_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write_same(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, Extents&& buffer_extents, ceph::bufferlist&& data,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      Extents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-      const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+      ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       DispatchResult* dispatch_result, Context** on_finish,

--- a/src/librbd/io/ObjectDispatchInterface.h
+++ b/src/librbd/io/ObjectDispatchInterface.h
@@ -50,7 +50,7 @@ struct ObjectDispatchInterface {
 
   virtual bool write_same(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      Extents&& buffer_extents, ceph::bufferlist&& data,
+      LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,

--- a/src/librbd/io/ObjectDispatchInterface.h
+++ b/src/librbd/io/ObjectDispatchInterface.h
@@ -28,39 +28,37 @@ struct ObjectDispatchInterface {
   virtual void shut_down(Context* on_finish) = 0;
 
   virtual bool read(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, librados::snap_t snap_id, int op_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      ExtentMap* extent_map, int* object_dispatch_flags,
-      DispatchResult* dispatch_result, Context** on_finish,
-      Context* on_dispatched) = 0;
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      librados::snap_t snap_id, int op_flags,const ZTracer::Trace &parent_trace,
+      ceph::bufferlist* read_data, ExtentMap* extent_map,
+      int* object_dispatch_flags, DispatchResult* dispatch_result,
+      Context** on_finish, Context* on_dispatched) = 0;
 
   virtual bool discard(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      const ::SnapContext &snapc, int discard_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) = 0;
 
   virtual bool write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) = 0;
 
   virtual bool write_same(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, Extents&& buffer_extents, ceph::bufferlist&& data,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      Extents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) = 0;
 
   virtual bool compare_and_write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-      const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+      ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       DispatchResult* dispatch_result, Context** on_finish,

--- a/src/librbd/io/ObjectDispatchSpec.h
+++ b/src/librbd/io/ObjectDispatchSpec.h
@@ -35,12 +35,11 @@ private:
 
 public:
   struct RequestBase {
-    std::string oid;
     uint64_t object_no;
     uint64_t object_off;
 
-    RequestBase(const std::string& oid, uint64_t object_no, uint64_t object_off)
-      : oid(oid), object_no(object_no), object_off(object_off) {
+    RequestBase(uint64_t object_no, uint64_t object_off)
+      : object_no(object_no), object_off(object_off) {
     }
   };
 
@@ -50,10 +49,10 @@ public:
     ceph::bufferlist* read_data;
     ExtentMap* extent_map;
 
-    ReadRequest(const std::string& oid, uint64_t object_no, uint64_t object_off,
-                uint64_t object_len, librados::snap_t snap_id,
-                ceph::bufferlist* read_data, ExtentMap* extent_map)
-      : RequestBase(oid, object_no, object_off),
+    ReadRequest(uint64_t object_no, uint64_t object_off, uint64_t object_len,
+                librados::snap_t snap_id, ceph::bufferlist* read_data,
+                ExtentMap* extent_map)
+      : RequestBase(object_no, object_off),
         object_len(object_len), snap_id(snap_id), read_data(read_data),
         extent_map(extent_map) {
     }
@@ -63,10 +62,9 @@ public:
     ::SnapContext snapc;
     uint64_t journal_tid;
 
-    WriteRequestBase(const std::string& oid, uint64_t object_no,
-                     uint64_t object_off, const ::SnapContext& snapc,
-                     uint64_t journal_tid)
-      : RequestBase(oid, object_no, object_off), snapc(snapc),
+    WriteRequestBase(uint64_t object_no, uint64_t object_off,
+                     const ::SnapContext& snapc, uint64_t journal_tid)
+      : RequestBase(object_no, object_off), snapc(snapc),
         journal_tid(journal_tid) {
     }
   };
@@ -75,11 +73,10 @@ public:
     uint64_t object_len;
     int discard_flags;
 
-    DiscardRequest(const std::string& oid, uint64_t object_no,
-                   uint64_t object_off, uint64_t object_len,
+    DiscardRequest(uint64_t object_no, uint64_t object_off, uint64_t object_len,
                    int discard_flags, const ::SnapContext& snapc,
                    uint64_t journal_tid)
-      : WriteRequestBase(oid, object_no, object_off, snapc, journal_tid),
+      : WriteRequestBase(object_no, object_off, snapc, journal_tid),
         object_len(object_len), discard_flags(discard_flags) {
     }
   };
@@ -87,10 +84,10 @@ public:
   struct WriteRequest : public WriteRequestBase {
     ceph::bufferlist data;
 
-    WriteRequest(const std::string& oid, uint64_t object_no,
-                 uint64_t object_off, ceph::bufferlist&& data,
-                 const ::SnapContext& snapc, uint64_t journal_tid)
-      : WriteRequestBase(oid, object_no, object_off, snapc, journal_tid),
+    WriteRequest(uint64_t object_no, uint64_t object_off,
+                 ceph::bufferlist&& data, const ::SnapContext& snapc,
+                 uint64_t journal_tid)
+      : WriteRequestBase(object_no, object_off, snapc, journal_tid),
         data(std::move(data)) {
     }
   };
@@ -100,11 +97,11 @@ public:
     Extents buffer_extents;
     ceph::bufferlist data;
 
-    WriteSameRequest(const std::string& oid, uint64_t object_no,
-                     uint64_t object_off, uint64_t object_len,
-                     Extents&& buffer_extents, ceph::bufferlist&& data,
-                     const ::SnapContext& snapc, uint64_t journal_tid)
-    : WriteRequestBase(oid, object_no, object_off, snapc, journal_tid),
+    WriteSameRequest(uint64_t object_no, uint64_t object_off,
+                     uint64_t object_len, Extents&& buffer_extents,
+                     ceph::bufferlist&& data, const ::SnapContext& snapc,
+                     uint64_t journal_tid)
+    : WriteRequestBase(object_no, object_off, snapc, journal_tid),
       object_len(object_len), buffer_extents(std::move(buffer_extents)),
       data(std::move(data)) {
     }
@@ -115,11 +112,11 @@ public:
     ceph::bufferlist data;
     uint64_t* mismatch_offset;
 
-    CompareAndWriteRequest(const std::string& oid, uint64_t object_no,
-                           uint64_t object_off, ceph::bufferlist&& cmp_data,
-                           ceph::bufferlist&& data, uint64_t* mismatch_offset,
+    CompareAndWriteRequest(uint64_t object_no, uint64_t object_off,
+                           ceph::bufferlist&& cmp_data, ceph::bufferlist&& data,
+                           uint64_t* mismatch_offset,
                            const ::SnapContext& snapc, uint64_t journal_tid)
-      : WriteRequestBase(oid, object_no, object_off, snapc, journal_tid),
+      : WriteRequestBase(object_no, object_off, snapc, journal_tid),
         cmp_data(std::move(cmp_data)), data(std::move(data)),
         mismatch_offset(mismatch_offset) {
     }
@@ -155,13 +152,13 @@ public:
   template <typename ImageCtxT>
   static ObjectDispatchSpec* create_read(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, librados::snap_t snap_id, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
       ExtentMap* extent_map, Context* on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
-                                  ReadRequest{oid, object_no, object_off,
+                                  ReadRequest{object_no, object_off,
                                               object_len, snap_id, read_data,
                                               extent_map},
                                   op_flags, parent_trace, on_finish);
@@ -170,13 +167,12 @@ public:
   template <typename ImageCtxT>
   static ObjectDispatchSpec* create_discard(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
-      uint64_t journal_tid, const ZTracer::Trace &parent_trace,
-      Context *on_finish) {
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      const ::SnapContext &snapc, int discard_flags, uint64_t journal_tid,
+      const ZTracer::Trace &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
-                                  DiscardRequest{oid, object_no, object_off,
+                                  DiscardRequest{object_no, object_off,
                                                  object_len, discard_flags,
                                                  snapc, journal_tid},
                                   0, parent_trace, on_finish);
@@ -185,13 +181,12 @@ public:
   template <typename ImageCtxT>
   static ObjectDispatchSpec* create_write(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
-      uint64_t journal_tid, const ZTracer::Trace &parent_trace,
-      Context *on_finish) {
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags, uint64_t journal_tid,
+      const ZTracer::Trace &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
-                                  WriteRequest{oid, object_no, object_off,
+                                  WriteRequest{object_no, object_off,
                                                std::move(data), snapc,
                                                journal_tid},
                                   op_flags, parent_trace, on_finish);
@@ -200,14 +195,13 @@ public:
   template <typename ImageCtxT>
   static ObjectDispatchSpec* create_write_same(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, Extents&& buffer_extents,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
-      uint64_t journal_tid, const ZTracer::Trace &parent_trace,
-      Context *on_finish) {
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      Extents&& buffer_extents, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags, uint64_t journal_tid,
+      const ZTracer::Trace &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
-                                  WriteSameRequest{oid, object_no, object_off,
+                                  WriteSameRequest{object_no, object_off,
                                                    object_len,
                                                    std::move(buffer_extents),
                                                    std::move(data), snapc,
@@ -218,14 +212,13 @@ public:
   template <typename ImageCtxT>
   static ObjectDispatchSpec* create_compare_and_write(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-      const ::SnapContext &snapc, uint64_t *mismatch_offset, int op_flags,
-      uint64_t journal_tid, const ZTracer::Trace &parent_trace,
-      Context *on_finish) {
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+      ceph::bufferlist&& write_data, const ::SnapContext &snapc,
+      uint64_t *mismatch_offset, int op_flags, uint64_t journal_tid,
+      const ZTracer::Trace &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
-                                  CompareAndWriteRequest{oid, object_no,
+                                  CompareAndWriteRequest{object_no,
                                                          object_off,
                                                          std::move(cmp_data),
                                                          std::move(write_data),

--- a/src/librbd/io/ObjectDispatchSpec.h
+++ b/src/librbd/io/ObjectDispatchSpec.h
@@ -94,11 +94,12 @@ public:
 
   struct WriteSameRequest : public WriteRequestBase {
     uint64_t object_len;
-    Extents buffer_extents;
+    LightweightBufferExtents buffer_extents;
     ceph::bufferlist data;
 
     WriteSameRequest(uint64_t object_no, uint64_t object_off,
-                     uint64_t object_len, Extents&& buffer_extents,
+                     uint64_t object_len,
+                     LightweightBufferExtents&& buffer_extents,
                      ceph::bufferlist&& data, const ::SnapContext& snapc,
                      uint64_t journal_tid)
     : WriteRequestBase(object_no, object_off, snapc, journal_tid),
@@ -196,7 +197,7 @@ public:
   static ObjectDispatchSpec* create_write_same(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      Extents&& buffer_extents, ceph::bufferlist&& data,
+      LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags, uint64_t journal_tid,
       const ZTracer::Trace &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -107,7 +107,7 @@ struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
 
   bool operator()(ObjectDispatchSpec::ReadRequest& read) const {
     return object_dispatch->read(
-      read.oid, read.object_no, read.object_off, read.object_len, read.snap_id,
+      read.object_no, read.object_off, read.object_len, read.snap_id,
       object_dispatch_spec->op_flags, object_dispatch_spec->parent_trace,
       read.read_data, read.extent_map,
       &object_dispatch_spec->object_dispatch_flags,
@@ -118,8 +118,8 @@ struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
 
   bool operator()(ObjectDispatchSpec::DiscardRequest& discard) const {
     return object_dispatch->discard(
-      discard.oid, discard.object_no, discard.object_off, discard.object_len,
-      discard.snapc, discard.discard_flags, object_dispatch_spec->parent_trace,
+      discard.object_no, discard.object_off, discard.object_len, discard.snapc,
+      discard.discard_flags, object_dispatch_spec->parent_trace,
       &object_dispatch_spec->object_dispatch_flags, &discard.journal_tid,
       &object_dispatch_spec->dispatch_result,
       &object_dispatch_spec->dispatcher_ctx.on_finish,
@@ -128,9 +128,8 @@ struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
 
   bool operator()(ObjectDispatchSpec::WriteRequest& write) const {
     return object_dispatch->write(
-      write.oid, write.object_no, write.object_off, std::move(write.data),
-      write.snapc, object_dispatch_spec->op_flags,
-      object_dispatch_spec->parent_trace,
+      write.object_no, write.object_off, std::move(write.data), write.snapc,
+      object_dispatch_spec->op_flags, object_dispatch_spec->parent_trace,
       &object_dispatch_spec->object_dispatch_flags, &write.journal_tid,
       &object_dispatch_spec->dispatch_result,
       &object_dispatch_spec->dispatcher_ctx.on_finish,
@@ -139,10 +138,10 @@ struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
 
   bool operator()(ObjectDispatchSpec::WriteSameRequest& write_same) const {
     return object_dispatch->write_same(
-      write_same.oid, write_same.object_no, write_same.object_off,
-      write_same.object_len, std::move(write_same.buffer_extents),
-      std::move(write_same.data), write_same.snapc,
-      object_dispatch_spec->op_flags, object_dispatch_spec->parent_trace,
+      write_same.object_no, write_same.object_off, write_same.object_len,
+      std::move(write_same.buffer_extents), std::move(write_same.data),
+      write_same.snapc, object_dispatch_spec->op_flags,
+      object_dispatch_spec->parent_trace,
       &object_dispatch_spec->object_dispatch_flags, &write_same.journal_tid,
       &object_dispatch_spec->dispatch_result,
       &object_dispatch_spec->dispatcher_ctx.on_finish,
@@ -152,11 +151,10 @@ struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
   bool operator()(
       ObjectDispatchSpec::CompareAndWriteRequest& compare_and_write) const {
     return object_dispatch->compare_and_write(
-      compare_and_write.oid, compare_and_write.object_no,
-      compare_and_write.object_off, std::move(compare_and_write.cmp_data),
-      std::move(compare_and_write.data), compare_and_write.snapc,
-      object_dispatch_spec->op_flags, object_dispatch_spec->parent_trace,
-      compare_and_write.mismatch_offset,
+      compare_and_write.object_no, compare_and_write.object_off,
+      std::move(compare_and_write.cmp_data), std::move(compare_and_write.data),
+      compare_and_write.snapc, object_dispatch_spec->op_flags,
+      object_dispatch_spec->parent_trace, compare_and_write.mismatch_offset,
       &object_dispatch_spec->object_dispatch_flags,
       &compare_and_write.journal_tid,
       &object_dispatch_spec->dispatch_result,

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -26,11 +26,15 @@
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
-#define dout_prefix *_dout << "librbd::io::ObjectRequest: " << this \
-                           << " " << __func__ << ": "
+#define dout_prefix *_dout << "librbd::io::ObjectRequest: " << this           \
+                           << " " << __func__ << ": "                         \
+                           << data_object_name(this->m_ictx,                  \
+                                               this->m_object_no) << " "
 
 namespace librbd {
 namespace io {
+
+using librbd::util::data_object_name;
 
 namespace {
 
@@ -47,58 +51,45 @@ inline bool is_copy_on_read(I *ictx, librados::snap_t snap_id) {
 
 template <typename I>
 ObjectRequest<I>*
-ObjectRequest<I>::create_write(I *ictx, const std::string &oid,
-                               uint64_t object_no, uint64_t object_off,
-                               ceph::bufferlist&& data,
-                               const ::SnapContext &snapc, int op_flags,
-			       const ZTracer::Trace &parent_trace,
-                               Context *completion) {
-  return new ObjectWriteRequest<I>(ictx, oid, object_no, object_off,
+ObjectRequest<I>::create_write(
+    I *ictx, uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+    const ::SnapContext &snapc, int op_flags,
+    const ZTracer::Trace &parent_trace, Context *completion) {
+  return new ObjectWriteRequest<I>(ictx, object_no, object_off,
                                    std::move(data), snapc, op_flags,
                                    parent_trace, completion);
 }
 
 template <typename I>
 ObjectRequest<I>*
-ObjectRequest<I>::create_discard(I *ictx, const std::string &oid,
-                                 uint64_t object_no, uint64_t object_off,
-                                 uint64_t object_len,
-                                 const ::SnapContext &snapc,
-                                 int discard_flags,
-                                 const ZTracer::Trace &parent_trace,
-                                 Context *completion) {
-  return new ObjectDiscardRequest<I>(ictx, oid, object_no, object_off,
+ObjectRequest<I>::create_discard(
+    I *ictx, uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    const ::SnapContext &snapc, int discard_flags,
+    const ZTracer::Trace &parent_trace, Context *completion) {
+  return new ObjectDiscardRequest<I>(ictx, object_no, object_off,
                                      object_len, snapc, discard_flags,
                                      parent_trace, completion);
 }
 
 template <typename I>
 ObjectRequest<I>*
-ObjectRequest<I>::create_write_same(I *ictx, const std::string &oid,
-                                   uint64_t object_no, uint64_t object_off,
-                                   uint64_t object_len,
-                                   ceph::bufferlist&& data,
-                                   const ::SnapContext &snapc, int op_flags,
-				   const ZTracer::Trace &parent_trace,
-                                   Context *completion) {
-  return new ObjectWriteSameRequest<I>(ictx, oid, object_no, object_off,
+ObjectRequest<I>::create_write_same(
+    I *ictx, uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+    const ZTracer::Trace &parent_trace, Context *completion) {
+  return new ObjectWriteSameRequest<I>(ictx, object_no, object_off,
                                        object_len, std::move(data), snapc,
                                        op_flags, parent_trace, completion);
 }
 
 template <typename I>
 ObjectRequest<I>*
-ObjectRequest<I>::create_compare_and_write(I *ictx, const std::string &oid,
-                                           uint64_t object_no,
-                                           uint64_t object_off,
-                                           ceph::bufferlist&& cmp_data,
-                                           ceph::bufferlist&& write_data,
-                                           const ::SnapContext &snapc,
-                                           uint64_t *mismatch_offset,
-                                           int op_flags,
-                                           const ZTracer::Trace &parent_trace,
-                                           Context *completion) {
-  return new ObjectCompareAndWriteRequest<I>(ictx, oid, object_no, object_off,
+ObjectRequest<I>::create_compare_and_write(
+    I *ictx, uint64_t object_no, uint64_t object_off,
+    ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
+    const ::SnapContext &snapc, uint64_t *mismatch_offset, int op_flags,
+    const ZTracer::Trace &parent_trace, Context *completion) {
+  return new ObjectCompareAndWriteRequest<I>(ictx, object_no, object_off,
                                              std::move(cmp_data),
                                              std::move(write_data), snapc,
                                              mismatch_offset, op_flags,
@@ -106,17 +97,16 @@ ObjectRequest<I>::create_compare_and_write(I *ictx, const std::string &oid,
 }
 
 template <typename I>
-ObjectRequest<I>::ObjectRequest(I *ictx, const std::string &oid,
-                                uint64_t objectno, uint64_t off,
-                                uint64_t len, librados::snap_t snap_id,
-                                const char *trace_name,
-                                const ZTracer::Trace &trace,
-				Context *completion)
-  : m_ictx(ictx), m_oid(oid), m_object_no(objectno), m_object_off(off),
+ObjectRequest<I>::ObjectRequest(
+    I *ictx, uint64_t objectno, uint64_t off, uint64_t len,
+    librados::snap_t snap_id, const char *trace_name,
+    const ZTracer::Trace &trace, Context *completion)
+  : m_ictx(ictx), m_object_no(objectno), m_object_off(off),
     m_object_len(len), m_snap_id(snap_id), m_completion(completion),
     m_trace(util::create_trace(*ictx, "", trace)) {
   if (m_trace.valid()) {
-    m_trace.copy_name(trace_name + std::string(" ") + oid);
+    m_trace.copy_name(trace_name + std::string(" ") +
+                      data_object_name(ictx, objectno));
     m_trace.event("start");
   }
 }
@@ -186,15 +176,11 @@ void ObjectRequest<I>::finish(int r) {
 /** read **/
 
 template <typename I>
-ObjectReadRequest<I>::ObjectReadRequest(I *ictx, const std::string &oid,
-                                        uint64_t objectno, uint64_t offset,
-                                        uint64_t len, librados::snap_t snap_id,
-                                        int op_flags,
-                                        const ZTracer::Trace &parent_trace,
-                                        bufferlist* read_data,
-                                        ExtentMap* extent_map,
-                                        Context *completion)
-  : ObjectRequest<I>(ictx, oid, objectno, offset, len, snap_id, "read",
+ObjectReadRequest<I>::ObjectReadRequest(
+    I *ictx, uint64_t objectno, uint64_t offset, uint64_t len,
+    librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
+    bufferlist* read_data, ExtentMap* extent_map, Context *completion)
+  : ObjectRequest<I>(ictx, objectno, offset, len, snap_id, "read",
                      parent_trace, completion),
     m_op_flags(op_flags), m_read_data(read_data), m_extent_map(extent_map) {
 }
@@ -236,7 +222,8 @@ void ObjectReadRequest<I>::read_object() {
     ObjectReadRequest<I>, &ObjectReadRequest<I>::handle_read_object>(this);
   int flags = image_ctx->get_read_flags(this->m_snap_id);
   int r = image_ctx->data_ctx.aio_operate(
-    this->m_oid, rados_completion, &op, flags, nullptr,
+    data_object_name(this->m_ictx, this->m_object_no), rados_completion, &op,
+    flags, nullptr,
     (this->m_trace.valid() ? this->m_trace.get_info() : nullptr));
   ceph_assert(r == 0);
 
@@ -343,8 +330,7 @@ void ObjectReadRequest<I>::copyup() {
   if (it == image_ctx->copyup_list.end()) {
     // create and kick off a CopyupRequest
     auto new_req = CopyupRequest<I>::create(
-      image_ctx, this->m_oid, this->m_object_no, std::move(parent_extents),
-      this->m_trace);
+      image_ctx, this->m_object_no, std::move(parent_extents), this->m_trace);
 
     image_ctx->copyup_list[this->m_object_no] = new_req;
     image_ctx->copyup_list_lock.Unlock();
@@ -363,11 +349,11 @@ void ObjectReadRequest<I>::copyup() {
 
 template <typename I>
 AbstractObjectWriteRequest<I>::AbstractObjectWriteRequest(
-    I *ictx, const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t len, const ::SnapContext &snapc, const char *trace_name,
+    I *ictx, uint64_t object_no, uint64_t object_off, uint64_t len,
+    const ::SnapContext &snapc, const char *trace_name,
     const ZTracer::Trace &parent_trace, Context *completion)
-  : ObjectRequest<I>(ictx, oid, object_no, object_off, len, CEPH_NOSNAP,
-                     trace_name, parent_trace, completion),
+  : ObjectRequest<I>(ictx, object_no, object_off, len, CEPH_NOSNAP, trace_name,
+                     parent_trace, completion),
     m_snap_seq(snapc.seq.val)
 {
   m_snaps.insert(m_snaps.end(), snapc.snaps.begin(), snapc.snaps.end());
@@ -412,7 +398,7 @@ void AbstractObjectWriteRequest<I>::add_write_hint(
 template <typename I>
 void AbstractObjectWriteRequest<I>::send() {
   I *image_ctx = this->m_ictx;
-  ldout(image_ctx->cct, 20) << this->get_op_type() << " " << this->m_oid << " "
+  ldout(image_ctx->cct, 20) << this->get_op_type() << " "
                             << this->m_object_off << "~" << this->m_object_len
                             << dendl;
   {
@@ -456,8 +442,8 @@ void AbstractObjectWriteRequest<I>::pre_write_object_map_update() {
   }
 
   uint8_t new_state = this->get_pre_write_object_map_state();
-  ldout(image_ctx->cct, 20) << this->m_oid << " " << this->m_object_off
-                            << "~" << this->m_object_len << dendl;
+  ldout(image_ctx->cct, 20) << this->m_object_off << "~" << this->m_object_len
+                            << dendl;
 
   if (image_ctx->object_map->template aio_update<
         AbstractObjectWriteRequest<I>,
@@ -510,7 +496,8 @@ void AbstractObjectWriteRequest<I>::write_object() {
     AbstractObjectWriteRequest<I>,
     &AbstractObjectWriteRequest<I>::handle_write_object>(this);
   int r = image_ctx->data_ctx.aio_operate(
-    this->m_oid, rados_completion, &write, m_snap_seq, m_snaps,
+    data_object_name(this->m_ictx, this->m_object_no), rados_completion,
+    &write, m_snap_seq, m_snaps,
     (this->m_trace.valid() ? this->m_trace.get_info() : nullptr));
   ceph_assert(r == 0);
   rados_completion->release();
@@ -566,8 +553,8 @@ void AbstractObjectWriteRequest<I>::copyup() {
   auto it = image_ctx->copyup_list.find(this->m_object_no);
   if (it == image_ctx->copyup_list.end()) {
     auto new_req = CopyupRequest<I>::create(
-      image_ctx, this->m_oid, this->m_object_no,
-      std::move(this->m_parent_extents), this->m_trace);
+      image_ctx, this->m_object_no, std::move(this->m_parent_extents),
+      this->m_trace);
     this->m_parent_extents.clear();
 
     // make sure to wait on this CopyupRequest

--- a/src/librbd/io/ReadResult.cc
+++ b/src/librbd/io/ReadResult.cc
@@ -120,7 +120,7 @@ void ReadResult::C_ImageReadRequest::finish(int r) {
 
 ReadResult::C_ObjectReadRequest::C_ObjectReadRequest(
     AioCompletion *aio_completion, uint64_t object_off, uint64_t object_len,
-    Extents&& buffer_extents)
+    LightweightBufferExtents&& buffer_extents)
   : aio_completion(aio_completion), object_off(object_off),
     object_len(object_len), buffer_extents(std::move(buffer_extents)) {
   aio_completion->add_request();

--- a/src/librbd/io/ReadResult.cc
+++ b/src/librbd/io/ReadResult.cc
@@ -138,14 +138,15 @@ void ReadResult::C_ObjectReadRequest::finish(int r) {
     ldout(cct, 10) << " got " << extent_map
                    << " for " << buffer_extents
                    << " bl " << bl.length() << dendl;
-    // handle the case where a sparse-read wasn't issued
-    if (extent_map.empty()) {
-      extent_map[object_off] = bl.length();
-    }
-
     aio_completion->lock.lock();
-    aio_completion->read_result.m_destriper.add_partial_sparse_result(
-      cct, bl, extent_map, object_off, buffer_extents);
+    if (!extent_map.empty()) {
+      aio_completion->read_result.m_destriper.add_partial_sparse_result(
+        cct, bl, extent_map, object_off, buffer_extents);
+    } else {
+      // handle the case where a sparse-read wasn't issued
+      aio_completion->read_result.m_destriper.add_partial_result(
+        cct, std::move(bl), buffer_extents);
+    }
     aio_completion->lock.unlock();
 
     r = object_len;

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -40,13 +40,14 @@ public:
     AioCompletion *aio_completion;
     uint64_t object_off;
     uint64_t object_len;
-    Extents buffer_extents;
+    LightweightBufferExtents buffer_extents;
 
     bufferlist bl;
     ExtentMap extent_map;
 
     C_ObjectReadRequest(AioCompletion *aio_completion, uint64_t object_off,
-                        uint64_t object_len, Extents&& buffer_extents);
+                        uint64_t object_len,
+                        LightweightBufferExtents&& buffer_extents);
 
     void finish(int r) override;
   };

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -158,8 +158,8 @@ void SimpleSchedulerObjectDispatch<I>::ObjectRequests::dispatch_delayed_requests
           }
         });
 
-    auto req = io::ObjectDispatchSpec::create_write(
-        image_ctx, io::OBJECT_DISPATCH_LAYER_SCHEDULER,
+    auto req = ObjectDispatchSpec::create_write(
+        image_ctx, OBJECT_DISPATCH_LAYER_SCHEDULER,
         m_object_no, offset, std::move(merged_requests.data), m_snapc,
         m_op_flags, 0, {}, ctx);
 
@@ -213,8 +213,8 @@ template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::read(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, io::ExtentMap* extent_map,
-    int* object_dispatch_flags, io::DispatchResult* dispatch_result,
+    ceph::bufferlist* read_data, ExtentMap* extent_map,
+    int* object_dispatch_flags, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
@@ -233,7 +233,7 @@ bool SimpleSchedulerObjectDispatch<I>::discard(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     const ::SnapContext &snapc, int discard_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
-    uint64_t* journal_tid, io::DispatchResult* dispatch_result,
+    uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
@@ -251,7 +251,7 @@ bool SimpleSchedulerObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
-    uint64_t* journal_tid, io::DispatchResult* dispatch_result,
+    uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
@@ -260,7 +260,7 @@ bool SimpleSchedulerObjectDispatch<I>::write(
   Mutex::Locker locker(m_lock);
   if (try_delay_write(object_no, object_off, std::move(data), snapc, op_flags,
                       *object_dispatch_flags, on_dispatched)) {
-    *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
+    *dispatch_result = DISPATCH_RESULT_COMPLETE;
     return true;
   }
 
@@ -273,10 +273,10 @@ bool SimpleSchedulerObjectDispatch<I>::write(
 template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
-    io::Extents&& buffer_extents, ceph::bufferlist&& data,
+    LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
-    uint64_t* journal_tid, io::DispatchResult* dispatch_result,
+    uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
@@ -295,7 +295,7 @@ bool SimpleSchedulerObjectDispatch<I>::compare_and_write(
     ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
-    io::DispatchResult* dispatch_result, Context** on_finish,
+    DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
@@ -310,8 +310,8 @@ bool SimpleSchedulerObjectDispatch<I>::compare_and_write(
 
 template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::flush(
-    io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
-    uint64_t* journal_tid, io::DispatchResult* dispatch_result,
+    FlushSource flush_source, const ZTracer::Trace &parent_trace,
+    uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << dendl;

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -49,39 +49,38 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, librados::snap_t snap_id, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
       io::ExtentMap* extent_map, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool discard(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      const ::SnapContext &snapc, int discard_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write_same(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, io::Extents&& buffer_extents,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      io::Extents&& buffer_extents, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-      const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+      ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -28,7 +28,7 @@ class LatencyStats;
  * Simple scheduler plugin for object dispatcher layer.
  */
 template <typename ImageCtxT = ImageCtx>
-class SimpleSchedulerObjectDispatch : public io::ObjectDispatchInterface {
+class SimpleSchedulerObjectDispatch : public ObjectDispatchInterface {
 private:
   // mock unit testing support
   typedef ::librbd::io::TypeTraits<ImageCtxT> TypeTraits;
@@ -41,8 +41,8 @@ public:
   SimpleSchedulerObjectDispatch(ImageCtxT* image_ctx);
   ~SimpleSchedulerObjectDispatch() override;
 
-  io::ObjectDispatchLayer get_object_dispatch_layer() const override {
-    return io::OBJECT_DISPATCH_LAYER_SCHEDULER;
+  ObjectDispatchLayer get_object_dispatch_layer() const override {
+    return OBJECT_DISPATCH_LAYER_SCHEDULER;
   }
 
   void init();
@@ -52,30 +52,30 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::ExtentMap* extent_map, int* object_dispatch_flags,
-      io::DispatchResult* dispatch_result, Context** on_finish,
+      ExtentMap* extent_map, int* object_dispatch_flags,
+      DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool discard(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       const ::SnapContext &snapc, int discard_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
-      uint64_t* journal_tid, io::DispatchResult* dispatch_result,
+      uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
-      uint64_t* journal_tid, io::DispatchResult* dispatch_result,
+      uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write_same(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      io::Extents&& buffer_extents, ceph::bufferlist&& data,
+      LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
-      uint64_t* journal_tid, io::DispatchResult* dispatch_result,
+      uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
@@ -83,12 +83,12 @@ public:
       ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
-      io::DispatchResult* dispatch_result, Context** on_finish,
+      DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
   bool flush(
-      io::FlushSource flush_source, const ZTracer::Trace &parent_trace,
-      uint64_t* journal_tid, io::DispatchResult* dispatch_result,
+      FlushSource flush_source, const ZTracer::Trace &parent_trace,
+      uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool invalidate_cache(Context* on_finish) override {

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_IO_TYPES_H
 
 #include "include/int_types.h"
+#include "osdc/StriperTypes.h"
 #include <map>
 #include <vector>
 
@@ -74,6 +75,10 @@ enum {
   OBJECT_DISPATCH_FLAG_FLUSH                    = 1UL << 0,
   OBJECT_DISPATCH_FLAG_WILL_RETRY_ON_ERROR      = 1UL << 1
 };
+
+using striper::LightweightBufferExtents;
+using striper::LightweightObjectExtent;
+using striper::LightweightObjectExtents;
 
 typedef std::vector<std::pair<uint64_t, uint64_t> > Extents;
 typedef std::map<uint64_t, uint64_t> ExtentMap;

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -10,7 +10,7 @@ namespace io {
 namespace util {
 
 bool assemble_write_same_extent(
-    const ObjectExtent &object_extent, const ceph::bufferlist& data,
+    const LightweightObjectExtent &object_extent, const ceph::bufferlist& data,
     ceph::bufferlist *ws_data, bool force_write) {
   size_t data_len = data.length();
 

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -6,6 +6,7 @@
 
 #include "include/int_types.h"
 #include "include/buffer_fwd.h"
+#include "librbd/io/Types.h"
 #include <map>
 
 class ObjectExtent;
@@ -14,7 +15,7 @@ namespace librbd {
 namespace io {
 namespace util {
 
-bool assemble_write_same_extent(const ObjectExtent &object_extent,
+bool assemble_write_same_extent(const LightweightObjectExtent &object_extent,
                                 const ceph::bufferlist& data,
                                 ceph::bufferlist *ws_data,
                                 bool force_write);

--- a/src/librbd/journal/ObjectDispatch.cc
+++ b/src/librbd/journal/ObjectDispatch.cc
@@ -129,7 +129,7 @@ bool ObjectDispatch<I>::write(
 template <typename I>
 bool ObjectDispatch<I>::write_same(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
-    io::Extents&& buffer_extents, ceph::bufferlist&& data,
+    io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,

--- a/src/librbd/journal/ObjectDispatch.cc
+++ b/src/librbd/journal/ObjectDispatch.cc
@@ -7,6 +7,7 @@
 #include "osdc/Striper.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Journal.h"
+#include "librbd/Utils.h"
 #include "librbd/io/ObjectDispatchSpec.h"
 #include "librbd/io/ObjectDispatcher.h"
 
@@ -17,6 +18,8 @@
 
 namespace librbd {
 namespace journal {
+
+using librbd::util::data_object_name;
 
 namespace {
 
@@ -75,8 +78,8 @@ void ObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool ObjectDispatch<I>::discard(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    const ::SnapContext &snapc, int discard_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -86,7 +89,8 @@ bool ObjectDispatch<I>::discard(
   }
 
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << object_len << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << object_len << dendl;
 
   *on_finish = new C_CommitIOEvent<I>(m_image_ctx, m_journal, object_no,
                                       object_off, object_len, *journal_tid,
@@ -99,8 +103,8 @@ bool ObjectDispatch<I>::discard(
 
 template <typename I>
 bool ObjectDispatch<I>::write(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+    uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+    const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -110,7 +114,8 @@ bool ObjectDispatch<I>::write(
   }
 
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << data.length() << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << data.length() << dendl;
 
   *on_finish = new C_CommitIOEvent<I>(m_image_ctx, m_journal, object_no,
                                       object_off, data.length(), *journal_tid,
@@ -123,8 +128,8 @@ bool ObjectDispatch<I>::write(
 
 template <typename I>
 bool ObjectDispatch<I>::write_same(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    uint64_t object_len, io::Extents&& buffer_extents, ceph::bufferlist&& data,
+    uint64_t object_no, uint64_t object_off, uint64_t object_len,
+    io::Extents&& buffer_extents, ceph::bufferlist&& data,
     const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
@@ -135,7 +140,8 @@ bool ObjectDispatch<I>::write_same(
   }
 
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << object_len << dendl;
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << object_len << dendl;
 
   *on_finish = new C_CommitIOEvent<I>(m_image_ctx, m_journal, object_no,
                                       object_off, object_len, *journal_tid,
@@ -148,9 +154,8 @@ bool ObjectDispatch<I>::write_same(
 
 template <typename I>
 bool ObjectDispatch<I>::compare_and_write(
-    const std::string &oid, uint64_t object_no, uint64_t object_off,
-    ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-    const ::SnapContext &snapc, int op_flags,
+    uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+    ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
     const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
     int* object_dispatch_flags, uint64_t* journal_tid,
     io::DispatchResult* dispatch_result, Context** on_finish,
@@ -161,7 +166,8 @@ bool ObjectDispatch<I>::compare_and_write(
   }
 
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << oid << " " << object_off << "~" << write_data.length()
+  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
+                 << object_off << "~" << write_data.length()
                  << dendl;
 
   *on_finish = new C_CommitIOEvent<I>(m_image_ctx, m_journal, object_no,

--- a/src/librbd/journal/ObjectDispatch.h
+++ b/src/librbd/journal/ObjectDispatch.h
@@ -63,7 +63,7 @@ public:
 
   bool write_same(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      io::Extents&& buffer_extents, ceph::bufferlist&& data,
+      io::LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,

--- a/src/librbd/journal/ObjectDispatch.h
+++ b/src/librbd/journal/ObjectDispatch.h
@@ -38,8 +38,8 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, librados::snap_t snap_id, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
       io::ExtentMap* extent_map, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
@@ -48,31 +48,30 @@ public:
   }
 
   bool discard(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      const ::SnapContext &snapc, int discard_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool write_same(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, io::Extents&& buffer_extents,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      io::Extents&& buffer_extents, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;
 
   bool compare_and_write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-      const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+      ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
       int* object_dispatch_flags, uint64_t* journal_tid,
       io::DispatchResult* dispatch_result, Context** on_finish,

--- a/src/librbd/operation/FlattenRequest.cc
+++ b/src/librbd/operation/FlattenRequest.cc
@@ -55,8 +55,7 @@ public:
     }
 
     bufferlist bl;
-    string oid = image_ctx.get_object_name(m_object_no);
-    auto req = new io::ObjectWriteRequest<I>(&image_ctx, oid, m_object_no, 0,
+    auto req = new io::ObjectWriteRequest<I>(&image_ctx, m_object_no, 0,
                                              std::move(bl), m_snapc, 0, {},
                                              this);
     if (!req->has_parent()) {

--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -118,8 +118,7 @@ private:
 
     if (is_within_overlap_bounds()) {
       bufferlist bl;
-      string oid = image_ctx.get_object_name(m_object_no);
-      auto req = new io::ObjectWriteRequest<I>(&image_ctx, oid, m_object_no, 0,
+      auto req = new io::ObjectWriteRequest<I>(&image_ctx, m_object_no, 0,
                                                std::move(bl), m_snapc, 0, {},
                                                ctx);
 

--- a/src/librbd/operation/TrimRequest.cc
+++ b/src/librbd/operation/TrimRequest.cc
@@ -47,7 +47,7 @@ public:
     ldout(image_ctx.cct, 10) << "removing (with copyup) " << oid << dendl;
 
     auto object_dispatch_spec = io::ObjectDispatchSpec::create_discard(
-      &image_ctx, io::OBJECT_DISPATCH_LAYER_NONE, oid, m_object_no, 0,
+      &image_ctx, io::OBJECT_DISPATCH_LAYER_NONE, m_object_no, 0,
       image_ctx.layout.object_size, m_snapc,
       io::OBJECT_DISCARD_FLAG_DISABLE_OBJECT_MAP_UPDATE, 0, {}, this);
     object_dispatch_spec->send();
@@ -346,8 +346,8 @@ void TrimRequest<I>::send_clean_boundary() {
     }
 
     auto object_dispatch_spec = io::ObjectDispatchSpec::create_discard(
-      &image_ctx, io::OBJECT_DISPATCH_LAYER_NONE, p->oid.name, p->objectno,
-      p->offset, p->length, snapc, 0, 0, {}, req_comp);
+      &image_ctx, io::OBJECT_DISPATCH_LAYER_NONE, p->objectno, p->offset,
+      p->length, snapc, 0, 0, {}, req_comp);
     object_dispatch_spec->send();
   }
   completion->finish_adding_requests();

--- a/src/osdc/Striper.h
+++ b/src/osdc/Striper.h
@@ -85,6 +85,10 @@ class CephContext;
       void add_partial_result(
 	CephContext *cct, ceph::buffer::list& bl,
 	const std::vector<std::pair<uint64_t,uint64_t> >& buffer_extents);
+      void add_partial_result(
+	  CephContext *cct, ceph::buffer::list&& bl,
+	  const striper::LightweightBufferExtents& buffer_extents);
+
       /**
        * add sparse read into results
        *
@@ -98,8 +102,13 @@ class CephContext;
 	CephContext *cct, ceph::buffer::list& bl,
 	const std::map<uint64_t, uint64_t>& bl_map, uint64_t bl_off,
 	const std::vector<std::pair<uint64_t,uint64_t> >& buffer_extents);
+      void add_partial_sparse_result(
+	  CephContext *cct, ceph::buffer::list& bl,
+	  const std::map<uint64_t, uint64_t>& bl_map, uint64_t bl_off,
+	  const striper::LightweightBufferExtents& buffer_extents);
 
-      void assemble_result(CephContext *cct, ceph::buffer::list& bl, bool zero_tail);
+      void assemble_result(CephContext *cct, ceph::buffer::list& bl,
+                           bool zero_tail);
 
       /**
        * @buffer copy read data into buffer
@@ -110,6 +119,13 @@ class CephContext;
       void assemble_result(CephContext *cct,
                            std::map<uint64_t, uint64_t> *extent_map,
                            ceph::buffer::list *bl);
+
+    private:
+      void add_partial_sparse_result(
+          CephContext *cct, bufferlist& bl,
+          std::map<uint64_t, uint64_t>::const_iterator* it,
+          const std::map<uint64_t, uint64_t>::const_iterator& end_it,
+          uint64_t* bl_off, uint64_t tofs, uint64_t tlen);
     };
 
   };

--- a/src/osdc/Striper.h
+++ b/src/osdc/Striper.h
@@ -17,6 +17,7 @@
 
 #include "include/types.h"
 #include "osd/osd_types.h"
+#include "osdc/StriperTypes.h"
 
 class CephContext;
 
@@ -24,6 +25,11 @@ class CephContext;
 
   class Striper {
   public:
+    static void file_to_extents(
+        CephContext *cct, const file_layout_t *layout, uint64_t offset,
+        uint64_t len, uint64_t trunc_size, uint64_t buffer_offset,
+        striper::LightweightObjectExtents* object_extents);
+
     /*
      * std::map (ino, layout, offset, len) to a (list of) ObjectExtents (byte
      * ranges in objects on (primary) osds)
@@ -53,10 +59,6 @@ class CephContext;
 
       file_to_extents(cct, buf, layout, offset, len, trunc_size, extents);
     }
-
-    static void assimilate_extents(
-      std::map<object_t, std::vector<ObjectExtent> >& object_extents,
-      std::vector<ObjectExtent>& extents);
 
     /**
      * reverse std::map an object extent to file extents

--- a/src/osdc/StriperTypes.h
+++ b/src/osdc/StriperTypes.h
@@ -1,0 +1,48 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_OSDC_STRIPER_TYPES_H
+#define CEPH_OSDC_STRIPER_TYPES_H
+
+#include "include/types.h"
+#include <boost/container/small_vector.hpp>
+#include <ios>
+#include <utility>
+
+namespace striper {
+
+// off -> len extents in (striped) buffer being mapped
+typedef std::pair<uint64_t,uint64_t> BufferExtent;
+typedef boost::container::small_vector<
+    BufferExtent, 4> LightweightBufferExtents;
+
+struct LightweightObjectExtent {
+  LightweightObjectExtent() = delete;
+  LightweightObjectExtent(uint64_t object_no, uint64_t offset,
+                          uint64_t length, uint64_t truncate_size)
+    : object_no(object_no), offset(offset), length(length),
+      truncate_size(truncate_size) {
+  }
+
+  uint64_t object_no;
+  uint64_t offset;        // in-object
+  uint64_t length;        // in-object
+  uint64_t truncate_size; // in-object
+  LightweightBufferExtents buffer_extents;
+};
+
+typedef boost::container::small_vector<
+    LightweightObjectExtent, 4> LightweightObjectExtents;
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const LightweightObjectExtent& ex) {
+  return os << "extent("
+            << ex.object_no << " "
+            << ex.offset << "~" << ex.length
+            << " -> " << ex.buffer_extents
+            << ")";
+}
+
+} // namespace striper
+
+#endif // CEPH_OSDC_STRIPER_TYPES_H

--- a/src/test/librbd/cache/test_mock_WriteAroundObjectDispatch.cc
+++ b/src/test/librbd/cache/test_mock_WriteAroundObjectDispatch.cc
@@ -72,7 +72,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThrough) {
   MockContext finish_ctx;
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
-  ASSERT_FALSE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                      nullptr, nullptr, &dispatch_result,
                                      &finish_ctx_ptr, &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
@@ -95,7 +95,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThroughUntilFlushed) {
   MockContext finish_ctx;
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
-  ASSERT_FALSE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                      nullptr, nullptr, &dispatch_result,
                                      &finish_ctx_ptr, &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
@@ -107,7 +107,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThroughUntilFlushed) {
   expect_context_complete(dispatch_ctx, 0);
   expect_context_complete(finish_ctx, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                      nullptr, nullptr, &dispatch_result,
                                      &finish_ctx_ptr, &dispatch_ctx));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -138,7 +138,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, DispatchIO) {
   expect_context_complete(dispatch_ctx, 0);
   expect_context_complete(finish_ctx, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr, &dispatch_ctx));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -170,7 +170,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr1, &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -183,7 +183,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   expect_context_complete(dispatch_ctx2, 0);
   expect_context_complete(finish_ctx2, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 4096, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr2, &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -193,7 +193,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   MockContext dispatch_ctx3;
   Context* finish_ctx_ptr3 = &finish_ctx3;
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 1024, std::move(data), {}, 0,
+  ASSERT_TRUE(object_dispatch.write(0, 1024, std::move(data), {}, 0,
                                     {}, nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr3, &dispatch_ctx3));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -235,7 +235,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, QueuedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr1, &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -245,7 +245,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, QueuedIO) {
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 8192, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 8192, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr2, &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -283,7 +283,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr1, &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -296,7 +296,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   expect_context_complete(dispatch_ctx2, 0);
   expect_context_complete(finish_ctx2, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 4096, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr2, &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -306,7 +306,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   MockContext dispatch_ctx3;
   Context* finish_ctx_ptr3 = &finish_ctx3;
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0,
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0,
                                     {}, nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr3, &dispatch_ctx3));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -368,7 +368,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnInFlightIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr1, &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -413,7 +413,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnQueuedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr1, &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -424,7 +424,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnQueuedIO) {
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 8192, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 8192, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr2, &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -477,7 +477,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushError) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr1, &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -517,7 +517,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIO) {
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
 
-  ASSERT_FALSE(object_dispatch.compare_and_write("oid", 0, 0, std::move(data),
+  ASSERT_FALSE(object_dispatch.compare_and_write(0, 0, std::move(data),
                                                  std::move(data), {}, 0, {},
                                                  nullptr, nullptr, nullptr,
                                                  &dispatch_result,
@@ -547,7 +547,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOInFlightIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr1, &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -558,7 +558,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOInFlightIO) {
   MockContext finish_ctx2;
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
-  ASSERT_TRUE(object_dispatch.compare_and_write("oid", 0, 0, std::move(data),
+  ASSERT_TRUE(object_dispatch.compare_and_write(0, 0, std::move(data),
                                                 std::move(data), {}, 0, {},
                                                 nullptr, nullptr, nullptr,
                                                 &dispatch_result,
@@ -593,7 +593,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 0, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr1, &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -604,7 +604,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   MockContext finish_ctx2;
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
-  ASSERT_TRUE(object_dispatch.write("oid", 0, 4096, std::move(data), {}, 0, {},
+  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, {},
                                     nullptr, nullptr, &dispatch_result,
                                     &finish_ctx_ptr2, &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
@@ -613,7 +613,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   MockContext finish_ctx3;
   MockContext dispatch_ctx3;
   Context* finish_ctx_ptr3 = &finish_ctx3;
-  ASSERT_TRUE(object_dispatch.compare_and_write("oid", 0, 0, std::move(data),
+  ASSERT_TRUE(object_dispatch.compare_and_write(0, 0, std::move(data),
                                                 std::move(data), {}, 0, {},
                                                 nullptr, nullptr, nullptr,
                                                 &dispatch_result,
@@ -648,7 +648,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FUA) {
   MockContext finish_ctx;
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
-  ASSERT_FALSE(object_dispatch.write("oid", 0, 0, std::move(data), {},
+  ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {},
                                      LIBRADOS_OP_FLAG_FADVISE_FUA, {},
                                      nullptr, nullptr, &dispatch_result,
                                      &finish_ctx_ptr, &dispatch_ctx));

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -373,11 +373,11 @@ TEST_F(TestMockIoCopyupRequest, Standard) {
                            0);
 
   expect_add_copyup_ops(mock_write_request);
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {{0, 4096}}, data,
-                       0);
-  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {{0, 4096}}, data, 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -431,10 +431,11 @@ TEST_F(TestMockIoCopyupRequest, StandardWithSnaps) {
                            0);
 
   expect_add_copyup_ops(mock_write_request);
-  expect_sparse_copyup(mock_image_ctx, 0, "oid", {{0, 4096}}, data, 0);
-  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+  expect_sparse_copyup(mock_image_ctx, 0, ictx->get_object_name(0), {{0, 4096}},
+                       data, 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -472,10 +473,10 @@ TEST_F(TestMockIoCopyupRequest, CopyOnRead) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            0);
 
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {{0, 4096}}, data,
-                       0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {{0, 4096}}, data, 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->send();
@@ -519,9 +520,10 @@ TEST_F(TestMockIoCopyupRequest, CopyOnReadWithSnaps) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS_CLEAN,
                            true, 0);
 
-  expect_sparse_copyup(mock_image_ctx, 0, "oid", {{0, 4096}}, data, 0);
+  expect_sparse_copyup(mock_image_ctx, 0, ictx->get_object_name(0), {{0, 4096}},
+                       data, 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->send();
@@ -562,10 +564,11 @@ TEST_F(TestMockIoCopyupRequest, DeepCopy) {
                            0);
 
   expect_add_copyup_ops(mock_write_request);
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {}, "", 0);
-  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {}, "", 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -603,9 +606,10 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyOnRead) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            0);
 
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {}, "", 0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {}, "", 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->send();
@@ -668,10 +672,11 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyWithPostSnaps) {
                            0);
 
   expect_add_copyup_ops(mock_write_request);
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {}, "", 0);
-  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {}, "", 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -739,10 +744,11 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyWithPreAndPostSnaps) {
                            0);
 
   expect_add_copyup_ops(mock_write_request);
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {}, "", 0);
-  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {}, "", 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -779,10 +785,11 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyup) {
                            0);
 
   expect_add_copyup_ops(mock_write_request);
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {}, "", 0);
-  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {}, "", 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -820,9 +827,10 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyOnRead) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            0);
 
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {}, "", 0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {}, "", 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->send();
@@ -856,7 +864,7 @@ TEST_F(TestMockIoCopyupRequest, NoOpCopyup) {
   MockAbstractObjectWriteRequest mock_write_request;
   expect_is_empty_write_op(mock_write_request, true);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -897,15 +905,15 @@ TEST_F(TestMockIoCopyupRequest, RestartWrite) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   expect_add_copyup_ops(mock_write_request1);
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", {{0, 4096}}, data,
-                       0);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {{0, 4096}}, data, 0);
 
   MockAbstractObjectWriteRequest mock_write_request2;
   EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-              write("oid", _, 0, 0, _))
+              write(ictx->get_object_name(0), _, 0, 0, _))
     .WillOnce(WithoutArgs(Invoke([req, &mock_write_request2]() {
                             req->append_request(&mock_write_request2);
                             return 0;
@@ -946,7 +954,7 @@ TEST_F(TestMockIoCopyupRequest, ReadFromParentError) {
   MockAbstractObjectWriteRequest mock_write_request;
   expect_is_empty_write_op(mock_write_request, false);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -983,7 +991,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyError) {
 
   expect_is_empty_write_op(mock_write_request, false);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -1024,7 +1032,7 @@ TEST_F(TestMockIoCopyupRequest, UpdateObjectMapError) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            -EINVAL);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -1074,10 +1082,11 @@ TEST_F(TestMockIoCopyupRequest, CopyupError) {
                            0);
 
   expect_add_copyup_ops(mock_write_request);
-  expect_sparse_copyup(mock_image_ctx, 0, "oid", {{0, 4096}}, data, -EPERM);
-  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+  expect_sparse_copyup(mock_image_ctx, 0, ictx->get_object_name(0), {{0, 4096}},
+                       data, -EPERM);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
@@ -1121,11 +1130,10 @@ TEST_F(TestMockIoCopyupRequest, SparseCopyupNotSupported) {
                            0);
 
   expect_add_copyup_ops(mock_write_request);
-  expect_copyup(mock_image_ctx, CEPH_NOSNAP, "oid", data, 0);
-  expect_write(mock_image_ctx, CEPH_NOSNAP, "oid", 0);
+  expect_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), data, 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
 
-  auto req = new MockCopyupRequest(&mock_image_ctx, "oid", 0,
-                                   {{0, 4096}}, {});
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request);
   req->send();

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -43,8 +43,7 @@ template <>
 struct CopyupRequest<librbd::MockTestImageCtx> : public CopyupRequest<librbd::MockImageCtx> {
   static CopyupRequest* s_instance;
   static CopyupRequest* create(librbd::MockTestImageCtx *ictx,
-                               const std::string &oid, uint64_t objectno,
-                               Extents &&image_extents,
+                               uint64_t objectno, Extents &&image_extents,
                                const ZTracer::Trace &parent_trace) {
     return s_instance;
   }
@@ -331,8 +330,7 @@ TEST_F(TestMockIoObjectRequest, Read) {
   ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0, {},
-    &bl, &extent_map, &ctx);
+    &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -360,9 +358,8 @@ TEST_F(TestMockIoObjectRequest, SparseReadThreshold) {
   ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0,
-    ictx->sparse_read_threshold_bytes, CEPH_NOSNAP, 0, {}, &bl, &extent_map,
-    &ctx);
+    &mock_image_ctx, 0, 0, ictx->sparse_read_threshold_bytes, CEPH_NOSNAP, 0,
+    {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -388,8 +385,7 @@ TEST_F(TestMockIoObjectRequest, ReadError) {
   ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0, {},
-    &bl, &extent_map, &ctx);
+    &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -436,8 +432,7 @@ TEST_F(TestMockIoObjectRequest, ParentRead) {
   ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0, {},
-    &bl, &extent_map, &ctx);
+    &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -484,8 +479,7 @@ TEST_F(TestMockIoObjectRequest, ParentReadError) {
   ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0, {},
-    &bl, &extent_map, &ctx);
+    &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -537,8 +531,7 @@ TEST_F(TestMockIoObjectRequest, CopyOnRead) {
   ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0, {},
-    &bl, &extent_map, &ctx);
+    &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -572,8 +565,7 @@ TEST_F(TestMockIoObjectRequest, Write) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -607,8 +599,7 @@ TEST_F(TestMockIoObjectRequest, WriteFull) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -641,8 +632,7 @@ TEST_F(TestMockIoObjectRequest, WriteObjectMap) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -663,8 +653,7 @@ TEST_F(TestMockIoObjectRequest, WriteError) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -717,8 +706,7 @@ TEST_F(TestMockIoObjectRequest, Copyup) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -773,8 +761,7 @@ TEST_F(TestMockIoObjectRequest, CopyupRestart) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -821,8 +808,7 @@ TEST_F(TestMockIoObjectRequest, CopyupOptimization) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -862,8 +848,7 @@ TEST_F(TestMockIoObjectRequest, CopyupError) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -896,8 +881,8 @@ TEST_F(TestMockIoObjectRequest, DiscardRemove) {
 
   C_SaferCond ctx;
   auto req = MockObjectDiscardRequest::create_discard(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0,
-    mock_image_ctx.get_object_size(), mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, mock_image_ctx.get_object_size(),
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -946,9 +931,8 @@ TEST_F(TestMockIoObjectRequest, DiscardRemoveTruncate) {
 
   C_SaferCond ctx;
   auto req = MockObjectDiscardRequest::create_discard(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0,
-    mock_image_ctx.get_object_size(), mock_image_ctx.snapc,
-    OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE, {}, &ctx);
+    &mock_image_ctx, 0, 0, mock_image_ctx.get_object_size(),
+    mock_image_ctx.snapc, OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1003,9 +987,8 @@ TEST_F(TestMockIoObjectRequest, DiscardTruncateAssertExists) {
 
   C_SaferCond ctx;
   auto req = MockObjectDiscardRequest::create_discard(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0,
-    mock_image_ctx.get_object_size(), mock_image_ctx.snapc,
-    OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE, {}, &ctx);
+    &mock_image_ctx, 0, 0, mock_image_ctx.get_object_size(),
+    mock_image_ctx.snapc, OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1039,8 +1022,8 @@ TEST_F(TestMockIoObjectRequest, DiscardTruncate) {
 
   C_SaferCond ctx;
   auto req = MockObjectDiscardRequest::create_discard(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 1,
-    mock_image_ctx.get_object_size() - 1, mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 1, mock_image_ctx.get_object_size() - 1,
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1071,8 +1054,7 @@ TEST_F(TestMockIoObjectRequest, DiscardZero) {
 
   C_SaferCond ctx;
   auto req = MockObjectDiscardRequest::create_discard(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 1, 1, mock_image_ctx.snapc,
-    0, {}, &ctx);
+    &mock_image_ctx, 0, 1, 1, mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1100,8 +1082,8 @@ TEST_F(TestMockIoObjectRequest, DiscardDisableObjectMapUpdate) {
 
   C_SaferCond ctx;
   auto req = MockObjectDiscardRequest::create_discard(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0,
-    mock_image_ctx.get_object_size(), mock_image_ctx.snapc,
+    &mock_image_ctx, 0, 0, mock_image_ctx.get_object_size(),
+    mock_image_ctx.snapc,
     OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE |
       OBJECT_DISCARD_FLAG_DISABLE_OBJECT_MAP_UPDATE, {}, &ctx);
   req->send();
@@ -1131,8 +1113,8 @@ TEST_F(TestMockIoObjectRequest, DiscardNoOp) {
 
   C_SaferCond ctx;
   auto req = MockObjectDiscardRequest::create_discard(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0,
-    mock_image_ctx.get_object_size(), mock_image_ctx.snapc,
+    &mock_image_ctx, 0, 0, mock_image_ctx.get_object_size(),
+    mock_image_ctx.snapc,
     OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE |
       OBJECT_DISCARD_FLAG_DISABLE_OBJECT_MAP_UPDATE, {},
     &ctx);
@@ -1169,8 +1151,7 @@ TEST_F(TestMockIoObjectRequest, WriteSame) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteSameRequest::create_write_same(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, 4096, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1209,8 +1190,8 @@ TEST_F(TestMockIoObjectRequest, CompareAndWrite) {
   C_SaferCond ctx;
   uint64_t mismatch_offset;
   auto req = MockObjectWriteSameRequest::create_compare_and_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(cmp_bl),
-    std::move(bl), mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(cmp_bl), std::move(bl),
+    mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1249,8 +1230,8 @@ TEST_F(TestMockIoObjectRequest, CompareAndWriteFull) {
   C_SaferCond ctx;
   uint64_t mismatch_offset;
   auto req = MockObjectWriteSameRequest::create_compare_and_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(cmp_bl),
-    std::move(bl), mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(cmp_bl), std::move(bl),
+    mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1311,8 +1292,8 @@ TEST_F(TestMockIoObjectRequest, CompareAndWriteCopyup) {
   C_SaferCond ctx;
   uint64_t mismatch_offset;
   auto req = MockObjectWriteSameRequest::create_compare_and_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(cmp_bl),
-    std::move(bl), mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(cmp_bl), std::move(bl),
+    mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1350,8 +1331,8 @@ TEST_F(TestMockIoObjectRequest, CompareAndWriteMismatch) {
   C_SaferCond ctx;
   uint64_t mismatch_offset;
   auto req = MockObjectWriteSameRequest::create_compare_and_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(cmp_bl),
-    std::move(bl), mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(cmp_bl), std::move(bl),
+    mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(-EILSEQ, ctx.wait());
   ASSERT_EQ(1ULL, mismatch_offset);
@@ -1385,8 +1366,7 @@ TEST_F(TestMockIoObjectRequest, ObjectMapError) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
-    mock_image_ctx.snapc, 0, {}, &ctx);
+    &mock_image_ctx, 0, 0, std::move(bl), mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(-EBLACKLISTED, ctx.wait());
 }

--- a/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
+++ b/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
@@ -113,8 +113,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Read) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.read(
-      ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0, {}, nullptr,
-      nullptr, nullptr, nullptr, &on_finish, nullptr));
+      0, 0, 4096, CEPH_NOSNAP, 0, {}, nullptr, nullptr, nullptr, nullptr,
+      &on_finish, nullptr));
   ASSERT_EQ(on_finish, &cond); // not modified
   on_finish->complete(0);
   ASSERT_EQ(0, cond.wait());
@@ -131,8 +131,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Discard) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.discard(
-      ictx->get_object_name(0), 0, 0, 4096, mock_image_ctx.snapc, 0, {},
-      nullptr, nullptr, nullptr, &on_finish, nullptr));
+      0, 0, 4096, mock_image_ctx.snapc, 0, {}, nullptr, nullptr, nullptr,
+      &on_finish, nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
   ASSERT_EQ(0, cond.wait());
@@ -152,8 +152,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Write) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish, nullptr));
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish, nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
   ASSERT_EQ(0, cond.wait());
@@ -172,9 +172,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteSame) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write_same(
-      ictx->get_object_name(0), 0, 0, 4096, std::move(buffer_extents),
-      std::move(data), mock_image_ctx.snapc, 0, {}, nullptr, nullptr, nullptr,
-      &on_finish, nullptr));
+      0, 0, 4096, std::move(buffer_extents), std::move(data),
+      mock_image_ctx.snapc, 0, {}, nullptr, nullptr, nullptr, &on_finish,
+      nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
   ASSERT_EQ(0, cond.wait());
@@ -193,9 +193,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, CompareAndWrite) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.compare_and_write(
-      ictx->get_object_name(0), 0, 0, std::move(cmp_data),
-      std::move(write_data), mock_image_ctx.snapc, 0, {}, nullptr, nullptr,
-      nullptr, nullptr, &on_finish, nullptr));
+      0, 0, std::move(cmp_data), std::move(write_data), mock_image_ctx.snapc, 0,
+      {}, nullptr, nullptr, nullptr, nullptr, &on_finish, nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
   ASSERT_EQ(0, cond.wait());
@@ -236,8 +235,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayed) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
   Context *timer_task = nullptr;
@@ -248,8 +247,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayed) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish2, &cond2);
@@ -283,8 +282,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayedFlush) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
   Context *timer_task = nullptr;
@@ -295,8 +294,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayedFlush) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish2, &cond2);
@@ -338,8 +337,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
   Context *timer_task = nullptr;
@@ -353,9 +352,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish2, &on_dispatched2));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish2, &cond2);
   ASSERT_NE(timer_task, nullptr);
@@ -367,9 +366,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish3 = &cond3;
   C_SaferCond on_dispatched3;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish3, &on_dispatched3));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3,
+      &on_dispatched3));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish3, &cond3);
 
@@ -380,9 +379,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish4 = &cond4;
   C_SaferCond on_dispatched4;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish4, &on_dispatched4));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish4,
+      &on_dispatched4));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish4, &cond4);
 
@@ -393,9 +392,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish5 = &cond5;
   C_SaferCond on_dispatched5;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish5, &on_dispatched5));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish5,
+      &on_dispatched5));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish5, &cond5);
 
@@ -406,9 +405,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish6 = &cond6;
   C_SaferCond on_dispatched6;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish6, &on_dispatched6));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish6,
+      &on_dispatched6));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish6, &cond6);
 
@@ -454,8 +453,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
   Context *timer_task = nullptr;
@@ -469,9 +468,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish2, &on_dispatched2));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish2, &cond2);
   ASSERT_NE(timer_task, nullptr);
@@ -485,9 +484,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   C_SaferCond cond3;
   Context *on_finish3 = &cond3;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish3, nullptr));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3, nullptr));
   ASSERT_NE(on_finish3, &cond3);
 
   on_finish1->complete(0);
@@ -518,8 +516,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
   // write (2) 0~10 (delayed)
@@ -534,9 +532,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish2, &on_dispatched2));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish2, &cond2);
   ASSERT_NE(timer_task, nullptr);
@@ -550,9 +548,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish3 = &cond3;
   C_SaferCond on_dispatched3;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish3, &on_dispatched3));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3,
+      &on_dispatched3));
   ASSERT_EQ(on_finish3, &cond3);
 
   // discard (1) (non-seq io)
@@ -563,8 +561,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond cond4;
   Context *on_finish4 = &cond4;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.discard(
-      ictx->get_object_name(0), 0, 4096, 4096, mock_image_ctx.snapc, 0, {},
-      nullptr, nullptr, nullptr, &on_finish4, nullptr));
+      0, 4096, 4096, mock_image_ctx.snapc, 0, {}, nullptr, nullptr, nullptr,
+      &on_finish4, nullptr));
   ASSERT_NE(on_finish4, &cond4);
   ASSERT_EQ(0, on_dispatched2.wait());
   ASSERT_EQ(0, on_dispatched3.wait());
@@ -580,9 +578,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish5 = &cond5;
   C_SaferCond on_dispatched5;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish5, &on_dispatched5));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish5,
+      &on_dispatched5));
   ASSERT_EQ(on_finish5, &cond5);
   ASSERT_NE(timer_task, nullptr);
 
@@ -594,8 +592,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond cond6;
   Context *on_finish6 = &cond6;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.discard(
-      ictx->get_object_name(0), 0, 4096, 4096, mock_image_ctx.snapc, 0, {},
-      nullptr, nullptr, nullptr, &on_finish6, nullptr));
+      0, 4096, 4096, mock_image_ctx.snapc, 0, {}, nullptr, nullptr, nullptr,
+      &on_finish6, nullptr));
   ASSERT_NE(on_finish6, &cond6);
   ASSERT_EQ(0, on_dispatched5.wait());
 
@@ -610,9 +608,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish7 = &cond7;
   C_SaferCond on_dispatched7;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, object_off, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish7, &on_dispatched7));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish7,
+      &on_dispatched7));
   ASSERT_EQ(on_finish7, &cond7);
   ASSERT_NE(timer_task, nullptr);
 
@@ -673,9 +671,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(object_no), object_no, 0, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr, nullptr,
-      &on_finish1, nullptr));
+      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
   Context *timer_task = nullptr;
@@ -687,9 +684,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(object_no), object_no, 0, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish2, &on_dispatched2));
+      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish2, &cond2);
   ASSERT_NE(timer_task, nullptr);
@@ -701,9 +698,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   C_SaferCond cond3;
   Context *on_finish3 = &cond3;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(object_no), object_no, 0, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr, nullptr,
-      &on_finish3, nullptr));
+      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish3, nullptr));
   ASSERT_NE(on_finish3, &cond3);
 
   data.clear();
@@ -711,9 +707,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   Context *on_finish4 = &cond4;
   C_SaferCond on_dispatched4;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(object_no), object_no, 0, std::move(data),
-      mock_image_ctx.snapc, 0, {}, &object_dispatch_flags, nullptr,
-      &dispatch_result, &on_finish4, &on_dispatched4));
+      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish4,
+      &on_dispatched4));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish4, &cond4);
 
@@ -758,8 +754,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Timer) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
   Context *timer_task = nullptr;
@@ -771,8 +767,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Timer) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      ictx->get_object_name(0), 0, 0, std::move(data), mock_image_ctx.snapc, 0,
-      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish2, &cond2);

--- a/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
+++ b/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
@@ -167,7 +167,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteSame) {
   MockSimpleSchedulerObjectDispatch
       mock_simple_scheduler_object_dispatch(&mock_image_ctx);
 
-  io::Extents buffer_extents;
+  io::LightweightBufferExtents buffer_extents;
   ceph::bufferlist data;
   C_SaferCond cond;
   Context *on_finish = &cond;

--- a/src/test/librbd/mock/io/MockObjectDispatch.h
+++ b/src/test/librbd/mock/io/MockObjectDispatch.h
@@ -67,12 +67,13 @@ public:
   }
 
   MOCK_METHOD10(execute_write_same,
-                bool(uint64_t, uint64_t, uint64_t, const Extents&,
+                bool(uint64_t, uint64_t, uint64_t,
+                     const LightweightBufferExtents&,
                      const ceph::bufferlist&, const ::SnapContext &, int*,
                      uint64_t*, DispatchResult*, Context *));
   bool write_same(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      Extents&& buffer_extents, ceph::bufferlist&& data,
+      LightweightBufferExtents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,

--- a/src/test/librbd/mock/io/MockObjectDispatch.h
+++ b/src/test/librbd/mock/io/MockObjectDispatch.h
@@ -28,8 +28,8 @@ public:
                bool(uint64_t, uint64_t, uint64_t, librados::snap_t,
                     ceph::bufferlist*, ExtentMap*, DispatchResult*, Context*));
   bool read(
-      const std::string& oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, librados::snap_t snap_id, int op_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace& parent_trace, ceph::bufferlist* read_data,
       ExtentMap* extent_map, int* dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
@@ -42,8 +42,8 @@ public:
                bool(uint64_t, uint64_t, uint64_t, const ::SnapContext &, int,
                     int*, uint64_t*, DispatchResult*, Context*));
   bool discard(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, const ::SnapContext &snapc, int discard_flags,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      const ::SnapContext &snapc, int discard_flags,
       const ZTracer::Trace &parent_trace, int* dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) {
@@ -57,8 +57,8 @@ public:
                     const ::SnapContext &, int*, uint64_t*, DispatchResult*,
                     Context *));
   bool write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
+      const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override {
@@ -71,8 +71,8 @@ public:
                      const ceph::bufferlist&, const ::SnapContext &, int*,
                      uint64_t*, DispatchResult*, Context *));
   bool write_same(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      uint64_t object_len, Extents&& buffer_extents, ceph::bufferlist&& data,
+      uint64_t object_no, uint64_t object_off, uint64_t object_len,
+      Extents&& buffer_extents, ceph::bufferlist&& data,
       const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, int* dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
@@ -87,9 +87,8 @@ public:
                     const ceph::bufferlist&, uint64_t*, int*, uint64_t*,
                     DispatchResult*, Context *));
   bool compare_and_write(
-      const std::string &oid, uint64_t object_no, uint64_t object_off,
-      ceph::bufferlist&& cmp_data, ceph::bufferlist&& write_data,
-      const ::SnapContext &snapc, int op_flags,
+      uint64_t object_no, uint64_t object_off, ceph::bufferlist&& cmp_data,
+      ceph::bufferlist&& write_data, const ::SnapContext &snapc, int op_flags,
       const ZTracer::Trace &parent_trace, uint64_t* mismatch_offset,
       int* dispatch_flags, uint64_t* journal_tid,
       DispatchResult* dispatch_result, Context** on_finish,


### PR DESCRIPTION
**random reads @ 4K**
57.2k (librbd) @ 308% CPU (185 IOPS/%CPU)
70.3k IOPS (librbd+tweaks) @ 352 % CPU (200 IOPS/%CPU)
97.8k IOPS (krbd)

**random writes @ 4K**
48.9K IOPS (librbd) @ 318% CPU (153 IOPS/%CPU)
57.4k IOPS (librbd+tweaks) @ 343% CPU (167 IOPS/%CPU)
85.2k IOPS (krbd)
