### PR TITLE
crimson/net: implement preemptive shutdown/close

### DIFF
--- a/src/crimson/net/Errors.cc
+++ b/src/crimson/net/Errors.cc
@@ -47,6 +47,8 @@ const std::error_category& net_category()
           return "invalid argument";
         case error::address_in_use:
           return "address in use";
+        case error::broken_pipe:
+          return "broken pipe";
         default:
           return "unknown";
       }
@@ -67,6 +69,8 @@ const std::error_category& net_category()
           return std::errc::invalid_argument;
         case error::address_in_use:
           return std::errc::address_in_use;
+        case error::broken_pipe:
+          return std::errc::broken_pipe;
         default:
           return std::error_condition(ev, *this);
       }
@@ -92,6 +96,9 @@ const std::error_category& net_category()
         case error::address_in_use:
           return cond == std::errc::address_in_use
               || cond == std::error_condition(EADDRINUSE, std::system_category());
+        case error::broken_pipe:
+          return cond == std::errc::broken_pipe
+              || cond == std::error_condition(EPIPE, std::system_category());
         default:
           return false;
       }
@@ -117,6 +124,9 @@ const std::error_category& net_category()
         case error::address_in_use:
           return code == std::errc::address_in_use
               || code == std::error_code(EADDRINUSE, std::system_category());
+        case error::broken_pipe:
+          return code == std::errc::broken_pipe
+              || code == std::error_code(EPIPE, std::system_category());
         default:
           return false;
       }

--- a/src/crimson/net/Errors.h
+++ b/src/crimson/net/Errors.h
@@ -31,6 +31,7 @@ enum class error {
   corrupted_message,
   invalid_argument,
   address_in_use,
+  broken_pipe,
 };
 
 /// net error category

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -55,10 +55,10 @@ seastar::future<> Protocol::close()
   assert(!close_ready.valid());
 
   if (socket) {
-    close_ready = socket->close()
-      .then([this] {
-        return pending_dispatch.close();
-      }).finally(std::move(cleanup));
+    socket->shutdown();
+    close_ready = pending_dispatch.close().finally([this] {
+      return socket->close();
+    }).finally(std::move(cleanup));
   } else {
     close_ready = pending_dispatch.close().finally(std::move(cleanup));
   }

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -22,6 +22,11 @@ class Socket
   seastar::input_stream<char> in;
   seastar::output_stream<char> out;
 
+#ifndef NDEBUG
+  bool down = false;
+  bool closed = false;
+#endif
+
   /// buffer state for read()
   struct {
     bufferlist buffer;
@@ -38,6 +43,12 @@ class Socket
       // the default buffer size 8192 is too small that may impact our write
       // performance. see seastar::net::connected_socket::output()
       out(socket.output(65536)) {}
+
+  ~Socket() {
+#ifndef NDEBUG
+    assert(closed);
+#endif
+  }
 
   Socket(Socket&& o) = delete;
 
@@ -79,12 +90,20 @@ class Socket
     return out.write(std::move(buf)).then([this] { return out.flush(); });
   }
 
+  // preemptively disable further reads or writes, can only be shutdown once.
+  void shutdown();
+
   /// Socket can only be closed once.
-  seastar::future<> close() {
-    return seastar::smp::submit_to(sid, [this] {
-        return seastar::when_all(
-          in.close(), out.close()).discard_result();
-      });
+  seastar::future<> close();
+
+  // shutdown input_stream only, for tests
+  void force_shutdown_in() {
+    socket.shutdown_input();
+  }
+
+  // shutdown output_stream only, for tests
+  void force_shutdown_out() {
+    socket.shutdown_output();
   }
 };
 

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -434,6 +434,145 @@ static seastar::future<> test_concurrent_dispatch(bool v2)
     });
 }
 
