### PR TITLE
Wip rocksdb track iterator

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -581,6 +581,89 @@ public:
   }
 };
 
+class InspectHook : public AdminSocketHook {
+private:
+  std::map<std::string, std::function<bool(Formatter*)>, std::less<> > instances;
+public:
+  bool hook(const std::string&& id, std::function<bool(Formatter*)> f) {
+    if (instances.count(id) == 1)
+      return false;
+    instances.emplace(id, f);
+    return true;
+  }
+  bool unhook(std::string_view id) {
+    auto it = instances.find(id);
+    if (it == instances.cend())
+      return false;
+    instances.erase(it);
+    return true;
+  }
+  bool empty() {
+    return instances.empty();
+  }
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+              std::string_view format, bufferlist& out) override {
+    stringstream ss;
+    Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
+    if (instances.size() != 1)
+      f->open_array_section("instances");
+    bool b = true;
+    for (auto &it: instances) {
+      f->open_object_section("instance");
+      f->dump_string("id", it.first);
+      b = it.second(f);
+      if (!b)
+        break;
+      f->close_section();
+    }
+
+    if (b) {
+      if (instances.size() != 1)
+        f->close_section();
+      f->flush(ss);
+      out.append(ss);
+    }
+    delete f;
+    return b;
+  }
+};
+
+bool AdminSocket::register_inspect(std::string_view command_path,
+                                   std::string_view id,
+                                   std::function<bool(Formatter*)> f)
+{
+  std::unique_lock l(inspect_lock);
+  auto it = inspects.find(command_path);
+  InspectHook* h;
+  if (it != inspects.cend()) {
+    h = it->second;
+  } else {
+    h = new InspectHook();
+    inspects.emplace(command_path, h);
+    int r = register_command(command_path, command_path, h, "debug info slot");
+    ceph_assert(r == 0);
+  }
+  return h->hook(std::string(id), f);
+}
+
+bool AdminSocket::unregister_inspect(std::string_view command_path,
+                                     std::string_view id)
+{
+  std::unique_lock l(inspect_lock);
+  auto it = inspects.find(command_path);
+  if (it == inspects.cend())
+    return false;
+  InspectHook* h = it->second;
+  h->unhook(id);
+  if (h->empty()) {
+    int r = unregister_command(command_path);
+    ceph_assert(r == 0);
+    delete h;
+    inspects.erase(it);
+  }
+  return true;
+}
+
 bool AdminSocket::init(const std::string& path)
 {
   ldout(m_cct, 5) << "init " << path << dendl;

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -37,6 +37,7 @@ public:
 		    std::string_view format, ceph::buffer::list& out) = 0;
   virtual ~AdminSocketHook() {}
 };
+class InspectHook;
 
 class AdminSocket
 {
@@ -95,6 +96,39 @@ public:
   void chown(uid_t uid, gid_t gid);
   void chmod(mode_t mode);
 
+  /**
+   * register an inspection probe on admin socket command
+   *
+   * Inspection probe is a simplified admin command that
+   * does not accept arguments. It extracts information in
+   * from running instance and returns it in formatted form.
+   * It is acceptable to register multiple probes under same command_path
+   * but 'id' must be different.
+   * In such case all registered probes are invoked, in undetermined order.
+   *
+   * @param command_path command string
+   * @param id probe specific identification
+   * @param function probe to invoke
+   *
+   * @return true for success, false otherwise
+   */
+  bool register_inspect(std::string_view command_path,
+                        std::string_view id,
+                        std::function<bool(Formatter*)> function);
+
+  /**
+   * unregister an inspection probe
+   *
+   * Remove previously registered probe.
+   *
+   * @param command_path command string
+   * @param id probe specific identification
+   *
+   * @return true for success, false otherwise
+   */
+
+  bool unregister_inspect(std::string_view command_path,
+                          std::string_view id);
 private:
 
   void shutdown();
@@ -134,6 +168,9 @@ private:
   };
 
   std::map<std::string, hook_info, std::less<>> hooks;
