### PR TITLE
mon: check probe against quorum_features instead

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1890,12 +1890,22 @@ void Monitor::handle_probe(MonOpRequestRef op)
     break;
 
   case MMonProbe::OP_MISSING_FEATURES:
-    derr << __func__ << " require release " << (int)m->mon_release << " > "
-	 << (int)ceph_release()
-	 << ", or missing features (have " << CEPH_FEATURES_ALL
-	 << ", required " << m->required_features
-	 << ", missing " << (m->required_features & ~CEPH_FEATURES_ALL) << ")"
-	 << dendl;
+    uint64_t missing = m->required_features & ~CEPH_FEATURES_ALL;
+    if (missing) {
+      derr << __func__
+	   << " missing features (have " << CEPH_FEATURES_ALL
+	   << ", required " << m->required_features
+	   << ", missing " << missing << ")" << dendl;
+    } else if (m->mon_release > ceph_release()) {
+      derr << __func__
+	   << " require release " << (int)m->mon_release << " > "
+	   << (int)ceph_release() << dendl;
+    } else {
+      derr << __func__
+	   << " missing features (unknown) - you may need to upgrade or "
+	   << " reach out to a developer." << dendl;
+    }
+    exit(EACCES);
     break;
   }
 }


### PR DESCRIPTION
mon: check probe against quorum_features instead

Fixes: http://tracker.ceph.com/issues/40081

and we add an additional commit to allow a monitor to gracefully exit if required features are not met.

Signed-off-by: Joao Eduardo Luis \<joao@suse.de>

