### PR TITLE
mgr/dashboard: show degraded/misplaced/unfound objects.

### DIFF
--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -7,6 +7,18 @@ from .helper import DashboardTestCase, JAny, JLeaf, JList, JObj
 class HealthTest(DashboardTestCase):
     CEPHFS = True
 
+    __pg_info_schema = JObj({
+        'object_stats': JObj({
+            'num_objects': int,
+            'num_object_copies': int,
+            'num_objects_degraded': int,
+            'num_objects_misplaced': int,
+            'num_objects_unfound': int
+        }),
+        'pgs_per_osd': float,
+        'statuses': JObj({}, allow_unknown=True, unknown_schema=int)
+    })
+
     def test_minimal_health(self):
         data = self._get('/api/health/minimal')
         self.assertStatus(200)
@@ -22,7 +34,6 @@ class HealthTest(DashboardTestCase):
                 'stats': JObj({
                     'total_avail_bytes': int,
                     'total_bytes': int,
-                    'total_objects': int,
                     'total_used_raw_bytes': int,
                 })
             }),
@@ -65,10 +76,7 @@ class HealthTest(DashboardTestCase):
                         'up': int,
                     })),
             }),
-            'pg_info': JObj({
-                'pgs_per_osd': float,
-                'statuses': JObj({}, allow_unknown=True, unknown_schema=int)
-            }),
+            'pg_info': self.__pg_info_schema,
             'pools': JList(JLeaf(dict)),
             'rgw': int,
             'scrub_status': str
@@ -134,7 +142,6 @@ class HealthTest(DashboardTestCase):
                 'stats': JObj({
                     'total_avail_bytes': int,
                     'total_bytes': int,
-                    'total_objects': int,
                     'total_used_bytes': int,
                     'total_used_raw_bytes': int,
                     'total_used_raw_ratio': float
@@ -243,10 +250,7 @@ class HealthTest(DashboardTestCase):
                         'up': int,
                     }, allow_unknown=True)),
             }, allow_unknown=True),
-            'pg_info': JObj({
-                'pgs_per_osd': float,
-                'statuses': JObj({}, allow_unknown=True, unknown_schema=int)
-            }),
+            'pg_info': self.__pg_info_schema,
             'pools': JList(JLeaf(dict)),
             'rgw': int,
             'scrub_status': str

--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -94,12 +94,10 @@ class HealthData(object):
 
         del df['stats_by_class']
 
