### PR TITLE
crimson/net: remove redundant std::move()

### DIFF
--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -143,7 +143,7 @@ seastar::future<Socket::tmp_buf> ProtocolV2::read_exactly(size_t bytes)
     return socket->read_exactly(bytes)
     .then([this] (auto bl) {
       rxbuf.append(buffer::create(bl.share()));
-      return std::move(bl);
+      return bl;
     });
   } else {
     return socket->read_exactly(bytes);
@@ -156,7 +156,7 @@ seastar::future<bufferlist> ProtocolV2::read(size_t bytes)
     return socket->read(bytes)
     .then([this] (auto buf) {
       rxbuf.append(buf);
-      return std::move(buf);
+      return buf;
     });
   } else {
     return socket->read(bytes);


### PR DESCRIPTION
see https://en.cppreference.com/w/cpp/language/copy_elision

it also silences warning like:

src/crimson/net/ProtocolV2.cc:146:26: warning: redundant move in return
statement [-Wredundant-move]
  146 |       return std::move(bl);
      |                          ^

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

