### PR TITLE
mgr/volumes: fix subvolume creation with quota

### DIFF
--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -159,7 +159,7 @@ class SubvolumeClient(object):
         self._mkdir_p(path, mode)
 
         if size is not None:
-            self.fs.setxattr(path, 'ceph.quota.max_bytes', size.encode('utf-8'), 0)
+            self.fs.setxattr(path, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
 
         # enforce security isolation, use separate namespace for this subvolume
         if namespace_isolated:


### PR DESCRIPTION
The quota variable should be a CephString type and not CephInt.

Fixes: http://tracker.ceph.com/issues/40152
Signed-off-by: Ramana Raja <rraja@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

