### PR TITLE
nautilus: build/ops: Ceph RPM build fails on openSUSE Tumbleweed with GCC 9

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1051,6 +1051,9 @@ integrated with the Ceph Manager Dashboard web UI.
 %autosetup -p1 -n @TARBALL_BASENAME@
 
 %build
+# LTO can be enabled as soon as the following GCC bug is fixed:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48200
+%define _lto_cflags %{nil}
 
 %if 0%{?rhel} == 7
 . /opt/rh/devtoolset-7/enable


### PR DESCRIPTION
http://tracker.ceph.com/issues/40067