### PR TITLE
[librbd]: [objectmap]assert in objectmap operator[]

### DIFF
--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -81,7 +81,9 @@ template <typename I>
 bool ObjectMap<I>::object_may_exist(uint64_t object_no) const
 {
   ceph_assert(m_image_ctx.image_lock.is_locked());
-
+  if (object_no >= m_object_map.size()){
+  	return true;
+  }
   // Fall back to default logic if object map is disabled or invalid
   if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
                                  m_image_ctx.image_lock)) {

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -69,6 +69,9 @@ public:
                   const boost::optional<uint8_t> &current_state,
                   const ZTracer::Trace &parent_trace, bool ignore_enoent,
                   T *callback_object) {
+  	if (start_object_no >= m_object_map.size()){
+  		return false;
+  	}
     return aio_update<T, MF>(snap_id, start_object_no, start_object_no + 1,
                              new_state, current_state, parent_trace,
                              ignore_enoent, callback_object);


### PR DESCRIPTION
resize(expand)image while vdbench has continuous io
i used tgt and vdbench to measure the io ratio of rbd image,at the same time i expanded the image .And i found that resize operation upate the object of objectmap,but the m_object_map has been opened and used in imagectx  will not been updated,so there has a possibility that we may assert in operator[] once the index goes beyound the m_object_map.size(). 