### PR TITLE
common/hobject: Error invocation of formula in documentation

### DIFF
--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -227,7 +227,7 @@ public:
    * Returns set S of strings such that for any object
    * h where h.match(bits, mask), there is some string
    * s \f$\in\f$ S such that s is a prefix of h.to_str().
-   * Furthermore, for any s $f\in\f$ S, s is a prefix of
+   * Furthermore, for any s \f$\in\f$ S, s is a prefix of
    * h.str() implies that h.match(bits, mask).
    */
   static std::set<std::string> get_prefixes(


### PR DESCRIPTION
Error invocation of formula in documentation, the second formula was started with `$f` instead of the correct `\f$`.


