### PR TITLE
osd: unify sources of no{up,down,in,out} flags into singleton helpers

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -244,7 +244,7 @@ seastar::future<> OSD::_preboot(version_t oldest, version_t newest)
     if (osdmap->get_epoch() > newest - 1) {
       throw std::runtime_error("i am destroyed");
     }
-  } else if (osdmap->test_flag(CEPH_OSDMAP_NOUP) || osdmap->is_noup(whoami)) {
+  } else if (osdmap->is_noup(whoami)) {
     logger().warn("osdmap NOUP flag is set, waiting for it to clear");
   } else if (!osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
     logger().error("osdmap SORTBITWISE OSDMap flag is NOT set; please set it");

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2538,29 +2538,8 @@ bool OSDMonitor::prepare_mark_me_down(MonOpRequestRef op)
 
 bool OSDMonitor::can_mark_down(int i)
 {
-  if (osdmap.test_flag(CEPH_OSDMAP_NODOWN)) {
-    dout(5) << __func__ << " NODOWN flag set, will not mark osd." << i
-            << " down" << dendl;
-    return false;
-  }
-
   if (osdmap.is_nodown(i)) {
     dout(5) << __func__ << " osd." << i << " is marked as nodown, "
-            << "will not mark it down" << dendl;
-    return false;
-  }
-
-  if (osdmap.get_osd_crush_node_flags(i) & CEPH_OSD_NODOWN) {
-    dout(5) << __func__ << " osd." << i
-	    << " is marked as nodown via a crush node flag, "
-            << "will not mark it down" << dendl;
-    return false;
-  }
-
-  if (auto class_id = osdmap.crush->get_item_class_id(i); class_id >= 0 &&
-      (osdmap.get_device_class_flags(class_id) & CEPH_OSD_NODOWN)) {
-    dout(5) << __func__ << " osd." << i
-            << " is marked as nodown via device class, "
             << "will not mark it down" << dendl;
     return false;
   }
@@ -2583,29 +2562,8 @@ bool OSDMonitor::can_mark_down(int i)
 
 bool OSDMonitor::can_mark_up(int i)
 {
-  if (osdmap.test_flag(CEPH_OSDMAP_NOUP)) {
-    dout(5) << __func__ << " NOUP flag set, will not mark osd." << i
-            << " up" << dendl;
-    return false;
-  }
-
   if (osdmap.is_noup(i)) {
     dout(5) << __func__ << " osd." << i << " is marked as noup, "
-            << "will not mark it up" << dendl;
-    return false;
-  }
-
-  if (osdmap.get_osd_crush_node_flags(i) & CEPH_OSD_NOUP) {
-    dout(5) << __func__ << " osd." << i
-	    << " is marked as noup via a crush node flag, "
-            << "will not mark it up" << dendl;
-    return false;
-  }
-
-  if (auto class_id = osdmap.crush->get_item_class_id(i); class_id >= 0 &&
-      (osdmap.get_device_class_flags(class_id) & CEPH_OSD_NOUP)) {
-    dout(5) << __func__ << " osd." << i
-            << " is marked as noup via device class, "
             << "will not mark it up" << dendl;
     return false;
   }
@@ -2619,28 +2577,8 @@ bool OSDMonitor::can_mark_up(int i)
  */
 bool OSDMonitor::can_mark_out(int i)
 {
-  if (osdmap.test_flag(CEPH_OSDMAP_NOOUT)) {
-    dout(5) << __func__ << " NOOUT flag set, will not mark osds out" << dendl;
-    return false;
-  }
-
   if (osdmap.is_noout(i)) {
     dout(5) << __func__ << " osd." << i << " is marked as noout, "
-            << "will not mark it out" << dendl;
-    return false;
-  }
-
-  if (osdmap.get_osd_crush_node_flags(i) & CEPH_OSD_NOOUT) {
-    dout(5) << __func__ << " osd." << i
-	    << " is marked as noout via a crush node flag, "
-            << "will not mark it out" << dendl;
-    return false;
-  }
-
-  if (auto class_id = osdmap.crush->get_item_class_id(i); class_id >= 0 &&
-      (osdmap.get_device_class_flags(class_id) & CEPH_OSD_NOOUT)) {
-    dout(5) << __func__ << " osd." << i
-            << " is marked as noout via device class, "
             << "will not mark it out" << dendl;
     return false;
   }
@@ -2669,29 +2607,8 @@ bool OSDMonitor::can_mark_out(int i)
 
 bool OSDMonitor::can_mark_in(int i)
 {
-  if (osdmap.test_flag(CEPH_OSDMAP_NOIN)) {
-    dout(5) << __func__ << " NOIN flag set, will not mark osd." << i
-            << " in" << dendl;
-    return false;
-  }
-
   if (osdmap.is_noin(i)) {
     dout(5) << __func__ << " osd." << i << " is marked as noin, "
-            << "will not mark it in" << dendl;
-    return false;
-  }
-
-  if (osdmap.get_osd_crush_node_flags(i) & CEPH_OSD_NOIN) {
-    dout(5) << __func__ << " osd." << i
-	    << " is marked as noin via a crush node flag, "
-            << "will not mark it in" << dendl;
-    return false;
-  }
-
-  if (auto class_id = osdmap.crush->get_item_class_id(i); class_id >= 0 &&
-      (osdmap.get_device_class_flags(class_id) & CEPH_OSD_NOIN)) {
-    dout(5) << __func__ << " osd." << i
-            << " is marked as noin via device class, "
             << "will not mark it in" << dendl;
     return false;
   }
@@ -10813,43 +10730,43 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       }
       if (do_set) {
         if (flags & CEPH_OSD_NOUP) {
-          any |= osdmap.is_noup(osd) ?
+          any |= osdmap.is_noup_by_osd(osd) ?
             pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOUP) :
             pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOUP);
         }
         if (flags & CEPH_OSD_NODOWN) {
-          any |= osdmap.is_nodown(osd) ?
+          any |= osdmap.is_nodown_by_osd(osd) ?
             pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NODOWN) :
             pending_inc.pending_osd_state_set(osd, CEPH_OSD_NODOWN);
         }
         if (flags & CEPH_OSD_NOIN) {
-          any |= osdmap.is_noin(osd) ?
+          any |= osdmap.is_noin_by_osd(osd) ?
             pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOIN) :
             pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOIN);
         }
         if (flags & CEPH_OSD_NOOUT) {
-          any |= osdmap.is_noout(osd) ?
+          any |= osdmap.is_noout_by_osd(osd) ?
             pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOOUT) :
             pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOOUT);
         }
       } else {
         if (flags & CEPH_OSD_NOUP) {
-          any |= osdmap.is_noup(osd) ?
+          any |= osdmap.is_noup_by_osd(osd) ?
             pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOUP) :
             pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOUP);
         }
         if (flags & CEPH_OSD_NODOWN) {
-          any |= osdmap.is_nodown(osd) ?
+          any |= osdmap.is_nodown_by_osd(osd) ?
             pending_inc.pending_osd_state_set(osd, CEPH_OSD_NODOWN) :
             pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NODOWN);
         }
         if (flags & CEPH_OSD_NOIN) {
-          any |= osdmap.is_noin(osd) ?
+          any |= osdmap.is_noin_by_osd(osd) ?
             pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOIN) :
             pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOIN);
         }
         if (flags & CEPH_OSD_NOOUT) {
-          any |= osdmap.is_noout(osd) ?
+          any |= osdmap.is_noout_by_osd(osd) ?
             pending_inc.pending_osd_state_set(osd, CEPH_OSD_NOOUT) :
             pending_inc.pending_osd_state_clear(osd, CEPH_OSD_NOOUT);
         }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5409,7 +5409,7 @@ void OSD::_preboot(epoch_t oldest, epoch_t newest)
     if (osdmap->get_epoch() > newest - 1) {
       exit(0);
     }
