### PR TITLE
[WIP] rgw/pubsub: add amqp and http endpoints to tests

### DIFF
--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -149,6 +149,7 @@ void rgw_pubsub_sub_dest::dump(Formatter *f) const
   encode_json("oid_prefix", oid_prefix, f);
   encode_json("push_endpoint", push_endpoint, f);
   encode_json("push_endpoint_args", push_endpoint_args, f);
+  encode_json("arn_topic", arn_topic, f);
 }
 
 void rgw_pubsub_sub_config::dump(Formatter *f) const

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -228,23 +228,28 @@ struct rgw_pubsub_sub_dest {
   std::string oid_prefix;
   std::string push_endpoint;
   std::string push_endpoint_args;
+  std::string arn_topic;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(bucket_name, bl);
     encode(oid_prefix, bl);
     encode(push_endpoint, bl);
     encode(push_endpoint_args, bl);
+    encode(arn_topic, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(bucket_name, bl);
     decode(oid_prefix, bl);
     decode(push_endpoint, bl);
     if (struct_v >= 2) {
         decode(push_endpoint_args, bl);
+    }
+    if (struct_v >= 3) {
+        decode(arn_topic, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -79,6 +79,7 @@ struct PSSubConfig {
   std::string data_bucket_name;
   std::string data_oid_prefix;
   std::string s3_id;
+  std::string arn_topic;
   RGWPubSubEndpoint::Ptr push_endpoint;
 
   void from_user_conf(CephContext *cct, const rgw_pubsub_sub_config& uc) {
@@ -88,10 +89,11 @@ struct PSSubConfig {
     data_bucket_name = uc.dest.bucket_name;
     data_oid_prefix = uc.dest.oid_prefix;
     s3_id = uc.s3_id;
+    arn_topic = uc.dest.arn_topic;
     if (!push_endpoint_name.empty()) {
       push_endpoint_args = uc.dest.push_endpoint_args;
       try {
-        push_endpoint = RGWPubSubEndpoint::create(push_endpoint_name, topic, string_to_args(push_endpoint_args), cct);
+        push_endpoint = RGWPubSubEndpoint::create(push_endpoint_name, arn_topic, string_to_args(push_endpoint_args), cct);
         ldout(cct, 20) << "push endpoint created: " << push_endpoint->to_str() << dendl;
       } catch (const RGWPubSubEndpoint::configuration_error& e) {
           ldout(cct, 1) << "ERROR: failed to create push endpoint: " 
@@ -120,10 +122,11 @@ struct PSSubConfig {
     data_bucket_name = config["data_bucket"](default_bucket_name.c_str());
     data_oid_prefix = config["data_oid_prefix"](default_oid_prefix.c_str());
     s3_id = config["s3_id"];
+    arn_topic = config["arn_topic"];
     if (!push_endpoint_name.empty()) {
       push_endpoint_args = config["push_endpoint_args"];
       try {
-        push_endpoint = RGWPubSubEndpoint::create(push_endpoint_name, topic, string_to_args(push_endpoint_args), cct);
+        push_endpoint = RGWPubSubEndpoint::create(push_endpoint_name, arn_topic, string_to_args(push_endpoint_args), cct);
         ldout(cct, 20) << "push endpoint created: " << push_endpoint->to_str() << dendl;
       } catch (const RGWPubSubEndpoint::configuration_error& e) {
         ldout(cct, 1) << "ERROR: failed to create push endpoint: " 

--- a/src/test/rgw/rgw_multi/tests_ps.py
+++ b/src/test/rgw/rgw_multi/tests_ps.py
@@ -88,7 +88,7 @@ class AMQPReceiver(object):
     """class for receiving and storing messages on a topic from the AMQP broker"""
     def __init__(self, exchange, topic):
         import pika
-        hostname = socket.gethostname()
+        hostname = socket.getfqdn()
         connection = pika.BlockingConnection(pika.ConnectionParameters(host=hostname))
         self.channel = connection.channel()
         self.channel.exchange_declare(exchange=exchange, exchange_type='topic')
@@ -210,7 +210,7 @@ def verify_s3_records_by_elements(records, keys, exact_match=False, deletions=Fa
 
 def init_rabbitmq():
     """ start a rabbitmq broker """
-    #hostname = socket.gethostname()
+    #hostname = socket.getfqdn()
     #port = str(random.randint(20000, 30000))
     #data_dir = './' + port + '_data'
     #log_dir = './' + port + '_log'
@@ -1090,7 +1090,7 @@ def test_ps_push_http():
     topic_name = bucket_name+TOPIC_SUFFIX
 
     # create random port for the http server
-    host = socket.gethostname()
+    host = socket.getfqdn()
     port = random.randint(10000, 20000)
     # start an http server in a separate thread
     task, httpd, = create_http_thread(host, port)
@@ -1150,7 +1150,7 @@ def test_ps_s3_push_http():
     topic_name = bucket_name+TOPIC_SUFFIX
 
     # create random port for the http server
-    host = socket.gethostname()
+    host = socket.getfqdn()
     port = random.randint(10000, 20000)
     # start an http server in a separate thread
     task, httpd, = create_http_thread(host, port)
@@ -1206,7 +1206,7 @@ def test_ps_s3_push_http():
 
 def test_ps_push_amqp():
     """ test pushing to amqp endpoint """
-    hostname = socket.gethostname()
+    hostname = socket.getfqdn()
     proc = init_rabbitmq()
     if proc is  None:
         return SkipTest('end2end amqp tests require rabbitmq-server installed')
@@ -1268,7 +1268,7 @@ def test_ps_push_amqp():
 
 def test_ps_s3_push_amqp():
     """ test pushing to amqp endpoint s3 record format"""
-    hostname = socket.gethostname()
+    hostname = socket.getfqdn()
     proc = init_rabbitmq()
     if proc is  None:
         return SkipTest('end2end amqp tests require rabbitmq-server installed')
@@ -1439,7 +1439,7 @@ def test_ps_s3_topic_update():
     topic_name = bucket_name+TOPIC_SUFFIX
 
     # create amqp topic
-    hostname = socket.gethostname()
+    hostname = socket.getfqdn()
     exchange = 'ex1'
     amqp_task, receiver = create_amqp_receiver_thread(exchange, topic_name)
     amqp_task.start()
@@ -1553,7 +1553,7 @@ def test_ps_s3_topic_update():
 
 def test_ps_s3_notification_update():
     """ test updating the topic of a notification"""
-    hostname = socket.gethostname()
+    hostname = socket.getfqdn()
     rabbit_proc = init_rabbitmq()
     if rabbit_proc is  None:
         return SkipTest('end2end amqp tests require rabbitmq-server installed')
@@ -1658,7 +1658,7 @@ def test_ps_s3_notification_update():
 
 def test_ps_s3_multiple_topics_notification():
     """ test notification creation with multiple topics"""
-    hostname = socket.gethostname()
+    hostname = socket.getfqdn()
     rabbit_proc = init_rabbitmq()
     if rabbit_proc is  None:
         return SkipTest('end2end amqp tests require rabbitmq-server installed')

--- a/src/test/rgw/rgw_multi/tests_ps.py
+++ b/src/test/rgw/rgw_multi/tests_ps.py
@@ -67,7 +67,7 @@ class HTTPPostHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 def http_thread_runner(httpd):
     """main thread function for the http server"""
     try:
-        log.info('HTTP Server started')
+        log.info('HTTP Server started on: %s', httpd.server_address)
         httpd.serve_forever()
         log.info('HTTP Server ended')
     except:
@@ -1090,7 +1090,7 @@ def test_ps_push_http():
     topic_name = bucket_name+TOPIC_SUFFIX
 
     # create random port for the http server
-    host = 'localhost'
+    host = socket.gethostname()
     port = random.randint(10000, 20000)
     # start an http server in a separate thread
     task, httpd, = create_http_thread(host, port)
@@ -1150,7 +1150,7 @@ def test_ps_s3_push_http():
     topic_name = bucket_name+TOPIC_SUFFIX
 
     # create random port for the http server
-    host = 'localhost'
+    host = socket.gethostname()
     port = random.randint(10000, 20000)
     # start an http server in a separate thread
     task, httpd, = create_http_thread(host, port)

--- a/src/test/rgw/rgw_multi/tests_ps.py
+++ b/src/test/rgw/rgw_multi/tests_ps.py
@@ -8,7 +8,6 @@ import subprocess
 import socket
 # import os
 import time
-import pika
 from .tests import get_realm, \
     ZonegroupConns, \
     zonegroup_meta_checkpoint, \
@@ -88,6 +87,7 @@ def create_http_thread(host, port):
 class AMQPReceiver(object):
     """class for receiving and storing messages on a topic from the AMQP broker"""
     def __init__(self, exchange, topic):
+        import pika
         hostname = socket.gethostname()
         connection = pika.BlockingConnection(pika.ConnectionParameters(host=hostname))
         self.channel = connection.channel()


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

* Automated end2end testing for amqp and http endpoints for pubsub
* Bug fix in the value of topic being sent to amqp - found by the test :-)
* Run using the master teuthology branch (end2end amqp tests are skipped) 
 
> Note that some of the processing had to be done in a separate thread.

Known Issues:
1. For the amqp end2end tests to run, the following teuthology PR: https://github.com/ceph/teuthology/pull/1292 must be merged. However, current PR **can be merged regardless**, if the rabbitmq-server is not installed on the destination, the end2end amqp tests will be skipped (see: ```failed to execute rabbitmq-server``` in teuthology.log)
2. Currently the code for running multiple rabbitmq-server instances on the same host is commented out. this should be added and tested, so that multiple users can execute the this suite on the same machine
3. ~Some of the tests are currently failing because of something that looks like a product bug. This will be fixed in a separate PR, should not block this one~
4. Currently I use "sleep" to make sure that the rabbitmq-server is up, this may be replaces with a checkpoint function based on "rabbitmqctl" CLI tool
5. **current blocker** (reason for DNM tag) is the fact that calling  ```socket.getfqdn()``` or ```socket.gethostname()``` in the test code return 127.0.0.1, so, the rgw cannot send the pubsub messages to the HTTP server
