### PR TITLE
cephfs-shell: du should ignore non-directory files

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -555,6 +555,9 @@ class CephFSMount(object):
     def get_osd_epoch(self):
         raise NotImplementedError()
 
+    def lstat(self, fs_path, follow_symlinks=False, wait=True):
+        return self.stat(fs_path, follow_symlinks=False, wait=True)
+
     def stat(self, fs_path, follow_symlinks=True, wait=True):
         """
         stat a file, and return the result as a dictionary like this:

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -555,7 +555,7 @@ class CephFSMount(object):
     def get_osd_epoch(self):
         raise NotImplementedError()
 
-    def stat(self, fs_path, wait=True):
+    def stat(self, fs_path, follow_symlinks=True, wait=True):
         """
         stat a file, and return the result as a dictionary like this:
         {
@@ -574,6 +574,10 @@ class CephFSMount(object):
         Raises exception on absent file.
         """
         abs_path = os.path.join(self.mountpoint, fs_path)
+        if follow_symlinks:
+            stat_call = "os.stat('" + abs_path + "')"
+        else:
+            stat_call = "os.lstat('" + abs_path + "')"
 
         pyscript = dedent("""
             import os
@@ -582,7 +586,7 @@ class CephFSMount(object):
             import sys
 
             try:
-                s = os.stat("{path}")
+                s = {stat_call}
             except OSError as e:
                 sys.exit(e.errno)
 
@@ -590,7 +594,7 @@ class CephFSMount(object):
             print json.dumps(
                 dict([(a, getattr(s, a)) for a in attrs]),
                 indent=2)
-            """).format(path=abs_path)
+            """).format(stat_call=stat_call)
         proc = self._run_python(pyscript)
         if wait:
             proc.wait()

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -2,6 +2,7 @@ import os
 import crypt
 import logging
 from tempfile import mkstemp as tempfile_mkstemp
+import math
 from StringIO import StringIO
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from tasks.cephfs.fuse_mount import FuseMount
@@ -9,6 +10,15 @@ from teuthology.exceptions import CommandFailedError
 
 log = logging.getLogger(__name__)
 
+def humansize(nbytes):
+    suffixes = ['B', 'K', 'M', 'G', 'T', 'P']
+    i = 0
+    while nbytes >= 1024 and i < len(suffixes)-1:
+        nbytes /= 1024.
+        i += 1
+    nbytes = math.ceil(nbytes)
+    f = ('%d' % nbytes).rstrip('.')
+    return '%s%s' % (f, suffixes[i])
 
 class TestCephFSShell(CephFSTestCase):
     CLIENTS_REQUIRED = 1

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -588,6 +588,29 @@ class TestDU(TestCephFSShell):
 #            log.info('ls -a failed')
 
 class TestMisc(TestCephFSShell):
+    def test_issue_cephfs_shell_cmd_at_invocation(self):
+        """
+        Test that `cephfs-shell -c conf cmd` works.
+        """
+        # choosing a long name since short ones have a higher probability
+        # of getting matched by coincidence.
+        dirname = 'somedirectory'
+        self.run_cephfs_shell_cmd(['mkdir', dirname])
+
+        # TODO: Once cephfs-shell can pickup its config variables from
+        # ceph.conf, set colors Never there and get rid of the same in
+        # following comamnd.
+        output = self.mount_a.client_remote.run(args=['cephfs-shell', '-c',
+            self.mount_a.config_path, 'set colors Never, ls'],
+            stdout=StringIO()).stdout.getvalue().strip()
+
+        if sys_version_info.major >= 3:
+            self.assertRegex(dirname, output)
+        elif sys_version_info.major < 3:
+            assert re_search(dirname, output) != None, "\n" + \
+                   "expected_output -\n{}\ndu_output -\n{}\n".format(
+                   dirname, output)
+
     def test_help(self):
         """
         Test that help outputs commands.

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -523,6 +523,22 @@ class TestDU(TestCephFSShell):
                        "expected_output -\n{}\ndu_output -\n{}\n".format(
                        expected_output, du_output)
 
+    def test_du_with_path_in_args(self):
+        expected_patterns_in_output, path_to_files = self._setup_files(True,
+            path_prefix='')
+
+        args = ['du', '/']
+        for path in path_to_files:
+            args.append(path)
+        du_output = self.get_cephfs_shell_cmd_output(args)
+
+        for expected_output in expected_patterns_in_output:
+            if sys_version_info.major >= 3:
+                self.assertRegex(expected_output, du_output)
+            elif sys_version_info.major < 3:
+                assert re_search(expected_output, du_output) != None, "\n" +\
+                       "expected_output -\n{}\ndu_output -\n{}\n".format(
+                       expected_output, du_output)
 
 #    def test_ls(self):
 #        """

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -375,6 +375,25 @@ class TestDU(TestCephFSShell):
                    "expected_output -\n{}\ndu_output -\n{}\n".format(
                    expected_output, du_output)
 
