### PR TITLE
nautilus: os/bluestore: fix missing discard in BlueStore::_kv_sync_thread

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10555,7 +10555,20 @@ void BlueStore::_kv_sync_thread()
 	if (!bluefs_extents_reclaiming.empty()) {
 	  dout(0) << __func__ << " releasing old bluefs 0x" << std::hex
 		   << bluefs_extents_reclaiming << std::dec << dendl;
+	  int r = 0;
+	  if (cct->_conf->bdev_enable_discard && cct->_conf->bdev_async_discard) {
+	    r = bdev->queue_discard(bluefs_extents_reclaiming);
+	    if (r == 0) {
+	      goto clear;
+	    }
+	  } else if (cct->_conf->bdev_enable_discard) {
+	    for (auto p = bluefs_extents_reclaiming.begin(); p != bluefs_extents_reclaiming.end(); ++p) {
+	      bdev->discard(p.get_start(), p.get_len());
+	    }
+	  }
+
 	  alloc->release(bluefs_extents_reclaiming);
+clear:
 	  bluefs_extents_reclaiming.clear();
 	}
       }


### PR DESCRIPTION
http://tracker.ceph.com/issues/39672