### PR TITLE
mgr/dashboard: Improve hints shown when message.xlf is invalid

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-unittests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-unittests.sh
@@ -34,7 +34,7 @@ fi
 
 # I18N
 npm run i18n
-i18n_lint=`grep -En "<source> |<source>$| </source>" src/locale/messages.xlf`
+i18n_lint=`awk '/<source> |<source>$| <\/source>/,/<\/context-group>/ {printf "%-4s ", NR; print}' src/locale/messages.xlf`
 if [[ ! -z $i18n_lint ]]; then
   echo -e "The following source translations in 'messages.xlf' need to be \
 fixed, please check the I18N suggestions in 'HACKING.rst':\n"


### PR DESCRIPTION
`run-frontend-unit-tests.sh`, among others, tests if the `message.xlf` file has a valid format that doesn't break translations. The result does not always contain a hint on where the developer made a mistake and has to look for to correct that mistake.

Before:

```
> ceph-dashboard@0.0.0 i18n /ceph/src/pybind/mgr/dashboard/frontend
> ng xi18n --i18n-format xlf --i18n-locale en-US --output-path locale --progress=false && ngx-extractor -i 'src/**/*.ts' -f xlf -o src/locale/messages.xlf -l en-US
The following source translations in 'messages.xlf' need to be fixed, please check the I18N suggestions in 'HACKING.rst':

1366:      </source>
1412:        <source>
1414:          </source>
1438:        <source>
1440:            </source>
```

After:
```
user@work-ng ~/src/ceph-3/src/pybind/mgr/dashboard (wip-pna-message-xlf-opt*) $ awk '/<source> |<source>$| <\/source>/,/<\/context-group>/ {printf "%-4s ", NR; print}' frontend/src/locale/message.xlf-broken
1366       </source>                                                            
1367         <context-group purpose="location">
1368           <context context-type="sourcefile">app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html</context>
1369           <context context-type="linenumber">48</context>
1370         </context-group>
1412         <source>
1413             Editing a silence will expire the old silence and recreate it as a new silence
1414           </source>
1415         <context-group purpose="location">
1416           <context context-type="sourcefile">app/ceph/cluster/prometheus/silence-form/silence-form.component.html</context>
1417           <context context-type="linenumber">61</context>
1418         </context-group>
1438         <source>
1439               If the start time lies in the past the creation time will be used
1440             </source>
1441         <context-group purpose="location">
1442           <context context-type="sourcefile">app/ceph/cluster/prometheus/silence-form/silence-form.component.html</context>
1443           <context context-type="linenumber">115</context>
1444         </context-group>
user@work-ng ~/src/ceph-3/src/pybind/mgr/dashboard (wip-pna-message-xlf-opt*) $ 

```

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

