### PR TITLE
doc: Update the sizing advice

### DIFF
--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -124,12 +124,17 @@ Sizing
 ======
 When using a :ref:`mixed spinning and solid drive setup
 <bluestore-mixed-device-config>` it is important to make a large-enough
-``block.db`` logical volume for Bluestore. Generally, ``block.db`` should have
-*as large as possible* logical volumes.
+``block.db`` logical volume for Bluestore.
 
-It is recommended that the ``block.db`` size isn't smaller than 4% of
-``block``. For example, if the ``block`` size is 1TB, then ``block.db``
-shouldn't be less than 40GB.
+Due to the internals of RocksDB useful ``block.db`` sizes are roughly in
+magnitudes of 3GB (e.g. 3GB, 30GB, 300GB).
+
+3GB should suffice for very small spinning disks up to a few hundred GB,
+for bigger disks you should partition 30GB for ``block.db``.
+
+``block`` sizes of 6TB and more can benefit from 300GB ``block.db`` size,
+but at that point it is proably adviceable to use 30GB and use the excess
+fast storage in another storage class.
 
 If *not* using a mix of fast and slow devices, it isn't required to create
 separate logical volumes for ``block.db`` (or ``block.wal``). Bluestore will


### PR DESCRIPTION
In mailingslists I found that users on several occasions used inefficient block.db sizes, either to low, so that the next level of RocksDB does not fit, or in excess of it, wasting space that could've been used better with device classes.

I hope this change might help others to avoid misconfigurations.

Signed-off-by: Dominik Hannen <d5k+h4n@posteo.de>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

