### PR TITLE
qa/rgw: extra s3tests tasks use rgw endpoint configuration

### DIFF
--- a/qa/tasks/ragweed.py
+++ b/qa/tasks/ragweed.py
@@ -356,7 +356,7 @@ def task(ctx, config):
                 'rgw':
                     {
                     'port'      : endpoint.port,
-                    'is_secure' : 'yes' if endpoint.cert else 'no',
+                    'is_secure' : endpoint.cert is not None,
                     },
                 'fixtures' : {},
                 'user system'  : {},

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -395,7 +395,7 @@ def task(ctx, config):
                 'DEFAULT':
                     {
                     'port'      : endpoint.port,
-                    'is_secure' : 'yes' if endpoint.cert else 'no',
+                    'is_secure' : endpoint.cert is not None,
                     'api_name'  : 'default',
                     },
                 'fixtures' : {},

--- a/qa/workunits/rgw/s3_bucket_quota.pl
+++ b/qa/workunits/rgw/s3_bucket_quota.pl
@@ -53,7 +53,7 @@ my $logmsg;
 my $kruft;
 my $s3;
 my $hostdom  = $ENV{RGW_FQDN}||hostfqdn();
-my $port     = $ENV{RGW_PORT}||7280;
+my $port     = $ENV{RGW_PORT}||80;
 our $hostname = "$hostdom:$port";
 our $testfileloc;
 my $rgw_user = "qa_user";

--- a/qa/workunits/rgw/s3_multipart_upload.pl
+++ b/qa/workunits/rgw/s3_multipart_upload.pl
@@ -48,7 +48,7 @@ Pod::Usage::pod2usage(-verbose => 1) && exit if ($help);
 #== local variables ===
 my $s3;
 my $hostdom  = $ENV{RGW_FQDN}||hostfqdn();
-my $port     = $ENV{RGW_PORT}||7280;
+my $port     = $ENV{RGW_PORT}||80;
 our $hostname = "$hostdom:$port";
 our $testfileloc;
 our $mytestfilename;

--- a/qa/workunits/rgw/s3_user_quota.pl
+++ b/qa/workunits/rgw/s3_user_quota.pl
@@ -52,7 +52,7 @@ my $logmsg;
 my $kruft;
 my $s3;
 my $hostdom  = $ENV{RGW_FQDN}||hostfqdn();
-my $port     = $ENV{RGW_PORT}||7280;
+my $port     = $ENV{RGW_PORT}||80;
 our $hostname = "$hostdom:$port";
 our $testfileloc;
 our $cnt;


### PR DESCRIPTION
the rgw task now defaults to ports 80/443. the s3tests/swift/ragweed tasks were updated accordingly, but I missed some of the other s3test-based tasks that don't run in the rgw suite

Fixes: http://tracker.ceph.com/issues/17882