### PR TITLE
mgr/dashboard: Ensure E2E tests can be run independently

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -184,6 +184,29 @@ Note::
    In case you have a somewhat particular environment, you might need to adapt
    `protractor.conf.js` to point to the appropriate destination.
 
+Making code reuseable
+"""""""""""""""""""""
+
+In order to make some code reuseable, you just need to put it in a derived
+class of the ``PageHelper``. If you create a new class derived from the
+``PageHelper``, please also register it in the ``Helper`` class, so that it can
+automatically be used by all other classes. To do so, you just need to create a
+new attribute on the ``Helper`` class and ensure it's instantiated in the
+constructor of the ``Helper`` class.
+
+.. code:: TypeScript
+
+   class Helper {
+      // ...
+      pools: PoolPageHelper;
+
+      constructor() {
+         this.pools = new PoolPageHelper();
+      }
+
+      // ...
+   }
+
 Further Help
 ~~~~~~~~~~~~
 

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -139,13 +139,13 @@ There are a few ways how you can try to resolve this:
 Running End-to-End Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-We use `Protractor <http://www.protractortest.org/>`__ to run our frontend e2e
+We use `Protractor <http://www.protractortest.org/>`__ to run our frontend E2E
 tests.
 
 Our ``run-frontend-e2e-tests.sh`` script will check if Chrome or Docker is
 installed and run the tests if either is found.
 
-Start all frontend e2e tests by running::
+Start all frontend E2E tests by running::
 
   $ ./run-frontend-e2e-tests.sh
 
@@ -173,12 +173,16 @@ Note:
 Writing End-to-End Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-When writing e2e tests you don't want to recompile every time from scratch to
-try out if your test has succeeded. As usual you have your development server
-open (``npm start``) which already has compiled all files. To attach
-`Protractor <http://www.protractortest.org/>`__ to this process, instead of
-spinning up it's own server, you can use ``npm run e2e -- --dev-server-target``
-or just ``npm run e2e:dev`` which is equivalent.
+When writing E2E tests, it is not necessary to compile the frontend code on
+each change of the test files. When your development environment is running
+(``npm start``), you can point Protractor to just use this environment.  To
+attach `Protractor <http://www.protractortest.org/>`__ to this process, run
+``npm run e2e:dev``.
+
+Note::
+
+   In case you have a somewhat particular environment, you might need to adapt
+   `protractor.conf.js` to point to the appropriate destination.
 
 Further Help
 ~~~~~~~~~~~~

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/images.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/images.e2e-spec.ts
@@ -18,17 +18,17 @@ describe('Images page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Images');
+      expect(ImagesPage.getBreadcrumbText()).toEqual('Images');
     });
 
     it('should show three tabs', () => {
-      expect(Helper.getTabsCount()).toEqual(3);
+      expect(ImagesPage.getTabsCount()).toEqual(3);
     });
 
     it('should show text for all tabs', () => {
-      expect(Helper.getTabText(0)).toEqual('Images');
-      expect(Helper.getTabText(1)).toEqual('Trash');
-      expect(Helper.getTabText(2)).toEqual('Overall Performance');
+      expect(ImagesPage.getTabText(0)).toEqual('Images');
+      expect(ImagesPage.getTabText(1)).toEqual('Trash');
+      expect(ImagesPage.getTabText(2)).toEqual('Overall Performance');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/images.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/images.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class ImagesPage {
-  navigateTo() {
-    return browser.get('/#/block/rbd');
-  }
+export class ImagesPage extends PageHelper {
+  pages = { index: '/#/block/rbd' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/iscsi.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/iscsi.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Iscsi Page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Overview');
+      expect(IscsiPage.getBreadcrumbText()).toEqual('Overview');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/iscsi.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/iscsi.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class IscsiPage {
-  navigateTo() {
-    return browser.get('/#/block/iscsi');
-  }
+export class IscsiPage extends PageHelper {
+  pages = { index: '/#/block/iscsi/overview' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/mirroring.e2e-spec.ts
@@ -18,17 +18,17 @@ describe('Mirroring page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Mirroring');
+      expect(MirroringPage.getBreadcrumbText()).toEqual('Mirroring');
     });
 
     it('should show three tabs', () => {
-      expect(Helper.getTabsCount()).toEqual(3);
+      expect(MirroringPage.getTabsCount()).toEqual(3);
     });
 
     it('should show text for all tabs', () => {
-      expect(Helper.getTabText(0)).toEqual('Issues');
-      expect(Helper.getTabText(1)).toEqual('Syncing');
-      expect(Helper.getTabText(2)).toEqual('Ready');
+      expect(MirroringPage.getTabText(0)).toEqual('Issues');
+      expect(MirroringPage.getTabText(1)).toEqual('Syncing');
+      expect(MirroringPage.getTabText(2)).toEqual('Ready');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/mirroring.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/mirroring.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class MirroringPage {
-  navigateTo() {
-    return browser.get('/#/block/mirroring');
-  }
+export class MirroringPage extends PageHelper {
+  pages = { index: '/#/block/mirroring' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/alerts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/alerts.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Alerts page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Alerts');
+      expect(AlertsPage.getBreadcrumbText()).toEqual('Alerts');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/alerts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/alerts.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class AlertsPage {
-  navigateTo() {
-    return browser.get('/#/alerts');
-  }
+export class AlertsPage extends PageHelper {
+  pages = { index: '/#/alerts' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Configuration page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Configuration');
+      expect(ConfigurationPage.getBreadcrumbText()).toEqual('Configuration');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class ConfigurationPage {
-  navigateTo() {
-    return browser.get('/#/configuration');
-  }
+export class ConfigurationPage extends PageHelper {
+  pages = { index: '/#/configuration' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/crush-map.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/crush-map.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('CRUSH map page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('CRUSH map');
+      expect(CrushMapPage.getBreadcrumbText()).toEqual('CRUSH map');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/crush-map.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/crush-map.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class CrushMapPage {
-  navigateTo() {
-    return browser.get('/#/crush-map');
-  }
+export class CrushMapPage extends PageHelper {
+  pages = { index: '/#/crush-map' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.e2e-spec.ts
@@ -18,19 +18,19 @@ describe('Hosts page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Hosts');
+      expect(HostsPage.getBreadcrumbText()).toEqual('Hosts');
     });
 
     it('should show two tabs', () => {
-      expect(Helper.getTabsCount()).toEqual(2);
+      expect(HostsPage.getTabsCount()).toEqual(2);
     });
 
     it('should show hosts list tab at first', () => {
-      expect(Helper.getTabText(0)).toEqual('Hosts List');
+      expect(HostsPage.getTabText(0)).toEqual('Hosts List');
     });
 
     it('should show overall performance as a second tab', () => {
-      expect(Helper.getTabText(1)).toEqual('Overall Performance');
+      expect(HostsPage.getTabText(1)).toEqual('Overall Performance');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class HostsPage {
-  navigateTo() {
-    return browser.get('/#/hosts');
-  }
+export class HostsPage extends PageHelper {
+  pages = { index: '/#/hosts' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
@@ -18,19 +18,19 @@ describe('Logs page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Logs');
+      expect(LogsPage.getBreadcrumbText()).toEqual('Logs');
     });
 
     it('should show two tabs', () => {
-      expect(Helper.getTabsCount()).toEqual(2);
+      expect(LogsPage.getTabsCount()).toEqual(2);
     });
 
     it('should show cluster logs tab at first', () => {
-      expect(Helper.getTabText(0)).toEqual('Cluster Logs');
+      expect(LogsPage.getTabText(0)).toEqual('Cluster Logs');
     });
 
     it('should show audit logs as a second tab', () => {
-      expect(Helper.getTabText(1)).toEqual('Audit Logs');
+      expect(LogsPage.getTabText(1)).toEqual('Audit Logs');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.po.ts
@@ -1,9 +1,8 @@
 import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
 browser.ignoreSynchronization = true;
 
-export class LogsPage {
-  navigateTo() {
-    return browser.get('/#/logs');
-  }
+export class LogsPage extends PageHelper {
+  pages = { index: '/#/logs' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/mgr-modules.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/mgr-modules.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Manager modules page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Manager modules');
+      expect(ManagerModulesPage.getBreadcrumbText()).toEqual('Manager modules');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/mgr-modules.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/mgr-modules.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class ManagerModulesPage {
-  navigateTo() {
-    return browser.get('/#/mgr-modules');
-  }
+export class ManagerModulesPage extends PageHelper {
+  pages = { index: '/#/mgr-modules' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Monitors page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Monitors');
+      expect(MonitorsPage.getBreadcrumbText()).toEqual('Monitors');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class MonitorsPage {
-  navigateTo() {
-    return browser.get('/#/monitor');
-  }
+export class MonitorsPage extends PageHelper {
+  pages = { index: '/#/monitor' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.e2e-spec.ts
@@ -18,19 +18,19 @@ describe('OSDs page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('OSDs');
+      expect(OSDsPage.getBreadcrumbText()).toEqual('OSDs');
     });
 
     it('should show two tabs', () => {
-      expect(Helper.getTabsCount()).toEqual(2);
+      expect(OSDsPage.getTabsCount()).toEqual(2);
     });
 
     it('should show OSDs list tab at first', () => {
-      expect(Helper.getTabText(0)).toEqual('OSDs List');
+      expect(OSDsPage.getTabText(0)).toEqual('OSDs List');
     });
 
     it('should show overall performance as a second tab', () => {
-      expect(Helper.getTabText(1)).toEqual('Overall Performance');
+      expect(OSDsPage.getTabText(1)).toEqual('Overall Performance');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class OSDsPage {
-  navigateTo() {
-    return browser.get('/#/osd');
-  }
+export class OSDsPage extends PageHelper {
+  pages = { index: '/#/osd' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/filesystems/filesystems.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/filesystems/filesystems.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Filesystems page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Filesystems');
+      expect(FilesystemsPage.getBreadcrumbText()).toEqual('Filesystems');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/filesystems/filesystems.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/filesystems/filesystems.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class FilesystemsPage {
-  navigateTo() {
-    return browser.get('/#/cephfs');
-  }
+export class FilesystemsPage extends PageHelper {
+  pages = { index: '/#/cephfs' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/helper.po.ts
@@ -1,4 +1,4 @@
-import { $, $$, browser } from 'protractor';
+import { browser } from 'protractor';
 
 export class Helper {
   static EC = browser.ExpectedConditions;
@@ -26,19 +26,5 @@ export class Helper {
 
         expect(browserLog.length).toEqual(0);
       });
-  }
-
-  static getBreadcrumbText() {
-    return $('.breadcrumb-item.active').getText();
-  }
-
-  static getTabText(idx) {
-    return $$('.nav.nav-tabs li')
-      .get(idx)
-      .getText();
-  }
-
-  static getTabsCount() {
-    return $$('.nav.nav-tabs li').count();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/nfs/nfs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/nfs/nfs.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Nfs page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('NFS');
+      expect(NfsPage.getBreadcrumbText()).toEqual('NFS');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/nfs/nfs.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/nfs/nfs.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class NfsPage {
-  navigateTo() {
-    return browser.get('/#/nfs');
-  }
+export class NfsPage extends PageHelper {
+  pages = { index: '/#/nfs' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/page-helper.po.ts
@@ -1,0 +1,27 @@
+import { $, $$, browser } from 'protractor';
+
+interface Pages {
+  index: string;
+}
+
+export abstract class PageHelper {
+  pages: Pages;
+
+  static getBreadcrumbText() {
+    return $('.breadcrumb-item.active').getText();
+  }
+
+  static getTabText(idx) {
+    return $$('.nav.nav-tabs li')
+      .get(idx)
+      .getText();
+  }
+
+  static getTabsCount() {
+    return $$('.nav.nav-tabs li').count();
+  }
+
+  navigateTo(page = null) {
+    return browser.get(this.pages[page || 'index']);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
@@ -1,11 +1,11 @@
 import { Helper } from '../helper.po';
-import { PoolsPage } from './pools.po';
+import { PoolPageHelper } from './pools.po';
 
 describe('Pools page', () => {
-  let page: PoolsPage;
+  let page: PoolPageHelper;
 
   beforeAll(() => {
-    page = new PoolsPage();
+    page = new PoolPageHelper();
   });
 
   afterEach(() => {
@@ -18,19 +18,19 @@ describe('Pools page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Pools');
+      expect(PoolPageHelper.getBreadcrumbText()).toEqual('Pools');
     });
 
     it('should show two tabs', () => {
-      expect(Helper.getTabsCount()).toEqual(2);
+      expect(PoolPageHelper.getTabsCount()).toEqual(2);
     });
 
     it('should show pools list tab at first', () => {
-      expect(Helper.getTabText(0)).toEqual('Pools List');
+      expect(PoolPageHelper.getTabText(0)).toEqual('Pools List');
     });
 
     it('should show overall performance as a second tab', () => {
-      expect(Helper.getTabText(1)).toEqual('Overall Performance');
+      expect(PoolPageHelper.getTabText(1)).toEqual('Overall Performance');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.po.ts
@@ -1,7 +1,8 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class PoolsPage {
-  navigateTo() {
-    return browser.get('/#/pool');
-  }
+export class PoolPageHelper extends PageHelper {
+  pages = {
+    index: '/#/pool',
+    create: '/#/pool/create'
+  };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('RGW buckets page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Buckets');
+      expect(BucketsPage.getBreadcrumbText()).toEqual('Buckets');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class BucketsPage {
-  navigateTo() {
-    return browser.get('/#/rgw/bucket');
-  }
+export class BucketsPage extends PageHelper {
+  pages = { index: '/#/rgw/bucket' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.e2e-spec.ts
@@ -18,19 +18,19 @@ describe('RGW daemons page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Daemons');
+      expect(DaemonsPage.getBreadcrumbText()).toEqual('Daemons');
     });
 
     it('should show two tabs', () => {
-      expect(Helper.getTabsCount()).toEqual(2);
+      expect(DaemonsPage.getTabsCount()).toEqual(2);
     });
 
     it('should show daemons list tab at first', () => {
-      expect(Helper.getTabText(0)).toEqual('Daemons List');
+      expect(DaemonsPage.getTabText(0)).toEqual('Daemons List');
     });
 
     it('should show overall performance as a second tab', () => {
-      expect(Helper.getTabText(1)).toEqual('Overall Performance');
+      expect(DaemonsPage.getTabText(1)).toEqual('Overall Performance');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class DaemonsPage {
-  navigateTo() {
-    return browser.get('/#/rgw/daemon');
-  }
+export class DaemonsPage extends PageHelper {
+  pages = { index: '/#/rgw/daemon' };
 }

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('RGW users page', () => {
     });
 
     it('should open and show breadcrumb', () => {
-      expect(Helper.getBreadcrumbText()).toEqual('Users');
+      expect(UsersPage.getBreadcrumbText()).toEqual('Users');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.po.ts
@@ -1,7 +1,5 @@
-import { browser } from 'protractor';
+import { PageHelper } from '../page-helper.po';
 
-export class UsersPage {
-  navigateTo() {
-    return browser.get('/#/rgw/user');
-  }
+export class UsersPage extends PageHelper {
+  pages = { index: '/#/rgw/user' };
 }


### PR DESCRIPTION
Introduces the PageHelper.

- Reads class attributes from Helpers to reduce boilerplace code for
  navigation.
- The PageHelper is supposed to be the new class for code that's reused
  across all Helpers.
- The Helper class is by now meant to be used for non page specific
  helper code, like used in the `checkConsole` method.
- The Helper class will act as central registry to enable all other
  tests to use helper functions of all derived PageHelper tests.

  Example (not contained in this PR!):

  `Helper.pools.create('foobar', ...);`

  This enables the RBD test to create a pool by itself, which makes it independent of the pools test and eventually allows us to run multiple browser instances simultaneously.

Fixes: http://tracker.ceph.com/issues/40397

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

