### PR TITLE
rgw: asio_frontend: switch to the try-catch version of ioc::run

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -638,7 +638,11 @@ int AsioFrontend::run()
       // request warnings on synchronous librados calls in this thread
       is_asio_thread = true;
       boost::system::error_code ec;
-      context.run(ec);
+      try {
+        context.run();
+      } catch (std::exception& e) {
+        ldout(cct,0) << "ERROR: io_context.run() threw exception: " << e.what() << dendl;
+      }
     });
   }
   return 0;


### PR DESCRIPTION
Since io_context.run(ec) is deprecated
https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/io_context/run/overload2.html
and may be removed in a future version of asio, switch to the exception throwing
overload. This addresses the intermittent crash seen in the java s3 tests and
the ocassional crash seen in high load scenarios where clients eventually drop
connections

Fixes: http://tracker.ceph.com/issues/40018
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

