### PR TITLE
librbd: fix issues with object-map/fast-diff feature interlock

### DIFF
--- a/src/librbd/operation/DisableFeaturesRequest.cc
+++ b/src/librbd/operation/DisableFeaturesRequest.cc
@@ -175,6 +175,13 @@ Context *DisableFeaturesRequest<I>::handle_acquire_exclusive_lock(int *result) {
 
   do {
     m_features &= image_ctx.features;
+
+    // interlock object-map and fast-diff together
+    if (((m_features & RBD_FEATURE_OBJECT_MAP) != 0) ||
+        ((m_features & RBD_FEATURE_FAST_DIFF) != 0)) {
+      m_features |= (RBD_FEATURE_OBJECT_MAP | RBD_FEATURE_FAST_DIFF);
+    }
+
     m_new_features = image_ctx.features & ~m_features;
     m_features_mask = m_features;
 
@@ -188,6 +195,7 @@ Context *DisableFeaturesRequest<I>::handle_acquire_exclusive_lock(int *result) {
         break;
       }
       m_features_mask |= (RBD_FEATURE_OBJECT_MAP |
+                          RBD_FEATURE_FAST_DIFF |
                           RBD_FEATURE_JOURNALING);
     }
     if ((m_features & RBD_FEATURE_FAST_DIFF) != 0) {

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -829,11 +829,6 @@ TEST_F(TestMockImageRefreshRequest, DisableExclusiveLock) {
                                                    false));
   }
 
-  if (ictx->test_features(RBD_FEATURE_FAST_DIFF)) {
-    ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_FAST_DIFF,
-                                                   false));
-  }
-
   if (ictx->test_features(RBD_FEATURE_OBJECT_MAP)) {
     ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_OBJECT_MAP,
                                                    false));
@@ -884,11 +879,6 @@ TEST_F(TestMockImageRefreshRequest, DisableExclusiveLockWhileAcquiringLock) {
                                                    false));
   }
 
-  if (ictx->test_features(RBD_FEATURE_FAST_DIFF)) {
-    ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_FAST_DIFF,
-                                                   false));
-  }
-
   if (ictx->test_features(RBD_FEATURE_OBJECT_MAP)) {
     ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_OBJECT_MAP,
                                                    false));
@@ -929,11 +919,6 @@ TEST_F(TestMockImageRefreshRequest, JournalDisabledByPolicy) {
 
   if (ictx->test_features(RBD_FEATURE_FAST_DIFF)) {
     ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_FAST_DIFF,
-                                                   false));
-  }
-
-  if (ictx->test_features(RBD_FEATURE_OBJECT_MAP)) {
-    ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_OBJECT_MAP,
                                                    false));
   }
 
@@ -981,11 +966,6 @@ TEST_F(TestMockImageRefreshRequest, EnableJournalWithExclusiveLock) {
                                                    false));
   }
 
-  if (ictx->test_features(RBD_FEATURE_OBJECT_MAP)) {
-    ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_OBJECT_MAP,
-                                                   false));
-  }
-
   ASSERT_EQ(0, ictx->state->refresh());
 
   MockRefreshImageCtx mock_image_ctx(*ictx);
@@ -1026,11 +1006,6 @@ TEST_F(TestMockImageRefreshRequest, EnableJournalWithoutExclusiveLock) {
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-
-  if (ictx->test_features(RBD_FEATURE_FAST_DIFF)) {
-    ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_FAST_DIFF,
-                                                   false));
-  }
 
   if (ictx->test_features(RBD_FEATURE_OBJECT_MAP)) {
     ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_OBJECT_MAP,
@@ -1221,11 +1196,6 @@ TEST_F(TestMockImageRefreshRequest, DisableObjectMap) {
 
   if (ictx->test_features(RBD_FEATURE_FAST_DIFF)) {
     ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_FAST_DIFF,
-                                                   false));
-  }
-
-  if (ictx->test_features(RBD_FEATURE_OBJECT_MAP)) {
-    ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_OBJECT_MAP,
                                                    false));
   }
 


### PR DESCRIPTION
Enabling/disabling one should enable/disable the other.

Fixes: http://tracker.ceph.com/issues/39521
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

