### PR TITLE
cephfs-shell: Fix multiple flake8 errors

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -107,7 +107,7 @@ def list_items(dir_name=''):
     else:
         try:
             d = cephfs.opendir(dir_name)
-        except:
+        except libcephfs.Error:
             dir_name = dir_name.decode('utf-8')
             return []
     dent = cephfs.readdir(d)
@@ -206,7 +206,7 @@ def is_dir_exists(dir_name, dir_=''):
     path_to_stat = os.path.join(dir_, dir_name)
     try:
         return ((cephfs.stat(path_to_stat).st_mode & 0o0040000) != 0)
-    except:
+    except libcephfs.Error:
         return False
 
 
@@ -218,7 +218,7 @@ def is_file_exists(file_name, dir_=''):
     try:
         # if its not a directory, then its a file
         return ((cephfs.stat(os.path.join(dir_, file_name)).st_mode & 0o0040000) == 0)
-    except:
+    except libcephfs.Error:
         return False
 
 
@@ -497,7 +497,7 @@ exists.')
             else:
                 try:
                     cephfs.mkdir(path, permission)
-                except:
+                except libcephfs.Error:
                     self.poutput("directory missing in the path; "
                                  "you may want to pass the -p argument")
                     return
@@ -815,7 +815,7 @@ sub-directories, files')
             if not is_pattern and dir_path != os.path.normpath(path):
                 try:
                     cephfs.rmdir(to_bytes(dir_path))
-                except:
+                except libcephfs.Error:
                     self.poutput('error: no such directory "%s"' % dir_path)
 
     def complete_rm(self, text, line, begidx, endidx):
@@ -840,7 +840,7 @@ sub-directories, files')
             else:
                 try:
                     cephfs.unlink(to_bytes(file_path))
-                except:
+                except libcephfs.Error:
                     self.poutput('%s: no such file' % file_path)
 
     def complete_mv(self, text, line, begidx, endidx):
@@ -861,7 +861,7 @@ sub-directories, files')
         """
         try:
             cephfs.rename(to_bytes(args.src_path), to_bytes(args.dest_path))
-        except:
+        except libcephfs.Error:
             self.poutput("error: need a file name to move to")
 
     def complete_cd(self, text, line, begidx, endidx):
@@ -890,7 +890,7 @@ sub-directories, files')
         else:
             try:
                 cephfs.chdir(to_bytes(args.dir_name))
-            except:
+            except libcephfs.Error:
                 self.poutput("%s: no such directory" % args.dir_name)
         self.working_dir = cephfs.getcwd().decode('utf-8')
         self.set_prompt()
@@ -919,7 +919,7 @@ sub-directories, files')
         mode = int(args.mode, base=8)
         try:
             cephfs.chmod(args.file_name, mode)
-        except:
+        except libcephfs.Error:
             self.poutput('%s: no such file or directory' % args.file_name)
 
     def complete_cat(self, text, line, begidx, endidx):

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -466,7 +466,6 @@ class CephFSShell(Cmd):
 
             setattr(namespace, self.dest, str(oct(o_mode)))
 
-
     mkdir_parser = argparse.ArgumentParser(
         description='Create the directory(ies), if they do not already exist.')
     mkdir_parser.add_argument('dirs', type=str,
@@ -501,7 +500,6 @@ exists.')
                     self.poutput("directory missing in the path; "
                                  "you may want to pass the -p argument")
                     return
-
 
     def complete_put(self, text, line, begidx, endidx):
         """

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -566,7 +566,7 @@ exists.')
         else:
             for src_dir, dirs, files in os.walk(root_src_dir):
                 dst_dir = src_dir.replace(root_src_dir, root_dst_dir, 1)
-                dst_dir = re.sub('\/+', '/', cephfs.getcwd().decode('utf-8') + dst_dir)
+                dst_dir = re.sub(r'\/+', '/', cephfs.getcwd().decode('utf-8') + dst_dir)
                 if args.force and dst_dir != '/' and not is_dir_exists(dst_dir[:-1]) and len(locate_file(dst_dir)) == 0:
                     try:
                         cephfs.mkdirs(to_bytes(dst_dir), 0o777)
@@ -587,7 +587,7 @@ exists.')
 
                 for file_ in files:
                     src_file = os.path.join(src_dir, file_)
-                    dst_file = re.sub('\/+', '/', '/' + dst_dir + '/' + file_)
+                    dst_file = re.sub(r'\/+', '/', '/' + dst_dir + '/' + file_)
                     if (not args.force) and is_file_exists(dst_file):
                         return
                     copy_from_local(src_file, os.path.join(

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -739,7 +739,7 @@ exists.')
                     print_long(cephfs.getcwd().decode(
                         'utf-8') + dir_name + '/' + path, is_dir, True)
                 elif args.long:
-                    print_long(cephfs.getcwd().decode( 'utf-8') +
+                    print_long(cephfs.getcwd().decode('utf-8') +
                                dir_name +
                                '/' +
                                path,

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -722,7 +722,6 @@ exists.')
             if not args.all:
                 items = [i for i in items if not i.d_name.startswith(b'.')]
 
-            flag = 0
             if args.S:
                 items = sorted(items, key=lambda item: cephfs.stat(
                     to_bytes(dir_name + '/' + item.d_name.decode('utf-8'))).st_size)


### PR DESCRIPTION
This patch set fixes the following flake8 errors and warnings:
* E722 do not use bare 'except'
* E303 too many blank lines
* W605 invalid escape sequence '\/'
* F841 local variable 'flag' is assigned to but never used
* E201 whitespace after '('

Fixes: https://tracker.ceph.com/issues/39717
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

