### PR TITLE
WIP: osd/osd_types: get rid of awkward [de]encoding of new pg_missing_item

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1405,7 +1405,7 @@ public:
 	  if (item.is_delete()) {
 	    ceph_assert(missing.may_include_deletes);
 	  }
-	  missing.add(oid, item.need, item.have, item.is_delete());
+	  missing.add(oid, std::move(item));
 	} else if (p->key().substr(0, 4) == string("dup_")) {
 	  pg_log_dup_t dup;
 	  decode(dup, bp);
@@ -1653,7 +1653,7 @@ public:
 	if (item.is_delete()) {
 	  ceph_assert(missing.may_include_deletes);
 	}
-	missing.add(oid, item.need, item.have, item.is_delete());
+	missing.add(oid, std::move(item));
       } else if (p.first.substr(0, 4) == string("dup_")) {
 	pg_log_dup_t dup;
 	decode(dup, bp);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4488,6 +4488,12 @@ public:
     tracker.changed(oid);
   }
 
+  void add(const hobject_t& oid, pg_missing_item&& item) {
+    rmissing[item.need.version] = oid;
+    missing.insert({oid, std::move(item)});
+    tracker.changed(oid);
+  }
+
   void rm(const hobject_t& oid, eversion_t v) {
     std::map<hobject_t, item>::iterator p = missing.find(oid);
     if (p != missing.end() && p->second.need <= v)


### PR DESCRIPTION
There is already a flags field which we can make use of.
Also if 'decode' failed to read the new clean_regions field off
the disk, then we should still be able to fall back to the traditional
way. 'mark_fully_dirty' ensures that happen.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

