### PR TITLE
nautilus: qa: ignore legacy bluestore stats errors

### DIFF
--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        bluestore warn on legacy statfs: false
+
 tasks:
 - mds_pre_upgrade:
 - print: "**** done mds pre-upgrade sequence"

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        bluestore warn on legacy statfs: false
+
 tasks:
 - mds_pre_upgrade:
 - print: "**** done mds pre-upgrade sequence"

--- a/qa/suites/fs/upgrade/snaps/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/snaps/tasks/2-upgrade.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        bluestore warn on legacy statfs: false
+
 tasks:
 - mds_pre_upgrade:
 - print: "**** done mds pre-upgrade sequence"


### PR DESCRIPTION
Partial-backport: 66f18ecd09973ceab4ff9ff177e69d9c61a30bf2
Fixes: http://tracker.ceph.com/issues/40374
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>