### PR TITLE
rgw: fix bucket limit check fill_status warnings

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1550,32 +1550,28 @@ int RGWBucketAdminOp::limit_check(RGWRados *store,
 	  continue;
 
 	for (const auto& s : stats) {
-	    num_objects += s.second.num_objects;
+	  num_objects += s.second.num_objects;
 	}
 
 	num_shards = info.num_shards;
 	uint64_t objs_per_shard =
 	  (num_shards) ? num_objects/num_shards : num_objects;
 	{
-	  bool warn = false;
+	  bool warn;
 	  stringstream ss;
-	  if (objs_per_shard > safe_max_objs_per_shard) {
-	    double over =
-	      100 - (safe_max_objs_per_shard/objs_per_shard * 100);
-	      ss << boost::format("OVER %4f%%") % over;
-	      warn = true;
+	  uint64_t fill_pct = objs_per_shard * 100 / safe_max_objs_per_shard;
+	  if (fill_pct > 100) {
+	    ss << "OVER " << fill_pct << "%";
+	    warn = true;
+	  } else if (fill_pct >= shard_warn_pct) {
+	    ss << "WARN " << fill_pct << "%";
+	    warn = true;
 	  } else {
-	    double fill_pct =
-	      objs_per_shard / safe_max_objs_per_shard * 100;
-	    if (fill_pct >= shard_warn_pct) {
-	      ss << boost::format("WARN %4f%%") % fill_pct;
-	      warn = true;
-	    } else {
-	      ss << "OK";
-	    }
+	    ss << "OK";
+	    warn = false;
 	  }
 
-	  if (warn || (! warnings_only)) {
+	  if (warn || !warnings_only) {
 	    formatter->open_object_section("bucket");
 	    formatter->dump_string("bucket", bucket.name);
 	    formatter->dump_string("tenant", bucket.tenant);


### PR DESCRIPTION
all variables in the calculation were ints, so the warning would
only ever trigger if objects_per_shard == limit_objects and the
percentage for > 100% used a granularity of 100%


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

