### PR TITLE
nautilus: mon: fix off-by-one rendering progress bar

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3023,7 +3023,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
 	ss << "    " << i.second.message << "\n";
 	ss << "      [";
 	unsigned j;
-	for (j=0; j < i.second.progress * 30; ++j) {
+	for (j = 0; j < (unsigned)(i.second.progress * 30.0); ++j) {
 	  ss << '=';
 	}
 	for (; j < 30; ++j) {


### PR DESCRIPTION
Ensure that if progress is < 1.0, we always have a '.' at the end of the
bar.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 0e49ad74f9ebbefb418f9eb1c8842dbe8f16fa18)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

