### PR TITLE
luminous: mds: avoid trimming too many log segments after mds failover

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -616,6 +616,13 @@ void MDLog::trim(int m)
 
   unsigned new_expiring_segments = 0;
 
+  unsigned max_expiring_segments = 0;
+  if (pre_segments_size > 0){
+    max_expiring_segments = max_segments/2;
+    assert(segments.size() >= pre_segments_size);
+    max_expiring_segments = std::max<unsigned>(max_expiring_segments,segments.size() - pre_segments_size);
+  }
+  
   map<uint64_t,LogSegment*>::iterator p = segments.begin();
   while (p != segments.end()) {
     if (stop < ceph_clock_now())
@@ -631,6 +638,10 @@ void MDLog::trim(int m)
     if (new_expiring_segments * 2 > num_remaining_segments)
       break;
 
+    if (max_expiring_segments > 0 &&
+	expiring_segments.size() >= max_expiring_segments)
+      break;
+    
     // look at first segment
     LogSegment *ls = p->second;
     assert(ls);
@@ -791,6 +802,8 @@ void MDLog::_trim_expired_segments()
 	     << ls->seq << "/0x" << std::hex << ls->offset << std::dec << dendl;
     expired_events -= ls->num_events;
     expired_segments.erase(ls);
+    if (pre_segments_size > 0)
+      pre_segments_size--;
     num_events -= ls->num_events;
       
     // this was the oldest segment, adjust expire pos
@@ -1427,6 +1440,7 @@ void MDLog::_replay_thread()
     if (mds->is_daemon_stopping()) {
       return;
     }
+    pre_segments_size = segments.size();  // get num of logs when replay is finished
     finish_contexts(g_ceph_context, waitfor_replay, r);  
   }
 

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -123,6 +123,7 @@ protected:
   map<uint64_t,LogSegment*> segments;
   set<LogSegment*> expiring_segments;
   set<LogSegment*> expired_segments;
+  std::size_t pre_segments_size = 0;            // the num of segments when the mds finished replay-journal, to calc the num of segments growing
   uint64_t event_seq;
   int expiring_events;
   int expired_events;


### PR DESCRIPTION
https://tracker.ceph.com/issues/40041