+seastar::future<> test_preemptive_shutdown(bool v2) {
+  struct test_state {
+    class Server final
+      : public ceph::net::Dispatcher,
+        public seastar::peering_sharded_service<Server> {
+      ceph::net::Messenger *msgr = nullptr;
+      ceph::auth::DummyAuthClientServer dummy_auth;
+
+      seastar::future<> ms_dispatch(ceph::net::Connection* c,
+                                    MessageRef m) override {
+        return c->send(MessageRef{new MPing, false});
+      }
+
+     public:
+      seastar::future<> init(const entity_name_t& name,
+                             const std::string& lname,
+                             const uint64_t nonce,
+                             const entity_addr_t& addr) {
+        return ceph::net::Messenger::create(name, lname, nonce, seastar::engine().cpu_id()
+        ).then([this, addr](ceph::net::Messenger *messenger) {
+          return container().invoke_on_all([messenger](auto& server) {
+            server.msgr = messenger->get_local_shard();
+            server.msgr->set_default_policy(ceph::net::SocketPolicy::stateless_server(0));
+            server.msgr->set_auth_client(&server.dummy_auth);
+            server.msgr->set_auth_server(&server.dummy_auth);
+          }).then([messenger, addr] {
+            return messenger->bind(entity_addrvec_t{addr});
+          }).then([this, messenger] {
+            return messenger->start(this);
+          });
+        });
+      }
+      entity_addr_t get_addr() const {
+        return msgr->get_myaddr();
+      }
+      seastar::future<> shutdown() {
+        return msgr->shutdown();
+      }
+      Dispatcher* get_local_shard() override {
+        return &(container().local());
+      }
+      seastar::future<> stop() {
+        return seastar::now();
+      }
+    };
+
+    class Client final
+      : public ceph::net::Dispatcher,
+        public seastar::peering_sharded_service<Client> {
+      ceph::net::Messenger *msgr = nullptr;
+      ceph::auth::DummyAuthClientServer dummy_auth;
+
+      bool stop_send = false;
+      seastar::promise<> stopped_send_promise;
+
+      seastar::future<> ms_dispatch(ceph::net::Connection* c,
+                                    MessageRef m) override {
+        return seastar::now();
+      }
+
+     public:
+      seastar::future<> init(const entity_name_t& name,
+                             const std::string& lname,
+                             const uint64_t nonce) {
+        return ceph::net::Messenger::create(name, lname, nonce, seastar::engine().cpu_id()
+        ).then([this](ceph::net::Messenger *messenger) {
+          return container().invoke_on_all([messenger](auto& client) {
+            client.msgr = messenger->get_local_shard();
+            client.msgr->set_default_policy(ceph::net::SocketPolicy::lossy_client(0));
+            client.msgr->set_auth_client(&client.dummy_auth);
+            client.msgr->set_auth_server(&client.dummy_auth);
+          }).then([this, messenger] {
+            return messenger->start(this);
+          });
+        });
+      }
+      seastar::future<> send_pings(const entity_addr_t& addr) {
+        return msgr->connect(addr, entity_name_t::TYPE_OSD
+        ).then([this](ceph::net::ConnectionXRef conn) {
+          seastar::do_until(
+            [this] { return stop_send; },
+            [this, conn = &**conn] {
+              return conn->send(MessageRef{new MPing, false}).then([] {
+                return seastar::sleep(0ms);
+              });
+            }
+          ).then_wrapped([this, conn] (auto fut) {
+            fut.forward_to(std::move(stopped_send_promise));
+          });
+        });
+      }
+      seastar::future<> shutdown() {
+        return msgr->shutdown().then([this] {
+          stop_send = true;
+          return stopped_send_promise.get_future();
+        });
+      }
+      Dispatcher* get_local_shard() override {
+        return &(container().local());
+      }
+      seastar::future<> stop() {
+        return seastar::now();
+      }
+    };
+  };
+
+  logger().info("test_preemptive_shutdown(v2={}):", v2);
+  return seastar::when_all_succeed(
+    ceph::net::create_sharded<test_state::Server>(),
+    ceph::net::create_sharded<test_state::Client>()
+  ).then([v2](test_state::Server *server,
+             test_state::Client *client) {
+    entity_addr_t addr;
+    addr.parse("127.0.0.1:9010", nullptr);
+    if (v2) {
+      addr.set_type(entity_addr_t::TYPE_MSGR2);
+    } else {
+      addr.set_type(entity_addr_t::TYPE_LEGACY);
+    }
+    addr.set_family(AF_INET);
+    return seastar::when_all_succeed(
+      server->init(entity_name_t::OSD(6), "server4", 7, addr),
+      client->init(entity_name_t::OSD(7), "client4", 8)
+    ).then([server, client] {
+      return client->send_pings(server->get_addr());
+    }).then([] {
+      return seastar::sleep(100ms);
+    }).then([client] {
+      logger().info("client shutdown...");
+      return client->shutdown();
+    }).finally([server] {
+      logger().info("server shutdown...");
+      return server->shutdown();
+    }).finally([] {
+      logger().info("test_preemptive_shutdown() done!\n");
+    });
+  });
+}
+
 }
 
 int main(int argc, char** argv)
