### PR TITLE
vstart_runner.py: upgrade list of commands that need root access

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -242,8 +242,11 @@ class LocalRemote(object):
 
         # We'll let sudo be a part of command even omit flag says otherwise in
         # cases of commands which can normally be ran only by root.
+        cmds_that_need_root_access = ['-u', 'useradd', 'passwd', 'usermod',
+                                      'userdel', 'groupadd', 'groupmod',
+                                      'groupdel', 'chown']
         try:
-            if args[args.index('sudo') + 1] in ['-u', 'passwd', 'chown']:
+            if args[args.index('sudo') + 1] in cmds_that_need_root_access:
                 omit_sudo = False
         except ValueError:
             pass


### PR DESCRIPTION
Upgrade list of commands that need root access so that we don't omit
sudo when running these commands.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug