### PR TITLE
cls/user: cls_user_set_buckets_info overwrites creation_time

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -148,6 +148,8 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     } else if (op.add) {
       // bucket id may have changed (ie reshard)
       entry.bucket.bucket_id = update_entry.bucket.bucket_id;
+      // creation date may have changed (ie delete/recreate bucket)
+      entry.creation_time = update_entry.creation_time;
     }
 
     if (ret < 0) {

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1299,3 +1299,13 @@ def test_bucket_index_log_trim():
     # verify cold bucket has empty bilog
     cold_bilog = bilog_list(zone.zone, cold_bucket.name)
     assert(len(cold_bilog) == 0)
+
+def test_bucket_creation_time():
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+
+    zone_buckets = [zone.get_connection().get_all_buckets() for zone in zonegroup_conns.rw_zones]
+    for z1, z2 in combinations(zone_buckets, 2):
+        for a, b in zip(z1, z2):
+            eq(a.name, b.name)
+            eq(a.creation_date, b.creation_date)


### PR DESCRIPTION
metadata sync of a new bucket entrypoint may call rgw_link_bucket() (which in turn calls into cls user) without deleting/unlinking the previous bucket entrypoint. this prevented the new bucket entrypoint from overwriting the creation_time of the old one

Fixes: http://tracker.ceph.com/issues/39635