### PR TITLE
scripts/kubejacker: Fix mgr_plugins target for centos

### DIFF
--- a/src/script/kubejacker/Dockerfile
+++ b/src/script/kubejacker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceph/ceph:latest
+FROM ceph/daemon-base:latest-master
 # for openSUSE, use:
 # FROM registry.opensuse.org/home/ssebastianwagner/rook-ceph/images/opensuse/leap:latest
 
@@ -11,6 +11,4 @@ FROM ceph/ceph:latest
 #ADD eclib.tar.gz /usr/local/lib64/ceph/erasure-code/
 #ADD clslib.tar.gz /usr/local/lib64/rados-classes/
 
-ADD mgr_plugins.tar.gz /usr/local/lib64/ceph/mgr
-# for openSUSE, use:
-# ADD mgr_plugins.tar.gz /usr/share/ceph/mgr
+ADD mgr_plugins.tar.gz /usr/share/ceph/mgr


### PR DESCRIPTION
Also use the latest master as default FROM

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

