### PR TITLE
common: avoid use of size_t in options

### DIFF
--- a/src/common/config_values.h
+++ b/src/common/config_values.h
@@ -50,7 +50,7 @@ public:
 #define OPTION_OPT_U32(name) uint64_t name;
 #define OPTION_OPT_U64(name) uint64_t name;
 #define OPTION_OPT_UUID(name) uuid_d name;
-#define OPTION_OPT_SIZE(name) size_t name;
+#define OPTION_OPT_SIZE(name) uint64_t name;
 #define OPTION(name, ty)       \
   public:                      \
     OPTION_##ty(name)          


### PR DESCRIPTION
Misc fixes for compilation of Ceph on 32 bit architectures in Ubuntu (armhf and i386).
