### PR TITLE
cmake: set empty-string RPATH for ceph-osd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -513,7 +513,8 @@ if(WITH_FUSE)
   target_link_libraries(ceph-osd ${FUSE_LIBRARIES})
 endif()
 set_target_properties(ceph-osd PROPERTIES
-  POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE})
+  POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE}
+  INSTALL_RPATH "")
 install(TARGETS ceph-osd DESTINATION bin)
 
 if (WITH_CEPHFS)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40295
Signed-off-by: Nathan Cutler <ncutler@suse.com>
