### PR TITLE
DNM: os/bluestore: Fix bluefs free balance

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2470,8 +2470,7 @@ int BlueFS::_expand_slow_device(uint64_t need, PExtentVector& extents)
     ceph_assert(id <= (int)alloc.size() && alloc[id]);
     auto min_need = round_up_to(need, min_alloc_size);
     need = std::max(need,
-      slow_dev_expander->get_recommended_expansion_delta(
-        alloc[id]->get_free(), block_all[id].size()));
+      slow_dev_expander->get_recommended_expansion_delta());
 
     need = round_up_to(need, min_alloc_size);
     dout(10) << __func__ << " expanding slow device by 0x"

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -57,8 +57,7 @@ class BlueFSDeviceExpander {
 protected:
   ~BlueFSDeviceExpander() {}
 public:
-  virtual uint64_t get_recommended_expansion_delta(uint64_t bluefs_free,
-    uint64_t bluefs_total) = 0;
+  virtual uint64_t get_recommended_expansion_delta() = 0;
   virtual int allocate_freespace(
     uint64_t min_size,
     uint64_t size,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5643,9 +5643,8 @@ int BlueStore::allocate_bluefs_freespace(
   return 0;
 }
 
-int64_t BlueStore::_get_bluefs_size_delta(uint64_t bluefs_freexxx, uint64_t bluefs_totalxxx)
+int64_t BlueStore::_get_bluefs_size_delta()
 {
-
   vector<pair<uint64_t,uint64_t>> bluefs_usage;  // <free, total> ...
   bluefs->get_usage(&bluefs_usage);
   uint64_t bluefs_free =  0;
@@ -5743,9 +5742,7 @@ int BlueStore::_balance_bluefs_freespace()
   }
 
   // fixme: look at primary bdev only for now
-  int64_t delta = _get_bluefs_size_delta(
-    bluefs_usage[bluefs_shared_bdev].first,
-    bluefs_usage[bluefs_shared_bdev].second);
+  int64_t delta = _get_bluefs_size_delta();
 
   // reclaim from bluefs?
   if (delta < 0) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5643,17 +5643,26 @@ int BlueStore::allocate_bluefs_freespace(
   return 0;
 }
 
-int64_t BlueStore::_get_bluefs_size_delta(uint64_t bluefs_free, uint64_t bluefs_total)
+int64_t BlueStore::_get_bluefs_size_delta(uint64_t bluefs_freexxx, uint64_t bluefs_totalxxx)
 {
-  float bluefs_free_ratio = (float)bluefs_free / (float)bluefs_total;
+
+  vector<pair<uint64_t,uint64_t>> bluefs_usage;  // <free, total> ...
+  bluefs->get_usage(&bluefs_usage);
+  uint64_t bluefs_free =  0;
+  uint64_t bluefs_total = 0;
+  for (auto& i:bluefs_usage) {
+    bluefs_free += i.first;
+    bluefs_total += i.second;
+  }
 
   uint64_t my_free = alloc->get_free();
   uint64_t total = bdev->get_size();
   float my_free_ratio = (float)my_free / (float)total;
 
   uint64_t total_free = bluefs_free + my_free;
-
   float bluefs_ratio = (float)bluefs_free / (float)total_free;
+
+  float bluefs_free_ratio = (float)bluefs_free / (float)bluefs_total;
 
   dout(10) << __func__
 	   << " bluefs " << byte_u_t(bluefs_free)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2250,7 +2250,7 @@ private:
 
   void _dump_alloc_on_failure();
 
-  int64_t _get_bluefs_size_delta(uint64_t bluefs_free, uint64_t bluefs_total);
+  int64_t _get_bluefs_size_delta();
   int _balance_bluefs_freespace();
 
   CollectionRef _get_collection(const coll_t& cid);
@@ -3013,9 +3013,8 @@ private:
   std::atomic<uint64_t> out_of_sync_fm = {0};
   // --------------------------------------------------------
   // BlueFSDeviceExpander implementation
-  uint64_t get_recommended_expansion_delta(uint64_t bluefs_free,
-    uint64_t bluefs_total) override {
-    auto delta = _get_bluefs_size_delta(bluefs_free, bluefs_total);
+  uint64_t get_recommended_expansion_delta() override {
+    auto delta = _get_bluefs_size_delta();
     return delta > 0 ? delta : 0;
   }
   int allocate_freespace(


### PR DESCRIPTION
Bluestore/BlueFS: fix calculaiton of free space of BlueFS to factor in free space on *block.db*

This should combat excessive allocations from *block* device. It has nothing to do with spillover from block.db to block.