### PR TITLE
mon/OSDMonitor: Use generic priority cache tuner for mon caches

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -1196,6 +1196,26 @@ Miscellaneous
 :Type: Integer
 :Default: 300
 
+``mon osd cache size min``
+
+:Description: The minimum amount of bytes to be kept mapped in memory for osd
+               monitor caches.
+:Type: 64-bit Integer
+:Default: 134217728
+
+``mon memory target``
+
+:Description: The amount of bytes pertaining to osd monitor caches and kv cache
+              to be kept mapped in memory with cache auto-tuning enabled.
+:Type: 64-bit Integer
+:Default: 2147483648
+
+``mon memory autotune``
+
+:Description: Autotune the cache memory being used for osd monitors and kv
+              database.
+:Type: Boolean
+:Default: True
 
 
 .. _Paxos: https://en.wikipedia.org/wiki/Paxos_(computer_science)

--- a/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
+++ b/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
@@ -1,0 +1,152 @@
+roles:
+- - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - osd.4
+  - osd.5
+  - osd.6
+  - osd.7
+  - osd.8
+  - osd.9
+  - osd.10
+  - osd.11
+  - osd.12
+  - osd.13
+  - osd.14
+  - client.0
+openstack:
+  - volumes: # attached to each instance
+      count: 4
+      size: 1 # GB
+overrides:
+  ceph:
+    conf:
+      mon:
+        mon memory target: 134217728 # reduced to 128_M
+        rocksdb cache size: 67108864 # reduced to 64_M
+        mon osd cache size: 100000
+        mon osd cache size min: 134217728
+      osd:
+        osd memory target: 1610612736 # reduced to 1.5_G
+        osd objectstore: bluestore
+        debug bluestore: 20
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+        osd max backfills: 9
+
+tasks:
+- install:
+    branch: wip-sseshasa2-testing-2019-07-30-1825 # change as appropriate
+- ceph:
+    create_rbd_pool: false
+    log-whitelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
+      - slow requests
+- interactive:
+- parallel:
+    - log-mon-rss
+    - stress-tasks
+    - benchload
+- exec:
+    client.0:
+      - "ceph_test_mon_memory_target 134217728" # mon memory target
+      - "ceph_test_mon_rss_usage 134217728"
+log-mon-rss:
+- background_exec:
+    client.0:
+      - while true
+      - do /usr/bin/ceph_test_log_rss_usage ceph-mon >> /var/log/ceph/ceph-mon-rss-usage.log
+      - sleep 300 # log rss usage every 5 mins. May be modified accordingly
+      - done
+- exec:
+    client.0:
+      - sleep 37860 # sum total of the radosbench test times below plus 60 secs
+benchload: # The total radosbench test below translates to 10.5 hrs
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+  - radosbench:
+      clients: [client.0]
+      time: 1800
+stress-tasks:
+- thrashosds:
+    op_delay: 1
+    bdev_inject_crash: 1
+    bdev_inject_crash_probability: .8
+    chance_down: 80
+    chance_pgnum_grow: 3
+    chance_pgpnum_fix: 1
+    chance_thrash_cluster_full: 0
+    chance_thrash_pg_upmap: 3
+    chance_thrash_pg_upmap_items: 3
+    min_in: 2

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -190,6 +190,9 @@ OPTION(mon_compact_on_bootstrap, OPT_BOOL)  // trigger leveldb compaction on boo
 OPTION(mon_compact_on_trim, OPT_BOOL)       // compact (a prefix) when we trim old states
 OPTION(mon_osd_cache_size, OPT_INT)  // the size of osdmaps cache, not to rely on underlying store's cache
 
+OPTION(mon_osd_cache_size_min, OPT_U64) // minimum amount of memory to cache osdmaps
+OPTION(mon_memory_target, OPT_U64) // amount of mapped memory for osdmaps
+OPTION(mon_memory_autotune, OPT_BOOL) // autotune cache memory for osdmap
 OPTION(mon_cpu_threads, OPT_INT)
 OPTION(mon_osd_mapping_pgs_per_chunk, OPT_INT)
 OPTION(mon_clean_pg_upmaps_per_chunk, OPT_U64)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1330,6 +1330,23 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description("maximum number of OSDMaps to cache in memory"),
 
