### PR TITLE
mgr/dashboard: Display iSCSI "logged in" info

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -671,6 +671,11 @@ class IscsiTarget(RESTController):
         gateway_name = target['portals'][0]['host']
         target_info = IscsiClient.instance(gateway_name=gateway_name).get_targetinfo(target_iqn)
         target['info'] = target_info
+        for client in target['clients']:
+            client_iqn = client['client_iqn']
+            client_info = IscsiClient.instance(gateway_name=gateway_name).get_clientinfo(
+                target_iqn, client_iqn)
+            client['info'] = client_info
 
     @staticmethod
     def _sorted_portals(portals):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.html
@@ -8,7 +8,7 @@
       <span>&nbsp;</span>
 
       <span class="label"
-            [ngClass]="{'label-success': ['in', 'up'].includes(node.status), 'label-danger': ['down', 'out'].includes(node.status)}">
+            [ngClass]="{'label-success': ['logged_in'].includes(node.status), 'label-danger': ['logged_out'].includes(node.status)}">
         {{ node.status }}
       </span>
     </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.spec.ts
@@ -59,6 +59,11 @@ describe('IscsiTargetDetailsComponent', () => {
             luns: [{ pool: 'rbd', image: 'disk_1' }],
             auth: {
               user: 'myiscsiusername'
+            },
+            info: {
+              alias: 'myhost',
+              ip_address: ['192.168.200.1'],
+              state: { LOGGED_IN: ['node1'] }
             }
           }
         ],
@@ -88,7 +93,12 @@ describe('IscsiTargetDetailsComponent', () => {
 
     expect(component.data).toBeUndefined();
     expect(component.metadata).toEqual({
-      'client_iqn.1994-05.com.redhat:rh7-client': { user: 'myiscsiusername' },
+      'client_iqn.1994-05.com.redhat:rh7-client': {
+        user: 'myiscsiusername',
+        alias: 'myhost',
+        ip_address: ['192.168.200.1'],
+        logged_in: ['node1']
+      },
       disk_rbd_disk_1: { backstore: 'backstore:1', controls: { hw_max_sectors: 1 } },
       root: { dataout_timeout: 2 }
     });
@@ -123,6 +133,7 @@ describe('IscsiTargetDetailsComponent', () => {
                 }
               ],
               id: 'client_iqn.1994-05.com.redhat:rh7-client',
+              status: 'logged_in',
               value: 'iqn.1994-05.com.redhat:rh7-client'
             }
           ],
@@ -178,7 +189,10 @@ describe('IscsiTargetDetailsComponent', () => {
       const node = new NodeEvent(tree);
       component.onNodeSelected(node);
       expect(component.data).toEqual([
-        { current: 'myiscsiusername', default: undefined, displayName: 'user' }
+        { current: 'myiscsiusername', default: undefined, displayName: 'user' },
+        { current: 'myhost', default: undefined, displayName: 'alias' },
+        { current: ['192.168.200.1'], default: undefined, displayName: 'ip_address' },
+        { current: ['node1'], default: undefined, displayName: 'logged_in' }
       ]);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
@@ -119,7 +119,13 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
 
     const clients = [];
     _.forEach(this.selectedItem.clients, (client) => {
-      this.metadata['client_' + client.client_iqn] = client.auth;
+      const client_metadata = _.cloneDeep(client.auth);
+      _.extend(client_metadata, client.info);
+      delete client_metadata['state'];
+      _.forEach(Object.keys(client.info.state), (state) => {
+        client_metadata[state.toLowerCase()] = client.info.state[state];
+      });
+      this.metadata['client_' + client.client_iqn] = client_metadata;
 
       const luns = [];
       client.luns.forEach((lun) => {
@@ -134,6 +140,7 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
 
       clients.push({
         value: client.client_iqn,
+        status: Object.keys(client.info.state).includes('LOGGED_IN') ? 'logged_in' : 'logged_out',
         id: 'client_' + client.client_iqn,
         children: luns
       });

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -219,3 +219,8 @@ class IscsiClient(RestClient):
     def get_targetinfo(self, target_iqn, request=None):
         # pylint: disable=unused-argument
         return request()
+
+    @RestClient.api_get('/api/clientinfo/{target_iqn}/{client_iqn}')
+    def get_clientinfo(self, target_iqn, client_iqn, request=None):
+        # pylint: disable=unused-argument
+        return request()

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -164,7 +164,12 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
                     "password": "myiscsipassword5",
                     "user": "myiscsiusername5",
                     "mutual_password": "myiscsipassword6",
-                    "mutual_user": "myiscsiusername6"}
+                    "mutual_user": "myiscsiusername6"},
+                "info": {
+                    "alias": "",
+                    "ip_address": [],
+                    "state": {}
+                }
             })
         self._update_iscsi_target(create_request, update_request, response)
 
@@ -302,7 +307,12 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
                     "password": None,
                     "user": None,
                     "mutual_password": None,
-                    "mutual_user": None}
+                    "mutual_user": None},
+                "info": {
+                    "alias": "",
+                    "ip_address": [],
+                    "state": {}
+                }
             })
         response['groups'][0]['members'].append('iqn.1994-05.com.redhat:rh7-client3')
         self._update_iscsi_target(create_request, update_request, response)
@@ -425,6 +435,11 @@ iscsi_target_response = {
                 'password': 'myiscsipassword1',
                 'mutual_password': 'myiscsipassword2',
                 'mutual_user': 'myiscsiusername2'
+            },
+            'info': {
+                'alias': '',
+                'ip_address': [],
+                'state': {}
             }
         },
         {
@@ -435,6 +450,11 @@ iscsi_target_response = {
                 'password': 'myiscsipassword3',
                 'mutual_password': 'myiscsipassword4',
                 'mutual_user': 'myiscsiusername4'
+            },
+            'info': {
+                'alias': '',
+                'ip_address': [],
+                'state': {}
             }
         }
     ],
@@ -661,7 +681,16 @@ class IscsiClientMock(object):
     def update_targetauth(self, target_iqn, action):
         self.config['targets'][target_iqn]['acl_enabled'] = (action == 'enable_acl')
 
-    def get_targetinfo(self, _):
+    def get_targetinfo(self, target_iqn):
+        # pylint: disable=unused-argument
         return {
             'num_sessions': 0
+        }
+
+    def get_clientinfo(self, target_iqn, client_iqn):
+        # pylint: disable=unused-argument
+        return {
+            'alias': '',
+            'ip_address': [],
+            'state': {}
         }


### PR DESCRIPTION
With this PR, the user will be able to see if an initiator is `logged-in` or `logged-out`.

Additionally the host `alias`, `ip`, and the target `portal` will be displayed in the initiator details:

![Screenshot from 2019-05-28 12-26-42](https://user-images.githubusercontent.com/14297426/58478998-41550080-814f-11e9-92ec-0b0bbe50f21a.png)


Fixes: https://tracker.ceph.com/issues/40046

Signed-off-by: Ricardo Marques <rimarques@suse.com>