+    def test_du_works_for_hardlinks(self):
+        regfilename = 'some_regfile'
+        regfile_abspath = path.join(self.mount_a.mountpoint, regfilename)
+        sudo_write_file(self.mount_a.client_remote, regfile_abspath, 'somedata')
+        hlinkname = 'some_hardlink'
+        hlink_abspath = path.join(self.mount_a.mountpoint, hlinkname)
+        self.mount_a.run_shell(['ln', regfile_abspath, hlink_abspath])
+
+        size = humansize(self.mount_a.stat(hlink_abspath)['st_size'])
+        expected_output = r'{}{}{}'.format(size, " +", hlinkname)
+
+        du_output = self.get_cephfs_shell_cmd_output('du ' + hlinkname)
+        if sys_version_info.major >= 3:
+            self.assertRegex(expected_output, du_output)
+        elif sys_version_info.major < 3:
+            assert re_search(expected_output, du_output) != None, "\n" + \
+                   "expected_output -\n{}\ndu_output -\n{}\n".format(
+                   expected_output, du_output)
+
 #    def test_ls(self):
 #        """
 #        Test that ls passes

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -40,6 +40,11 @@ class TestCephFSShell(CephFSTestCase):
         return mount_x.client_remote.run(args=args, stdout=StringIO(),
                                            stdin=stdin)
 
+    def get_cephfs_shell_cmd_output(self, cmd, mount_x=None, opts=None,
+                                    stdin=None):
+        return self.run_cephfs_shell_cmd(cmd, mount_x, opts, stdin).stdout.\
+            getvalue().strip()
+
     def get_cephfs_shell_script_output(self, script, mount_x=None, stdin=None):
         return self.run_cephfs_shell_script(script, mount_x, stdin).stdout.\
             getvalue().strip()
@@ -65,7 +70,7 @@ class TestMkdir(TestCephFSShell):
         """
         Test that mkdir creates directory
         """
-        o = self.run_cephfs_shell_cmd("mkdir d1")
+        o = self.get_cephfs_shell_cmd_output("mkdir d1")
         log.info("cephfs-shell output:\n{}".format(o))
 
         o = self.mount_a.stat('d1')
@@ -75,7 +80,7 @@ class TestMkdir(TestCephFSShell):
         """
         Test that mkdir fails with octal mode greater than 0777
         """
-        o = self.run_cephfs_shell_cmd("mkdir -m 07000 d2")
+        o = self.get_cephfs_shell_cmd_output("mkdir -m 07000 d2")
         log.info("cephfs-shell output:\n{}".format(o))
 
         # mkdir d2 should fail
@@ -89,7 +94,7 @@ class TestMkdir(TestCephFSShell):
         """
         Test that mkdir fails with negative octal mode
         """
-        o = self.run_cephfs_shell_cmd("mkdir -m -0755 d3")
+        o = self.get_cephfs_shell_cmd_output("mkdir -m -0755 d3")
         log.info("cephfs-shell output:\n{}".format(o))
 
         # mkdir d3 should fail
@@ -103,7 +108,7 @@ class TestMkdir(TestCephFSShell):
         """
         Test that mkdir passes with non-octal mode
         """
-        o = self.run_cephfs_shell_cmd("mkdir -m u=rwx d4")
+        o = self.get_cephfs_shell_cmd_output("mkdir -m u=rwx d4")
         log.info("cephfs-shell output:\n{}".format(o))
 
         # mkdir d4 should pass
@@ -114,7 +119,7 @@ class TestMkdir(TestCephFSShell):
         """
         Test that mkdir failes with bad non-octal mode
         """
-        o = self.run_cephfs_shell_cmd("mkdir -m ugx=0755 d5")
+        o = self.get_cephfs_shell_cmd_output("mkdir -m ugx=0755 d5")
         log.info("cephfs-shell output:\n{}".format(o))
 
         # mkdir d5 should fail
@@ -128,7 +133,7 @@ class TestMkdir(TestCephFSShell):
         """
         Test that mkdir fails without path option for creating path
         """
-        o = self.run_cephfs_shell_cmd("mkdir d5/d6/d7")
+        o = self.get_cephfs_shell_cmd_output("mkdir d5/d6/d7")
         log.info("cephfs-shell output:\n{}".format(o))
 
         # mkdir d5/d6/d7 should fail
@@ -142,7 +147,7 @@ class TestMkdir(TestCephFSShell):
         """
         Test that mkdir passes with path option for creating path
         """
-        o = self.run_cephfs_shell_cmd("mkdir -p d5/d6/d7")
+        o = self.get_cephfs_shell_cmd_output("mkdir -p d5/d6/d7")
         log.info("cephfs-shell output:\n{}".format(o))
 
         # mkdir d5/d6/d7 should pass
@@ -162,7 +167,7 @@ class TestGetAndPut(TestCephFSShell):
         self.run_cephfs_shell_cmd('!dd if=/dev/urandom of=p1/dump3 bs=3M count=1')
 
         # copy the whole directory over to the cephfs
-        o = self.run_cephfs_shell_cmd("put p1")
+        o = self.get_cephfs_shell_cmd_output("put p1")
         log.info("cephfs-shell output:\n{}".format(o))
 
         # put p1 should pass
@@ -176,20 +181,20 @@ class TestGetAndPut(TestCephFSShell):
         log.info("mount_a output:\n{}".format(o))
 
         self.run_cephfs_shell_cmd('!rm -rf p1')
-        o = self.run_cephfs_shell_cmd("get p1")
-        o = self.run_cephfs_shell_cmd('!stat p1 || echo $?')
+        o = self.get_cephfs_shell_cmd_output("get p1")
+        o = self.get_cephfs_shell_cmd_output('!stat p1 || echo $?')
         log.info("cephfs-shell output:\n{}".format(o))
         self.validate_stat_output(o)
 
-        o = self.run_cephfs_shell_cmd('!stat p1/dump1 || echo $?')
+        o = self.get_cephfs_shell_cmd_output('!stat p1/dump1 || echo $?')
         log.info("cephfs-shell output:\n{}".format(o))
         self.validate_stat_output(o)
 
-        o = self.run_cephfs_shell_cmd('!stat p1/dump2 || echo $?')
+        o = self.get_cephfs_shell_cmd_output('!stat p1/dump2 || echo $?')
         log.info("cephfs-shell output:\n{}".format(o))
         self.validate_stat_output(o)
 
-        o = self.run_cephfs_shell_cmd('!stat p1/dump3 || echo $?')
+        o = self.get_cephfs_shell_cmd_output('!stat p1/dump3 || echo $?')
         log.info("cephfs-shell output:\n{}".format(o))
         self.validate_stat_output(o)
 
