### PR TITLE
mgr/diskprediction_cloud: Service unavailable

### DIFF
--- a/src/pybind/mgr/diskprediction_cloud/module.py
+++ b/src/pybind/mgr/diskprediction_cloud/module.py
@@ -82,11 +82,11 @@ class Module(MgrModule):
         },
         {
             'name': 'diskprediction_ssl_target_name_override',
-            'default': 'api.diskprophet.com'
+            'default': 'localhost'
         },
         {
             'name': 'diskprediction_default_authority',
-            'default': 'api.diskprophet.com'
+            'default': 'localhost'
         },
         {
             'name': 'sleep_interval',
@@ -398,7 +398,7 @@ class Module(MgrModule):
                         restart_agent = True
                         break
             except Exception as IOError:
-                self.log.error('disk prediction plugin faield to started and try to restart')
+                self.log.error('disk prediction plugin failed to started and try to restart')
                 restart_agent = True
 
             if restart_agent:


### PR DESCRIPTION
Reset the grpc ssl_target_name_override and default_authority
 default to be 'localhost'.

Fixes: http://tracker.ceph.com/issues/40478
Signed-off-by: Rick Chen <rick.chen@prophetstor.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

