### PR TITLE
msg/async: add comments for commit 294c41f18adada6ab.

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -346,8 +346,11 @@ void ProtocolV1::write_event() {
       } else if (r < 0) {
         ldout(cct, 1) << __func__ << " send msg failed" << dendl;
         break;
-      } else if (r > 0)
-        break;
+      } else if (r > 0) {
+	// Outbound message in-progress, thread will be re-awoken
+	// when the outbound socket is writeable again
+	break;
+      }
     } while (can_write == WriteStatus::CANWRITE);
     write_in_progress = false;
     connection->write_lock.unlock();

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -626,8 +626,11 @@ void ProtocolV2::write_event() {
       } else if (r < 0) {
         ldout(cct, 1) << __func__ << " send msg failed" << dendl;
         break;
-      } else if (r > 0)
+      } else if (r > 0) {
+	// Outbound message in-progress, thread will be re-awoken
+	// when the outbound socket is writeable again
         break;
+      }
     } while (can_write);
     write_in_progress = false;
 


### PR DESCRIPTION
Consider this case:
```
    send-thread					msg-work
					    write_event()
					     r = write_message()
connection->write_lock.lock()
if (.. && !write_in_progress) {
  write_in_progress = true;
  add external_event
}
connection->write_lock.unlock()
					  connection->write_lock.lock()
					  if (r > 0)
					    break;
					  } while ();
					  write_in_progress = false;
```
For this case, we don't add external_event and in write_event we don't
check out_q whether empty rather than break.
This make msg-work never wake up again.
Fortunately, if write_message() > 0, in AsyncConnection::_try_send will
add an EVENT_WRITEABLE to wake up msg-work. So bug can't occur.

I add comment to descript this and hope get the better method to fix
this.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

