### PR TITLE
mon: fix off-by-one rendering progress bar

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3031,7 +3031,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
 	ss << "    " << i.second.message << "\n";
 	ss << "      [";
 	unsigned j;
-	for (j=0; j < i.second.progress * 30; ++j) {
+	for (j = 0; j < (unsigned)(i.second.progress * 30.0); ++j) {
 	  ss << '=';
 	}
 	for (; j < 30; ++j) {


### PR DESCRIPTION
Ensure that if progress is < 1.0, we always have a '.' at the end of the
bar.

Signed-off-by: Sage Weil <sage@redhat.com>