### PR TITLE
mgr/dashboard: take portal_ip_addresses as a list

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -544,19 +544,20 @@ class IscsiClientMock(object):
             "portals": {}
         }
 
-    def create_gateway(self, target_iqn, gateway_name, ip_address):
+    def create_gateway(self, target_iqn, gateway_name, ip_addresses):
         target_config = self.config['targets'][target_iqn]
         if 'ip_list' not in target_config:
             target_config['ip_list'] = []
-        target_config['ip_list'] += ip_address
+        target_config['ip_list'] += ip_addresses
         target_config['portals'][gateway_name] = {
-            "portal_ip_addresses": ip_address
+            "portal_ip_addresses": ip_addresses
         }
 
     def delete_gateway(self, target_iqn, gateway_name):
         target_config = self.config['targets'][target_iqn]
         portal_config = target_config['portals'][gateway_name]
-        target_config['ip_list'].remove(portal_config['portal_ip_address'])
+        for ip in portal_config['portal_ip_addresses']:
+            target_config['ip_list'].remove(ip)
         target_config['portals'].pop(gateway_name)
 
     def create_disk(self, pool, image, backstore):


### PR DESCRIPTION
it's a follow-up fix of #28084

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

