### PR TITLE
ceph_volume_client: decode d_name before using it

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -306,7 +306,7 @@ class CephFSVolumeClient(object):
             # Identify auth IDs from auth meta filenames. The auth meta files
             # are named as, "$<auth_id><meta filename extension>"
             regex = "^\$(.*){0}$".format(re.escape(META_FILE_EXT))
-            match = re.search(regex, d.d_name)
+            match = re.search(regex, d.d_name.decode(encoding='utf-8'))
             if match:
                 auth_ids.append(match.group(1))
 
@@ -754,11 +754,12 @@ class CephFSVolumeClient(object):
             dir_handle = self.fs.opendir(root_path)
             d = self.fs.readdir(dir_handle)
             while d:
-                if d.d_name not in [".", ".."]:
+                d_name = d.d_name.decode(encoding='utf-8')
+                if d_name not in [".", ".."]:
                     # Do not use os.path.join because it is sensitive
                     # to string encoding, we just pass through dnames
                     # as byte arrays
-                    d_full = "{0}/{1}".format(root_path, d.d_name)
+                    d_full = u"{0}/{1}".format(root_path, d_name)
                     if d.is_dir():
                         rmtree(d_full)
                     else:


### PR DESCRIPTION
d_name is received as byte array but the code intends to use it as
a string. Therefore, convert it before using.

Fixes: http://tracker.ceph.com/issues/39406

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug