### PR TITLE
mds: omit changing lock state when no reconnected_cap changed dirty_caps

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5483,8 +5483,10 @@ void MDCache::choose_lock_states_and_reconnect_caps()
       for (const auto &it : q->second)
 	dirty_caps |= it.second.dirty_caps;
     }
-    in->choose_lock_states(dirty_caps);
-    dout(15) << " chose lock states on " << *in << dendl;
+    if (dirty_caps) {
+      in->choose_lock_states(dirty_caps);
+      dout(15) << " chose lock states on " << *in << dendl;
+    }
 
     if (in->snaprealm && !rejoin_pending_snaprealms.count(in)) {
       in->get(CInode::PIN_OPENINGSNAPPARENTS);


### PR DESCRIPTION
This is for accelerating rejoin phase.

Signed-off-by: Shen Hang <harryshen18@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

