### PR TITLE
cephfs-shell: Add tox for testing with flake8

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -111,7 +111,7 @@ function run() {
     BUILD_MAKEOPTS=${BUILD_MAKEOPTS:-$DEFAULT_MAKEOPTS}
     test "$BUILD_MAKEOPTS" && echo "make will run with option(s) $BUILD_MAKEOPTS"
     CHECK_MAKEOPTS=${CHECK_MAKEOPTS:-$DEFAULT_MAKEOPTS}
-    CMAKE_BUILD_OPTS="-DWITH_GTEST_PARALLEL=ON -DWITH_FIO=ON -DWITH_SEASTAR=ON"
+    CMAKE_BUILD_OPTS="-DWITH_GTEST_PARALLEL=ON -DWITH_FIO=ON -DWITH_SEASTAR=ON -DWITH_CEPHFS_SHELL=ON"
     CMAKE_BUILD_OPTS+=$(detect_ceph_dev_pkgs)
     cat <<EOM
 Note that the binaries produced by this script do not contain correct time

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -580,6 +580,13 @@ if(WITH_MGR)
   list(APPEND tox_tests run-tox-python-common)
 endif()
 
+if(WITH_CEPHFS_SHELL)
+  add_test(NAME run-tox-cephfs-shell COMMAND bash ${CMAKE_SOURCE_DIR}/src/tools/cephfs/run-tox.sh)
+  list(APPEND tox_tests run-tox-cephfs-shell)
+  set(CEPHFS_SHELL_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/cephfs-shell-virtualenv)
+  list(APPEND env_vars_for_tox_tests CEPHFS_SHELL_VIRTUALENV=${CEPHFS_SHELL_VIRTUALENV})
+endif()
+
 set_property(
   TEST ${tox_tests}
   PROPERTY ENVIRONMENT ${env_vars_for_tox_tests})

--- a/src/tools/cephfs/CMakeLists.txt
+++ b/src/tools/cephfs/CMakeLists.txt
@@ -41,9 +41,10 @@ install(TARGETS
 option(WITH_CEPHFS_SHELL "install cephfs-shell" OFF)
 if(WITH_CEPHFS_SHELL)
   if(NOT WITH_PYTHON3)
-    message(SEND_ERROR "Please enable WITH_PYTHON3 for cephfs-shell")
+    message(WARNING "Please enable WITH_PYTHON3 for cephfs-shell")
+  else()
+    include(Distutils)
+    distutils_install_module(cephfs-shell
+      PYTHON_VERSION 3)
   endif()
-  include(Distutils)
-  distutils_install_module(cephfs-shell
-    PYTHON_VERSION 3)
 endif()

--- a/src/tools/cephfs/run-tox.sh
+++ b/src/tools/cephfs/run-tox.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+TOX_PATH=${CEPH_ROOT}/src/tools/cephfs/tox.ini
+CEPHFS=${CEPH_ROOT}/src/tools/cephfs
+
+tox -c ${TOX_PATH} -e flake8
+TOX_STATUS="$?"
+test "$TOX_STATUS" -ne "0"
+rm -rf ${CEPHFS}/.tox/
+rm -rf ${CEPHFS}/cephfs_shell.egg-info/
+exit $TOX_STATUS

--- a/src/tools/cephfs/tox.ini
+++ b/src/tools/cephfs/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+skipsdist = true
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 --ignore=W503 --max-line-length=100 cephfs-shell


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/39947
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

