### PR TITLE
doc: Update 'python-rtslib' and 'tcmu-runner' min versions

### DIFF
--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -17,9 +17,9 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
    -  ``targetcli-2.1.fb47`` or newer package
 
-   -  ``python-rtslib-2.1.fb64`` or newer package
+   -  ``python-rtslib-2.1.fb68`` or newer package
 
-   -  ``tcmu-runner-1.3.0`` or newer package
+   -  ``tcmu-runner-1.4.0`` or newer package
 
    -  ``ceph-iscsi-2.7`` or newer package
 


### PR DESCRIPTION
Update `python-rtslib` and `tcmu-runner` min versions to match `ceph-iscsi' spec file.

Signed-off-by: Ricardo Marques <rimarques@suse.com>