### PR TITLE
msg: support callback when message is sent.

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4012,6 +4012,8 @@ struct AnonConnection : public Connection {
   int send_message(Message *m) override {
     ceph_assert(!"send_message on anonymous connection");
   }
+  void message_sent(const MessageRef&) override {}
+  void set_message_sent_callback(std::function<void(const MessageRef&)> sent) override {}
   void send_keepalive() override {
     ceph_assert(!"send_keepalive on anonymous connection");
   }

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -126,10 +126,13 @@ public:
    *
    * @param m The Message to send. The Messenger consumes a single reference
    * when you pass it in.
-   *
    * @return 0 on success, or -errno on failure.
    */
   virtual int send_message(Message *m) = 0;
+  // called to notify the connection that message is sent
+  virtual void message_sent(const MessageRef&) = 0;
+  // Callback called when a message is sent.
+  virtual void set_message_sent_callback(std::function<void(const MessageRef&)> sent) = 0;
 
   virtual int send_message2(MessageRef m)
   {

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1255,6 +1255,7 @@ public:
   void maybe_request_map();
 
   void enable_blacklist_events();
+  void sent_callback(const MessageRef&);
 private:
 
   void _maybe_request_map();
@@ -1908,6 +1909,8 @@ public:
   std::map<ceph_tid_t,StatfsOp*> statfs_ops;
   std::map<ceph_tid_t,PoolOp*> pool_ops;
   std::atomic<unsigned> num_homeless_ops{0};
+  std::map<ceph_tid_t, unsigned> op_refs;
+  std::map<ceph_tid_t, std::function<void()> > waiting_for_op_release;
 
   OSDSession *homeless_session;
 

--- a/src/test/direct_messenger/DirectMessenger.cc
+++ b/src/test/direct_messenger/DirectMessenger.cc
@@ -43,6 +43,8 @@ class DirectConnection : public Connection {
 
   /// pass the given message directly to our dispatchers
   int send_message(Message *m) override;
+  virtual void message_sent(const MessageRef&) override {}
+  virtual void set_message_sent_callback(std::function<void(const MessageRef&)> sent) override {}
 
   /// release our pointer to the peer connection. later calls to is_connected()
   /// will return false, and send_message() will fail with -ENOTCONN


### PR DESCRIPTION
To support copy-less writes in librados c api, we need to [ensure that all references of a message's buffer have been released](https://github.com/yuyuyu101/ceph/commit/794b49b#r15707924). When a pg is moved, its message will be resent, resulting two references in the messenger layer. Objecter should wait for the two references to be released before it can call message's onfinish.

To support this, we add a mechanism to call a callback when a message is sent in messenger layer, which Objecter can use to maintain message's references and call message's onfinish only when all references have been released.
See comments of https://github.com/ceph/ceph/pull/25689 .