### PR TITLE
nautilus: cephfs: client: ceph.dir.rctime xattr value incorrectly prefixes 09 to the nanoseconds component 

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11785,7 +11785,7 @@ size_t Client::_vxattrcb_dir_rbytes(Inode *in, char *val, size_t size)
 }
 size_t Client::_vxattrcb_dir_rctime(Inode *in, char *val, size_t size)
 {
-  return snprintf(val, size, "%ld.09%ld", (long)in->rstat.rctime.sec(),
+  return snprintf(val, size, "%ld.%09ld", (long)in->rstat.rctime.sec(),
       (long)in->rstat.rctime.nsec());
 }
 bool Client::_vxattrcb_dir_pin_exists(Inode *in)


### PR DESCRIPTION
http://tracker.ceph.com/issues/40167