### PR TITLE
script/ceph-backport.sh: Add prepare function

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -31,17 +31,19 @@
 #
 # Once you have the actual values for the above variables, create a file
 # $HOME/bin/backport_common.sh with the following contents
-# 
+#
 # redmine_key=[your_redmine_key]
 # redmine_user_id=[your_redmine_user_id]
 # github_token=[your_github_personal_access_token]
 # github_user=[your_github_username]
 #
-# You can also optionally add the remote repo's name in this file, like
+# You can also optionally add yours and ceph remote repo's name in this file,
+# like
 #
 # github_repo=[your_github_repo_name]
+# ceph_repo=[ceph_github_repo_name]
 #
-# If you don't add it, it will default to "origin".
+# If you don't add it, it will default to "origin" and "upstream", respectively.
 #
 # Obviously, since this file contains secrets, you should protect it from
 # exposure using all available means (restricted file privileges, encrypted
@@ -57,6 +59,13 @@
 # With this script, backporting workflow for backport issue
 # http://tracker.ceph.com/issues/19206 (a jewel backport)
 # becomes something like this:
+#
+# For simple backports you can just run:
+#
+# ceph-backport.sh 19206 jewel --prepare
+# ceph-backport.sh 19206 jewel
+#
+# alternatively, you can prepare the backport manually:
 #
 # git remote add ceph http://github.com/ceph/ceph.git
 # git fetch ceph
@@ -84,10 +93,11 @@ test "$redmine_user_id" || failed_required_variable_check redmine_user_id
 test "$github_token"    || failed_required_variable_check github_token
 test "$github_user"     || failed_required_variable_check github_user
 : "${github_repo:=origin}"
+: "${ceph_repo:=upstream}"
 
 function usage () {
     echo "Usage:"
-    echo "   $0 [BACKPORT_TRACKER_ISSUE_NUMBER] [MILESTONE]"
+    echo "   $0 [BACKPORT_TRACKER_ISSUE_NUMBER] [MILESTONE] [--prepare]"
     echo
     echo "Example:"
     echo "   $0 19206 jewel"
@@ -132,7 +142,42 @@ then
 fi
 
 title=$(curl --silent 'http://tracker.ceph.com/issues/'$issue.json?key=$redmine_key | jq .issue.subject | tr -d '\\"')
-echo "Issue title: $title" 
+echo "Issue title: $title"
+
+function prepare () {
+    related_issue=$(curl --silent http://tracker.ceph.com/issues/$issue.json?include=relations |
+                    jq '.issue.relations[] | select(.relation_type | contains("copied_to")) | .issue_id')
+    [ -z "$related_issue" ] && echo "Could not find original issue." && return 1
+    echo "Original issue: $related_issue"
+
+    pr=$(curl --silent http://tracker.ceph.com/issues/$related_issue.json |
+         jq '.issue.custom_fields[] | select(.id | contains(21)) | .value' |
+         tr -d '\\"')
+    [ -z "$pr" ] && echo "Could not find PR." && return 1
+    echo "Original PR: $pr"
+
+    number=$(curl --silent 'https://api.github.com/repos/ceph/ceph/pulls/'$pr | jq .commits)
+    [ -z "$number" ] && echo "Could not determine the number of commits." && return 1
+    echo "Found $number commit(s)"
+
+    git fetch $ceph_repo
+    echo "fetch latest $milestone branch."
+
+    git checkout $ceph_repo/$milestone -b wip-$issue-$milestone
+
+    git fetch $ceph_repo pull/$pr/head:pr-$pr
+
+    git cherry-pick -x pr-$pr~$number..pr-$pr
+    echo "cherry picked pr-$pr into wip-$issue-$milestone"
+
+    exit 0
+}
+
+if [[ $* == *--prepare* ]]
+then
+    echo "'--prepare' found, will only prepare the backport"
+    prepare
+fi
 
 git push -u $github_repo wip-$issue-$milestone
 


### PR DESCRIPTION
Add a new flag, --prepare, that when used will fetch all necessary info and
cherrypick all original commits automatically.
It will also prevent the main code to be executed.

After running with --prepare, and if there were no conflicts, you can simply
remove the flag from the command and run the script again.
This time it will run the main code and create the PR and update the backport
issue.

p.e.:
ceph-backport.sh 19206 jewel --prepare
ceph-backport.sh 19206 jewel

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

