### PR TITLE
common,osd: add hash algorithms for dedup fingerprint 

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -2043,6 +2043,8 @@ void buffer::list::invalidate_crc()
 
 #include "common/ceph_crypto.h"
 using ceph::crypto::SHA1;
+using ceph::crypto::SHA256;
+using ceph::crypto::SHA512;
 
 sha1_digest_t buffer::list::sha1()
 {
@@ -2053,6 +2055,28 @@ sha1_digest_t buffer::list::sha1()
   }
   sha1_gen.Final(fingerprint);
   return sha1_digest_t(fingerprint);
+}
+
+sha256_digest_t buffer::list::sha256()
+{
+  unsigned char fingerprint[CEPH_CRYPTO_SHA256_DIGESTSIZE];
+  SHA256 sha256_gen;
+  for (auto& p : _buffers) {
+    sha256_gen.Update((const unsigned char *)p.c_str(), p.length());
+  }
+  sha256_gen.Final(fingerprint);
+  return sha256_digest_t(fingerprint);
+}
+
+sha512_digest_t buffer::list::sha512()
+{
+  unsigned char fingerprint[CEPH_CRYPTO_SHA512_DIGESTSIZE];
+  SHA512 sha512_gen;
+  for (auto& p : _buffers) {
+    sha512_gen.Update((const unsigned char *)p.c_str(), p.length());
+  }
+  sha512_gen.Final(fingerprint);
+  return sha512_digest_t(fingerprint);
 }
 
 /**

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -10,6 +10,7 @@
 #define CEPH_CRYPTO_SHA1_DIGESTSIZE 20
 #define CEPH_CRYPTO_HMACSHA256_DIGESTSIZE 32
 #define CEPH_CRYPTO_SHA256_DIGESTSIZE 32
+#define CEPH_CRYPTO_SHA512_DIGESTSIZE 64
 
 #ifdef USE_NSS
 // you *must* use CRYPTO_CXXFLAGS in CMakeLists.txt for including this include
@@ -33,6 +34,7 @@ extern "C" {
   const EVP_MD *EVP_md5(void);
   const EVP_MD *EVP_sha1(void);
   const EVP_MD *EVP_sha256(void);
+  const EVP_MD *EVP_sha512(void);
 }
 #endif /*USE_OPENSSL*/
 
@@ -115,6 +117,11 @@ namespace ceph {
       public:
         SHA256 () : NSSDigest(SEC_OID_SHA256, CEPH_CRYPTO_SHA256_DIGESTSIZE) { }
       };
+
+      class SHA512 : public NSSDigest {
+      public:
+        SHA512 () : NSSDigest(SEC_OID_SHA512, CEPH_CRYPTO_SHA512_DIGESTSIZE) { }
+      };
     }
   }
 }
@@ -149,6 +156,11 @@ namespace ceph {
       class SHA256 : public OpenSSLDigest {
       public:
         SHA256 () : OpenSSLDigest(EVP_sha256()) { }
+      };
+
+      class SHA512 : public OpenSSLDigest {
+      public:
+        SHA512 () : OpenSSLDigest(EVP_sha512()) { }
       };
     }
   }
