### PR TITLE
 qa/tasks/cbt.py: add support for client_endpoints

### DIFF
--- a/qa/suites/perf-basic/workloads/client_endpoint_rbd_4K_rand_write.yaml
+++ b/qa/suites/perf-basic/workloads/client_endpoint_rbd_4K_rand_write.yaml
@@ -1,0 +1,32 @@
+meta:
+- desc: |
+   Run librbdfio benchmark using cbt client endpoint for rbd.
+   4K randwrite workload.
+
+tasks:
+- cbt:
+    benchmarks:
+      fio:
+        client_endpoints: 'fiotest'
+        op_size: [4096]
+        time: 300
+        mode: ['randwrite']
+        norandommap: True
+        size: 4096
+        iodepth: [32]
+        osd_ra: [4096]
+        pool_profile: 'rbd'
+        log_avg_msec: 100
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        rbd:
+          pg_size: 256
+          pgp_size: 256
+          replication: 3
+
+    client_endpoints:
+      fiotest:
+        driver: 'librbd'

--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -46,9 +46,9 @@ class CBT(Task):
 
         benchmark_config = self.config.get('benchmarks')
         benchmark_type = benchmark_config.keys()[0]
-        if benchmark_type == 'librbdfio':
+        if benchmark_type in ['librbdfio', 'fio']:
           testdir = misc.get_testdir(self.ctx)
-          benchmark_config['librbdfio']['cmd_path'] = os.path.join(testdir, 'fio/fio')
+          benchmark_config[benchmark_type]['cmd_path'] = os.path.join(testdir, 'fio/fio')
         if benchmark_type == 'cosbench':
             # create cosbench_dir and cosbench_xml_dir
             testdir = misc.get_testdir(self.ctx)
@@ -62,10 +62,12 @@ class CBT(Task):
             ips = [host for (host, port) in
                    (remote.ssh.get_transport().getpeername() for (remote, role_list) in remotes_and_roles)]
             benchmark_config['cosbench']['auth'] = "username=cosbench:operator;password=intel2012;url=http://%s:80/auth/v1.0;retry=9" %(ips[0])
+        client_endpoints_config = self.config.get('client_endpoints', None)
 
         return dict(
             cluster=cluster_config,
             benchmarks=benchmark_config,
+            client_endpoints = client_endpoints_config,
             )
 
     def install_dependencies(self):
@@ -82,7 +84,7 @@ class CBT(Task):
         benchmark_type = self.cbt_config.get('benchmarks').keys()[0]
         self.log.info('benchmark: %s', benchmark_type)
 
-        if benchmark_type == 'librbdfio':
+        if benchmark_type in ['librbdfio', 'fio']:
             # install fio
             testdir = misc.get_testdir(self.ctx)
             self.first_mon.run(
@@ -226,7 +228,7 @@ class CBT(Task):
             ]
         )
         benchmark_type = self.cbt_config.get('benchmarks').keys()[0]
-        if benchmark_type == 'librbdfio':
+        if benchmark_type in ['librbdfio', 'fio']:
             self.first_mon.run(
                 args=[
                     'rm', '--one-file-system', '-rf', '--',


### PR DESCRIPTION
- Add support to the cbt task to work with client_endpoints

- Add a sample workload to use client_endpoints


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

