### PR TITLE
mgr/dashboard: Change the provider of services to root

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
@@ -10,7 +10,6 @@ import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-h
 import { ApiModule } from '../../../shared/api/api.module';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
-import { ServicesModule } from '../../../shared/services/services.module';
 import { RbdSnapshotFormComponent } from './rbd-snapshot-form.component';
 
 describe('RbdSnapshotFormComponent', () => {
@@ -22,7 +21,6 @@ describe('RbdSnapshotFormComponent', () => {
       ReactiveFormsModule,
       ComponentsModule,
       HttpClientTestingModule,
-      ServicesModule,
       ApiModule,
       ToastModule.forRoot(),
       RouterTestingModule

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -24,7 +24,6 @@ import { Permissions } from '../../../shared/models/permissions';
 import { PipesModule } from '../../../shared/pipes/pipes.module';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
-import { ServicesModule } from '../../../shared/services/services.module';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskListService } from '../../../shared/services/task-list.service';
 import { RbdSnapshotListComponent } from './rbd-snapshot-list.component';
@@ -50,7 +49,6 @@ describe('RbdSnapshotListComponent', () => {
       DataTableModule,
       ComponentsModule,
       ToastModule.forRoot(),
-      ServicesModule,
       ApiModule,
       HttpClientTestingModule,
       RouterTestingModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
@@ -9,7 +9,6 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
-import { ServicesModule } from '../../shared/services/services.module';
 import { SharedModule } from '../../shared/shared.module';
 import { BlockModule } from '../block/block.module';
 import { CephSharedModule } from '../shared/ceph-shared.module';
@@ -28,7 +27,6 @@ import { PoolListComponent } from './pool-list/pool-list.component';
     RouterModule,
     ReactiveFormsModule,
     BsDropdownModule,
-    ServicesModule,
     TooltipModule.forRoot(),
     BlockModule
   ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.spec.ts
@@ -4,7 +4,6 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { PipesModule } from '../../pipes/pipes.module';
-import { ServicesModule } from '../../services/services.module';
 import { UsageBarComponent } from './usage-bar.component';
 
 describe('UsageBarComponent', () => {
@@ -12,7 +11,7 @@ describe('UsageBarComponent', () => {
   let fixture: ComponentFixture<UsageBarComponent>;
 
   configureTestBed({
-    imports: [PipesModule, ServicesModule, TooltipModule.forRoot()],
+    imports: [PipesModule, TooltipModule.forRoot()],
     declarations: [UsageBarComponent]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-builder.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-builder.ts
@@ -1,14 +1,13 @@
 import { Injectable } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 
-import { ServicesModule } from '../services/services.module';
 import { CdFormGroup } from './cd-form-group';
 
 /**
  * CdFormBuilder extends FormBuilder to create an CdFormGroup based form.
  */
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class CdFormBuilder extends FormBuilder {
   group(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
@@ -17,10 +17,9 @@ import { CdNotificationConfig } from '../models/cd-notification';
 import { FinishedTask } from '../models/finished-task';
 import { AuthStorageService } from './auth-storage.service';
 import { NotificationService } from './notification.service';
-import { ServicesModule } from './services.module';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class ApiInterceptorService implements HttpInterceptor {
   constructor(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
@@ -2,10 +2,9 @@ import { Injectable } from '@angular/core';
 import { CanActivate, CanActivateChild, Router } from '@angular/router';
 
 import { AuthStorageService } from './auth-storage.service';
-import { ServicesModule } from './services.module';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class AuthGuardService implements CanActivate, CanActivateChild {
   constructor(private router: Router, private authStorageService: AuthStorageService) {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
 
 import { Permissions } from '../models/permissions';
-import { ServicesModule } from './services.module';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class AuthStorageService {
   constructor() {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles-guard.service.ts
@@ -4,10 +4,9 @@ import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router } from '@
 import { map } from 'rxjs/operators';
 
 import { FeatureTogglesMap, FeatureTogglesService } from './feature-toggles.service';
-import { ServicesModule } from './services.module';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class FeatureTogglesGuardService implements CanActivate, CanActivateChild {
   constructor(private router: Router, private featureToggles: FeatureTogglesService) {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles.service.ts
@@ -4,13 +4,11 @@ import { Injectable } from '@angular/core';
 import { Observable, timer } from 'rxjs';
 import { flatMap, shareReplay } from 'rxjs/operators';
 
-import { ServicesModule } from './services.module';
-
 export type FeatureTogglesMap = Map<string, boolean>;
 export type FeatureTogglesMap$ = Observable<FeatureTogglesMap>;
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class FeatureTogglesService {
   readonly API_URL: string = 'api/feature_toggles';

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
@@ -2,10 +2,8 @@ import { Injectable } from '@angular/core';
 
 import * as _ from 'lodash';
 
-import { ServicesModule } from './services.module';
-
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class FormatterService {
   constructor() {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
@@ -5,8 +5,6 @@ import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router } from '@
 import { of as observableOf } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { ServicesModule } from './services.module';
-
 /**
  * This service checks if a route can be activated by executing a
  * REST API call to '/api/<apiPath>/status'. If the returned response
@@ -33,7 +31,7 @@ import { ServicesModule } from './services.module';
  * ...
  */
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class ModuleStatusGuardService implements CanActivate, CanActivateChild {
   // TODO: Hotfix - remove WHITELIST'ing when a generic ErrorComponent is implemented

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -8,11 +8,10 @@ import { NotificationType } from '../enum/notification-type.enum';
 import { CdNotification, CdNotificationConfig } from '../models/cd-notification';
 import { FinishedTask } from '../models/finished-task';
 import { CdDatePipe } from '../pipes/cd-date.pipe';
-import { ServicesModule } from './services.module';
 import { TaskMessageService } from './task-message.service';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class NotificationService {
   private hideToasties = false;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.ts
@@ -10,10 +10,9 @@ import {
   PrometheusNotificationAlert
 } from '../models/prometheus-alerts';
 import { NotificationService } from './notification.service';
-import { ServicesModule } from './services.module';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class PrometheusAlertFormatter {
   constructor(private notificationService: NotificationService) {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
@@ -5,10 +5,9 @@ import * as _ from 'lodash';
 import { PrometheusService } from '../api/prometheus.service';
 import { PrometheusAlert, PrometheusCustomAlert } from '../models/prometheus-alerts';
 import { PrometheusAlertFormatter } from './prometheus-alert-formatter';
-import { ServicesModule } from './services.module';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class PrometheusAlertService {
   private canAlertsBeNotified = false;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.ts
@@ -6,10 +6,9 @@ import { PrometheusService } from '../api/prometheus.service';
 import { CdNotificationConfig } from '../models/cd-notification';
 import { PrometheusNotification } from '../models/prometheus-alerts';
 import { PrometheusAlertFormatter } from './prometheus-alert-formatter';
-import { ServicesModule } from './services.module';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class PrometheusNotificationService {
   private notifications: PrometheusNotification[];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/rbd-configuration.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/rbd-configuration.service.ts
@@ -7,7 +7,6 @@ import {
   RbdConfigurationSection,
   RbdConfigurationType
 } from '../models/configuration';
-import { ServicesModule } from './services.module';
 
 /**
  * Define here which options should be made available under which section heading.
@@ -15,7 +14,7 @@ import { ServicesModule } from './services.module';
  * this information.
  */
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class RbdConfigurationService {
   readonly sections: RbdConfigurationSection[];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/refresh-interval.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/refresh-interval.service.ts
@@ -2,9 +2,8 @@ import { Injectable, OnDestroy } from '@angular/core';
 
 import { BehaviorSubject, interval, Subscription } from 'rxjs';
 
-import { ServicesModule } from './services.module';
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class RefreshIntervalService implements OnDestroy {
   private intervalTime: number;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/services.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/services.module.ts
@@ -1,7 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-  imports: [CommonModule]
-})
-export class ServicesModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
@@ -6,10 +6,9 @@ import * as _ from 'lodash';
 import { BehaviorSubject, Subscription } from 'rxjs';
 
 import { ExecutingTask } from '../models/executing-task';
-import { ServicesModule } from './services.module';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class SummaryService {
   // Observable sources

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.ts
@@ -5,7 +5,6 @@ import * as _ from 'lodash';
 import { ExecutingTask } from '../models/executing-task';
 import { FinishedTask } from '../models/finished-task';
 import { Task } from '../models/task';
-import { ServicesModule } from './services.module';
 import { SummaryService } from './summary.service';
 
 class TaskSubscription {
@@ -21,7 +20,7 @@ class TaskSubscription {
 }
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class TaskManagerService {
   subscriptions: Array<TaskSubscription> = [];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -5,7 +5,6 @@ import { I18n } from '@ngx-translate/i18n-polyfill';
 import { Components } from '../enum/components.enum';
 import { FinishedTask } from '../models/finished-task';
 import { Task } from '../models/task';
-import { ServicesModule } from './services.module';
 
 export class TaskMessageOperation {
   running: string;
@@ -55,7 +54,7 @@ class TaskMessage {
 }
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class TaskMessageService {
   constructor(private i18n: I18n) {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.ts
@@ -6,13 +6,12 @@ import { NotificationType } from '../enum/notification-type.enum';
 import { ExecutingTask } from '../models/executing-task';
 import { FinishedTask } from '../models/finished-task';
 import { NotificationService } from './notification.service';
-import { ServicesModule } from './services.module';
 import { SummaryService } from './summary.service';
 import { TaskManagerService } from './task-manager.service';
 import { TaskMessageService } from './task-message.service';
 
 @Injectable({
-  providedIn: ServicesModule
+  providedIn: 'root'
 })
 export class TaskWrapperService {
   constructor(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/shared.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/shared.module.ts
@@ -9,27 +9,18 @@ import { PipesModule } from './pipes/pipes.module';
 import { AuthGuardService } from './services/auth-guard.service';
 import { AuthStorageService } from './services/auth-storage.service';
 import { FormatterService } from './services/formatter.service';
-import { ServicesModule } from './services/services.module';
 
 @NgModule({
   imports: [
     CommonModule,
     PipesModule,
     ComponentsModule,
-    ServicesModule,
     DataTableModule,
     ApiModule,
     DirectivesModule
   ],
   declarations: [],
-  exports: [
-    ComponentsModule,
-    PipesModule,
-    ServicesModule,
-    DataTableModule,
-    ApiModule,
-    DirectivesModule
-  ],
+  exports: [ComponentsModule, PipesModule, DataTableModule, ApiModule, DirectivesModule],
   providers: [AuthStorageService, AuthGuardService, FormatterService]
 })
 export class SharedModule {}


### PR DESCRIPTION
It looks like that even if we provide a service only in 1 module, there are
still situations where angular will create multiple instances of that service.

By setting root as its providers, this no longer happens.

Fixes: http://tracker.ceph.com/issues/39996

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

