### PR TITLE
test/crimson: fix msgr test of ref counter racing

### DIFF
--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -57,6 +57,8 @@ seastar::future<bool> SocketConnection::is_connected()
 seastar::future<> SocketConnection::send(MessageRef msg)
 {
   logger().debug("{} --> {} === {}", messenger, get_peer_addr(), *msg);
+  // Cannot send msg from another core now, its ref counter can be contaminated!
+  ceph_assert(seastar::engine().cpu_id() == shard_id());
   return seastar::smp::submit_to(shard_id(), [this, msg=std::move(msg)] {
     return protocol->send(std::move(msg));
   });


### PR DESCRIPTION
Unit test of foreign dispatch will cause random undefined behavior issue because of the racing to the `MessageRef` ref counter from multiple cores.

Currently we don't support foreign dispatch a message because:
* This is not efficient because ref-count modification to a foreign core needs extra cross-core communications, so it should be discouraged.
* In current 1:1 mapping OSD, there is no need to do foreign dispatch for the messages.

If we must implement foreign dispatch, one possible way is that:
* Messenger needs to be modified to hold a nested seastar smart ptr of the sending message because of foreign-dispatch.

Signed-off-by: Yingxin Cheng <yingxincheng@gmail.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

