### PR TITLE
[RFC] rgw: raise default rgw_bucket_index_max_aio to 128

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5543,7 +5543,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_bucket_index_max_aio", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(8)
+    .set_default(128)
     .set_description("Max number of concurrent RADOS requests when handling bucket shards."),
 
     Option("rgw_enable_quota_threads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
the maximum of 8 outstanding shard requests on a bucket index is an unnecessary bottleneck, especially for CLSRGWIssueBucketList which already has issues scaling to larger shard counts. the Objecter's inflight ops throttle is already preventing us from flooding the osds with requests