### PR TITLE
ceph_volume_client: convert string to bytes object

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -476,7 +476,7 @@ class CephFSVolumeClient(object):
             self.evict(premount_evict)
             log.debug("Premount eviction of {0} completes".format(premount_evict))
         log.debug("CephFS mounting...")
-        self.fs.mount(filesystem_name=self.fs_name)
+        self.fs.mount(filesystem_name=to_bytes(self.fs_name))
         log.debug("Connection to cephfs complete")
 
         # Recover from partial auth updates due to a previous

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -27,9 +27,9 @@ def to_bytes(param):
     Helper method that returns byte representation of the given parameter.
     '''
     if isinstance(param, str):
-        return param.encode()
+        return param.encode('utf-8')
     else:
-        return str(param).encode()
+        return str(param).encode('utf-8')
 
 class RadosError(Exception):
     """

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -28,6 +28,8 @@ def to_bytes(param):
     '''
     if isinstance(param, str):
         return param.encode('utf-8')
+    elif param is None:
+        return param
     else:
         return str(param).encode('utf-8')
 


### PR DESCRIPTION
mount method in libcephfs's cython modules expects filesystem_name to
be a bytes object. Therefore, convert string to bytes object
beforehand.

Fixes: http://tracker.ceph.com/issues/40369

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug