### PR TITLE
journal: properly advance read offset after skipping invalid range

### DIFF
--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -172,6 +172,8 @@ int ObjectPlayer::handle_fetch_complete(int r, const bufferlist &bl,
       m_invalid_ranges.insert(invalid_start_off,
                               invalid_end_off - invalid_start_off);
       invalid = false;
+
+      m_read_bl_off = invalid_end_off;
     }
 
     EntryKey entry_key(std::make_pair(entry.get_tag_tid(),

--- a/src/test/journal/test_ObjectPlayer.cc
+++ b/src/test/journal/test_ObjectPlayer.cc
@@ -155,21 +155,25 @@ TYPED_TEST(TestObjectPlayer, FetchCorrupt) {
 
   journal::Entry entry1(234, 123, this->create_payload(std::string(24, '1')));
   journal::Entry entry2(234, 124, this->create_payload(std::string(24, '2')));
+  journal::Entry entry3(234, 125, this->create_payload(std::string(24, '3')));
 
   bufferlist bl;
   encode(entry1, bl);
-  encode(this->create_payload("corruption"), bl);
+  encode(this->create_payload("corruption" + std::string(1024, 'X')), bl);
   encode(entry2, bl);
+  encode(this->create_payload("corruption" + std::string(1024, 'Y')), bl);
+  encode(entry3, bl);
   ASSERT_EQ(0, this->append(this->get_object_name(oid), bl));
 
   journal::ObjectPlayerPtr object = this->create_object(oid, 14);
   ASSERT_EQ(-EBADMSG, this->fetch(object));
+  ASSERT_EQ(0, this->fetch(object));
 
   journal::ObjectPlayer::Entries entries;
   object->get_entries(&entries);
-  ASSERT_EQ(2U, entries.size());
+  ASSERT_EQ(3U, entries.size());
 
-  journal::ObjectPlayer::Entries expected_entries = {entry1, entry2};
+  journal::ObjectPlayer::Entries expected_entries = {entry1, entry2, entry3};
   ASSERT_EQ(expected_entries, entries);
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/40409
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

