### PR TITLE
mgr/dashboard: Support minimum password complexity rules

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/user.py
+++ b/src/pybind/mgr/dashboard/controllers/user.py
@@ -10,8 +10,40 @@ from ..exceptions import DashboardException, UserAlreadyExists, \
 from ..security import Scope
 from ..services.access_control import SYSTEM_ROLES
 from ..services.auth import JwtManager
+import re
 
 
+# minimum password complexity rules
+def check_password_complexity(password, username):
+    """
+    Suggested rules for password complexity
+    - at least 6 chars in length
+    - must not be the same as the user account name
+    - consist of characters from the following groups
+    - alphabetic a-z, A-Z
+    - numbers 0-9
+    - special chars: !_@
+    - must use at least 1 special char
+    """
+    if password == username:
+        raise DashboardException(msg='Password is the same as the username.\
+                                      It has to be different',
+                                 code='password-the-same-as-username',
+                                 component='Update/Create user')
+
+    password_min_complex = re.compile('^(?=\\S{6,20}$)(?=.*[!_@])(?=.*[a-z])'
+                                      '(?=.*[A-Z])(?=.*[0-9])')
+
+    if not password_min_complex.match(password):
+        raise DashboardException(msg='Password is not strong enough. <br/>\
+                                      It has to contains at least 6 chars. <br/>\
+                                      It must use at least 1 special char (!_@). <br/>\
+                                      It has to consist of alphabetic\
+                                       (a-z and A-Z) and numeric (0-9) chars.',
+                                 code='not-strong-enough-password',
+                                 component='Update/Create user')
+
+                                 
 @ApiController('/user', Scope.USER)
 class User(RESTController):
     @staticmethod
@@ -52,6 +84,8 @@ class User(RESTController):
         if roles:
             user_roles = User._get_user_roles(roles)
         try:
+            if password:
+                check_password_complexity(password, username)
             user = mgr.ACCESS_CTRL_DB.create_user(username, password, name, email)
         except UserAlreadyExists:
             raise DashboardException(msg='Username already exists',
@@ -79,10 +113,15 @@ class User(RESTController):
             user = mgr.ACCESS_CTRL_DB.get_user(username)
         except UserDoesNotExist:
             raise cherrypy.HTTPError(404)
+        if not password and not name and not email and (user.to_dict())['roles'] == roles:
+            raise DashboardException(msg='All fields are empty, cannot update the user',
+                                     code='cannot_update_user',
+                                     component='user')
         user_roles = []
         if roles:
             user_roles = User._get_user_roles(roles)
         if password:
+            check_password_complexity(password, username)
             user.set_password(password)
         user.name = name
         user.email = email


### PR DESCRIPTION
Support minimum password complexity rules: 
1. checks if the password is different than user name. 
2. Checks whether the password fulfill required basic rules.

Complexity is checked during creating user and editing user.

Fixes: https://tracker.ceph.com/issues/25232
Signed-off-by: Dziomdziora, Elżbieta <elzbieta.dziomdziora@ts.fujitsu.coom>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

