### PR TITLE
mimic: cephfs: mount.ceph.c: do not pass nofail to the kernel

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -150,6 +150,8 @@ static char *parse_options(const char *data, int *filesys_flags)
 			skip = 1;  /* ignore */
 		} else if (strncmp(data, "_netdev", 7) == 0) {
 			skip = 1;  /* ignore */
+		} else if (strncmp(data, "nofail", 6) == 0) {
+			skip = 1;  /* ignore */
 
 		} else if (strncmp(data, "secretfile", 10) == 0) {
 			if (!value || !*value) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/39233