@@ -211,17 +216,17 @@ class TestGetAndPut(TestCephFSShell):
         """
         s = 'C' * 1024
         s_hash = crypt.crypt(s, '.A')
-        o = self.run_cephfs_shell_cmd("put - dump4", stdin=s)
+        o = self.get_cephfs_shell_cmd_output("put - dump4", stdin=s)
         log.info("cephfs-shell output:\n{}".format(o))
 
         # put - dump4 should pass
         o = self.mount_a.stat('dump4')
         log.info("mount_a output:\n{}".format(o))
 
-        o = self.run_cephfs_shell_cmd("get dump4 .")
+        o = self.get_cephfs_shell_cmd_output("get dump4 .")
         log.info("cephfs-shell output:\n{}".format(o))
 
-        o = self.run_cephfs_shell_cmd("!cat dump4")
+        o = self.get_cephfs_shell_cmd_output("!cat dump4")
         o_hash = crypt.crypt(o, '.A')
 
         # s_hash must be equal to o_hash
@@ -234,7 +239,7 @@ class TestGetAndPut(TestCephFSShell):
         Test that get passes with target name
         """
         s = 'D' * 1024
-        o = self.run_cephfs_shell_cmd("put - dump5", stdin=s)
+        o = self.get_cephfs_shell_cmd_output("put - dump5", stdin=s)
         log.info("cephfs-shell output:\n{}".format(o))
 
         # put - dump5 should pass
@@ -242,8 +247,8 @@ class TestGetAndPut(TestCephFSShell):
         log.info("mount_a output:\n{}".format(o))
 
         # get dump5 should fail
-        o = self.run_cephfs_shell_cmd("get dump5")
-        o = self.run_cephfs_shell_cmd("!stat dump5 || echo $?")
+        o = self.get_cephfs_shell_cmd_output("get dump5")
+        o = self.get_cephfs_shell_cmd_output("!stat dump5 || echo $?")
         log.info("cephfs-shell output:\n{}".format(o))
         l = o.split('\n')
         try:
@@ -263,7 +268,7 @@ class TestGetAndPut(TestCephFSShell):
         """
         s = 'E' * 1024
         s_hash = crypt.crypt(s, '.A')
-        o = self.run_cephfs_shell_cmd("put - dump6", stdin=s)
+        o = self.get_cephfs_shell_cmd_output("put - dump6", stdin=s)
         log.info("cephfs-shell output:\n{}".format(o))
 
         # put - dump6 should pass
@@ -271,7 +276,7 @@ class TestGetAndPut(TestCephFSShell):
         log.info("mount_a output:\n{}".format(o))
 
         # get dump6 - should pass
-        o = self.run_cephfs_shell_cmd("get dump6 -")
+        o = self.get_cephfs_shell_cmd_output("get dump6 -")
         o_hash = crypt.crypt(o, '.A')
         log.info("cephfs-shell output:\n{}".format(o))
 
@@ -313,7 +318,7 @@ class TestCD(TestCephFSShell):
 #        """
 #        Test that ls passes
 #        """
-#        o = self.run_cephfs_shell_cmd("ls")
+#        o = self.get_cephfs_shell_cmd_output("ls")
 #        log.info("cephfs-shell output:\n{}".format(o))
 #
 #        o = self.mount_a.run_shell(['ls']).stdout.getvalue().strip().replace("\n", " ").split()
@@ -329,7 +334,7 @@ class TestCD(TestCephFSShell):
 #        """
 #        Test that ls -a passes
 #        """
-#        o = self.run_cephfs_shell_cmd("ls -a")
+#        o = self.get_cephfs_shell_cmd_output("ls -a")
 #        log.info("cephfs-shell output:\n{}".format(o))
 #
 #        o = self.mount_a.run_shell(['ls', '-a']).stdout.getvalue().strip().replace("\n", " ").split()
