### PR TITLE
qa/tasks: upgrade command arguments checks in vstart_runner.py

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -254,6 +254,9 @@ class LocalRemote(object):
         errmsg = "Don't surround arguments commands by quotes if it " + \
                  "contains spaces.\nargs - %s" % (args)
         for arg in args:
+            if isinstance(arg, Raw):
+                continue
+
             if (arg[0] in ['"', "'"] or arg[-1] in ['"', "'"]) and \
                (arg.find(' ') != -1 and 0 < arg.find(' ') < len(arg) - 1):
                 raise RuntimeError(errmsg)


### PR DESCRIPTION
Exempt run.Raw from checks in vstart_runner.py as most of them are meant for strings.
    
https://tracker.ceph.com/issues/39554
Signed-off-by: Rishabh Dave <ridave@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug