### PR TITLE
rgw_file: all directories are virtual with respect to contents

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -810,7 +810,7 @@ namespace rgw {
     default:
       break;
     };
-
+    /* if rgw_fh is a directory, mtime will be advanced */
     return rgw_fh->stat(st);
   } /* RGWLibFS::getattr */
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -239,6 +239,15 @@ namespace rgw {
 
     void clear_state();
 
+    void advance_mtime() {
+      /* intended for use on directories, fast-forward mtime so as to
+       * ensure a new, higher value for the change attribute */
+      lock_guard guard(mtx);
+      /* sets ctime as well as mtime, to avoid masking updates should
+       * ctime inexplicably hold a higher value */
+      set_times(real_clock::now());
+    }
+
     boost::variant<file, directory> variant_type;
 
     uint16_t depth;
@@ -349,6 +358,8 @@ namespace rgw {
       switch (fh.fh_type) {
       case RGW_FS_TYPE_DIRECTORY:
 	state.unix_mode = RGW_RWXMODE|S_IFDIR;
+	/* virtual directories are always invalid */
+	advance_mtime();
 	break;
       case RGW_FS_TYPE_FILE:
 	state.unix_mode = RGW_RWMODE|S_IFREG;
@@ -420,8 +431,12 @@ namespace rgw {
 
       if (mask & RGW_SETATTR_ATIME)
 	state.atime = st->st_atim;
-      if (mask & RGW_SETATTR_MTIME)
-	state.mtime = st->st_mtim;
+
+      if (mask & RGW_SETATTR_MTIME) {
+	if (fh.fh_type != RGW_FS_TYPE_DIRECTORY)
+	  state.mtime = st->st_mtim;
+      }
+
       if (mask & RGW_SETATTR_CTIME)
 	state.ctime = st->st_ctim;
     }
@@ -437,18 +452,10 @@ namespace rgw {
 
       st->st_mode = state.unix_mode;
 
-#ifdef HAVE_STAT_ST_MTIMESPEC_TV_NSEC
-      st->st_atimespec = state.atime;
-      st->st_mtimespec = state.mtime;
-      st->st_ctimespec = state.ctime;
-#else
-      st->st_atim = state.atime;
-      st->st_mtim = state.mtime;
-      st->st_ctim = state.ctime;
-#endif
-
       switch (fh.fh_type) {
       case RGW_FS_TYPE_DIRECTORY:
+	/* virtual directories are always invalid */
+	advance_mtime();
 	st->st_nlink = state.nlink;
 	break;
       case RGW_FS_TYPE_FILE:
@@ -466,6 +473,16 @@ namespace rgw {
       default:
 	break;
       }
+
+#ifdef HAVE_STAT_ST_MTIMESPEC_TV_NSEC
+      st->st_atimespec = state.atime;
+      st->st_mtimespec = state.mtime;
+      st->st_ctimespec = state.ctime;
+#else
+      st->st_atim = state.atime;
+      st->st_mtim = state.mtime;
+      st->st_ctim = state.ctime;
+#endif
 
       return 0;
     }


### PR DESCRIPTION
This change causes directory handles to always report an mtime of
"now."  This is not an invalidate per se--it interacts with the
nfs implementation to produce that result when the implementation
updates its cached attributes.  Hence, it can be modulated by timers
or other rules governing attribute caching at the upper layer.

Fixes: http://tracker.ceph.com/issues/40204

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

