### PR TITLE
nautilus: qa: stop testing simple messenger in fs qa

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/cephfs-shell/simple.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cephfs-shell/simple.yaml
@@ -1,1 +1,0 @@
-.qa/msgr/simple.yaml

--- a/qa/suites/fs/basic_functional/tasks/sessionmap/simple.yaml
+++ b/qa/suites/fs/basic_functional/tasks/sessionmap/simple.yaml
@@ -1,1 +1,0 @@
-.qa/msgr/simple.yaml

--- a/qa/suites/fs/basic_functional/tasks/volume-client/task/test/simple.yaml
+++ b/qa/suites/fs/basic_functional/tasks/volume-client/task/test/simple.yaml
@@ -1,1 +1,0 @@
-.qa/msgr/simple.yaml


### PR DESCRIPTION
897a1f738566263fde42832dc23f34a99a554b62 was incomplete.

Fixes: http://tracker.ceph.com/issues/40373
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>