### PR TITLE
os/bluestore: show device name in "osd metadata output"

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -177,10 +177,10 @@ public:
 
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const = 0;
 
-  virtual int get_devname(std::string *out) {
+  virtual int get_devname(std::string *out) const {
     return -ENOENT;
   }
-  virtual int get_devices(std::set<std::string> *ls) {
+  virtual int get_devices(std::set<std::string> *ls) const {
     std::string s;
     if (get_devname(&s) == 0) {
       ls->insert(s);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -223,7 +223,7 @@ out_fail:
   return r;
 }
 
-int KernelDevice::get_devices(std::set<std::string> *ls)
+int KernelDevice::get_devices(std::set<std::string> *ls) const
 {
   if (devname.empty()) {
     return 0;
@@ -272,6 +272,22 @@ int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm)
     uint64_t total, avail;
     get_vdo_utilization(vdo_fd, &total, &avail);
     (*pm)[prefix + "vdo_physical_size"] = stringify(total);
+  }
+
+  {
+    string res_names;
+    std::set<std::string> devnames;
+    if (get_devices(&devnames) == 0) {
+      for (auto& dev : devnames) {
+	if (!res_names.empty()) {
+	  res_names += ",";
+	}
+	res_names += dev;
+      }
+      if (res_names.size()) {
+	(*pm)[prefix + "devices"] = res_names;
+      }
+    }
   }
 
   struct stat st;

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -117,14 +117,14 @@ public:
   void discard_drain() override;
 
   int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
-  int get_devname(std::string *s) override {
+  int get_devname(std::string *s) const override {
     if (devname.empty()) {
       return -ENOENT;
     }
     *s = devname;
     return 0;
   }
-  int get_devices(std::set<std::string> *ls) override;
+  int get_devices(std::set<std::string> *ls) const override;
 
   bool get_thin_utilization(uint64_t *total, uint64_t *avail) const override;
 


### PR DESCRIPTION
Before the patch "ceph osd metadata" output could look like (lvm is in use):
"bluefs_db_partition_path": "/dev/dm-3",
...
"bluestore_bdev_path": "/home/if/ceph/build/dev/osd0/block",
...
"device_ids": "nvme0n1=INTEL_SSDPEDMD400G4_CVFT724400A6400LGN,sda=SAMSUNG_MZ7KM960HMJP-00005_S3F3NX0K501737",

So it was still questionable what's the actual HW id of DB or WAL or main devices.

The patch brings missing element to build the full mapping by adding:
"bluefs_db_devices": "nvme0n1",
"bluestore_bdev_devices": "sda",
"bluefs_wal_devices": "nvme0n1",

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

