### PR TITLE
rgw_file: include tenant when hashing bucket names

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1109,13 +1109,13 @@ namespace rgw {
 
   fh_key RGWFileHandle::make_fhk(const std::string& name)
   {
-    if (depth <= 1) {
-      std::string tenanted_name =
-	get_fs()->get_user()->user_id.to_str() + ":" + name;
-      return fh_key(fhk.fh_hk.object, tenanted_name.c_str());
+    std::string tenant = get_fs()->get_user()->user_id.to_str();
+    if (depth == 0) {
+      /* S3 bucket -- assert mount-at-bucket case reaches here */
+      return fh_key(name, name, tenant);
     } else {
       std::string key_name = make_key_name(name.c_str());
-      return fh_key(fhk.fh_hk.bucket, key_name.c_str());
+      return fh_key(fhk.fh_hk.bucket, key_name.c_str(), tenant);
     }
   }
 

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -942,6 +942,15 @@ namespace rgw {
     rele();
   } /* RGWLibFS::close */
 
+  inline std::ostream& operator<<(std::ostream &os, fh_key const &fhk) {
+    os << "<fh_key: bucket=";
+    os << fhk.fh_hk.bucket;
+    os << "; object=";
+    os << fhk.fh_hk.object;
+    os << ">";
+    return os;
+  }
+
   inline std::ostream& operator<<(std::ostream &os, struct timespec const &ts) {
       os << "<timespec: tv_sec=";
       os << ts.tv_sec;

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -144,6 +144,9 @@ namespace rgw {
       }
       DECODE_FINISH(bl);
     }
+
+    friend std::ostream& operator<<(std::ostream &os, fh_key const &fhk);
+
   }; /* fh_key */
 
   WRITE_CLASS_ENCODER(fh_key);
@@ -1055,14 +1058,14 @@ namespace rgw {
 
       std::string obj_name{name};
       std::string key_name{parent->make_key_name(name)};
+      fh_key fhk = parent->make_fhk(obj_name);
 
       lsubdout(get_context(), rgw, 10)
 	<< __func__ << " lookup called on "
 	<< parent->object_name() << " for " << key_name
 	<< " (" << obj_name << ")"
+	<< " -> " << fhk
 	<< dendl;
-
-      fh_key fhk = parent->make_fhk(obj_name);
 
     retry:
       RGWFileHandle* fh =

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -116,10 +116,12 @@ namespace rgw {
       fh_hk.bucket = bk;
       fh_hk.object = XXH64(_o, ::strlen(_o), seed);
     }
-    
-    fh_key(const std::string& _b, const std::string& _o)
+
+    fh_key(const std::string& _b, const std::string& _o,
+	   const std::string& _t /* tenant */)
       : version(0) {
-      fh_hk.bucket = XXH64(_b.c_str(), _o.length(), seed);
+      std::string tb = _t + ":" + _b;
+      fh_hk.bucket = XXH64(tb.c_str(), _o.length(), seed);
       fh_hk.object = XXH64(_o.c_str(), _o.length(), seed);
     }
 
@@ -522,14 +524,7 @@ namespace rgw {
       return key_name;
     }
 
-    fh_key make_fhk(const std::string& name) const {
-      if (depth <= 1)
-	return fh_key(fhk.fh_hk.object, name.c_str());
-      else {
-	std::string key_name = make_key_name(name.c_str());
-	return fh_key(fhk.fh_hk.bucket, key_name.c_str());
-      }
-    }
+    fh_key make_fhk(const std::string& name);
 
     void add_marker(uint64_t off, const rgw_obj_key& marker,
 		    uint8_t obj_type) {

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -111,18 +111,20 @@ namespace rgw {
       fh_hk.object = ok;
     }
 
-    fh_key(const uint64_t bk, const char *_o)
+    fh_key(const uint64_t bk, const char *_o, const std::string& _t)
       : version(0) {
       fh_hk.bucket = bk;
-      fh_hk.object = XXH64(_o, ::strlen(_o), seed);
+      std::string to = _t + ":" + _o;
+      fh_hk.object = XXH64(to.c_str(), to.length(), seed);
     }
 
     fh_key(const std::string& _b, const std::string& _o,
 	   const std::string& _t /* tenant */)
       : version(0) {
       std::string tb = _t + ":" + _b;
-      fh_hk.bucket = XXH64(tb.c_str(), _o.length(), seed);
-      fh_hk.object = XXH64(_o.c_str(), _o.length(), seed);
+      std::string to = _t + ":" + _o;
+      fh_hk.bucket = XXH64(tb.c_str(), tb.length(), seed);
+      fh_hk.object = XXH64(to.c_str(), to.length(), seed);
     }
 
     void encode(buffer::list& bl) const {


### PR DESCRIPTION
Prevent identical paths from distinct tenants from colliding in
RGW NFS handle cache.

Fixes: http://tracker.ceph.com/issues/40118

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

