### PR TITLE
A core file generates when resizing the volume during R/W with vdbench

### DIFF
--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -82,7 +82,7 @@ bool ObjectMap<I>::object_may_exist(uint64_t object_no) const
 {
   ceph_assert(m_image_ctx.image_lock.is_locked());
   if (object_no >= m_object_map.size()){
-  	return true;
+    return true;
   }
   // Fall back to default logic if object map is disabled or invalid
   if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -81,7 +81,9 @@ template <typename I>
 bool ObjectMap<I>::object_may_exist(uint64_t object_no) const
 {
   ceph_assert(m_image_ctx.image_lock.is_locked());
-
+  if (object_no >= m_object_map.size()){
+  	return true;
+  }
   // Fall back to default logic if object map is disabled or invalid
   if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
                                  m_image_ctx.image_lock)) {

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -62,16 +62,16 @@ public:
 
   void aio_save(Context *on_finish);
   void aio_resize(uint64_t new_size, uint8_t default_object_state,
-		  Context *on_finish);
+                  Context *on_finish);
 
   template <typename T, void(T::*MF)(int) = &T::complete>
   bool aio_update(uint64_t snap_id, uint64_t start_object_no, uint8_t new_state,
                   const boost::optional<uint8_t> &current_state,
                   const ZTracer::Trace &parent_trace, bool ignore_enoent,
                   T *callback_object) {
-  	if (start_object_no >= m_object_map.size()){
-  		return false;
-  	}
+    if (start_object_no >= m_object_map.size()) {
+      return false;
+    }
     return aio_update<T, MF>(snap_id, start_object_no, start_object_no + 1,
                              new_state, current_state, parent_trace,
                              ignore_enoent, callback_object);

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -69,6 +69,9 @@ public:
                   const boost::optional<uint8_t> &current_state,
                   const ZTracer::Trace &parent_trace, bool ignore_enoent,
                   T *callback_object) {
+  	if (start_object_no >= m_object_map.size()){
+  		return false;
+  	}
     return aio_update<T, MF>(snap_id, start_object_no, start_object_no + 1,
                              new_state, current_state, parent_trace,
                              ignore_enoent, callback_object);


### PR DESCRIPTION
rbd: assert happens when resizing the image during testing

when continous R/W being in progress, resizing the image will chage the size of the object-map, but the correspoding info in the memory does not update, so memory-access errors will occur and the program will go down 

Signed-off-by: yanghongjie <yanghongjie@inspur.com>