### PR TITLE
os/bluestore: Trim cache on add rather than in loop.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -898,16 +898,23 @@ BlueStore::Cache *BlueStore::Cache::create(CephContext* cct, string type,
   return c;
 }
 
-void BlueStore::Cache::trim(uint64_t onode_max, uint64_t buffer_max)
+void BlueStore::Cache::trim_onodes()
 {
   std::lock_guard l(lock);
-  _trim(onode_max, buffer_max);
+  _trim_onodes();
 }
 
-void BlueStore::Cache::trim_all()
+void BlueStore::Cache::trim_buffers()
 {
   std::lock_guard l(lock);
-  _trim(0, 0);
+  _trim_buffers();
+}
+
+void BlueStore::Cache::flush()
+{
+  std::lock_guard l(lock);
+  _trim_buffers_to(0);
+  _trim_onodes_to(0);
 }
 
 // LRUCache
@@ -921,33 +928,11 @@ void BlueStore::LRUCache::_touch_onode(OnodeRef& o)
   onode_lru.push_front(*o);
 }
 
-void BlueStore::LRUCache::_trim(uint64_t onode_max, uint64_t buffer_max)
-{
-  dout(20) << __func__ << " onodes " << onode_lru.size() << " / " << onode_max
-	   << " buffers " << buffer_size << " / " << buffer_max
-	   << dendl;
-
-  _audit("trim start");
-
-  // buffers
-  while (buffer_size > buffer_max) {
-    auto i = buffer_lru.rbegin();
-    if (i == buffer_lru.rend()) {
-      // stop if buffer_lru is now empty
-      break;
-    }
-
-    Buffer *b = &*i;
-    ceph_assert(b->is_clean());
-    dout(20) << __func__ << " rm " << *b << dendl;
-    b->space->_rm_buffer(this, b);
-  }
-
-  // onodes
-  if (onode_max >= onode_lru.size()) {
+void BlueStore::LRUCache::_trim_onodes_to(uint64_t max) {
+  if (max >= onode_lru.size()) {
     return; // don't even try
   }
-  uint64_t num = onode_lru.size() - onode_max;
+  uint64_t num = onode_lru.size() - max;
 
   auto p = onode_lru.end();
   ceph_assert(p != onode_lru.begin());
@@ -959,7 +944,7 @@ void BlueStore::LRUCache::_trim(uint64_t onode_max, uint64_t buffer_max)
     int refs = o->nref.load();
     if (refs > 1) {
       dout(20) << __func__ << "  " << o->oid << " has " << refs
-	       << " refs, skipping" << dendl;
+               << " refs, skipping" << dendl;
       if (++skipped >= max_skipped) {
         dout(20) << __func__ << " maximum skip pinned reached; stopping with "
                  << num << " left to trim" << dendl;
@@ -985,6 +970,21 @@ void BlueStore::LRUCache::_trim(uint64_t onode_max, uint64_t buffer_max)
     o->c->onode_map.remove(o->oid);
     o->put();
     --num;
+  }
+}
+
+void BlueStore::LRUCache::_trim_buffers_to(uint64_t max) {
+  while (buffer_size > max) {
+    auto i = buffer_lru.rbegin();
+    if (i == buffer_lru.rend()) {
+      // stop if buffer_lru is now empty
+      break;
+    }
+
+    Buffer *b = &*i;
+    ceph_assert(b->is_clean());
+    dout(20) << __func__ << " rm " << *b << dendl;
+    b->space->_rm_buffer(this, b);
   }
 }
 
@@ -1139,18 +1139,56 @@ void BlueStore::TwoQCache::_adjust_buffer_size(Buffer *b, int64_t delta)
   }
 }
 
-void BlueStore::TwoQCache::_trim(uint64_t onode_max, uint64_t buffer_max)
-{
-  dout(20) << __func__ << " onodes " << onode_lru.size() << " / " << onode_max
-	   << " buffers " << buffer_bytes << " / " << buffer_max
-	   << dendl;
+void BlueStore::TwoQCache::_trim_onodes_to(uint64_t max) {
+  if (max >= onode_lru.size()) {
+    return; // don't even try
+  }
+  uint64_t num = onode_lru.size() - max;
 
-  _audit("trim start");
+  auto p = onode_lru.end();
+  ceph_assert(p != onode_lru.begin());
+  --p;
+  int skipped = 0;
+  int max_skipped = g_conf()->bluestore_cache_trim_max_skip_pinned;
+  while (num > 0) {
+    Onode *o = &*p;
+    dout(20) << __func__ << " considering " << o << dendl;
+    int refs = o->nref.load();
+    if (refs > 1) {
+      dout(20) << __func__ << "  " << o->oid << " has " << refs
+               << " refs; skipping" << dendl;
+      if (++skipped >= max_skipped) {
+        dout(20) << __func__ << " maximum skip pinned reached; stopping with "
+                 << num << " left to trim" << dendl;
+        break;
+      }
 
-  // buffers
-  if (buffer_bytes > buffer_max) {
-    uint64_t kin = buffer_max * cct->_conf->bluestore_2q_cache_kin_ratio;
-    uint64_t khot = buffer_max - kin;
+      if (p == onode_lru.begin()) {
+        break;
+      } else {
+        p--;
+        num--;
+        continue;
+      }
+    }
+    dout(30) << __func__ << " " << o->oid << " num=" << num <<" lru size="<<onode_lru.size()<< dendl;
+    if (p != onode_lru.begin()) {
+      onode_lru.erase(p--);
+    } else {
+      onode_lru.erase(p);
+      ceph_assert(num == 1);
+    }
+    o->get();  // paranoia
+    o->c->onode_map.remove(o->oid);
+    o->put();
+    --num;
+  }
+}
+
+void BlueStore::TwoQCache::_trim_buffers_to(uint64_t max) {
+  if (buffer_bytes > max) {
+    uint64_t kin = max * cct->_conf->bluestore_2q_cache_kin_ratio;
+    uint64_t khot = max - kin;
 
     // pre-calculate kout based on average buffer size too,
     // which is typical(the warm_in and hot lists may change later)
@@ -1159,7 +1197,7 @@ void BlueStore::TwoQCache::_trim(uint64_t onode_max, uint64_t buffer_max)
     if (buffer_num) {
       uint64_t buffer_avg_size = buffer_bytes / buffer_num;
       ceph_assert(buffer_avg_size);
-      uint64_t calculated_buffer_num = buffer_max / buffer_avg_size;
+      uint64_t calculated_buffer_num = max / buffer_avg_size;
       kout = calculated_buffer_num * cct->_conf->bluestore_2q_cache_kout_ratio;
     }
 
@@ -1238,51 +1276,6 @@ void BlueStore::TwoQCache::_trim(uint64_t onode_max, uint64_t buffer_max)
       dout(20) << __func__ << " buffer_warm_out rm " << *b << dendl;
       b->space->_rm_buffer(this, b);
     }
-  }
-
-  // onodes
-  if (onode_max >= onode_lru.size()) {
-    return; // don't even try
-  }
-  uint64_t num = onode_lru.size() - onode_max;
-
-  auto p = onode_lru.end();
-  ceph_assert(p != onode_lru.begin());
-  --p;
-  int skipped = 0;
-  int max_skipped = g_conf()->bluestore_cache_trim_max_skip_pinned;
-  while (num > 0) {
-    Onode *o = &*p;
-    dout(20) << __func__ << " considering " << o << dendl;
-    int refs = o->nref.load();
-    if (refs > 1) {
-      dout(20) << __func__ << "  " << o->oid << " has " << refs
-	       << " refs; skipping" << dendl;
-      if (++skipped >= max_skipped) {
-        dout(20) << __func__ << " maximum skip pinned reached; stopping with "
-                 << num << " left to trim" << dendl;
-        break;
-      }
-
-      if (p == onode_lru.begin()) {
-        break;
-      } else {
-        p--;
-        num--;
-        continue;
-      }
-    }
-    dout(30) << __func__ << " " << o->oid << " num=" << num <<" lru size="<<onode_lru.size()<< dendl;
-    if (p != onode_lru.begin()) {
-      onode_lru.erase(p--);
-    } else {
-      onode_lru.erase(p);
-      ceph_assert(num == 1);
-    }
-    o->get();  // paranoia
-    o->c->onode_map.remove(o->oid);
-    o->put();
-    --num;
   }
 }
 
@@ -1413,6 +1406,7 @@ int BlueStore::BufferSpace::_discard(Cache* cache, uint32_t offset, uint32_t len
     cache->_audit("discard end 2");
     break;
   }
+  cache->_trim_buffers();
   return cache_private;
 }
 
@@ -1517,7 +1511,7 @@ void BlueStore::BufferSpace::_finish_write(Cache* cache, uint64_t seq)
       ldout(cache->cct, 20) << __func__ << " added " << *b << dendl;
     }
   }
