### PR TITLE
osd/PG: do not queue scrub if PG is not active when unblock

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11185,7 +11185,11 @@ void PrimaryLogPG::kick_object_context_blocked(ObjectContextRef obc)
 
   if (obc->requeue_scrub_on_unblock) {
     obc->requeue_scrub_on_unblock = false;
-    requeue_scrub();
+    // only requeue if we are still active: we may be unblocking
+    // because we are resetting for a new peering interval
+    if (is_active()) {
+      requeue_scrub();
+    }
   }
 }
 


### PR DESCRIPTION
- we are scrubbing
- we block scrub on an object
- we have an interval reset on epoch X
- we unblock and queue scrub in epoch X
- we finish the reset (we are no longer scrubbing)
- we process the PGScrub on epoch X, it is still epoch X, and we are not
  scrubbing
  -> assert

Fix by not queueing scrub if we are unblocking and the PG is no longer
active (because we are mid-way through the peering reset).

Fixes: http://tracker.ceph.com/issues/40451
Signed-off-by: Sage Weil <sage@redhat.com>