### PR TITLE
osd: give recovery ops initialized by client op a higher priority

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -438,6 +438,31 @@ Operations
 :Valid Range: 1-63
 
 
+``osd kick recovery op priority``
+
+:Description: The priority set for recovery operations that are forced by
+              client operations.
+              The new "mclock_opclass/mclock_client" queue basically prioritizes
+              operations based on the class they belong to. The priority property
+              of an operation, if lower than a specific value (64, by default),
+              will get ignored and hence all operations from the same class will
+              be treated fairly in a FIFO fashion (but still limited by the total
+              IOPS or bandwidth available for the corresponding class).
+              To reduce the impact of performance, a more general strategy would be
+              enforcing some limitations on the IOPS or bandwidth for the background
+              recovery (or backfill) operation class. However, this way we'll end up
+              blocking client operations too if they are currently blocked by some
+              degraded objects which need to be recovered first.
+              We hereby grant recovery operations of this kind a higher priority
+              to force them to use strict priority ordering, which should still
+              be of significance once we switch to the new "mclock_opclass/mclock_client"
+              queue.
+
+:Type: 32-bit Integer
+:Default: ``64``
+:Valid Range: 64-255
+
+
 ``osd scrub priority``
 
 :Description: The default priority set for a scheduled scrub work queue when the

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -837,6 +837,7 @@ OPTION(mon_rocksdb_options, OPT_STR)
 OPTION(osd_client_op_priority, OPT_U32)
 OPTION(osd_recovery_op_priority, OPT_U32)
 OPTION(osd_peering_op_priority, OPT_U32)
+OPTION(osd_kick_recovery_op_priority, OPT_U32)
 
 OPTION(osd_snap_trim_priority, OPT_U32)
 OPTION(osd_snap_trim_cost, OPT_U32) // set default cost equal to 1MB io

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3948,6 +3948,12 @@ std::vector<Option> get_global_options() {
     .set_default(255)
     .set_description(""),
 
+    Option("osd_kick_recovery_op_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(64)
+    .set_description("priority for recovery ops instantized by client ops, "
+                     "default to 64 to use strict priority ordering")
+    .add_see_also("osd_recovery_op_priority"),
+
     Option("osd_snap_trim_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
     .set_description(""),

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -572,13 +572,13 @@ void PrimaryLogPG::maybe_kick_recovery(
     dout(7) << "object " << soid << " v " << v << ", recovering." << dendl;
     PGBackend::RecoveryHandle *h = pgbackend->open_recovery_op();
     if (is_missing_object(soid)) {
-      recover_missing(soid, v, cct->_conf->osd_client_op_priority, h);
+      recover_missing(soid, v, cct->_conf->osd_kick_recovery_op_priority, h);
     } else if (recovery_state.get_missing_loc().is_deleted(soid)) {
       prep_object_replica_deletes(soid, v, h, &work_started);
     } else {
       prep_object_replica_pushes(soid, v, h, &work_started);
     }
-    pgbackend->run_recovery_op(h, cct->_conf->osd_client_op_priority);
+    pgbackend->run_recovery_op(h, cct->_conf->osd_kick_recovery_op_priority);
   }
 }
 


### PR DESCRIPTION
to use strict priority ordering.

The new "mclock_opclass/mclock_client" queue basically prioritizes
operations based on the class they belong to. The priority property
of an operation, if lower than a specific value (64, by default),
will get ignored and hence all operations from the same class will
be treated fairly in a FIFO fashion (but still limited by the total
IOPS or bandwidth available for the corresponding class).

To reduce the impact of performance, a more general strategy would be
enforcing some limitations on the IOPS or bandwidth for the background
recovery (or backfill) operation class. However, this way we'll end up
blocking client operations too if they are currently blocked by some
degraded objects which need to be recovered first.

We hereby grant recovery operations of this kind a higher priority
to force them to use strict priority ordering, which should still
be of significance once we switch to the new "mclock_opclass/mclock_client"
queue.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

