### PR TITLE
luminous: librbd: ensure compare-and-write doesn't skip compare after copyup

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -157,7 +157,8 @@ void librados::ObjectOperation::cmpext(uint64_t off,
                                        int *prval)
 {
   ::ObjectOperation *o = &impl->o;
-  o->cmpext(off, cmp_bl, prval);
+  bufferlist c = cmp_bl;
+  o->cmpext(off, c, prval);
 }
 
 void librados::ObjectOperation::cmpxattr(const char *name, uint8_t op, const bufferlist& v)

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -6007,6 +6007,7 @@ ostream& operator<<(ostream& out, const OSDOp& op)
     case CEPH_OSD_OP_ZERO:
     case CEPH_OSD_OP_APPEND:
     case CEPH_OSD_OP_MAPEXT:
+    case CEPH_OSD_OP_CMPEXT:
       out << " " << op.op.extent.offset << "~" << op.op.extent.length;
       if (op.op.extent.truncate_seq)
 	out << " [" << op.op.extent.truncate_seq << "@"

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -20,6 +20,17 @@ static void to_vector(const interval_set<uint64_t> &set,
   }
 }
 
+// see PrimaryLogPG::finish_extent_cmp()
+static int cmpext_compare(const bufferlist &bl, const bufferlist &read_bl) {
+  for (uint64_t idx = 0; idx < bl.length(); ++idx) {
+    char read_byte = (idx < read_bl.length() ? read_bl[idx] : 0);
+    if (bl[idx] != read_byte) {
+      return -MAX_ERRNO - idx;
+    }
+  }
+  return 0;
+}
+
 namespace librados {
 
 TestMemIoCtxImpl::TestMemIoCtxImpl() {
@@ -620,32 +631,30 @@ int TestMemIoCtxImpl::writesame(const std::string& oid, bufferlist& bl, size_t l
 
 int TestMemIoCtxImpl::cmpext(const std::string& oid, uint64_t off,
                              bufferlist& cmp_bl) {
-  if (get_snap_read() != CEPH_NOSNAP) {
-    return -EROFS;
-  } else if (m_client->is_blacklisted()) {
+  if (m_client->is_blacklisted()) {
     return -EBLACKLISTED;
   }
 
-  if (cmp_bl.length() == 0) {
-    return -EINVAL;
-  }
+  bufferlist read_bl;
+  uint64_t len = cmp_bl.length();
 
   TestMemCluster::SharedFile file;
   {
-    RWLock::WLocker l(m_pool->file_lock);
-    file = get_file(oid, true, get_snap_context());
+    RWLock::RLocker l(m_pool->file_lock);
+    file = get_file(oid, false, get_snap_context());
+    if (file == NULL) {
+      return cmpext_compare(cmp_bl, read_bl);
+    }
   }
 
   RWLock::RLocker l(file->lock);
-  size_t len = cmp_bl.length();
-  ensure_minimum_length(off + len, &file->data);
-  if (len > 0 && off <= len) {
-    for (uint64_t p = off; p < len; p++)  {
-      if (file->data[p] != cmp_bl[p])
-        return -MAX_ERRNO - p;
-    }
+  if (off >= file->data.length()) {
+    len = 0;
+  } else if (off + len > file->data.length()) {
+    len = file->data.length() - off;
   }
-  return 0;
+  read_bl.substr_of(file->data, off, len);
+  return cmpext_compare(cmp_bl, read_bl);
 }
 
 int TestMemIoCtxImpl::xattr_get(const std::string& oid,

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -231,7 +231,7 @@ public:
     *passed = ((flags & RBD_FLAG_OBJECT_MAP_INVALID) == 0);
   }
 
-  std::string get_temp_image_name() {
+  static std::string get_temp_image_name() {
     ++_image_number;
     return "image" + stringify(_image_number);
   }

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3984,6 +3984,130 @@ TEST_F(TestLibRBD, TestPendingAio)
   rados_ioctx_destroy(ioctx);
 }
 
+void compare_and_write_copyup(librados::IoCtx &ioctx, bool deep_copyup,
+                              bool *passed)
+{
+  librbd::RBD rbd;
+  std::string parent_name = TestLibRBD::get_temp_image_name();
+  uint64_t size = 2 << 20;
+  int order = 0;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(), size, &order));
+
+  librbd::Image parent_image;
+  ASSERT_EQ(0, rbd.open(ioctx, parent_image, parent_name.c_str(), NULL));
+
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  ASSERT_EQ((ssize_t)bl.length(), parent_image.write(0, bl.length(), bl));
+
+  ASSERT_EQ(0, parent_image.snap_create("snap1"));
+  ASSERT_EQ(0, parent_image.snap_protect("snap1"));
+
+  uint64_t features;
+  ASSERT_EQ(0, parent_image.features(&features));
+
+  std::string clone_name = TestLibRBD::get_temp_image_name();
+  EXPECT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "snap1", ioctx,
+       clone_name.c_str(), features, &order));
+
+  librbd::Image clone_image;
+  ASSERT_EQ(0, rbd.open(ioctx, clone_image, clone_name.c_str(), NULL));
+  if (deep_copyup) {
+    ASSERT_EQ(0, clone_image.snap_create("snap1"));
+  }
+
+  bufferlist cmp_bl;
+  cmp_bl.append(std::string(96, '1'));
+  bufferlist write_bl;
+  write_bl.append(std::string(512, '2'));
+  uint64_t mismatch_off;
+  ASSERT_EQ((ssize_t)write_bl.length(),
+            clone_image.compare_and_write(512, write_bl.length(), cmp_bl,
+                                          write_bl, &mismatch_off, 0));
+
+  bufferlist read_bl;
+  ASSERT_EQ(4096, clone_image.read(0, 4096, read_bl));
+
+  bufferlist expected_bl;
+  expected_bl.append(std::string(512, '1'));
+  expected_bl.append(std::string(512, '2'));
+  expected_bl.append(std::string(3072, '1'));
+  ASSERT_TRUE(expected_bl.contents_equal(read_bl));
+  *passed = true;
+}
+
+TEST_F(TestLibRBD, CompareAndWriteCopyup)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  ASSERT_PASSED(compare_and_write_copyup, ioctx, false);
+  ASSERT_PASSED(compare_and_write_copyup, ioctx, true);
+}
+
+void compare_and_write_copyup_mismatch(librados::IoCtx &ioctx,
+                                       bool deep_copyup, bool *passed)
+{
+  librbd::RBD rbd;
+  std::string parent_name = TestLibRBD::get_temp_image_name();
+  uint64_t size = 2 << 20;
+  int order = 0;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(), size, &order));
+
+  librbd::Image parent_image;
+  ASSERT_EQ(0, rbd.open(ioctx, parent_image, parent_name.c_str(), NULL));
+
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  ASSERT_EQ((ssize_t)bl.length(), parent_image.write(0, bl.length(), bl));
+
+  ASSERT_EQ(0, parent_image.snap_create("snap1"));
+  ASSERT_EQ(0, parent_image.snap_protect("snap1"));
+
+  uint64_t features;
+  ASSERT_EQ(0, parent_image.features(&features));
+
+  std::string clone_name = TestLibRBD::get_temp_image_name();
+  EXPECT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "snap1", ioctx,
+       clone_name.c_str(), features, &order));
+
+  librbd::Image clone_image;
+  ASSERT_EQ(0, rbd.open(ioctx, clone_image, clone_name.c_str(), NULL));
+  if (deep_copyup) {
+    ASSERT_EQ(0, clone_image.snap_create("snap1"));
+  }
+
+  bufferlist cmp_bl;
+  cmp_bl.append(std::string(48, '1'));
+  cmp_bl.append(std::string(48, '3'));
+  bufferlist write_bl;
+  write_bl.append(std::string(512, '2'));
+  uint64_t mismatch_off;
+  ASSERT_EQ(-EILSEQ,
+            clone_image.compare_and_write(512, write_bl.length(), cmp_bl,
+                                          write_bl, &mismatch_off, 0));
+  ASSERT_EQ(48U, mismatch_off);
+
+  bufferlist read_bl;
+  ASSERT_EQ(4096, clone_image.read(0, 4096, read_bl));
+
+  ASSERT_TRUE(bl.contents_equal(read_bl));
+  *passed = true;
+}
+
+TEST_F(TestLibRBD, CompareAndWriteCopyupMismatch)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  ASSERT_PASSED(compare_and_write_copyup_mismatch, ioctx, false);
+  ASSERT_PASSED(compare_and_write_copyup_mismatch, ioctx, true);
+}
+
 TEST_F(TestLibRBD, Flatten)
 {
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);


### PR DESCRIPTION
http://tracker.ceph.com/issues/38440