### PR TITLE
nautilus: qa: use curl in wait_for_radosgw() in util/rgw.py

### DIFF
--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -140,7 +140,8 @@ def start_rgw(ctx, config, clients):
         endpoint = ctx.rgw.role_endpoints[client]
         url = endpoint.url()
         log.info('Polling {client} until it starts accepting connections on {url}'.format(client=client, url=url))
-        wait_for_radosgw(url)
+        (remote,) = ctx.cluster.only(client).remotes.iterkeys()
+        wait_for_radosgw(url, remote)
 
     try:
         yield

--- a/qa/tasks/rgw_multisite.py
+++ b/qa/tasks/rgw_multisite.py
@@ -226,7 +226,7 @@ class Gateway(multisite.Gateway):
         """ (re)start the daemon """
         self.daemon.restart()
         # wait until startup completes
-        wait_for_radosgw(self.endpoint())
+        wait_for_radosgw(self.endpoint(), self.remote)
 
     def stop(self):
         """ stop the daemon """


### PR DESCRIPTION
backport tracker: http://tracker.ceph.com/issues/40346