### PR TITLE
mgr/dashboard: fix some performance data are not displayed

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
@@ -44,7 +44,7 @@
        *ngIf="grafanaPermission.read"
        heading="Performance Details">
     <cd-grafana [grafanaPath]="'mds-performance?var-mds_servers=mds.' + grafanaId"
-                uid="rRfFzWtik"
+                uid="tbO9LAiZz"
                 grafanaStyle="one">
     </cd-grafana>
   </tab>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
@@ -2,7 +2,7 @@
   <tab i18n-heading
        heading="Performance Details">
     <cd-grafana [grafanaPath]="'host-details?var-ceph_hosts=' + host['hostname']"
-                uid="7IGu2Ttmz"
+                uid="rtOg0AiWz"
                 grafanaStyle="three">
     </cd-grafana>
   </tab>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -28,7 +28,7 @@
        *ngIf="permissions.grafana.read"
        heading="Overall Performance">
     <cd-grafana [grafanaPath]="'host-overview?'"
-                uid="lxnjcTAmk"
+                uid="y0KGL0iZz"
                 grafanaStyle="two">
     </cd-grafana>
   </tab>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -44,8 +44,8 @@
   <tab i18n-heading
        *ngIf="grafanaPermission.read"
        heading="Performance Details">
-    <cd-grafana [grafanaPath]="'osd-device-details?var-osd_id=' + osd['id']"
-                uid="MKj_9ipiz"
+    <cd-grafana [grafanaPath]="'osd-device-details?var-osd=osd.' + osd['id']"
+                uid="CrAHE0iZz"
                 grafanaStyle="GrafanaStyles.two">
     </cd-grafana>
   </tab>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
@@ -13,7 +13,7 @@
        heading="Performance Details">
     <cd-grafana [grafanaPath]="'ceph-pool-detail?var-pool_name='
                 + selection.first()['pool_name']"
-                uid="8ypfkWpik"
+                uid="-xyV8KCiz"
                 grafanaStyle="one">
     </cd-grafana>
   </tab>


### PR DESCRIPTION
Several Grafana dashboards were updated and their uids are changed.
Update corresponding uids in angular templates. Also fix that when a user
clicks performance details of an OSD, wrong OSD metrics are displayed.

Fixes: http://tracker.ceph.com/issues/39971
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

