### PR TITLE
Revert "mon/OSDMonitor: report pg[pgp]_num_target instead of pg[pgp]_…

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5437,10 +5437,10 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
         ceph_assert(i != ALL_CHOICES.end());
 	switch(*it) {
 	  case PG_NUM:
-	    f->dump_int("pg_num", p->get_pg_num_target());
+	    f->dump_int("pg_num", p->get_pg_num());
 	    break;
 	  case PGP_NUM:
-	    f->dump_int("pgp_num", p->get_pgp_num_target());
+	    f->dump_int("pgp_num", p->get_pgp_num());
 	    break;
 	  case SIZE:
 	    f->dump_int("size", p->get_size());
@@ -5595,10 +5595,10 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	choices_map_t::const_iterator i;
 	switch(*it) {
 	  case PG_NUM:
-	    ss << "pg_num: " << p->get_pg_num_target() << "\n";
+	    ss << "pg_num: " << p->get_pg_num() << "\n";
 	    break;
 	  case PGP_NUM:
-	    ss << "pgp_num: " << p->get_pgp_num_target() << "\n";
+	    ss << "pgp_num: " << p->get_pgp_num() << "\n";
 	    break;
 	  case SIZE:
 	    ss << "size: " << p->get_size() << "\n";


### PR DESCRIPTION
…num"

This reverts commit a160dc416a7c19eccce66f36719468680cd151f4.
Since it does not mean to fix anything, I'd like to leave it
the way it is.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


-----------------------

See: https://github.com/ceph/ceph/pull/28490


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

