### PR TITLE
rgw: fix rgw crash and set correct error code

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4477,9 +4477,14 @@ rgw::auth::s3::STSEngine::get_session_token(const boost::string_view& session_to
     ldout(cct, 0) << "ERROR: Decryption failed: " << error << dendl;
     return -EPERM;
   } else {
-    dec_output.append('\0');
-    auto iter = dec_output.cbegin();
-    decode(token, iter);
+    try {
+      dec_output.append('\0');
+      auto iter = dec_output.cbegin();
+      decode(token, iter);
+    } catch (const buffer::error& e) {
+      ldout(cct, 0) << "ERROR: decode SessionToken failed: " << error << dendl;
+      return -EINVAL;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
when we use bad sts session token, it will cause rgw crash, and we need set the error code friendly
Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>