### PR TITLE
cmake/modules: replace ";" with " " in compile flags

### DIFF
--- a/cmake/modules/FindSanitizers.cmake
+++ b/cmake/modules/FindSanitizers.cmake
@@ -44,6 +44,8 @@ if(Sanitizers_COMPILE_OPTIONS)
     "-fno-omit-frame-pointer")
 endif()
 
+string (REPLACE ";" " " Sanitizers_COMPILE_OPTIONS "${Sanitizers_COMPILE_OPTIONS}")
+
 include(CheckCXXSourceCompiles)
 set(CMAKE_REQUIRED_FLAGS ${Sanitizers_COMPILE_OPTIONS})
 set(CMAKE_REQUIRED_LIBRARIES ${Sanitizers_COMPILE_OPTIONS})


### PR DESCRIPTION
as the flags should be a string, not a list

tested using

cmake -DCMAKE_LINKER=gold -DWITH_ASAN=ON -DWITH_ASAN_LEAK=ON \
-DCMAKE_BUILD_TYPE=Debug

on ubuntu xenial

without this change, cmake will fail with following warning:

CMake Error at src/CMakeLists.txt:112 (message):
  The compiler /usr/bin/c++ has no C++17 support.

-- Configuring incomplete, errors occurred!

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

