### PR TITLE
os/bluestore: speed up pool removal by introducing collection list prefetch

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1062,6 +1062,8 @@ OPTION(bluestore_debug_enforce_settings, OPT_STR)
 OPTION(bluestore_volume_selection_policy, OPT_STR)
 OPTION(bluestore_volume_selection_reserved_factor, OPT_DOUBLE)
 OPTION(bluestore_volume_selection_reserved, OPT_INT)
+OPTION(bluestore_collection_list_min_prefetch, OPT_INT)
+OPTION(bluestore_collection_list_prefetch, OPT_INT)
 
 OPTION(kstore_max_ops, OPT_U64)
 OPTION(kstore_max_bytes, OPT_U64)

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1064,6 +1064,7 @@ OPTION(bluestore_volume_selection_reserved_factor, OPT_DOUBLE)
 OPTION(bluestore_volume_selection_reserved, OPT_INT)
 OPTION(bluestore_collection_list_min_prefetch, OPT_INT)
 OPTION(bluestore_collection_list_prefetch, OPT_INT)
+OPTION(bluestore_kv_sync_util_logging_s, OPT_INT)
 
 OPTION(kstore_max_ops, OPT_U64)
 OPTION(kstore_max_bytes, OPT_U64)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4688,6 +4688,14 @@ std::vector<Option> get_global_options() {
     .set_description("Number of additional entries prefetched during collection listing")
     .set_long_description("Number of additional entries prefetched during collection listing. Applied if listing boundaries aren't specified"),
 
+    Option("bluestore_kv_sync_util_logging_s", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(10)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("KV sync thread utilization logging period")
+    .set_long_description("How often (in secons) to log KV sync thread utilization, "
+      "not logged if set to 0 or utilization for the period is 0%"),
+
+
     // -----------------------------------------
     // kstore
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4676,6 +4676,18 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description("Enables Linux io_uring API instead of libaio"),
 
+    Option("bluestore_collection_list_min_prefetch", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(30)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("Number of additional entries prefetched during collection listing")
+    .set_long_description("Number of additional entries prefetched during collection listing. Applied if listing boundaries aren't specified"),
+
+    Option("bluestore_collection_list_prefetch", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(512)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("Number of additional entries prefetched during collection listing")
+    .set_long_description("Number of additional entries prefetched during collection listing. Applied if listing boundaries aren't specified"),
+
     // -----------------------------------------
     // kstore
 

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -507,7 +507,7 @@ static int os_readdir(const char *path,
       while (true) {
 	vector<ghobject_t> ls;
 	int r = fs->store->collection_list(
-	  ch, next, last, 1000, &ls, &next);
+	  ch, next, last, 1000, &ls, &next, 0);
 	if (r < 0)
 	  return r;
 	for (auto p : ls) {

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -672,7 +672,8 @@ public:
   virtual int collection_list(CollectionHandle &c,
 			      const ghobject_t& start, const ghobject_t& end,
 			      int max,
-			      std::vector<ghobject_t> *ls, ghobject_t *next) = 0;
+			      std::vector<ghobject_t> *ls, ghobject_t *next,
+			      int flags) = 0;
 
 
   /// OMAP

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11866,7 +11866,25 @@ void BlueStore::_kv_sync_thread()
   ceph_assert(!kv_sync_started);
   kv_sync_started = true;
   kv_cond.notify_all();
+
+  auto t0 = mono_clock::now();
+  timespan twait = ceph::make_timespan(0);
+  size_t kv_submitted = 0;
+
   while (true) {
+    auto period = cct->_conf->bluestore_kv_sync_util_logging_s;
+    auto observation_period =
+      ceph::make_timespan(period);
+    auto elapsed = mono_clock::now() - t0;
+    if (period && elapsed >= observation_period) {
+      dout(0) << __func__ << " utilization: idle "
+	      << twait << " of " << elapsed
+	      << ", submitted: " << kv_submitted
+	      <<dendl;
+      t0 = mono_clock::now();
+      twait = ceph::make_timespan(0);
+      kv_submitted = 0;
+    }
     ceph_assert(kv_committing.empty());
     if (kv_queue.empty() &&
 	((deferred_done_queue.empty() && deferred_stable_queue.empty()) ||
@@ -11874,8 +11892,11 @@ void BlueStore::_kv_sync_thread()
       if (kv_stop)
 	break;
       dout(20) << __func__ << " sleep" << dendl;
+      auto t = mono_clock::now();
       kv_sync_in_progress = false;
       kv_cond.wait(l);
+      twait += mono_clock::now() - t;
+
       dout(20) << __func__ << " wake" << dendl;
     } else {
       deque<TransContext*> kv_submitting;
@@ -11969,6 +11990,7 @@ void BlueStore::_kv_sync_thread()
       for (auto txc : kv_committing) {
 	throttle.log_state_latency(*txc, logger, l_bluestore_state_kv_queued_lat);
 	if (txc->state == TransContext::STATE_KV_QUEUED) {
+	  ++kv_submitted; // FIXME minor: we might want to count ops in transactions
 	  _txc_apply_kv(txc, false);
 	  --txc->osr->kv_committing_serially;
 	} else {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10357,7 +10357,7 @@ int BlueStore::collection_empty(CollectionHandle& ch, bool *empty)
   vector<ghobject_t> ls;
   ghobject_t next;
   int r = collection_list(ch, ghobject_t(), ghobject_t::get_max(), 1,
-			  &ls, &next);
+			  &ls, &next, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
   if (r < 0) {
     derr << __func__ << " collection_list returned: " << cpp_strerror(r)
          << dendl;
@@ -10379,16 +10379,17 @@ int BlueStore::collection_bits(CollectionHandle& ch)
 
 int BlueStore::collection_list(
   CollectionHandle &c_, const ghobject_t& start, const ghobject_t& end, int max,
-  vector<ghobject_t> *ls, ghobject_t *pnext)
+  vector<ghobject_t> *ls, ghobject_t *pnext, int flags)
 {
   Collection *c = static_cast<Collection *>(c_.get());
   c->flush();
   dout(15) << __func__ << " " << c->cid
-           << " start " << start << " end " << end << " max " << max << dendl;
+           << " start " << start << " end " << end << " max " << max
+	   << " flags " << flags << dendl;
   int r;
   {
     std::shared_lock l(c->lock);
-    r = _collection_list(c, start, end, max, ls, pnext);
+    r = _collection_list(c, start, end, max, ls, pnext, flags);
   }
 
   dout(10) << __func__ << " " << c->cid
@@ -10400,7 +10401,7 @@ int BlueStore::collection_list(
 
 int BlueStore::_collection_list(
   Collection *c, const ghobject_t& start, const ghobject_t& end, int max,
-  vector<ghobject_t> *ls, ghobject_t *pnext)
+  vector<ghobject_t> *ls, ghobject_t *pnext, int flags)
 {
 
   if (!c->exists)
@@ -15024,7 +15025,8 @@ int BlueStore::_remove_collection(TransContext *txc, const coll_t &cid,
     // then check if all of them are marked as non-existent.
     // Bypass the check if (next != ghobject_t::get_max())
     r = _collection_list(c->get(), ghobject_t(), ghobject_t::get_max(),
-                         nonexistent_count + 1, &ls, &next);
+                         nonexistent_count + 1, &ls, &next,
+			 CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
     if (r >= 0) {
       // If true mean collecton has more objects than nonexistent_count,
       // so bypass check.

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2436,7 +2436,7 @@ private:
 
   int _collection_list(
     Collection *c, const ghobject_t& start, const ghobject_t& end,
-    int max, std::vector<ghobject_t> *ls, ghobject_t *next);
+    int max, std::vector<ghobject_t> *ls, ghobject_t *next, int flags);
 
   template <typename T, typename F>
   T select_option(const std::string& opt_name, T val1, F f) {
@@ -2755,7 +2755,9 @@ public:
 		      const ghobject_t& start,
 		      const ghobject_t& end,
 		      int max,
-		      std::vector<ghobject_t> *ls, ghobject_t *next) override;
+		      std::vector<ghobject_t> *ls,
+		      ghobject_t *next,
+		      int flags) override;
 
   int omap_get(
     CollectionHandle &c,     ///< [in] Collection containing oid

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4943,7 +4943,7 @@ int FileStore::_collection_remove_recursive(const coll_t &cid,
   ghobject_t max;
   while (!max.is_max()) {
     r = collection_list(cid, max, ghobject_t::get_max(),
-			300, &objects, &max);
+			300, &objects, &max, 0);
     if (r < 0)
       return r;
     for (vector<ghobject_t>::iterator i = objects.begin();
@@ -5140,7 +5140,7 @@ int FileStore::collection_list(const coll_t& c,
 			       const ghobject_t& orig_start,
 			       const ghobject_t& end,
 			       int max,
-			       vector<ghobject_t> *ls, ghobject_t *next)
+			       vector<ghobject_t> *ls, ghobject_t *next, int flags)
 {
   ghobject_t start = orig_start;
   if (start.is_max())
@@ -5180,7 +5180,7 @@ int FileStore::collection_list(const coll_t& c,
     if (start < sep) {
       dout(10) << __FUNC__ << ": first checking temp pool" << dendl;
       coll_t temp = c.get_temp();
-      int r = collection_list(temp, start, end, max, ls, next);
+      int r = collection_list(temp, start, end, max, ls, next, flags);
       if (r < 0)
 	return r;
       if (*next != ghobject_t::get_max())
@@ -5908,7 +5908,8 @@ int FileStore::_merge_collection(const coll_t& cid,
 	next, ghobject_t::get_max(),
 	get_ideal_list_max(),
 	&objects,
-	&next);
+	&next,
+	0);
       if (objects.empty())
 	break;
       for (vector<ghobject_t>::iterator i = objects.begin();
@@ -5991,7 +5992,8 @@ int FileStore::_split_collection(const coll_t& cid,
 	next, ghobject_t::get_max(),
 	get_ideal_list_max(),
 	&objects,
-	&next);
+	&next,
+	0);
       if (objects.empty())
 	break;
       for (vector<ghobject_t>::iterator i = objects.begin();
@@ -6010,7 +6012,8 @@ int FileStore::_split_collection(const coll_t& cid,
 	next, ghobject_t::get_max(),
 	get_ideal_list_max(),
 	&objects,
-	&next);
+	&next,
+	0);
       if (objects.empty())
 	break;
       for (vector<ghobject_t>::iterator i = objects.begin();

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -706,13 +706,13 @@ public:
   int collection_bits(CollectionHandle& c) override;
   int collection_list(CollectionHandle& c,
 		      const ghobject_t& start, const ghobject_t& end, int max,
-		      std::vector<ghobject_t> *ls, ghobject_t *next) override {
+		      std::vector<ghobject_t> *ls, ghobject_t *next, int flags) override {
     c->flush();
-    return collection_list(c->cid, start, end, max, ls, next);
+    return collection_list(c->cid, start, end, max, ls, next, flags);
   }
   int collection_list(const coll_t& cid,
 		      const ghobject_t& start, const ghobject_t& end, int max,
-		      std::vector<ghobject_t> *ls, ghobject_t *next);
+		      std::vector<ghobject_t> *ls, ghobject_t *next, int flags);
   int list_collections(std::vector<coll_t>& ls) override;
   int list_collections(std::vector<coll_t>& ls, bool include_temp);
   int collection_stat(const coll_t& c, struct stat *st);

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1404,7 +1404,7 @@ int KStore::collection_empty(CollectionHandle& ch, bool *empty)
   vector<ghobject_t> ls;
   ghobject_t next;
   int r = collection_list(ch, ghobject_t(), ghobject_t::get_max(), 1,
-			  &ls, &next);
+			  &ls, &next, 0);
   if (r < 0) {
     derr << __func__ << " collection_list returned: " << cpp_strerror(r)
          << dendl;
@@ -1426,7 +1426,7 @@ int KStore::collection_bits(CollectionHandle& ch)
 
 int KStore::collection_list(
   CollectionHandle &c_, const ghobject_t& start, const ghobject_t& end, int max,
-  vector<ghobject_t> *ls, ghobject_t *pnext)
+  vector<ghobject_t> *ls, ghobject_t *pnext, int flags)
 
 {
   Collection *c = static_cast<Collection*>(c_.get());

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -496,7 +496,7 @@ public:
   int collection_list(
     CollectionHandle &c, const ghobject_t& start, const ghobject_t& end,
     int max,
-    std::vector<ghobject_t> *ls, ghobject_t *next) override;
+    std::vector<ghobject_t> *ls, ghobject_t *next, int flags) override;
 
   using ObjectStore::omap_get;
   int omap_get(

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -439,7 +439,8 @@ int MemStore::collection_list(CollectionHandle& ch,
 			      const ghobject_t& start,
 			      const ghobject_t& end,
 			      int max,
-			      std::vector<ghobject_t> *ls, ghobject_t *next)
+			      std::vector<ghobject_t> *ls, ghobject_t *next,
+			      int flags)
 {
   Collection *c = static_cast<Collection*>(ch.get());
   std::shared_lock l{c->lock};

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -328,7 +328,8 @@ public:
   int collection_bits(CollectionHandle& c) override;
   int collection_list(CollectionHandle& cid,
 		      const ghobject_t& start, const ghobject_t& end, int max,
-		      std::vector<ghobject_t> *ls, ghobject_t *next) override;
+		      std::vector<ghobject_t> *ls, ghobject_t *next,
+		      int flags) override;
 
   using ObjectStore::omap_get;
   int omap_get(

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4407,7 +4407,7 @@ void OSD::clear_temp_objects()
       ceph_assert(ch);
       store->collection_list(ch, next, ghobject_t::get_max(),
 			     store->get_ideal_list_max(),
-			     &objects, &next);
+			     &objects, &next, 0);
       if (objects.empty())
 	break;
       vector<ghobject_t>::iterator q;
@@ -4463,7 +4463,7 @@ void OSD::recursive_remove_collection(CephContext* cct,
   while (true) {
     objects.clear();
     store->collection_list(ch, next, ghobject_t::get_max(),
-      max, &objects, &next);
+      max, &objects, &next, 0);
     generic_dout(10) << __func__ << " " << objects << dendl;
     if (objects.empty())
       break;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4456,14 +4456,16 @@ void OSD::recursive_remove_collection(CephContext* cct,
   ObjectStore::Transaction t;
   SnapMapper mapper(cct, &driver, 0, 0, 0, pgid.shard);
 
-  ghobject_t next;
   int max = cct->_conf->osd_target_transaction_size;
   vector<ghobject_t> objects;
   objects.reserve(max);
   while (true) {
+    // do not preserve next to enable collection list prefetching
+    ghobject_t next;
     objects.clear();
     store->collection_list(ch, next, ghobject_t::get_max(),
-      max, &objects, &next, 0);
+      max, &objects, &next,
+      CEPH_OSD_OP_FLAG_FADVISE_WILLNEED | CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL);
     generic_dout(10) << __func__ << " " << objects << dendl;
     if (objects.empty())
       break;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3836,7 +3836,7 @@ void PG::do_delete_work(ObjectStore::Transaction &t)
     max,
     &olist,
     &next,
-    0);
+    CEPH_OSD_OP_FLAG_FADVISE_WILLNEED | CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL);
   dout(20) << __func__ << " " << olist << dendl;
 
   OSDriver::OSTransaction _t(osdriver.get_transaction(&t));

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3835,7 +3835,8 @@ void PG::do_delete_work(ObjectStore::Transaction &t)
     ghobject_t::get_max(),
     max,
     &olist,
-    &next);
+    &next,
+    0);
   dout(20) << __func__ << " " << olist << dendl;
 
   OSDriver::OSTransaction _t(osdriver.get_transaction(&t));

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -372,7 +372,8 @@ int PGBackend::objects_list_partial(
       ghobject_t::get_max(),
       max - ls->size(),
       &objects,
-      &_next);
+      &_next,
+      0);
     if (r != 0) {
       derr << __func__ << " list collection " << ch << " got: " << cpp_strerror(r) << dendl;
       break;
@@ -407,7 +408,8 @@ int PGBackend::objects_list_range(
     ghobject_t(end, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
     INT_MAX,
     &objects,
-    NULL);
+    NULL,
+    0);
   ls->reserve(objects.size());
   for (vector<ghobject_t>::iterator i = objects.begin();
        i != objects.end();

--- a/src/test/objectstore/FileStoreDiff.cc
+++ b/src/test/objectstore/FileStoreDiff.cc
@@ -138,14 +138,14 @@ bool FileStoreDiff::diff_objects(FileStore *a_store, FileStore *b_store, coll_t 
   int err;
   std::vector<ghobject_t> b_objects, a_objects;
   err = b_store->collection_list(coll, ghobject_t(), ghobject_t::get_max(),
-				 INT_MAX, &b_objects, NULL);
+				 INT_MAX, &b_objects, NULL, 0);
   if (err < 0) {
     cout << "diff_objects list on verify coll " << coll.to_str()
 	    << " returns " << err << std::endl;
     return true;
   }
   err = a_store->collection_list(coll, ghobject_t(), ghobject_t::get_max(),
-				 INT_MAX, &a_objects, NULL);
+				 INT_MAX, &a_objects, NULL, 0);
   if (err < 0) {
     cout << "diff_objects list on store coll " << coll.to_str()
               << " returns " << err << std::endl;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2840,7 +2840,7 @@ TEST_P(StoreTest, SimpleListTest) {
     while (!next.is_max()) {
       int r = store->collection_list(ch, current, ghobject_t::get_max(),
 				     50,
-				     &objects, &next);
+				     &objects, &next, 0);
       ASSERT_EQ(r, 0);
       ASSERT_TRUE(sorted(objects));
       cout << " got " << objects.size() << " next " << next << std::endl;
@@ -2904,7 +2904,7 @@ TEST_P(StoreTest, ListEndTest) {
     vector<ghobject_t> objects;
     ghobject_t next;
     int r = store->collection_list(ch, ghobject_t(), end, 500,
-				   &objects, &next);
+				   &objects, &next, 0);
     ASSERT_EQ(r, 0);
     for (auto &p : objects) {
       ASSERT_NE(p, end);
@@ -2984,7 +2984,7 @@ TEST_P(StoreTest, MultipoolListTest) {
     ghobject_t next, current;
     while (!next.is_max()) {
       int r = store->collection_list(ch, current, ghobject_t::get_max(), 50,
-				     &objects, &next);
+				     &objects, &next, 0);
       ASSERT_EQ(r, 0);
       cout << " got " << objects.size() << " next " << next << std::endl;
       for (vector<ghobject_t>::iterator p = objects.begin(); p != objects.end();
@@ -3650,7 +3650,8 @@ TEST_P(StoreTest, ManyObjectTest) {
 
   set<ghobject_t> listed, listed2;
   vector<ghobject_t> objects;
-  r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(), INT_MAX, &objects, 0);
+  r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(), INT_MAX,
+    &objects, nullptr, 0);
   ASSERT_EQ(r, 0);
 
   cerr << "objects.size() is " << objects.size() << std::endl;
@@ -3670,8 +3671,8 @@ TEST_P(StoreTest, ManyObjectTest) {
     ghobject_t::get_max(),
     50,
     &objects,
-    &next
-    );
+    &next,
+    0);
   ASSERT_EQ(r, 0);
   ASSERT_TRUE(objects.empty());
 
@@ -3682,7 +3683,8 @@ TEST_P(StoreTest, ManyObjectTest) {
     r = store->collection_list(ch, start, ghobject_t::get_max(),
 			       50,
 			       &objects,
-			       &next);
+			       &next,
+			       0);
     ASSERT_TRUE(sorted(objects));
     ASSERT_EQ(r, 0);
     listed.insert(objects.begin(), objects.end());
@@ -3910,7 +3912,7 @@ public:
     while (1) {
       vector<ghobject_t> objects;
       int r = store->collection_list(ch, next, ghobject_t::get_max(),
-                                     10, &objects, &next);
+				     10, &objects, nullptr, 0);
       ceph_assert(r >= 0);
       if (objects.size() == 0)
         break;
@@ -4562,7 +4564,7 @@ public:
     while (1) {
       //cerr << "scanning..." << std::endl;
       int r = store->collection_list(ch, current, ghobject_t::get_max(), 100,
-				     &objects, &next);
+				     &objects, &next, 0);
       ASSERT_EQ(r, 0);
       ASSERT_TRUE(sorted(objects));
       objects_set.insert(objects.begin(), objects.end());
@@ -4596,7 +4598,7 @@ public:
     }
 
     int r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
-				   INT_MAX, &objects, 0);
+				   INT_MAX, &objects, nullptr, 0);
     ASSERT_EQ(r, 0);
     objects_set2.insert(objects.begin(), objects.end());
     ASSERT_EQ(objects_set2.size(), available_objects.size());
@@ -5010,7 +5012,8 @@ TEST_P(StoreTest, HashCollisionTest) {
   }
   }
   vector<ghobject_t> objects;
-  r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(), INT_MAX, &objects, 0);
+  r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(), INT_MAX,
+    &objects, nullptr, 0);
   ASSERT_EQ(r, 0);
   set<ghobject_t> listed(objects.begin(), objects.end());
   cerr << "listed.size() is " << listed.size() << " and created.size() is " << created.size() << std::endl;
@@ -5020,7 +5023,7 @@ TEST_P(StoreTest, HashCollisionTest) {
   ghobject_t current, next;
   while (1) {
     r = store->collection_list(ch, current, ghobject_t::get_max(), 60,
-			       &objects, &next);
+			       &objects, &next, 0);
     ASSERT_EQ(r, 0);
     ASSERT_TRUE(sorted(objects));
     for (vector<ghobject_t>::iterator i = objects.begin();
@@ -5109,7 +5112,7 @@ TEST_P(StoreTest, ScrubTest) {
 
   vector<ghobject_t> objects;
   r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
-			     INT_MAX, &objects, 0);
+			     INT_MAX, &objects, nullptr, 0);
   ASSERT_EQ(r, 0);
   set<ghobject_t> listed(objects.begin(), objects.end());
   cerr << "listed.size() is " << listed.size() << " and created.size() is " << created.size() << std::endl;
@@ -5119,7 +5122,7 @@ TEST_P(StoreTest, ScrubTest) {
   ghobject_t current, next;
   while (1) {
     r = store->collection_list(ch, current, ghobject_t::get_max(), 60,
-			       &objects, &next);
+			       &objects, &next, 0);
     ASSERT_EQ(r, 0);
     ASSERT_TRUE(sorted(objects));
     for (vector<ghobject_t>::iterator i = objects.begin();
@@ -5584,7 +5587,7 @@ void colsplittest(
   // check
   vector<ghobject_t> objects;
   r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
-			     INT_MAX, &objects, 0);
+			     INT_MAX, &objects, nullptr, 0);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(objects.size(), num_objects);
   for (vector<ghobject_t>::iterator i = objects.begin();
@@ -5595,7 +5598,7 @@ void colsplittest(
 
   objects.clear();
   r = store->collection_list(tch, ghobject_t(), ghobject_t::get_max(),
-			     INT_MAX, &objects, 0);
+			     INT_MAX, &objects, nullptr, 0);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(objects.size(), num_objects);
   for (vector<ghobject_t>::iterator i = objects.begin();
@@ -5617,7 +5620,7 @@ void colsplittest(
   {
     vector<ghobject_t> objects;
     r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
-			       INT_MAX, &objects, 0);
+			       INT_MAX, &objects, nullptr, 0);
     ASSERT_EQ(r, 0);
     ASSERT_EQ(objects.size(), num_objects * 2); // both halves
     unsigned size = 0;
@@ -5755,7 +5758,7 @@ void test_merge_skewed(ObjectStore *store,
   {
     vector<ghobject_t> got;
     store->collection_list(cha, ghobject_t(), ghobject_t::get_max(), INT_MAX,
-			   &got, 0);
+			   &got, nullptr, 0);
     set<ghobject_t> gotset;
     for (auto& o : got) {
       ASSERT_TRUE(aobjects.count(o) || bobjects.count(o));
@@ -6064,7 +6067,7 @@ TEST_P(StoreTest, BigRGWObjectName) {
   {
     vector<ghobject_t> objects;
     r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
-			       INT_MAX, &objects, 0);
+			       INT_MAX, &objects, nullptr, 0);
     ASSERT_EQ(r, 0);
     ASSERT_EQ(objects.size(), 1u);
     ASSERT_EQ(objects[0], oid2);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -93,7 +93,8 @@ int _action_on_all_objects_in_pg(ObjectStore *store, coll_t coll, action_on_obje
 				   ghobject_t::get_max(),
 				   LIST_AT_A_TIME,
 				   &list,
-				   &next);
+				   &next,
+				   0);
     if (r < 0) {
       cerr << "Error listing collection: " << coll << ", "
 	   << cpp_strerror(r) << std::endl;
@@ -864,7 +865,7 @@ int ObjectStoreTool::export_files(ObjectStore *store, coll_t coll)
   while (!next.is_max()) {
     vector<ghobject_t> objects;
     int r = store->collection_list(ch, next, ghobject_t::get_max(), 300,
-      &objects, &next);
+      &objects, &next, 0);
     if (r < 0)
       return r;
     for (vector<ghobject_t>::iterator i = objects.begin();
@@ -2978,7 +2979,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
     uint64_t bytes = 0, keys = 0;
     while (true) {
       vector<ghobject_t> ls;
-      r = src->collection_list(ch, pos, ghobject_t::get_max(), 1000, &ls, &pos);
+      r = src->collection_list(ch, pos, ghobject_t::get_max(), 1000, &ls, &pos, 0);
       if (r < 0) {
 	cerr << "collection_list on " << cid << " from " << pos << " got: "
 	     << cpp_strerror(r) << std::endl;


### PR DESCRIPTION
Also optionally retrieves onode during collection listing and puts it into the cache to reuse during removal.
Signed-off-by: Igor Fedotov <ifedotov@suse,com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

