### PR TITLE
rpm: Disable LTO in spec when being used.

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1065,6 +1065,9 @@ integrated with the Ceph Manager Dashboard web UI.
 %autosetup -p1 -n @TARBALL_BASENAME@
 
 %build
+# LTO can be enabled as soon as the following GCC bug is fixed:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48200
+%define _lto_cflags %{nil}
 
 %if 0%{?rhel} == 7
 . /opt/rh/devtoolset-8/enable


### PR DESCRIPTION
SUSE-specific workaround for https://tracker.ceph.com/issues/40060

Fixes Tumbleweed FTBFS tracked at: http://tracker.ceph.com/issues/39974