### PR TITLE
filestore: correctly assert on EIO in read()

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3423,6 +3423,7 @@ int FileStore::read(
   if (got < 0) {
     dout(10) << __FUNC__ << ": (" << cid << "/" << oid << ") pread error: " << cpp_strerror(got) << dendl;
     lfn_close(fd);
+    ceph_assert(!m_filestore_fail_eio || l != -EIO);
     return got;
   }
   bptr.set_length(got);   // properly size the buffer


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40245

Signed-off-by: Greg Farnum <gfarnum@redhat.com>