### PR TITLE
vstart.sh: Fix problem that all extra_conf got merged into single line.

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -360,7 +360,8 @@ case $1 in
         shift
         ;;
     -o )
-        extra_conf="$extra_conf	$2"
+        extra_conf="$extra_conf	$2
+"
         shift
         ;;
     --cache )


### PR DESCRIPTION
This effectively made it impossible to add more then 1 "-o" extra_conf parameters.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>
