### PR TITLE
mgr/progress: Look at PG state when PG epoch >= OSDMap epoch

### DIFF
--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -135,6 +135,8 @@ class PgRecoveryEvent(Event):
 
         self._progress = 0.0
 
+        self._start_epoch = _module.get_osdmap().get_epoch() 
+
         self.id = str(uuid.uuid4())
         self._refresh()
 
@@ -142,7 +144,7 @@ class PgRecoveryEvent(Event):
     def evacuating_osds(self):
         return self. _evacuate_osds
 
-    def pg_update(self, pg_dump, log, start_epoch):
+    def pg_update(self, pg_dump, log):
         # FIXME: O(pg_num) in python
         # FIXME: far more fields getting pythonized than we really care about
         pg_to_state = dict([(p['pgid'], p) for p in pg_dump['pg_stats']])
@@ -181,7 +183,7 @@ class PgRecoveryEvent(Event):
                 complete.add(pg)
                 continue
             # Only checks the state of each PGs when it's epoch >= the OSDMap's epoch
-            if int(info['reported_epoch']) < int(start_epoch):
+            if int(info['reported_epoch']) < int(self._start_epoch):
                 continue
 
             state = info['state']
@@ -363,7 +365,7 @@ class Module(MgrModule):
             which_pgs=affected_pgs,
             evacuate_osds=[osd_id]
         )
-        ev.pg_update(self.get("pg_dump"), self.log, self.get_osdmap().get_epoch())
+        ev.pg_update(self.get("pg_dump"), self.log)
         self._events[ev.id] = ev
 
     def _osd_in(self, osd_id):
@@ -411,7 +413,7 @@ class Module(MgrModule):
             data = self.get("pg_dump")
             for ev_id, ev in self._events.items():
                 if isinstance(ev, PgRecoveryEvent):
-                    ev.pg_update(data, self.log, self.get_osdmap().get_epoch())
+                    ev.pg_update(data, self.log)
                     self.maybe_complete(ev)
 
     def maybe_complete(self, event):

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -142,7 +142,7 @@ class PgRecoveryEvent(Event):
     def evacuating_osds(self):
         return self. _evacuate_osds
 
-    def pg_update(self, pg_dump, log):
+    def pg_update(self, pg_dump, log,latest_osd_map_epoch):
         # FIXME: O(pg_num) in python
         # FIXME: far more fields getting pythonized than we really care about
         pg_to_state = dict([(p['pgid'], p) for p in pg_dump['pg_stats']])
@@ -179,6 +179,9 @@ class PgRecoveryEvent(Event):
             except KeyError:
                 # The PG is gone!  Probably a pool was deleted. Drop it.
                 complete.add(pg)
+                continue
+            #Only checks the state of each PGs when it's epoch >= the OSDMap's epoch
+            if int(info['reported_epoch']) < int(latest_osd_map_epoch):
                 continue
 
             state = info['state']
@@ -360,7 +363,7 @@ class Module(MgrModule):
             which_pgs=affected_pgs,
             evacuate_osds=[osd_id]
         )
-        ev.pg_update(self.get("pg_dump"), self.log)
+        ev.pg_update(self.get("pg_dump"), self.log,self._latest_osdmap.get_epoch())
         self._events[ev.id] = ev
 
     def _osd_in(self, osd_id):
@@ -408,7 +411,7 @@ class Module(MgrModule):
             data = self.get("pg_dump")
             for ev_id, ev in self._events.items():
                 if isinstance(ev, PgRecoveryEvent):
-                    ev.pg_update(data, self.log)
+                    ev.pg_update(data, self.log,self._latest_osdmap.get_epoch())
                     self.maybe_complete(ev)
 
     def maybe_complete(self, event):


### PR DESCRIPTION
add an if statement to only allow PGs to
only look at it's PG state when it's epoch
is greater than or equal to the OSDMap's
epoch.

Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

