### PR TITLE
mgr/dashboard: check embedded Grafana dashboard references

### DIFF
--- a/src/pybind/mgr/dashboard/ci/check_grafana_uids.py
+++ b/src/pybind/mgr/dashboard/ci/check_grafana_uids.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=F0401
+"""
+This script does:
+* Scan through Angular html templates and extract <cd-grafana> tags
+* Check if every tag has a corresponding Grafana dashboard by `uid`
+
+Usage:
+    python <script> <angular_app_dir> <grafana_dashboard_dir>
+
+e.g.
+    cd /ceph/src/pybind/mgr/dashboard
+    python ci/<script> frontend/src/app /ceph/monitoring/grafana/dashboards
+"""
+import argparse
+import copy
+import json
+import os
+
+import six
+from six.moves.html_parser import HTMLParser
+
+
+class TemplateParser(HTMLParser):
+
+    def __init__(self, _file, search_tag):
+        if six.PY3:
+            super(TemplateParser, self).__init__()
+        else:
+            # HTMLParser is not a new-style class in py2
+            HTMLParser.__init__(self)
+        self.search_tag = search_tag
+        self.file = _file
+        self.parsed_data = []
+
+    def parse(self):
+        with open(self.file) as f:
+            self.feed(f.read())
+
+    def handle_starttag(self, tag, attrs):
+        if tag != self.search_tag:
+            return
+        tag_data = {
+            'file': self.file,
+            'attrs': dict(attrs),
+            'line': self.getpos()[0]
+        }
+        self.parsed_data.append(tag_data)
+
+    def error(self, message):
+        error_msg = 'fail to parse file {} (@{}): {}'.\
+            format(self.file, self.getpos(), message)
+        exit(error_msg)
+
+
+def stdout(msg):
+    six.print_(msg)
+
+
+def get_files(base_dir, file_ext):
+    result = []
+    for root, _, files in os.walk(base_dir):
+        for _file in files:
+            if _file.endswith('.{}'.format(file_ext)):
+                result.append(os.path.join(root, _file))
+    return result
+
+
+def get_tags(base_dir, tag='cd-grafana'):
+    templates = get_files(base_dir, 'html')
+    tags = []
+    for templ in templates:
+        parser = TemplateParser(templ, tag)
+        parser.parse()
+        if parser.parsed_data:
+            tags.extend(parser.parsed_data)
+    return tags
+
+
+def get_grafana_dashboards(base_dir):
+    json_files = get_files(base_dir, 'json')
+    dashboards = {}
+    for json_file in json_files:
+        with open(json_file) as f:
+            dashboard_config = json.load(f)
+            uid = dashboard_config.get('uid')
+            if not uid:
+                continue
+            if uid in dashboards:
+                # duplicated uids
+                error_msg = 'Duplicated UID {} found, already defined in {}'.\
+                    format(uid, dashboards[uid]['file'])
+                exit(error_msg)
+            dashboards[uid] = {
+                'file': json_file,
+                'title': dashboard_config['title']
+            }
+    return dashboards
+
+
+def parse_args():
+    long_desc = ('Check every <cd-grafana> component in Angular template has a'
+                 ' mapped Grafana dashboard.')
+    parser = argparse.ArgumentParser(description=long_desc)
+    parser.add_argument('angular_app_dir', type=str,
+                        help='Angular app base directory')
+    parser.add_argument('grafana_dash_dir', type=str,
+                        help='Directory contains Grafana dashboard JSON files')
+    parser.add_argument('--verbose', action='store_true',
+                        help='Display verbose mapping information.')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    tags = get_tags(args.angular_app_dir)
+    grafana_dashboards = get_grafana_dashboards(args.grafana_dash_dir)
+    verbose = args.verbose
+
+    if not tags:
+        error_msg = 'Can not find any cd-grafana component under {}'.\
+            format(args.angular_app_dir)
+        exit(error_msg)
+
+    if verbose:
+        stdout('Found mappings:')
+    no_dashboard_tags = []
+    for tag in tags:
+        uid = tag['attrs']['uid']
+        if uid not in grafana_dashboards:
+            no_dashboard_tags.append(copy.copy(tag))
+            continue
+        if verbose:
+            msg = '{} ({}:{}) \n\t-> {} ({})'.\
+                format(uid, tag['file'], tag['line'],
+                       grafana_dashboards[uid]['title'],
+                       grafana_dashboards[uid]['file'])
+            stdout(msg)
+
+    if no_dashboard_tags:
+        title = ('Checking Grafana dashboards UIDs: ERROR\n'
+                 'Components that have no mapped Grafana dashboards:\n')
+        lines = ('{} ({}:{})'.format(tag['attrs']['uid'],
+                                     tag['file'],
+                                     tag['line'])
+                 for tag in no_dashboard_tags)
+        error_msg = title + '\n'.join(lines)
+        exit(error_msg)
+    else:
+        stdout('Checking Grafana dashboards UIDs: OK')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/pybind/mgr/dashboard/run-tox.sh
+++ b/src/pybind/mgr/dashboard/run-tox.sh
@@ -30,7 +30,7 @@ if [ "$WITH_PYTHON2" = "ON" ]; then
   if [[ -n "$@" ]]; then
     ENV_LIST+="py27-run,"
   else
-    ENV_LIST+="py27-cov,py27-lint,"
+    ENV_LIST+="py27-cov,py27-lint,py27-check,"
   fi
 fi
 # WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
@@ -39,7 +39,7 @@ if [[ "$WITH_PYTHON3" =~ (^3|^ON) ]]; then
   if [[ -n "$@" ]]; then
     ENV_LIST+="py3-run,"
   else
-    ENV_LIST+="py3-cov,py3-lint"
+    ENV_LIST+="py3-cov,py3-lint,py3-check,"
   fi
 fi
 # use bash string manipulation to strip off any trailing comma

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-{cov,lint,run},py3-{cov,lint,run}
+envlist = py27-{cov,lint,run,check},py3-{cov,lint,run,check}
 skipsdist = true
 toxworkdir = {env:CEPH_BUILD_DIR}/dashboard
 minversion = 2.8.1
@@ -24,6 +24,7 @@ commands=
     cov: coverage combine {toxinidir}/{env:COVERAGE_FILE}
     cov: coverage report
     cov: coverage xml
-    lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services exceptions.py grafana.py
+    lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services exceptions.py grafana.py ci/check_grafana_uids.py
     lint: pycodestyle --max-line-length=100 --exclude=.tox,venv,frontend,.vscode --ignore=E402,E121,E123,E126,E226,E24,E704,W503,E741 .
+    check: python ci/check_grafana_uids.py frontend/src/app ../../../../monitoring/grafana/dashboards
     run: {posargs}


### PR DESCRIPTION
Add a script to check a cd-grafana component always refers to an
existing Grafana dashboard and integrate it in frontend unit tests.

Fixes: http://tracker.ceph.com/issues/40008

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

