### PR TITLE
zstd: upgrade to v1.4.0

### DIFF
--- a/src/compressor/zstd/ZstdCompressor.h
+++ b/src/compressor/zstd/ZstdCompressor.h
@@ -48,7 +48,7 @@ class ZstdCompressor : public Compressor {
       inbuf.size = p.get_ptr_and_advance(left, (const char**)&inbuf.src);
       left -= inbuf.size;
       ZSTD_EndDirective const zed = (left==0) ? ZSTD_e_end : ZSTD_e_continue;
-      size_t r = ZSTD_compress_generic(s, &outbuf, &inbuf, zed);
+      size_t r = ZSTD_compressStream2(s, &outbuf, &inbuf, zed);
       if (ZSTD_isError(r)) {
 	return -EINVAL;
       }


### PR DESCRIPTION
Our current version v1.3.2 dates from Oct 2017, and the changelog in the meantime cites several performance fixes.
This is untested.