### PR TITLE
nautilus: osd: Output Base64 encoding of CRC header if binary data present

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -329,7 +329,7 @@ void dump_services(Formatter* f, const map<string, list<string> >& services, con
 
 // If non-printable characters found then convert bufferlist to
 // base64 encoded string indicating whether it did.
-string cleanbin(bufferlist &bl, bool &base64)
+string cleanbin(bufferlist &bl, bool &base64, bool show)
 {
   bufferlist::iterator it;
   for (it = bl.begin(); it != bl.end(); ++it) {
@@ -345,6 +345,8 @@ string cleanbin(bufferlist &bl, bool &base64)
   bufferlist b64;
   bl.encode_base64(b64);
   string encoded(b64.c_str(), b64.length());
+  if (show)
+    encoded = "Base64:" + encoded;
   base64 = true;
   return encoded;
 }
@@ -356,9 +358,7 @@ string cleanbin(string &str)
   bool base64;
   bufferlist bl;
   bl.append(str);
-  string result = cleanbin(bl, base64);
-  if (base64)
-    result = "Base64:" + result;
+  string result = cleanbin(bl, base64, true);
   return result;
 }
 

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -90,7 +90,7 @@ void dump_services(Formatter* f, const map<string, list<int> >& services, const 
 /// @param type the service type of given @p services, for example @p osd or @p mon.
 void dump_services(Formatter* f, const map<string, list<string> >& services, const char* type);
 
-string cleanbin(bufferlist &bl, bool &b64);
+string cleanbin(bufferlist &bl, bool &b64, bool show = false);
 string cleanbin(string &str);
 
 namespace ceph::util {

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -21,6 +21,7 @@
 #include "messages/MOSDPGPushReply.h"
 #include "common/EventTrace.h"
 #include "include/random.h"
+#include "include/util.h"
 #include "OSD.h"
 
 #define dout_context cct
@@ -659,8 +660,8 @@ int ReplicatedBackend::be_deep_scrub(
       return 0;
     }
     if (r == 0 && hdrbl.length()) {
-      dout(25) << "CRC header " << string(hdrbl.c_str(), hdrbl.length())
-	       << dendl;
+      bool encoded = false;
+      dout(25) << "CRC header " << cleanbin(hdrbl, encoded, true) << dendl;
       pos.omap_hash << hdrbl;
     }
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/39738