### PR TITLE
After cancelling the volume mapping with a full pool,error happens wh…

### DIFF
--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -81,7 +81,9 @@ template <typename I>
 bool ObjectMap<I>::object_may_exist(uint64_t object_no) const
 {
   ceph_assert(m_image_ctx.image_lock.is_locked());
-
+  if (object_no >= m_object_map.size()){
+  	return true;
+  }
   // Fall back to default logic if object map is disabled or invalid
   if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
                                  m_image_ctx.image_lock)) {

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -69,6 +69,9 @@ public:
                   const boost::optional<uint8_t> &current_state,
                   const ZTracer::Trace &parent_trace, bool ignore_enoent,
                   T *callback_object) {
+  	if (start_object_no >= m_object_map.size()){
+  		return false;
+  	}
     return aio_update<T, MF>(snap_id, start_object_no, start_object_no + 1,
                              new_state, current_state, parent_trace,
                              ignore_enoent, callback_object);


### PR DESCRIPTION
…en deleting the lun


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [rbd]

[A longer multiline description]
During the test, i found out that after cancelling the volume mapping with a full pool,error happened when deleting the corresponding lun, a core file generated

Signed-off-by: [inspur001] <[yanghongjie@inspur.com]>

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

