### PR TITLE
mimic: rgw: fix bucket may redundantly list keys after BI_PREFIX_CHAR

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -173,8 +173,12 @@ static int get_obj_vals(cls_method_context_t hctx, const string& start, const st
   auto upper = std::lower_bound(lower, pkeys->end(), new_start, comp);
   pkeys->erase(lower, upper);
 
-  if (num_entries == (int)pkeys->size())
+  if (num_entries == (int)pkeys->size() || !(*pmore))
     return 0;
+
+  if (pkeys->rbegin()->first > new_start) {
+    new_start = pkeys->rbegin()->first;
+  }
 
   map<string, bufferlist> new_keys;
 

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -176,7 +176,7 @@ static int get_obj_vals(cls_method_context_t hctx, const string& start, const st
   if (num_entries == (int)pkeys->size() || !(*pmore))
     return 0;
 
-  if (pkeys->rbegin()->first > new_start) {
+  if (pkeys->size() && new_start < pkeys->rbegin()->first) {
     new_start = pkeys->rbegin()->first;
   }
 


### PR DESCRIPTION
backport tracker: http://tracker.ceph.com/issues/40147