### PR TITLE
qa/suites/rados/multimon: fix failures

### DIFF
--- a/qa/suites/rados/multimon/clusters/21.yaml
+++ b/qa/suites/rados/multimon/clusters/21.yaml
@@ -1,7 +1,7 @@
 roles:
-- [mon.a, mon.d, mon.g, mon.j, mon.m, mon.p, mon.s, osd.0]
+- [mon.a, mon.d, mon.g, mon.j, mon.m, mon.p, mon.s]
 - [mon.b, mon.e, mon.h, mon.k, mon.n, mon.q, mon.t, mgr.x]
-- [mon.c, mon.f, mon.i, mon.l, mon.o, mon.r, mon.u, osd.1]
+- [mon.c, mon.f, mon.i, mon.l, mon.o, mon.r, mon.u]
 openstack:
 - volumes: # attached to each instance
     count: 1

--- a/qa/suites/rados/multimon/clusters/3.yaml
+++ b/qa/suites/rados/multimon/clusters/3.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mon.c, osd.0]
-- [mon.b, mgr.x, osd.1]
+- [mon.a, mon.c]
+- [mon.b, mgr.x]
 openstack:
 - volumes: # attached to each instance
     count: 2

--- a/qa/suites/rados/multimon/clusters/6.yaml
+++ b/qa/suites/rados/multimon/clusters/6.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mon.c, mon.e, mgr.x, osd.0]
-- [mon.b, mon.d, mon.f, mgr.y, osd.1]
+- [mon.a, mon.c, mon.e, mgr.x]
+- [mon.b, mon.d, mon.f, mgr.y]
 openstack:
 - volumes: # attached to each instance
     count: 1

--- a/qa/suites/rados/multimon/clusters/9.yaml
+++ b/qa/suites/rados/multimon/clusters/9.yaml
@@ -1,7 +1,7 @@
 roles:
-- [mon.a, mon.d, mon.g, osd.0]
+- [mon.a, mon.d, mon.g]
 - [mon.b, mon.e, mon.h, mgr.x]
-- [mon.c, mon.f, mon.i, osd.1]
+- [mon.c, mon.f, mon.i]
 openstack:
 - volumes: # attached to each instance
     count: 1

--- a/qa/suites/rados/multimon/no_pools.yaml
+++ b/qa/suites/rados/multimon/no_pools.yaml
@@ -1,0 +1,3 @@
+overrides:
+  ceph:
+    create_rbd_pool: false

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -2,7 +2,7 @@ tasks:
 - install:
 - exec:
     mon.b:
-    - date -u -s @$(expr $(date -u +%s) + 10)
+    - date -u -s @$(expr $(date -u +%s) + 2)
 - ceph:
     wait-for-healthy: false
     log-whitelist:


### PR DESCRIPTION
These have been failing consistently for a while now.  The symptoms are:

- osds fail to come up because they can't authenticate in time, and/or because their boot messages aren't processed (because the mons don't form quorum)
- 'ceph osd dump' and similar CLI commands fail
- MON_CLOCK_SKEW warning doesn't appear.  This happens when the ceph task blocks for a long time setting crush tunables (or something else) until NTP fixes the skew, and then the actual test runs but sees no skew.

The mon quorum problem is intermittent, and depends on whether the skewed mons (mon.b's host) is rank 0 or not.

This PR does a few things:

- removes all OSDs from the test
- no RBD pool
- skews clocks by 2s instead of 10s, allowing mon quorum to form reliably.

Needs to be backported to nautilus.