### PR TITLE
ceph-volume: util: Use proper param substition

### DIFF
--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -214,9 +214,9 @@ def device_is_mounted(dev, destination=None):
                     )
                     return True
             else:
-                logger.info('%s was found as mounted')
+                logger.info('%s was found as mounted', dev)
                 return True
-    logger.info('%s was not found as mounted')
+    logger.info('%s was not found as mounted', dev)
     return False
 
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/25030


Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

