### PR TITLE
mds: skip openfiletable's node prefetch

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7970,6 +7970,10 @@ std::vector<Option> get_mds_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("mds_oft_fetch_batch", Option::TYPE_INT, Option::LEVEL_BASIC)
+    .set_default(1000)
+    .set_description("number of files to be fetched in one run"),
+
     Option("mds_kill_mdstable_at", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(0)
     .set_description(""),

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -52,9 +52,55 @@ WRITE_CLASS_ENCODER(Anchor)
 
 class RecoveredAnchor : public Anchor {
 public:
+  typedef enum {
+    STATE_UNFETCHED,
+    STATE_FETCHED,
+    STATE_RECOVERED,
+    STATE_NOENT,
+  } RecoveredAnchorState;
+protected:
+  RecoveredAnchorState state = STATE_UNFETCHED;
+  bool touched = false;
+public:
   RecoveredAnchor() {}
 
   mds_rank_t auth = MDS_RANK_NONE; // auth hint
+
+  void touch() {
+    touched = true;
+  }
+
+  bool is_touched() {
+    return touched;
+  }
+
+  bool is_fetched() {
+    return state == STATE_FETCHED;
+  }
+
+  void set_fetched() {
+    state = STATE_FETCHED;
+  }
+
+  bool is_recovered() {
+    return state == STATE_RECOVERED;
+  }
+
+  void set_recovered() {
+    state = STATE_RECOVERED;
+  }
+
+  bool is_noent() {
+    return state == STATE_NOENT;
+  }
+
+  void set_noent() {
+    state = STATE_NOENT;
+  }
+
+  RecoveredAnchorState get_state() {
+    return state;
+  }
 };
 
 class OpenedAnchor : public Anchor {

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5279,4 +5279,21 @@ void CInode::get_subtree_dirfrags(std::vector<CDir*>& v) const
   }
 }
 
+bool CInode::needs_recover() {
+  if (is_file()) {
+    for (map<client_t,client_writeable_range_t>::iterator p = inode.client_ranges.begin();
+        p != inode.client_ranges.end();
+        ++p) {
+      Capability *cap = get_client_cap(p->first);
+      if (cap) {
+        cap->mark_clientwriteable();
+      } else {
+        dout(10) << " client." << p->first << " has range " << p->second << " but no cap on " << *this << dendl;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 MEMPOOL_DEFINE_OBJECT_FACTORY(CInode, co_inode, mds_co);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -333,6 +333,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const uint64_t WAIT_FROZEN      = (1<<1);
   static const uint64_t WAIT_TRUNC       = (1<<2);
   static const uint64_t WAIT_FLOCK       = (1<<3);
+  static const uint64_t WAIT_ONLOADRECOVERED   = (1<<4);
   
   static const uint64_t WAIT_ANY_MASK	= (uint64_t)(-1);
 
@@ -669,6 +670,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void decode_snap_blob(const ceph::buffer::list &bl);
   void encode_store(ceph::buffer::list& bl, uint64_t features);
   void decode_store(ceph::buffer::list::const_iterator& bl);
+
+  bool needs_recover();
 
   void add_dir_waiter(frag_t fg, MDSContext *c);
   void take_dir_waiting(frag_t fg, MDSContext::vec& ls);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5329,16 +5329,12 @@ bool MDCache::process_imported_caps()
 {
   dout(10) << "process_imported_caps" << dendl;
 
-  if (!open_file_table.is_prefetched() &&
-      open_file_table.prefetch_inodes()) {
-    open_file_table.wait_for_prefetch(
-	new MDSInternalContextWrapper(mds,
-	  new LambdaContext([this](int r) {
-	    ceph_assert(rejoin_gather.count(mds->get_nodeid()));
-	    process_imported_caps();
-	    })
-	  )
-	);
+  if (!open_file_table.is_loaded()) {
+    open_file_table.wait_for_load(new MDSInternalContextWrapper(mds,
+          new LambdaContext([this](int r) {
+            ceph_assert(rejoin_gather.count(mds->get_nodeid()));
+            process_imported_caps();
+            })));
     return true;
   }
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -724,6 +724,7 @@ void MDSRankDispatcher::tick()
   sessionmap.update_average_session_age();
 
   if (is_active() || is_stopping()) {
+    mdcache->open_file_table.fetch_files();
     mdlog->trim();  // NOT during recovery!
   }
 

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -38,11 +38,6 @@ public:
   void notify_unlink(CInode *in);
   bool is_any_dirty() const { return !dirty_items.empty(); }
 
-  void _fetch_file_finish(inodeno_t ino, int r);
-  void _open_ino_finish(inodeno_t ino, int r);
-  void _prefetch_inodes();
-  void _prefetch_dirfrags();
-
   void commit(MDSContext *c, uint64_t log_seq, int op_prio);
   uint64_t get_committed_log_seq() const { return committed_log_seq; }
   uint64_t get_committing_log_seq() const { return committing_log_seq; }
@@ -144,6 +139,7 @@ protected:
   void _open_ino_finish(inodeno_t ino, int r);
   void _prefetch_inodes();
   void _prefetch_dirfrags();
+  void _fetch_file_finish(inodeno_t ino, int r);
 
   MDSRank *mds;
 

--- a/src/mds/RecoveryQueue.cc
+++ b/src/mds/RecoveryQueue.cc
@@ -228,6 +228,11 @@ void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime)
     mds->locker->check_inode_max_size(in, true, 0,  size, mtime);
     mds->locker->eval(in, CEPH_LOCK_IFILE);
     in->auth_unpin(this);
+
+    mds->mdcache->open_file_table.set_recovered_anchor_recovered(in->ino());
+    MDSContext::vec finished;
+    in->take_waiting(CInode::WAIT_ONLOADRECOVERED, finished);
+    mds->queue_waiters(finished);
   }
 
   advance();

--- a/src/mds/RecoveryQueue.cc
+++ b/src/mds/RecoveryQueue.cc
@@ -209,7 +209,6 @@ void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime)
 
   logger->set(l_mdc_num_recovering_processing, file_recovering.size());
   logger->inc(l_mdc_recovery_completed);
-  in->state_clear(CInode::STATE_RECOVERING);
 
   if (restart) {
     if (in->item_recover_queue.is_on_list()) {
@@ -225,6 +224,7 @@ void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime)
     _start(in);
   } else if (!_is_in_any_recover_queue(in)) {
     // journal
+    in->state_clear(CInode::STATE_RECOVERING);
     mds->locker->check_inode_max_size(in, true, 0,  size, mtime);
     mds->locker->eval(in, CEPH_LOCK_IFILE);
     in->auth_unpin(this);


### PR DESCRIPTION
The kernel client keeps files' relative caps so that it wouldn't need to
consult mds for the caps unless they're revoke explicitly, which could
leave large amounts of files open on the mdses. To prevent the mds from
loading large amounts not really opened files, the client would drop those
caps when reconnecting to mdses.

However, when the mdses recover from some kind of disaster, files cached
by clients before the reconnect are still "opened" in the openfiletable,
which makes the inodes prefetch phase of openfiletable load large amounts
inodes whose caps are probably already dropped by clients. The worst scenario
is that mdses can never come to up:active unless administrators adjust the
heartbeat grace to a very large value.

Fixes: http://tracker.ceph.com/issues/40159
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

