### PR TITLE
mds: count purge queue items left in journal

### DIFF
--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -89,6 +89,7 @@ enum {
   l_pq_executing_ops,
   l_pq_executing,
   l_pq_executed,
+  l_pq_item_in_journal,
   l_pq_last
 };
 
@@ -166,6 +167,8 @@ protected:
   std::vector<Context*> waiting_for_recovery;
 
   void _go_readonly(int r);
+
+  size_t purge_item_journal_size;
 
 public:
   void init();

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -534,6 +534,9 @@ public:
   uint64_t get_read_pos() const { return read_pos; }
   uint64_t get_expire_pos() const { return expire_pos; }
   uint64_t get_trimmed_pos() const { return trimmed_pos; }
+  size_t get_journal_envelope_size() const { 
+    return journal_stream.get_envelope_size(); 
+  }
 };
 WRITE_CLASS_ENCODER(Journaler::Header)
 


### PR DESCRIPTION
MDS purge queue didn't have a perf counter to record how many items still left in journal. Even when MDS restarted, there was no any hint to know how many inodes haven't been really deleted from disks, so it is not easy to monitor disk usage, do flow control, etc.

Now we add a new perf counter called "l_pq_item_in_journal". Although it is an approximation value, I think we can tolerate with this and also it doesn't need to be precise.

Fixes: http://tracker.ceph.com/issues/40121

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

