### PR TITLE
debian/: use ceph-osd for packaging crimson-osd

### DIFF
--- a/debian/ceph-crimson-osd.dirs
+++ b/debian/ceph-crimson-osd.dirs
@@ -1,1 +1,0 @@
-var/lib/ceph/osd

--- a/debian/ceph-crimson-osd.install
+++ b/debian/ceph-crimson-osd.install
@@ -1,1 +1,0 @@
-usr/bin/crimson-osd

--- a/debian/ceph-osd.install
+++ b/debian/ceph-osd.install
@@ -1,10 +1,12 @@
+#! /usr/bin/dh-exec
+
 lib/systemd/system/ceph-osd*
 lib/systemd/system/ceph-volume@.service
 usr/bin/ceph-bluestore-tool
 usr/bin/ceph-clsinfo
 usr/bin/ceph-objectstore-tool
 usr/bin/ceph-osdomap-tool
-usr/bin/ceph-osd
+usr/bin/${CEPH_OSD_BASENAME} => /usr/bin/ceph-osd
 usr/bin/ceph_objectstore_bench
 usr/lib/ceph/ceph-osd-prestart.sh
 usr/lib/libos_tp.so*

--- a/debian/control
+++ b/debian/control
@@ -380,37 +380,6 @@ Description: debugging symbols for ceph-osd
  .
  This package contains the debugging symbols for ceph-osd.
 
-# Crimson Package: ceph-crimson-osd
-# Crimson Architecture: linux-any
-# Crimson Depends: ceph-base (= ${binary:Version}),
-# Crimson          ceph-osd (= ${binary:Version}),
-# Crimson          lvm2,
-# Crimson          sudo,
-# Crimson          ${misc:Depends},
-# Crimson          ${python:Depends},
-# Crimson          ${shlibs:Depends},
-# Crimson Description: OSD server for the ceph storage system
-# Crimson  Ceph is a massively scalable, open-source, distributed
-# Crimson  storage system that runs on commodity hardware and delivers object,
-# Crimson  block and file system storage.
-# Crimson  .
-# Crimson  This package contains the Object Storage Daemon for the Ceph storage system.
-# Crimson  It is responsible for storing objects on a local file system
-# Crimson  and providing access to them over the network.
-
-# Crimson Package: ceph-crimson-osd-dbg
-# Crimson Architecture: linux-any
-# Crimson Section: debug
-# Crimson Priority: extra
-# Crimson Depends: ceph-crimson-osd (= ${binary:Version}),
-# Crimson          ${misc:Depends},
-# Crimson Description: debugging symbols for ceph-crimson-osd
-# Crimson  Ceph is a massively scalable, open-source, distributed
-# Crimson  storage system that runs on commodity hardware and delivers object,
-# Crimson  block and file system storage.
-# Crimson  .
-# Crimson  This package contains the debugging symbols for ceph-osd.
-
 Package: ceph-fuse
 Architecture: linux-any
 Depends: ${misc:Depends},

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,11 @@ ifneq (,$(findstring WITH_STATIC_LIBSTDCXX,$(CEPH_EXTRA_CMAKE_ARGS)))
   # see http://tracker.ceph.com/issues/25209
   export DEB_LDFLAGS_MAINT_STRIP = -Wl,-Bsymbolic-functions
 endif
+ifeq (,$(findstring WITH_SEASTAR,$(CEPH_EXTRA_CMAKE_ARGS)))
+  export CEPH_OSD_BASENAME = ceph-osd
+else
+  export CEPH_OSD_BASENAME = crimson-osd
+endif
 
 extraopts += -DWITH_OCF=ON -DWITH_LTTNG=ON
 extraopts += -DWITH_PYTHON3=ON -DWITH_MGR_DASHBOARD_FRONTEND=OFF


### PR DESCRIPTION
* debian/: remove ceph-crimson-osd package.
* debian/control: set `CEPH_OSD_BASENAME` env variable, which
  will be consumed by `ceph-osd.install`. alternatively, we could
  rename crimson-osd to ceph-osd in `override_dh_auto_install`,
  but let's go with this way at this moment, unless `mv` in
  `override_dh_auto_install` is proved to be better.
* ceph-osd.install: replace ceph-osd with crimson-osd if
  `CEPH_EXTRA_CMAKE_ARGS` has `WITH_SEASTAR` in it. this only
  happens when we are packaging the "crimson" flavor packages from
  jenkins.
* ceph-osd.install: `chmod +x` this file, as we need to use
  `/usr/bin/dh-exec` as the interpreter of it to perform variable
  substitution and install.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

