### PR TITLE
common: fix parse_env nullptr deref

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -461,11 +461,11 @@ void md_config_t::parse_env(unsigned entity_type,
   if (!args_var) {
     args_var = "CEPH_ARGS";
   }
-  if (getenv("CEPH_KEYRING")) {
-    _set_val(values, tracker, getenv("CEPH_KEYRING"), *find_option("keyring"),
-	     CONF_ENV, nullptr);
+  if (auto s = getenv("CEPH_KEYRING"); s) {
+    string err;
+    _set_val(values, tracker, s, *find_option("keyring"), CONF_ENV, &err);
   }
-  if (const char *dir = getenv("CEPH_LIB")) {
+  if (auto dir = getenv("CEPH_LIB"); dir) {
     for (auto name : { "erasure_code_dir", "plugin_dir", "osd_class_dir" }) {
     std::string err;
       const Option *o = find_option(name);
@@ -473,15 +473,15 @@ void md_config_t::parse_env(unsigned entity_type,
       _set_val(values, tracker, dir, *o, CONF_ENV, &err);
     }
   }
-  const char *pod_req = getenv("POD_MEMORY_REQUEST");
-  if (pod_req) {
+  if (auto pod_req = getenv("POD_MEMORY_REQUEST"); pod_req) {
+    string err;
     uint64_t v = atoll(pod_req);
     if (v) {
       switch (entity_type) {
       case CEPH_ENTITY_TYPE_OSD:
 	_set_val(values, tracker, stringify(v),
 		 *find_option("osd_memory_target"),
-		 CONF_ENV, nullptr);
+		 CONF_ENV, &err);
 	break;
       }
     }
@@ -1291,6 +1291,7 @@ int md_config_t::_set_val(
   std::string *error_message)
 {
   Option::value_t new_value;
+  ceph_assert(error_message);
   int r = opt.parse_value(raw_val, &new_value, error_message);
   if (r < 0) {
     return r;

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -131,6 +131,25 @@ TEST_F(test_config_proxy, expand_meta)
   test_expand_meta();
 }
 
+TEST(md_config_t, parse_env)
+{
+  {
+    ConfigProxy conf{false};
+    setenv("POD_MEMORY_REQUEST", "1", 1);
+    conf.parse_env(CEPH_ENTITY_TYPE_OSD);
+  }
+  {
+    ConfigProxy conf{false};
+    setenv("POD_MEMORY_REQUEST", "0", 1);
+    conf.parse_env(CEPH_ENTITY_TYPE_OSD);
+  }
+  {
+    ConfigProxy conf{false};
+    setenv("CEPH_KEYRING", "", 1);
+    conf.parse_env(CEPH_ENTITY_TYPE_OSD);
+  }
+}
+
 TEST(md_config_t, set_val)
 {
   int buf_size = 1024;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/39599
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

