### PR TITLE
librbd: mirror image enable/disable should enable/disable journaling

### DIFF
--- a/qa/workunits/rbd/rbd_mirror.sh
+++ b/qa/workunits/rbd/rbd_mirror.sh
@@ -298,6 +298,7 @@ done
 
 set_pool_mirror_mode ${CLUSTER2} ${POOL} 'pool'
 for i in ${image2} ${image4}; do
+  enable_journaling ${CLUSTER2} ${POOL} ${i}
   wait_for_image_present ${CLUSTER1} ${POOL} ${i} 'present'
   wait_for_snap_present ${CLUSTER1} ${POOL} ${i} 'snap2'
   wait_for_image_replay_started ${CLUSTER1} ${POOL} ${i}
@@ -324,6 +325,7 @@ fi
 start_mirrors ${CLUSTER1}
 wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'deleted'
 set_pool_mirror_mode ${CLUSTER2} ${POOL} 'pool'
+enable_journaling ${CLUSTER2} ${POOL} ${image}
 wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'present'
 wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
 

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -731,6 +731,15 @@ create_image()
 	--image-feature layering,exclusive-lock,journaling $@ ${image}
 }
 
+enable_journaling()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+
+    rbd --cluster ${cluster} -p ${pool} feature enable ${image} journaling
+}
+
 set_image_meta()
 {
     local cluster=$1

--- a/src/test/librbd/test_mirroring.cc
+++ b/src/test/librbd/test_mirroring.cc
@@ -113,6 +113,14 @@ public:
     ASSERT_EQ(mirror_state == RBD_MIRROR_IMAGE_ENABLED ? -ENOENT : -EINVAL,
               image.mirror_image_get_instance_id(&instance_id));
 
+    if (mirror_mode == RBD_MIRROR_MODE_IMAGE &&
+        mirror_state == RBD_MIRROR_IMAGE_DISABLED) {
+      // disabling image mirroring automatically disables journaling feature
+      uint64_t new_features;
+      ASSERT_EQ(0, image.features(&new_features));
+      ASSERT_EQ(0, new_features & RBD_FEATURE_JOURNALING);
+    }
+
     ASSERT_EQ(0, image.close());
     ASSERT_EQ(0, m_rbd.remove(m_ioctx, image_name.c_str()));
     ASSERT_EQ(0, m_rbd.mirror_mode_set(m_ioctx, RBD_MIRROR_MODE_DISABLED));
@@ -381,6 +389,14 @@ TEST_F(TestMirroring, DisableImageMirror_In_MirrorModeImage) {
       RBD_MIRROR_IMAGE_DISABLED);
 }
 
+TEST_F(TestMirroring, DisableImageMirror_In_MirrorModeImage_NoObjectMap) {
+  uint64_t features = 0;
+  features |= RBD_FEATURE_EXCLUSIVE_LOCK;
+  features |= RBD_FEATURE_JOURNALING;
+  check_mirror_image_disable(RBD_MIRROR_MODE_IMAGE, features, 0,
+      RBD_MIRROR_IMAGE_DISABLED);
+}
+
 TEST_F(TestMirroring, DisableImageMirror_In_MirrorModePool) {
   uint64_t features = 0;
   features |= RBD_FEATURE_OBJECT_MAP;
@@ -470,12 +486,34 @@ TEST_F(TestMirroring, DisableJournalingWithPeer) {
   ASSERT_EQ(0, m_rbd.mirror_mode_set(m_ioctx, RBD_MIRROR_MODE_DISABLED));
 }
 
-TEST_F(TestMirroring, EnableImageMirror_WithoutJournaling) {
+TEST_F(TestMirroring, EnableImageMirror_In_MirrorModeDisabled_WithoutJournaling) {
   uint64_t features = 0;
   features |= RBD_FEATURE_OBJECT_MAP;
   features |= RBD_FEATURE_EXCLUSIVE_LOCK;
   check_mirror_image_enable(RBD_MIRROR_MODE_DISABLED, features, -EINVAL,
       RBD_MIRROR_IMAGE_DISABLED);
+}
+
+TEST_F(TestMirroring, EnableImageMirror_In_MirrorModePool_WithoutJournaling) {
+  uint64_t features = 0;
+  features |= RBD_FEATURE_OBJECT_MAP;
+  features |= RBD_FEATURE_EXCLUSIVE_LOCK;
+  check_mirror_image_enable(RBD_MIRROR_MODE_POOL, features, -EINVAL,
+      RBD_MIRROR_IMAGE_DISABLED);
+}
+
+TEST_F(TestMirroring, EnableImageMirror_In_MirrorModeImage_WithoutJournaling) {
+  uint64_t features = 0;
+  features |= RBD_FEATURE_OBJECT_MAP;
+  features |= RBD_FEATURE_EXCLUSIVE_LOCK;
+  check_mirror_image_enable(RBD_MIRROR_MODE_IMAGE, features, 0,
+      RBD_MIRROR_IMAGE_ENABLED);
+}
+
+TEST_F(TestMirroring, EnableImageMirror_In_MirrorModeImage_WithoutExclusiveLock) {
+  uint64_t features = 0;
+  check_mirror_image_enable(RBD_MIRROR_MODE_IMAGE, features, 0,
+      RBD_MIRROR_IMAGE_ENABLED);
 }
 
 TEST_F(TestMirroring, CreateImage_In_MirrorModeDisabled) {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/40071
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

