### PR TITLE
mon: fix 'node ls' command errors. 

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -818,6 +818,7 @@ void MDSMonitor::_updated(MonOpRequestRef op)
 
 void MDSMonitor::on_active()
 {
+  init();
   tick();
   update_logger();
 


### PR DESCRIPTION
 When a peon turns into a leader, its MDSMonitor::pending_metadata may has some old data, we need a update.
 For example, one mds restart during a monitor as a peon,then the monitor turns into a leader, but its  MDSMonitor::pending_metadata has not be updated, the old data in MDSMonitor::pending_metadata will be deleted by MDSMonitor::remove_from_metadata function. 
So, pending_metadata will lose one mds's metadata. We need to update  MDSMonitor::pending_metadata when a peon turns into a leader.

 Fixes: https://tracker.ceph.com/issues/40197
Signed-off-by: wangshuguangbj  wangshuguang@inspur.com