### PR TITLE
RGW:1.Using get_val instead of using the deprecated method of getting par…

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1150,7 +1150,7 @@ struct tombstone_entry {
 
 class RGWIndexCompletionManager;
 
-class RGWRados : public AdminSocketHook
+class RGWRados : public AdminSocketHook, public md_config_obs_t
 {
   friend class RGWGC;
   friend class RGWMetaNotifier;
@@ -1246,7 +1246,7 @@ class RGWRados : public AdminSocketHook
 
   // This field represents the number of bucket index object shards
   uint32_t bucket_index_max_shards;
-
+  
   int get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx);
   int get_obj_head_ref(const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_rados_ref *ref);
   int get_system_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref);
@@ -1308,6 +1308,10 @@ public:
                quota_handler(NULL),
                cr_registry(NULL),
                meta_mgr(NULL), data_log(NULL), reshard(NULL) {}
+
+  const char** get_tracked_conf_keys() const override;
+  void handle_conf_change(const ConfigProxy& conf,
+                          const std::set<std::string>& changed) override;
 
   RGWRados& set_use_cache(bool status) {
     use_cache = status;
@@ -1419,6 +1423,7 @@ public:
   int init_svc(bool raw);
   int init_rados();
   int init_complete();
+  void set_max_shards();
   int initialize();
   void finalize();
 

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1001,7 +1001,9 @@ int RGWPutObj_ObjStore::verify_params()
 {
   if (s->length) {
     off_t len = atoll(s->length);
-    if (len > (off_t)(s->cct->_conf->rgw_max_put_size)) {
+    size_t max_put_size;
+    max_put_size = s->cct->_conf.get_val<size_t>("rgw_max_put_size");
+    if (len > max_put_size) {
       return -ERR_TOO_LARGE;
     }
   }
@@ -1056,8 +1058,9 @@ int RGWPutObj_ObjStore::get_data(bufferlist& bl)
 
     ACCOUNTING_IO(s)->set_account(false);
   }
-
-  if ((uint64_t)ofs + len > s->cct->_conf->rgw_max_put_size) {
+  size_t max_put_size;
+  max_put_size = s->cct->_conf.get_val<size_t>("rgw_max_put_size");
+  if ((uint64_t)ofs + len > max_put_size) {
     return -ERR_TOO_LARGE;
   }
 
@@ -1378,7 +1381,9 @@ int RGWPostObj_ObjStore::verify_params()
     return -ERR_LENGTH_REQUIRED;
   }
   off_t len = atoll(s->length);
-  if (len > (off_t)(s->cct->_conf->rgw_max_put_size)) {
+  size_t max_put_size;
+  max_put_size = s->cct->_conf.get_val<size_t>("rgw_max_put_size");
+  if (len > max_put_size) {
     return -ERR_TOO_LARGE;
   }
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1699,7 +1699,9 @@ RGWBulkUploadOp_ObjStore_SWIFT::create_stream()
       }
 
       curpos += read_len;
-      return curpos > s->cct->_conf->rgw_max_put_size ? -ERR_TOO_LARGE
+      size_t max_put_size;
+      max_put_size = s->cct->_conf.get_val<size_t>("rgw_max_put_size");
+      return curpos > max_put_size ? -ERR_TOO_LARGE
                                                       : read_len;
     }
 


### PR DESCRIPTION
…ameters

2:Using config observer api to dynamically convert rgw_override_bucket_index_max_shards

Signed-off-by: Albin Antony <aantony@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

