### PR TITLE
mgr/zabbix: Fix typo in key name for PGs in backfill_wait state

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -59,3 +59,9 @@
   bucket reshard in earlier versions of RGW. One subcommand lists such
   objects and the other deletes them. Read the troubleshooting section
   of the dynamic resharding docs for details.
+
+* In the Zabbix Mgr Module there was a typo in the key being send
+  to Zabbix for PGs in backfill_wait state. The key that was sent
+  was 'wait_backfill' and the correct name is 'backfill_wait'.
+  Update your Zabbix template accordingly so that it accepts the
+  new key being send to Zabbix.

--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -153,7 +153,7 @@ class Module(MgrModule):
 
         pg_states = ['active', 'peering', 'clean', 'scrubbing', 'undersized',
                      'backfilling', 'recovering', 'degraded', 'inconsistent',
-                     'remapped', 'backfill_toofull', 'wait_backfill',
+                     'remapped', 'backfill_toofull', 'backfill_wait',
                      'recovery_wait']
 
         for state in pg_states:

--- a/src/pybind/mgr/zabbix/zabbix_template.xml
+++ b/src/pybind/mgr/zabbix/zabbix_template.xml
@@ -755,12 +755,12 @@
                     <logtimefmt/>
                 </item>
                 <item>
-                    <name>Number of Placement Groups in wait_backfill state</name>
+                    <name>Number of Placement Groups in backfill_wait state</name>
                     <type>2</type>
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>ceph.num_pg_wait_backfill</key>
+                    <key>ceph.num_pg_backfill_wait</key>
                     <delay>0</delay>
                     <history>90</history>
                     <trends>365</trends>
@@ -787,7 +787,7 @@
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <description>Total number of Placement Groups in wait_backfill state</description>
+                    <description>Total number of Placement Groups in backfill_wait state</description>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/39666

Signed-off-by: Wido den Hollander <wido@42on.com>
