### PR TITLE
os/bluestore: bluefs_preextend_wal_files=true

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4224,8 +4224,8 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluefs_preextend_wal_files", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
-    .set_description(""),
+    .set_default(true)
+    .set_description("Preextent rocksdb wal files on mkfs to avoid performance penalty for young stores"),
 
     Option("bluestore_bluefs", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)


### PR DESCRIPTION
This should merge with the fix for https://tracker.ceph.com/issues/18375

Signed-off-by: Sage Weil <sage@redhat.com>