### PR TITLE
mgr/dashboard: Fix tcmu-runner perf counters page

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard/controllers/perf_counters.py
@@ -74,6 +74,11 @@ class MgrPerfCounter(PerfCounter):
     service_type = 'mgr'
 
 
+@ApiController('perf_counters/tcmu-runner', Scope.ISCSI)
+class TcmuRunnerPerfCounter(PerfCounter):
+    service_type = 'tcmu-runner'
+
+
 @ApiController('perf_counters')
 class PerfCounters(RESTController):
     def list(self):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -80,7 +80,7 @@ export class HostsComponent implements OnInit {
       .then((resp) => {
         resp.map((host) => {
           host.services.map((service) => {
-            service.cdLink = `/perf_counters/${service.type}/${service.id}`;
+            service.cdLink = `/perf_counters/${service.type}/${encodeURIComponent(service.id)}`;
             const permission = this.permissions[typeToPermissionKey[service.type]];
             service.canRead = permission ? permission.read : false;
             return service;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.ts
@@ -18,7 +18,7 @@ export class PerformanceCounterComponent {
       this.fromLink = params.fromLink || PerformanceCounterComponent.defaultFromLink;
     });
     this.route.params.subscribe((params: { type: string; id: string }) => {
-      this.serviceId = params.id;
+      this.serviceId = decodeURIComponent(params.id);
       this.serviceType = params.type;
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.ts
@@ -4,8 +4,10 @@ import { Injectable } from '@angular/core';
 import { of as observableOf } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
+import { cdEncode } from '../decorators/cd-encode';
 import { ApiModule } from './api.module';
 
+@cdEncode
 @Injectable({
   providedIn: ApiModule
 })
@@ -19,8 +21,7 @@ export class PerformanceCounterService {
   }
 
   get(service_type: string, service_id: string) {
-    const serviceType = service_type.replace('-', '_');
-    return this.http.get(`${this.url}/${serviceType}/${service_id}`).pipe(
+    return this.http.get(`${this.url}/${service_type}/${service_id}`).pipe(
       mergeMap((resp) => {
         return observableOf(resp['counters']);
       })

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1098,7 +1098,7 @@ class MgrModule(ceph_module.BaseMgrModule):
 
     def get_all_perf_counters(self, prio_limit=PRIO_USEFUL,
                               services=("mds", "mon", "osd",
-                                        "rbd-mirror", "rgw")):
+                                        "rbd-mirror", "rgw", "tcmu-runner")):
         """
         Return the perf counters currently known to this ceph-mgr
         instance, filtered by priority equal to or greater than `prio_limit`.


### PR DESCRIPTION
With this PR the user will be correctly redirected to the `tcmu-runner` perf counters page (instead of "404-NotFound" page).

Fixes: https://tracker.ceph.com/issues/39954

Signed-off-by: Ricardo Marques <rimarques@suse.com>
