### PR TITLE
check rdma configuration and fix some logic problem

### DIFF
--- a/src/msg/SimplePolicyMessenger.h
+++ b/src/msg/SimplePolicyMessenger.h
@@ -30,8 +30,7 @@ private:
 
 public:
 
-  SimplePolicyMessenger(CephContext *cct, entity_name_t name,
-			string mname, uint64_t _nonce)
+  SimplePolicyMessenger(CephContext *cct, entity_name_t name)
     : Messenger(cct, name)
     {
     }

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -276,7 +276,7 @@ class C_handle_reap : public EventCallback {
 
 AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
                                const std::string &type, string mname, uint64_t _nonce)
-  : SimplePolicyMessenger(cct, name,mname, _nonce),
+  : SimplePolicyMessenger(cct, name),
     dispatch_queue(cct, this, mname),
     nonce(_nonce)
 {

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -155,13 +155,13 @@ void Processor::start()
 
   // start thread
   worker->center.submit_to(worker->center.get_id(), [this]() {
-      for (auto& l : listen_sockets) {
-	if (l) {   
-          if (l.fd() == -1) {
+      for (auto& listen_socket : listen_sockets) {
+	if (listen_socket) {
+          if (listen_socket.fd() == -1) {
             ldout(msgr->cct, 1) << __func__ << " Erro: processor restart after listen_socket.fd closed. " << this << dendl;
             return;
           }
-	  worker->center.create_file_event(l.fd(), EVENT_READABLE,
+	  worker->center.create_file_event(listen_socket.fd(), EVENT_READABLE,
 					   listen_handler); }
       }
     }, false);

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -100,15 +100,15 @@ ostream& EventCenter::_event_prefix(std::ostream *_dout)
                 << " time_id=" << time_event_next_id << ").";
 }
 
-int EventCenter::init(int n, unsigned i, const std::string &t)
+int EventCenter::init(int nevent, unsigned center_id, const std::string &type)
 {
   // can't init multi times
-  ceph_assert(nevent == 0);
+  ceph_assert(this->nevent == 0);
 
-  type = t;
-  idx = i;
+  this->type = type;
+  this->center_id = center_id;
 
-  if (t == "dpdk") {
+  if (type == "dpdk") {
 #ifdef HAVE_DPDK
     driver = new DPDKDriver(cct);
 #endif
@@ -129,14 +129,14 @@ int EventCenter::init(int n, unsigned i, const std::string &t)
     return -1;
   }
 
-  int r = driver->init(this, n);
+  int r = driver->init(this, nevent);
   if (r < 0) {
     lderr(cct) << __func__ << " failed to init event driver." << dendl;
     return r;
   }
 
-  file_events.resize(n);
-  nevent = n;
+  file_events.resize(nevent);
+  this->nevent = nevent;
 
   if (!driver->need_wakeup())
     return 0;
@@ -190,13 +190,13 @@ EventCenter::~EventCenter()
 void EventCenter::set_owner()
 {
   owner = pthread_self();
-  ldout(cct, 2) << __func__ << " idx=" << idx << " owner=" << owner << dendl;
+  ldout(cct, 2) << __func__ << " center_id=" << center_id << " owner=" << owner << dendl;
   if (!global_centers) {
     global_centers = &cct->lookup_or_create_singleton_object<
       EventCenter::AssociatedCenters>(
 	"AsyncMessenger::EventCenter::global_center::" + type, true);
     ceph_assert(global_centers);
-    global_centers->centers[idx] = this;
+    global_centers->centers[center_id] = this;
     if (driver->need_wakeup()) {
       notify_handler = new C_handle_notify(this, cct);
       int r = create_file_event(notify_receive_fd, EVENT_READABLE, notify_handler);
@@ -391,29 +391,30 @@ int EventCenter::process_events(unsigned timeout_microseconds,  ceph::timespan *
   vector<FiredFileEvent> fired_events;
   numevents = driver->event_wait(fired_events, &tv);
   auto working_start = ceph::mono_clock::now();
-  for (int j = 0; j < numevents; j++) {
+  for (int event_id = 0; event_id < numevents; event_id++) {
     int rfired = 0;
     FileEvent *event;
     EventCallbackRef cb;
-    event = _get_file_event(fired_events[j].fd);
+    event = _get_file_event(fired_events[event_id].fd);
 
     /* note the event->mask & mask & ... code: maybe an already processed
     * event removed an element that fired and we still didn't
     * processed, so we check if the event is still valid. */
-    if (event->mask & fired_events[j].mask & EVENT_READABLE) {
+    if (event->mask & fired_events[event_id].mask & EVENT_READABLE) {
       rfired = 1;
       cb = event->read_cb;
-      cb->do_request(fired_events[j].fd);
+      cb->do_request(fired_events[event_id].fd);
     }
 
-    if (event->mask & fired_events[j].mask & EVENT_WRITABLE) {
+    if (event->mask & fired_events[event_id].mask & EVENT_WRITABLE) {
       if (!rfired || event->read_cb != event->write_cb) {
         cb = event->write_cb;
-        cb->do_request(fired_events[j].fd);
+        cb->do_request(fired_events[event_id].fd);
       }
     }
 
-    ldout(cct, 30) << __func__ << " event_wq process is " << fired_events[j].fd << " mask is " << fired_events[j].mask << dendl;
+    ldout(cct, 30) << __func__ << " event_wq process is " << fired_events[event_id].fd
+                   << " mask is " << fired_events[event_id].mask << dendl;
   }
 
   if (trigger_time)

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -247,13 +247,12 @@ class EventCenter {
     ceph_assert(i < MAX_EVENTCENTER && global_centers);
     EventCenter *c = global_centers->centers[i];
     ceph_assert(c);
-    if (!nowait && c->in_thread()) {
-      f();
-      return ;
-    }
     if (nowait) {
       C_submit_event<func> *event = new C_submit_event<func>(std::move(f), true);
       c->dispatch_event_external(event);
+    } else if (c->in_thread()) {
+      f();
+      return;
     } else {
       C_submit_event<func> event(std::move(f), false);
       c->dispatch_event_external(&event);

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -172,7 +172,7 @@ class EventCenter {
   int notify_send_fd;
   NetHandler net;
   EventCallbackRef notify_handler;
-  unsigned idx;
+  unsigned center_id;
   AssociatedCenters *global_centers = nullptr;
 
   int process_time_events();
@@ -187,14 +187,14 @@ class EventCenter {
     external_num_events(0),
     driver(NULL), time_event_next_id(1),
     notify_receive_fd(-1), notify_send_fd(-1), net(c),
-    notify_handler(NULL), idx(0) { }
+    notify_handler(NULL), center_id(0) { }
   ~EventCenter();
   ostream& _event_prefix(std::ostream *_dout);
 
-  int init(int nevent, unsigned idx, const std::string &t);
+  int init(int nevent, unsigned center_id, const std::string &type);
   void set_owner();
   pthread_t get_owner() const { return owner; }
-  unsigned get_id() const { return idx; }
+  unsigned get_id() const { return center_id; }
 
   EventDriver *get_driver() { return driver; }
 
@@ -221,8 +221,8 @@ class EventCenter {
     func f;
     bool nonwait;
    public:
-    C_submit_event(func &&_f, bool nw)
-      : f(std::move(_f)), nonwait(nw) {}
+    C_submit_event(func &&_f, bool nowait)
+      : f(std::move(_f)), nonwait(nowait) {}
     void do_request(uint64_t id) override {
       f();
       lock.lock();

--- a/src/msg/async/EventEpoll.h
+++ b/src/msg/async/EventEpoll.h
@@ -26,10 +26,10 @@ class EpollDriver : public EventDriver {
   int epfd;
   struct epoll_event *events;
   CephContext *cct;
-  int size;
+  int nevent;
 
  public:
-  explicit EpollDriver(CephContext *c): epfd(-1), events(NULL), cct(c), size(0) {}
+  explicit EpollDriver(CephContext *c): epfd(-1), events(NULL), cct(c), nevent(0) {}
   ~EpollDriver() override {
     if (epfd != -1)
       close(epfd);

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -161,9 +161,6 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
   int fd() const override {
     return _fd;
   }
-  int socket_fd() const override {
-    return _fd;
-  }
   friend class PosixServerSocketImpl;
   friend class PosixNetworkStack;
 };

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -33,7 +33,6 @@ class ConnectedSocketImpl {
   virtual void shutdown() = 0;
   virtual void close() = 0;
   virtual int fd() const = 0;
-  virtual int socket_fd() const = 0;
 };
 
 class ConnectedSocket;
@@ -129,9 +128,6 @@ class ConnectedSocket {
   /// Get file descriptor
   int fd() const {
     return _csi->fd();
-  }
-  int socket_fd() const {
-    return _csi->socket_fd();
   }
 
   explicit operator bool() const {

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -231,8 +231,8 @@ class Worker {
   Worker(const Worker&) = delete;
   Worker& operator=(const Worker&) = delete;
 
-  Worker(CephContext *c, unsigned i)
-    : cct(c), perf_logger(NULL), id(i), references(0), center(c) {
+  Worker(CephContext *c, unsigned worker_id)
+    : cct(c), perf_logger(NULL), id(worker_id), references(0), center(c) {
     char name[128];
     sprintf(name, "AsyncMessenger::Worker-%u", id);
     // initialize perf_logger
@@ -339,8 +339,8 @@ class NetworkStack {
   void start();
   void stop();
   virtual Worker *get_worker();
-  Worker *get_worker(unsigned i) {
-    return workers[i];
+  Worker *get_worker(unsigned worker_id) {
+    return workers[worker_id];
   }
   void drain();
   unsigned get_num_worker() const {

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -176,10 +176,6 @@ class NativeConnectedSocketImpl : public ConnectedSocketImpl {
   virtual int fd() const override {
     return _conn.fd();
   }
-  virtual int socket_fd() const override {
-    return _conn.fd();
-  }
-
 };
 
 template <typename Protocol>

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -785,7 +785,8 @@ Infiniband::MemoryManager::MemoryManager(CephContext *c, Device *d, ProtectionDo
                   (c->_conf->ms_async_rdma_receive_buffers < 2 * c->_conf->ms_async_rdma_receive_queue_len ?
                    c->_conf->ms_async_rdma_receive_buffers :  2 * c->_conf->ms_async_rdma_receive_queue_len) :
                   // rx pool is infinite, we can set any initial size that we want
-                   2 * c->_conf->ms_async_rdma_receive_queue_len)
+                   2 * c->_conf->ms_async_rdma_receive_queue_len,
+                   device->device_attr.max_mr_size / (sizeof(Chunk) + cct->_conf->ms_async_rdma_buffer_size))
 {
 }
 

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -561,10 +561,16 @@ bool Infiniband::MemoryManager::Chunk::full()
   return offset == bytes;
 }
 
-void Infiniband::MemoryManager::Chunk::clear()
+void Infiniband::MemoryManager::Chunk::reset_read_chunk()
 {
   offset = 0;
   bound = 0;
+}
+
+void Infiniband::MemoryManager::Chunk::reset_write_chunk()
+{
+  offset = 0;
+  bound = bytes;
 }
 
 Infiniband::MemoryManager::Cluster::Cluster(MemoryManager& m, uint32_t s)
@@ -612,7 +618,7 @@ void Infiniband::MemoryManager::Cluster::take_back(std::vector<Chunk*> &ck)
 {
   std::lock_guard l{lock};
   for (auto c : ck) {
-    c->clear();
+    c->reset_write_chunk();
     free_chunks.push_back(c);
   }
 }

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -541,16 +541,10 @@ uint32_t Infiniband::MemoryManager::Chunk::get_bound()
 uint32_t Infiniband::MemoryManager::Chunk::read(char* buf, uint32_t len)
 {
   uint32_t left = get_size();
-  if (left >= len) {
-    memcpy(buf, buffer+offset, len);
-    offset += len;
-    return len;
-  } else {
-    memcpy(buf, buffer+offset, left);
-    offset = 0;
-    bound = 0;
-    return left;
-  }
+  uint32_t read_len = left <= len ? left : len;
+  memcpy(buf, buffer + offset, read_len);
+  offset += read_len;
+  return read_len;
 }
 
 uint32_t Infiniband::MemoryManager::Chunk::write(char* buf, uint32_t len)

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -921,11 +921,9 @@ void Infiniband::init()
     rx_queue_len = device->device_attr.max_qp_wr;
   if (rx_queue_len > cct->_conf->ms_async_rdma_receive_queue_len) {
     rx_queue_len = cct->_conf->ms_async_rdma_receive_queue_len;
-    ldout(cct, 1) << __func__ << " receive queue length is " << rx_queue_len << " receive buffers" << dendl;
+    ldout(cct, 1) << __func__ << " assigning: " << rx_queue_len << " receive buffers" << dendl;
   } else {
-    ldout(cct, 0) << __func__ << " requested receive queue length " <<
-                  cct->_conf->ms_async_rdma_receive_queue_len <<
-                  " is too big. Setting " << rx_queue_len << dendl;
+    ldout(cct, 0) << __func__ << " using the max allowed receive buffers: " << rx_queue_len << dendl;
   }
 
   // check for the misconfiguration

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -915,8 +915,10 @@ void Infiniband::init()
   ceph_assert(NetHandler(cct).set_nonblock(device->ctxt->async_fd) == 0);
 
   support_srq = cct->_conf->ms_async_rdma_support_srq;
-  if (support_srq)
+  if (support_srq) {
+    ceph_assert(device->device_attr.max_srq);
     rx_queue_len = device->device_attr.max_srq_wr;
+  }
   else
     rx_queue_len = device->device_attr.max_qp_wr;
   if (rx_queue_len > cct->_conf->ms_async_rdma_receive_queue_len) {

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -746,7 +746,8 @@ void Infiniband::MemoryManager::PoolAllocator::free(char * const block)
   mem_info *m;
   std::lock_guard l{lock};
     
-  m = reinterpret_cast<mem_info *>(block) - 1;
+  Chunk *mem_info_chunk = reinterpret_cast<Chunk *>(block);
+  m = reinterpret_cast<mem_info *>(reinterpret_cast<char *>(mem_info_chunk) - offsetof(mem_info, chunks));
   m->ctx->update_stats(-m->nbufs);
   ibv_dereg_mr(m->mr);
   m->ctx->manager->free(m);

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -353,15 +353,14 @@ int Infiniband::QueuePair::get_state() const
 bool Infiniband::QueuePair::is_error() const
 {
   ibv_qp_attr qpa;
-  ibv_qp_init_attr qpia;
 
-  int r = ibv_query_qp(qp, &qpa, -1, &qpia);
+  int r = get_state();
   if (r) {
     lderr(cct) << __func__ << " failed to get state: "
       << cpp_strerror(errno) << dendl;
     return true;
   }
-  return qpa.cur_qp_state == IBV_QPS_ERR;
+  return qpa.qp_state == IBV_QPS_ERR;
 }
 
 

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -549,16 +549,10 @@ uint32_t Infiniband::MemoryManager::Chunk::read(char* buf, uint32_t len)
 
 uint32_t Infiniband::MemoryManager::Chunk::write(char* buf, uint32_t len)
 {
-  uint32_t left = bytes - offset;
-  if (left >= len) {
-    memcpy(buffer+offset, buf, len);
-    offset += len;
-    return len;
-  } else {
-    memcpy(buffer+offset, buf, left);
-    offset = bytes;
-    return left;
-  }
+  uint32_t write_len = (bytes - offset) <= len ? (bytes - offset) : len;
+  memcpy(buffer + offset, buf, write_len);
+  offset += write_len;
+  return write_len;
 }
 
 bool Infiniband::MemoryManager::Chunk::full()

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -143,7 +143,8 @@ void Device::binding_port(CephContext *cct, int port_num) {
       ldout(cct, 1) << __func__ << " found active port " << static_cast<int>(port_id) << dendl;
       break;
     } else {
-      ldout(cct, 10) << __func__ << " port " << port_id << " is not what we want. state: " << port->get_port_attr()->state << ")"<< dendl;
+      ldout(cct, 10) << __func__ << " port " << port_id << " is not what we want. state: "
+                     << ibv_port_state_str(port->get_port_attr()->state) << dendl;
       delete port;
     }
   }

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -854,14 +854,7 @@ int Infiniband::MemoryManager::get_send_buffers(std::vector<Chunk*> &c, size_t b
 static std::atomic<bool> init_prereq = {false};
 
 void Infiniband::verify_prereq(CephContext *cct) {
-
-  //On RDMA MUST be called before fork
-   int rc = ibv_fork_init();
-   if (rc) {
-      lderr(cct) << __func__ << " failed to call ibv_for_init(). On RDMA must be called before fork. Application aborts." << dendl;
-      ceph_abort();
-   }
-
+   int rc = 0;
    ldout(cct, 20) << __func__ << " ms_async_rdma_enable_hugepage value is: " << cct->_conf->ms_async_rdma_enable_hugepage <<  dendl;
    if (cct->_conf->ms_async_rdma_enable_hugepage){
      rc =  setenv("RDMAV_HUGEPAGES_SAFE","1",1);
@@ -870,6 +863,13 @@ void Infiniband::verify_prereq(CephContext *cct) {
        lderr(cct) << __func__ << " failed to export RDMA_HUGEPAGES_SAFE. On RDMA must be exported before using huge pages. Application aborts." << dendl;
        ceph_abort();
      }
+   }
+
+  //On RDMA MUST be called before fork
+   rc = ibv_fork_init();
+   if (rc) {
+      lderr(cct) << __func__ << " failed to call ibv_for_init(). On RDMA must be called before fork. Application aborts." << dendl;
+      ceph_abort();
    }
 
    //Check ulimit

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -180,7 +180,6 @@ Infiniband::QueuePair::QueuePair(
     lderr(cct) << __func__ << " invalid queue pair type" << cpp_strerror(errno) << dendl;
     ceph_abort();
   }
-  pd = infiniband.pd->pd;
 }
 
 int Infiniband::QueuePair::init()
@@ -354,23 +353,6 @@ int Infiniband::QueuePair::get_state() const
   return qpa.qp_state;
 }
 
-/**
- * Return true if the queue pair is in an error state, false otherwise.
- */
-bool Infiniband::QueuePair::is_error() const
-{
-  ibv_qp_attr qpa;
-
-  int r = get_state();
-  if (r) {
-    lderr(cct) << __func__ << " failed to get state: "
-      << cpp_strerror(errno) << dendl;
-    return true;
-  }
-  return qpa.qp_state == IBV_QPS_ERR;
-}
-
-
 Infiniband::CompletionChannel::CompletionChannel(CephContext *c, Infiniband &ib)
   : cct(c), infiniband(ib), channel(NULL), cq(NULL), cq_events_that_need_ack(0)
 {
@@ -509,19 +491,9 @@ Infiniband::MemoryManager::Chunk::~Chunk()
 {
 }
 
-void Infiniband::MemoryManager::Chunk::set_offset(uint32_t o)
-{
-  offset = o;
-}
-
 uint32_t Infiniband::MemoryManager::Chunk::get_offset()
 {
   return offset;
-}
-
-void Infiniband::MemoryManager::Chunk::set_bound(uint32_t b)
-{
-  bound = b;
 }
 
 uint32_t Infiniband::MemoryManager::Chunk::get_size() const

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -140,7 +140,7 @@ void Device::binding_port(CephContext *cct, int port_num) {
     Port *port = new Port(cct, ctxt, port_id);
     if (port_id == port_num && port->get_port_attr()->state == IBV_PORT_ACTIVE) {
       active_port = port;
-      ldout(cct, 1) << __func__ << " found active port " << port_id << dendl;
+      ldout(cct, 1) << __func__ << " found active port " << static_cast<int>(port_id) << dendl;
       break;
     } else {
       ldout(cct, 10) << __func__ << " port " << port_id << " is not what we want. state: " << port->get_port_attr()->state << ")"<< dendl;

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -174,7 +174,7 @@ Infiniband::QueuePair::QueuePair(
   q_key(q_key),
   dead(false)
 {
-  initial_psn = lrand48() & 0xffffff;
+  initial_psn = lrand48() & PSN_MSK;
   if (type != IBV_QPT_RC && type != IBV_QPT_UD && type != IBV_QPT_RAW_PACKET) {
     lderr(cct) << __func__ << " invalid queue pair type" << cpp_strerror(errno) << dendl;
     ceph_abort();

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -943,6 +943,12 @@ void Infiniband::init()
     ldout(cct, 0) << __func__ << " using the max allowed send buffers: " << tx_queue_len << dendl;
   }
 
+  //check for the memory region size misconfiguration
+  if ((uint64_t)cct->_conf->ms_async_rdma_buffer_size * tx_queue_len > device->device_attr.max_mr_size) {
+    lderr(cct) << __func__ << " Out of max memory region size " << dendl;
+    ceph_abort();
+  }
+
   ldout(cct, 1) << __func__ << " device allow " << device->device_attr.max_cqe
                 << " completion entries" << dendl;
 

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -168,13 +168,12 @@ Infiniband::QueuePair::QueuePair(
   cm_id(cid),
   txcq(txcq),
   rxcq(rxcq),
-  initial_psn(0),
+  initial_psn(lrand48() & PSN_MSK),
   max_send_wr(tx_queue_len),
   max_recv_wr(rx_queue_len),
   q_key(q_key),
   dead(false)
 {
-  initial_psn = lrand48() & PSN_MSK;
   if (type != IBV_QPT_RC && type != IBV_QPT_UD && type != IBV_QPT_RAW_PACKET) {
     lderr(cct) << __func__ << " invalid queue pair type" << cpp_strerror(errno) << dendl;
     ceph_abort();

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -522,6 +522,11 @@ void Infiniband::MemoryManager::Chunk::set_bound(uint32_t b)
   bound = b;
 }
 
+uint32_t Infiniband::MemoryManager::Chunk::get_size() const
+{
+  return bound - offset;
+}
+
 void Infiniband::MemoryManager::Chunk::prepare_read(uint32_t b)
 {
   offset = 0;
@@ -535,7 +540,7 @@ uint32_t Infiniband::MemoryManager::Chunk::get_bound()
 
 uint32_t Infiniband::MemoryManager::Chunk::read(char* buf, uint32_t len)
 {
-  uint32_t left = bound - offset;
+  uint32_t left = get_size();
   if (left >= len) {
     memcpy(buf, buffer+offset, len);
     offset += len;
@@ -565,11 +570,6 @@ uint32_t Infiniband::MemoryManager::Chunk::write(char* buf, uint32_t len)
 bool Infiniband::MemoryManager::Chunk::full()
 {
   return offset == bytes;
-}
-
-bool Infiniband::MemoryManager::Chunk::over()
-{
-  return Infiniband::MemoryManager::Chunk::offset == bound;
 }
 
 void Infiniband::MemoryManager::Chunk::clear()

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -206,9 +206,7 @@ class Infiniband {
       Chunk(ibv_mr* m, uint32_t bytes, char* buffer, uint32_t offset = 0, uint32_t bound = 0, uint32_t lkey = 0);
       ~Chunk();
 
-      void set_offset(uint32_t o);
       uint32_t get_offset();
-      void set_bound(uint32_t b);
       uint32_t get_size() const;
       void prepare_read(uint32_t b);
       uint32_t get_bound();
@@ -476,10 +474,6 @@ class Infiniband {
      * Get the state of a QueuePair.
      */
     int get_state() const;
-    /**
-     * Return true if the queue pair is in an error state, false otherwise.
-     */
-    bool is_error() const;
     void add_tx_wr(uint32_t amt) { tx_wr_inflight += amt; }
     void dec_tx_wr(uint32_t amt) { tx_wr_inflight -= amt; }
     uint32_t get_tx_wr() const { return tx_wr_inflight; }

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -209,12 +209,12 @@ class Infiniband {
       void set_offset(uint32_t o);
       uint32_t get_offset();
       void set_bound(uint32_t b);
+      uint32_t get_size() const;
       void prepare_read(uint32_t b);
       uint32_t get_bound();
       uint32_t read(char* buf, uint32_t len);
       uint32_t write(char* buf, uint32_t len);
       bool full();
-      bool over();
       void clear();
 
      public:

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -215,7 +215,8 @@ class Infiniband {
       uint32_t read(char* buf, uint32_t len);
       uint32_t write(char* buf, uint32_t len);
       bool full();
-      void clear();
+      void reset_read_chunk();
+      void reset_write_chunk();
 
      public:
       ibv_mr* mr;

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -37,9 +37,9 @@
 #include "msg/msg_types.h"
 #include "msg/async/net_handler.h"
 
-#define HUGE_PAGE_SIZE (2 * 1024 * 1024)
-#define ALIGN_TO_PAGE_SIZE(x) \
-  (((x) + HUGE_PAGE_SIZE -1) / HUGE_PAGE_SIZE * HUGE_PAGE_SIZE)
+#define HUGE_PAGE_SIZE_2MB (2 * 1024 * 1024)
+#define ALIGN_TO_PAGE_2MB(x) \
+    (((x) + (HUGE_PAGE_SIZE_2MB - 1)) & ~(HUGE_PAGE_SIZE_2MB - 1))
 
 #define PSN_LEN 24
 #define PSN_MSK ((1 << PSN_LEN) - 1)

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -203,7 +203,7 @@ class Infiniband {
    public:
     class Chunk {
      public:
-      Chunk(ibv_mr* m, uint32_t len, char* b);
+      Chunk(ibv_mr* m, uint32_t bytes, char* buffer, uint32_t offset = 0, uint32_t bound = 0, uint32_t lkey = 0);
       ~Chunk();
 
       void set_offset(uint32_t o);
@@ -219,10 +219,10 @@ class Infiniband {
 
      public:
       ibv_mr* mr;
-      uint32_t lkey = 0;
+      uint32_t lkey;
       uint32_t bytes;
-      uint32_t bound = 0;
       uint32_t offset;
+      uint32_t bound;
       char* buffer; // TODO: remove buffer/refactor TX
       char  data[0];
     };

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -58,7 +58,7 @@ class CephContext;
 class Port {
   struct ibv_context* ctxt;
   int port_num;
-  struct ibv_port_attr* port_attr;
+  struct ibv_port_attr port_attr;
   uint16_t lid;
   int gid_idx = 0;
   union ibv_gid gid;
@@ -68,7 +68,7 @@ class Port {
   uint16_t get_lid() { return lid; }
   ibv_gid  get_gid() { return gid; }
   int get_port_num() { return port_num; }
-  ibv_port_attr* get_port_attr() { return port_attr; }
+  ibv_port_attr* get_port_attr() { return &port_attr; }
   int get_gid_idx() { return gid_idx; }
 };
 

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -41,6 +41,9 @@
 #define ALIGN_TO_PAGE_SIZE(x) \
   (((x) + HUGE_PAGE_SIZE -1) / HUGE_PAGE_SIZE * HUGE_PAGE_SIZE)
 
+#define PSN_LEN 24
+#define PSN_MSK ((1 << PSN_LEN) - 1)
+
 struct IBSYNMsg {
   uint16_t lid;
   uint32_t qpn;

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -257,9 +257,9 @@ void RDMAConnectedSocketImpl::handle_connection() {
 
 ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
 {
-  uint64_t i = 0;
-  int r = ::read(notify_fd, &i, sizeof(i));
-  ldout(cct, 20) << __func__ << " notify_fd : " << i << " in " << my_msg.qpn << " r = " << r << dendl;
+  eventfd_t event_val = 0;
+  int r = eventfd_read(notify_fd, &event_val);
+  ldout(cct, 20) << __func__ << " notify_fd : " << event_val << " in " << my_msg.qpn << " r = " << r << dendl;
   
   if (!active) {
     ldout(cct, 1) << __func__ << " when ib not active. len: " << len << dendl;
@@ -618,11 +618,9 @@ void RDMAConnectedSocketImpl::cleanup() {
 
 void RDMAConnectedSocketImpl::notify()
 {
-  // note: notify_fd is an event fd (man eventfd)
-  // write argument must be a 64bit integer
-  uint64_t i = 1;
-
-  ceph_assert(sizeof(i) == write(notify_fd, &i, sizeof(i)));
+  eventfd_t event_val = 1;
+  int r = eventfd_write(notify_fd, event_val);
+  ceph_assert(r == 0);
 }
 
 void RDMAConnectedSocketImpl::shutdown()

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -19,15 +19,16 @@
 #undef dout_prefix
 #define dout_prefix *_dout << " RDMAConnectedSocketImpl "
 
-RDMAConnectedSocketImpl::RDMAConnectedSocketImpl(CephContext *cct, shared_ptr<Infiniband> &ib, RDMADispatcher* s,
-						 RDMAWorker *w)
+RDMAConnectedSocketImpl::RDMAConnectedSocketImpl(CephContext *cct, shared_ptr<Infiniband> &ib,
+                                                 shared_ptr<RDMADispatcher>& rdma_dispatcher,
+                                                 RDMAWorker *w)
   : cct(cct), connected(0), error(0), ib(ib),
-    dispatcher(s), worker(w),
+    dispatcher(rdma_dispatcher), worker(w),
     is_server(false), con_handler(new C_handle_connection(this)),
     active(false), pending(false)
 {
   if (!cct->_conf->ms_async_rdma_cm) {
-    qp = ib->create_queue_pair(cct, s->get_tx_cq(), s->get_rx_cq(), IBV_QPT_RC, NULL);
+    qp = ib->create_queue_pair(cct, dispatcher->get_tx_cq(), dispatcher->get_rx_cq(), IBV_QPT_RC, NULL);
     my_msg.qpn = qp->get_local_qp_number();
     my_msg.psn = qp->get_initial_psn();
     my_msg.lid = ib->get_lid();

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -578,7 +578,7 @@ int RDMAConnectedSocketImpl::post_work_request(std::vector<Chunk*> &tx_buffers)
     ++current_buffer;
   }
 
-  ibv_send_wr *bad_tx_work_request;
+  ibv_send_wr *bad_tx_work_request = nullptr;
   if (ibv_post_send(qp->get_qp(), iswr, &bad_tx_work_request)) {
     ldout(cct, 1) << __func__ << " failed to send data"
                   << " (most probably should be peer not ready): "
@@ -600,7 +600,7 @@ void RDMAConnectedSocketImpl::fin() {
   wr.num_sge = 0;
   wr.opcode = IBV_WR_SEND;
   wr.send_flags = IBV_SEND_SIGNALED;
-  ibv_send_wr* bad_tx_work_request;
+  ibv_send_wr* bad_tx_work_request = nullptr;
   if (ibv_post_send(qp->get_qp(), &wr, &bad_tx_work_request)) {
     ldout(cct, 1) << __func__ << " failed to send message="
                   << " ibv_post_send failed(most probably should be peer not ready): "

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -346,7 +346,7 @@ ssize_t RDMAConnectedSocketImpl::read_buffers(char* buf, size_t len)
     tmp = (*c)->read(buf+read, len-read);
     read += tmp;
     ldout(cct, 25) << __func__ << " this iter read: " << tmp << " bytes." << " offset: " << (*c)->get_offset() << " ,bound: " << (*c)->get_bound()  << ". Chunk:" << *c  << dendl;
-    if ((*c)->over()) {
+    if ((*c)->get_size() == 0) {
       dispatcher->post_chunk_to_pool(*c);
       update_post_backlog();
       ldout(cct, 25) << __func__ << " one chunk over." << dendl;
@@ -356,7 +356,7 @@ ssize_t RDMAConnectedSocketImpl::read_buffers(char* buf, size_t len)
     }
   }
 
-  if (c != buffers.end() && (*c)->over())
+  if (c != buffers.end() && (*c)->get_size() == 0)
     ++c;
   buffers.erase(buffers.begin(), c);
   ldout(cct, 25) << __func__ << " got " << read  << " bytes, buffers size: " << buffers.size() << dendl;

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -297,7 +297,7 @@ ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
     Chunk* chunk = reinterpret_cast<Chunk *>(response->wr_id);
     chunk->prepare_read(response->byte_len);
     if (chunk->get_size() == 0) {
-      chunk->clear();
+      chunk->reset_read_chunk();
       dispatcher->perf_logger->inc(l_msgr_rdma_rx_fin);
       if (connected) {
         error = ECONNRESET;
@@ -315,7 +315,7 @@ ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
       buffers.push_back(chunk);
       ldout(cct, 25) << __func__ << " buffers add a chunk: " << chunk->get_offset() << ":" << chunk->get_bound() << dendl;
     } else {
-      chunk->clear();
+      chunk->reset_read_chunk();
       dispatcher->post_chunk_to_pool(chunk);
       update_post_backlog();
     }
@@ -349,7 +349,7 @@ ssize_t RDMAConnectedSocketImpl::read_buffers(char* buf, size_t len)
                    << (*pchunk)->get_offset() << " ,bound: " << (*pchunk)->get_bound() << dendl;
 
     if ((*pchunk)->get_size() == 0) {
-      (*pchunk)->clear();
+      (*pchunk)->reset_read_chunk();
       dispatcher->post_chunk_to_pool(*pchunk);
       update_post_backlog();
       ldout(cct, 25) << __func__ << " read over one chunk " << dendl;

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -299,6 +299,7 @@ ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
     chunk->prepare_read(response->byte_len);
     worker->perf_logger->inc(l_msgr_rdma_rx_bytes, response->byte_len);
     if (response->byte_len == 0) {
+      chunk->clear();
       dispatcher->perf_logger->inc(l_msgr_rdma_rx_fin);
       if (connected) {
         error = ECONNRESET;
@@ -315,6 +316,7 @@ ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
         ldout(cct, 25) << __func__ << " buffers add a chunk: " << chunk->get_offset() << ":" << chunk->get_bound() << dendl;
       } else {
         read += chunk->read(buf+read, response->byte_len);
+        chunk->clear();
         dispatcher->post_chunk_to_pool(chunk);
         update_post_backlog();
       }
@@ -347,6 +349,7 @@ ssize_t RDMAConnectedSocketImpl::read_buffers(char* buf, size_t len)
     read += tmp;
     ldout(cct, 25) << __func__ << " this iter read: " << tmp << " bytes." << " offset: " << (*c)->get_offset() << " ,bound: " << (*c)->get_bound()  << ". Chunk:" << *c  << dendl;
     if ((*c)->get_size() == 0) {
+      (*c)->clear();
       dispatcher->post_chunk_to_pool(*c);
       update_post_backlog();
       ldout(cct, 25) << __func__ << " one chunk over." << dendl;

--- a/src/msg/async/rdma/RDMAIWARPConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAIWARPConnectedSocketImpl.cc
@@ -7,9 +7,10 @@
 #define TIMEOUT_MS 3000
 #define RETRY_COUNT 7
 
-RDMAIWARPConnectedSocketImpl::RDMAIWARPConnectedSocketImpl(CephContext *cct, shared_ptr<Infiniband>& ib, RDMADispatcher* s,
-						 RDMAWorker *w, RDMACMInfo *info)
-  : RDMAConnectedSocketImpl(cct, ib, s, w), cm_con_handler(new C_handle_cm_connection(this))
+RDMAIWARPConnectedSocketImpl::RDMAIWARPConnectedSocketImpl(CephContext *cct, shared_ptr<Infiniband>& ib,
+                                                           shared_ptr<RDMADispatcher>& rdma_dispatcher,
+                                                           RDMAWorker *w, RDMACMInfo *info)
+  : RDMAConnectedSocketImpl(cct, ib, rdma_dispatcher, w), cm_con_handler(new C_handle_cm_connection(this))
 {
   status = IDLE;
   notify_fd = eventfd(0, EFD_CLOEXEC|EFD_NONBLOCK);

--- a/src/msg/async/rdma/RDMAIWARPConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAIWARPConnectedSocketImpl.cc
@@ -7,7 +7,7 @@
 #define TIMEOUT_MS 3000
 #define RETRY_COUNT 7
 
-RDMAIWARPConnectedSocketImpl::RDMAIWARPConnectedSocketImpl(CephContext *cct, Infiniband* ib, RDMADispatcher* s,
+RDMAIWARPConnectedSocketImpl::RDMAIWARPConnectedSocketImpl(CephContext *cct, shared_ptr<Infiniband>& ib, RDMADispatcher* s,
 						 RDMAWorker *w, RDMACMInfo *info)
   : RDMAConnectedSocketImpl(cct, ib, s, w), cm_con_handler(new C_handle_cm_connection(this))
 {
@@ -156,13 +156,13 @@ void RDMAIWARPConnectedSocketImpl::activate() {
 
 int RDMAIWARPConnectedSocketImpl::alloc_resource() {
   ldout(cct, 30) << __func__ << dendl;
-  qp = infiniband->create_queue_pair(cct, dispatcher->get_tx_cq(),
+  qp = ib->create_queue_pair(cct, dispatcher->get_tx_cq(),
       dispatcher->get_rx_cq(), IBV_QPT_RC, cm_id);
   if (!qp) {
     return -1;
   }
   if (!cct->_conf->ms_async_rdma_support_srq)
-    dispatcher->post_chunks_to_rq(infiniband->get_rx_queue_len(), qp->get_qp());
+    dispatcher->post_chunks_to_rq(ib->get_rx_queue_len(), qp->get_qp());
   dispatcher->register_qp(qp, this);
   dispatcher->perf_logger->inc(l_msgr_rdma_created_queue_pair);
   dispatcher->perf_logger->inc(l_msgr_rdma_active_queue_pair);

--- a/src/msg/async/rdma/RDMAIWARPServerSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAIWARPServerSocketImpl.cc
@@ -8,9 +8,9 @@
 #define dout_prefix *_dout << " RDMAIWARPServerSocketImpl "
 
 RDMAIWARPServerSocketImpl::RDMAIWARPServerSocketImpl(
-  CephContext *cct, Infiniband* i,
+  CephContext *cct, shared_ptr<Infiniband>& ib,
   RDMADispatcher *s, RDMAWorker *w, entity_addr_t& a, unsigned addr_slot)
-  : RDMAServerSocketImpl(cct, i, s, w, a, addr_slot)
+  : RDMAServerSocketImpl(cct, ib, s, w, a, addr_slot)
 {
 }
 
@@ -76,7 +76,7 @@ int RDMAIWARPServerSocketImpl::accept(ConnectedSocket *sock, const SocketOptions
 
   RDMACMInfo info(new_cm_id, event_channel, remote_conn_param->qp_num);
   RDMAIWARPConnectedSocketImpl* server =
-    new RDMAIWARPConnectedSocketImpl(cct, infiniband, dispatcher, dynamic_cast<RDMAWorker*>(w), &info);
+    new RDMAIWARPConnectedSocketImpl(cct, ib, dispatcher, dynamic_cast<RDMAWorker*>(w), &info);
 
   memset(&local_conn_param, 0, sizeof(local_conn_param));
   local_conn_param.qp_num = server->get_local_qpn();

--- a/src/msg/async/rdma/RDMAIWARPServerSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAIWARPServerSocketImpl.cc
@@ -9,8 +9,9 @@
 
 RDMAIWARPServerSocketImpl::RDMAIWARPServerSocketImpl(
   CephContext *cct, shared_ptr<Infiniband>& ib,
-  RDMADispatcher *s, RDMAWorker *w, entity_addr_t& a, unsigned addr_slot)
-  : RDMAServerSocketImpl(cct, ib, s, w, a, addr_slot)
+  shared_ptr<RDMADispatcher>& rdma_dispatcher, RDMAWorker *w,
+  entity_addr_t& a, unsigned addr_slot)
+  : RDMAServerSocketImpl(cct, ib, rdma_dispatcher, w, a, addr_slot)
 {
 }
 

--- a/src/msg/async/rdma/RDMAServerSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAServerSocketImpl.cc
@@ -25,10 +25,10 @@
 #define dout_prefix *_dout << " RDMAServerSocketImpl "
 
 RDMAServerSocketImpl::RDMAServerSocketImpl(
-  CephContext *cct, Infiniband* i, RDMADispatcher *s, RDMAWorker *w,
+  CephContext *cct, shared_ptr<Infiniband>& ib, RDMADispatcher *s, RDMAWorker *w,
   entity_addr_t& a, unsigned slot)
   : ServerSocketImpl(a.get_type(), slot),
-    cct(cct), net(cct), server_setup_socket(-1), infiniband(i),
+    cct(cct), net(cct), server_setup_socket(-1), ib(ib),
     dispatcher(s), worker(w), sa(a)
 {
 }
@@ -111,7 +111,7 @@ int RDMAServerSocketImpl::accept(ConnectedSocket *sock, const SocketOptions &opt
 
   RDMAConnectedSocketImpl* server;
   //Worker* w = dispatcher->get_stack()->get_worker();
-  server = new RDMAConnectedSocketImpl(cct, infiniband, dispatcher, dynamic_cast<RDMAWorker*>(w));
+  server = new RDMAConnectedSocketImpl(cct, ib, dispatcher, dynamic_cast<RDMAWorker*>(w));
   server->set_accept_fd(sd);
   ldout(cct, 20) << __func__ << " accepted a new QP, tcp_fd: " << sd << dendl;
   std::unique_ptr<RDMAConnectedSocketImpl> csi(server);

--- a/src/msg/async/rdma/RDMAServerSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAServerSocketImpl.cc
@@ -25,11 +25,12 @@
 #define dout_prefix *_dout << " RDMAServerSocketImpl "
 
 RDMAServerSocketImpl::RDMAServerSocketImpl(
-  CephContext *cct, shared_ptr<Infiniband>& ib, RDMADispatcher *s, RDMAWorker *w,
-  entity_addr_t& a, unsigned slot)
+  CephContext *cct, shared_ptr<Infiniband>& ib,
+  shared_ptr<RDMADispatcher>& rdma_dispatcher,
+  RDMAWorker *w, entity_addr_t& a, unsigned slot)
   : ServerSocketImpl(a.get_type(), slot),
     cct(cct), net(cct), server_setup_socket(-1), ib(ib),
-    dispatcher(s), worker(w), sa(a)
+    dispatcher(rdma_dispatcher), worker(w), sa(a)
 {
 }
 

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -43,9 +43,8 @@ RDMADispatcher::~RDMADispatcher()
   delete async_handler;
 }
 
-RDMADispatcher::RDMADispatcher(CephContext* c, RDMAStack* s, shared_ptr<Infiniband>& ib)
-  : cct(c), ib(ib), async_handler(new C_handle_cq_async(this)),
-  stack(s)
+RDMADispatcher::RDMADispatcher(CephContext* c, shared_ptr<Infiniband>& ib)
+  : cct(c), ib(ib), async_handler(new C_handle_cq_async(this))
 {
   PerfCountersBuilder plb(cct, "AsyncMessenger::RDMADispatcher", l_msgr_rdma_dispatcher_first, l_msgr_rdma_dispatcher_last);
 
@@ -656,7 +655,7 @@ void RDMAWorker::handle_pending_message()
 }
 
 RDMAStack::RDMAStack(CephContext *cct, const string &t)
-  : NetworkStack(cct, t), ib(make_shared<Infiniband>(cct)), dispatcher(cct, this, ib)
+  : NetworkStack(cct, t), ib(make_shared<Infiniband>(cct)), dispatcher(cct, ib)
 {
   ldout(cct, 20) << __func__ << " constructing RDMAStack..." << dendl;
 

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -315,10 +315,10 @@ void RDMADispatcher::polling()
 
         struct pollfd channel_poll[2];
         channel_poll[0].fd = tx_cc->get_fd();
-        channel_poll[0].events = POLLIN | POLLERR | POLLNVAL | POLLHUP;
+        channel_poll[0].events = POLLIN;
         channel_poll[0].revents = 0;
         channel_poll[1].fd = rx_cc->get_fd();
-        channel_poll[1].events = POLLIN | POLLERR | POLLNVAL | POLLHUP;
+        channel_poll[1].events = POLLIN;
         channel_poll[1].revents = 0;
         r = 0;
         perf_logger->set(l_msgr_rdma_polling, 0);

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -531,7 +531,7 @@ void RDMADispatcher::handle_rx_event(ibv_wc *cqe, int rx_number)
 }
 
 RDMAWorker::RDMAWorker(CephContext *c, unsigned i)
-  : Worker(c, i), stack(nullptr),
+  : Worker(c, i),
     tx_handler(new C_handle_cq_tx(this))
 {
   // initialize perf_logger
@@ -661,7 +661,6 @@ RDMAStack::RDMAStack(CephContext *cct, const string &t)
   unsigned num = get_num_worker();
   for (unsigned i = 0; i < num; ++i) {
     RDMAWorker* w = dynamic_cast<RDMAWorker*>(get_worker(i));
-    w->set_stack(this);
     w->set_dispatcher(rdma_dispatcher);
     w->set_ib(ib);
   }

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -530,8 +530,8 @@ void RDMADispatcher::handle_rx_event(ibv_wc *cqe, int rx_number)
   polled.clear();
 }
 
-RDMAWorker::RDMAWorker(CephContext *c, unsigned i)
-  : Worker(c, i),
+RDMAWorker::RDMAWorker(CephContext *c, unsigned worker_id)
+  : Worker(c, worker_id),
     tx_handler(new C_handle_cq_tx(this))
 {
   // initialize perf_logger

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -131,7 +131,6 @@ class RDMAWorker : public Worker {
   typedef Infiniband::MemoryManager::Chunk Chunk;
   typedef Infiniband::MemoryManager MemoryManager;
   typedef std::vector<Chunk*>::iterator ChunkIter;
-  RDMAStack *stack;
   shared_ptr<Infiniband> ib;
   EventCallbackRef tx_handler;
   std::list<RDMAConnectedSocketImpl*> pending_sent_conns;
@@ -156,14 +155,12 @@ class RDMAWorker : public Worker {
 		     const SocketOptions &opts, ServerSocket *) override;
   virtual int connect(const entity_addr_t &addr, const SocketOptions &opts, ConnectedSocket *socket) override;
   virtual void initialize() override;
-  RDMAStack *get_stack() { return stack; }
   int get_reged_mem(RDMAConnectedSocketImpl *o, std::vector<Chunk*> &c, size_t bytes);
   void remove_pending_conn(RDMAConnectedSocketImpl *o) {
     ceph_assert(center.in_thread());
     pending_sent_conns.remove(o);
   }
   void handle_pending_message();
-  void set_stack(RDMAStack *s) { stack = s; }
   void set_dispatcher(shared_ptr<RDMADispatcher>& dispatcher) { this->dispatcher = dispatcher; }
   void set_ib(shared_ptr<Infiniband> &ib) {this->ib = ib;}
   void notify_worker() {

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -78,7 +78,6 @@ class RDMADispatcher {
     ceph::make_mutex("RDMADispatcher::for worker pending list");
   // fixme: lockfree
   std::list<RDMAWorker*> pending_workers;
-  RDMAStack* stack;
 
   class C_handle_cq_async : public EventCallback {
     RDMADispatcher *dispatcher;
@@ -93,7 +92,7 @@ class RDMADispatcher {
  public:
   PerfCounters *perf_logger;
 
-  explicit RDMADispatcher(CephContext* c, RDMAStack* s, shared_ptr<Infiniband>& ib);
+  explicit RDMADispatcher(CephContext* c, shared_ptr<Infiniband>& ib);
   virtual ~RDMADispatcher();
   void handle_async_event();
 
@@ -109,7 +108,6 @@ class RDMADispatcher {
     pending_workers.push_back(w);
     ++num_pending_workers;
   }
-  RDMAStack* get_stack() { return stack; }
   RDMAConnectedSocketImpl* get_conn_lockless(uint32_t qp);
   QueuePair* get_qp(uint32_t qp);
   void erase_qpn_lockless(uint32_t qpn);

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -118,6 +118,7 @@ class RDMADispatcher {
   void notify_pending_workers();
   void handle_tx_event(ibv_wc *cqe, int n);
   void post_tx_buffer(std::vector<Chunk*> &chunks);
+  void handle_rx_event(ibv_wc *cqe, int rx_number);
 
   std::atomic<uint64_t> inflight = {0};
 

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -228,7 +228,6 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   virtual void shutdown() override;
   virtual void close() override;
   virtual int fd() const override { return notify_fd; }
-  virtual int socket_fd() const override { return tcp_fd; }
   void fault();
   const char* get_qp_state() { return Infiniband::qp_state_string(qp->get_state()); }
   ssize_t submit(bool more);
@@ -325,7 +324,6 @@ class RDMAServerSocketImpl : public ServerSocketImpl {
   virtual int accept(ConnectedSocket *s, const SocketOptions &opts, entity_addr_t *out, Worker *w) override;
   virtual void abort_accept() override;
   virtual int fd() const override { return server_setup_socket; }
-  int get_fd() { return server_setup_socket; }
 };
 
 class RDMAIWARPServerSocketImpl : public RDMAServerSocketImpl {

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -207,6 +207,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   int post_backlog = 0;
 
   void notify();
+  void buffer_prefetch(void);
   ssize_t read_buffers(char* buf, size_t len);
   int post_work_request(std::vector<Chunk*>&);
   size_t tx_copy_chunk(std::vector<Chunk*> &tx_buffers, size_t req_copy_len,

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -209,6 +209,9 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   void notify();
   ssize_t read_buffers(char* buf, size_t len);
   int post_work_request(std::vector<Chunk*>&);
+  size_t tx_copy_chunk(std::vector<Chunk*> &tx_buffers, size_t req_copy_len,
+      decltype(std::cbegin(pending_bl.buffers()))& start,
+      const decltype(std::cbegin(pending_bl.buffers()))& end);
 
  public:
   RDMAConnectedSocketImpl(CephContext *cct, Infiniband* ib, RDMADispatcher* s,


### PR DESCRIPTION
1. check rdma configuration is under hardware limitation.
2. fix ibv_port_attr object memory leak by using the object instead of allocating in the heap.
3. fix logic between RDMAV_HUGEPAGES_SAFE and ibv_fork_init.
4. fix error argument to get right qp state
5. separate Device construction when rdma_cm is used.
6. refine/simplify some function implementation.
7. decouple RDMAWorker & RDMAStack, RDMADispatcher & RDMAStack
8. remove redundant code.
9. rename var to improve readability.

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>

