### PR TITLE
mimic: bluestore: 50-100% iops lost due to bluefs_preextend_wal_files = false

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -692,8 +692,8 @@ int KernelDevice::_sync_write(uint64_t off, bufferlist &bl, bool buffered)
     return r;
   }
   if (buffered) {
-    // initiate IO (but do not wait)
-    r = ::sync_file_range(fd_buffered, off, len, SYNC_FILE_RANGE_WRITE);
+    // initiate IO and wait till it completes
+    r = ::sync_file_range(fd_buffered, off, len, SYNC_FILE_RANGE_WRITE|SYNC_FILE_RANGE_WAIT_AFTER|SYNC_FILE_RANGE_WAIT_BEFORE);
     if (r < 0) {
       r = -errno;
       derr << __func__ << " sync_file_range error: " << cpp_strerror(r) << dendl;


### PR DESCRIPTION
http://tracker.ceph.com/issues/40280