### PR TITLE
[RFC] crimson/net: make use of the proposed input buffer factory

### DIFF
--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -139,7 +139,7 @@ void ProtocolV2::enable_recording()
   record_io = true;
 }
 
-seastar::future<Socket::tmp_buf> ProtocolV2::read_exactly(size_t bytes)
+seastar::future<Socket::read_buffer_t> ProtocolV2::read_exactly(size_t bytes)
 {
   if (unlikely(record_io)) {
     return socket->read_exactly(bytes)

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -188,6 +188,11 @@ ProtocolV2::create(seastar::compat::polymorphic_allocator<char>* const allocator
   // space for segments_n, epilogue_n and preable_n+1
   return seastar::make_temporary_buffer<char>(allocator, 8192);
 #else
+
+  if (!last_returned.empty()) {
+    return std::move(last_returned);
+  }
+
   if (rx_segments_desc.empty()) {
     // space just for the ceph banner + preamble_0
     // FIXME: magic
@@ -199,7 +204,7 @@ ProtocolV2::create(seastar::compat::polymorphic_allocator<char>* const allocator
       segment_size_sum += segment.length;
     }
     return seastar::make_temporary_buffer<char>(allocator,
-      segment_size_sum + FRAME_PLAIN_EPILOGUE_SIZE + FRAME_PREAMBLE_SIZE);
+        segment_size_sum + FRAME_PLAIN_EPILOGUE_SIZE + FRAME_PREAMBLE_SIZE);
   }
 
   // TODO: implement prefetching for very small (under 4K) chunk sizes to not

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -9,20 +9,7 @@
 
 namespace ceph::net {
 
-class ProtocolV2 final : public Protocol,
-                         public seastar::net::input_buffer_factory {
-  // TODO: the ibf is basically a thing living at the Socket level.
-  // Likely the protocols should use an interface to tell it about
-  // frame structure (xor just next read size + alignment).
-  buffer_t last_returned;
-
-  buffer_t
-  create(seastar::compat::polymorphic_allocator<char>* const allocator) override;
-
-  void return_unused(buffer_t&& buf) {
-    last_returned = std::move(buf);
-  }
-
+class ProtocolV2 final : public Protocol {
  public:
   ProtocolV2(Dispatcher& dispatcher,
              SocketConnection& conn,

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -92,7 +92,7 @@ class ProtocolV2 final : public Protocol,
   ceph::bufferlist txbuf;
 
   void enable_recording();
-  seastar::future<Socket::tmp_buf> read_exactly(size_t bytes);
+  seastar::future<Socket::read_buffer_t> read_exactly(size_t bytes);
   seastar::future<bufferlist> read(size_t bytes);
   seastar::future<> write(bufferlist&& buf);
   seastar::future<> write_flush(bufferlist&& buf);

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -9,7 +9,14 @@
 
 namespace ceph::net {
 
-class ProtocolV2 final : public Protocol {
+class ProtocolV2 final : public Protocol,
+                         public seastar::net::input_buffer_factory {
+  // TODO: the ibf is basically a thing living at the Socket level.
+  // Likely the protocols should use an interface to tell it about
+  // frame structure (xor just next read size + alignment).
+  seastar::temporary_buffer<char>
+  create(seastar::compat::polymorphic_allocator<char>* const allocator) override;
+
  public:
   ProtocolV2(Dispatcher& dispatcher,
              SocketConnection& conn,

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -14,8 +14,14 @@ class ProtocolV2 final : public Protocol,
   // TODO: the ibf is basically a thing living at the Socket level.
   // Likely the protocols should use an interface to tell it about
   // frame structure (xor just next read size + alignment).
-  seastar::temporary_buffer<char>
+  buffer_t last_returned;
+
+  buffer_t
   create(seastar::compat::polymorphic_allocator<char>* const allocator) override;
+
+  void return_unused(buffer_t&& buf) {
+    last_returned = std::move(buf);
+  }
 
  public:
   ProtocolV2(Dispatcher& dispatcher,

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -26,7 +26,7 @@ struct bufferlist_consumer {
     if (remaining >= data.size()) {
       // consume the whole buffer
       remaining -= data.size();
-      bl.append(buffer::create_foreign(std::move(data)));
+      bl.append(buffer::create(std::move(data)));
       if (remaining > 0) {
         // return none to request more segments
         return seastar::make_ready_future<consumption_result_type>(
@@ -39,7 +39,7 @@ struct bufferlist_consumer {
     }
     if (remaining > 0) {
       // consume the front
-      bl.append(buffer::create_foreign(data.share(0, remaining)));
+      bl.append(buffer::create(data.share(0, remaining)));
       data.trim_front(remaining);
       remaining = 0;
     }

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "Socket.h"
+#include <seastar/core/polymorphic_temporary_buffer.hh>
 
 #include "Errors.h"
 
@@ -20,6 +21,49 @@ inline seastar::temporary_buffer<char> sharing_split(
 
 } // anonymous namespace
 
+void Socket::return_unused(buffer_t&& buf) {
+  returned_rxbuf = std::move(buf);
+}
+
+seastar::temporary_buffer<char>
+Socket::create(seastar::compat::polymorphic_allocator<char>* const allocator)
+{
+#if 0
+  return seastar::make_temporary_buffer<char>(allocator, 8192);
+#else
+
+  if (!returned_rxbuf.empty()) {
+    return std::move(returned_rxbuf);
+  }
+
+  logger().debug("{}: read_hint: .further_bytes={}, alignment: .base={}, .at={}",
+                 __func__,
+                 read_hint.further_bytes,
+                 read_hint.alignment.base,
+                 read_hint.alignment.at);
+
+  auto ret = seastar::make_temporary_buffer<char>(allocator,
+    read_hint.alignment.base + read_hint.further_bytes);
+
+  if (read_hint.alignment.base) {
+    const auto offset_in_buf = read_hint.alignment.base
+      - p2phase<uintptr_t>(reinterpret_cast<uintptr_t>(ret.get()),
+                           read_hint.alignment.base)
+      - read_hint.alignment.at;
+    ret.trim_front(offset_in_buf);
+    ret.trim(read_hint.further_bytes);
+  }
+
+  hinted_rxbuf = ceph::buffer::create(ret.share());
+  return ret;
+
+  // TODO: implement prefetching for very small (under 4K) chunk sizes to not
+  // hurt RADOS' reads while the POSIX stack is being used (and till it lacks
+  // io_uring support).
+#endif
+}
+
+
 seastar::future<bufferlist> Socket::read(const size_t bytes)
 {
   r.remaining = bytes;
@@ -37,8 +81,32 @@ seastar::future<bufferlist> Socket::read(const size_t bytes)
         });
       }
 
+      // That's the reason for `hinted_rxbuf` – the variant of `bl::append()`
+      // doing the bptr fusion (see implementation). The nice side effect is
+      // not instantiating `bufferptr` nor `raw_seastar_local_ptr`.
+      // Be aware that an allocator is free to arrange chunk's control block
+      // as it wants. In the consequence *adjacent* chunks can be produced by
+      // different calls to e.g. `malloc()`, and thus they must be reclaimed
+      // separately.
+      //
+      // Alternatives:
+      //  * extend `seastar::temporary_buffer` to offer the same feature as
+      //    `ceph::bufferptr` with its `get_raw()` method: verification that
+      //    two adjacent instances are really spanning the same memory chunk
+      //    (from memory allocator's PoV).
+      //  * Ensure for all allocators that two separated chunks are never ever
+      //    adjacent.
       const size_t round_size = std::min(r.remaining, wrapping_rxbuf.size());
-      r.sgl.push_back(buffer::create(sharing_split(wrapping_rxbuf, round_size)));
+      if (hinted_rxbuf.c_str() <= wrapping_rxbuf.get() &&
+          hinted_rxbuf.end_c_str() >= wrapping_rxbuf.get() + wrapping_rxbuf.size()) {
+        // yay, S* gave us back (a part of) buffer the ibf had produced.
+        // In other words: the wrapping_rxbuf is *subset* of hinted_rxbuf.
+        size_t offset = wrapping_rxbuf.get() - hinted_rxbuf.c_str();
+        r.sgl.append(hinted_rxbuf, offset, round_size);
+        wrapping_rxbuf.trim_front(round_size);
+      } else {
+        r.sgl.push_back(buffer::create(sharing_split(wrapping_rxbuf, round_size)));
+      }
       r.remaining -= round_size;
       return seastar::now();
     }

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -32,12 +32,16 @@ class Socket : private seastar::net::input_buffer_factory
   struct construct_tag {};
 
   // input_buffer_factory
-  seastar::temporary_buffer<char>
+  buffer_t
   create(seastar::compat::polymorphic_allocator<char>* const allocator) override {
     ceph_assert(ibf);
     // XXX: we'll have deep, multi-stage delegation. CPU's front-end might not
     // be supper happy. Profile and refactor if necessary.
     return ibf->create(allocator);
+  }
+
+  void return_unused(buffer_t&& buf) {
+    return ibf->return_unused(std::move(buf));
   }
 
  public:


### PR DESCRIPTION
Performance comparison
====================
Average write bandwidth (MB/s) for single `rados bench` load generator.

chunk size | 0d94a3a7a8b6eeee8d16cd5e937811c67471f6a1 | b1024cfba9334f5f04f5a983713185bbb0ac7569   | reference
----------: | -----------------: | -----------------: | -------:
4 KB       |   84.71 |   82.38 |   84.65
8 KB       |  175.56 |  169.21 |  170.67
32 KB      |  648.03 |  629.25 | 604.519
128 KB     | 2185.79 | 2088.15 | 1623.47
512 KB     | 3904.72 | 3858.18 | 2156.67
4 MB       | 3708.27 | 3714.58 | 2072.82


The part for Seastar is: https://github.com/ceph/seastar/pull/6.
CC: @cyx1231st, @tchaikov.