-  } else if (osdmap->test_flag(CEPH_OSDMAP_NOUP) || osdmap->is_noup(whoami)) {
+  } else if (osdmap->is_noup(whoami)) {
     derr << "osdmap NOUP flag is set, waiting for it to clear" << dendl;
   } else if (!osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
     derr << "osdmap SORTBITWISE OSDMap flag is NOT set; please set it"
@@ -7707,9 +7707,7 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
       }
     }
 
-    if ((osdmap->test_flag(CEPH_OSDMAP_NOUP) !=
-        newmap->test_flag(CEPH_OSDMAP_NOUP)) ||
-        (osdmap->is_noup(whoami) != newmap->is_noup(whoami))) {
+    if (osdmap->is_noup(whoami) != newmap->is_noup(whoami)) {
       dout(10) << __func__ << " NOUP flag changed in " << newmap->get_epoch()
 	       << dendl;
       if (is_booting()) {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -844,64 +844,72 @@ public:
   unsigned get_crush_node_flags(int id) const;
   unsigned get_device_class_flags(int id) const;
 
-  bool is_noup(int osd) const {
+  bool is_noup_by_osd(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_NOUP);
   }
 
-  bool is_nodown(int osd) const {
+  bool is_nodown_by_osd(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_NODOWN);
   }
 
-  bool is_noin(int osd) const {
+  bool is_noin_by_osd(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_NOIN);
   }
 
-  bool is_noout(int osd) const {
+  bool is_noout_by_osd(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_NOOUT);
   }
 
-  void get_noup_osds(std::vector<int> *osds) const {
-    ceph_assert(osds);
-    osds->clear();
-
-    for (int i = 0; i < max_osd; i++) {
-      if (is_noup(i)) {
-        osds->push_back(i);
-      }
-    }
+  bool is_noup(int osd) const {
+    if (test_flag(CEPH_OSDMAP_NOUP)) // global?
+      return true;
+    if (is_noup_by_osd(osd)) // by osd?
+      return true;
+    if (get_osd_crush_node_flags(osd) & CEPH_OSD_NOUP) // by crush-node?
+      return true;
+    if (auto class_id = crush->get_item_class_id(osd); class_id >= 0 &&
+        get_device_class_flags(class_id) & CEPH_OSD_NOUP) // by device-class?
+      return true;
+    return false;
   }
 
-  void get_nodown_osds(std::vector<int> *osds) const {
-    ceph_assert(osds);
-    osds->clear();
-
-    for (int i = 0; i < max_osd; i++) {
-      if (is_nodown(i)) {
-        osds->push_back(i);
-      }
-    }
+  bool is_nodown(int osd) const {
+    if (test_flag(CEPH_OSDMAP_NODOWN))
+      return true;
+    if (is_nodown_by_osd(osd))
+      return true;
+    if (get_osd_crush_node_flags(osd) & CEPH_OSD_NODOWN)
+      return true;
+    if (auto class_id = crush->get_item_class_id(osd); class_id >= 0 &&
+        get_device_class_flags(class_id) & CEPH_OSD_NODOWN)
+      return true;
+    return false;
   }
 
-  void get_noin_osds(std::vector<int> *osds) const {
-    ceph_assert(osds);
-    osds->clear();
-
-    for (int i = 0; i < max_osd; i++) {
-      if (is_noin(i)) {
-        osds->push_back(i);
-      }
-    }
+  bool is_noin(int osd) const {
+    if (test_flag(CEPH_OSDMAP_NOIN))
+      return true;
+    if (is_noin_by_osd(osd))
+      return true;
+    if (get_osd_crush_node_flags(osd) & CEPH_OSD_NOIN)
+      return true;
+    if (auto class_id = crush->get_item_class_id(osd); class_id >= 0 &&
+        get_device_class_flags(class_id) & CEPH_OSD_NOIN)
+      return true;
+    return false;
   }
 
-  void get_noout_osds(std::vector<int> *osds) const {
-    ceph_assert(osds);
-    osds->clear();
-
-    for (int i = 0; i < max_osd; i++) {
-      if (is_noout(i)) {
-        osds->push_back(i);
-      }
-    }
+  bool is_noout(int osd) const {
+    if (test_flag(CEPH_OSDMAP_NOOUT))
+      return true;
+    if (is_noout_by_osd(osd))
+      return true;
+    if (get_osd_crush_node_flags(osd) & CEPH_OSD_NOOUT)
+      return true;
+    if (auto class_id = crush->get_item_class_id(osd); class_id >= 0 &&
+        get_device_class_flags(class_id) & CEPH_OSD_NOOUT)
+      return true;
+    return false;
   }
 
   /**


### PR DESCRIPTION
Currently there are various ways to set no{up,down,in,out} flags,
by osd, by crush node, or by device class.

Use traditional is_no{up,down,in,out} helper to catch-all,
and add special wrappers for certain internal consumers.

This way osd won't ignore the noup flag set by the new crush node,
device class, or any future sources.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

