### PR TITLE
mgr/balancer: fix initial weight-set value for newly created osds

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1050,8 +1050,12 @@ class Module(MgrModule):
                         if actual[osd] > 0:
                             calc_weight = target[osd] / actual[osd] * weight * ow
                         else:
-                            # not enough to go on here... keep orig weight
-                            calc_weight = weight / orig_osd_weight[osd]
+                            # for newly created osds, reset calc_weight at target value
+                            # this way weight-set will end up absorbing *step* of its
+                            # target (final) value at the very beginning and slowly catch up later.
+                            # note that if this turns out causing too many misplaced
+                            # pgs, then we'll reduce step and retry
+                            calc_weight = target[osd]
                         new_weight = weight * (1.0 - step) + calc_weight * step
                         self.log.debug('Reweight osd.%d %f -> %f', osd, weight,
                                        new_weight)

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -426,6 +426,11 @@ class Module(MgrModule):
                            'Try "ceph osd set-require-min-compat-client luminous" ' \
                            'before enabling this mode' % min_compat_client
                     return (-errno.EPERM, '', warn)
+            elif command['mode'] == 'crush-compat':
+                ms = MappingState(self.get_osdmap(),
+                                  self.get("pg_dump"),
+                                  'initialize compat weight-set')
+                self.get_compat_weight_set_weights(ms) # ignore error
             self.set_module_option('mode', command['mode'])
             return (0, '', '')
         elif command['prefix'] == 'balancer on':


### PR DESCRIPTION
This is a follow-up fix for https://github.com/ceph/ceph/pull/26955,
which should make any OSD addition start with a zeroed weight-set weight.
But without this fix, the balancer won't be able to handle it properly..

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

