### PR TITLE
mgr/dashboard: fix backend error when updating RBD interlocked features

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -479,6 +479,7 @@ class RbdTest(DashboardTestCase):
         self._validate_image(img, features_name=["layering"])
         self.edit_image('rbd', 'edit_img',
                         features=["fast-diff", "object-map", "exclusive-lock"])
+        self.assertStatus(200)
         img = self._get('/api/block/image/rbd/edit_img')
         self.assertStatus(200)
         self._validate_image(img, features_name=['exclusive-lock',
@@ -486,6 +487,7 @@ class RbdTest(DashboardTestCase):
                                                  'object-map'])
         self.edit_image('rbd', 'edit_img',
                         features=["journaling", "exclusive-lock"])
+        self.assertStatus(200)
         img = self._get('/api/block/image/rbd/edit_img')
         self.assertStatus(200)
         self._validate_image(img, features_name=['exclusive-lock',

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -275,12 +275,16 @@ class Rbd(RESTController):
                 _sort_features(curr_features, enable=False)
                 for feature in curr_features:
                     if feature not in features and feature in self.ALLOW_DISABLE_FEATURES:
+                        if feature not in format_bitmask(image.features()):
+                            continue
                         f_bitmask = format_features([feature])
                         image.update_features(f_bitmask, False)
                 # check enabled features
                 _sort_features(features)
                 for feature in features:
                     if feature not in curr_features and feature in self.ALLOW_ENABLE_FEATURES:
+                        if feature in format_bitmask(image.features()):
+                            continue
                         f_bitmask = format_features([feature])
                         image.update_features(f_bitmask, True)
 


### PR DESCRIPTION
Now object-map and fast-diff features are interlocked. Allow
enabling/disabling these two features together without raising an already
enabled/disabled error.

Fixes: http://tracker.ceph.com/issues/39933
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

