### PR TITLE
cls/rgw: keep issuing bilog trim ops after reset

### DIFF
--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -276,14 +276,14 @@ public:
         break;
     }
 
-    int num_completions, r = 0;
+    int num_completions = 0, r = 0;
     map<int, string> objs;
     map<int, string> *pobjs = (need_multiple_rounds() ? &objs : NULL);
     while (manager.wait_for_completions(valid_ret_code(), &num_completions, &r, pobjs)) {
       if (r >= 0 && ret >= 0) {
-        for(int i = 0; i < num_completions && iter != objs_container.end(); ++i, ++iter) {
+        for (; num_completions && iter != objs_container.end(); --num_completions, ++iter) {
           int issue_ret = issue_op(iter->first, iter->second);
-          if(issue_ret < 0) {
+          if (issue_ret < 0) {
             ret = issue_ret;
             break;
           }
@@ -295,6 +295,14 @@ public:
         // For those objects which need another round, use them to reset
         // the container
         reset_container(objs);
+        iter = objs_container.begin();
+        for (; num_completions && iter != objs_container.end(); --num_completions, ++iter) {
+          int issue_ret = issue_op(iter->first, iter->second);
+          if (issue_ret < 0) {
+            ret = issue_ret;
+            break;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
The CLSRGWIssueBILogTrim class is intended to keep submitting cls_log_trim operations on each bucket index shard until they return -ENODATA to signal there's no more to trim.

However, if the while loop in CLSRGWConcurrentIO::operator() gets to the end of the shard list and collects all of its completions, wait_for_completions() will return false and exit the loop. This is always the case when num_shards = 1.

Fixes: http://tracker.ceph.com/issues/40187