### PR TITLE
mimic: rgw: cls_bucket_list_unordered lists a single shard

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -207,20 +207,33 @@ void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, string&
   o.exec(RGW_CLASS, RGW_BUCKET_COMPLETE_OP, in);
 }
 
-static bool issue_bucket_list_op(librados::IoCtx& io_ctx,
-    const string& oid, const cls_rgw_obj_key& start_obj, const string& filter_prefix,
-    uint32_t num_entries, bool list_versions, BucketIndexAioManager *manager,
-    struct rgw_cls_list_ret *pdata) {
+void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
+                            const cls_rgw_obj_key& start_obj,
+                            const std::string& filter_prefix,
+                            uint32_t num_entries,
+                            bool list_versions,
+                            rgw_cls_list_ret* result)
+{
   bufferlist in;
-  struct rgw_cls_list_op call;
+  rgw_cls_list_op call;
   call.start_obj = start_obj;
   call.filter_prefix = filter_prefix;
   call.num_entries = num_entries;
   call.list_versions = list_versions;
   encode(call, in);
 
+  op.exec(RGW_CLASS, RGW_BUCKET_LIST, in, new ClsBucketIndexOpCtx<rgw_cls_list_ret>(result, NULL));
+}
+
+static bool issue_bucket_list_op(librados::IoCtx& io_ctx, const string& oid,
+				 const cls_rgw_obj_key& start_obj,
+				 const string& filter_prefix,
+				 uint32_t num_entries, bool list_versions,
+				 BucketIndexAioManager *manager,
+				 rgw_cls_list_ret *pdata) {
   librados::ObjectReadOperation op;
-  op.exec(RGW_CLASS, RGW_BUCKET_LIST, in, new ClsBucketIndexOpCtx<struct rgw_cls_list_ret>(pdata, NULL));
+  cls_rgw_bucket_list_op(op, start_obj, filter_prefix,
+                         num_entries, list_versions, pdata);
   return manager->aio_operate(io_ctx, oid, &op);
 }
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -419,6 +419,13 @@ public:
   start_obj(_start_obj), filter_prefix(_filter_prefix), num_entries(_num_entries), list_versions(_list_versions), result(list_results) {}
 };
 
+void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
+                            const cls_rgw_obj_key& start_obj,
+                            const std::string& filter_prefix,
+                            uint32_t num_entries,
+                            bool list_versions,
+                            rgw_cls_list_ret* result);
+
 class CLSRGWIssueBILogList : public CLSRGWConcurrentIO {
   map<int, struct cls_rgw_bi_log_list_ret>& result;
   BucketIndexShardsManager& marker_mgr;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -13373,19 +13373,16 @@ int RGWRados::cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
   while (count <= num_entries &&
 	 ((shard_id >= 0 && current_shard == uint32_t(shard_id)) ||
 	  current_shard < num_shards)) {
-    // key   - oid (for different shards if there is any)
-    // value - list result for the corresponding oid (shard), it is filled by
-    //         the AIO callback
-    map<int, struct rgw_cls_list_ret> list_results;
-    r = CLSRGWIssueBucketList(index_ctx, my_start, prefix, num_entries,
-			      list_versions, oids, list_results,
-			      cct->_conf->rgw_bucket_index_max_aio)();
+    const std::string& oid = oids[current_shard];
+    rgw_cls_list_ret result;
+
+    librados::ObjectReadOperation op;
+    cls_rgw_bucket_list_op(op, my_start, prefix, num_entries,
+                           list_versions, &result);
+    r = index_ctx.operate(oid, &op, nullptr);
     if (r < 0)
       return r;
 
-    const std::string& oid = oids[current_shard];
-    assert(list_results.find(current_shard) != list_results.end());
-    auto& result = list_results[current_shard];
     for (auto& entry : result.dir.m) {
       rgw_bucket_dir_entry& dirent = entry.second;
 


### PR DESCRIPTION
backport tracker: http://tracker.ceph.com/issues/39411