### PR TITLE
common/options: make mon_clean_pg_upmaps_per_chunk unsigned

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -187,7 +187,7 @@ OPTION(mon_osd_cache_size, OPT_INT)  // the size of osdmaps cache, not to rely o
 
 OPTION(mon_cpu_threads, OPT_INT)
 OPTION(mon_osd_mapping_pgs_per_chunk, OPT_INT)
-OPTION(mon_clean_pg_upmaps_per_chunk, OPT_INT)
+OPTION(mon_clean_pg_upmaps_per_chunk, OPT_U64)
 OPTION(mon_osd_max_creating_pgs, OPT_INT)
 OPTION(mon_tick_interval, OPT_INT)
 OPTION(mon_session_timeout, OPT_INT)    // must send keepalive or subscribe

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1320,7 +1320,7 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description("granularity of PG placement calculation background work"),
 
-    Option("mon_clean_pg_upmaps_per_chunk", Option::TYPE_INT, Option::LEVEL_DEV)
+    Option("mon_clean_pg_upmaps_per_chunk", Option::TYPE_UINT, Option::LEVEL_DEV)
     .set_default(256)
     .add_service("mon")
     .set_description("granularity of PG upmap validation background work"),


### PR DESCRIPTION
we don't use a negative number for some different purpose, for instance,
for disabling this option. and this helps to silence following warning:

/home/jenkins-build/build/workspace/ceph-pull-requests/src/mon/OSDMonitor.cc:
In member function 'virtual void
OSDMonitor::encode_pending(MonitorDBStore::TransactionRef)':
/home/jenkins-build/build/workspace/ceph-pull-requests/src/mon/OSDMonitor.cc:1195:31:
warning: comparison of integer expressions of different signedness:
'std::vector<pg_t>::size_type' {aka 'long unsigned int'} and 'int64_t'
{aka 'long int'} [-Wsign-compare]
       if (pgs_to_check.size() < g_conf()->mon_clean_pg_upmaps_per_chunk
* 2) {
           ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

