### PR TITLE
crimson, common: RefCountedObj doesn't use atomics in Seastar builds.

### DIFF
--- a/src/common/RefCountedObj.h
+++ b/src/common/RefCountedObj.h
@@ -72,7 +72,12 @@ public:
   }
 
 private:
+#ifndef WITH_SEASTAR
   mutable std::atomic<uint64_t> nref;
+#else
+  // crimson is single threaded at the moment
+  mutable uint64_t nref;
+#endif
   CephContext *cct;
 };
 


### PR DESCRIPTION
This patch is [side-effect of the regression investigation](https://github.com/ceph/ceph/commit/c3b385ba0766e89bd426f5aa6cd451d68f6f00e3#commitcomment-33514817).  In the future we might want to consider `ceph::atomic` for applying in other places as well (`bufferlist`?).

Related-To: https://github.com/ceph/ceph/pull/28071