### PR TITLE
mgr/progress: Bug fix complete event when OSD marked in

### DIFF
--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -360,16 +360,7 @@ class Module(MgrModule):
         self.log.warn("{0} PGs affected by osd.{1} being marked {2}".format(
             len(affected_pgs), osd_id, marked))
 
-        if len(affected_pgs) > 0:
-            ev = PgRecoveryEvent(
-               "Rebalancing after osd.{0} marked {1}".format(osd_id, marked),
-               refs=[("osd", osd_id)],
-               which_pgs=affected_pgs,
-               evacuate_osds=[osd_id]
-            )
-            ev.pg_update(self.get("pg_dump"), self.log)
-            self._events[ev.id] = ev
-            
+           
         # In the case of the osd coming back in, we might need to cancel 
         # previous recovery event for that osd
         if marked == "in":
@@ -380,6 +371,16 @@ class Module(MgrModule):
                     ))
                     self._complete(ev)
 
+        if len(affected_pgs) > 0:
+            ev = PgRecoveryEvent(
+                    "Rebalancing after osd.{0} marked {1}".format(osd_id, marked),
+                    refs=[("osd", osd_id)],
+                    which_pgs=affected_pgs,
+                    evacuate_osds=[osd_id]
+                    )
+            ev.pg_update(self.get("pg_dump"), self.log)
+            self._events[ev.id] = ev
+                 
     def _osdmap_changed(self, old_osdmap, new_osdmap):
         old_dump = old_osdmap.dump()
         new_dump = new_osdmap.dump()


### PR DESCRIPTION
Swap the order of checking for complete event
when OSD is marked in and creating a
PG Recovery event so that the event
doesn't cancel itself.

Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

