### PR TITLE
os/memstore, crimson/os: introduce memstore_debug_omit_block_device_write

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -891,6 +891,7 @@ OPTION(osd_discard_disconnected_ops, OPT_BOOL)
 OPTION(memstore_device_bytes, OPT_U64)
 OPTION(memstore_page_set, OPT_BOOL)
 OPTION(memstore_page_size, OPT_U64)
+OPTION(memstore_debug_omit_block_device_write, OPT_BOOL)
 
 OPTION(bdev_debug_inflight_ios, OPT_BOOL)
 OPTION(bdev_inject_crash, OPT_INT)  // if N>0, then ~ 1/N IOs will complete before we crash on flush.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4107,6 +4107,11 @@ std::vector<Option> get_global_options() {
     .set_default(64_K)
     .set_description(""),
 
+    Option("memstore_debug_omit_block_device_write", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .add_see_also("bluestore_debug_omit_block_device_write")
+    .set_description("write metadata only"),
+
     Option("objectstore_blackhole", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description(""),

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -1045,7 +1045,7 @@ int MemStore::_write(const coll_t& cid, const ghobject_t& oid,
     return -ENOENT;
 
   ObjectRef o = c->get_or_create_object(oid);
-  if (len > 0) {
+  if (len > 0 && !cct->_conf->memstore_debug_omit_block_device_write) {
     const ssize_t old_size = o->get_size();
     o->write(offset, bl);
     used_bytes += (o->get_size() - old_size);
@@ -1074,6 +1074,8 @@ int MemStore::_truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size)
   ObjectRef o = c->get_object(oid);
   if (!o)
     return -ENOENT;
+  if (cct->_conf->memstore_debug_omit_block_device_write)
+    return 0;
   const ssize_t old_size = o->get_size();
   int r = o->truncate(size);
   used_bytes += (o->get_size() - old_size);


### PR DESCRIPTION
The rationale is that large-chunk write testing with `cyanstore` or `memstore` can easily exhaust host's memory. The commit approaches the problem by introduction of a debug configurable analogical to existing `bluestore_debug_omit_block_device_write`. Although these stores lack the *block device* concept, the naming schema has been preserved for the sake of similarity.