### PR TITLE
nautilus: mgr/dashboard: local variable 'cluster_id' referenced before assignment error when trying to list NFS Ganesha daemons

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nfsganesha.py
+++ b/src/pybind/mgr/dashboard/controllers/nfsganesha.py
@@ -254,8 +254,8 @@ class NFSGaneshaService(RESTController):
                     'status': status_dict[cluster_id][daemon_id]['status'],
                     'desc': status_dict[cluster_id][daemon_id]['desc']
                 }
-                for daemon_id in status_dict[cluster_id]
                 for cluster_id in status_dict
+                for daemon_id in status_dict[cluster_id]
             ]
 
         result = []


### PR DESCRIPTION
http://tracker.ceph.com/issues/40031