+    Option("mon_osd_cache_size_min", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .set_default(128_M)
+    .add_service("mon")
+    .set_description("The minimum amount of bytes to be kept mapped in memory for osd monitor caches."),
+
+    Option("mon_memory_target", Option::TYPE_SIZE, Option::LEVEL_BASIC)
+    .set_default(2_G)
+    .set_flag(Option::FLAG_RUNTIME)
+    .add_service("mon")
+    .set_description("The amount of bytes pertaining to osd monitor caches and kv cache to be kept mapped in memory with cache auto-tuning enabled"),
+
+    Option("mon_memory_autotune", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(true)
+    .set_flag(Option::FLAG_RUNTIME)
+    .add_service("mon")
+    .set_description("Autotune the cache memory being used for osd monitors and kv database"),
+
     Option("mon_cpu_threads", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(4)
     .add_service("mon")
@@ -3913,6 +3930,7 @@ std::vector<Option> get_global_options() {
 
     Option("rocksdb_cache_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(512_M)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description(""),
 
     Option("rocksdb_cache_row_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -30,6 +30,7 @@
 #include "common/debug.h"
 #include "common/safe_io.h"
 #include "common/blkdev.h"
+#include "common/PriorityCache.h"
 
 #define dout_context g_ceph_context
 
@@ -54,6 +55,10 @@ class MonitorDBStore
     get_device_by_path(path.c_str(), partition, devname,
 		       sizeof(devname));
     return devname;
+  }
+
+  std::shared_ptr<PriorityCache::PriCache> get_priority_cache() const {
+    return db->get_priority_cache();
   }
 
   struct Op {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -209,12 +209,17 @@ struct osdmap_manifest_t {
 };
 WRITE_CLASS_ENCODER(osdmap_manifest_t);
 
-class OSDMonitor : public PaxosService {
+class OSDMonitor : public PaxosService,
+                   public md_config_obs_t {
   CephContext *cct;
 
 public:
   OSDMap osdmap;
 
+  // config observer
+  const char** get_tracked_conf_keys() const override;
+  void handle_conf_change(const ConfigProxy& conf,
+    const std::set<std::string> &changed) override;
   // [leader]
   OSDMap::Incremental pending_inc;
   map<int, bufferlist> pending_metadata;
@@ -225,6 +230,7 @@ public:
   map<int64_t,set<snapid_t>> pending_pseudo_purged_snaps;
   std::shared_ptr<PriorityCache::PriCache> rocksdb_binned_kv_cache = nullptr;
   std::shared_ptr<PriorityCache::Manager> pcm = nullptr;
+  ceph::mutex balancer_lock = ceph::make_mutex("OSDMonitor::balancer_lock");
 
   map<int,double> osd_weight;
 
@@ -324,6 +330,7 @@ private:
   int _set_cache_ratios();
   void _set_new_cache_sizes();
   void _set_cache_autotuning();
+  int _update_mon_cache_settings();
 
   friend struct OSDMemCache;
   friend struct IncCache;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -27,6 +27,7 @@
 #include "include/types.h"
 #include "include/encoding.h"
 #include "common/simple_cache.hpp"
+#include "common/PriorityCache.h"
 #include "msg/Messenger.h"
 
 #include "osd/OSDMap.h"
@@ -222,6 +223,8 @@ public:
   map<int,utime_t>    down_pending_out;  // osd down -> out
   bool priority_convert = false;
   map<int64_t,set<snapid_t>> pending_pseudo_purged_snaps;
+  std::shared_ptr<PriorityCache::PriCache> rocksdb_binned_kv_cache = nullptr;
+  std::shared_ptr<PriorityCache::Manager> pcm = nullptr;
 
   map<int,double> osd_weight;
 
@@ -304,6 +307,27 @@ private:
   bool is_prune_enabled() const;
   bool is_prune_supported() const;
   bool do_prune(MonitorDBStore::TransactionRef tx);
+
+  // Priority cache control
+  uint32_t mon_osd_cache_size = 0;  ///< Number of cached OSDMaps
+  uint64_t rocksdb_cache_size = 0;  ///< Cache for kv Db
+  double cache_kv_ratio = 0;        ///< Cache ratio dedicated to kv
+  double cache_inc_ratio = 0;       ///< Cache ratio dedicated to inc
+  double cache_full_ratio = 0;      ///< Cache ratio dedicated to full
+  uint64_t mon_memory_base = 0;     ///< Mon base memory for cache autotuning
+  double mon_memory_fragmentation = 0; ///< Expected memory fragmentation
+  uint64_t mon_memory_target = 0;   ///< Mon target memory for cache autotuning
+  uint64_t mon_memory_min = 0;      ///< Min memory to cache osdmaps
+  bool mon_memory_autotune = false; ///< Cache auto tune setting
+  int register_cache_with_pcm();
+  int _set_cache_sizes();
+  int _set_cache_ratios();
+  void _set_new_cache_sizes();
+  void _set_cache_autotuning();
+
+  friend struct OSDMemCache;
+  friend struct IncCache;
+  friend struct FullCache;
 
   /**
    * we haven't delegated full version stashing to paxosservice for some time

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -354,6 +354,10 @@ public:
       o.back()->seq = 30;
     }
 
+    size_t length() {
+      return sizeof(_Header);
+    }
+
     _Header() : seq(0), parent(0), num_children(1) {}
   };
 

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -39,3 +39,27 @@ add_executable(unittest_mon_montypes
   )
 add_ceph_unittest(unittest_mon_montypes)
 target_link_libraries(unittest_mon_montypes mon global)
+
+# ceph_test_mon_memory_target
+add_executable(ceph_test_mon_memory_target
+  test_mon_memory_target.cc
+  )
+target_link_libraries(ceph_test_mon_memory_target ${UNITTEST_LIBS} Boost::system)
+install(TARGETS ceph_test_mon_memory_target
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# ceph_test_mon_log_rss_usage
+add_executable(ceph_test_log_rss_usage
+  test_log_rss_usage.cc
+  )
+target_link_libraries(ceph_test_log_rss_usage ${UNITTEST_LIBS})
+install(TARGETS ceph_test_log_rss_usage
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# ceph_test_mon_rss_usage
+add_executable(ceph_test_mon_rss_usage
+  test_mon_rss_usage.cc
+  )
+target_link_libraries(ceph_test_mon_rss_usage ${UNITTEST_LIBS})
+install(TARGETS ceph_test_mon_rss_usage
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/mon/test_log_rss_usage.cc
+++ b/src/test/mon/test_log_rss_usage.cc
@@ -1,0 +1,101 @@
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+using namespace std;
+
+int getPidByName(string procName)
+{
+  int pid = -1;
+
+  // Open the /proc directory
+  DIR *dp = opendir("/proc");
+  if (dp != NULL)
+  {
+    // Enumerate all entries in '/proc' until process is found
+    struct dirent *dirp;
+    while (pid < 0 && (dirp = readdir(dp)))
+    {
+      // Skip non-numeric entries
+      int id = atoi(dirp->d_name);
+      if (id > 0)
+      {
+        // Read contents of virtual /proc/{pid}/cmdline file
+        string cmdPath = string("/proc/") + dirp->d_name + "/cmdline";
+        ifstream cmdFile(cmdPath.c_str());
+        string cmdLine;
+        getline(cmdFile, cmdLine);
+        if (!cmdLine.empty())
+        {
+          // Keep first cmdline item which contains the program path
+          size_t pos = cmdLine.find('\0');
+          if (pos != string::npos) {
+            cmdLine = cmdLine.substr(0, pos);
+          }
+          // Get program name only, removing the path
+          pos = cmdLine.rfind('/');
+          if (pos != string::npos) {
+            cmdLine = cmdLine.substr(pos + 1);
+          }
+          // Compare against requested process name
+          if (procName == cmdLine) {
+            pid = id;
+          }
+        }
+      }
+    }
+  }
+
+  closedir(dp);
+
+  return pid;
+}
+
+uint64_t getRssUsage(string pid)
+{
+  int totalSize = 0;
+  int resSize = 0;
+
+  string statmPath = string("/proc/") + pid + "/statm";
+  ifstream buffer(statmPath);
+  buffer >> totalSize >> resSize;
+  buffer.close();
+
+  long page_size = sysconf(_SC_PAGE_SIZE);
+  uint64_t rss = resSize * page_size;
+
+  return rss;
+}
+
+int main(int argc, char* argv[])
+{
+  if (argc != 2) {
+    cout << "Syntax: "
+         << "ceph_test_log_rss_usage <process name>"
+         << endl;
+    exit(EINVAL);
+  }
+  uint64_t rss = 0;
+  int pid = getPidByName(argv[1]);
+  string rssUsage;
+
+  // Use the pid to get RSS memory usage
+  // and print it to stdout
+  if (pid != -1) {
+    rss = getRssUsage(to_string(pid));
+  } else {
+    cout << "Process " << argv[1] << " NOT FOUND!\n" << endl;
+    exit(ESRCH);
+  }
+
+  rssUsage = to_string(rss) + ":" + to_string(pid) + ":";
+  cout << rssUsage.c_str() << endl;
+  return 0;
+}

--- a/src/test/mon/test_mon_memory_target.cc
+++ b/src/test/mon/test_mon_memory_target.cc
@@ -1,0 +1,78 @@
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <numeric>
+#include <regex>
+#include <system_error>
+
+#include <boost/process.hpp>
+#include <boost/tokenizer.hpp>
+
+namespace bp = boost::process;
+using namespace std;
+
+int main(int argc, char** argv)
+{
+  cout << "Mon Memory Target Test" << endl;
+
+  if (argc != 2) {
+    cout << "Syntax: "
+         << "ceph_test_mon_memory_target <mon-memory-target-bytes>"
+         << endl;
+    exit(EINVAL);
+  }
+
+  string target_directory("/var/log/ceph/");
+  unsigned long maxallowed = stoul(argv[1], nullptr, 10);
+  regex reg(R"(cache_size:(\d*)\s)");
+
+  string grep_command("grep _set_new_cache_sizes " + target_directory
+                      + "ceph-mon.a.log");
+  bp::ipstream is;
+  error_code ec;
+  bp::child grep(grep_command, bp::std_out > is, ec);
+  if (ec) {
+    cout << "Error grepping logs! Exiting" << endl;
+    cout << "Error: " << ec.value() << " " << ec.message() << endl;
+    exit(ec.value());
+  }
+
+  string line;
+  vector<unsigned long> results;
+  while (grep.running() && getline(is, line) && !line.empty()) {
+    smatch match;
+    if (regex_search(line, match, reg)) {
+      results.push_back(stoul(match[1].str()));
+    }
+  }
+
+  if (results.empty()) {
+    cout << "Error: No grep results found!" << endl;
+    exit(ENOENT);
+  }
+
+  auto maxe = *(max_element(results.begin(), results.end()));
+  cout << "Results for mon_memory_target:" << endl;
+  cout << "Max: " << maxe << endl;
+  cout << "Min: " << *(min_element(results.begin(), results.end())) << endl;
+  auto sum = accumulate(results.begin(), results.end(),
+                        static_cast<unsigned long long>(0));
+  auto mean = sum / results.size();
+  cout << "Mean average: " << mean << endl;
+  vector<unsigned long> diff(results.size());
+  transform(results.begin(), results.end(), diff.begin(),
+            [mean](unsigned long x) { return x - mean; });
+  auto sump = inner_product(diff.begin(), diff.end(), diff.begin(), 0.0);
+  auto stdev = sqrt(sump / results.size());
+  cout << "Standard deviation: " << stdev << endl;
+
+  if (maxe > maxallowed) {
+    cout << "Error: Mon memory consumption exceeds maximum allowed!" << endl;
+    exit(ENOMEM);
+  }
+
+  grep.wait();
+
+  cout << "Completed successfully" << endl;
+  return 0;
+}

--- a/src/test/mon/test_mon_rss_usage.cc
+++ b/src/test/mon/test_mon_rss_usage.cc
@@ -1,0 +1,72 @@
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <numeric>
+#include <regex>
+#include <cmath>
+#include <system_error>
+
+using namespace std;
+
+int main(int argc, char **argv)
+{
+  cout << "Mon RSS Usage Test" << endl;
+
+  if (argc != 2) {
+    cout << "Syntax: "
+         << "ceph_test_mon_rss_usage <mon-memory-target-bytes>"
+         << endl;
+    exit(EINVAL);
+  }
+
+  unsigned long maxallowed = stoul(argv[1], nullptr, 10);
+  // Set max allowed RSS usage to be 125% of mon-memory-target
+  maxallowed *= 1.25;
+
+  string target_directory("/var/log/ceph/");
+  string filePath = target_directory + "ceph-mon-rss-usage.log";
+  ifstream buffer(filePath.c_str());
+  string line;
+  vector<unsigned long> results;
+  while(getline(buffer, line) && !line.empty()) {
+    string rssUsage;
+    size_t pos = line.find(':');
+    if (pos != string::npos) {
+      rssUsage = line.substr(0, pos);
+    }
+    if (!rssUsage.empty()) {
+      results.push_back(stoul(rssUsage));
+    }
+  }
+
+  buffer.close();
+  if (results.empty()) {
+    cout << "Error: No grep results found!" << endl;
+    exit(ENOENT);
+  }
+
+  auto maxe = *(max_element(results.begin(), results.end()));
+  cout << "Stats for mon RSS Memory Usage:" << endl;
+  cout << "Parsed " << results.size() << " entries." << endl;
+  cout << "Max: " << maxe << endl;
+  cout << "Min: " << *(min_element(results.begin(), results.end())) << endl;
+  auto sum = accumulate(results.begin(), results.end(),
+                        static_cast<unsigned long long>(0));
+  auto mean = sum / results.size();
+  cout << "Mean average: " << mean << endl;
+  vector<unsigned long> diff(results.size());
+  transform(results.begin(), results.end(), diff.begin(),
+            [mean](unsigned long x) { return x - mean; });
+  auto sump = inner_product(diff.begin(), diff.end(), diff.begin(), 0.0);
+  auto stdev = sqrt(sump / results.size());
+  cout << fixed <<  "Standard deviation: " << stdev << endl;
+
+  if (maxe > maxallowed) {
+    cout << "Error: Mon RSS memory usage exceeds maximum allowed!" << endl;
+    exit(ENOMEM);
+  }
+
+  cout << "Completed successfully" << endl;
+  return 0;
+}


### PR DESCRIPTION
Use the priority cache tuner for mon caches. Also implement a config observer to handle changes to mon cache sizes.

Fixes: http://tracker.ceph.com/issues/40870

Signed-off-by: Sridhar Seshasayee sseshasa@redhat.com


- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug