### PR TITLE
mgr/dashboard: use mds_mem.dn for fs dentries

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -57,7 +57,8 @@ class CephFS(RESTController):
             "mds.imported_inodes",
             "mds.inodes",
             "mds.caps",
-            "mds.subtrees"
+            "mds.subtrees",
+            "mds_mem.ino"
         ]
 
         fs_id = self.fs_id_to_int(fs_id)
@@ -126,7 +127,7 @@ class CephFS(RESTController):
             if up:
                 gid = mdsmap['up']["mds_{0}".format(rank)]
                 info = mdsmap['info']['gid_{0}'.format(gid)]
-                dns = mgr.get_latest("mds", info['name'], "mds.inodes")
+                dns = mgr.get_latest("mds", info['name'], "mds_mem.dn")
                 inos = mgr.get_latest("mds", info['name'], "mds_mem.ino")
 
                 if rank == 0:
@@ -187,7 +188,7 @@ class CephFS(RESTController):
                 continue
 
             inos = mgr.get_latest("mds", daemon_info['name'], "mds_mem.ino")
-            dns = mgr.get_latest("mds", daemon_info['name'], "mds.inodes")
+            dns = mgr.get_latest("mds", daemon_info['name'], "mds_mem.dn")
 
             activity = CephService.get_rate(
                 "mds", daemon_info['name'], "mds_log.replay")

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-chart/cephfs-chart.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-chart/cephfs-chart.component.ts
@@ -19,7 +19,7 @@ export class CephfsChartComponent implements OnChanges, OnInit {
   @Input()
   mdsCounter: any;
 
-  lhsCounter = 'mds.inodes';
+  lhsCounter = 'mds_mem.ino';
   rhsCounter = 'mds_server.handle_client_request';
 
   chart: any;


### PR DESCRIPTION
mds_mem.dn is more accurate for representing fs dentries.
Switching from mds.inodes to mds_mem.dn creates consistency with output
of `ceph fs status` command.

Also in Cephfs counter chart, series of mds_mem.ino is displayed now
for consistency.

See https://github.com/ceph/ceph/pull/15255

Fixes: https://tracker.ceph.com/issues/40097
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket

