### PR TITLE
osd: copy (don't move) pg list when sending beacon

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5825,7 +5825,7 @@ void OSD::send_beacon(const ceph::coarse_mono_clock::time_point& now)
     {
       std::lock_guard l{min_last_epoch_clean_lock};
       beacon = new MOSDBeacon(osdmap->get_epoch(), min_last_epoch_clean);
-      std::swap(beacon->pgs, min_last_epoch_clean_pgs);
+      beacon->pgs = min_last_epoch_clean_pgs;
       last_sent_beacon = now;
     }
     monc->send_mon_message(beacon);


### PR DESCRIPTION
If we move the list, then a second beacon sent before the pg list refreshes
will be empty.

Fixes: http://tracker.ceph.com/issues/40377
Signed-off-by: Sage Weil <sage@redhat.com>