### PR TITLE
nautilus: mon: check probe against quorum_features instead

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1849,7 +1849,8 @@ void Monitor::handle_probe_probe(MonOpRequestRef op)
 
   dout(10) << "handle_probe_probe " << m->get_source_inst() << *m
 	   << " features " << m->get_connection()->get_features() << dendl;
-  uint64_t missing = required_features & ~m->get_connection()->get_features();
+  uint64_t missing =
+    get_quorum_con_features() & ~m->get_connection()->get_features();
   if ((m->mon_release > 0 && m->mon_release < monmap->min_mon_release) ||
       missing) {
     dout(1) << " peer " << m->get_source_addr()


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/28671 which is still open (!)

---

mon: check probe against quorum_features instead

Fixes: http://tracker.ceph.com/issues/40081

Signed-off-by: Joao Eduardo Luis <joao@suse.com>
(cherry picked from commit 8e54c895e8c9a26da2ca8ad76bf308eb125b8013)

Conflicts:
      - mon/Monitor.cc: due to previous selective cherry-pick 9d0404b0350,
      in which we ignored a few recent changes; those would be hard to
      backport due to them overhauling feature naming and access (i.e.,
      ceph_release_t). As such, we are, once more, selectively patching to
      ignore those changes.

also adds a commit to allow the monitor to shutdown gracefully if required features are not met, instead of just probing forever.