### PR TITLE
Add structures for tracking in progress operations

### DIFF
--- a/src/crimson/common/type_helpers.h
+++ b/src/crimson/common/type_helpers.h
@@ -1,0 +1,8 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "boost/intrusive_ptr.hpp"
+
+template<typename T> using Ref = boost::intrusive_ptr<T>;

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -78,6 +78,27 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
   }
   auto get_last_keepalive() const { return last_keepalive; }
   auto get_last_keepalive_ack() const { return last_keepalive_ack; }
+
+  seastar::shared_ptr<Connection> get_shared() {
+    return shared_from_this();
+  }
+
+  struct user_private_t {
+    virtual ~user_private_t() = default;
+  };
+private:
+  unique_ptr<user_private_t> user_private;
+public:
+  bool has_user_private() const {
+    return user_private != nullptr;
+  }
+  void set_user_private(unique_ptr<user_private_t> new_user_private) {
+    user_private = std::move(new_user_private);
+  }
+  user_private_t &get_user_private() {
+    ceph_assert(user_private);
+    return *user_private;
+  }
 };
 
 inline ostream& operator<<(ostream& out, const Connection& conn) {

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -11,6 +11,11 @@ add_executable(crimson-osd
   replicated_backend.cc
   shard_services.cc
   osd_operation.cc
+  osd_operations/client_request.cc
+  osd_operations/peering_event.cc
+  osd_operations/compound_peering_request.cc
+  osdmap_gate.cc
+  pg_map.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PeeringState.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGPeeringEvent.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGStateUtils.cc

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(crimson-osd
   osd_operations/client_request.cc
   osd_operations/peering_event.cc
   osd_operations/compound_peering_request.cc
+  osd_operations/pg_advance_map.cc
   osdmap_gate.cc
   pg_map.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PeeringState.cc

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(crimson-osd
   pg_meta.cc
   replicated_backend.cc
   shard_services.cc
+  osd_operation.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PeeringState.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGPeeringEvent.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGStateUtils.cc

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
                                               CEPH_ENTITY_TYPE_OSD,
                                               &cluster_name,
                                               &conf_file_list);
-  seastar::sharded<OSD> osd;
+  seastar::sharded<ceph::osd::OSD> osd;
   seastar::sharded<ceph::net::SocketMessenger> cluster_msgr, client_msgr;
   seastar::sharded<ceph::net::SocketMessenger> hb_front_msgr, hb_back_msgr;
   using ceph::common::sharded_conf;
@@ -145,13 +145,13 @@ int main(int argc, char* argv[])
         if (config.count("mkfs")) {
           osd.invoke_on(
 	    0,
-	    &OSD::mkfs,
+	    &ceph::osd::OSD::mkfs,
 	    local_conf().get_val<uuid_d>("osd_uuid"),
 	    local_conf().get_val<uuid_d>("fsid")).then([] {
 	      seastar::engine().exit(0);
 	    }).get();
         } else {
-          osd.invoke_on(0, &OSD::start).get();
+          osd.invoke_on(0, &ceph::osd::OSD::start).get();
         }
       });
     });

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -651,6 +651,7 @@ seastar::future<Ref<PG>> OSD::handle_pg_create_info(
 	  logger().info("{} new pg {}", __func__, *pg);
 	  pgs.emplace(info->pgid, pg);
 	  return seastar::when_all_succeed(
+	    advance_pg_to(pg, osdmap->get_epoch()),
 	    pg->get_need_up_thru() ? _send_alive() : seastar::now(),
 	    shard_services.dispatch_context(
 	      pg->get_collection_ref(),

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -47,6 +47,8 @@ namespace {
 using ceph::common::local_conf;
 using ceph::os::FuturizedStore;
 
+namespace ceph::osd {
+
 OSD::OSD(int id, uint32_t nonce,
          ceph::net::Messenger& cluster_msgr,
          ceph::net::Messenger& public_msgr,
@@ -1202,4 +1204,6 @@ seastar::future<> OSD::advance_pg_to(Ref<PG> pg, epoch_t to)
 	      std::move(rctx)));
 	});
     });
+}
+
 }

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -33,7 +33,6 @@ class MOSDMap;
 class MOSDOp;
 class OSDMap;
 class OSDMeta;
-class PG;
 class Heartbeat;
 
 namespace ceph::mon {
@@ -50,6 +49,8 @@ namespace ceph::os {
   class Transaction;
 }
 
+namespace ceph::osd {
+class PG;
 
 class OSD : public ceph::net::Dispatcher,
 	    private OSDMapService,
@@ -254,3 +255,5 @@ private:
   seastar::future<> send_beacon();
   void update_heartbeat_peers();
 };
+
+}

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -13,6 +13,7 @@
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/timer.hh>
 
+#include "crimson/common/type_helpers.h"
 #include "crimson/common/auth_handler.h"
 #include "crimson/common/simple_lru.h"
 #include "crimson/common/shared_lru.h"
@@ -49,7 +50,6 @@ namespace ceph::os {
   class Transaction;
 }
 
-template<typename T> using Ref = boost::intrusive_ptr<T>;
 
 class OSD : public ceph::net::Dispatcher,
 	    private OSDMapService,

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -188,7 +188,6 @@ public:
   blocking_future<Ref<PG>> wait_for_pg(
     spg_t pgid);
 
-  seastar::future<> advance_pg_to(Ref<PG> pg, epoch_t to);
   bool should_restart() const;
   seastar::future<> restart();
   seastar::future<> shutdown();
@@ -196,6 +195,7 @@ public:
   seastar::future<> send_beacon();
   void update_heartbeat_peers();
 
+  friend class PGAdvanceMap;
 };
 
 }

--- a/src/crimson/osd/osd_connection_priv.h
+++ b/src/crimson/osd/osd_connection_priv.h
@@ -1,0 +1,25 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/net/Connection.h"
+#include "crimson/osd/osd_operation.h"
+#include "crimson/osd/osd_operations/client_request.h"
+#include "crimson/osd/osd_operations/peering_event.h"
+
+namespace ceph::osd {
+
+struct OSDConnectionPriv : public ceph::net::Connection::user_private_t {
+  ClientRequest::ConnectionPipeline client_request_conn_pipeline;
+  RemotePeeringEvent::ConnectionPipeline peering_request_conn_pipeline;
+};
+
+static OSDConnectionPriv &get_osd_priv(ceph::net::Connection *conn) {
+  if (!conn->has_user_private()) {
+    conn->set_user_private(std::make_unique<OSDConnectionPriv>());
+  }
+  return static_cast<OSDConnectionPriv&>(conn->get_user_private());
+}
+
+}

--- a/src/crimson/osd/osd_operation.cc
+++ b/src/crimson/osd/osd_operation.cc
@@ -1,0 +1,79 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "osd_operation.h"
+
+namespace ceph::osd {
+
+void Operation::dump(Formatter *f)
+{
+  f->open_object_section("operation");
+  f->dump_string("type", get_type_name());
+  f->dump_unsigned("id", id);
+  {
+    f->open_object_section("detail");
+    dump_detail(f);
+    f->close_section();
+  }
+  f->open_array_section("blockers");
+  for (auto &blocker : blockers) {
+    blocker->dump(f);
+  }
+  f->close_section();
+  f->close_section();
+}
+
+void Operation::dump_brief(Formatter *f)
+{
+  f->open_object_section("operation");
+  f->dump_string("type", get_type_name());
+  f->dump_unsigned("id", id);
+  f->close_section();
+}
+
+std::ostream &operator<<(std::ostream &lhs, const Operation &rhs) {
+  lhs << rhs.get_type_name() << "(id=" << rhs.get_id() << ", detail=";
+  rhs.print(lhs);
+  lhs << ")";
+  return lhs;
+}
+
+void Blocker::dump(Formatter *f) const
+{
+  f->open_object_section("blocker");
+  f->dump_string("op_type", get_type_name());
+  {
+    f->open_object_section("detail");
+    dump_detail(f);
+    f->close_section();
+  }
+  f->close_section();
+}
+
+void OrderedPipelinePhase::Handle::exit()
+{
+  if (phase) {
+    phase->mutex.unlock();
+    phase = nullptr;
+  }
+}
+
+blocking_future<> OrderedPipelinePhase::Handle::enter(
+  OrderedPipelinePhase &new_phase)
+{
+  auto fut = new_phase.mutex.lock();
+  exit();
+  phase = &new_phase;
+  return new_phase.make_blocking_future(std::move(fut));
+}
+
+OrderedPipelinePhase::Handle::~Handle()
+{
+  exit();
+}
+
+void OrderedPipelinePhase::dump_detail(Formatter *f) const
+{
+}
+
+}

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -1,0 +1,269 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <seastar/core/shared_mutex.hh>
+#include <seastar/core/future.hh>
+
+#include <vector>
+#include <array>
+#include <algorithm>
+#include <set>
+#include <boost/intrusive/list.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
+#include "common/Formatter.h"
+
+namespace ceph::osd {
+
+enum class OperationTypeCode {
+  client_request = 0,
+  peering_event,
+  compound_peering_request,
+  last_op
+};
+
+static constexpr const char* const OP_NAMES[] = {
+  "client_write",
+  "peering_event",
+  "compound_peering_request"
+};
+
+// prevent the addition of OperationTypeCode-s with no matching OP_NAMES entry:
+static_assert(
+  (sizeof(OP_NAMES)/sizeof(OP_NAMES[0])) ==
+  static_cast<int>(OperationTypeCode::last_op));
+
+class OperationRegistry;
+
+using registry_hook_t = boost::intrusive::list_member_hook<
+  boost::intrusive::link_mode<boost::intrusive::auto_unlink>>;
+
+class Operation;
+class Blocker;
+
+/**
+ * Provides an abstraction for registering and unregistering a blocker
+ * for the duration of a future becoming available.
+ */
+template <typename... T>
+class blocking_future {
+  friend class Operation;
+  friend class Blocker;
+  Blocker *blocker;
+  seastar::future<T...> fut;
+  blocking_future(Blocker *b, seastar::future<T...> &&f)
+    : blocker(b), fut(std::move(f)) {}
+
+  template <typename... V, typename... U>
+  friend blocking_future<V...> make_ready_blocking_future(U&&... args);
+};
+
+template <typename... V, typename... U>
+blocking_future<V...> make_ready_blocking_future(U&&... args) {
+  return blocking_future<V...>(
+    nullptr,
+    seastar::make_ready_future<V...>(std::forward<U>(args)...));
+}
+
+/**
+ * Provides an interface for dumping diagnostic information about
+ * why a particular op is not making progress.
+ */
+class Blocker {
+protected:
+  virtual void dump_detail(Formatter *f) const = 0;
+
+public:
+  template <typename... T>
+  blocking_future<T...> make_blocking_future(seastar::future<T...> &&f) {
+    return blocking_future(this, std::move(f));
+  }
+
+  void dump(Formatter *f) const;
+
+  virtual const char *get_type_name() const = 0;
+
+  virtual ~Blocker() = default;
+};
+
+template <typename T>
+class BlockerT : public Blocker {
+public:
+  const char *get_type_name() const final {
+    return T::type_name;
+  }
+
+  virtual ~BlockerT() = default;
+};
+
+/**
+ * Common base for all crimson-osd operations.  Mainly provides
+ * an interface for registering ops in flight and dumping
+ * diagnostic information.
+ */
+class Operation : public boost::intrusive_ref_counter<
+  Operation, boost::thread_unsafe_counter> {
+  friend class OperationRegistry;
+  registry_hook_t registry_hook;
+
+  std::vector<Blocker*> blockers;
+  uint64_t id = 0;
+  void set_id(uint64_t in_id) {
+    id = in_id;
+  }
+protected:
+  virtual void dump_detail(Formatter *f) const = 0;
+
+public:
+  uint64_t get_id() const {
+    return id;
+  }
+
+  virtual OperationTypeCode get_type() const = 0;
+  virtual const char *get_type_name() const = 0;
+  virtual void print(std::ostream &) const = 0;
+
+  void add_blocker(Blocker *b) {
+    blockers.push_back(b);
+  }
+
+  void clear_blocker(Blocker *b) {
+    auto iter = std::find(blockers.begin(), blockers.end(), b);
+    if (iter != blockers.end()) {
+      blockers.erase(iter);
+    }
+  }
+
+  template <typename... T>
+  seastar::future<T...> with_blocking_future(blocking_future<T...> &&f) {
+    if (f.fut.available() || f.fut.failed()) {
+      return std::move(f.fut);
+    }
+    ceph_assert(f.blocker);
+    add_blocker(f.blocker);
+    return std::move(f.fut).then_wrapped([this, blocker=f.blocker](auto &&arg) {
+      clear_blocker(blocker);
+      return std::move(arg);
+    });
+  }
+
+  void dump(Formatter *f);
+  void dump_brief(Formatter *f);
+  virtual ~Operation() = default;
+};
+using OperationRef = boost::intrusive_ptr<Operation>;
+
+std::ostream &operator<<(std::ostream &, const Operation &op);
+
+template <typename T>
+class OperationT : public Operation {
+
+protected:
+  virtual void dump_detail(Formatter *f) const = 0;
+
+public:
+  static constexpr const char *type_name = OP_NAMES[static_cast<int>(T::type)];
+  using IRef = boost::intrusive_ptr<T>;
+
+  OperationTypeCode get_type() const final {
+    return T::type;
+  }
+
+  const char *get_type_name() const final {
+    return T::type_name;
+  }
+
+  virtual ~OperationT() = default;
+};
+
+/**
+ * Maintains a set of lists of all active ops.
+ */
+class OperationRegistry {
+  friend class Operation;
+  using op_list_member_option = boost::intrusive::member_hook<
+    Operation,
+    registry_hook_t,
+    &Operation::registry_hook
+    >;
+  using op_list = boost::intrusive::list<
+    Operation,
+    op_list_member_option,
+    boost::intrusive::constant_time_size<false>>;
+
+  std::array<
+    op_list,
+    static_cast<int>(OperationTypeCode::last_op)
+  > registries;
+
+  std::array<
+    uint64_t,
+    static_cast<int>(OperationTypeCode::last_op)
+  > op_id_counters = {};
+
+public:
+  template <typename T, typename... Args>
+  typename T::IRef create_operation(Args&&... args) {
+    typename T::IRef op = new T(std::forward<Args>(args)...);
+    registries[static_cast<int>(T::type)].push_back(*op);
+    op->set_id(op_id_counters[static_cast<int>(T::type)]++);
+    return op;
+  }
+};
+
+/**
+ * Ensures that at most one op may consider itself in the phase at a time.
+ * Ops will see enter() unblock in the order in which they tried to enter
+ * the phase.  entering (though not necessarily waiting for the future to
+ * resolve) a new phase prior to exiting the previous one will ensure that
+ * the op ordering is preserved.
+ */
+class OrderedPipelinePhase : public Blocker {
+  const char * name;
+
+protected:
+  virtual void dump_detail(Formatter *f) const final;
+  const char *get_type_name() const final {
+    return name;
+  }
+
+public:
+  seastar::shared_mutex mutex;
+
+  /**
+   * Used to encapsulate pipeline residency state.
+   */
+  class Handle {
+    OrderedPipelinePhase *phase = nullptr;
+
+  public:
+    Handle() = default;
+
+    Handle(const Handle&) = delete;
+    Handle(Handle&&) = delete;
+    Handle &operator=(const Handle&) = delete;
+    Handle &operator=(Handle&&) = delete;
+
+    /**
+     * Returns a future which unblocks when the handle has entered the passed
+     * OrderedPipelinePhase.  If already in a phase, enter will also release
+     * that phase after placing itself in the queue for the next one to preserve
+     * ordering.
+     */
+    blocking_future<> enter(OrderedPipelinePhase &phase);
+
+    /**
+     * Releases the current phase if there is one.  Called in ~Handle().
+     */
+    void exit();
+
+    ~Handle();
+  };
+
+  OrderedPipelinePhase(const char *name) : name(name) {}
+};
+
+}

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -20,15 +20,19 @@ namespace ceph::osd {
 
 enum class OperationTypeCode {
   client_request = 0,
-  peering_event,
-  compound_peering_request,
-  last_op
+  peering_event = 1,
+  compound_peering_request = 2,
+  pg_advance_map = 3,
+  pg_creation = 4,
+  last_op = 5
 };
 
 static constexpr const char* const OP_NAMES[] = {
-  "client_write",
+  "client_request",
   "peering_event",
-  "compound_peering_request"
+  "compound_peering_request",
+  "pg_advance_map",
+  "pg_creation",
 };
 
 // prevent the addition of OperationTypeCode-s with no matching OP_NAMES entry:

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -1,0 +1,76 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <seastar/core/future.hh>
+
+#include "messages/MOSDOp.h"
+
+#include "crimson/osd/pg.h"
+#include "crimson/osd/osd.h"
+#include "common/Formatter.h"
+#include "crimson/osd/osd_operations/client_request.h"
+#include "crimson/osd/osd_connection_priv.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace ceph::osd {
+
+ClientRequest::ClientRequest(
+  OSD &osd, ceph::net::ConnectionRef conn, Ref<MOSDOp> &&m)
+  : osd(osd), conn(conn), m(m)
+{}
+
+void ClientRequest::print(std::ostream &lhs) const
+{
+  lhs << *m;
+}
+
+void ClientRequest::dump_detail(Formatter *f) const
+{
+}
+
+ClientRequest::ConnectionPipeline &ClientRequest::cp()
+{
+  return get_osd_priv(conn.get()).client_request_conn_pipeline;
+}
+
+ClientRequest::PGPipeline &ClientRequest::pp(PG &pg)
+{
+  return pg.client_request_pg_pipeline;
+}
+
+seastar::future<> ClientRequest::start()
+{
+  logger().debug("{}: start", *this);
+
+  IRef ref = this;
+  with_blocking_future(handle.enter(cp().await_map))
+    .then([this]() {
+      return with_blocking_future(osd.osdmap_gate.wait_for_map(m->get_map_epoch()));
+    }).then([this](epoch_t epoch) {
+      return with_blocking_future(handle.enter(cp().get_pg));
+    }).then([this] {
+      return with_blocking_future(osd.wait_for_pg(m->get_spg()));
+    }).then([this, ref=std::move(ref)](Ref<PG> pg) {
+      return seastar::do_with(
+	std::move(pg), std::move(ref), [this](auto pg, auto op) {
+	return with_blocking_future(
+	  handle.enter(pp(*pg).await_map)
+	).then([this, pg] {
+	  return with_blocking_future(
+	    pg->osdmap_gate.wait_for_map(m->get_map_epoch()));
+	}).then([this, pg] (auto) {
+	  return with_blocking_future(handle.enter(pp(*pg).process));
+	}).then([this, pg] {
+	  return pg->handle_op(conn.get(), std::move(m));
+	});
+      });
+    });
+  return seastar::make_ready_future();
+}
+
+}

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -48,7 +48,7 @@ seastar::future<> ClientRequest::start()
   logger().debug("{}: start", *this);
 
   IRef ref = this;
-  with_blocking_future(handle.enter(cp().await_map))
+  return with_blocking_future(handle.enter(cp().await_map))
     .then([this]() {
       return with_blocking_future(osd.osdmap_gate.wait_for_map(m->get_map_epoch()));
     }).then([this](epoch_t epoch) {
@@ -70,7 +70,6 @@ seastar::future<> ClientRequest::start()
 	});
       });
     });
-  return seastar::make_ready_future();
 }
 
 }

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -1,0 +1,55 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/net/Connection.h"
+#include "crimson/osd/osd_operation.h"
+#include "crimson/common/type_helpers.h"
+
+class MOSDOp;
+
+namespace ceph::osd {
+class PG;
+class OSD;
+
+class ClientRequest final : public OperationT<ClientRequest> {
+  OSD &osd;
+  ceph::net::ConnectionRef conn;
+  Ref<MOSDOp> m;
+  OrderedPipelinePhase::Handle handle;
+
+public:
+  class ConnectionPipeline {
+    OrderedPipelinePhase await_map = {
+      "ClientRequest::ConnectionPipeline::await_map"
+    };
+    OrderedPipelinePhase get_pg = {
+      "ClientRequest::ConnectionPipeline::get_pg"
+    };
+    friend class ClientRequest;
+  };
+  class PGPipeline {
+    OrderedPipelinePhase await_map = {
+      "ClientRequest::PGPipeline::await_map"
+    };
+    OrderedPipelinePhase process = {
+      "ClientRequest::PGPipeline::process"
+    };
+    friend class ClientRequest;
+  };
+
+  static constexpr OperationTypeCode type = OperationTypeCode::client_request;
+
+  ClientRequest(OSD &osd, ceph::net::ConnectionRef, Ref<MOSDOp> &&m);
+
+  void print(std::ostream &) const final;
+  void dump_detail(Formatter *f) const final;
+  seastar::future<> start();
+
+private:
+  ConnectionPipeline &cp();
+  PGPipeline &pp(PG &pg);
+};
+
+}

--- a/src/crimson/osd/osd_operations/compound_peering_request.cc
+++ b/src/crimson/osd/osd_operations/compound_peering_request.cc
@@ -1,0 +1,321 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <seastar/core/future.hh>
+
+#include "osd/PeeringState.h"
+
+#include "messages/MOSDPGInfo.h"
+#include "messages/MOSDPGNotify.h"
+#include "messages/MOSDPGQuery.h"
+#include "messages/MOSDPGCreate2.h"
+
+#include "common/Formatter.h"
+
+#include "crimson/osd/pg.h"
+#include "crimson/osd/osd.h"
+#include "crimson/osd/osd_operations/compound_peering_request.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace {
+using namespace ceph::osd;
+
+struct compound_state {
+  seastar::promise<BufferedRecoveryMessages> promise;
+  BufferedRecoveryMessages ctx;
+  ~compound_state() {
+    promise.set_value(std::move(ctx));
+  }
+};
+using compound_state_ref = seastar::lw_shared_ptr<compound_state>;
+
+class PeeringSubEvent : public RemotePeeringEvent {
+  compound_state_ref state;
+public:
+  template <typename... Args>
+  PeeringSubEvent(compound_state_ref state, Args &&... args) :
+    RemotePeeringEvent(std::forward<Args>(args)...), state(state) {}
+
+  seastar::future<> complete_rctx(Ref<ceph::osd::PG> pg) final {
+    logger().debug("{}: submitting ctx transaction", *this);
+    state->ctx.accept_buffered_messages(ctx);
+    state = {};
+    if (!pg) {
+      ceph_assert(ctx.transaction.empty());
+      return seastar::now();
+    } else {
+      return osd.get_shard_services().dispatch_context_transaction(
+	pg->get_collection_ref(), ctx);
+    }
+  }
+};
+
+std::vector<OperationRef> handle_pg_create(
+  OSD &osd,
+  ceph::net::ConnectionRef conn,
+  compound_state_ref state,
+  Ref<MOSDPGCreate2> m)
+{
+  std::vector<OperationRef> ret;
+  for (auto &p : m->pgs) {
+    const spg_t &pgid = p.first;
+    const auto &[created, created_stamp] = p.second;
+    auto q = m->pg_extra.find(pgid);
+    ceph_assert(q != m->pg_extra.end());
+    logger().debug(
+      "{}, {} {} e{} @{} history {} pi {}",
+      __func__,
+      pgid,
+      created,
+      created_stamp,
+      q->second.first,
+      q->second.second);
+    if (!q->second.second.empty() &&
+	m->epoch < q->second.second.get_bounds().second) {
+      logger().error(
+	"got pg_create on {} epoch {} unmatched past_intervals (history {})",
+	pgid,
+	m->epoch,
+	q->second.second,
+	q->second.first);
+    } else {
+      auto op = osd.get_shard_services().start_operation<PeeringSubEvent>(
+	state,
+	osd,
+	conn,
+	osd.get_shard_services(),
+	pg_shard_t(),
+	pgid,
+	m->epoch,
+	m->epoch,
+	NullEvt(),
+	true,
+	new PGCreateInfo(
+	  pgid,
+	  m->epoch,
+	  q->second.first,
+	  q->second.second,
+	  true));
+    }
+  }
+  return ret;
+}
+
+std::vector<OperationRef> handle_pg_notify(
+  OSD &osd,
+  ceph::net::ConnectionRef conn,
+  compound_state_ref state,
+  Ref<MOSDPGNotify> m)
+{
+  std::vector<OperationRef> ret;
+  ret.reserve(m->get_pg_list().size());
+  const int from = m->get_source().num();
+  for (auto &p : m->get_pg_list()) {
+    auto& [pg_notify, past_intervals] = p;
+    spg_t pgid{pg_notify.info.pgid.pgid, pg_notify.to};
+    MNotifyRec notify{pgid,
+		      pg_shard_t{from, pg_notify.from},
+		      pg_notify,
+		      0, // the features is not used
+		      past_intervals};
+    logger().debug("handle_pg_notify on {} from {}", pgid.pgid, from);
+    auto create_info = new PGCreateInfo{
+      pgid,
+      pg_notify.query_epoch,
+      pg_notify.info.history,
+      past_intervals,
+      false};
+    auto op = osd.get_shard_services().start_operation<PeeringSubEvent>(
+      state,
+      osd,
+      conn,
+      osd.get_shard_services(),
+      pg_shard_t(from, pg_notify.from),
+      pgid,
+      pg_notify.epoch_sent,
+      pg_notify.query_epoch,
+      notify,
+      true, // requires_pg
+      create_info);
+    op->start();
+    ret.push_back(op);
+  }
+  return ret;
+}
+
+std::vector<OperationRef> handle_pg_info(
+  OSD &osd,
+  ceph::net::ConnectionRef conn,
+  compound_state_ref state,
+  Ref<MOSDPGInfo> m)
+{
+  std::vector<OperationRef> ret;
+  ret.reserve(m->pg_list.size());
+  const int from = m->get_source().num();
+  for (auto &p : m->pg_list) {
+    auto& pg_notify = p.first;
+    spg_t pgid{pg_notify.info.pgid.pgid, pg_notify.to};
+    logger().debug("handle_pg_info on {} from {}", pgid.pgid, from);
+    MInfoRec info{pg_shard_t{from, pg_notify.from},
+		  pg_notify.info,
+		  pg_notify.epoch_sent};
+    auto op = osd.get_shard_services().start_operation<PeeringSubEvent>(
+	state,
+	osd,
+	conn,
+	osd.get_shard_services(),
+	pg_shard_t(from, pg_notify.from),
+	pgid,
+	pg_notify.epoch_sent,
+	pg_notify.query_epoch,
+	std::move(info));
+    ret.push_back(op);
+  }
+  return ret;
+}
+
+class QuerySubEvent : public PeeringSubEvent {
+public:
+  template <typename... Args>
+  QuerySubEvent(Args &&... args) :
+    PeeringSubEvent(std::forward<Args>(args)...) {}
+
+  void on_pg_absent() final {
+    logger().debug("handle_pg_query on absent pg {} from {}", pgid, from);
+    pg_info_t empty(pgid);
+    ctx.notify_list[from.osd].emplace_back(
+      pg_notify_t(
+	from.shard, pgid.shard,
+	evt.get_epoch_sent(),
+	osd.get_shard_services().get_osdmap()->get_epoch(),
+	empty),
+      PastIntervals());
+  }
+};
+
+std::vector<OperationRef> handle_pg_query(
+  OSD &osd,
+  ceph::net::ConnectionRef conn,
+  compound_state_ref state,
+  Ref<MOSDPGQuery> m)
+{
+  std::vector<OperationRef> ret;
+  ret.reserve(m->pg_list.size());
+  const int from = m->get_source().num();
+  for (auto &p : m->pg_list) {
+    auto& [pgid, pg_query] = p;
+    MQuery query{pgid, pg_shard_t{from, pg_query.from},
+		 pg_query, pg_query.epoch_sent};
+    logger().debug("handle_pg_query on {} from {}", pgid, from);
+    auto op = osd.get_shard_services().start_operation<QuerySubEvent>(
+      state,
+      osd,
+      conn,
+      osd.get_shard_services(),
+      pg_shard_t(from, pg_query.from),
+      pgid,
+      pg_query.epoch_sent,
+      pg_query.epoch_sent,
+      std::move(query));
+    ret.push_back(op);
+  }
+  return ret;
+}
+
+struct SubOpBlocker : BlockerT<SubOpBlocker> {
+  static constexpr const char * type_name = "CompoundOpBlocker";
+
+  std::vector<OperationRef> subops;
+  SubOpBlocker(std::vector<OperationRef> &&subops) : subops(subops) {}
+
+  virtual void dump_detail(Formatter *f) const {
+    f->open_array_section("dependent_operations");
+    {
+      for (auto &i : subops) {
+	i->dump_brief(f);
+      }
+    }
+    f->close_section();
+  }
+};
+
+} // namespace
+
+namespace ceph::osd {
+
+CompoundPeeringRequest::CompoundPeeringRequest(
+  OSD &osd, ceph::net::ConnectionRef conn, Ref<Message> m)
+  : osd(osd),
+    conn(conn),
+    m(m)
+{}
+
+void CompoundPeeringRequest::print(std::ostream &lhs) const
+{
+  lhs << *m;
+}
+
+void CompoundPeeringRequest::dump_detail(Formatter *f) const
+{
+  f->dump_stream("message") << *m;
+}
+
+seastar::future<> CompoundPeeringRequest::start()
+{
+  logger().info("{}: starting", *this);
+  auto state = seastar::make_lw_shared<compound_state>();
+  auto blocker = std::make_unique<SubOpBlocker>(
+    [&] {
+      switch (m->get_type()) {
+      case MSG_OSD_PG_CREATE2:
+	return handle_pg_create(
+	  osd,
+	  conn,
+	  state,
+	  boost::static_pointer_cast<MOSDPGCreate2>(m));
+      case MSG_OSD_PG_NOTIFY:
+	return handle_pg_notify(
+	  osd,
+	  conn,
+	  state,
+	  boost::static_pointer_cast<MOSDPGNotify>(m));
+      case MSG_OSD_PG_INFO:
+	return handle_pg_info(
+	  osd,
+	  conn,
+	  state,
+	  boost::static_pointer_cast<MOSDPGInfo>(m));
+      case MSG_OSD_PG_QUERY:
+	return handle_pg_query(
+	  osd,
+	  conn,
+	  state,
+	  boost::static_pointer_cast<MOSDPGQuery>(m));
+      default:
+	ceph_assert("Invalid message type" == 0);
+	return std::vector<OperationRef>();
+      }
+    }());
+
+  add_blocker(blocker.get());
+  IRef ref = this;
+  logger().info("{}: about to fork future", *this);
+  state->promise.get_future().then(
+    [this, blocker=std::move(blocker)](auto &&ctx) {
+      clear_blocker(blocker.get());
+      logger().info("{}: sub events complete", *this);
+      return osd.get_shard_services().dispatch_context_messages(std::move(ctx));
+    }).then([this, ref=std::move(ref)] {
+      logger().info("{}: complete", *this);
+    });
+
+  logger().info("{}: forked, returning", *this);
+  return seastar::now();
+}
+
+} // namespace ceph::osd

