### PR TITLE
mimic: common/util: handle long lines in /proc/cpuinfo

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -208,7 +208,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   // processor
   f = fopen(PROCPREFIX "/proc/cpuinfo", "r");
   if (f) {
-    char buf[100];
+    char buf[1024];
     while (!feof(f)) {
       char *line = fgets(buf, sizeof(buf), f);
       if (!line)


### PR DESCRIPTION
http://tracker.ceph.com/issues/39475