### PR TITLE
mon/OSDMonitor: add pool id to json in pool ls

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5260,6 +5260,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  if (detail == "detail") {
 	    f->open_object_section("pool");
 	    f->dump_string("pool_name", osdmap.get_pool_name(it->first));
+	    f->dump_int("pool_id", it->first);
 	    it->second.dump(f.get());
 	    f->close_section();
 	  } else {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40370
Signed-off-by: Paul Emmerich <paul.emmerich@croit.io>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

