### PR TITLE
cls/rgw: test before accessing pkeys->rbegin()

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -176,7 +176,7 @@ static int get_obj_vals(cls_method_context_t hctx, const string& start, const st
   if (num_entries == (int)pkeys->size() || !(*pmore))
     return 0;
 
-  if (pkeys->rbegin()->first > new_start) {
+  if (pkeys->size() && new_start < pkeys->rbegin()->first) {
     new_start = pkeys->rbegin()->first;
   }
 


### PR DESCRIPTION
if pkeys is empty here, dereferencing rbegin() will crash

follow-up fix for https://github.com/ceph/ceph/pull/28188

Fixes: http://tracker.ceph.com/issues/39984