### PR TITLE
sample.ceph.conf: correct the default value of filestore merge threshold

### DIFF
--- a/src/sample.ceph.conf
+++ b/src/sample.ceph.conf
@@ -396,7 +396,7 @@
     # Min number of files in a subdir before merging into parent NOTE: A negative value means to disable subdir merging
     # Type: Integer
     # Required: No
-    # Default:  10
+    # Default:  -10
     ;filestore merge threshold    = -10
 
     # filestore_split_multiple * abs(filestore_merge_threshold) * 16 is the maximum number of files in a subdirectory before splitting into child directories.


### PR DESCRIPTION
Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->


