### PR TITLE
rgw: fix Metadata search is not available when using tenants

### DIFF
--- a/src/rgw/rgw_es_query.cc
+++ b/src/rgw/rgw_es_query.cc
@@ -149,7 +149,9 @@ public:
   }
   virtual ~ESQueryNode_Bool() {
     delete first;
+    first = nullptr;
     delete second;
+    second = nullptr;
   }
 
   void dump(Formatter *f) const override {
@@ -157,7 +159,9 @@ public:
     const char *section = (op == "and" ? "must" : "should");
     f->open_array_section(section);
     encode_json("entry", *first, f);
-    encode_json("entry", *second, f);
+    if (second) {
+      encode_json("entry", *second, f);
+    }
     f->close_section();
     f->close_section();
   }
@@ -670,8 +674,10 @@ bool ESQueryCompiler::compile(string *perr) {
     return false;
   }
 
-  if (!convert(infix, perr)) {
-    return false;
+  if (!infix.empty()) {
+    if (!convert(infix, perr)) {
+      return false;
+    }
   }
 
   for (auto& c : eq_conds) {
@@ -689,6 +695,8 @@ bool ESQueryCompiler::compile(string *perr) {
 }
 
 void ESQueryCompiler::dump(Formatter *f) const {
-  encode_json("query", *query_root, f);
+  if (query_root) {
+    encode_json("query", *query_root, f);
+  }
 }
 

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -166,7 +166,7 @@ void RGWMetadataSearchOp::execute()
   list<pair<string, string> > conds;
 
   if (!s->user->system) {
-    conds.push_back(make_pair("permissions", s->user->user_id.to_str()));
+    conds.push_back(make_pair("permissions.keyword", s->user->user_id.to_str()));
   }
 
   if (!s->bucket_name.empty()) {
@@ -189,13 +189,14 @@ void RGWMetadataSearchOp::execute()
                                   { "content_type", "meta.content_type" },
                                   { "storageclass", "meta.storage_class" },
                                   { "storage_class", "meta.storage_class" },
+				  { "permissions", "permissions.keyword" },
   };
   es_query.set_field_aliases(&aliases);
 
   static map<string, ESEntityTypeMap::EntityType> generic_map = { {"bucket", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"name", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"instance", ESEntityTypeMap::ES_ENTITY_STR},
-                                                           {"permissions", ESEntityTypeMap::ES_ENTITY_STR},
+                                                           {"permissions.keyword", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"meta.etag", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"meta.content_type", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"meta.mtime", ESEntityTypeMap::ES_ENTITY_DATE},
@@ -204,7 +205,7 @@ void RGWMetadataSearchOp::execute()
   ESEntityTypeMap gm(generic_map);
   es_query.set_generic_type_map(&gm);
 
-  static set<string> restricted_fields = { {"permissions"} };
+  static set<string> restricted_fields = { {"permissions.keyword"} };
   es_query.set_restricted_fields(&restricted_fields);
 
   map<string, ESEntityTypeMap::EntityType> custom_map;

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -165,8 +165,10 @@ void RGWMetadataSearchOp::execute()
 
   list<pair<string, string> > conds;
 
+  set<string> restricted_fields = { { } };
   if (!s->user->system) {
     conds.push_back(make_pair("permissions.keyword", s->user->user_id.to_str()));
+    restricted_fields = { {"permissions.keyword"} };
   }
 
   if (!s->bucket_name.empty()) {
@@ -205,7 +207,6 @@ void RGWMetadataSearchOp::execute()
   ESEntityTypeMap gm(generic_map);
   es_query.set_generic_type_map(&gm);
 
-  static set<string> restricted_fields = { {"permissions.keyword"} };
   es_query.set_restricted_fields(&restricted_fields);
 
   map<string, ESEntityTypeMap::EntityType> custom_map;


### PR DESCRIPTION
http://tracker.ceph.com/issues/39940

Fixes: http://tracker.ceph.com/issues/39940
Signed-off-by: Snow Si  silonghu@inspur.com

src/rgw/rgw_sync_module_es_rest.cc: modify permissions ->permissions.keyword

rgw: fix Metadata search is not available when using tenants
tenant$uid: xxcs$test
permissions: xxcs$test
a.Elasticsearch PUT OBJECT: (permissions: xxcs)->OBJECT; (permissions: test)->OBJECT (permissions.keyword: xxcs$test) -> OBJECT
b.Elasticsearch Query: (permissions == xxcs$test) can not -> OBJECT; (permissions.keyword == xxcs$test) can -> OBJECT

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

