### PR TITLE
nautilus: common: Clang requires a default constructor, but it can be empty

### DIFF
--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -224,6 +224,7 @@ public:
   static void generate_test_instances(std::list<BitVector *> &o);
 private:
   struct NoInitAllocator : public std::allocator<__u32> {
+    NoInitAllocator() {}
     NoInitAllocator(const std::allocator<__u32>& alloc)
       : std::allocator<__u32>(alloc) {
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/39573