### PR TITLE
cmake: set empty INSTALL_RPATH on crypto shared libs

### DIFF
--- a/src/crypto/isa-l/CMakeLists.txt
+++ b/src/crypto/isa-l/CMakeLists.txt
@@ -31,5 +31,8 @@ endif(HAVE_GOOD_YASM_ELF64)
 
 add_library(ceph_crypto_isal SHARED ${isal_crypto_plugin_srcs})
 target_include_directories(ceph_crypto_isal PRIVATE ${isal_dir}/include)
-set_target_properties(ceph_crypto_isal PROPERTIES VERSION 1.0.0 SOVERSION 1)
+set_target_properties(ceph_crypto_isal PROPERTIES
+  VERSION 1.0.0
+  SOVERSION 1
+  INSTALL_RPATH "")
 install(TARGETS ceph_crypto_isal DESTINATION ${crypto_plugin_dir})

--- a/src/crypto/openssl/CMakeLists.txt
+++ b/src/crypto/openssl/CMakeLists.txt
@@ -7,4 +7,5 @@ set(openssl_crypto_plugin_srcs
 add_library(ceph_crypto_openssl SHARED ${openssl_crypto_plugin_srcs})
 target_link_libraries(ceph_crypto_openssl PRIVATE crypto)
 add_dependencies(crypto_plugins ceph_crypto_openssl)
+set_target_properties(ceph_crypto_openssl PROPERTIES INSTALL_RPATH "")
 install(TARGETS ceph_crypto_openssl DESTINATION ${crypto_plugin_dir})


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40398
Signed-off-by: Nathan Cutler <ncutler@suse.com>