### PR TITLE
qa/workunits/rbd: fix compare_images and compare_image_snapshots

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -929,25 +929,43 @@ stress_write_image()
 	2> ${TEMPDIR}/rbd-mirror-random-write.log || true
 }
 
+show_diff()
+{
+    local file1=$1
+    local file2=$2
+
+    xxd ${file1} > ${file1}.xxd
+    xxd ${file2} > ${file2}.xxd
+    sdiff -s ${file1}.xxd ${file2}.xxd | head -n 64
+    rm -f ${file1}.xxd ${file2}.xxd
+}
+
 compare_images()
 {
     local pool=$1
     local image=$2
+    local ret=0
 
     local rmt_export=${TEMPDIR}/${CLUSTER2}-${pool}-${image}.export
     local loc_export=${TEMPDIR}/${CLUSTER1}-${pool}-${image}.export
 
     rm -f ${rmt_export} ${loc_export}
-    rbd --cluster ${CLUSTER2} -p ${pool} export ${image} - | xxd > ${rmt_export}
-    rbd --cluster ${CLUSTER1} -p ${pool} export ${image} - | xxd > ${loc_export}
-    sdiff -s ${rmt_export} ${loc_export} | head -n 64
+    rbd --cluster ${CLUSTER2} -p ${pool} export ${image} ${rmt_export}
+    rbd --cluster ${CLUSTER1} -p ${pool} export ${image} ${loc_export}
+    if ! cmp ${rmt_export} ${loc_export}
+    then
+        show_diff ${rmt_export} ${loc_export}
+        ret=1
+    fi
     rm -f ${rmt_export} ${loc_export}
+    return ${ret}
 }
 
 compare_image_snapshots()
 {
     local pool=$1
     local image=$2
+    local ret=0
 
     local rmt_export=${TEMPDIR}/${CLUSTER2}-${pool}-${image}.export
     local loc_export=${TEMPDIR}/${CLUSTER1}-${pool}-${image}.export
@@ -957,11 +975,16 @@ compare_image_snapshots()
                            $XMLSTARLET sel -t -v "//snapshot/name" | \
                            grep -E -v "^\.rbd-mirror\."); do
         rm -f ${rmt_export} ${loc_export}
-        rbd --cluster ${CLUSTER2} -p ${pool} export ${image}@${snap_name} - | xxd > ${rmt_export}
-        rbd --cluster ${CLUSTER1} -p ${pool} export ${image}@${snap_name} - | xxd > ${loc_export}
-        sdiff -s ${rmt_export} ${loc_export} | head -n 64
+        rbd --cluster ${CLUSTER2} -p ${pool} export ${image}@${snap_name} ${rmt_export}
+        rbd --cluster ${CLUSTER1} -p ${pool} export ${image}@${snap_name} ${loc_export}
+        if ! cmp ${rmt_export} ${loc_export}
+        then
+            show_diff ${rmt_export} ${loc_export}
+            ret=1
+        fi
     done
     rm -f ${rmt_export} ${loc_export}
+    return ${ret}
 }
 
 demote_image()


### PR DESCRIPTION
Due to pipe, sdiff return code was ignored. Also the compare functions
spent most of time in xxd, which was normally unnecessary.

Signed-off-by: Mykola Golub <mgolub@suse.com>

Probaly should be backported together with or after #22043  (https://tracker.ceph.com/issues/24139)

https://tracker.ceph.com/issues/24139

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

