### PR TITLE
librbd: avoid dereferencing an empty container during deep-copy

### DIFF
--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -143,8 +143,9 @@ void ImageCopyRequest<I>::handle_object_copy(uint64_t object_no, int r) {
       }
     } else {
       m_copied_objects.push(object_no);
-      while (!m_updating_progress && m_copied_objects.top() ==
-             (m_object_number ? *m_object_number + 1 : 0)) {
+      while (!m_updating_progress && !m_copied_objects.empty() &&
+             m_copied_objects.top() ==
+               (m_object_number ? *m_object_number + 1 : 0)) {
         m_object_number = m_copied_objects.top();
         m_copied_objects.pop();
         uint64_t progress_object_no = *m_object_number + 1;


### PR DESCRIPTION
While updating the image copy progress, a 'while' loop will pop the
last item from the queue and then deference the empty queue.

Fixes: http://tracker.ceph.com/issues/40368
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