-        df['stats']['total_objects'] = sum(
-            [p['stats']['objects'] for p in df['pools']])
         if self._minimal:
             df = dict(stats=self._partial_dict(
                 df['stats'],
-                ['total_avail_bytes', 'total_bytes', 'total_objects',
+                ['total_avail_bytes', 'total_bytes',
                  'total_used_raw_bytes']
             ))
         return df
@@ -163,10 +161,7 @@ class HealthData(object):
         return osd_map
 
     def pg_info(self):
-        pg_info = CephService.get_pg_info()
-        if self._minimal:
-            pg_info = self._partial_dict(pg_info, ['pgs_per_osd', 'statuses'])
-        return pg_info
+        return CephService.get_pg_info()
 
     def pools(self):
         pools = CephService.get_pool_list_with_stats()

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
+import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
 import { FormatterService } from '../../../shared/services/formatter.service';
 import { HealthPieComponent } from './health-pie.component';
 
@@ -13,7 +14,7 @@ describe('HealthPieComponent', () => {
   configureTestBed({
     schemas: [NO_ERRORS_SCHEMA],
     declarations: [HealthPieComponent],
-    providers: [DimlessBinaryPipe, FormatterService]
+    providers: [DimlessBinaryPipe, DimlessPipe, FormatterService]
   });
 
   beforeEach(() => {
@@ -23,34 +24,6 @@ describe('HealthPieComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('Set doughnut if nothing received', () => {
-    component.chartType = '';
-    fixture.detectChanges();
-
-    expect(component.chartConfig.chartType).toEqual('doughnut');
-  });
-
-  it('Set doughnut if not allowed value received', () => {
-    component.chartType = 'badType';
-    fixture.detectChanges();
-
-    expect(component.chartConfig.chartType).toEqual('doughnut');
-  });
-
-  it('Set doughnut if doughnut received', () => {
-    component.chartType = 'doughnut';
-    fixture.detectChanges();
-
-    expect(component.chartConfig.chartType).toEqual('doughnut');
-  });
-
-  it('Set pie if pie received', () => {
-    component.chartType = 'pie';
-    fixture.detectChanges();
-
-    expect(component.chartConfig.chartType).toEqual('pie');
   });
 
   it('Add slice border if there is more than one slice with numeric non zero value', () => {
@@ -80,5 +53,22 @@ describe('HealthPieComponent', () => {
     component.ngOnChanges();
 
     expect(component.chartConfig.dataset[0].data).toEqual(initialData);
+  });
+
+  describe('tooltip body', () => {
+    const tooltipBody = ['text: 10000'];
+
+    it('should return amount converted to appropriate units', () => {
+      component.isBytesData = false;
+      expect(component['getChartTooltipBody'](tooltipBody)).toEqual('text: 10 k');
+
+      component.isBytesData = true;
+      expect(component['getChartTooltipBody'](tooltipBody)).toEqual('text: 9.8 KiB');
+    });
+
+    it('should not return amount when showing label as tooltip', () => {
+      component.showLabelAsTooltip = true;
+      expect(component['getChartTooltipBody'](tooltipBody)).toEqual('text');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -148,9 +148,6 @@
                     *ngIf="healthData.client_perf">
         <cd-health-pie *ngIf="isClientReadWriteChartShowable()"
                        [data]="healthData"
-                       [isBytesData]="false"
-                       chartType="pie"
-                       [displayLegend]="true"
                        (prepareFn)="prepareReadWriteRatio($event[0], $event[1])">
         </cd-health-pie>
         <span *ngIf="!isClientReadWriteChartShowable()">
@@ -183,7 +180,6 @@
                  class="row info-group"
                  *ngIf="healthData.pools
                  || healthData.df
-                 || healthData.df?.stats?.total_objects != null
                  || healthData.pg_info">
 
     <div class="cd-container-flex">
@@ -204,9 +200,8 @@
                     contentClass="content-chart"
                     *ngIf="healthData.df">
         <cd-health-pie [data]="healthData"
+                       [config]="rawCapacityChartConfig"
                        [showLabelAsTooltip]="true"
-                       chartType="pie"
-                       [displayLegend]="true"
                        (prepareFn)="prepareRawUsage($event[0], $event[1])">
         </cd-health-pie>
       </cd-info-card>
@@ -215,9 +210,12 @@
                     i18n-cardTitle
                     class="cd-col-5"
                     cardClass="card-medium"
-                    contentClass="content-medium content-highlight"
-                    *ngIf="healthData.df?.stats?.total_objects != null">
-        {{ healthData.df?.stats?.total_objects }}
+                    contentClass="content-chart"
+                    *ngIf="healthData.pg_info?.object_stats?.num_objects != null">
+        <cd-health-pie [data]="healthData"
+                       [config]="objectsChartConfig"
+                       (prepareFn)="prepareObjects($event[0], $event[1])">
+        </cd-health-pie>
       </cd-info-card>
 
       <cd-info-card cardTitle="PGs per OSD"
@@ -250,8 +248,7 @@
                #pgStatusTarget="bs-popover"
                placement="bottom">
             <cd-health-pie [data]="healthData"
-                           chartType="pie"
-                           [displayLegend]="true"
+                           [config]="pgStatusChartConfig"
                            (prepareFn)="preparePgStatus($event[0], $event[1])">
             </cd-health-pie>
           </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -7,6 +7,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { HealthService } from '../../../shared/api/health.service';
 import { Permissions } from '../../../shared/models/permissions';
 import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
+import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import {
   FeatureTogglesMap$,
@@ -27,6 +28,39 @@ export class HealthComponent implements OnInit, OnDestroy {
   permissions: Permissions;
   enabledFeature$: FeatureTogglesMap$;
 
+  rawCapacityChartConfig = {
+    options: {
+      title: { display: true, position: 'bottom' }
+    }
+  };
+  objectsChartConfig = {
+    options: {
+      title: { display: true, position: 'bottom' }
+    },
+    colors: [
+      {
+        backgroundColor: [
+          HealthPieColor.DEFAULT_GREEN,
+          HealthPieColor.DEFAULT_MAGENTA,
+          HealthPieColor.DEFAULT_ORANGE,
+          HealthPieColor.DEFAULT_RED
+        ]
+      }
+    ]
+  };
+  pgStatusChartConfig = {
+    colors: [
+      {
+        backgroundColor: [
+          HealthPieColor.DEFAULT_GREEN,
+          HealthPieColor.DEFAULT_BLUE,
+          HealthPieColor.DEFAULT_ORANGE,
+          HealthPieColor.DEFAULT_RED
+        ]
+      }
+    ]
+  };
+
   constructor(
     private healthService: HealthService,
     private i18n: I18n,
@@ -34,7 +68,8 @@ export class HealthComponent implements OnInit, OnDestroy {
     private pgCategoryService: PgCategoryService,
     private featureToggles: FeatureTogglesService,
     private refreshIntervalService: RefreshIntervalService,
-    private dimlessBinary: DimlessBinaryPipe
+    private dimlessBinary: DimlessBinaryPipe,
+    private dimless: DimlessPipe
   ) {
     this.permissions = this.authStorageService.getPermissions();
     this.enabledFeature$ = this.featureToggles.get();
@@ -63,12 +98,20 @@ export class HealthComponent implements OnInit, OnDestroy {
 
     const total =
       this.healthData.client_perf.write_op_per_sec + this.healthData.client_perf.read_op_per_sec;
-    const calcPercentage = (status) =>
-      Math.round(((this.healthData.client_perf[status] || 0) / total) * 100);
 
-    ratioLabels.push(`${this.i18n('Writes')} (${calcPercentage('write_op_per_sec')}%)`);
+    ratioLabels.push(
+      `${this.i18n('Writes')} (${this.calcPercentage(
+        this.healthData.client_perf.write_op_per_sec,
+        total
+      )}%)`
+    );
     ratioData.push(this.healthData.client_perf.write_op_per_sec);
-    ratioLabels.push(`${this.i18n('Reads')} (${calcPercentage('read_op_per_sec')}%)`);
+    ratioLabels.push(
+      `${this.i18n('Reads')} (${this.calcPercentage(
+        this.healthData.client_perf.read_op_per_sec,
+        total
+      )}%)`
+    );
     ratioData.push(this.healthData.client_perf.read_op_per_sec);
 
     chart.dataset[0].data = ratioData;
@@ -76,20 +119,17 @@ export class HealthComponent implements OnInit, OnDestroy {
   }
 
   prepareRawUsage(chart, data) {
-    const percentAvailable = Math.round(
-      100 *
-        ((data.df.stats.total_bytes - data.df.stats.total_used_raw_bytes) /
-          data.df.stats.total_bytes)
+    const percentAvailable = this.calcPercentage(
+      data.df.stats.total_bytes - data.df.stats.total_used_raw_bytes,
+      data.df.stats.total_bytes
     );
-
-    const percentUsed = Math.round(
-      100 * (data.df.stats.total_used_raw_bytes / data.df.stats.total_bytes)
+    const percentUsed = this.calcPercentage(
+      data.df.stats.total_used_raw_bytes,
+      data.df.stats.total_bytes
     );
 
     chart.dataset[0].data = [data.df.stats.total_used_raw_bytes, data.df.stats.total_avail_bytes];
-    if (chart === 'doughnut') {
-      chart.options.cutoutPercentage = 65;
-    }
+
     chart.labels = [
       `${this.dimlessBinary.transform(data.df.stats.total_used_raw_bytes)} ${this.i18n(
         'Used'
@@ -99,25 +139,13 @@ export class HealthComponent implements OnInit, OnDestroy {
       )} ${this.i18n('Avail.')} (${percentAvailable}%)`
     ];
 
-    chart.options.title = {
-      display: true,
-      text: `${this.dimlessBinary.transform(data.df.stats.total_bytes)} total`,
-      position: 'bottom'
-    };
+    chart.options.title.text = `${this.dimlessBinary.transform(
+      data.df.stats.total_bytes
+    )} ${this.i18n('total')}`;
   }
 
   preparePgStatus(chart, data) {
     const categoryPgAmount = {};
-    chart.colors = [
-      {
-        backgroundColor: [
-          HealthPieColor.DEFAULT_GREEN,
-          HealthPieColor.DEFAULT_BLUE,
-          HealthPieColor.DEFAULT_ORANGE,
-          HealthPieColor.DEFAULT_RED
-        ]
-      }
-    ];
 
     _.forEach(data.pg_info.statuses, (pgAmount, pgStatesText) => {
       const categoryType = this.pgCategoryService.getTypeByStates(pgStatesText);
@@ -132,15 +160,62 @@ export class HealthComponent implements OnInit, OnDestroy {
       .getAllTypes()
       .map((categoryType) => categoryPgAmount[categoryType]);
 
-    const calcPercentage = (status) =>
-      Math.round(((categoryPgAmount[status] || 0) / data.pg_info.pgs_per_osd) * 100) || 0;
+    chart.labels = [
+      `${this.i18n('Clean')} (${this.calcPercentage(
+        categoryPgAmount['clean'],
+        data.pg_info.pgs_per_osd
+      )}%)`,
+      `${this.i18n('Working')} (${this.calcPercentage(
+        categoryPgAmount['working'],
+        data.pg_info.pgs_per_osd
+      )}%)`,
+      `${this.i18n('Warning')} (${this.calcPercentage(
+        categoryPgAmount['warning'],
+        data.pg_info.pgs_per_osd
+      )}%)`,
+      `${this.i18n('Unknown')} (${this.calcPercentage(
+        categoryPgAmount['unknown'],
+        data.pg_info.pgs_per_osd
+      )}%)`
+    ];
+  }
+
+  prepareObjects(chart, data) {
+    const totalReplicas = data.pg_info.object_stats.num_object_copies;
+    const healthy =
+      totalReplicas -
+      data.pg_info.object_stats.num_objects_misplaced -
+      data.pg_info.object_stats.num_objects_degraded -
+      data.pg_info.object_stats.num_objects_unfound;
 
     chart.labels = [
-      `${this.i18n('Clean')} (${calcPercentage('clean')}%)`,
-      `${this.i18n('Working')} (${calcPercentage('working')}%)`,
-      `${this.i18n('Warning')} (${calcPercentage('warning')}%)`,
-      `${this.i18n('Unknown')} (${calcPercentage('unknown')}%)`
+      `${this.i18n('Healthy')} (${this.calcPercentage(healthy, totalReplicas)}%)`,
+      `${this.i18n('Misplaced')} (${this.calcPercentage(
+        data.pg_info.object_stats.num_objects_misplaced,
+        totalReplicas
+      )}%)`,
+      `${this.i18n('Degraded')} (${this.calcPercentage(
+        data.pg_info.object_stats.num_objects_degraded,
+        totalReplicas
+      )}%)`,
+      `${this.i18n('Unfound')} (${this.calcPercentage(
+        data.pg_info.object_stats.num_objects_unfound,
+        totalReplicas
+      )}%)`
     ];
+
+    chart.dataset[0].data = [
+      healthy,
+      data.pg_info.object_stats.num_objects_misplaced,
+      data.pg_info.object_stats.num_objects_degraded,
+      data.pg_info.object_stats.num_objects_unfound
+    ];
+
+    chart.options.title.text = `${this.dimless.transform(
+      data.pg_info.object_stats.num_objects
+    )} ${this.i18n('total')} (${this.dimless.transform(totalReplicas)} ${this.i18n('replicas')})`;
+
+    chart.options.maintainAspectRatio = window.innerWidth >= 375;
   }
 
   isClientReadWriteChartShowable() {
@@ -148,5 +223,13 @@ export class HealthComponent implements OnInit, OnDestroy {
     const writeOps = this.healthData.client_perf.write_op_per_sec || 0;
 
     return readOps + writeOps > 0;
+  }
+
+  private calcPercentage(dividend: number, divisor: number) {
+    if (!_.isNumber(dividend) || !_.isNumber(divisor) || divisor === 0) {
+      return 0;
+    }
+
+    return Math.round((dividend / divisor) * 100);
   }
 }


### PR DESCRIPTION
* Landing Page 'Objects' card now is a chart that shows more info about objects.
* Fix: Dimless/dimlessBinary pipe applied to amount displayed in 
  chart slice tooltip body (if shown).
* Refactoring: simplified way of setting chart initial config
  via 'config' @Input; erased redundant @Inputs.
  Updated chart component default config (for the sake of simplicity).

Fixes: https://tracker.ceph.com/issues/39613

Signed-off-by: Alfonso Martínez <almartin@redhat.com>

![39613-objects-chart](https://user-images.githubusercontent.com/6780162/57780038-ac521080-7727-11e9-903a-a8683d450040.png)


- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