--- a/src/crimson/osd/osd_operations/compound_peering_request.h
+++ b/src/crimson/osd/osd_operations/compound_peering_request.h
@@ -1,0 +1,40 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <iostream>
+#include <seastar/core/future.hh>
+
+#include "msg/MessageRef.h"
+
+#include "crimson/net/Connection.h"
+#include "crimson/osd/osd_operation.h"
+
+namespace ceph::osd {
+
+class OSD;
+class PG;
+
+using osd_id_t = int;
+
+class CompoundPeeringRequest : public OperationT<CompoundPeeringRequest> {
+public:
+  static constexpr OperationTypeCode type =
+    OperationTypeCode::compound_peering_request;
+
+private:
+  OSD &osd;
+  ceph::net::ConnectionRef conn;
+  Ref<Message> m;
+
+public:
+  CompoundPeeringRequest(
+    OSD &osd, ceph::net::ConnectionRef conn, Ref<Message> m);
+
+  void print(std::ostream &) const final;
+  void dump_detail(Formatter *f) const final;
+  seastar::future<> start();
+};
+
+}

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -1,0 +1,120 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <seastar/core/future.hh>
+
+#include "crimson/osd/pg.h"
+#include "crimson/osd/osd.h"
+#include "common/Formatter.h"
+#include "crimson/osd/osd_operations/peering_event.h"
+#include "crimson/osd/osd_connection_priv.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace ceph::osd {
+
+void PeeringEvent::print(std::ostream &lhs) const
+{
+  lhs << "PeeringEvent("
+      << "from=" << from
+      << " pgid=" << pgid
+      << " sent=" << evt.get_epoch_sent()
+      << " requested=" << evt.get_epoch_requested()
+      << " evt=" << evt.get_desc()
+      << ")";
+}
+
+void PeeringEvent::dump_detail(Formatter *f) const
+{
+  f->open_object_section("PeeringEvent");
+  f->dump_stream("from") << from;
+  f->dump_stream("pgid") << pgid;
+  f->dump_int("sent", evt.get_epoch_sent());
+  f->dump_int("requested", evt.get_epoch_requested());
+  f->dump_string("evt", evt.get_desc());
+  f->close_section();
+}
+
+
+PeeringEvent::PGPipeline &PeeringEvent::pp(PG &pg)
+{
+  return pg.peering_request_pg_pipeline;
+}
+
+seastar::future<> PeeringEvent::start()
+{
+
+  logger().debug("{}: start", *this);
+
+  IRef ref = this;
+  get_pg().then([this](Ref<PG> pg) {
+    if (!pg) {
+      logger().debug("{}: pg absent, did not create", *this);
+      on_pg_absent();
+      handle.exit();
+      return complete_rctx(pg);
+    } else {
+      logger().debug("{}: pg present", *this);
+      return with_blocking_future(handle.enter(pp(*pg).await_map)
+      ).then([this, pg] {
+	return with_blocking_future(
+	  pg->osdmap_gate.wait_for_map(evt.get_epoch_sent()));
+      }).then([this, pg](auto) {
+	return with_blocking_future(handle.enter(pp(*pg).process));
+      }).then([this, pg] {
+	pg->do_peering_event(evt, ctx);
+	handle.exit();
+	return complete_rctx(pg);
+      });
+    }
+  }).then([this, ref=std::move(ref)] {
+    logger().debug("{}: complete", *this);
+  });
+  return seastar::make_ready_future();
+}
+
+void PeeringEvent::on_pg_absent()
+{
+  logger().debug("{}: pg absent, dropping", *this);
+}
+
+seastar::future<> PeeringEvent::complete_rctx(Ref<PG> pg)
+{
+  logger().debug("{}: submitting ctx", *this);
+  return shard_services.dispatch_context(
+    pg->get_collection_ref(),
+    std::move(ctx));
+}
+
+RemotePeeringEvent::ConnectionPipeline &RemotePeeringEvent::cp()
+{
+  return get_osd_priv(conn.get()).peering_request_conn_pipeline;
+}
+
+seastar::future<Ref<PG>> RemotePeeringEvent::get_pg() {
+  return with_blocking_future(
+    handle.enter(cp().await_map)
+  ).then([this] {
+    return with_blocking_future(
+      osd.osdmap_gate.wait_for_map(evt.get_epoch_sent()));
+  }).then([this](auto epoch) {
+    logger().debug("{}: got map {}", *this, epoch);
+    return with_blocking_future(handle.enter(cp().get_pg));
+  }).then([this] {
+    return with_blocking_future(
+      osd.get_or_create_pg(
+	pgid, evt.get_epoch_sent(), std::move(evt.create_info)));
+  });
+}
+
+seastar::future<Ref<PG>> LocalPeeringEvent::get_pg() {
+  return seastar::make_ready_future<Ref<PG>>(pg);
+}
+
+LocalPeeringEvent::~LocalPeeringEvent() {}
+
+}

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -51,7 +51,7 @@ seastar::future<> PeeringEvent::start()
   logger().debug("{}: start", *this);
 
   IRef ref = this;
