### PR TITLE
common: no need to include ceph_assert.h

### DIFF
--- a/src/common/convenience.h
+++ b/src/common/convenience.h
@@ -21,10 +21,6 @@
 
 #include <boost/optional.hpp>
 
-#include "include/ceph_assert.h" // I despise you. Not you the reader, I'm talking
-                            // to the include file.
-
-
 #ifndef CEPH_COMMON_CONVENIENCE_H
 #define CEPH_COMMON_CONVENIENCE_H
 

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -296,7 +296,6 @@ target_link_libraries(unittest_iso_8601 ceph-common)
 add_ceph_unittest(unittest_iso_8601)
 
 add_executable(unittest_convenience test_convenience.cc)
-target_link_libraries(unittest_convenience ceph-common)
 add_ceph_unittest(unittest_convenience)
 
 add_executable(unittest_bounded_key_counter


### PR DESCRIPTION
src/common/convenience.h is a header-only library, and it does not use
dout or ceph_assert() utilities. so there is no need to include
`ceph_assert.h`.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

