### PR TITLE
mgr/dashboard: Display correct dialog title

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.ts
@@ -55,8 +55,8 @@ export class RgwUserS3KeyModalComponent {
    * @param {boolean} viewing
    */
   setViewing(viewing: boolean = true) {
-    this.action = this.actionLabels.SHOW;
     this.viewing = viewing;
+    this.action = this.viewing ? this.actionLabels.SHOW : this.actionLabels.CREATE;
   }
 
   /**


### PR DESCRIPTION
The dialog to create a new S3 key shows the title 'Show S3 key' instead of 'Create S3 key'.

Fixes: https://tracker.ceph.com/issues/40047

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

