### PR TITLE
crimson/osd/pg_meta: use initializer list for passing set<>

### DIFF
--- a/src/crimson/osd/pg_meta.cc
+++ b/src/crimson/osd/pg_meta.cc
@@ -32,11 +32,10 @@ namespace {
 seastar::future<epoch_t> PGMeta::get_epoch()
 {
   auto ch = store->open_collection(coll_t{pgid});
-  std::set<std::string> keys{infover_key.data(), 
-                             epoch_key.data()};
   return store->omap_get_values(ch,
                                 pgid.make_pgmeta_oid(),
-                                keys).then(
+                                {string{infover_key},
+                                 string{epoch_key}}).then(
     [](auto&& values) {
       {
         // sanity check
@@ -57,13 +56,12 @@ seastar::future<epoch_t> PGMeta::get_epoch()
 seastar::future<pg_info_t, PastIntervals> PGMeta::load()
 {
   auto ch = store->open_collection(coll_t{pgid});
-  std::set<std::string> keys{infover_key.data(),
-                             info_key.data(),
-                             biginfo_key.data(),
-                             fastinfo_key.data()};
   return store->omap_get_values(ch,
                                 pgid.make_pgmeta_oid(),
-                                keys).then(
+                                {string{infover_key},
+                                 string{info_key},
+                                 string{biginfo_key},
+                                 string{fastinfo_key}}).then(
     [this](auto&& values) {
       {
         // sanity check


### PR DESCRIPTION
we cannot assume that the data in string views are always nul
terminated.

this change partially reverts 82fedbd0089073cfe86640eaa7d73ed1e2545c31.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

