### PR TITLE
mds: cleanup truncating inodes when standby replay mds trim log segments

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7273,6 +7273,13 @@ void MDCache::standby_trim_segment(LogSegment *ls)
     in->dirfragtreelock.remove_dirty();
     try_trim_inode(in);
   }
+  while (!ls->truncating_inodes.empty()) {
+    auto it = ls->truncating_inodes.begin();
+    CInode *in = *it;
+    ls->truncating_inodes.erase(it);
+    in->put(CInode::PIN_TRUNCATING);
+    try_trim_inode(in);
+  }
 }
 
 void MDCache::handle_cache_expire(const cref_t<MCacheExpire> &m)


### PR DESCRIPTION
Standby replay mds first trims expired log segments, then replays new
log segments. It's possible a 'truncate_start' log event is in expired,
but its 'truncate_finish' counterpart is the new log segments. When mds
replays the 'truncate_finish' log event, log segment that contains the
'truncate_start' is already trimmed, so mds does nothing. This causes
leak of Inode::PIN_TRUNCATING and trigger assertion when removing
corresponding inode.

Fixes: https://tracker.ceph.com/issues/40477
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

