### PR TITLE
luminous: mds: don't carry ref in MDSRankDispatcher::ms_dispatch

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -965,8 +965,10 @@ bool MDSRankDispatcher::ms_dispatch(Message *m)
 {
   if (m->get_source().is_client()) {
     Session *session = static_cast<Session*>(m->get_connection()->get_priv());
-    if (session)
+    if (session) {
+      session->put(); // do not carry ref
       session->last_seen = Session::clock::now();
+    }
   }
 
   inc_dispatch_depth();


### PR DESCRIPTION
Backport 5dd000eb44e39567657a346451eec6adba3efb63 forgot to put the
session ref, which causes an assert in MDSRank::get_session if the
session is closed.

Fixes: http://tracker.ceph.com/issues/40200
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>

This is luminous only!