@@ -458,6 +597,10 @@ int main(int argc, char** argv)
       return test_concurrent_dispatch(false);
     }).then([] {
       return test_concurrent_dispatch(true);
+    }).then([] {
+      return test_preemptive_shutdown(false);
+    }).then([] {
+      return test_preemptive_shutdown(true);
     }).then([] {
       std::cout << "All tests succeeded" << std::endl;
     }).handle_exception([] (auto eptr) {

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -17,6 +17,7 @@ using seastar::future;
 using ceph::net::error;
 using ceph::net::Socket;
 using ceph::net::SocketFRef;
+using ceph::net::stop_t;
 
 static seastar::logger logger{"test"};
 
@@ -180,6 +181,276 @@ future<> test_accept() {
   });
 }
 
+class SocketFactory final
+    : public SocketFactoryBase<SocketFactory> {
+  const seastar::shard_id target_shard;
+  seastar::promise<SocketFRef> socket_promise;
+
+  future<> bind_accept() override {
+    return SocketFactoryBase<SocketFactory>::bind_accept();
+  }
+
+  future<SocketFRef> get_accepted() {
+    return socket_promise.get_future();
+  }
+
+ public:
+  SocketFactory(seastar::shard_id shard) : target_shard{shard} {}
+
+  future<> handle_server_socket(SocketFRef&& socket) override {
+    return container().invoke_on(target_shard,
+        [socket = std::move(socket)] (auto& factory) mutable {
+      factory.socket_promise.set_value(std::move(socket));
+    });
+  }
+
+  static future<SocketFRef, SocketFRef> get_sockets() {
+    return ceph::net::create_sharded<SocketFactory>(seastar::engine().cpu_id()
+    ).then([] (SocketFactory* factory) {
+      return factory->bind_accept().then([factory] {
+        return connect();
+      }).then([factory] (auto fp_client_socket) {
+        return factory->get_accepted(
+        ).then([fp_client_socket = std::move(fp_client_socket)]
+              (auto fp_server_socket) mutable {
+          return seastar::make_ready_future<SocketFRef, SocketFRef>(
+              std::move(fp_client_socket), std::move(fp_server_socket));
+        });
+      }).finally([factory] {
+        return factory->shutdown();
+      });
+    });
+  }
+};
+
+class Connection {
+  static const uint64_t DATA_TAIL = 5327;
+  static const unsigned DATA_SIZE = 4096;
+  std::array<uint64_t, DATA_SIZE> data = {0};
+
+  void verify_data_read(const uint64_t read_data[]) {
+    ceph_assert(read_data[0] == read_count);
+    ceph_assert(data[DATA_SIZE - 1] = DATA_TAIL);
+  }
+
+  SocketFRef socket;
+  uint64_t write_count = 0;
+  uint64_t read_count = 0;
+
+  Connection(SocketFRef&& socket) : socket{std::move(socket)} {
+    data[DATA_SIZE - 1] = DATA_TAIL;
+  }
+
+  future<> dispatch_write(unsigned round = 0, bool force_shut = false) {
+    return seastar::repeat([this, round, force_shut] {
+      if (round != 0 && round <= write_count) {
+        return seastar::futurize_apply([this, force_shut] {
+          if (force_shut) {
+            socket->force_shutdown_out();
+          }
+        }).then([] {
+          return seastar::make_ready_future<stop_t>(stop_t::yes);
+        });
+      } else {
+        data[0] = write_count;
+        return socket->write(seastar::net::packet(
+            reinterpret_cast<const char*>(&data), sizeof(data))
+        ).then([this] {
+          return socket->flush();
+        }).then([this] {
+          write_count += 1;
+          return seastar::make_ready_future<stop_t>(stop_t::no);
+        });
+      }
+    });
+  }
+
+  future<> dispatch_write_unbounded() {
+    return dispatch_write(
+    ).then([] {
+      ceph_abort();
+    }).handle_exception_type([] (const std::system_error& e) {
+      if (e.code() != error::broken_pipe &&
+          e.code() != error::connection_reset) {
+        logger.error("dispatch_write_unbounded(): "
+                     "unexpected error {}", e);
+        throw;
+      }
+      // successful
+      logger.debug("dispatch_write_unbounded(): "
+                   "expected error {}", e);
+    });
+  }
+
+  future<> dispatch_read(unsigned round = 0, bool force_shut = false) {
+    return seastar::repeat([this, round, force_shut] {
+      if (round != 0 && round <= read_count) {
+        return seastar::futurize_apply([this, force_shut] {
+          if (force_shut) {
+            socket->force_shutdown_in();
+          }
+        }).then([] {
+          return seastar::make_ready_future<stop_t>(stop_t::yes);
+        });
+      } else {
+        return seastar::futurize_apply([this] {
+          // we want to test both Socket::read() and Socket::read_exactly()
+          if (read_count % 2) {
+            return socket->read(DATA_SIZE * sizeof(uint64_t)
+            ).then([this] (ceph::bufferlist bl) {
+              uint64_t read_data[DATA_SIZE];
+              auto p = bl.cbegin();
+              ::ceph::decode_raw(read_data, p);
+              verify_data_read(read_data);
+            });
+          } else {
+            return socket->read_exactly(DATA_SIZE * sizeof(uint64_t)
+            ).then([this] (auto buf) {
+              auto read_data = reinterpret_cast<const uint64_t*>(buf.get());
+              verify_data_read(read_data);
+            });
+          }
+        }).then([this] {
+          ++read_count;
+          return seastar::make_ready_future<stop_t>(stop_t::no);
+        });
+      }
+    });
+  }
+
+  future<> dispatch_read_unbounded() {
+    return dispatch_read(
+    ).then([] {
+      ceph_abort();
+    }).handle_exception_type([] (const std::system_error& e) {
+      if (e.code() != error::read_eof
+       && e.code() != error::connection_reset) {
+        logger.error("dispatch_read_unbounded(): "
+                     "unexpected error {}", e);
+        throw;
+      }
+      // successful
+      logger.debug("dispatch_read_unbounded(): "
+                   "expected error {}", e);
+    });
+  }
+
+  void shutdown() {
+    socket->shutdown();
+  }
+
+  future<> close() {
+    return socket->close();
+  }
+
+ public:
+  static future<> dispatch_rw_bounded(SocketFRef&& socket, bool is_client,
+                                      unsigned round, bool force_shut = false) {
+    return seastar::smp::submit_to(is_client ? 0 : 1,
+        [socket = std::move(socket), round, force_shut] () mutable {
+      return seastar::do_with(Connection{std::move(socket)},
+                              [round, force_shut] (auto& conn) {
+        ceph_assert(round != 0);
+        return seastar::when_all_succeed(
+          conn.dispatch_write(round, force_shut),
+          conn.dispatch_read(round, force_shut)
+        ).finally([&conn] {
+          return conn.close();
+        });
+      });
+    }).handle_exception([is_client] (auto eptr) {
+      logger.error("dispatch_rw_bounded(): {} got unexpected exception {}",
+                   is_client ? "client" : "server", eptr);
+      ceph_abort();
+    });
+  }
+
+  static future<> dispatch_rw_unbounded(SocketFRef&& socket, bool is_client,
+                                        bool preemptive_shut = false) {
+    return seastar::smp::submit_to(is_client ? 0 : 1,
+        [socket = std::move(socket), preemptive_shut, is_client] () mutable {
+      return seastar::do_with(Connection{std::move(socket)},
+                              [preemptive_shut, is_client] (auto& conn) {
+        return seastar::when_all_succeed(
+          conn.dispatch_write_unbounded(),
+          conn.dispatch_read_unbounded(),
+          seastar::futurize_apply([&conn, preemptive_shut] {
+            if (preemptive_shut) {
+              return seastar::sleep(100ms).then([&conn] { conn.shutdown(); });
+            } else {
+              return seastar::now();
+            }
+          })
+        ).finally([&conn] {
+          return conn.close();
+        });
+      });
+    }).handle_exception([is_client] (auto eptr) {
+      logger.error("dispatch_rw_unbounded(): {} got unexpected exception {}",
+                   is_client ? "client" : "server", eptr);
+      ceph_abort();
+    });
+  }
+};
+
+future<> test_read_write() {
+  logger.info("test_read_write()...");
+  return SocketFactory::get_sockets(
+  ).then([] (auto client_socket, auto server_socket) {
+    return seastar::when_all_succeed(
+      Connection::dispatch_rw_bounded(std::move(client_socket), true, 128),
+      Connection::dispatch_rw_bounded(std::move(server_socket), false, 128)
+    );
+  }).handle_exception([] (auto eptr) {
+    logger.error("test_read_write() got unexpeted exception {}", eptr);
+    ceph_abort();
+  });
+}
+
+future<> test_unexpected_down() {
+  logger.info("test_unexpected_down()...");
+  return SocketFactory::get_sockets(
+  ).then([] (auto client_socket, auto server_socket) {
+    return seastar::when_all_succeed(
+      Connection::dispatch_rw_bounded(std::move(client_socket), true, 128, true),
+      Connection::dispatch_rw_unbounded(std::move(server_socket), false)
+    );
+  }).handle_exception([] (auto eptr) {
+    logger.error("test_unexpected_down() got unexpeted exception {}", eptr);
+    ceph_abort();
+  });
+}
+
+future<> test_shutdown_propagated() {
+  logger.info("test_shutdown_propagated()...");
+  return SocketFactory::get_sockets(
+  ).then([] (auto client_socket, auto server_socket) {
+    client_socket->shutdown();
+    return Connection::dispatch_rw_unbounded(std::move(server_socket), false
+    ).finally([client_socket = std::move(client_socket)] () mutable {
+      return client_socket->close(
+      ).finally([cleanup = std::move(client_socket)] {});
+    });
+  }).handle_exception([] (auto eptr) {
+    logger.error("test_shutdown_propagated() got unexpeted exception {}", eptr);
+    ceph_abort();
+  });
+}
+
+future<> test_preemptive_down() {
+  logger.info("test_preemptive_down()...");
+  return SocketFactory::get_sockets(
+  ).then([] (auto client_socket, auto server_socket) {
+    return seastar::when_all_succeed(
+      Connection::dispatch_rw_unbounded(std::move(client_socket), true, true),
+      Connection::dispatch_rw_unbounded(std::move(server_socket), false)
+    );
+  }).handle_exception([] (auto eptr) {
+    logger.error("test_preemptive_down() got unexpeted exception {}", eptr);
+    ceph_abort();
+  });
+}
+
 }
 
 int main(int argc, char** argv)
@@ -190,6 +461,14 @@ int main(int argc, char** argv)
       return test_bind_same();
     }).then([] {
       return test_accept();
+    }).then([] {
+      return test_read_write();
+    }).then([] {
+      return test_unexpected_down();
+    }).then([] {
+      return test_shutdown_propagated();
+    }).then([] {
+      return test_preemptive_down();
     }).then([] {
       logger.info("All tests succeeded");
     }).handle_exception([] (auto eptr) {


### PR DESCRIPTION
After this change, the messenger should be able to:
* preemptive shutdown `Socket`
* preemptive shutdown `Connection`
* preemptive shutdown `Messenger`

No impact on the I/O path.
Also added unit-tests for messenger.

Depends on #28623 