### PR TITLE
ceph-volume: systemd: Give wal/db devices time to be detected

### DIFF
--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -120,29 +120,31 @@ def main(args=None):
     tries = os.environ.get('CEPH_VOLUME_SYSTEMD_TRIES', 30)
     interval = os.environ.get('CEPH_VOLUME_SYSTEMD_INTERVAL', 5)
 
-    block_volume = get_block_volume(extra_data)
-    wal_device = block_volume['tags']['ceph.wal_device']
-    db_device = block_volume['tags']['ceph.db_device']
+    if sub_command == 'lvm':
+        block_volume = get_block_volume(extra_data)
+        wal_device = block_volume['tags']['ceph.wal_device']
+        db_device = block_volume['tags']['ceph.db_device']
 
     while tries > 0:
         try:
-            # Waiting for WAL/DB availability
-            if wal_device:
-                wal_volume = get_wal_volume(wal_device)
-                if not wal_volume:
-                    logger.warning('failed to find wal volume %s, retries left: %s', wal_device, tries)
-                    tries -= 1
-                    time.sleep(interval)
-                    continue
-                logger.info('successfully found wal volume')
-            if db_device:
-                db_volume = get_db_volume(db_device)
-                if not db_volume:
-                    logger.warning('failed to find wal volume %s, retries left: %s', db_device, tries)
-                    tries -= 1
-                    time.sleep(interval)
-                    continue
-                logger.info('successfully found db volume')
+            if sub_command == 'lvm':
+                # Waiting for WAL/DB availability
+                if wal_device:
+                    wal_volume = get_wal_volume(wal_device)
+                    if not wal_volume:
+                        logger.warning('failed to find wal volume %s, retries left: %s', wal_device, tries)
+                        tries -= 1
+                        time.sleep(interval)
+                        continue
+                    logger.info('successfully found wal volume')
+                if db_device:
+                    db_volume = get_db_volume(db_device)
+                    if not db_volume:
+                        logger.warning('failed to find wal volume %s, retries left: %s', db_device, tries)
+                        tries -= 1
+                        time.sleep(interval)
+                        continue
+                    logger.info('successfully found db volume')
 
             # don't log any output to the terminal, just rely on stderr/stdout
             # going to logging

--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -8,6 +8,7 @@ import sys
 import time
 import logging
 from ceph_volume import log, process
+from ceph_volume.api.lvm import Volumes
 from ceph_volume.exceptions import SuffixParsingError
 
 
@@ -48,6 +49,30 @@ def parse_osd_uuid(string):
     if not osd_uuid:
         raise SuffixParsingError('OSD uuid', string)
     return osd_uuid
+
+
+def get_block_volume(string):
+    volumes = Volumes()
+    osd_id = string.split('-', 1)[0]
+    osd_fsid = string.split('-', 1)[1]
+    tags={'ceph.type':'block', 'ceph.osd_id':osd_id, 'ceph.osd_fsid':osd_fsid}
+    print tags
+    block_volume = volumes.get(lv_tags=tags).as_dict()
+    return block_volume
+
+
+def get_wal_volume(wal_device):
+    volumes = Volumes()
+    tags={'ceph.type':'wal', 'ceph.wal_device':wal_device}
+    wal_volume = volumes.get(lv_tags=tags)
+    return wal_volume
+
+
+def get_db_volume(db_device):
+    volumes = Volumes()
+    tags={'ceph.type':'db', 'ceph.db_device':db_device}
+    db_volume = volumes.get(lv_tags=tags)
+    return db_volume
 
 
 def main(args=None):
@@ -94,8 +119,31 @@ def main(args=None):
 
     tries = os.environ.get('CEPH_VOLUME_SYSTEMD_TRIES', 30)
     interval = os.environ.get('CEPH_VOLUME_SYSTEMD_INTERVAL', 5)
+
+    block_volume = get_block_volume(extra_data)
+    wal_device = block_volume['tags']['ceph.wal_device']
+    db_device = block_volume['tags']['ceph.db_device']
+
     while tries > 0:
         try:
+            # Waiting for WAL/DB availability
+            if wal_device:
+                wal_volume = get_wal_volume(wal_device)
+                if not wal_volume:
+                    logger.warning('failed to find wal volume %s, retries left: %s', wal_device, tries)
+                    tries -= 1
+                    time.sleep(interval)
+                    continue
+                logger.info('successfully found wal volume')
+            if db_device:
+                db_volume = get_db_volume(db_device)
+                if not db_volume:
+                    logger.warning('failed to find wal volume %s, retries left: %s', db_device, tries)
+                    tries -= 1
+                    time.sleep(interval)
+                    continue
+                logger.info('successfully found db volume')
+
             # don't log any output to the terminal, just rely on stderr/stdout
             # going to logging
             process.run(command, terminal_logging=False)

--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -56,7 +56,7 @@ def get_block_volume(string):
     osd_id = string.split('-', 1)[0]
     osd_fsid = string.split('-', 1)[1]
     tags={'ceph.type':'block', 'ceph.osd_id':osd_id, 'ceph.osd_fsid':osd_fsid}
-    block_volume = volumes.get(lv_tags=tags).as_dict()
+    block_volume = volumes.get(lv_tags=tags)
     return block_volume
 
 
@@ -121,29 +121,29 @@ def main(args=None):
 
     if sub_command == 'lvm':
         block_volume = get_block_volume(extra_data)
-        wal_device = block_volume['tags']['ceph.wal_device']
-        db_device = block_volume['tags']['ceph.db_device']
+        if block_volume:
+            wal_device = block_volume.tags['ceph.wal_device']
+            db_device = block_volume.tags['ceph.db_device']
 
     while tries > 0:
         try:
-            if sub_command == 'lvm':
-                # Waiting for WAL/DB availability
-                if wal_device:
-                    wal_volume = get_wal_volume(wal_device)
-                    if not wal_volume:
-                        logger.warning('failed to find wal volume %s, retries left: %s', wal_device, tries)
-                        tries -= 1
-                        time.sleep(interval)
-                        continue
-                    logger.info('successfully found wal volume')
-                if db_device:
-                    db_volume = get_db_volume(db_device)
-                    if not db_volume:
-                        logger.warning('failed to find wal volume %s, retries left: %s', db_device, tries)
-                        tries -= 1
-                        time.sleep(interval)
-                        continue
-                    logger.info('successfully found db volume')
+            # Waiting for WAL/DB availability
+            if wal_device:
+                wal_volume = get_wal_volume(wal_device)
+                if not wal_volume:
+                    logger.warning('failed to find wal volume %s, retries left: %s', wal_device, tries)
+                    tries -= 1
+                    time.sleep(interval)
+                    continue
+                logger.info('successfully found wal volume')
+            if db_device:
+                db_volume = get_db_volume(db_device)
+                if not db_volume:
+                    logger.warning('failed to find wal volume %s, retries left: %s', db_device, tries)
+                    tries -= 1
+                    time.sleep(interval)
+                    continue
+                logger.info('successfully found db volume')
 
             # don't log any output to the terminal, just rely on stderr/stdout
             # going to logging

--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -122,8 +122,8 @@ def main(args=None):
     if sub_command == 'lvm':
         block_volume = get_block_volume(extra_data)
         if block_volume:
-            wal_device = block_volume.tags['ceph.wal_device']
-            db_device = block_volume.tags['ceph.db_device']
+            wal_device = block_volume.tags.get('ceph.wal_device')
+            db_device = block_volume.tags.get('ceph.db_device')
 
     while tries > 0:
         try:

--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -56,7 +56,6 @@ def get_block_volume(string):
     osd_id = string.split('-', 1)[0]
     osd_fsid = string.split('-', 1)[1]
     tags={'ceph.type':'block', 'ceph.osd_id':osd_id, 'ceph.osd_fsid':osd_fsid}
-    print tags
     block_volume = volumes.get(lv_tags=tags).as_dict()
     return block_volume
 

--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -121,6 +121,8 @@ def main(args=None):
 
     if sub_command == 'lvm':
         block_volume = get_block_volume(extra_data)
+        wal_device = None
+        db_device = None
         if block_volume:
             wal_device = block_volume.tags.get('ceph.wal_device')
             db_device = block_volume.tags.get('ceph.db_device')


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/40100
Signed-off-by: David Casier <david.casier@aevoo.fr>

In the following coreycb proposal, the command was evaluated before waiting for WAL / DB devices to arrive :
https://github.com/ceph/ceph/pull/28357/commits/f2df1f971905ec4dd09cefb6e2a3ac3fc300bbf3

In order to keep an equivalent timeout, I propose to put in the same loop