### PR TITLE
ceph.in: do not preload libasan if it is found

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -129,9 +129,8 @@ if os.path.exists(os.path.join(MYPDIR, "CMakeCache.txt")) \
         pythonlib_path = os.path.join(lib_path,
                                       "cython_modules",
                                       get_pythonlib_dir())
-        if asan_lib_path.endswith('NOTFOUND'):
-            with_asan = False
-        elif with_seastar and build_type == 'Debug':
+        if (with_seastar and build_type == 'Debug' and
+            not asan_lib_path.endswith('NOTFOUND')):
             with_asan = True
         respawn_in_path(lib_path, pybind_path, pythonlib_path,
                         asan_lib_path if with_asan else None)


### PR DESCRIPTION
before this change, `asan_lib_path` could be `None` when we check it to
see if it ends with `NOTFOUND`. this happens if WITH_SEASTAR=OFF or
WITH_ASAN=OFF, as in that case, find_package(Sanitizers) is not called,
hence `ASAN_LIBRARY` won't be set.

in this change, libasan is only preloaded if

- (WITH_SEASTAR=ON and CMAKE_BUILD_TYPE=Debug and ASAN_LIBRARY is found)
  or
- (WITH_ASAN)

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

