### PR TITLE
cephfs-shell: Catch OSError exceptions in 'lcd'

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1007,13 +1007,11 @@ sub-directories, files')
         """
         Moves into the given local directory
         """
-
-        path = os.path.expanduser(args.path)
-        if os.path.isdir(path):
-            os.chdir(path)
-            # self.poutput(get_all_possible_paths(args.path))
-        else:
-            self.poutput("%s: no such directory" % path)
+        try:
+            os.chdir(os.path.expanduser(args.path))
+        except OSError as e:
+            self.perror("Cannot change to {}: {}".format(e.filename,
+                        e.strerror), False)
 
     def complete_lls(self, text, line, begidx, endidx):
         """


### PR DESCRIPTION
This patch adds try-except statement to catch the OSError exceptions.

Fixes: http://tracker.ceph.com/issues/40243
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->


