### PR TITLE
nautilus: mgr/dashboard: Only one root node is shown in the crush map viewer

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.html
@@ -9,6 +9,7 @@
       <div class="panel-body">
         <div class="col-sm-6 col-lg-6">
           <tree [tree]="tree"
+                [settings]="{rootIsVisible: false}"
                 (nodeSelected)="onNodeSelected($event)">
             <ng-template let-node>
               <span class="label"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
@@ -2,10 +2,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { of } from 'rxjs';
-
 import { TreeModule } from 'ng2-tree';
 import { TabsModule } from 'ngx-bootstrap/tabs';
+import { of } from 'rxjs';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { HealthService } from '../../../shared/api/health.service';
@@ -64,24 +63,88 @@ describe('CrushmapComponent', () => {
           { children: [1, 0, 2], type: 'host', name: 'my-host', id: -2 },
           { status: 'up', type: 'osd', name: 'osd.0', id: 0 },
           { status: 'down', type: 'osd', name: 'osd.1', id: 1 },
-          { status: 'up', type: 'osd', name: 'osd.2', id: 2 }
+          { status: 'up', type: 'osd', name: 'osd.2', id: 2 },
+          { children: [-4], type: 'root', name: 'default-2', id: -3 },
+          { children: [4], type: 'host', name: 'my-host-2', id: -4 },
+          { status: 'up', type: 'osd', name: 'osd.0-2', id: 4 }
         ]);
       });
 
-      it('should have tree structure derived from a root', () => {
-        expect(component.tree.value).toBe('default (root)');
-      });
-
-      it('should have one host child with 3 osd children', () => {
-        expect(component.tree.children.length).toBe(1);
-        expect(component.tree.children[0].value).toBe('my-host (host)');
-        expect(component.tree.children[0].children.length).toBe(3);
-      });
-
-      it('should have 3 osds in orderd', () => {
-        expect(component.tree.children[0].children[0].value).toBe('osd.0 (osd)');
-        expect(component.tree.children[0].children[1].value).toBe('osd.1 (osd)');
-        expect(component.tree.children[0].children[2].value).toBe('osd.2 (osd)');
+      it('should have two root nodes', () => {
+        expect(component.tree.children).toEqual([
+          {
+            children: [
+              {
+                children: [
+                  {
+                    id: 4,
+                    settings: {
+                      static: true
+                    },
+                    status: 'up',
+                    value: 'osd.0-2 (osd)'
+                  }
+                ],
+                id: -4,
+                settings: {
+                  static: true
+                },
+                status: undefined,
+                value: 'my-host-2 (host)'
+              }
+            ],
+            id: -3,
+            settings: {
+              static: true
+            },
+            status: undefined,
+            value: 'default-2 (root)'
+          },
+          {
+            children: [
+              {
+                children: [
+                  {
+                    id: 0,
+                    settings: {
+                      static: true
+                    },
+                    status: 'up',
+                    value: 'osd.0 (osd)'
+                  },
+                  {
+                    id: 1,
+                    settings: {
+                      static: true
+                    },
+                    status: 'down',
+                    value: 'osd.1 (osd)'
+                  },
+                  {
+                    id: 2,
+                    settings: {
+                      static: true
+                    },
+                    status: 'up',
+                    value: 'osd.2 (osd)'
+                  }
+                ],
+                id: -2,
+                settings: {
+                  static: true
+                },
+                status: undefined,
+                value: 'my-host (host)'
+              }
+            ],
+            id: -1,
+            settings: {
+              static: true
+            },
+            status: undefined,
+            value: 'default (root)'
+          }
+        ]);
       });
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.ts
@@ -34,12 +34,22 @@ export class CrushmapComponent implements OnInit {
       };
     }
 
-    const rootNodeId = nodes[0].id || null;
+    const roots = [];
     nodes.reverse().forEach((node) => {
+      if (node.type === 'root') {
+        roots.push(node.id);
+      }
       treeNodeMap[node.id] = this.generateTreeLeaf(node, treeNodeMap);
     });
 
-    return treeNodeMap[rootNodeId];
+    const children = roots.map((id) => {
+      return treeNodeMap[id];
+    });
+
+    return {
+      value: 'CRUSH map',
+      children: children
+    };
   }
 
   private generateTreeLeaf(node: any, treeNodeMap) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/40077