### PR TITLE
osd: share curmap in handle_osd_ping

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4565,7 +4565,7 @@ void OSD::handle_osd_ping(MOSDPing *m)
 	if (is_active()) {
 	  ConnectionRef con = service.get_con_osd_cluster(from, curmap->get_epoch());
 	  if (con) {
-	    service.maybe_share_map(con.get(), get_osdmap(), m->map_epoch);
+	    service.maybe_share_map(con.get(), curmap, m->map_epoch);
 	  }
 	}
       } else if (!curmap->exists(from) ||
@@ -4659,7 +4659,7 @@ void OSD::handle_osd_ping(MOSDPing *m)
 	if (is_active()) {
 	  ConnectionRef con = service.get_con_osd_cluster(from, curmap->get_epoch());
 	  if (con) {
-	    service.maybe_share_map(con.get(), get_osdmap(), m->map_epoch);
+	    service.maybe_share_map(con.get(), curmap, m->map_epoch);
 	  }
 	}
       }


### PR DESCRIPTION
We just took the curmap ref above; do not call get_osdmap() again.

I think it may explain a weird segv I saw here in ~shared_ptr, although
I'm not quite certain.  Regardless, this change is correct and better.

(gdb) bt

Signed-off-by: Sage Weil <sage@redhat.com>