### PR TITLE
msg: fix addr2 encoding for sockaddrs

### DIFF
--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -489,16 +489,16 @@ struct entity_addr_t {
     }
     encode(nonce, bl);
     __u32 elen = get_sockaddr_len();
+#if (__FreeBSD__) || defined(__APPLE__)
+      elen -= sizeof(u.sa.sa_len);
+#endif
     encode(elen, bl);
     if (elen) {
-#if (__FreeBSD__) || defined(__APPLE__)
-      __le16 ss_family = u.sa.sa_family;
+      uint16_t ss_family = u.sa.sa_family;
+
       encode(ss_family, bl);
-      bl.append(u.sa.sa_data,
-		elen - sizeof(u.sa.sa_len) - sizeof(u.sa.sa_family));
-#else
-      bl.append((char*)get_sockaddr(), elen);
-#endif
+      elen -= sizeof(u.sa.sa_family);
+      bl.append(u.sa.sa_data, elen);
     }
     ENCODE_FINISH(bl);
   }
@@ -520,7 +520,8 @@ struct entity_addr_t {
     if (elen) {
 #if defined(__FreeBSD__) || defined(__APPLE__)
       u.sa.sa_len = 0;
-      __le16 ss_family;
+#endif
+      uint16_t ss_family;
       if (elen < sizeof(ss_family)) {
 	throw buffer::malformed_input("elen smaller than family len");
       }
@@ -531,17 +532,6 @@ struct entity_addr_t {
 	throw buffer::malformed_input("elen exceeds sockaddr len");
       }
       bl.copy(elen, u.sa.sa_data);
-#else
-      if (elen < sizeof(u.sa.sa_family)) {
-	throw ceph::buffer::malformed_input("elen smaller than family len");
-      }
-      bl.copy(sizeof(u.sa.sa_family), (char*)&u.sa.sa_family);
-      if (elen > get_sockaddr_len()) {
-	throw ceph::buffer::malformed_input("elen exceeds sockaddr len");
-      }
-      elen -= sizeof(u.sa.sa_family);
-      bl.copy(elen, u.sa.sa_data);
-#endif
     }
     DECODE_FINISH(bl);
   }


### PR DESCRIPTION
Currently, the sockaddr sa_family field is being sent across the wire
without any sort of endianness conversion.

Redefine the new-style entity_addr_t encoding to encode the sa_family
field as little-endian. This will allow LE machines in the field to
keep limping along, but note that BE machines may break until they are
all fixed.

To do this, use the code that was initially written for BSD/Apple
machines to encode the different fields separately.

Fixes: http://tracker.ceph.com/issues/40114
Signed-off-by: Jeff Layton <jlayton@redhat.com>

I'm running some smoke tests against this now, but it seems to behave well enough with some basic testing on my home rig. Note that there could be conflicts with https://github.com/ceph/ceph/pull/26606 here, so we may want to clean that up and get it merged first before we do this.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

