### PR TITLE
qa/standalone/ceph-helpers: resurrect all OSD before waiting for health

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ ! -e Makefile -o ! -d bin ]; then
+if [ ! -e CMakeCache.txt -o ! -d bin ]; then
     echo 'run this from the build dir'
     exit 1
 fi

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1628,13 +1628,18 @@ function test_wait_for_health_ok() {
     setup $dir || return 1
     run_mon $dir a --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
     run_mgr $dir x --mon_pg_warn_min_per_osd=0 || return 1
+    # start osd_pool_default_size OSDs
     run_osd $dir 0 || return 1
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
     ceph osd down 0 || return 1
+    # expect TOO_FEW_OSDS warning
     ! TIMEOUT=1 wait_for_health_ok || return 1
+    # resurrect all OSDs
     activate_osd $dir 0 || return 1
+    activate_osd $dir 1 || return 1
+    activate_osd $dir 2 || return 1
     wait_for_health_ok || return 1
     teardown $dir || return 1
 }


### PR DESCRIPTION
this change should address the test failure at http://pulpito.ceph.com/kchai-2019-05-30_13:01:13-rados-wip-kefu-testing-2019-05-30-0110-distro-basic-mira/