### PR TITLE
librados: move buffer free functions to inline namespace

### DIFF
--- a/src/common/buffer_seastar.cc
+++ b/src/common/buffer_seastar.cc
@@ -31,10 +31,6 @@ class raw_seastar_foreign_ptr : public raw {
   }
 };
 
-raw* create_foreign(temporary_buffer&& buf) {
-  return new raw_seastar_foreign_ptr(std::move(buf));
-}
-
 class raw_seastar_local_ptr : public raw {
   temporary_buffer buf;
  public:
@@ -45,9 +41,17 @@ class raw_seastar_local_ptr : public raw {
   }
 };
 
+inline namespace v14_2_0 {
+
+raw* create_foreign(temporary_buffer&& buf) {
+  return new raw_seastar_foreign_ptr(std::move(buf));
+}
+
 raw* create(temporary_buffer&& buf) {
   return new raw_seastar_local_ptr(std::move(buf));
 }
+
+} // inline namespace v14_2_0
 
 // buffer::ptr conversions
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -102,6 +102,8 @@ struct unique_leakable_ptr : public std::unique_ptr<T, ceph::nop_delete<T>> {
 };
 
 namespace buffer CEPH_BUFFER_API {
+inline namespace v14_2_0 {
+
   /*
    * exceptions
    */
@@ -180,8 +182,6 @@ namespace buffer CEPH_BUFFER_API {
   /// destructed on this cpu
   raw* create(seastar::temporary_buffer<char>&& buf);
 #endif
-
-inline namespace v14_2_0 {
 
   /*
    * a buffer pointer.  references (a subsequence of) a raw buffer.
@@ -1302,7 +1302,7 @@ inline bool operator<=(bufferlist& l, bufferlist& r) {
 
 std::ostream& operator<<(std::ostream& out, const buffer::ptr& bp);
 
-std::ostream& operator<<(std::ostream& out, const raw &r);
+std::ostream& operator<<(std::ostream& out, const buffer::raw &r);
 
 std::ostream& operator<<(std::ostream& out, const buffer::list& bl);
 

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -24,6 +24,8 @@
 #include "include/spinlock.h"
 
 namespace ceph::buffer {
+inline namespace v14_2_0 {
+
   class raw {
   public:
     // In the future we might want to have a slab allocator here with few
@@ -118,6 +120,8 @@ public:
       last_crc_offset.second = std::numeric_limits<size_t>::max();
     }
   };
+
+} // inline namespace v14_2_0
 } // namespace ceph::buffer
 
 #endif // CEPH_BUFFER_RAW_H


### PR DESCRIPTION
'buffer::raw' factory methods and similar methods are now
wrapped in the 'v14_2_0' inline namespace for export via the
public librados API.

Fixes: http://tracker.ceph.com/issues/39972
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

