### PR TITLE
osd: flush object's content to preserve original content when dedup is enabled

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -471,6 +471,7 @@ enum {
 	CEPH_OSD_OP_FLAG_FADVISE_NOCACHE   = 0x40, /* data will be accessed only once by this client */
 	CEPH_OSD_OP_FLAG_WITH_REFERENCE   = 0x80, /* need reference couting */
 	CEPH_OSD_OP_FLAG_BYPASS_CLEAN_CACHE = 0x100, /* bypass ObjectStore cache, mainly for deep-scrub */
+	CEPH_OSD_OP_FLAG_USING_ORIG_CONTENT   = 0x200, /* a new oid will be generated via using original content */
 };
 
 #define EOLDSNAPC    85  /* ORDERSNAP flag set; writer has old snapc*/


### PR DESCRIPTION
Let’s assume that we have an object named foo = "abcdefgh" in metadata pool,
and two chunks exist in chunk pool, chunk_A = "1234" and chunk_B = "ABCD".
Then we do

$ ceph osd pool set mp fingerprint_algorithm sha1  --yes-i-really-mean-it

$ rados -p mp set-chunk foo 0 4 --target-pool cp chunk_A 0 --with-reference

$ rados -p mp set-chunk foo 4 4 --target-pool cp chunk_B 0 --with-reference

If we then try to read foo, we get "1234ABCD" instead of "abcdefgh".
The data stored in the original foo is completely lost.
This is our intended design of set-chunk. 

However, if we use dedup, unlike normal set-chunk, new objects will be created 
in the chunk pool ( OIDs are H(1234) and H(ABCD) ).
This seems a little bit complex. Some users might want to dedup original object's content
directly. For example, 

$ ceph osd pool set mp fingerprint_algorithm sha1  --yes-i-really-mean-it

$ rados -p mp set-chunk foo 0 4 --target-pool cp --with-reference --using-orig-content

This command makes a new OID using original object's content ("abcd") and
we don't need to configure chunk_A.


Signed-off-by: Myoungwon Oh <omwmw@sk.com>
Signed-off-by: Tsung-Ju (Andy) Lii <usefulalgorithm@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

