### PR TITLE
cephfs:/tools/cephfs/Resetter.cc : Resolve a memory leak

### DIFF
--- a/src/tools/cephfs/Resetter.cc
+++ b/src/tools/cephfs/Resetter.cc
@@ -203,6 +203,10 @@ int Resetter::_write_reset_event(Journaler *journaler)
 
   cout << "writing EResetJournal entry" << std::endl;
   journaler->append_entry(bl);
+  if (NULL != le){
+  delete le;
+  le = NULL;
+  }
 
   int ret;
   {


### PR DESCRIPTION
the problem is in function Resetter::_write_reset_event.
 If we don't delete "le", there will be a memory leak. 
 Signed-off-by: "liwei021111" <li_wei02@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

