### PR TITLE
mgr/dashboard: Optimize portal IPs calculation

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -570,10 +570,8 @@ class IscsiTarget(RESTController):
     def _config_to_target(target_iqn, config):
         target_config = config['targets'][target_iqn]
         portals = []
-        for host in target_config['portals'].keys():
-            ips = IscsiClient.instance(gateway_name=host).get_ip_addresses()['data']
-            portal_ips = [ip for ip in ips if ip in target_config['ip_list']]
-            for portal_ip in portal_ips:
+        for host, portal_config in target_config['portals'].items():
+            for portal_ip in portal_config['portal_ip_addresses']:
                 portal = {
                     'host': host,
                     'ip': portal_ip

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -475,7 +475,7 @@ class IscsiClientMock(object):
             "gateways": {},
             "targets": {},
             "updated": "",
-            "version": 5
+            "version": 9
         }
 
     @classmethod
@@ -550,7 +550,7 @@ class IscsiClientMock(object):
             target_config['ip_list'] = []
         target_config['ip_list'] += ip_address
         target_config['portals'][gateway_name] = {
-            "portal_ip_address": ip_address[0]
+            "portal_ip_addresses": ip_address
         }
 
     def create_disk(self, pool, image, backstore):


### PR DESCRIPTION
Now that portal IPs are part of the ceph-iscsi config (since https://github.com/ceph/ceph-iscsi/pull/63) we don't have to calculate this information, we just use the `portal_ip_addresses` field returned by ceph-iscsi directly.

Signed-off-by: Ricardo Marques <rimarques@suse.com>
