### PR TITLE
rgw: incorrect return value when processing CORS headers

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1409,8 +1409,9 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
 
   /* Custom: */
   origin = orig;
-  op_ret = read_bucket_cors();
-  if (op_ret < 0) {
+  int temp_op_ret = read_bucket_cors();
+  if (temp_op_ret < 0) {
+    op_ret = temp_op_ret;
     return false;
   }
 


### PR DESCRIPTION
- Problem: The length of the response is not the same as the content-length header. When using nginx as a reverse proxy,  nginx rejects the reponse from radosgw due to the incorrect length of the message and returns 502 error.

- Modified incorrect op_ret handling in the generate_cors_headers method.
  For example, RGWGetBucketWebsite returns 404 if there is no website setting
  in the bucket. In this case the variable op_ret is set to some error value.
  However, the current implementation changes the op_ret variable
  to 0(success) when processing the cors header. It causes an invalid http
  response(http body longer than content-length).

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