+
+  std::mutex inspect_lock;
+  std::map<std::string, InspectHook*, std::less<> > inspects;
 
   friend class AdminSocketTest;
   friend class HelpHook;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -44,6 +44,8 @@ enum {
   l_rocksdb_write_memtable_time,
   l_rocksdb_write_delay_time,
   l_rocksdb_write_pre_and_post_process_time,
+  l_rocksdb_oldest_active_iterator,
+  l_rocksdb_iterator_age,
   l_rocksdb_last,
 };
 
@@ -116,6 +118,22 @@ class RocksDBStore : public KeyValueDB {
   void compact_range_async(const string& start, const string& end);
 
 public:
+  struct TrackedIterator {
+    rocksdb::Iterator* iterator;
+    utime_t created;
+    TrackedIterator(rocksdb::Iterator* iterator,
+		    utime_t& created)
+    : iterator(iterator), created(created) { }
+  };
+private:
+  static std::mutex iterator_lock;
+  static std::vector<uint64_t> iterators_histogram; //in miliseconds [0]=<0..1), [1]=<1..2), [2]=<2..4)
+  static std::list<TrackedIterator> tracked_iterators;
+  std::list<TrackedIterator>::iterator iterator_created(rocksdb::Iterator* it);
+  void iterator_deleted(std::list<TrackedIterator>::iterator);
+  friend class CFIteratorImpl;
+  static bool dump_iterators(Formatter* f);
+public:
   /// compact the underlying rocksdb store
   bool compact_on_mount;
   bool disableWAL;
@@ -146,24 +164,7 @@ public:
     compact_range_async(combine_strings(prefix, start), combine_strings(prefix, end));
   }
 
-  RocksDBStore(CephContext *c, const string &path, map<string,string> opt, void *p) :
-    cct(c),
-    logger(NULL),
-    path(path),
-    kv_options(opt),
-    priv(p),
-    db(NULL),
-    env(static_cast<rocksdb::Env*>(p)),
-    dbstats(NULL),
-    compact_queue_lock("RocksDBStore::compact_thread_lock"),
-    compact_queue_stop(false),
-    compact_thread(this),
-    compact_on_mount(false),
-    disableWAL(false),
-    enable_rmrange(cct->_conf->rocksdb_enable_rmrange),
-    max_items_rmrange(cct->_conf.get_val<uint64_t>("rocksdb_max_items_rmrange"))
-  {}
-
+  RocksDBStore(CephContext *c, const string &path, map<string,string> opt, void *p);
   ~RocksDBStore() override;
 
   static bool check_omap_dir(string &omap_dir);
@@ -358,14 +359,29 @@ public:
     bufferlist *out) override;
 
 
+  class RocksDBWholeSpaceIteratorImpl;
+  class IteratorTracker;
+  friend class IteratorTracker;
+
+  class IteratorTracker {
+    RocksDBStore& db;
+    std::list<TrackedIterator>::iterator it_it;
+  public:
+    IteratorTracker(RocksDBStore& db, rocksdb::Iterator* it) : db(db) {
+      it_it = db.iterator_created(it);
+    }
+    ~IteratorTracker() {
+      db.iterator_deleted(it_it);
+    }
+  };
+
   class RocksDBWholeSpaceIteratorImpl :
-    public KeyValueDB::WholeSpaceIteratorImpl {
+    public KeyValueDB::WholeSpaceIteratorImpl, public IteratorTracker {
   protected:
     rocksdb::Iterator *dbiter;
   public:
-    explicit RocksDBWholeSpaceIteratorImpl(rocksdb::Iterator *iter) :
-      dbiter(iter) { }
-    //virtual ~RocksDBWholeSpaceIteratorImpl() { }
+    explicit RocksDBWholeSpaceIteratorImpl(RocksDBStore& db, rocksdb::Iterator *iter) :
+      IteratorTracker(db, iter), dbiter(iter) { }
     ~RocksDBWholeSpaceIteratorImpl() override;
 
     int seek_to_first() override;


### PR DESCRIPTION
This pull request provides simple tool to check whether we create RocksDB iterators that became stale and influence ability to compact db properly.
It is related to https://bugzilla.redhat.com/show_bug.cgi?id=1600138, "Spillover of RocksDB to slow device".
It is based on now stale https://github.com/aclamk/ceph/tree/wip-info-admin-socket. 