### PR TITLE
mds: fix non empty error when rm a dir

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2104,9 +2104,13 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
 	dout(10) << "predirty_journal_parents updating size on " << *parent << dendl;
 	if (in->is_dir()) {
 	  pf->fragstat.nsubdirs += linkunlink;
+	  if (pf->fragstat.nsubdirs < 0)
+            pf->fragstat.nsubdirs = 0;
 	  //pf->rstat.rsubdirs += linkunlink;
 	} else {
  	  pf->fragstat.nfiles += linkunlink;
+	  if (pf->fragstat.nfiles < 0)
+              pf->fragstat.nfiles = 0;
  	  //pf->rstat.rfiles += linkunlink;
 	}
       }


### PR DESCRIPTION
mds: check fragstat.nsubdirs & fragstat.nfiles can't be minus, fix non empty error when rm a dir.

Signed-off-by: Zhaoqinhu <zhaoqinhu@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

