### PR TITLE
nautilus: pybind/mgr: fix format for rbd-mirror prometheus metrics

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -6,6 +6,7 @@ import six
 import threading
 from collections import defaultdict, namedtuple
 import rados
+import re
 import time
 
 PG_STATES = [
@@ -657,6 +658,25 @@ class MgrModule(ceph_module.BaseMgrModule):
             return 'histogram'
 
         return ''
+
+    def _perfpath_to_path_labels(self, daemon, path):
+        label_names = ("ceph_daemon",)
+        labels = (daemon,)
+
+        if daemon.startswith('rbd-mirror.'):
+            match = re.match(
+                r'^rbd_mirror_([^/]+)/(?:(?:([^/]+)/)?)(.*)\.(replay(?:_bytes|_latency)?)$',
+                path
+            )
+            if match:
+                path = 'rbd_mirror_' + match.group(4)
+                pool = match.group(1)
+                namespace = match.group(2) or ''
+                image = match.group(3)
+                label_names += ('pool', 'namespace', 'image')
+                labels += (pool, namespace, image)
+
+        return path, label_names, labels,
 
     def _perfvalue_to_value(self, stattype, value):
         if stattype & self.PERFCOUNTER_TIME:

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -852,6 +852,9 @@ class Module(MgrModule):
                     self.log.debug('ignoring %s, type %s' % (path, stattype))
                     continue
 
+                path, label_names, labels = self._perfpath_to_path_labels(
+                    daemon, path)
+
                 # Get the value of the counter
                 value = self._perfvalue_to_value(
                     counter_info['type'], counter_info['value'])
@@ -864,9 +867,9 @@ class Module(MgrModule):
                             stattype,
                             _path,
                             counter_info['description'] + ' Total',
-                            ("ceph_daemon",),
+                            label_names,
                         )
-                    self.metrics[_path].set(value, (daemon,))
+                    self.metrics[_path].set(value, labels)
 
                     _path = path + '_count'
                     if _path not in self.metrics:
@@ -874,18 +877,18 @@ class Module(MgrModule):
                             'counter',
                             _path,
                             counter_info['description'] + ' Count',
-                            ("ceph_daemon",),
+                            label_names,
                         )
-                    self.metrics[_path].set(counter_info['count'], (daemon,))
+                    self.metrics[_path].set(counter_info['count'], labels,)
                 else:
                     if path not in self.metrics:
                         self.metrics[path] = Metric(
                             stattype,
                             path,
                             counter_info['description'],
-                            ("ceph_daemon",),
+                            label_names,
                         )
-                    self.metrics[path].set(value, (daemon,))
+                    self.metrics[path].set(value, labels)
 
         self.get_rbd_stats()
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -120,8 +120,7 @@ class Metric(object):
 
         def promethize(path):
             ''' replace illegal metric name characters '''
-            result = path.replace('.', '_').replace(
-                '+', '_plus').replace('::', '_').replace(' ', '_')
+            result = re.sub(r'[./\s]|::', '_', path).replace('+', '_plus')
 
             # Hyphens usually turn into underscores, unless they are
             # trailing


### PR DESCRIPTION
https://tracker.ceph.com/issues/40122
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

