### PR TITLE
mgr/dashboard: consider 'mon_allow_pool_delete' flag

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -286,7 +286,6 @@ class ClusterConfigurationTest(DashboardTestCase):
         """
         This test case is intended to check the existence of all hard coded config options used by
         the dashboard.
-
         If you include further hard coded options in the dashboard, feel free to add them to the
         list.
         """
@@ -326,7 +325,8 @@ class ClusterConfigurationTest(DashboardTestCase):
             'osd_scrub_interval_randomize_ratio',  # osd-pg-scrub
             'osd_scrub_invalid_stats',  # osd-pg-scrub
             'osd_scrub_load_threshold',  # osd-pg-scrub
-            'osd_scrub_max_preemptions'  # osd-pg-scrub
+            'osd_scrub_max_preemptions',  # osd-pg-scrub
+            'mon_allow_pool_delete'  # pool-list
         ]
 
         for config_option in hard_coded_options:

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -8,6 +8,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 import { of } from 'rxjs';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { PoolService } from '../../../shared/api/pool.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
 import { ExecutingTask } from '../../../shared/models/executing-task';
@@ -65,6 +66,56 @@ describe('PoolListComponent', () => {
 
   it('should have columns that are sortable', () => {
     expect(component.columns.every((column) => Boolean(column.prop))).toBeTruthy();
+  });
+
+  describe('monAllowPoolDelete', () => {
+    let configurationService: ConfigurationService;
+
+    beforeEach(() => {
+      configurationService = TestBed.get(ConfigurationService);
+    });
+
+    it('should set value correctly if mon_allow_pool_delete flag is set to true', () => {
+      const configOption = {
+        name: 'mon_allow_pool_delete',
+        value: [
+          {
+            section: 'mon',
+            value: 'true'
+          }
+        ]
+      };
+      spyOn(configurationService, 'get').and.returnValue(of(configOption));
+      fixture = TestBed.createComponent(PoolListComponent);
+      component = fixture.componentInstance;
+      expect(component.monAllowPoolDelete).toBe(true);
+    });
+
+    it('should set value correctly if mon_allow_pool_delete flag is set to false', () => {
+      const configOption = {
+        name: 'mon_allow_pool_delete',
+        value: [
+          {
+            section: 'mon',
+            value: 'false'
+          }
+        ]
+      };
+      spyOn(configurationService, 'get').and.returnValue(of(configOption));
+      fixture = TestBed.createComponent(PoolListComponent);
+      component = fixture.componentInstance;
+      expect(component.monAllowPoolDelete).toBe(false);
+    });
+
+    it('should set value correctly if mon_allow_pool_delete flag is not set', () => {
+      const configOption = {
+        name: 'mon_allow_pool_delete'
+      };
+      spyOn(configurationService, 'get').and.returnValue(of(configOption));
+      fixture = TestBed.createComponent(PoolListComponent);
+      component = fixture.componentInstance;
+      expect(component.monAllowPoolDelete).toBe(false);
+    });
   });
 
   describe('pool deletion', () => {
@@ -346,6 +397,20 @@ describe('PoolListComponent', () => {
       expect(component.selectionCacheTiers).toEqual([{ pg_num: 256, pool: 0, pool_name: 'a' }]);
       setSelectionTiers([]);
       expect(component.selectionCacheTiers).toEqual([]);
+    });
+  });
+
+  describe('getDisableDesc', () => {
+    it('should return message if mon_allow_pool_delete flag is set to false', () => {
+      component.monAllowPoolDelete = false;
+      expect(component.getDisableDesc()).toBe(
+        'Pool deletion is disabled by the mon_allow_pool_delete configuration setting.'
+      );
+    });
+
+    it('should return undefined if mon_allow_pool_delete flag is set to true', () => {
+      component.monAllowPoolDelete = true;
+      expect(component.getDisableDesc()).toBeUndefined();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.html
@@ -24,7 +24,8 @@
     <ng-container *ngFor="let action of dropDownActions">
       <li role="menuitem"
           class="{{ toClassName(action['name']) }}"
-          [ngClass]="{'disabled': disableSelectionAction(action)}">
+          [ngClass]="{'disabled': disableSelectionAction(action)}"
+          data-toggle="tooltip" title="{{ useDisableDesc(action) }}">
         <a class="dropdown-item"
            (click)="useClickAction(action)"
            [routerLink]="useRouterLink(action)">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.scss
@@ -1,0 +1,4 @@
+.dropdown-menu > .disabled > a {
+  pointer-events: auto;
+  cursor: default !important;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.spec.ts
@@ -284,4 +284,51 @@ describe('TableActionsComponent', () => {
     expect(component.toClassName('Mark x down')).toBe('mark-x-down');
     expect(component.toClassName('?Su*per!')).toBe('super');
   });
+
+  describe('useDisableDesc', () => {
+    it('should return a description if disableDesc is set for action', () => {
+      const deleteWithDescAction: CdTableAction = {
+        permission: 'delete',
+        icon: 'fa-times',
+        canBePrimary: (selection: CdTableSelection) => selection.hasSelection,
+        disableDesc: () => {
+          return 'Delete action disabled description';
+        },
+        name: 'DeleteDesc'
+      };
+
+      expect(component.useDisableDesc(deleteWithDescAction)).toBe(
+        'Delete action disabled description'
+      );
+    });
+
+    it('should return no description if disableDesc is not set for action', () => {
+      expect(component.useDisableDesc(deleteAction)).toBeUndefined();
+    });
+  });
+
+  describe('useClickAction', () => {
+    const editClickAction: CdTableAction = {
+      permission: 'update',
+      icon: 'fa-pencil',
+      name: 'Edit',
+      click: () => {
+        return 'Edit action click';
+      }
+    };
+
+    it('should call click action if action is not disabled', () => {
+      editClickAction.disable = () => {
+        return false;
+      };
+      expect(component.useClickAction(editClickAction)).toBe('Edit action click');
+    });
+
+    it('should not call click action if action is disabled', () => {
+      editClickAction.disable = () => {
+        return true;
+      };
+      expect(component.useClickAction(editClickAction)).toBeFalsy();
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.ts
@@ -132,6 +132,17 @@ export class TableActionsComponent implements OnInit {
   }
 
   useClickAction(action: CdTableAction) {
-    return action.click && action.click();
+    /**
+     * In order to show tooltips for deactivated menu items, the class
+     * 'pointer-events: auto;' has been added to the .scss file which also
+     * re-activates the click-event.
+     * To prevent calling the click-event on deactivated elements we also have
+     * to check here if it's disabled.
+     */
+    return !this.disableSelectionAction(action) && action.click && action.click();
+  }
+
+  useDisableDesc(action: CdTableAction) {
+    return action.disableDesc && action.disableDesc();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-action.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-action.ts
@@ -23,6 +23,13 @@ export class CdTableAction {
   disable?: (_: CdTableSelection) => boolean;
 
   /**
+   * In some cases you might want to give the user a hint why a button is
+   * disabled. The specified message will be shown to the user as a button
+   * tooltip.
+   */
+  disableDesc?: Function;
+
+  /**
    * Defines if the button can become 'primary' (displayed as button and not
    * 'hidden' in the menu). Only one button can be primary at a time. By
    * default all 'create' actions can be the action button if no or multiple


### PR DESCRIPTION
The pull request adds two parts:

1. The possibility to show description tooltips for disabled menu items.
2.  It checks if the 'mon_allow_pool_delete' flag is set. If not, disable the menu item to delete a pool and show a description why.

Fixes: https://tracker.ceph.com/issues/39533
Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""

"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

