### PR TITLE
luminous: tests: use curl in wait_for_radosgw() in util/rgw.py 

### DIFF
--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -96,7 +96,8 @@ def start_rgw(ctx, config, clients):
         host, port = ctx.rgw.role_endpoints[client]
         endpoint = 'http://{host}:{port}/'.format(host=host, port=port)
         log.info('Polling {client} until it starts accepting connections on {endpoint}'.format(client=client, endpoint=endpoint))
-        wait_for_radosgw(endpoint)
+        (remote,) = ctx.cluster.only(client).remotes.iterkeys()
+        wait_for_radosgw(endpoint, remote)
 
     try:
         yield

--- a/qa/tasks/rgw_multisite.py
+++ b/qa/tasks/rgw_multisite.py
@@ -226,7 +226,7 @@ class Gateway(multisite.Gateway):
         """ (re)start the daemon """
         self.daemon.restart()
         # wait until startup completes
-        wait_for_radosgw(self.endpoint())
+        wait_for_radosgw(self.endpoint(), self.remote)
 
     def stop(self):
         """ stop the daemon """


### PR DESCRIPTION
http://tracker.ceph.com/issues/40347