### PR TITLE
cmake: link libosd against libos

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -500,7 +500,7 @@ set(ceph_osd_srcs
   ceph_osd.cc)
 add_executable(ceph-osd ${ceph_osd_srcs})
 add_dependencies(ceph-osd erasure_code_plugins)
-target_link_libraries(ceph-osd osd os global-static common
+target_link_libraries(ceph-osd osd global-static ceph-common
   ${BLKID_LIBRARIES})
 if(WITH_FUSE)
   target_link_libraries(ceph-osd ${FUSE_LIBRARIES})

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -75,7 +75,7 @@ add_library(os STATIC ${libos_srcs}
   $<TARGET_OBJECTS:kv_objs>
   $<TARGET_OBJECTS:common_prioritycache_obj>)
 
-target_link_libraries(os heap_profiler)
+target_link_libraries(os heap_profiler ceph-common)
 
 if(WITH_BLUEFS)
   add_library(bluefs SHARED 

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(osd
   PUBLIC dmclock::dmclock
   PRIVATE
   ${LEVELDB_LIBRARIES}
-  heap_profiler cpu_profiler ${CMAKE_DL_LIBS})
+  heap_profiler cpu_profiler os ${CMAKE_DL_LIBS})
 if(WITH_LTTNG)
   add_dependencies(osd osd-tp pg-tp)
 endif()


### PR DESCRIPTION
otherwise we could run into:

../../../lib/libosd.a(OSD.cc.o): In function
`OSD::enable_disable_fuse(bool)':
/home/jenkins-build/build/workspace/ceph-pull-requests/src/osd/OSD.cc:2613:
undefined reference to `FuseStore::stop()'
/home/jenkins-build/build/workspace/ceph-pull-requests/src/osd/OSD.cc:2614:
undefined reference to `FuseStore::~FuseStore()'
/home/jenkins-build/build/workspace/ceph-pull-requests/src/osd/OSD.cc:2635:
undefined reference to `FuseStore::FuseStore(ObjectStore*, std::string)'
/home/jenkins-build/build/workspace/ceph-pull-requests/src/osd/OSD.cc:2636:
undefined reference to `FuseStore::start()'
/home/jenkins-build/build/workspace/ceph-pull-requests/src/osd/OSD.cc:2639:
undefined reference to `FuseStore::~FuseStore()'
../../../lib/libosd.a(PrimaryLogPG.cc.o): In function
`PrimaryLogPG::do_osd_ops(PrimaryLogPG::OpContext*, std::vector<OSDOp,
std::allocator<OSDOp> >&)':
/home/jenkins-build/build/workspace/ceph-pull-requests/src/osd/PrimaryLogPG.cc:7420:
undefined reference to
`decode_str_str_map_to_bl(ceph::buffer::v14_2_0::list::iterator_impl<true>&,
ceph::buffer::v14_2_0::list*)'
/home/jenkins-build/build/workspace/ceph-pull-requests/src/osd/PrimaryLogPG.cc:7502:
undefined reference to
`decode_str_set_to_bl(ceph::buffer::v14_2_0::list::iterator_impl<true>&,
ceph::buffer::v14_2_0::list*)'

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

