### PR TITLE
mds: wake up lock waiters after forcibly changing lock state

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -1484,6 +1484,8 @@ CInode *MDCache::cow_inode(CInode *in, snapid_t last)
       in->client_snap_caps.clear();
       in->item_open_file.remove_myself();
       in->item_caps.remove_myself();
+
+      MDSContext::vec finished;
       for (const auto &p : client_snap_caps) {
 	SimpleLock *lock = in->get_lock(p.first);
 	ceph_assert(lock);
@@ -1492,10 +1494,13 @@ CInode *MDCache::cow_inode(CInode *in, snapid_t last)
 	  lock->put_wrlock();
 	  (void)q; /* unused */
 	}
-	ceph_assert(!lock->get_num_wrlocks());
-	lock->set_state(LOCK_SYNC);
-	in->auth_unpin(lock);
+	if (!lock->get_num_wrlocks()) {
+	  lock->set_state(LOCK_SYNC);
+	  lock->take_waiting(SimpleLock::WAIT_STABLE|SimpleLock::WAIT_RD, finished);
+	  in->auth_unpin(lock);
+	}
       }
+      mds->queue_waiters(finished);
     }
     return oldin;
   }


### PR DESCRIPTION
commit df79944 "mds: cleanup unneeded client_snap_caps when
splitting snap inode" is incomplete.

Fixes: http://tracker.ceph.com/issues/39987
 
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

