### PR TITLE
doc: update ceph ansible iscsi info

### DIFF
--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -30,19 +30,19 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
       ::
 
-          [ceph-iscsi-gw]
+          [iscsigws]
           ceph-igw-1
           ceph-igw-2
 
 .. note::
   If co-locating the iSCSI gateway with an OSD node, then add the OSD node to the
-  ``[ceph-iscsi-gw]`` section.
+  ``[iscsigws]`` section.
 
 **Configuring:**
 
 The ``ceph-ansible`` package places a file in the ``/usr/share/ceph-ansible/group_vars/``
-directory called ``ceph-iscsi-gw.sample``. Create a copy of this sample file named
-``ceph-iscsi-gw.yml``. Review the following Ansible variables and descriptions,
+directory called ``iscsigws.yml.sample``. Create a copy of this sample file named
+``iscsigws.yml``. Review the following Ansible variables and descriptions,
 and update accordingly.
 
 +--------------------------------------+--------------------------------------+
@@ -85,7 +85,7 @@ and update accordingly.
 |                                      | the access point for iSCSI traffic.  |
 |                                      | Each IP should correspond to an IP   |
 |                                      | available on the hosts defined in    |
-|                                      | the ``ceph-iscsi-gw`` host group in  |
+|                                      | the ``iscsigws`` host group in  |
 |                                      | ``/etc/ansible/hosts``.              |
 +--------------------------------------+--------------------------------------+
 | ``rbd_devices``                      | This section defines the RBD images  |
@@ -146,7 +146,7 @@ On the Ansible installer node, perform the following steps.
    ::
 
        # cd /usr/share/ceph-ansible
-       # ansible-playbook ceph-iscsi-gw.yml
+       # ansible-playbook iscsigws.yml
 
    .. note::
     The Ansible playbook will handle RPM dependencies, RBD creation
@@ -200,7 +200,7 @@ interacting with the ``rbd-target-gw`` Systemd service.
 
 **Administration:**
 
-Within the ``/usr/share/ceph-ansible/group_vars/ceph-iscsi-gw`` file
+Within the ``/usr/share/ceph-ansible/group_vars/iscsigws.yml`` file
 there are a number of operational workflows that the Ansible playbook
 supports.
 
@@ -210,7 +210,7 @@ supports.
   the operating system.
 
 +--------------------------------------+--------------------------------------+
-| I want to…​                          | Update the ``ceph-iscsi-gw`` file    |
+| I want to…​                          | Update the ``iscsisgwi.yml`` file    |
 |                                      | by…​                                 |
 +======================================+======================================+
 | Add more RBD images                  | Adding another entry to the          |
@@ -264,7 +264,7 @@ change across the iSCSI gateway nodes.
 
 ::
 
-    # ansible-playbook ceph-iscsi-gw.yml
+    # ansible-playbook iscsigws.yml
 
 **Removing the Configuration:**
 

--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -111,19 +111,19 @@ On the Ansible installer node, perform the following steps.
 **Service Management:**
 
 The ``ceph-iscsi`` package installs the configuration management
-logic and a Systemd service called ``rbd-target-gw``. When the Systemd
-service is enabled, the ``rbd-target-gw`` will start at boot time and
+logic and a Systemd service called ``rbd-target-api``. When the Systemd
+service is enabled, the ``rbd-target-api`` will start at boot time and
 will restore the Linux IO state. The Ansible playbook disables the
 target service during the deployment. Below are the outcomes of when
-interacting with the ``rbd-target-gw`` Systemd service.
+interacting with the ``rbd-target-api`` Systemd service.
 
 ::
 
-    # systemctl <start|stop|restart|reload> rbd-target-gw
+    # systemctl <start|stop|restart|reload> rbd-target-api
 
 -  ``reload``
 
-   A reload request will force ``rbd-target-gw`` to reread the
+   A reload request will force ``rbd-target-api`` to reread the
    configuration and apply it to the current running environment. This
    is normally not required, since changes are deployed in parallel from
    Ansible to all iSCSI gateway nodes

--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -43,7 +43,8 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 The ``ceph-ansible`` package places a file in the ``/usr/share/ceph-ansible/group_vars/``
 directory called ``iscsigws.yml.sample``. Create a copy of this sample file named
 ``iscsigws.yml``. Review the following Ansible variables and descriptions,
-and update accordingly.
+and update accordingly. See the ``iscsigws.yml.sample`` for a full list of
+advanced variables.
 
 +--------------------------------------+--------------------------------------+
 | Variable                             | Meaning/Purpose                      |
@@ -71,6 +72,26 @@ and update accordingly.
 |                                      | set to true for at least the first   |
 |                                      | run to ensure multipathd and lvm are |
 |                                      | configured properly.                 |
++--------------------------------------+--------------------------------------+
+| ``api_user``                         | The user name for the API. The       |
+|                                      | default is `admin`.                  |
++--------------------------------------+--------------------------------------+
+| ``api_password``                     | The password for using the API. The  |
+|                                      | default is `admin`.                  |
++--------------------------------------+--------------------------------------+
+| ``api_port``                         | The TCP port number for using the    |
+|                                      | API. The default is `5000`.          |
++--------------------------------------+--------------------------------------+
+| ``api_secure``                       | True if TLS must be used. The        |
+|                                      | default is `false`. If true the user |
+|                                      | must create the necessary            |
+|                                      | certificate and key files. See the   |
+|                                      | gwcli man file for details.          |
++--------------------------------------+--------------------------------------+
+| ``trusted_ip_list``                  | A list of IPv4 or IPv6 addresses     |
+|                                      | who have access to the API. By       |
+|                                      | default, only the iSCSI gateway      |
+|                                      | nodes have access.                   |
 +--------------------------------------+--------------------------------------+
 
 **Deploying:**

--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -146,7 +146,7 @@ On the Ansible installer node, perform the following steps.
    ::
 
        # cd /usr/share/ceph-ansible
-       # ansible-playbook iscsigws.yml
+       # ansible-playbook site.yml --limit iscsigws
 
    .. note::
     The Ansible playbook will handle RPM dependencies, RBD creation
@@ -264,7 +264,7 @@ change across the iSCSI gateway nodes.
 
 ::
 
-    # ansible-playbook iscsigws.yml
+    # ansible-playbook site.yml --limit iscsigws
 
 **Removing the Configuration:**
 


### PR DESCRIPTION
ceph-iscsi-config-/cli has been merged into a single repo ceph-iscsi. This updates the ceph-ansible iscsi gw instructions for the new combined project, and also fixes some misc bugs in that doc for things like misnamed groups, missing settings, and old or odd commands.

Signed-off-by: Mike Christie <mchristi@redhat.com>