### PR TITLE
osd: redundant getattr on ec pool when get_object_context

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10809,13 +10809,23 @@ ObjectContextRef PrimaryLogPG::get_object_context(
   } else {
     dout(10) << __func__ << ": obc NOT found in cache: " << soid << dendl;
     // check disk
+    map<string, bufferlist> attr_cache;
     bufferlist bv;
     if (attrs) {
       auto it_oi = attrs->find(OI_ATTR);
       ceph_assert(it_oi != attrs->end());
       bv = it_oi->second;
     } else {
-      int r = pgbackend->objects_get_attr(soid, OI_ATTR, &bv);
+      int r;
+      if (pool.info.is_erasure()) {
+	r = pgbackend->objects_get_attrs(
+	  soid,
+	  &attr_cache);
+	if (r >= 0)
+	  bv = attr_cache[OI_ATTR];
+      } else {
+	r = pgbackend->objects_get_attr(soid, OI_ATTR, &bv);
+      }
       if (r < 0) {
 	if (!can_create) {
 	  dout(10) << __func__ << ": no obc for soid "
@@ -10869,10 +10879,7 @@ ObjectContextRef PrimaryLogPG::get_object_context(
       if (attrs) {
 	obc->attr_cache = *attrs;
       } else {
-	int r = pgbackend->objects_get_attrs(
-	  soid,
-	  &obc->attr_cache);
-	ceph_assert(r == 0);
+	obc->attr_cache = std::move(attr_cache);
       }
     }
 


### PR DESCRIPTION
synchronous getattr is costly, make ec pool invoke it once will
improve performance.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

