### PR TITLE
vstart_runner: split unicode arguments into lists

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -237,7 +237,7 @@ class LocalRemote(object):
     def _perform_checks_and_return_list_of_args(self, args, omit_sudo):
         # Since Python's shell simulation can only work when commands are
         # provided as a list of argumensts...
-        if isinstance(args, str):
+        if isinstance(args, str) or isinstance(args, unicode):
             args = args.split()
 
         # We'll let sudo be a part of command even omit flag says otherwise in

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -264,8 +264,8 @@ class LocalRemote(object):
         # the desired effect.
         errmsg = 'The entire command to executed as other user should be a ' +\
                  'single argument.\nargs - %s' % (args)
-        if ('sudo' in args or 'python' in args or 'python2' in args or
-           'python3' in args) and '-c' in args:
+        if 'sudo' in args and '-u' in args and '-c' in args and \
+           args.count('-c') == 1:
             if args.index('-c') != len(args) - 2 and \
                args[args.index('-c') + 2].find('-') == -1:
                 raise RuntimeError(errmsg)


### PR DESCRIPTION
Split not just string arguments but also unicode arguments into lists.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug