### PR TITLE
mimic: mds: avoid sending too many osd requests at once after mds restarts

### DIFF
--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -123,6 +123,7 @@ protected:
   map<uint64_t,LogSegment*> segments;
   set<LogSegment*> expiring_segments;
   set<LogSegment*> expired_segments;
+  std::size_t pre_segments_size = 0;            // the num of segments when the mds finished replay-journal, to calc the num of segments growing
   uint64_t event_seq;
   int expiring_events;
   int expired_events;


### PR DESCRIPTION
http://tracker.ceph.com/issues/40042