-  get_pg().then([this](Ref<PG> pg) {
+  return get_pg().then([this](Ref<PG> pg) {
     if (!pg) {
       logger().debug("{}: pg absent, did not create", *this);
       on_pg_absent();
@@ -74,7 +74,6 @@ seastar::future<> PeeringEvent::start()
   }).then([this, ref=std::move(ref)] {
     logger().debug("{}: complete", *this);
   });
-  return seastar::make_ready_future();
 }
 
 void PeeringEvent::on_pg_absent()

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -29,6 +29,7 @@ public:
       "PeeringEvent::PGPipeline::process"
     };
     friend class PeeringEvent;
+    friend class PGAdvanceMap;
   };
 
 protected:

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -1,0 +1,123 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <iostream>
+#include <seastar/core/future.hh>
+
+#include "crimson/osd/osd_operation.h"
+#include "osd/osd_types.h"
+#include "osd/PGPeeringEvent.h"
+#include "osd/PeeringState.h"
+
+namespace ceph::osd {
+
+class OSD;
+class ShardServices;
+class PG;
+
+class PeeringEvent : public OperationT<PeeringEvent> {
+public:
+  static constexpr OperationTypeCode type = OperationTypeCode::peering_event;
+
+  class PGPipeline {
+    OrderedPipelinePhase await_map = {
+      "PeeringEvent::PGPipeline::await_map"
+    };
+    OrderedPipelinePhase process = {
+      "PeeringEvent::PGPipeline::process"
+    };
+    friend class PeeringEvent;
+  };
+
+protected:
+  OrderedPipelinePhase::Handle handle;
+  PGPipeline &pp(PG &pg);
+
+  ShardServices &shard_services;
+  PeeringCtx ctx;
+  pg_shard_t from;
+  spg_t pgid;
+  PGPeeringEvent evt;
+
+  const pg_shard_t get_from() const {
+    return from;
+  }
+
+  const spg_t get_pgid() const {
+    return pgid;
+  }
+
+  const PGPeeringEvent &get_event() const {
+    return evt;
+  }
+
+  virtual void on_pg_absent();
+  virtual seastar::future<> complete_rctx(Ref<PG>);
+  virtual seastar::future<Ref<PG>> get_pg() = 0;
+
+public:
+  template <typename... Args>
+  PeeringEvent(
+    ShardServices &shard_services, const pg_shard_t &from, const spg_t &pgid,
+    Args&&... args) :
+    shard_services(shard_services),
+    from(from),
+    pgid(pgid),
+    evt(std::forward<Args>(args)...)
+  {}
+
+
+  void print(std::ostream &) const final;
+  void dump_detail(Formatter *f) const final;
+  seastar::future<> start();
+};
+
+class RemotePeeringEvent : public PeeringEvent {
+protected:
+  OSD &osd;
+  ceph::net::ConnectionRef conn;
+
+  seastar::future<Ref<PG>> get_pg() final;
+
+public:
+  class ConnectionPipeline {
+    OrderedPipelinePhase await_map = {
+      "PeeringRequest::ConnectionPipeline::await_map"
+    };
+    OrderedPipelinePhase get_pg = {
+      "PeeringRequest::ConnectionPipeline::get_pg"
+    };
+    friend class RemotePeeringEvent;
+  };
+
+  template <typename... Args>
+  RemotePeeringEvent(OSD &osd, ceph::net::ConnectionRef conn, Args&&... args) :
+    PeeringEvent(std::forward<Args>(args)...),
+    osd(osd),
+    conn(conn)
+  {}
+
+private:
+  ConnectionPipeline &cp();
+};
+
+class LocalPeeringEvent final : public PeeringEvent {
+protected:
+  seastar::future<Ref<PG>> get_pg() final;
+
+  Ref<PG> pg;
+
+public:
+  template <typename... Args>
+  LocalPeeringEvent(Ref<PG> pg, Args&&... args) :
+    PeeringEvent(std::forward<Args>(args)...),
+    pg(pg)
+  {}
+
+  virtual ~LocalPeeringEvent();
+};
+
+
+}

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -1,0 +1,95 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <seastar/core/future.hh>
+
+#include <boost/smart_ptr/local_shared_ptr.hpp>
+#include "include/types.h"
+#include "crimson/osd/osd_operations/pg_advance_map.h"
+#include "crimson/osd/pg.h"
+#include "crimson/osd/osd.h"
+#include "common/Formatter.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace ceph::osd {
+
+PGAdvanceMap::PGAdvanceMap(
+  OSD &osd, Ref<PG> pg, epoch_t from, epoch_t to)
+  : osd(osd), pg(pg), from(from), to(to), do_init(false) {}
+
+PGAdvanceMap::PGAdvanceMap(
+  OSD &osd, Ref<PG> pg, epoch_t from, epoch_t to,
+  PeeringCtx &&rctx, bool do_init)
+  : osd(osd), pg(pg), from(from), to(to),
+    rctx(std::move(rctx)), do_init(do_init) {}
+
+PGAdvanceMap::~PGAdvanceMap() {}
+
+void PGAdvanceMap::print(std::ostream &lhs) const
+{
+  lhs << "PGAdvanceMap("
+      << "pg=" << pg->get_pgid()
+      << " from=" << from
+      << " to=" << to;
+  if (do_init) {
+    lhs << " do_init";
+  }
+  lhs << ")";
+}
+
+void PGAdvanceMap::dump_detail(Formatter *f) const
+{
+  f->open_object_section("PGAdvanceMap");
+  f->dump_stream("pgid") << pg->get_pgid();
+  f->dump_int("from", from);
+  f->dump_int("to", to);
+  f->dump_bool("do_init", do_init);
+  f->close_section();
+}
+
+seastar::future<> PGAdvanceMap::start()
+{
+  using cached_map_t = boost::local_shared_ptr<const OSDMap>;
+
+  logger().debug("{}: start", *this);
+
+  IRef ref = this;
+  return with_blocking_future(
+    handle.enter(pg->peering_request_pg_pipeline.process))
+    .then([this] {
+      if (do_init) {
+	pg->handle_initialize(rctx);
+	pg->handle_activate_map(rctx);
+      }
+      return seastar::do_for_each(
+	boost::make_counting_iterator(from + 1),
+	boost::make_counting_iterator(to + 1),
+	[this](epoch_t next_epoch) {
+	  return osd.get_map(next_epoch).then(
+	    [this] (cached_map_t&& next_map) {
+	      pg->handle_advance_map(next_map, rctx);
+	    });
+	}).then([this] {
+	  pg->handle_activate_map(rctx);
+	  handle.exit();
+	  if (do_init) {
+	    osd.pg_map.pg_created(pg->get_pgid(), pg);
+	    logger().info("{} new pg {}", __func__, *pg);
+	  }
+	  return seastar::when_all_succeed(
+	    pg->get_need_up_thru() ? osd._send_alive() : seastar::now(),
+	    osd.shard_services.dispatch_context(
+	      pg->get_collection_ref(),
+	      std::move(rctx)));
+	});
+    }).then([this, ref=std::move(ref)] {
+      logger().debug("{}: complete", *this);
+    });
+}
+
+}

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -1,0 +1,48 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <iostream>
+#include <seastar/core/future.hh>
+
+#include "crimson/osd/osd_operation.h"
+#include "osd/osd_types.h"
+#include "crimson/common/type_helpers.h"
+#include "osd/PeeringState.h"
+
+namespace ceph::osd {
+
+class OSD;
+class PG;
+
+class PGAdvanceMap : public OperationT<PGAdvanceMap> {
+public:
+  static constexpr OperationTypeCode type = OperationTypeCode::pg_advance_map;
+
+protected:
+  OrderedPipelinePhase::Handle handle;
+
+  OSD &osd;
+  Ref<PG> pg;
+
+  epoch_t from;
+  epoch_t to;
+
+  PeeringCtx rctx;
+  const bool do_init;
+
+public:
+  PGAdvanceMap(
+    OSD &osd, Ref<PG> pg, epoch_t from, epoch_t to);
+  PGAdvanceMap(
+    OSD &osd, Ref<PG> pg, epoch_t from, epoch_t to,
+    PeeringCtx &&rctx, bool do_init);
+  ~PGAdvanceMap();
+
+  void print(std::ostream &) const final;
+  void dump_detail(Formatter *f) const final;
+  seastar::future<> start();
+};
+
+}

--- a/src/crimson/osd/osdmap_gate.cc
+++ b/src/crimson/osd/osdmap_gate.cc
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/osd/osdmap_gate.h"
+#include "crimson/osd/shard_services.h"
+#include "common/Formatter.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace ceph::osd {
+
+void OSDMapGate::OSDMapBlocker::dump_detail(Formatter *f) const
+{
+  f->open_object_section("OSDMapGate");
+  f->dump_int("epoch", epoch);
+  f->close_section();
+}
+
+blocking_future<epoch_t> OSDMapGate::wait_for_map(epoch_t epoch)
+{
+  if (current >= epoch) {
+    return make_ready_blocking_future<epoch_t>(current);
+  } else {
+    logger().info("evt epoch is {}, i have {}, will wait", epoch, current);
+    auto &blocker = waiting_peering.emplace(
+      epoch, make_pair(blocker_type, epoch)).first->second;
+    auto fut = blocker.promise.get_shared_future();
+    if (shard_services) {
+      return blocker.make_blocking_future(
+	(*shard_services).get().osdmap_subscribe(current, true).then(
+	  [fut=std::move(fut)]() mutable {
+	    return std::move(fut);
+	  }));
+    } else {
+      return blocker.make_blocking_future(std::move(fut));
+    }
+  }
+}
+
+void OSDMapGate::got_map(epoch_t epoch) {
+  current = epoch;
+  auto first = waiting_peering.begin();
+  auto last = waiting_peering.upper_bound(epoch);
+  std::for_each(first, last, [epoch, this](auto& blocked_requests) {
+    blocked_requests.second.promise.set_value(epoch);
+  });
+  waiting_peering.erase(first, last);
+}
+
+}

