### PR TITLE
rgw_file: advance_mtime() should consider namespace expiration

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -238,15 +238,7 @@ namespace rgw {
     };
 
     void clear_state();
-
-    void advance_mtime() {
-      /* intended for use on directories, fast-forward mtime so as to
-       * ensure a new, higher value for the change attribute */
-      lock_guard guard(mtx);
-      /* sets ctime as well as mtime, to avoid masking updates should
-       * ctime inexplicably hold a higher value */
-      set_times(real_clock::now());
-    }
+    void advance_mtime();
 
     boost::variant<file, directory> variant_type;
 


### PR DESCRIPTION
Predictably, slow NFS operations like READDIR will overlap mtime
advance, so don't advance faster than the nfs namespace
expiration timer.

Fixes: http://tracker.ceph.com/issues/40415

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

