### PR TITLE
osd: Don't randomize deep scrubs when noscrub set

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1334,7 +1334,11 @@ bool PG::sched_scrub()
 
   bool deep_coin_flip = false;
   // Only add random deep scrubs when NOT user initiated scrub
-  if (!scrubber.must_scrub)
+  // If we randomize when noscrub set then it guarantees
+  // we will deep scrub because this function is called often.
+  if (!time_for_deep && !scrubber.must_scrub
+       && !(get_osdmap()->test_flag(CEPH_OSDMAP_NOSCRUB)
+	    || pool.info.has_flag(pg_pool_t::FLAG_NOSCRUB)))
       deep_coin_flip = (rand() % 100) < cct->_conf->osd_deep_scrub_randomize_ratio * 100;
   dout(20) << __func__ << ": time_for_deep=" << time_for_deep << " deep_coin_flip=" << deep_coin_flip << dendl;
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40198

Signed-off-by: David Zafman <dzafman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Includes tests for new functionality or reproducer for bug

