### PR TITLE
osd_types: add ec profile to plain text osd pool ls detail output

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2145,8 +2145,11 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
 
 ostream& operator<<(ostream& out, const pg_pool_t& p)
 {
-  out << p.get_type_name()
-      << " size " << p.get_size()
+  out << p.get_type_name();
+  if (p.get_type_name() == "erasure") {
+    out << " profile " << p.erasure_code_profile;
+  }
+  out  << " size " << p.get_size()
       << " min_size " << p.get_min_size()
       << " crush_rule " << p.get_crush_rule()
       << " object_hash " << p.get_object_hash_name()


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40009

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

The detailed ec pool output should contain the ec profile.
Old output:
`pool 1 'ec' erasure size 4 min_size 3 crush_rule 1 object_hash rjenkins pg_num 8 pgp_num 8 autoscale_mode warn last_change 16 flags hashpspool stripe_width 8192`
New output:
`pool 1 'ec' erasure profile ec-profile size 4 min_size 3 crush_rule 1 object_hash rjenkins pg_num 8 pgp_num 8 autoscale_mode warn last_change 16 flags hashpspool stripe_width 8192`