@@ -346,6 +351,6 @@ class TestMisc(TestCephFSShell):
         Test that help outputs commands.
         """
 
-        o = self.run_cephfs_shell_cmd("help")
+        o = self.get_cephfs_shell_cmd_output("help")
 
         log.info("output:\n{}".format(o))

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -27,6 +27,9 @@ class TestCephFSShell(CephFSTestCase):
         if mount_x is None:
             mount_x = self.mount_a
 
+        if isinstance(cmd, list):
+            cmd = " ".join(cmd)
+
         args = ["cephfs-shell", "-c", mount_x.config_path]
         if opts is not None:
             args.extend(opts)

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -540,6 +540,22 @@ class TestDU(TestCephFSShell):
                        "expected_output -\n{}\ndu_output -\n{}\n".format(
                        expected_output, du_output)
 
+    def test_du_with_no_args(self):
+        expected_patterns_in_output = self._setup_files()
+
+        du_output = self.get_cephfs_shell_cmd_output('du')
+
+        for expected_output in expected_patterns_in_output:
+            # Since CWD is CephFS root and being non-recursive expect only
+            # CWD in DU report.
+            if expected_output.find('/') == len(expected_output) - 1:
+                if sys_version_info.major >= 3:
+                    self.assertRegex(expected_output, du_output)
+                elif sys_version_info.major < 3:
+                    assert re_search(expected_output, du_output) != None, "\n" + \
+                        "expected_output -\n{}\ndu_output -\n{}\n".format(
+                        expected_output, du_output)
+
 #    def test_ls(self):
 #        """
 #        Test that ls passes

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -22,6 +22,7 @@ else:
     str_type = str
 
 cdef int AT_SYMLINK_NOFOLLOW = 0x100
+cdef int CEPH_STATX_BASIC_STATS = 0x7ffu
 
 cdef extern from "Python.h":
     # These are in cpython/string.pxd, but use "object" types instead of
@@ -1111,12 +1112,12 @@ cdef class LibCephFS(object):
 
         if follow_symlink:
             with nogil:
-                # FIXME: replace magic number with CEPH_STATX_BASIC_STATS
-                ret = ceph_statx(self.cluster, _path, &stx, 0x7ffu, 0)
+                ret = ceph_statx(self.cluster, _path, &stx,
+                                 CEPH_STATX_BASIC_STATS, 0)
         else:
             with nogil:
-                ret = ceph_statx(self.cluster, _path, &stx, 0x7ffu,
-                                 AT_SYMLINK_NOFOLLOW)
+                ret = ceph_statx(self.cluster, _path, &stx,
+                                 CEPH_STATX_BASIC_STATS, AT_SYMLINK_NOFOLLOW)
 
         if ret < 0:
             raise make_ex(ret, "error in stat: {}".format(path.decode('utf-8')))
@@ -1155,8 +1156,8 @@ cdef class LibCephFS(object):
             statx stx
 
         with nogil:
-            # FIXME: replace magic number with CEPH_STATX_BASIC_STATS
-            ret = ceph_fstatx(self.cluster, _fd, &stx, 0x7ffu, 0)
+            ret = ceph_fstatx(self.cluster, _fd, &stx,
+                              CEPH_STATX_BASIC_STATS, 0)
         if ret < 0:
             raise make_ex(ret, "error in fsat")
         return StatResult(st_dev=stx.stx_dev, st_ino=stx.stx_ino,

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -21,6 +21,7 @@ if sys.version_info[0] < 3:
 else:
     str_type = str
 
+cdef int AT_SYMLINK_NOFOLLOW = 0x100
 
 cdef extern from "Python.h":
     # These are in cpython/string.pxd, but use "object" types instead of
@@ -1095,7 +1096,7 @@ cdef class LibCephFS(object):
             raise make_ex(ret, "error in setxattr")
 
 
-    def stat(self, path):
+    def stat(self, path, follow_symlink=True):
         """
         Get a file's extended statistics and attributes.
         
@@ -1108,9 +1109,15 @@ cdef class LibCephFS(object):
             char* _path = path
             statx stx
 
-        with nogil:
-            # FIXME: replace magic number with CEPH_STATX_BASIC_STATS
-            ret = ceph_statx(self.cluster, _path, &stx, 0x7ffu, 0)
+        if follow_symlink:
+            with nogil:
+                # FIXME: replace magic number with CEPH_STATX_BASIC_STATS
+                ret = ceph_statx(self.cluster, _path, &stx, 0x7ffu, 0)
+        else:
+            with nogil:
+                ret = ceph_statx(self.cluster, _path, &stx, 0x7ffu,
+                                 AT_SYMLINK_NOFOLLOW)
+
         if ret < 0:
             raise make_ex(ret, "error in stat: {}".format(path.decode('utf-8')))
         return StatResult(st_dev=stx.stx_dev, st_ino=stx.stx_ino,
@@ -1122,6 +1129,16 @@ cdef class LibCephFS(object):
                           st_atime=datetime.fromtimestamp(stx.stx_atime.tv_sec),
                           st_mtime=datetime.fromtimestamp(stx.stx_mtime.tv_sec),
                           st_ctime=datetime.fromtimestamp(stx.stx_ctime.tv_sec))
+
+    def lstat(self, path):
+        """
+        Get a file's extended statistics and attributes. When file's a
+        symbolic link, return the informaion of the link itself rather
+        than that of the file it points too.
+
+        :param path: the file or directory to get the statistics of.
+        """
+        return self.stat(path, follow_symlink=False)
 
     def fstat(self, fd):
         """

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -102,9 +102,21 @@ def get_chunks(file_size):
     yield(chunk_start, final_chunk_size)
 
 
-def to_bytes(string):
-    return bytes(string, encoding='utf-8')
-
+def to_bytes(param):
+    # don't convert as follows as it can lead unusable results like coverting
+    # [1, 2, 3, 4] to '[1, 2, 3, 4]' -
+    # str(param).encode('utf-8')
+    if isinstance(param, bytes):
+        return param
+    elif isinstance(param, str):
+        return bytes(param, encoding='utf-8')
+    elif isinstance(param, list):
+        return [i.encode('utf-8') if isinstance(i, str) else to_bytes(i) for \
+                i in param]
+    elif isinstance(param, int) or isinstance(param, float):
+        return str(param).encode('utf-8')
+    elif param is None:
+        return None
 
 def ls(path, opts=''):
     # opts tries to be like /bin/ls opts

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1123,8 +1123,8 @@ sub-directories, files')
     du_parser = argparse.ArgumentParser(
         description='Disk Usage of a Directory')
     du_parser.add_argument('dirs', type=str, action=path_to_bytes,
-                           help='Name of the directory.', nargs='?',
-                           default='.')
+                           help='Name of the directory.', nargs='*',
+                           default='')
     du_parser.add_argument('-r', action='store_true',
                            help='Recursive Disk usage of all directories.')
 
@@ -1133,19 +1133,36 @@ sub-directories, files')
         """
         Disk Usage of a Directory
         """
+        dir_passed = args.dirs
         if args.dirs == b'':
-            args.dirs = cephfs.getcwd()
-        for dir_ in args.dirs:
+            dir_passed = cephfs.getcwd()
+            if len(dir_passed) > 1:
+                dir_passed = dir_passed.split()
+
+        for dir_ in dir_passed:
+            dir_trav = sorted(set(dirwalk(dir_)))
+            if args.dirs and not dir_trav:
+                dir_trav.append(dir_)
+            else:
+                dir_trav.append('.')
+
             if args.r:
-                for i in reversed(sorted(set(dirwalk(dir_)))):
-                    i = os.path.normpath(i)
-                    try:
-                        xattr = cephfs.getxattr(i, 'ceph.dir.rbytes')
-                        self.poutput('{:10s} {}'.format(
-                            humansize(int(xattr.decode('utf-8'))), '.'
-                            + i.decode('utf-8')))
-                    except libcephfs.Error:
-                        continue
+                dir_trav = reversed(dir_trav)
+
+            for i in dir_trav:
+                try:
+                    i_path = os.path.normpath(i)
+                    if (i != '.') and (i_path[0] == '/'):
+                        i = '.' + i_path
+
+                    xattr = cephfs.getxattr(i_path,
+                                            'ceph.dir.rbytes')
+                    self.poutput('{:10s} {}'.format(humansize(int(
+                                 xattr.decode('utf-8'))), i.decode('utf-8'))
+                except (libcephfs.Error, OSError):
+                    self.perror('{}: no such directory exists'.format(dir_),
+                                False)
+                    continue
             else:
                 dir_ = os.path.normpath(dir_)
                 self.poutput('{:10s} {}'.format(humansize(int(cephfs.getxattr(

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -14,6 +14,7 @@ import fnmatch
 import math
 import re
 import shlex
+import stat
 
 if sys.version_info.major < 3:
     raise RuntimeError("cephfs-shell is only compatible with python3")
@@ -1152,16 +1153,25 @@ sub-directories, files')
             for i in dir_trav:
                 try:
                     i_path = os.path.normpath(i)
-                    if (i != '.') and (i_path[0] == '/'):
+                    if (i is not '.') and (i_path[0] is '/'):
                         i = '.' + i_path
 
-                    xattr = cephfs.getxattr(i_path,
-                                            'ceph.dir.rbytes')
-                    self.poutput('{:10s} {}'.format(humansize(int(
-                                 xattr.decode('utf-8'))), i.decode('utf-8'))
+                    st = cephfs.lstat(i_path)
+
+                    if stat.S_ISDIR(st.st_mode):
+                        dusage = int(cephfs.getxattr(i_path,
+                            'ceph.dir.rbytes').decode('utf-8'))
+                    elif stat.S_ISREG(st.st_mode) or stat.S_ISLNK(st.st_mode):
+                        dusage = st.st_size
+
+                    self.poutput('{:10s} {}'.format(humansize(dusage),
+                                 i.decode('utf-8')))
+                    # Assigning dusage None to avoid cases where its value
+                    # from previous iterations ends up being reused.
+                    dusage = None
                 except (libcephfs.Error, OSError):
-                    self.perror('{}: no such directory exists'.format(dir_),
-                                False)
+                    self.perror('{}: no such directory exists'.format(
+                                dir_), False)
                     continue
             else:
                 dir_ = os.path.normpath(dir_)

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1135,58 +1135,47 @@ sub-directories, files')
 
     du_parser = argparse.ArgumentParser(
         description='Disk Usage of a Directory')
-    du_parser.add_argument('dirs', type=str, action=path_to_bytes,
+    du_parser.add_argument('paths', type=str, action=path_to_bytes,
                            help='Name of the directory.', nargs='*',
-                           default='')
+                           default=[b'.'])
     du_parser.add_argument('-r', action='store_true',
                            help='Recursive Disk usage of all directories.')
 
     @with_argparser(du_parser)
     def do_du(self, args):
         """
-        Disk Usage of a Directory
+        Print disk usage of a given path(s).
         """
-        dir_passed = args.dirs
-        if args.dirs == b'':
-            dir_passed = cephfs.getcwd()
-            if len(dir_passed) > 1:
-                dir_passed = dir_passed.split()
+        def print_disk_usage(files):
+            if isinstance(files, bytes):
+                files = (files, )
 
-        for dir_ in dir_passed:
-            dir_trav = sorted(set(dirwalk(dir_)))
-            if args.dirs and not dir_trav:
-                dir_trav.append(dir_)
-            else:
-                dir_trav.append('.')
-
-            for i in dir_trav:
+            for f in files:
                 try:
-                    i_path = os.path.normpath(i)
-                    if (i is not '.') and (i_path[0] is '/'):
-                        i = '.' + i_path
-
-                    st = cephfs.lstat(i_path)
+                    st = cephfs.lstat(f)
 
                     if stat.S_ISDIR(st.st_mode):
-                        dusage = int(cephfs.getxattr(i_path,
-                            'ceph.dir.rbytes').decode('utf-8'))
-                    elif stat.S_ISREG(st.st_mode) or stat.S_ISLNK(st.st_mode):
+                        dusage = int(cephfs.getxattr(f,
+                                     'ceph.dir.rbytes').decode('utf-8'))
+                    else:
                         dusage = st.st_size
 
+                    # print path in local context
+                    f = os.path.normpath(f)
+                    if f[0] is ord('/'):
+                        f = b'.' + f
                     self.poutput('{:10s} {}'.format(humansize(dusage),
-                                 i.decode('utf-8')))
-                    # Assigning dusage None to avoid cases where its value
-                    # from previous iterations ends up being reused.
-                    dusage = None
+                        f.decode('utf-8')))
                 except (libcephfs.Error, OSError):
-                    self.perror('{}: no such directory exists'.format(
-                                dir_), False)
+                    self.perror('{} : no such directory exists'.format(f.\
+                        decode('utf-8')), False)
                     continue
+
+        for path in args.paths:
+            if args.r:
+                print_disk_usage(sorted(set(dirwalk(path)).union({path})))
             else:
-                dir_ = os.path.normpath(dir_)
-                self.poutput('{:10s} {}'.format(humansize(int(cephfs.getxattr(
-                    dir_, 'ceph.dir.rbytes').decode('utf-8'))), '.'
-                    + dir_.decode('utf-8')))
+                print_disk_usage(path)
 
     quota_parser = argparse.ArgumentParser(
         description='Quota management for a Directory')

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1168,7 +1168,7 @@ sub-directories, files')
                         f.decode('utf-8')))
                 except (libcephfs.Error, OSError):
                     self.perror('{} : no such directory exists'.format(f.\
-                        decode('utf-8')), False)
+                        decode('utf-8')), apply_style=True)
                     continue
 
         for path in args.paths:

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -417,6 +417,20 @@ class CephFSShell(Cmd):
             values = to_bytes(values)
             setattr(namespace, self.dest, values)
 
+    # TODO: move the necessary contents from here to `class path_to_bytes`.
+    class get_list_of_bytes_path(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            values = to_bytes(values)
+
+            if values == b'.':
+                values = cephfs.getcwd()
+            else:
+                for i in values:
+                    if i == b'.':
+                        values[values.index(i)] = cephfs.getcwd()
+
+            setattr(namespace, self.dest, values)
+
     def complete_mkdir(self, text, line, begidx, endidx):
         """
         auto complete of file name.
@@ -1132,7 +1146,7 @@ sub-directories, files')
 
     du_parser = argparse.ArgumentParser(
         description='Disk Usage of a Directory')
-    du_parser.add_argument('paths', type=str, action=path_to_bytes,
+    du_parser.add_argument('paths', type=str, action=get_list_of_bytes_path,
                            help='Name of the directory.', nargs='*',
                            default=[b'.'])
     du_parser.add_argument('-r', action='store_true',

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -414,10 +414,7 @@ class CephFSShell(Cmd):
 
     class path_to_bytes(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
-            if isinstance(values, str):
-                values = to_bytes(values)
-            if isinstance(values, list):
-                values = list(map(to_bytes, values))
+            values = to_bytes(values)
             setattr(namespace, self.dest, values)
 
     def complete_mkdir(self, text, line, begidx, endidx):

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1159,9 +1159,6 @@ sub-directories, files')
             else:
                 dir_trav.append('.')
 
-            if args.r:
-                dir_trav = reversed(dir_trav)
-
             for i in dir_trav:
                 try:
                     i_path = os.path.normpath(i)


### PR DESCRIPTION
This commit makes du ignore non-directory files since it crashes when
it tries to get the extended attributes 'ceph.dir.rbytes' from
non-directory files.
    
http://tracker.ceph.com/issues/40371

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug