### PR TITLE
common/secret.c: fix key parsing when doing a remount

### DIFF
--- a/src/common/secret.c
+++ b/src/common/secret.c
@@ -101,8 +101,8 @@ int get_secret_option(const char *secret, const char *key_name,
 
   option[olen] = '\0';
 
-
-  if (secret) {
+  /* when parsing kernel options (-o remount) we get '<hidden>' as the secret */
+  if (secret && (strcmp(secret, "<hidden>") != 0)) {
     ret = set_kernel_secret(secret, key_name);
     if (ret < 0) {
       if (ret == -ENODEV || ret == -ENOSYS) {


### PR DESCRIPTION
When doing a CephFS remount (-o remount) the secret is parsed from procfs
and we get '<hidden>' as a result and the mount will fail with:

  secret is not valid base64: Invalid argument.
  adding ceph secret key to kernel failed: Invalid argument.

As the kernel already have the key, we simply need to use it.

Fixes: https://tracker.ceph.com/issues/39951
Signed-off-by: Luis Henriques <lhenriques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

