### PR TITLE
luminous: os/bluestore: fix duplicate allocations in bmap allocator

### DIFF
--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -23,7 +23,7 @@ int64_t BitmapAllocator::allocate(
   int64_t hint, PExtentVector *extents)
 {
   uint64_t allocated = 0;
-
+  size_t old_size = extents->size();
   ldout(cct, 10) << __func__ << std::hex << " 0x" << want_size
 		 << "/" << alloc_unit << "," << max_alloc_size << "," << hint
 		 << std::dec << dendl;
@@ -34,7 +34,8 @@ int64_t BitmapAllocator::allocate(
   if (!allocated) {
     return -ENOSPC;
   }
-  for (auto e : *extents) {
+  for (auto i = old_size; i < extents->size(); ++i) {
+    auto& e = (*extents)[i];
     ldout(cct, 10) << __func__
                    << " extent: 0x" << std::hex << e.offset << "~" << e.length
 		   << "/" << alloc_unit << "," << max_alloc_size << "," << hint

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -36,7 +36,7 @@ int64_t BitmapAllocator::allocate(
   }
   for (auto e : *extents) {
     ldout(cct, 10) << __func__
-                   << " 0x" << std::hex << e.offset << "~" << e.length
+                   << " extent: 0x" << std::hex << e.offset << "~" << e.length
 		   << "/" << alloc_unit << "," << max_alloc_size << "," << hint
 		   << std::dec << dendl;
   }

--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -363,7 +363,7 @@ interval_t AllocatorLevel01Loose::_allocate_l1_contiguous(uint64_t length,
     if (ctx.affordable_len) {
       assert(ctx.affordable_len >= length);
       assert((length % l0_granularity) == 0);
-      auto pos_start = ctx.affordable_offs + length / l0_granularity;
+      auto pos_start = ctx.affordable_offs / l0_granularity;
       auto pos_end = (ctx.affordable_offs + length) / l0_granularity;
       _mark_alloc_l1_l0(pos_start, pos_end);
       res = interval_t(ctx.affordable_offs, length);


### PR DESCRIPTION
https://tracker.ceph.com/issues/40422
