### PR TITLE
mds: don't mark cap NEEDSNAPFLUSH if client has no pending capsnap

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2981,7 +2981,8 @@ void Locker::handle_client_caps(const cref_t<MClientCaps> &m)
 
       // client flushes and releases caps at the same time. make sure MDCache::cow_inode()
       // properly setup CInode::client_need_snapflush
-      if ((dirty & ~cap->issued()) && !need_snapflush)
+      if (!need_snapflush && (dirty & ~cap->issued()) &&
+	  (m->flags & MClientCaps::FLAG_PENDING_CAPSNAP))
 	cap->mark_needsnapflush();
     }
 


### PR DESCRIPTION
This avoid getting wrlocks and setup client_snap_caps on snap inode.
Because there is no further snapflush that triggers releasing these
wrlocks.

Fixes: https://tracker.ceph.com/issues/40361
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

