### PR TITLE
ceph_volume: bug in osd_id_available

### DIFF
--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -198,6 +198,8 @@ def osd_id_available(osd_id):
 
     output = json.loads(''.join(stdout).strip())
     osds = output['nodes']
+    if 'stray' in output:
+        osds += output['stray']
     osd = [osd for osd in osds if str(osd['id']) == str(osd_id)]
     if osd and osd[0].get('status') == "destroyed":
         return True


### PR DESCRIPTION
This is about creating osd with user-specified rather than
automatically assigned ID.  The problem is discussed here:

    http://lists.ceph.com/pipermail/ceph-users-ceph.com/2018-October/030292.html

But the solution proposed therein fails in Nautilus 14.2.0:

    # ceph osd new cat /proc/sys/kernel/random/uuid 4
    4
    # ceph osd destroy 4 --yes-i-really-mean-it
    destroyed osd.4
    # ceph-volume lvm create --osd-id 4 --bluestore --data vg0/osd4
    Running command: /usr/bin/ceph-authtool --gen-print-key
    Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring osd tree -f json
    -->  RuntimeError: The osd ID 4 is already in use or does not exist.

It turned out the function osd_id_available returns False for
destroyed OSD.  The reason is the destroyed OSD appearing under a
separate "stray" key in the output of ceph osd tree -f json:

    {
        "stray": [
            {
                "status": "destroyed",
                "reweight": 0,
                "exists": 1,
                "crush_weight": 0,
                "primary_affinity": 1,
                "name": "osd.4",
                "type_id": 0,
                "depth": 0,
                "id": 4,
                "type": "osd"
            }
        ],
        "nodes": [
            {
    ...

while the original code in osd_id_available only handles
the "nodes" key.

Note1: It would be nice if someone with fluent Python hacked a bit
further to differentiate the error messages:

RuntimeError: The osd ID 4 is already in use. or
RuntimeError: The osd ID 4 is does not exist.

Note2: This is only a minimal fix. The ultimate fix would eliminate the
need to "ceph osd new" followed by "ceph osd destroy" before
"ceph-volume lvm create --osd-id ID_OF_MY_CHOICE".

Fixes: http://tracker.ceph.com/issues/36307 (but see Note2)
Signed-off-by: Yury Shevchuk <sizif@botik.ru>


