### PR TITLE
blobhash.h: remove extra [[fallthrough]]

### DIFF
--- a/src/include/blobhash.h
+++ b/src/include/blobhash.h
@@ -38,7 +38,6 @@ public:
       [[fallthrough]];
     case 1:
       acc ^= buf[0];
-      [[fallthrough]];
     }
     return H(acc);
   }


### PR DESCRIPTION
Compilation fails in Clang at src/include/blobhash.h:41:7 with error:
```
fallthrough annotation does not directly precede switch label
      [[fallthrough]];
      ^
```

Clang does not accept the <code>[[fallthrough]]</code> annotation if it does not precede a labelled case statement. It compiles without issue under GCC.

Examples: https://en.cppreference.com/w/cpp/language/attributes/fallthrough

Fixes: https://tracker.ceph.com/issues/40052
Signed-off-by: Thomas Johnson <NTmatter@gmail.com>