### PR TITLE
nautilus: osd/PG: do not use approx_missing_objects pre-nautilus

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1569,11 +1569,13 @@ protected:
   void choose_async_recovery_ec(const map<pg_shard_t, pg_info_t> &all_info,
                                 const pg_info_t &auth_info,
                                 vector<int> *want,
-                                set<pg_shard_t> *async_recovery) const;
+                                set<pg_shard_t> *async_recovery,
+                                const OSDMapRef osdmap) const;
   void choose_async_recovery_replicated(const map<pg_shard_t, pg_info_t> &all_info,
                                         const pg_info_t &auth_info,
                                         vector<int> *want,
-                                        set<pg_shard_t> *async_recovery) const;
+                                        set<pg_shard_t> *async_recovery,
+                                        const OSDMapRef osdmap) const;
 
   bool recoverable_and_ge_min_size(const vector<int> &want) const;
   bool choose_acting(pg_shard_t &auth_log_shard,


### PR DESCRIPTION
http://tracker.ceph.com/issues/39512