### PR TITLE
test_volume_client: rewrite test_put_object_versioned

### DIFF
--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -32,6 +32,7 @@ class TestVolumeClient(CephFSTestCase):
 from __future__ import print_function
 from ceph_volume_client import CephFSVolumeClient, VolumePath
 import logging
+from rados import OSError as rados_OSError
 log = logging.getLogger("ceph_volume_client")
 log.addHandler(logging.StreamHandler())
 log.setLevel(logging.DEBUG)
@@ -995,14 +996,19 @@ vc.disconnect()
 
         # Test if put_object_versioned() crosschecks the version of the
         # given object. Being a negative test, an exception is expected.
-        with self.assertRaises(CommandFailedError):
-            self._volume_client_python(vc_mount, dedent("""
-                data, version = vc.get_object_and_version("{pool_name}", "{obj_name}")
-                data += 'm1'
-                vc.put_object("{pool_name}", "{obj_name}", data)
-                data += 'm2'
-                vc.put_object_versioned("{pool_name}", "{obj_name}", data, version)
-            """).format(pool_name=pool_name, obj_name=obj_name))
+        expected_exception = 'rados_OSError'
+        output = self._volume_client_python(vc_mount, dedent("""
+                    data, version = vc.get_object_and_version("{pool_name}", "{obj_name}")
+                    data += 'm1'
+                    vc.put_object("{pool_name}", "{obj_name}", data)
+                    data += 'm2'
+                    try:
+                        vc.put_object_versioned("{pool_name}", "{obj_name}", data, version)
+                    except {expected_exception}:
+                        print('{expected_exception} raised')
+                """).format(pool_name=pool_name, obj_name=obj_name,
+                            expected_exception=expected_exception))
+        self.assertEqual(expected_exception + ' raised', output)
 
     def test_delete_object(self):
         vc_mount = self.mounts[1]


### PR DESCRIPTION
The test succeeds if it receives a CommandFailedError exception from the
embedded python progam. This manner of testing success is unreliable
since the embedded python program contains multiple statements and the
exception may be raised by any of those. Rewrite the test to fix this
issue.

Note: Couldn't test if test_put_object_versioned() works fine with this
rewriting since Python 2 compatible libraries are not generated anymore
even when -DWITH_PYTHON2=ON was passed as an argument to do_cmake.sh.
However, this should not be a problem since the PR #27718 would make it
compatible with Python 3.

Fixes: http://tracker.ceph.com/issues/39510



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug