### PR TITLE
common: OutputDataSocket retakes mutex on error path

### DIFF
--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -303,6 +303,7 @@ int OutputDataSocket::dump_data(int fd)
       ret = safe_write(fd, delim.c_str(), delim.length());
     }
     if (ret < 0) {
+      std::scoped_lock lock(m_lock);
       for (; iter != l.end(); ++iter) {
         bufferlist& bl = *iter;
 	data.push_back(bl);


### PR DESCRIPTION
the list of buffers is protected by mutex m_lock. when dump_data() fails and puts unwritten buffers back into the list, it needs to reaquire the lock

Fixes: http://tracker.ceph.com/issues/40188