### PR TITLE
nautilus: cephfs-shell: mkdir error for relative path

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -479,7 +479,8 @@ exists.')
         Create directory.
         """
         for dir_name in args.dirs:
-            path = to_bytes('/' + dir_name)
+            path = to_bytes(dir_name)
+
             if args.mode:
                 permission = int(args.mode, 8)
             else:


### PR DESCRIPTION
http://tracker.ceph.com/issues/39960