### PR TITLE
systemd: add selinux flag in ceph.tmpfiles.d

### DIFF
--- a/systemd/ceph.tmpfiles.d
+++ b/systemd/ceph.tmpfiles.d
@@ -1,1 +1,1 @@
-d /run/ceph 0770 ceph ceph -
+dz /run/ceph 0770 ceph ceph -


### PR DESCRIPTION
Without this flag, some files in /run/ are mislabelled after a reboot
ending up with some services on the system not working properly.
(seen in containerized deployment).

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
