### PR TITLE
objecter: delete the osdmap correctly when receiving new ones

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1213,6 +1213,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
 
           emit_blacklist_events(*osdmap, *new_osdmap);
 
+	  delete osdmap;
           osdmap = new_osdmap;
 
 	  logger->inc(l_osdc_map_full);


### PR DESCRIPTION
We were erroneously decoding a new map and then pointer-assigning it
without deleting the existing map. Fix that!

Fixes: http://tracker.ceph.com/issues/39723

Signed-off-by: Greg Farnum <gfarnum@redhat.com>