### PR TITLE
buffer.h: remove list::iterator_impl::advance(size_t)

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -727,9 +727,7 @@ inline namespace v14_2_0 {
 	//return off == bl->length();
       }
 
-      void advance(int o) = delete;
       void advance(unsigned o);
-      void advance(size_t o) { advance(static_cast<unsigned>(o)); }
       void seek(unsigned o);
       char operator*() const;
       iterator_impl& operator++();


### PR DESCRIPTION
quote from Radoslaw's comment

> In general we could remove it as the `buffer` library tends to
> disrespects `size_t` – `list::_len` and `ptr::_len` are both `unsigned`.
> There are some exceptions like `size_t buffer::ptr::get_offset()` (used
> altogether with `::advance` in `denc.h`) but they deserve rework as
> well.

and in this very case, we simply cast `size_t` to `unsigned`. so we
could silently trim a 64bits integer to 32bit on 64bits architecture.

so for better portability, we can just remove it. also, this function is
inlined, so the ABI is not changed.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

