### PR TITLE
nautilus: Rados.get_fsid() returning bytes in python3

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -1160,26 +1160,23 @@ Rados object in state %s." % self.state)
         """
         self.require_state("connected")
         cdef:
-            char *ret_buf
-            size_t buf_len = 37
-            PyObject* ret_s = NULL
+            char *ret_buf = NULL
+            size_t buf_len = 64
 
-        ret_s = PyBytes_FromStringAndSize(NULL, buf_len)
         try:
-            ret_buf = PyBytes_AsString(ret_s)
-            with nogil:
-                ret = rados_cluster_fsid(self.cluster, ret_buf, buf_len)
-            if ret < 0:
-                raise make_ex(ret, "error getting cluster fsid")
-            if ret != <int>buf_len:
-                _PyBytes_Resize(&ret_s, ret)
-            return <object>ret_s
+            while True:
+                ret_buf = <char *>realloc_chk(ret_buf, buf_len)
+                with nogil:
+                    ret = rados_cluster_fsid(self.cluster, ret_buf, buf_len)
+                if ret == -errno.ERANGE:
+                    buf_len = buf_len * 2
+                elif ret < 0:
+                    raise make_ex(ret, "error getting cluster fsid")
+                else:
+                    break
+            return decode_cstr(ret_buf)
         finally:
-            # We DECREF unconditionally: the cast to object above will have
-            # INCREFed if necessary. This also takes care of exceptions,
-            # including if _PyString_Resize fails (that will free the string
-            # itself and set ret_s to NULL, hence XDECREF).
-            ref.Py_XDECREF(ret_s)
+            free(ret_buf)
 
     @requires(('ioctx_name', str_type))
     def open_ioctx(self, ioctx_name):

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -10,6 +10,7 @@ import threading
 import json
 import errno
 import os
+import re
 import sys
 
 # Are we running Python 2.x
@@ -240,7 +241,7 @@ class TestRados(object):
 
     def test_get_fsid(self):
         fsid = self.rados.get_fsid()
-        eq(len(fsid), 36)
+        assert re.match('[0-9a-f\-]{36}', fsid, re.I)
 
     def test_blacklist_add(self):
         self.rados.blacklist_add("1.2.3.4/123", 1)


### PR DESCRIPTION
http://tracker.ceph.com/issues/40192