### PR TITLE
mgr/dashboard: Pool form uses different loading spinner

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -1,10 +1,7 @@
+<cd-loading-panel *ngIf="!(info && ecProfiles)"
+                  i18n>Loading...</cd-loading-panel>
+
 <div class="col-sm-12 col-lg-6">
-  <h1 *ngIf="!(info && ecProfiles)"
-      class="jumbotron">
-    <i [ngClass]="[icons.spinner, icons.pulse, icons.large]"
-       class="text-primary"></i>
-    <ng-container i18n>Loading...</ng-container>
-  </h1>
   <form name="form"
         *ngIf="info && ecProfiles"
         #formDir="ngForm"


### PR DESCRIPTION
Use the 'cd-loading-panel' element to display the loading progress.

Fixes: https://tracker.ceph.com/issues/40427

Old loading spinner in pool form:
![old_loading](https://user-images.githubusercontent.com/1897962/59754908-55d87480-9287-11e9-8c67-19a1912572e7.gif)

Using existing loading spinner:
![new_loading](https://user-images.githubusercontent.com/1897962/59754925-5c66ec00-9287-11e9-89f8-207e9a22b233.gif)

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

