### PR TITLE
crimson: support pgnls and delete op

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1538,3 +1538,5 @@ OPTION(rgw_sts_token_introspection_url, OPT_STR)  // url for introspecting web t
 OPTION(rgw_sts_client_id, OPT_STR) // Client Id
 OPTION(rgw_sts_client_secret, OPT_STR) // Client Secret
 OPTION(debug_allow_any_pool_priority, OPT_BOOL)
+
+OPTION(crimson_debug_pg_always_active, OPT_BOOL)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8240,6 +8240,10 @@ std::vector<Option> get_mds_client_options() {
     Option("debug_allow_any_pool_priority", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description("Allow any pool priority to be set to test conversion to new range"),
+
+    Option("crimson_debug_pg_always_active", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(true)
+    .set_description("remove me once crimson peering works"),
   });
 }
 

--- a/src/crimson/os/cyan_store.h
+++ b/src/crimson/os/cyan_store.h
@@ -78,6 +78,11 @@ public:
     CollectionRef c,
     const ghobject_t& oid,
     std::vector<std::string>&& keys);
+  seastar::future<std::vector<ghobject_t>, ghobject_t> list_objects(
+    CollectionRef c,
+    const ghobject_t& start,
+    const ghobject_t& end,
+    uint64_t limit);
   CollectionRef create_new_collection(const coll_t& cid);
   CollectionRef open_collection(const coll_t& cid);
   std::vector<coll_t> list_collections();

--- a/src/crimson/os/cyan_store.h
+++ b/src/crimson/os/cyan_store.h
@@ -96,6 +96,7 @@ public:
   uuid_d get_fsid() const;
 
 private:
+  int _remove(const coll_t& cid, const ghobject_t& oid);
   int _touch(const coll_t& cid, const ghobject_t& oid);
   int _write(const coll_t& cid, const ghobject_t& oid,
 	     uint64_t offset, size_t len, const bufferlist& bl,

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1006,6 +1006,8 @@ PG::do_osd_op(ObjectState& os, OSDOp& osd_op, ceph::os::Transaction& txn)
         osd_op.outdata = std::move(bl);
 	return seastar::now();
     });
+  case CEPH_OSD_OP_DELETE:
+    return backend->remove(os, txn);
   default:
     throw std::runtime_error(
       fmt::format("op '{}' not supported", ceph_osd_op_name(op.op)));

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -960,6 +960,9 @@ seastar::future<> PG::share_pg_info()
 seastar::future<> PG::wait_for_active()
 {
   logger().debug("wait_for_active: {}", pg_state_string(info.stats.state));
+  if (local_conf()->crimson_debug_pg_always_active) {
+    return seastar::now();
+  }
   if (test_state(PG_STATE_ACTIVE)) {
     return seastar::now();
   } else {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -134,6 +134,9 @@ private:
     ObjectState& os,
     OSDOp& op,
     ceph::os::Transaction& txn);
+  seastar::future<ceph::bufferlist> do_pgnls(ceph::bufferlist& indata,
+					     const std::string& nspace,
+					     uint64_t limit);
 
 private:
   const spg_t pgid;

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -275,6 +275,20 @@ seastar::future<> PGBackend::writefull(
   return seastar::now();
 }
 
+seastar::future<> PGBackend::remove(ObjectState& os,
+                                    ceph::os::Transaction& txn)
+{
+  // todo: snapset
+  txn.remove(coll->cid, ghobject_t{os.oi.soid, ghobject_t::NO_GEN, shard});
+  os.oi.size = 0;
+  os.oi.new_object();
+  // todo: update watchers
+  if (os.oi.is_whiteout()) {
+    os.oi.clear_flag(object_info_t::FLAG_WHITEOUT);
+  }
+  return seastar::now();
+}
+
 seastar::future<std::vector<hobject_t>, hobject_t>
 PGBackend::list_objects(const hobject_t& start, uint64_t limit)
 {

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1,6 +1,9 @@
 #include "pg_backend.h"
 
 #include <optional>
+#include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/algorithm/copy.hpp>
 #include <fmt/ostream.h>
 #include <seastar/core/print.hh>
 
@@ -270,4 +273,33 @@ seastar::future<> PGBackend::writefull(
     os.oi.size = op.extent.length;
   }
   return seastar::now();
+}
+
+seastar::future<std::vector<hobject_t>, hobject_t>
+PGBackend::list_objects(const hobject_t& start, uint64_t limit)
+{
+  auto gstart = start.is_min() ? ghobject_t{} : ghobject_t{start, 0, shard};
+  return store->list_objects(coll,
+                             gstart,
+                             ghobject_t::get_max(),
+                             limit)
+    .then([this](std::vector<ghobject_t> gobjects, ghobject_t next) {
+      std::vector<hobject_t> objects;
+      boost::copy(gobjects |
+        boost::adaptors::filtered([](const ghobject_t& o) {
+          if (o.is_pgmeta()) {
+            return false;
+          } else if (o.hobj.is_temp()) {
+            return false;
+          } else {
+            return o.is_no_gen();
+          }
+        }) |
+        boost::adaptors::transformed([](const ghobject_t& o) {
+          return o.hobj;
+        }),
+        std::back_inserter(objects));
+      return seastar::make_ready_future<std::vector<hobject_t>, hobject_t>(
+        objects, next.hobj);
+    });
 }

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -41,6 +41,9 @@ public:
 				   size_t truncate_size,
 				   uint32_t truncate_seq,
 				   uint32_t flags);
+  seastar::future<> remove(
+    ObjectState& os,
+    ceph::os::Transaction& txn);
   seastar::future<> writefull(
     ObjectState& os,
     const OSDOp& osd_op,

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -49,6 +49,9 @@ public:
     cached_os_t&& os,
     ceph::os::Transaction&& txn,
     const MOSDOp& m);
+  seastar::future<std::vector<hobject_t>, hobject_t> list_objects(
+    const hobject_t& start,
+    uint64_t limit);
 
 protected:
   const shard_id_t shard;


### PR DESCRIPTION
i want to use "rados cleanup" to remove objects, so i can repeat the write-read test using crimson-osd without recreating the cluster.