### PR TITLE
nautilus: mds: output lock state in format dump

### DIFF
--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -30,6 +30,7 @@ void SimpleLock::dump(Formatter *f) const {
   }
   f->close_section();
 
+  f->dump_string("state", get_state_name(get_state()));
   f->dump_bool("is_leased", is_leased());
   f->dump_int("num_rdlocks", get_num_rdlocks());
   f->dump_int("num_wrlocks", get_num_wrlocks());


### PR DESCRIPTION
http://tracker.ceph.com/issues/39670