### PR TITLE
cephfs-shell: Fix 'lls' command errors

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1024,28 +1024,23 @@ sub-directories, files')
 
     lls_parser = argparse.ArgumentParser(
         description='List files in local system.')
-    lls_parser.add_argument('paths', help='Paths', nargs='*', default=[''])
+    lls_parser.add_argument('paths', help='Paths', nargs='*')
 
     @with_argparser(lls_parser)
     def do_lls(self, args):
         """
         Lists all files and folders in the current local directory
         """
-
-        if len(args.paths) == 0 or (len(args.paths) == 1 and
-                                    args.paths[0] == ''):
-            if len(args.paths) > 0:
-                args.paths.pop(0)
-            args.paths.append(os.getcwd())
-        for path in args.paths:
-            if not os.path.isabs(path):
-                path = os.path.relpath(path)
-            if os.path.isdir(path):
-                self.poutput("%s:" % path)
-                items = os.listdir(path)
-                print_list(items)
-            else:
-                self.poutput("%s: no such directory" % path)
+        if not args.paths:
+            print_list(os.listdir(os.getcwd()))
+        else:
+            for path in args.paths:
+                try:
+                    items = os.listdir(path)
+                    self.poutput("{}:".format(path))
+                    print_list(items)
+                except OSError as e:
+                    self.perror("'{}': {}".format(e.filename, e.strerror), False)
         # Arguments to the with_argpaser decorator function are sticky.
         # The items in args.path do not get overwritten in subsequent calls.
         # The arguments remain in args.paths after the function exits and we


### PR DESCRIPTION
This patch fixes following:
* Not printing complete path when '..' is passed as argument.
* Printing of path for current working directory.
* No need to set default value for add_argument. As it returns empty list with
  nargs='*'.
* No need to check for absolute path. os.listdir takes both relative and
  absolute path.
* Use try-catch instead of if-else statement to catch exceptions.

Fixes: http://tracker.ceph.com/issues/40244
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->