@@ -337,6 +349,7 @@ namespace ceph {
     using ceph::crypto::ssl::SHA256;
     using ceph::crypto::ssl::MD5;
     using ceph::crypto::ssl::SHA1;
+    using ceph::crypto::ssl::SHA512;
 
     using ceph::crypto::ssl::HMACSHA256;
     using ceph::crypto::ssl::HMACSHA1;
@@ -348,6 +361,7 @@ namespace ceph {
     using ceph::crypto::nss::SHA256;
     using ceph::crypto::nss::MD5;
     using ceph::crypto::nss::SHA1;
+    using ceph::crypto::nss::SHA512;
 
     using ceph::crypto::nss::HMACSHA256;
     using ceph::crypto::nss::HMACSHA1;

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -76,6 +76,8 @@ class deleter;
 template<uint8_t S>
 struct sha_digest_t;
 using sha1_digest_t = sha_digest_t<20>;
+using sha256_digest_t = sha_digest_t<32>;
+using sha512_digest_t = sha_digest_t<64>;
 
 template<typename T> class DencDumper;
 
@@ -1233,6 +1235,8 @@ inline namespace v14_2_0 {
     uint32_t crc32c(uint32_t crc) const;
     void invalidate_crc();
     sha1_digest_t sha1();
+    sha256_digest_t sha256();
+    sha512_digest_t sha512();
 
     // These functions return a bufferlist with a pointer to a single
     // static buffer. They /must/ not outlive the memory they

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -623,5 +623,8 @@ WRITE_CLASS_ENCODER(sha1_digest_t)
 using sha256_digest_t = sha_digest_t<32>;
 WRITE_CLASS_ENCODER(sha256_digest_t)
 
+using md5_digest_t = sha_digest_t<16>;
+WRITE_CLASS_ENCODER(md5_digest_t)
+
 
 #endif

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1455,12 +1455,18 @@ public:
   typedef enum {
     TYPE_FINGERPRINT_NONE = 0,
     TYPE_FINGERPRINT_SHA1 = 1,     
+    TYPE_FINGERPRINT_SHA256 = 2,     
+    TYPE_FINGERPRINT_SHA512 = 3,     
   } fingerprint_t;
   static fingerprint_t get_fingerprint_from_str(const std::string& s) {
     if (s == "none")
       return TYPE_FINGERPRINT_NONE;
     if (s == "sha1")
       return TYPE_FINGERPRINT_SHA1;
+    if (s == "sha256")
+      return TYPE_FINGERPRINT_SHA256;
+    if (s == "sha512")
+      return TYPE_FINGERPRINT_SHA512;
     return (fingerprint_t)-1;
   }
   const fingerprint_t get_fingerprint_type() const {
@@ -1479,6 +1485,8 @@ public:
     switch (m) {
     case TYPE_FINGERPRINT_NONE: return "none";
     case TYPE_FINGERPRINT_SHA1: return "sha1";
+    case TYPE_FINGERPRINT_SHA256: return "sha256";
+    case TYPE_FINGERPRINT_SHA512: return "sha512";
     default: return "unknown";
     }
   }

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2911,6 +2911,86 @@ TEST(BufferList, TestSHA1) {
   }
 }
 
+TEST(BufferList, TestSHA256) {
+  {
+    bufferlist bl;
+    sha256_digest_t sha256 = bl.sha256();
+    EXPECT_EQ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", sha256.to_str());
+  }
+  {
+    bufferlist bl;
+    bl.append("");
+    sha256_digest_t sha256 = bl.sha256();
+    EXPECT_EQ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", sha256.to_str());
+  }
+  {
+    bufferlist bl;
+    bl.append("Hello");
+    sha256_digest_t sha256 = bl.sha256();
+    EXPECT_EQ("185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969", sha256.to_str());
+  }
+  {
+    bufferlist bl, bl2;
+    bl.append("Hello");
+    bl2.append(", world!");
+    bl.claim_append(bl2);
+    sha256_digest_t sha256 = bl.sha256();
+    EXPECT_EQ("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3", sha256.to_str());
+    bl2.append("  How are you today?");
+    bl.claim_append(bl2);
+    sha256 = bl.sha256();
+    EXPECT_EQ("e85f57f8bb018bd4f7beed6f27488cef22b13d5e06e8b8a27cac8b087c2a549e", sha256.to_str());
+  }
+  {
+    bufferptr p(65536);
+    memset(p.c_str(), 0, 65536);
+    bufferlist bl;
+    bl.append(p);
+    sha256_digest_t sha256 = bl.sha256();
+    EXPECT_EQ("de2f256064a0af797747c2b97505dc0b9f3df0de4f489eac731c23ae9ca9cc31", sha256.to_str());
+  }
+}
+
+TEST(BufferList, TestSHA512) {
+  {
+    bufferlist bl;
+    sha512_digest_t sha512 = bl.sha512();
+    EXPECT_EQ("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e", sha512.to_str());
+  }
+  {
+    bufferlist bl;
+    bl.append("");
+    sha512_digest_t sha512 = bl.sha512();
+    EXPECT_EQ("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e", sha512.to_str());
+  }
+  {
+    bufferlist bl;
+    bl.append("Hello");
+    sha512_digest_t sha512 = bl.sha512();
+    EXPECT_EQ("3615f80c9d293ed7402687f94b22d58e529b8cc7916f8fac7fddf7fbd5af4cf777d3d795a7a00a16bf7e7f3fb9561ee9baae480da9fe7a18769e71886b03f315", sha512.to_str());
+  }
+  {
+    bufferlist bl, bl2;
+    bl.append("Hello");
+    bl2.append(", world!");
+    bl.claim_append(bl2);
+    sha512_digest_t sha512 = bl.sha512();
+    EXPECT_EQ("c1527cd893c124773d811911970c8fe6e857d6df5dc9226bd8a160614c0cd963a4ddea2b94bb7d36021ef9d865d5cea294a82dd49a0bb269f51f6e7a57f79421", sha512.to_str());
+    bl2.append("  How are you today?");
+    bl.claim_append(bl2);
+    sha512 = bl.sha512();
+    EXPECT_EQ("7d50e299496754f9a0d158e018d4b733f2ef51c487b43b50719ffdabe3c3da5a347029741056887b4ffa2ddd0aa9e0dd358b8ed9da9a4f3455f44896fc8e5395", sha512.to_str());
+  }
+  {
+    bufferptr p(65536);
+    memset(p.c_str(), 0, 65536);
+    bufferlist bl;
+    bl.append(p);
+    sha512_digest_t sha512 = bl.sha512();
+    EXPECT_EQ("73e4153936dab198397b74ee9efc26093dda721eaab2f8d92786891153b45b04265a161b169c988edb0db2c53124607b6eaaa816559c5ce54f3dbc9fa6a7a4b2", sha512.to_str());
+  }
+}
+
 TEST(BufferHash, all) {
   {
     bufferlist bl;

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -59,7 +59,7 @@ void usage()
   cout << "   --object <object_name> " << std::endl;
   cout << "   --chunk-size <size> chunk-size (byte) " << std::endl;
   cout << "   --chunk-algorithm <fixed|rabin> " << std::endl;
-  cout << "   --fingerprint-algorithm <sha1> " << std::endl;
+  cout << "   --fingerprint-algorithm <sha1|sha256|sha512> " << std::endl;
   cout << "   --chunk-pool <pool name> " << std::endl;
   cout << "   --max-thread <threads> " << std::endl;
   cout << "   --report-perioid <seconds> " << std::endl;
@@ -371,6 +371,12 @@ void EstimateDedupRatio::add_chunk_fp_to_stat(bufferlist &chunk)
   if (fp_algo == "sha1") {
     sha1_digest_t sha1_val = chunk.sha1();
     fp = sha1_val.to_str();
+  } else if (fp_algo == "sha256") {
+    sha256_digest_t sha256_val = chunk.sha256();
+    fp = sha256_val.to_str();
+  } else if (fp_algo == "sha512") {
+    sha512_digest_t sha512_val = chunk.sha512();
+    fp = sha512_val.to_str();
   } else if (chunk_algo == "rabin") {
     uint64_t hash = rabin.gen_rabin_hash(chunk.c_str(), 0, chunk.length());
     fp = to_string(hash);
@@ -569,7 +575,8 @@ int estimate_dedup_ratio(const std::map < std::string, std::string > &opts,
   i = opts.find("fingerprint-algorithm");
   if (i != opts.end()) {
     fp_algo = i->second.c_str();
-    if (fp_algo != "sha1" && fp_algo != "rabin") {
+    if (fp_algo != "sha1" && fp_algo != "rabin"
+	&& fp_algo != "sha256" && fp_algo != "sha512") {
       usage_exit();
     }
   } else {


### PR DESCRIPTION
add sha256, sha512 to use those algorithms as fingerprint IDs for dedup tier

Signed-off-by: Myoungwon Oh <omwmw@sk.com>