### PR TITLE
osd: update comment as sub_op_scrub_map has been removed

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2812,7 +2812,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 
       case PG::Scrubber::WAIT_REPLICAS:
         if (!scrubber.waiting_on_whom.empty()) {
-          // will be requeued by sub_op_scrub_map
+          // will be requeued by do_replica_scrub_map
           dout(10) << "wait for replicas to build scrub map" << dendl;
           done = true;
 	  break;


### PR DESCRIPTION
sub_op_scrub_map replaced by do_replica_scrub_map, sync the comments.

Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

