### PR TITLE
nautilus: osd/PG: fix last_complete re-calculation on splitting

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2654,10 +2654,9 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
   info.log_tail = pg_log.get_tail();
   child->info.log_tail = child->pg_log.get_tail();
 
-  if (info.last_complete < pg_log.get_tail())
-    info.last_complete = pg_log.get_tail();
-  if (child->info.last_complete < child->pg_log.get_tail())
-    child->info.last_complete = child->pg_log.get_tail();
+  // reset last_complete, we might have modified pg_log & missing above
+  pg_log.reset_complete_to(&info);
+  child->pg_log.reset_complete_to(&child->info);
 
   // Info
   child->info.history = info.history;

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -797,6 +797,8 @@ public:
   }
 
   void reset_complete_to(pg_info_t *info) {
+    if (log.log.empty()) // caller is split_into()
+      return;
     log.complete_to = log.log.begin();
     ceph_assert(log.complete_to != log.log.end());
     auto oldest_need = missing.get_oldest_need();


### PR DESCRIPTION
http://tracker.ceph.com/issues/39539