### PR TITLE
luminous: ceph-volume: use the Device.rotational property instead of sys_api

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -31,7 +31,7 @@ def bluestore_single_type(device_facts):
     Detect devices that are just HDDs or solid state so that a 1:1
     device-to-osd provisioning can be done
     """
-    types = [device.sys_api['rotational'] for device in device_facts]
+    types = [device.rotational for device in device_facts]
     if len(set(types)) == 1:
         return strategies.bluestore.SingleType
 
@@ -41,7 +41,7 @@ def bluestore_mixed_type(device_facts):
     Detect if devices are HDDs as well as solid state so that block.db can be
     placed in solid devices while data is kept in the spinning drives.
     """
-    types = [device.sys_api['rotational'] for device in device_facts]
+    types = [device.rotational for device in device_facts]
     if len(set(types)) > 1:
         return strategies.bluestore.MixedType
 
@@ -51,7 +51,7 @@ def filestore_single_type(device_facts):
     Detect devices that are just HDDs or solid state so that a 1:1
     device-to-osd provisioning can be done, keeping the journal on the OSD
     """
-    types = [device.sys_api['rotational'] for device in device_facts]
+    types = [device.rotational for device in device_facts]
     if len(set(types)) == 1:
         return strategies.filestore.SingleType
 
@@ -61,7 +61,7 @@ def filestore_mixed_type(device_facts):
     Detect if devices are HDDs as well as solid state so that the journal can be
     placed in solid devices while data is kept in the spinning drives.
     """
-    types = [device.sys_api['rotational'] for device in device_facts]
+    types = [device.rotational for device in device_facts]
     if len(set(types)) > 1:
         return strategies.filestore.MixedType
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/strategies.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/strategies.py
@@ -6,8 +6,8 @@ class Strategy(object):
         self.args = args
         self.osds_per_device = args.osds_per_device
         self.devices = devices
-        self.hdds = [device for device in devices if device.sys_api['rotational'] == '1']
-        self.ssds = [device for device in devices if device.sys_api['rotational'] == '0']
+        self.hdds = [device for device in devices if device.rotational]
+        self.ssds = [device for device in devices if not device.rotational]
         self.computed = {'osds': [], 'vgs': [], 'filtered_devices': args.filtered_devices}
 
     def validate_compute(self):

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -7,7 +7,7 @@ class TestSingleType(object):
     def test_hdd_device_is_large_enough(self, fakedevice, factory):
         args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         computed_osd = bluestore.SingleType(devices, args).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 100
@@ -18,7 +18,7 @@ class TestSingleType(object):
     def test_sdd_device_is_large_enough(self, fakedevice, factory):
         args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
         ]
         computed_osd = bluestore.SingleType(devices, args).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 100
@@ -29,7 +29,7 @@ class TestSingleType(object):
     def test_device_cannot_have_many_osds_per_device(self, fakedevice, factory):
         args = factory(filtered_devices=[], osds_per_device=3, block_db_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             bluestore.SingleType(devices, args)
@@ -38,7 +38,7 @@ class TestSingleType(object):
     def test_device_is_lvm_member_fails(self, fakedevice, factory):
         args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=True, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             bluestore.SingleType(devices, args)
@@ -53,8 +53,8 @@ class TestMixedTypeConfiguredSize(object):
         # 3GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 3147483640)
         args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType(devices, args).computed['osds'][0]
@@ -69,8 +69,8 @@ class TestMixedTypeConfiguredSize(object):
         # 7GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 7747483640)
         args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:
@@ -82,8 +82,8 @@ class TestMixedTypeConfiguredSize(object):
         # 3GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 3147483640)
         args = factory(filtered_devices=[], osds_per_device=2, block_db_size=None)
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=60737400000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:
@@ -97,8 +97,8 @@ class TestMixedTypeLargeAsPossible(object):
     def test_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
         args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType(devices, args).computed['osds'][0]
@@ -113,8 +113,8 @@ class TestMixedTypeLargeAsPossible(object):
     def test_multi_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
         args = factory(filtered_devices=[], osds_per_device=2, block_db_size=None)
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=60073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=60073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=60073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType(devices, args).computed['osds'][0]
@@ -129,8 +129,8 @@ class TestMixedTypeLargeAsPossible(object):
     def test_multi_hdd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
         args = factory(filtered_devices=[], osds_per_device=2, block_db_size=None)
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=60737400000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
@@ -9,7 +9,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '5120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=12073740000))
         ]
         computed_osd = filestore.SingleType(devices, args).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 55
@@ -21,7 +21,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '5120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -32,7 +32,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '5120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=12073740000))
         ]
         computed_osd = filestore.SingleType(devices, args).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 55
@@ -44,7 +44,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '5120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -55,7 +55,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '5120')
         args = factory(filtered_devices=[], osds_per_device=4, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=16073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -66,7 +66,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '5120')
         args = factory(filtered_devices=[], osds_per_device=4, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=16073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -77,7 +77,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '5120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=True, rotational=True, sys_api=dict(size=12073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -87,7 +87,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -98,7 +98,7 @@ class TestSingleType(object):
         conf_ceph(get_safe=lambda *a: '120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -112,8 +112,8 @@ class TestMixedType(object):
         conf_ceph(get_safe=lambda *a: '120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)
@@ -124,8 +124,8 @@ class TestMixedType(object):
         conf_ceph(get_safe=lambda *a: '7120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)
@@ -136,8 +136,8 @@ class TestMixedType(object):
         conf_ceph(get_safe=lambda *a: '5120')
         args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=True, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)
@@ -147,9 +147,9 @@ class TestMixedType(object):
         # fast PV, because ssd is an LVM member
         CephPV = lvm.PVolume(vg_name='fast', pv_name='/dev/sda', pv_tags='')
         ssd = fakedevice(
-            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV]
+            used_by_ceph=False, is_lvm_member=True, rotational=False, sys_api=dict(size=6073740000), pvs_api=[CephPV]
         )
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         # when get_api_vgs() gets called, it will return this one VG
         stub_vgs([
             dict(
@@ -171,12 +171,12 @@ class TestMixedType(object):
         CephPV1 = lvm.PVolume(vg_name='fast1', pv_name='/dev/sda', pv_tags='')
         CephPV2 = lvm.PVolume(vg_name='fast2', pv_name='/dev/sdb', pv_tags='')
         ssd1 = fakedevice(
-            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV1]
+            used_by_ceph=False, is_lvm_member=True, rotational=False, sys_api=dict(size=6073740000), pvs_api=[CephPV1]
         )
         ssd2 = fakedevice(
-            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV2]
+            used_by_ceph=False, is_lvm_member=True, rotational=False, sys_api=dict(size=6073740000), pvs_api=[CephPV2]
         )
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         # when get_api_vgs() gets called, it will return this one VG
         stub_vgs([
             dict(
@@ -201,8 +201,8 @@ class TestMixedType(object):
         conf_ceph(get_safe=lambda *a: '15120')
         args = factory(filtered_devices=[], osds_per_device=2, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000)),
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
+            fakedevice(is_lvm_member=False, rotational=False, sys_api=dict(size=16073740000)),
+            fakedevice(is_lvm_member=False, rotational=True, sys_api=dict(size=16073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)

--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27, py35, py36, flake8
+skip_missing_interpreters = true
 
 [testenv]
 deps=


### PR DESCRIPTION
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1666822

Backport of #28060