### PR TITLE
nautilus: cephfs-shell: Revert "cephfs.pyx: add py3 compatibility"

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -722,13 +722,11 @@ cdef class LibCephFS(object):
         if not dirent:
             return None
 
-        d_name = dirent.d_name if sys.version[0:2] == '2.' else dirent.d_name.\
-                 decode()
         return DirEntry(d_ino=dirent.d_ino,
                         d_off=dirent.d_off,
                         d_reclen=dirent.d_reclen,
                         d_type=dirent.d_type,
-                        d_name=d_name)
+                        d_name=dirent.d_name)
 
     def closedir(self, DirResult dir_handler):
         """


### PR DESCRIPTION
This reverts commit 5106582fc7edae7f39161cf89e566c020fcfa0ce.

Signed-off-by: Varsha Rao <varao@redhat.com>
(cherry picked from commit 417836de308a8b642fec5f03d819800142155b34)

This revert was missing from #27531


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

