### PR TITLE
install-deps.sh: Typo for krb5 on FreeBSD

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -248,7 +248,7 @@ if [ x$(uname)x = xFreeBSDx ]; then
         www/npm \
         www/fcgi \
         security/nss \
-        security/kbr5 \
+        security/krb5 \
         security/oath-toolkit \
         sysutils/flock \
         sysutils/fusefs-libs \


### PR DESCRIPTION
The FreeBSD dependency install specifies security/kbr5 instead of security/krb5

To reproduce, run `./do_freebsd.sh` or `./install-deps.sh` on a FreeBSD host. The install fails with:
`pkg: No packages available to install matching 'security/kbr5' have been found in the repositories`

Fixes: https://tracker.ceph.com/issues/40050
Signed-off-by: Thomas Johnson <NTmatter@gmail.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