-
+  cache->_trim_buffers();
   cache->_audit("finish_write end");
 }
 
@@ -1569,6 +1563,7 @@ void BlueStore::BufferSpace::split(Cache* cache, size_t pos, BlueStore::BufferSp
     }
   }
   ceph_assert(writing.empty());
+  cache->_trim_buffers();
 }
 
 // OnodeSpace
@@ -1589,6 +1584,7 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::add(const ghobject_t& oid, OnodeRef o
   ldout(cache->cct, 30) << __func__ << " " << oid << " " << o << dendl;
   onode_map[oid] = o;
   cache->_add_onode(o, 1);
+  cache->_trim_onodes();
   return o;
 }
 
@@ -1663,7 +1659,7 @@ void BlueStore::OnodeSpace::rename(
   oldo.reset(new Onode(o->c, old_oid, o->key));
   po->second = oldo;
   cache->_add_onode(po->second, 1);
-
+  cache->_trim_onodes();
   // add at new position and fix oid, key
   onode_map.insert(make_pair(new_oid, o));
   cache->_touch_onode(o);
@@ -3636,6 +3632,7 @@ void BlueStore::Collection::split_cache(
       }
     }
   }
+  dest->cache->_trim_onodes();
 }
 
 // =======================================================
@@ -3702,8 +3699,8 @@ void *BlueStore::MempoolThread::entry()
       next_resize += resize_interval;
     }
 
-    // Now Trim
-    _trim_shards(interval_stats_trim);
+    // Now Resize the shards 
+    _resize_shards(interval_stats_trim);
     interval_stats_trim = false;
 
     store->_update_cache_logger();
@@ -3724,7 +3721,7 @@ void BlueStore::MempoolThread::_adjust_cache_settings()
   data_cache->set_cache_ratio(store->cache_data_ratio);
 }
 
-void BlueStore::MempoolThread::_trim_shards(bool interval_stats)
+void BlueStore::MempoolThread::_resize_shards(bool interval_stats)
 {
   auto cct = store->cct;
   size_t num_shards = store->cache_shards.size();
@@ -3774,7 +3771,8 @@ void BlueStore::MempoolThread::_trim_shards(bool interval_stats)
                  << " max_shard_buffer: " << max_shard_buffer << dendl;
 
   for (auto i : store->cache_shards) {
-    i->trim(max_shard_onodes, max_shard_buffer);
+    i->set_onode_max(max_shard_onodes);
+    i->set_buffer_max(max_shard_buffer);
   }
 }
 
@@ -13708,7 +13706,7 @@ void BlueStore::_flush_cache()
 {
   dout(10) << __func__ << dendl;
   for (auto i : cache_shards) {
-    i->trim_all();
+    i->flush();
     ceph_assert(i->empty());
   }
   for (auto& p : coll_map) {
@@ -13734,7 +13732,7 @@ int BlueStore::flush_cache(ostream *os)
 {
   dout(10) << __func__ << dendl;
   for (auto i : cache_shards) {
-    i->trim_all();
+    i->flush();
   }
 
   return 0;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -347,6 +347,7 @@ public:
 			     flags);
       b->cache_private = _discard(cache, offset, bl.length());
       _add_buffer(cache, b, (flags & Buffer::FLAG_NOCACHE) ? 0 : 1, nullptr);
+      cache->_trim_buffers();
     }
     void _finish_write(Cache* cache, uint64_t seq);
     void did_read(Cache* cache, uint32_t offset, bufferlist& bl) {
@@ -354,6 +355,7 @@ public:
       Buffer *b = new Buffer(this, Buffer::STATE_CLEAN, 0, offset, bl);
       b->cache_private = _discard(cache, offset, bl.length());
       _add_buffer(cache, b, 1, nullptr);
+      cache->_trim_buffers();
     }
 
     void read(Cache* cache, uint32_t offset, uint32_t length,
@@ -1096,6 +1098,8 @@ public:
 
     std::atomic<uint64_t> num_extents = {0};
     std::atomic<uint64_t> num_blobs = {0};
+    std::atomic<uint64_t> onode_max = {0};
+    std::atomic<uint64_t> buffer_max = {0};
 
     std::array<std::pair<ghobject_t, mono_clock::time_point>, 64> dumped_onodes;
 
@@ -1131,11 +1135,28 @@ public:
       --num_blobs;
     }
 
-    void trim(uint64_t onode_max, uint64_t buffer_max);
+    void set_onode_max(uint64_t max) {
+      onode_max = max;
+    }
 
-    void trim_all();
+    void set_buffer_max(uint64_t max) {
+      buffer_max = max;
+    }
 
-    virtual void _trim(uint64_t onode_max, uint64_t buffer_max) = 0;
+    void flush();
+    void trim_onodes();
+    void trim_buffers();
+
+    virtual void _trim_onodes_to(uint64_t max) = 0;
+    virtual void _trim_buffers_to(uint64_t max) = 0;
+
+    void _trim_onodes() {
+      _trim_onodes_to(onode_max);
+    }
+
+    void _trim_buffers() {
+      _trim_buffers_to(buffer_max);
+    }
 
     virtual void add_stats(uint64_t *onodes, uint64_t *extents,
 			   uint64_t *blobs,
@@ -1227,7 +1248,8 @@ public:
       _audit("_touch_buffer end");
     }
 
-    void _trim(uint64_t onode_max, uint64_t buffer_max) override;
+    void _trim_onodes_to(uint64_t max) override;
+    void _trim_buffers_to(uint64_t max) override;
 
     void add_stats(uint64_t *onodes, uint64_t *extents,
 		   uint64_t *blobs,
@@ -1322,7 +1344,8 @@ public:
       _audit("_touch_buffer end");
     }
 
-    void _trim(uint64_t onode_max, uint64_t buffer_max) override;
+    void _trim_onodes_to(uint64_t max) override;
+    void _trim_buffers_to(uint64_t max) override;
 
     void add_stats(uint64_t *onodes, uint64_t *extents,
 		   uint64_t *blobs,
@@ -2158,7 +2181,7 @@ private:
 
   private:
     void _adjust_cache_settings();
-    void _trim_shards(bool interval_stats);
+    void _resize_shards(bool interval_stats);
     void _tune_cache_size(bool interval_stats);
     void _balance_cache(
         const std::list<std::shared_ptr<PriorityCache::PriCache>>& caches);


### PR DESCRIPTION
Signed-off-by: Mark Nelson <mnelson@redhat.com>

This PR changes the way that the bluestore cache works to trim onodes and buffers immediately after insertion rather than in a loop inside the mempool thread.  Arguably this still allows the caches to slightly exceed their limits (though by a much smaller amount), however it was easier to implement this way vs freeing the space upfront.  It still results in tighter control of memory, especially for buffer cache.  

Because the cache lock is no longer being taken and held periodically in the mempool thread and instead is being held longer in other threads (fewer locks/unlocks overall), this change has significant effects on bluestore performance and thread/lock contention.  Specifically, performance improved by about 20-25% during a highly concurrent 4K librbd random write workload to an OSD backed by an Intel P3700 NVMe drive:

![FIO+LibRBD 4K RandWrite High-Concurrency (Single-OSD)](https://user-images.githubusercontent.com/1286295/59551600-b5f6b000-8f41-11e9-87f9-dfeef4a75f16.png)

Tail latency (as recorded by fio) also improved dramatically:

| Latency (ms) | Master | wip-bs-cache-evict |
| -- | -- | -- |
| min | 0.305 | 0.308 |
| avg | 8.934625 | 7.094215 |
| 99.9th percentile | 86 | 71 |
| 99.99th percentile | 334 | 113 |
| max | 1142.1 | 571.779 |

Buffer memory is kept on a tighter leash as well.  An interesting side effect is that the priority cache is more aggressively limiting the aggregate cache size to keep total OSD memory usage under control with the new code.  Usually this has a negative effect on performance because a greater percentage of onode reads will have to come from rocksdb block_cache or disk.  In prior testing however it's been observed that higher random write throughput can result in worse cache-memory efficiency which may explain what we are seeing here.  #27705 avoids double caching onodes in the block_cache which may have an even more dramatic effect when combined with this PR.

![OSD Memory Usage during Pre-Fill and 4KB RandWrite Test (Master 2Q Trial 0)](https://user-images.githubusercontent.com/1286295/59551489-d7569c80-8f3f-11e9-9f39-890f6358ddb9.png)
![OSD Memory Usage during Pre-Fill and 4KB RandWrite Test (wip-bs-cache-evict 2Q Trial 0)](https://user-images.githubusercontent.com/1286295/59551488-d7569c80-8f3f-11e9-8bca-c8b1dc3a57ac.png)

To help explain the lower latency and improved performance, gdbpmp was used to look at lock contention behavior before and after the new code was applied.  In master, significant time is spent in the mempool_thread holding the cache lock while performing trim (and for relatively long periods of time):

```
      + 22.90% BlueStore::MempoolThread::_trim_shards
      | + 22.90% BlueStore::Cache::trim
      |   + 22.90% BlueStore::TwoQCache::_trim
      |     + 20.70% BlueStore::Onode::put
      |     | + 20.40% ~Onode
```

However in wip-bs-cache-evict, onode-specific trim is spread across every tp_osd_tp thread and happens more often in shorter bursts:
```
          |     |   |   |   |     + 0.60% BlueStore::TwoQCache::_trim_onodes_to
        | |   |     |   |   | | | + 1.20% BlueStore::TwoQCache::_trim_onodes_to
          |         |   |   | |   + 1.10% BlueStore::TwoQCache::_trim_onodes_to
        | |   | |   | | | | | |   + 0.60% BlueStore::TwoQCache::_trim_onodes_to
          |       | |   |   | | | + 0.70% BlueStore::TwoQCache::_trim_onodes_to
        | |   | | | |   |   | | | + 0.60% BlueStore::TwoQCache::_trim_onodes_to
          |   | |   |   |         + 0.80% BlueStore::TwoQCache::_trim_onodes_to
          |   |     |   |   | | | + 1.80% BlueStore::TwoQCache::_trim_onodes_to
          |         |   | |   |   + 2.10% BlueStore::TwoQCache::_trim_onodes_to
        | |   |     |   |   | |   + 1.20% BlueStore::TwoQCache::_trim_onodes_to
          |   | |   |   |     | | + 1.60% BlueStore::TwoQCache::_trim_onodes_to
          |   |     |   |   | | | + 2.30% BlueStore::TwoQCache::_trim_onodes_to
          |     | | |   |     |   + 1.90% BlueStore::TwoQCache::_trim_onodes_to
        | |   | | | |   |   | | | + 2.60% BlueStore::TwoQCache::_trim_onodes_to
          |     | | |   |     |   + 1.30% BlueStore::TwoQCache::_trim_onodes_to
```

For example, in the new code, onode trim primarily happens when BlueStore::getattr is called:

```
          |     |   |   | + 1.60% BlueStore::getattr
          |     |   |   |   + 1.50% BlueStore::Collection::get_onode
          |     |   |   |   | + 0.90% BlueStore::OnodeSpace::lookup
          |     |   |   |   | | + 0.80% lock_guard
          |     |   |   |   | | | + 0.80% lock
          |     |   |   |   | | |   + 0.80% __gthread_recursive_mutex_lock
          |     |   |   |   | | |     + 0.80% __gthread_mutex_lock
          |     |   |   |   | | |       + 0.80% pthread_mutex_lock
          |     |   |   |   | | |         + 0.80% _L_lock_870
          |     |   |   |   | | |           + 0.80% __lll_lock_wait
          |     |   |   |   | | + 0.10% BlueStore::TwoQCache::_touch_onode
          |     |   |   |   | + 0.60% BlueStore::OnodeSpace::add
          |     |   |   |   |   + 0.60% _trim_onodes
          |     |   |   |   |     + 0.60% BlueStore::TwoQCache::_trim_onodes_to
```

In the original code the mempool thread _trim loop clears both onodes and buffers, but in the new code buffers are trimmed independently of onodes.  Some of this is distributed across the tp_osd_tp threads:

```
          |     |   | |   |   | |       |       + 0.20% BlueStore::TwoQCache::_trim_buffers_to
        | |   |     | | | |   | | | |   | | |   + 0.60% BlueStore::TwoQCache::_trim_buffers_to
          |         | | | |   | |   |   |   |   + 0.30% BlueStore::TwoQCache::_trim_buffers_to
        | |   | |   | | | | | | | | |   |       + 0.30% BlueStore::TwoQCache::_trim_buffers_to
          |       | | | | |   | |   |   |   | | + 0.60% BlueStore::TwoQCache::_trim_buffers_to
        | |   | | | | | | |   | |   |   | |     + 0.30% BlueStore::TwoQCache::_trim_buffers_to
          |   | |   | | | |   | |   |   |       + 0.40% BlueStore::TwoQCache::_trim_buffers_to
          |   |     | |   |   | |   |   | | |   + 0.20% BlueStore::TwoQCache::_trim_buffers_to
          |         | |   |   | |       |       + 0.20% BlueStore::TwoQCache::_trim_buffers_to
        | |   |     | |   |   | |   | | |   |   + 0.10% BlueStore::TwoQCache::_trim_buffers_to
          |   | |   | |   |   | |   |   |       + 0.30% BlueStore::TwoQCache::_trim_buffers_to
          |   |     | | | |   | |   |   |   |   + 0.50% BlueStore::TwoQCache::_trim_buffers_to
          |     | | | | | |   | |   |   |   | | + 0.20% BlueStore::TwoQCache::_trim_buffers_to
        | |   | | | | |   |   | |   |   | | |   + 0.10% BlueStore::TwoQCache::_trim_buffers_to
        | |   | |   | | | | | | |   |   | | |   + 0.30% BlueStore::TwoQCache::_trim_buffers_to
          |     | | | | | |   | |   |   |   |   + 0.40% BlueStore::TwoQCache::_trim_buffers_to
```

While a significant portion of it now happens in bstore_kv_final during _finish_write.  This may be concerning on the surface, but finish_write would have had to wait for the mempool thread to release the cache lock to complete writes anyway as we will see below.

```
        | | | | | + 7.00% BlueStore::TwoQCache::_trim_buffers_to
```

While performance is significantly higher in wip-bs-cache-evict for 4K random writes, more aggregate time is also spent waiting on the cache lock to perform onode lookups. It's possible that this could be due to additional time spent in trim walking over pinned cache items (since onode/buffer trim is called more often now).  It's also possible this is simply due to the fact that we are writing faster and have more opportunities for onode reads to wait on the lock.  It may be worth testing additional cache shards to see if that helps.

Average time the tp_osd_tp threads spent contending on the cache lock during onode lookup:
```
master: 0.89%
wip-bs-cache-evict: 1.90%
```

On the other hand, this PR results in a dramatic reduction in time spent contending on the cache lock in bstore_kv_final during SharedBlob::finish_write.  

master
```
        + 41.40% BlueStore::_txc_state_proc
        | + 31.30% BlueStore::_txc_finish
        | | + 25.20% BlueStore::SharedBlob::finish_write
        | | | + 23.20% lock_guard
        | | | | + 23.20% lock
```
wip-bs-cache-evict:
```
        + 36.30% BlueStore::_txc_state_proc
        | + 25.70% BlueStore::_txc_finish
        | | + 18.90% BlueStore::SharedBlob::finish_write
        | | | + 10.00% lock_guard
        | | | | + 10.00% lock
```

Finish_write no longer needs to wait for (relatively) long periods of time for the mempool thread to perform large onode/buffer cache evictions which drive tail latency up.  Future options to further improve performance may include finer grained locking (independent onode/buffer locks?  More shards?).


- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

