### PR TITLE
luminous: mon/AuthMonitor: don't validate fs caps on authorize

### DIFF
--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -129,8 +129,8 @@ private:
     pending_auth.push_back(inc);
   }
 
-  /* validate mon/osd/mds caps ; don't care about caps for other services as
-   * we don't know how to validate them */
+  /* validate mon/osd/mds caps; fail on unrecognized service/type */
+  bool valid_caps(const string& type, const string& caps, ostream *out);
   bool valid_caps(const vector<string>& caps, ostream *out);
 
   void on_active() override;


### PR DESCRIPTION
https://tracker.ceph.com/issues/39395
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

