### PR TITLE
osdc/Objecter: fix OSDMap leak in handle_osd_map

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1213,6 +1213,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
 
           emit_blacklist_events(*osdmap, *new_osdmap);
 
+	  delete osdmap;
           osdmap = new_osdmap;
 
 	  logger->inc(l_osdc_map_full);


### PR DESCRIPTION
If there are threads accessing osdmap unlocked they may walk into freed
memory, but that means the caller is buggy: we are holding the rwlock.

Fixes: http://tracker.ceph.com/issues/20491
Signed-off-by: Sage Weil <sage@redhat.com>