--- a/src/crimson/osd/osdmap_gate.h
+++ b/src/crimson/osd/osdmap_gate.h
@@ -1,0 +1,67 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <optional>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_future.hh>
+
+#include "include/types.h"
+#include "crimson/osd/osd_operation.h"
+
+namespace ceph {
+  class Formatter;
+  namespace osd {
+    class ShardServices;
+  }
+}
+
+namespace ceph::osd {
+
+class OSDMapGate {
+  struct OSDMapBlocker : public Blocker {
+    const char * type_name;
+    epoch_t epoch;
+
+    OSDMapBlocker(std::pair<const char *, epoch_t> args)
+      : type_name(args.first), epoch(args.second) {}
+
+    OSDMapBlocker(const OSDMapBlocker &) = delete;
+    OSDMapBlocker(OSDMapBlocker &&) = delete;
+    OSDMapBlocker &operator=(const OSDMapBlocker &) = delete;
+    OSDMapBlocker &operator=(OSDMapBlocker &&) = delete;
+
+    seastar::shared_promise<epoch_t> promise;
+
+    void dump_detail(Formatter *f) const final;
+    const char *get_type_name() const final {
+      return type_name;
+    }
+  };
+
+  // order the promises in descending order of the waited osdmap epoch,
+  // so we can access all the waiters expecting a map whose epoch is less
+  // than a given epoch
+  using waiting_peering_t = std::map<epoch_t,
+				     OSDMapBlocker,
+				     std::greater<epoch_t>>;
+  const char *blocker_type;
+  waiting_peering_t waiting_peering;
+  epoch_t current = 0;
+  std::optional<std::reference_wrapper<ShardServices>> shard_services;
+public:
+  OSDMapGate(
+    const char *blocker_type,
+    std::optional<std::reference_wrapper<ShardServices>> shard_services)
+    : blocker_type(blocker_type), shard_services(shard_services) {}
+
+  // wait for an osdmap whose epoch is greater or equal to given epoch
+  blocking_future<epoch_t> wait_for_map(epoch_t epoch);
+  void got_map(epoch_t epoch);
+};
+
+}

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -40,6 +40,8 @@ namespace {
   }
 }
 
+namespace ceph::osd {
+
 using ceph::common::local_conf;
 
 class RecoverablePredicate : public IsPGRecoverablePredicate {
@@ -64,7 +66,7 @@ PG::PG(
   pg_pool_t&& pool,
   std::string&& name,
   cached_map_t osdmap,
-  ceph::osd::ShardServices &shard_services,
+  ShardServices &shard_services,
   ec_profile_t profile)
   : pgid{pgid},
     pg_whoami{pg_shard},
@@ -405,4 +407,6 @@ seastar::future<> PG::handle_op(ceph::net::Connection* conn,
   }).then([conn](Ref<MOSDOpReply> reply) {
     return conn->send(reply);
   });
+}
+
 }

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -24,15 +24,18 @@
 
 #include "osd/OSDMap.h"
 
+#include "os/Transaction.h"
+
 #include "crimson/net/Connection.h"
 #include "crimson/net/Messenger.h"
 #include "crimson/os/cyan_collection.h"
-#include "crimson/os/futurized_store.h"
 #include "os/Transaction.h"
+#include "crimson/os/cyan_store.h"
+
 #include "crimson/osd/exceptions.h"
 #include "crimson/osd/pg_meta.h"
