### PR TITLE
cephfs-shell: Fixes the string-byte error produced on passing '*' pattern to rmdir, rm or ls

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -129,8 +129,9 @@ def glob(path, pattern):
     if path == '/' or is_dir_exists(os.path.basename(path),
                                         parent_dir):
         for i in ls(path, opts='A'):
-            if fnmatch.fnmatch(i.d_name, pattern):
-                paths.append(os.path.join(path, i.d_name))
+            dname = i.d_name.decode('utf-8')
+            if fnmatch.fnmatch(dname, pattern):
+                paths.append(os.path.join(path, dname))
     return paths
 
 

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -793,8 +793,9 @@ exists.')
     rmdir_parser.add_argument('paths', help='Directory Path.', nargs='+')
     rmdir_parser.add_argument('-p', '--parent', action='store_true',
                               help='Remove parent directories as necessary. \
-When this option is specified, no error is reported if a directory has any \
-sub-directories, files')
+                              When this option is specified, no error is \
+                              reported if a directory has any sub-directories,\
+                              files')
 
     @with_argparser(rmdir_parser)
     def do_rmdir(self, args):
@@ -814,7 +815,7 @@ sub-directories, files')
                 dirs = []
                 for i in all_items:
                     for item in ls(path):
-                        d_name = item.d_name
+                        d_name = item.d_name.decode('utf-8')
                         if os.path.basename(i) == d_name:
                             if item.is_dir():
                                 dirs.append(os.path.join(path, d_name))

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -116,7 +116,7 @@ def ls(path, opts=''):
                 elif almost_all and dent.d_name in (b'.', b'..'):
                     continue
                 yield dent
-    except cephfs.ObjectNotFound:
+    except libcephfs.ObjectNotFound:
         return []
 
 def glob(path, pattern):
@@ -824,20 +824,18 @@ exists.')
                 continue
             else:
                 is_pattern = False
-            path = ''
-            path = os.path.normpath(os.path.join(
-                cephfs.getcwd().decode('utf-8'), path))
+            path = os.path.normpath(os.path.join(cephfs.getcwd().decode(
+                                    'utf-8'), path))
             if args.parent:
-                files = reversed(
-                    sorted(set(dirwalk(path))))
-                for path in files:
-                    path = os.path.normpath(path)
-                    if path[1:] != path:
+                files = reversed(sorted(set(dirwalk(path))))
+                for filepath in files:
+                    filepath = os.path.normpath(filepath)
+                    if filepath[1:] != path:
                         try:
-                            cephfs.rmdir(path)
+                            cephfs.rmdir(filepath)
                         except libcephfs.Error:
-                            cephfs.unlink(path)
-            if not is_pattern and path != os.path.normpath(path):
+                            cephfs.unlink(filepath)
+            if not is_pattern and path != os.path.normpath(''):
                 try:
                     cephfs.rmdir(path)
                 except libcephfs.Error:


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
This patch series fixes
* TypeError produced due to using byte object instead of string type.
* 'rmdir *' not removing the empty directories bug.

Fixes: https://tracker.ceph.com/issues/40297
Fixes: https://tracker.ceph.com/issues/40298
Signed-off-by: Varsha Rao <varao@redhat.com>