### PR TITLE
common: sort best-matched commond by req argument count

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1154,10 +1154,15 @@ def validate_command(sigdict, args, verbose=False):
         else:
             bestcmds.append(cmd)
 
-    # Sort bestcmds by number of args so we can try shortest first
+    # Sort bestcmds by number of req args so we can try shortest first
     # (relies on a cmdsig being key,val where val is a list of len 1)
-    bestcmds_sorted = sorted(bestcmds, key=lambda c: len(c['sig']))
 
+    def grade(cmd):
+      # prefer optional arguments over required ones
+      sigs = cmd['sig']
+      return sum(map(lambda sig: sig.req, sigs))
+
+    bestcmds_sorted = sorted(bestcmds, key=grade)
     if verbose:
         print("bestcmds_sorted: ", file=sys.stderr)
         pprint.PrettyPrinter(stream=sys.stderr).pprint(bestcmds_sorted)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40292

Signed-off-by: Chang Liu <liuchang0812@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

