### PR TITLE
test_volume_client: fix test_put_object_versioned()

### DIFF
--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -34,6 +34,7 @@ class TestVolumeClient(CephFSTestCase):
         return client.run_python("""
 from __future__ import print_function
 from ceph_volume_client import CephFSVolumeClient, VolumePath
+from sys import version_info as sys_version_info
 import logging
 log = logging.getLogger("ceph_volume_client")
 log.addHandler(logging.StreamHandler())
@@ -999,9 +1000,19 @@ vc.disconnect()
         with self.assertRaises(CommandFailedError):
             self._volume_client_python(vc_mount, dedent("""
                 data, version = vc.get_object_and_version("{pool_name}", "{obj_name}")
-                data += 'm1'
+
+                if sys_version_info.major < 3:
+                    data = data + 'm1'
+                elif sys_version_info.major > 3:
+                    data = str.encode(data.decode('utf-8') + 'm1')
+
                 vc.put_object("{pool_name}", "{obj_name}", data)
-                data += 'm2'
+
+                if sys_version_info.major < 3:
+                    data = data + 'm2'
+                elif sys_version_info.major > 3:
+                    data = str.encode(data.decode('utf-8') + 'm2')
+
                 vc.put_object_versioned("{pool_name}", "{obj_name}", data, version)
             """).format(pool_name=pool_name, obj_name=obj_name))
 

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -965,7 +965,7 @@ vc.disconnect()
             obj_data = obj_data
         )))
 
-    def test_put_object_versioned(self):
+    def test_version_check_for_put_object_versioned(self):
         vc_mount = self.mounts[1]
         vc_mount.umount_wait()
         self._configure_vc_auth(vc_mount, "manila")

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -36,6 +36,7 @@ class TestVolumeClient(CephFSTestCase):
 from __future__ import print_function
 from ceph_volume_client import CephFSVolumeClient, VolumePath
 from sys import version_info as sys_version_info
+from rados import OSError as rados_OSError
 import logging
 log = logging.getLogger("ceph_volume_client")
 log.addHandler(logging.StreamHandler())
@@ -976,24 +977,30 @@ vc.disconnect()
 
         # Test if put_object_versioned() crosschecks the version of the
         # given object. Being a negative test, an exception is expected.
-        with self.assertRaises(CommandFailedError):
-            self._volume_client_python(vc_mount, dedent("""
-                data, version = vc.get_object_and_version("{pool_name}", "{obj_name}")
+        expected_exception = 'rados_OSError'
+        output = self._volume_client_python(vc_mount, dedent("""
+            data, version = vc.get_object_and_version("{pool_name}", "{obj_name}")
 
-                if sys_version_info.major < 3:
-                    data = data + 'm1'
-                elif sys_version_info.major > 3:
-                    data = str.encode(data.decode('utf-8') + 'm1')
+            if sys_version_info.major < 3:
+                data = data + 'm1'
+            elif sys_version_info.major > 3:
+                data = str.encode(data.decode('utf-8') + 'm1')
 
-                vc.put_object("{pool_name}", "{obj_name}", data)
+            vc.put_object("{pool_name}", "{obj_name}", data)
 
-                if sys_version_info.major < 3:
-                    data = data + 'm2'
-                elif sys_version_info.major > 3:
-                    data = str.encode(data.decode('utf-8') + 'm2')
+            if sys_version_info.major < 3:
+                data = data + 'm2'
+            elif sys_version_info.major > 3:
+                data = str.encode(data.decode('utf-8') + 'm2')
 
+            try:
                 vc.put_object_versioned("{pool_name}", "{obj_name}", data, version)
-            """).format(pool_name=pool_name, obj_name=obj_name))
+            except {expected_exception}:
+                print('{expected_exception} raised')
+        """).format(pool_name=pool_name, obj_name=obj_name,
+                    expected_exception=expected_exception))
+        self.assertEqual(expected_exception + ' raised', output)
+
 
     def test_delete_object(self):
         vc_mount = self.mounts[1]

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -15,7 +15,7 @@ class TestVolumeClient(CephFSTestCase):
     # One for looking at the global filesystem, one for being
     # the VolumeClient, two for mounting the created shares
     CLIENTS_REQUIRED = 4
-    default_py_version = 'python'
+    default_py_version = 'python3'
 
     def setUp(self):
         CephFSTestCase.setUp(self)
@@ -964,6 +964,29 @@ vc.disconnect()
             obj_name = obj_name,
             obj_data = obj_data
         )))
+
+    def test_put_object_versioned(self):
+        vc_mount = self.mounts[1]
+        vc_mount.umount_wait()
+        self._configure_vc_auth(vc_mount, "manila")
+
+        obj_data = 'test_data'
+        obj_name = 'test_vc_obj'
+        pool_name = self.fs.get_data_pool_names()[0]
+        self.fs.rados(['put', obj_name, '-'], pool=pool_name, stdin_data=obj_data)
+
+        self._volume_client_python(vc_mount, dedent("""
+            data, version_before = vc.get_object_and_version("{pool_name}", "{obj_name}")
+
+            if sys_version_info.major < 3:
+                data = data + 'modification1'
+            elif sys_version_info.major > 3:
+                data = str.encode(data.decode() + 'modification1')
+
+            vc.put_object_versioned("{pool_name}", "{obj_name}", data, version_before)
+            data, version_after = vc.get_object_and_version("{pool_name}", "{obj_name}")
+            assert version_after == version_before + 1
+        """).format(pool_name=pool_name, obj_name=obj_name))
 
     def test_version_check_for_put_object_versioned(self):
         vc_mount = self.mounts[1]


### PR DESCRIPTION
This PR...

* makes `test_put_object_versioned()` Python 3 compatible (with this all
  embedded Python programs in test_volume_client.py are Python 3 compatible)
* fixes the bug in `test_put_object_versioned()`
* renames `test_put_object_versioned()` since it's more than a simple test
* adds a basic positive test for `put_object_versioned()`

Besides,

* makes `sudo_write_file()` Python 3 compatible
* `_sudo_write_file()` is moved from test_volume_client.py to
  cephfs_test_case.py so that other  testsuites can use it too
* renames `_sudo_write_file()` to `sudo_write_file()` since other classes
  are encouraged to use it


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug