### PR TITLE
luminous: doc: rgw: Update config-ref.rst to correct Luminous values

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -3,11 +3,11 @@
 ======================================
 
 The following settings may added to the Ceph configuration file (i.e., usually
-``ceph.conf``) under the ``[client.radosgw.{instance-name}]`` section. The
+``ceph.conf``) under the ``[client.rgw.{instance-name}]`` section. The
 settings may contain default values. If you do not specify each setting in the
 Ceph configuration file, the default value will be set automatically.
 
-Configuration variables set under the ``[client.radosgw.{instance-name}]``
+Configuration variables set under the ``[client.rgw.{instance-name}]``
 section will not apply to rgw or radosgw-admin commands without an instance-name
 specified in the command. Thus variables meant to be applied to all RGW
 instances or all radosgw-admin commands can be put into the ``[global]`` or the
@@ -432,7 +432,7 @@ You may include the following settings in your Ceph configuration
 file under each ``[client.radosgw.{instance-name}]`` instance.
 
 
-``rgw zone``
+``rgw_zone``
 
 :Description: The name of the zone for the gateway instance. If no zone is
               set, a cluster-wide default can be configured with the command


### PR DESCRIPTION
These changes correct the documentation for what I've found to be valid on Luminous 12.2.12.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

