### PR TITLE
ceph.spec.in: grafana-dashboards package depends on grafana

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2250,9 +2250,9 @@ exit 0
 
 %files grafana-dashboards
 %if 0%{?suse_version}
-%attr(0750,root,grafana) %dir %{_sysconfdir}/grafana
-%attr(0750,root,grafana) %dir %{_sysconfdir}/grafana/dashboards
-%attr(0750,root,grafana) %dir %{_sysconfdir}/grafana/dashboards/ceph-dashboard
+%attr(0755,root,root) %dir %{_sysconfdir}/grafana
+%attr(0755,root,root) %dir %{_sysconfdir}/grafana/dashboards
+%attr(0755,root,root) %dir %{_sysconfdir}/grafana/dashboards/ceph-dashboard
 %else
 %attr(0755,root,root) %dir %{_sysconfdir}/grafana/dashboards/ceph-dashboard
 %endif


### PR DESCRIPTION
Otherwise this will create an issue if grafana-dashboards is installed
before grafana. In this case /etc/grafana/dashboards/ceph-dashboard will
be owned by root:root and grafana won't be able to read the dashboards.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>