### PR TITLE
mgr/PyModuleRegistry: log error if we can't find any modules to load

### DIFF
--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -66,7 +66,8 @@ void PyModuleRegistry::init()
 
   std::list<std::string> failed_modules;
 
-  std::set<std::string> module_names = probe_modules();
+  const std::string module_path = g_conf().get_val<std::string>("mgr_module_path");
+  std::set<std::string> module_names = probe_modules(module_path);
   // Load python code
   for (const auto& module_name : module_names) {
     dout(1) << "Loading python module '" << module_name << "'" << dendl;
@@ -88,7 +89,9 @@ void PyModuleRegistry::init()
     // report its loading error
     modules[module_name] = std::move(mod);
   }
-
+  if (module_names.empty()) {
+    clog->error() << "No ceph-mgr modules found in " << module_path;
+  }
   if (!failed_modules.empty()) {
     clog->error() << "Failed to load ceph-mgr modules: " << joinify(
         failed_modules.begin(), failed_modules.end(), std::string(", "));
@@ -255,10 +258,8 @@ void PyModuleRegistry::shutdown()
   Py_Finalize();
 }
 
-std::set<std::string> PyModuleRegistry::probe_modules() const
+std::set<std::string> PyModuleRegistry::probe_modules(const std::string &path) const
 {
-  std::string path = g_conf().get_val<std::string>("mgr_module_path");
-
   DIR *dir = opendir(path.c_str());
   if (!dir) {
     return {};

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -55,7 +55,7 @@ private:
   /**
    * Discover python modules from local disk
    */
-  std::set<std::string> probe_modules() const;
+  std::set<std::string> probe_modules(const std::string &path) const;
 
   PyModuleConfig module_config;
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/39662
Signed-off-by: Tim Serong <tserong@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