-
-#include "pg_backend.h"
+#include "crimson/osd/pg_backend.h"
+#include "crimson/osd/osd_operations/peering_event.h"
 
 namespace {
   seastar::logger& logger() {
@@ -72,6 +75,7 @@ PG::PG(
     pg_whoami{pg_shard},
     coll_ref(shard_services.get_store().open_collection(coll)),
     pgmeta_oid{pgid.make_pgmeta_oid()},
+    osdmap_gate("PG::osdmap_gate", std::nullopt),
     shard_services{shard_services},
     osdmap{osdmap},
     backend(
@@ -98,27 +102,26 @@ PG::PG(
   peering_state.set_backend_predicates(
     new ReadablePredicate(pg_whoami),
     new RecoverablePredicate());
+  osdmap_gate.got_map(osdmap->get_epoch());
 }
 
+PG::~PG() {}
+
 bool PG::try_flush_or_schedule_async() {
-// FIXME once there's a good way to schedule an "async" peering event
-#if 0
   shard_services.get_store().do_transaction(
     coll_ref,
     ObjectStore::Transaction()).then(
-      [this, epoch=peering_state.get_osdmap()->get_epoch()](){
-	if (!peering_state.pg_has_reset_since(epoch)) {
-	  PeeringCtx rctx;
-	  auto evt = PeeringState::IntervalFlush();
-	  do_peering_event(evt, rctx);
-	  return shard_services.dispatch_context(std::move(rctx));
-	} else {
-	  return seastar::now();
-	}
+      [this, epoch=peering_state.get_osdmap()->get_epoch()]() {
+	return shard_services.start_operation<LocalPeeringEvent>(
+	  this,
+	  shard_services,
+	  pg_whoami,
+	  pgid,
+	  epoch,
+	  epoch,
+	  PeeringState::IntervalFlush());
       });
   return false;
-#endif
-  return true;
 }
 
 void PG::log_state_enter(const char *state) {
@@ -232,6 +235,7 @@ void PG::handle_advance_map(
     newacting,
     acting_primary,
     rctx);
+  osdmap_gate.got_map(next_map->get_epoch());
 }
 
 void PG::handle_activate_map(PeeringCtx &rctx)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -71,6 +71,14 @@ public:
 
   ~PG();
 
+  const pg_shard_t &get_pg_whoami() const {
+    return pg_whoami;
+  }
+
+  const spg_t&get_pgid() const {
+    return pgid;
+  }
+
   // EpochSource
   epoch_t get_osdmap_epoch() const final {
     return peering_state.get_osdmap_epoch();
@@ -437,6 +445,7 @@ private:
   friend std::ostream& operator<<(std::ostream&, const PG& pg);
   friend class ClientRequest;
   friend class PeeringEvent;
+  friend class PGAdvanceMap;
 };
 
 std::ostream& operator<<(std::ostream&, const PG& pg);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -14,12 +14,16 @@
 #include "common/dout.h"
 #include "crimson/net/Fwd.h"
 #include "os/Transaction.h"
-#include "crimson/osd/shard_services.h"
 #include "osd/osd_types.h"
 #include "osd/osd_internal_types.h"
 #include "osd/PeeringState.h"
 
 #include "crimson/common/type_helpers.h"
+#include "crimson/osd/osd_operations/client_request.h"
+#include "crimson/osd/osd_operations/peering_event.h"
+#include "crimson/osd/shard_services.h"
+#include "crimson/osd/osdmap_gate.h"
+
 class OSDMap;
 class MQuery;
 class PGBackend;
@@ -36,6 +40,9 @@ namespace ceph::os {
   class FuturizedStore;
 }
 
+namespace ceph::osd {
+class ClientRequest;
+
 class PG : public boost::intrusive_ref_counter<
   PG,
   boost::thread_unsafe_counter>,
@@ -44,6 +51,9 @@ class PG : public boost::intrusive_ref_counter<
 {
   using ec_profile_t = std::map<std::string,std::string>;
   using cached_map_t = boost::local_shared_ptr<const OSDMap>;
+
+  ClientRequest::PGPipeline client_request_pg_pipeline;
+  PeeringEvent::PGPipeline peering_request_pg_pipeline;
 
   spg_t pgid;
   pg_shard_t pg_whoami;
@@ -56,8 +66,10 @@ public:
      pg_pool_t&& pool,
      std::string&& name,
      cached_map_t osdmap,
-     ceph::osd::ShardServices &shard_services,
+     ShardServices &shard_services,
      ec_profile_t profile);
+
+  ~PG();
 
   // EpochSource
   epoch_t get_osdmap_epoch() const final {
@@ -187,7 +199,7 @@ public:
     t.register_on_commit(
       new LambdaContext([this, on_commit](){
 	PeeringCtx rctx;
-        do_peering_event(on_commit, rctx);
+        do_peering_event(*on_commit, rctx);
 	shard_services.dispatch_context(std::move(rctx));
     }));
   }
@@ -389,16 +401,6 @@ public:
 
   void do_peering_event(
     PGPeeringEvent& evt, PeeringCtx &rctx);
-  void do_peering_event(
-    std::unique_ptr<PGPeeringEvent> evt,
-    PeeringCtx &rctx) {
-    return do_peering_event(*evt, rctx);
-  }
-  void do_peering_event(
-    PGPeeringEventRef evt,
-    PeeringCtx &rctx) {
-    return do_peering_event(*evt, rctx);
-  }
 
   void handle_advance_map(cached_map_t next_map, PeeringCtx &rctx);
   void handle_activate_map(PeeringCtx &rctx);
@@ -421,6 +423,7 @@ private:
 					     uint64_t limit);
 
 private:
+  OSDMapGate osdmap_gate;
   ShardServices &shard_services;
 
   cached_map_t osdmap;
@@ -432,6 +435,10 @@ private:
   seastar::future<> wait_for_active();
 
   friend std::ostream& operator<<(std::ostream&, const PG& pg);
+  friend class ClientRequest;
+  friend class PeeringEvent;
 };
 
 std::ostream& operator<<(std::ostream&, const PG& pg);
+
+}

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -19,7 +19,7 @@
 #include "osd/osd_internal_types.h"
 #include "osd/PeeringState.h"
 
-template<typename T> using Ref = boost::intrusive_ptr<T>;
+#include "crimson/common/type_helpers.h"
 class OSDMap;
 class MQuery;
 class PGBackend;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -421,7 +421,7 @@ private:
 					     uint64_t limit);
 
 private:
-  ceph::osd::ShardServices &shard_services;
+  ShardServices &shard_services;
 
   cached_map_t osdmap;
   std::unique_ptr<PGBackend> backend;

--- a/src/crimson/osd/pg_map.cc
+++ b/src/crimson/osd/pg_map.cc
@@ -1,0 +1,70 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/osd/pg_map.h"
+
+#include "crimson/osd/pg.h"
+#include "common/Formatter.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace ceph::osd {
+
+PGMap::PGCreationState::PGCreationState(spg_t pgid) : pgid(pgid) {}
+PGMap::PGCreationState::~PGCreationState() {}
+
+void PGMap::PGCreationState::dump_detail(Formatter *f) const
+{
+  f->dump_stream("pgid") << pgid;
+  f->dump_bool("creating", creating);
+}
+
+std::pair<blocking_future<Ref<PG>>, bool> PGMap::get_pg(spg_t pgid, bool wait)
+{
+  if (auto pg = pgs.find(pgid); pg != pgs.end()) {
+    return make_pair(make_ready_blocking_future<Ref<PG>>(pg->second), true);
+  } else if (!wait) {
+    return make_pair(make_ready_blocking_future<Ref<PG>>(nullptr), true);
+  } else {
+    auto &state = pgs_creating.emplace(pgid, pgid).first->second;
+    return make_pair(
+      state.make_blocking_future(state.promise.get_shared_future()),
+      state.creating);
+  }
+}
+
+void PGMap::set_creating(spg_t pgid)
+{
+  logger().debug("Creating {}", pgid);
+  ceph_assert(pgs.count(pgid) == 0);
+  auto pg = pgs_creating.find(pgid);
+  ceph_assert(pg != pgs_creating.end());
+  ceph_assert(pg->second.creating == false);
+  pg->second.creating = true;
+}
+
+void PGMap::pg_created(spg_t pgid, Ref<PG> pg)
+{
+  logger().debug("Created {}", pgid);
+  ceph_assert(!pgs.count(pgid));
+  pgs.emplace(pgid, pg);
+
+  auto state = pgs_creating.find(pgid);
+  ceph_assert(state != pgs_creating.end());
+  state->second.promise.set_value(pg);
+  pgs_creating.erase(pgid);
+}
+
+void PGMap::pg_loaded(spg_t pgid, Ref<PG> pg)
+{
+  ceph_assert(!pgs.count(pgid));
+  pgs.emplace(pgid, pg);
+}
+
+PGMap::~PGMap() {}
+
+}

--- a/src/crimson/osd/pg_map.h
+++ b/src/crimson/osd/pg_map.h
@@ -11,6 +11,7 @@
 #include "include/types.h"
 #include "crimson/common/type_helpers.h"
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/pg.h"
 #include "osd/osd_types.h"
 
 namespace ceph::osd {

--- a/src/crimson/osd/pg_map.h
+++ b/src/crimson/osd/pg_map.h
@@ -1,0 +1,69 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <map>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_future.hh>
+
+#include "include/types.h"
+#include "crimson/common/type_helpers.h"
+#include "crimson/osd/osd_operation.h"
+#include "osd/osd_types.h"
+
+namespace ceph::osd {
+class PG;
+
+class PGMap {
+  struct PGCreationState : BlockerT<PGCreationState> {
+    static constexpr const char * type_name = "PGCreation";
+
+    void dump_detail(Formatter *f) const final;
+
+    spg_t pgid;
+    seastar::shared_promise<Ref<PG>> promise;
+    bool creating = false;
+    PGCreationState(spg_t pgid);
+
+    PGCreationState(const PGCreationState &) = delete;
+    PGCreationState(PGCreationState &&) = delete;
+    PGCreationState &operator=(const PGCreationState &) = delete;
+    PGCreationState &operator=(PGCreationState &&) = delete;
+
+    ~PGCreationState();
+  };
+
+  std::map<spg_t, PGCreationState> pgs_creating;
+  std::map<spg_t, Ref<PG>> pgs;
+
+public:
+  /**
+   * Get future for pg with a bool indicating whether it's already being
+   * created.
+   */
+  std::pair<blocking_future<Ref<PG>>, bool> get_pg(spg_t pgid, bool wait=true);
+
+  /**
+   * Set creating
+   */
+  void set_creating(spg_t pgid);
+
+  /**
+   * Set newly created pg
+   */
+  void pg_created(spg_t pgid, Ref<PG> pg);
+
+  /**
+   * Add newly loaded pg
+   */
+  void pg_loaded(spg_t pgid, Ref<PG> pg);
+
+  decltype(pgs) &get_pgs() { return pgs; }
+
+  PGMap() = default;
+  ~PGMap();
+};
+
+}

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -74,10 +74,9 @@ public:
   OperationRegistry registry;
 
   template <typename T, typename... Args>
-  typename T::IRef start_operation(Args&&... args) {
+  auto start_operation(Args&&... args) {
     auto op = registry.create_operation<T>(std::forward<Args>(args)...);
-    op->start();
-    return op;
+    return std::make_pair(op, op->start());
   }
 
   // Loggers

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -53,16 +53,16 @@ public:
     }
     desc = out.str();
   }
-  epoch_t get_epoch_sent() {
+  epoch_t get_epoch_sent() const {
     return epoch_sent;
   }
-  epoch_t get_epoch_requested() {
+  epoch_t get_epoch_requested() const {
     return epoch_requested;
   }
-  const boost::statechart::event_base &get_event() {
+  const boost::statechart::event_base &get_event() const {
     return *evt;
   }
-  const std::string& get_desc() {
+  const std::string& get_desc() const {
     return desc;
   }
 };

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -17,6 +17,16 @@
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
 
+BufferedRecoveryMessages::BufferedRecoveryMessages(PeeringCtx &ctx)
+  : query_map(std::move(ctx.query_map)),
+    info_map(std::move(ctx.info_map)),
+    notify_list(std::move(ctx.notify_list))
+{
+  ctx.query_map.clear();
+  ctx.info_map.clear();
+  ctx.notify_list.clear();
+}
+
 void PGPool::update(CephContext *cct, OSDMapRef map)
 {
   const pg_pool_t *pi = map->get_pg_pool(id);


### PR DESCRIPTION
The idea is to add machinery for registering ops as being in progress with a per-shard registry as well as some concept of the op being "blocked".