### PR TITLE
doc: note explicitly that "profile rbd" allows blacklisting

### DIFF
--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -242,8 +242,10 @@ The following entries describe valid capability profiles:
 
 :Description: Gives a user permissions to manipulate RBD images. When used
               as a Monitor cap, it provides the minimal privileges required
-              by an RBD client application. When used as an OSD cap, it
-              provides read-write access to an RBD client application.
+              by an RBD client application; this includes the ability
+	      to blacklist other client users. When used as an OSD cap, it
+              provides read-write access to the specified pool to an
+	      RBD client application.
 
 ``profile rbd-mirror`` (Monitor only)
 


### PR DESCRIPTION
The Luminous release notes tell users to ensure that rbd clients have
the ability to blacklist other client users; this is provided by
"profile rbd", which this change now documents explicitly in the user
management documentation.

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>
