### PR TITLE
cephfs-shell: Add error message for invalid ls commands

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -117,8 +117,9 @@ def ls(path, opts=''):
                 elif almost_all and dent.d_name in (b'.', b'..'):
                     continue
                 yield dent
-    except cephfs.ObjectNotFound:
-        return []
+    except libcephfs.ObjectNotFound:
+        perror('{}: no such directory exists'.format(path), end='\n',
+               apply_style=True)
 
 
 def glob(path, pattern):


### PR DESCRIPTION
This patch prints the following error message on invalid ls command:
```
CephFS:~/>>> ls
t/   u/   y
CephFS:~/>>> ls k
k: no such directory exists
```
Fixes: https://tracker.ceph.com/issues/40430
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

