### PR TITLE
nautilus: mds: check dir fragment to split dir if mkdir makes it oversized.

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5830,6 +5830,11 @@ void Server::handle_client_mkdir(MDRequestRef& mdr)
   le->metablob.add_opened_ino(newi->ino());
 
   journal_and_reply(mdr, newi, dn, le, new C_MDS_mknod_finish(this, mdr, dn, newi));
+
+  // We hit_dir (via hit_inode) in our finish callback, but by then we might
+  // have overshot the split size (multiple mkdir in flight), so here is
+  // an early chance to split the dir if this mkdir makes it oversized.
+  mds->balancer->maybe_fragment(dir, false);
 }
 
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/39690