### PR TITLE
mds: recall caps from quiescent sessions

### DIFF
--- a/qa/tasks/cephfs/test_journal_repair.py
+++ b/qa/tasks/cephfs/test_journal_repair.py
@@ -315,7 +315,7 @@ class TestJournalRepair(CephFSTestCase):
         # Should see one session
         session_data = json.loads(self.fs.table_tool(
             ["all", "show", "session"]))
-        self.assertEqual(len(session_data["0"]["data"]["Sessions"]), 1)
+        self.assertEqual(len(session_data["0"]["data"]["sessions"]), 1)
         self.assertEqual(session_data["0"]["result"], 0)
 
         # Should see no snaps
@@ -344,7 +344,7 @@ class TestJournalRepair(CephFSTestCase):
         # Should see 0 sessions
         session_data = json.loads(self.fs.table_tool(
             ["all", "show", "session"]))
-        self.assertEqual(len(session_data["0"]["data"]["Sessions"]), 0)
+        self.assertEqual(len(session_data["0"]["data"]["sessions"]), 0)
         self.assertEqual(session_data["0"]["result"], 0)
 
         # Should see entire inode range now marked free

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -106,7 +106,7 @@ class TestSessionMap(CephFSTestCase):
         table_json = json.loads(self.fs.table_tool(["0", "show", "session"]))
         log.info("SessionMap: {0}".format(json.dumps(table_json, indent=2)))
         self.assertEqual(table_json['0']['result'], 0)
-        self.assertEqual(len(table_json['0']['data']['Sessions']), 2)
+        self.assertEqual(len(table_json['0']['data']['sessions']), 2)
 
         # Now, induce a "force_open_sessions" event by exporting a dir
         self.mount_a.run_shell(["mkdir", "bravo"])
@@ -147,7 +147,7 @@ class TestSessionMap(CephFSTestCase):
         table_json = json.loads(self.fs.table_tool(["0", "show", "session"]))
         log.info("SessionMap: {0}".format(json.dumps(table_json, indent=2)))
         self.assertEqual(table_json['0']['result'], 0)
-        self.assertEqual(len(table_json['0']['data']['Sessions']), 0)
+        self.assertEqual(len(table_json['0']['data']['sessions']), 0)
 
     def _configure_auth(self, mount, id_name, mds_caps, osd_caps=None, mon_caps=None):
         """

--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -51,7 +51,7 @@ void DecayCounter::dump(Formatter *f) const
 {
   decay();
   f->dump_float("value", val);
-  f->dump_float("halflife", rate.k);
+  f->dump_float("halflife", rate.get_halflife());
 }
 
 void DecayCounter::generate_test_instances(std::list<DecayCounter*>& ls)

--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -29,8 +29,8 @@ void DecayCounter::decode(bufferlist::const_iterator &p)
 {
   DECODE_START_LEGACY_COMPAT_LEN(5, 4, 4, p);
   if (struct_v < 2) {
-    double half_life = 0.0;
-    decode(half_life, p);
+    double k = 0.0;
+    decode(k, p);
   }
   if (struct_v < 3) {
     double k = 0.0;

--- a/src/common/DecayCounter.h
+++ b/src/common/DecayCounter.h
@@ -44,6 +44,9 @@ public:
   void set_halflife(double hl) {
     k = log(.5) / hl;
   }
+  double get_halflife() const {
+    return log(.5) / k;
+  }
 
 private:
   double k = 0;             // k = ln(.5)/half_life

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7823,6 +7823,18 @@ std::vector<Option> get_mds_options() {
     .set_default(60.0)
     .set_description("decay rate for warning on slow session cap recall"),
 
+    Option("mds_session_cache_liveness_decay_rate", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .add_see_also("mds_session_cache_liveness_magnitude")
+    .set_default(5_min)
+    .set_description("decay rate for session liveness leading to preemptive cap recall")
+    .set_long_description("This determines how long a session needs to be quiescent before the MDS begins preemptively recalling capabilities. The default of 5 minutes will cause 10 halvings of the decay counter after 1 hour, or 1/1024. The default magnitude of 10 (1^10 or 1024) is chosen so that the MDS considers a previously chatty session (approximately) to be quiescent after 1 hour."),
+
+    Option("mds_session_cache_liveness_magnitude", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .add_see_also("mds_session_cache_liveness_decay_rate")
+    .set_default(10)
+    .set_description("decay magnitude for preemptively recalling caps on quiet client")
+    .set_long_description("This is the order of magnitude difference (in base 2) of the internal liveness decay counter and the number of capabilities the session holds. When this difference occurs, the MDS treats the session as quiescent and begins recalling capabilities."),
+
     Option("mds_freeze_tree_timeout", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(30)
     .set_description(""),

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -175,7 +175,8 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
           trim_client_leases();
           trim();
           check_memory_usage();
-          mds->server->recall_client_state(nullptr, Server::RecallFlags::ENFORCE_MAX);
+          auto flags = Server::RecallFlags::ENFORCE_MAX|Server::RecallFlags::ENFORCE_LIVENESS;
+          mds->server->recall_client_state(nullptr, flags);
           upkeep_last_trim = clock::now();
         } else {
           dout(10) << "cache not ready for trimming" << dendl;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7593,7 +7593,7 @@ void MDCache::check_memory_usage()
   mds->mlogger->set(l_mdm_heap, last.get_heap());
 
   if (cache_toofull()) {
-    mds->server->recall_client_state(nullptr);
+    mds->server->recall_client_state(nullptr, Server::RecallFlags::TRIM);
   }
 
   // If the cache size had exceeded its limit, but we're back in bounds

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1220,9 +1220,6 @@ void MDSDaemon::ms_handle_accept(Connection *con)
   // request to open a session (initial state of Session is `closed`)
   if (!s) {
     s = new Session(con);
-    s->info.auth_name = con->get_peer_entity_name();
-    s->info.inst.addr = con->get_peer_socket_addr();
-    s->info.inst.name = n;
     dout(10) << " new session " << s << " for " << s->info.inst
 	     << " con " << con << dendl;
     con->set_priv(RefCountedPtr{s, false});

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3671,6 +3671,7 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_recall_max_decay_rate",
     "mds_recall_warning_decay_rate",
     "mds_request_load_average_decay_rate",
+    "mds_session_cache_liveness_decay_rate",
     NULL
   };
   return KEYS;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3658,43 +3658,40 @@ epoch_t MDSRank::get_osd_epoch() const
 const char** MDSRankDispatcher::get_tracked_conf_keys() const
 {
   static const char* KEYS[] = {
-    "mds_op_complaint_time", "mds_op_log_threshold",
-    "mds_op_history_size", "mds_op_history_duration",
-    "mds_enable_op_tracker",
-    "mds_log_pause",
-    // clog & admin clog
+    "clog_to_graylog",
+    "clog_to_graylog_host",
+    "clog_to_graylog_port",
     "clog_to_monitors",
     "clog_to_syslog",
     "clog_to_syslog_facility",
     "clog_to_syslog_level",
-    "clog_to_graylog",
-    "clog_to_graylog_host",
-    "clog_to_graylog_port",
-    // MDCache
-    "mds_cache_size",
-    "mds_cache_memory_limit",
-    "mds_cache_reservation",
-    "mds_health_cache_threshold",
-    "mds_cache_mid",
-    "mds_dump_cache_threshold_formatter",
-    "mds_cache_trim_decay_rate",
-    "mds_dump_cache_threshold_file",
-    // MDBalancer
+    "fsid",
+    "host",
     "mds_bal_fragment_dirs",
     "mds_bal_fragment_interval",
-    // PurgeQueue
+    "mds_cache_memory_limit",
+    "mds_cache_mid",
+    "mds_cache_reservation",
+    "mds_cache_size",
+    "mds_cache_trim_decay_rate",
+    "mds_cap_revoke_eviction_timeout",
+    "mds_dump_cache_threshold_file",
+    "mds_dump_cache_threshold_formatter",
+    "mds_enable_op_tracker",
+    "mds_health_cache_threshold",
+    "mds_inject_migrator_session_race",
+    "mds_log_pause",
+    "mds_max_export_size",
+    "mds_max_purge_files",
     "mds_max_purge_ops",
     "mds_max_purge_ops_per_pg",
-    "mds_max_purge_files",
-    // Migrator
-    "mds_max_export_size",
-    "mds_inject_migrator_session_race",
-    "host",
-    "fsid",
-    "mds_cap_revoke_eviction_timeout",
-    // SessionMap
-    "mds_request_load_average_decay_rate",
+    "mds_op_complaint_time",
+    "mds_op_history_duration",
+    "mds_op_history_size",
+    "mds_op_log_threshold",
     "mds_recall_max_decay_rate",
+    "mds_recall_warning_decay_rate",
+    "mds_request_load_average_decay_rate",
     NULL
   };
   return KEYS;

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -633,7 +633,7 @@ public:
   void handle_osd_map();
   void update_log_config();
 
-  const char** get_tracked_conf_keys() const final;
+  const char** get_tracked_conf_keys() const override final;
   void handle_conf_change(const ConfigProxy& conf, const std::set<std::string>& changed) override;
 
   bool handle_command(

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1566,8 +1566,9 @@ void Server::recover_filelocks(CInode *in, bufferlist locks, int64_t client)
 std::pair<bool, uint64_t> Server::recall_client_state(MDSGatherBuilder* gather, RecallFlags flags)
 {
   const auto now = clock::now();
-  const bool steady = flags&RecallFlags::STEADY;
-  const bool enforce_max = flags&RecallFlags::ENFORCE_MAX;
+  const bool steady = !!(flags&RecallFlags::STEADY);
+  const bool enforce_max = !!(flags&RecallFlags::ENFORCE_MAX);
+  const bool trim = !!(flags&RecallFlags::TRIM);
 
   const auto max_caps_per_client = g_conf().get_val<uint64_t>("mds_max_caps_per_client");
   const auto min_caps_per_client = g_conf().get_val<uint64_t>("mds_min_caps_per_client");
@@ -1579,14 +1580,14 @@ std::pair<bool, uint64_t> Server::recall_client_state(MDSGatherBuilder* gather, 
            << " min=" << min_caps_per_client
            << " max=" << max_caps_per_client
            << " total=" << Capability::count()
-           << " flags=0x" << std::hex << flags
+           << " flags=" << flags
            << dendl;
 
   /* trim caps of sessions with the most caps first */
   std::multimap<uint64_t, Session*> caps_session;
-  auto f = [&caps_session, enforce_max, max_caps_per_client](auto& s) {
+  auto f = [&caps_session, enforce_max, trim, max_caps_per_client](auto& s) {
     auto num_caps = s->caps.size();
-    if (!enforce_max || num_caps > max_caps_per_client) {
+    if (trim || (enforce_max && num_caps > max_caps_per_client)) {
       caps_session.emplace(std::piecewise_construct, std::forward_as_tuple(num_caps), std::forward_as_tuple(s));
     }
   };

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1207,6 +1207,7 @@ void Server::reconnect_clients(MDSContext *reconnect_done_)
   for (auto session : sessions) {
     if (session->is_open()) {
       client_reconnect_gather.insert(session->get_client());
+      session->set_reconnecting(true);
       session->last_cap_renew = now;
     }
   }
@@ -1356,6 +1357,7 @@ void Server::handle_client_reconnect(const cref_t<MClientReconnect> &m)
 
     // remove from gather set
     client_reconnect_gather.erase(from);
+    session->set_reconnecting(false);
     if (client_reconnect_gather.empty())
       reconnect_gather_finish();
   }

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -174,6 +174,7 @@ public:
     STEADY = (1<<0),
     ENFORCE_MAX = (1<<1),
     TRIM = (1<<2),
+    ENFORCE_LIVENESS = (1<<3),
   };
   std::pair<bool, uint64_t> recall_client_state(MDSGatherBuilder* gather, RecallFlags=RecallFlags::NONE);
   void force_clients_readonly();

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -169,12 +169,13 @@ public:
   void reconnect_tick();
   void recover_filelocks(CInode *in, bufferlist locks, int64_t client);
 
-  enum RecallFlags {
+  enum class RecallFlags : uint64_t {
     NONE = 0,
     STEADY = (1<<0),
     ENFORCE_MAX = (1<<1),
+    TRIM = (1<<2),
   };
-  std::pair<bool, uint64_t> recall_client_state(MDSGatherBuilder* gather, enum RecallFlags=RecallFlags::NONE);
+  std::pair<bool, uint64_t> recall_client_state(MDSGatherBuilder* gather, RecallFlags=RecallFlags::NONE);
   void force_clients_readonly();
 
   // -- requests --
@@ -352,5 +353,22 @@ private:
   DecayCounter recall_throttle;
   time last_recall_state;
 };
+
+static inline constexpr auto operator|(Server::RecallFlags a, Server::RecallFlags b) {
+  using T = std::underlying_type<Server::RecallFlags>::type;
+  return static_cast<Server::RecallFlags>(static_cast<T>(a) | static_cast<T>(b));
+}
+static inline constexpr auto operator&(Server::RecallFlags a, Server::RecallFlags b) {
+  using T = std::underlying_type<Server::RecallFlags>::type;
+  return static_cast<Server::RecallFlags>(static_cast<T>(a) & static_cast<T>(b));
+}
+static inline std::ostream& operator<<(std::ostream& os, const Server::RecallFlags& f) {
+  using T = std::underlying_type<Server::RecallFlags>::type;
+  return os << "0x" << std::hex << static_cast<T>(f) << std::dec;
+}
+static inline constexpr bool operator!(const Server::RecallFlags& f) {
+  using T = std::underlying_type<Server::RecallFlags>::type;
+  return static_cast<T>(f) == static_cast<T>(0);
+}
 
 #endif

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1001,7 +1001,7 @@ int Session::check_access(CInode *in, unsigned mask,
   if (!auth_caps.is_capable(path, in->inode.uid, in->inode.gid, in->inode.mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
 			    new_uid, new_gid,
-			    socket_addr)) {
+			    info.inst.addr)) {
     return -EACCES;
   }
   return 0;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -874,18 +874,16 @@ void SessionMap::save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
  * Calculate the length of the `requests` member list,
  * because elist does not have a size() method.
  *
- * O(N) runtime.  This would be const, but elist doesn't
- * have const iterators.
+ * O(N) runtime.
  */
-size_t Session::get_request_count()
+size_t Session::get_request_count() const
 {
   size_t result = 0;
 
-  elist<MDRequestImpl*>::iterator p = requests.begin(
-      member_offset(MDRequestImpl, item_session_request));
-  while (!p.end()) {
+  auto it = requests.begin(member_offset(MDRequestImpl, item_session_request));
+  while (!it.end()) {
     ++result;
-    ++p;
+    ++it;
   }
 
   return result;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1037,7 +1037,6 @@ void SessionMap::handle_conf_change(const std::set<std::string>& changed)
 
   if (changed.count("mds_request_load_average_decay_rate")) {
     auto d = g_conf().get_val<double>("mds_request_load_average_decay_rate");
-    dout(20) << __func__ << " decay rate changed to " << d << dendl;
 
     decay_rate = d;
     total_load_avg = DecayCounter(d);

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -176,8 +176,11 @@ public:
 
   list<ref_t<Message>> preopen_out_queue;  ///< messages for client, queued before they connect
 
-  elist<MDRequestImpl*> requests;
-  size_t get_request_count();
+  /* This is mutable to allow get_request_count to be const. elist does not
+   * support const iterators yet.
+   */
+  mutable elist<MDRequestImpl*> requests;
+  size_t get_request_count() const;
 
   interval_set<inodeno_t> pending_prealloc_inos; // journaling prealloc, will be added to prealloc_inos
 

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -172,7 +172,6 @@ public:
 protected:
   ConnectionRef connection;
 public:
-  entity_addr_t socket_addr;
   xlist<Session*>::item item_session_list;
 
   list<ref_t<Message>> preopen_out_queue;  ///< messages for client, queued before they connect
@@ -422,8 +421,11 @@ public:
 
   void set_connection(ConnectionRef con) {
     connection = std::move(con);
-    if (connection) {
-      socket_addr = connection->get_peer_socket_addr();
+    auto& c = connection;
+    if (c) {
+      info.auth_name = c->get_peer_entity_name();
+      info.inst.addr = c->get_peer_socket_addr();
+      info.inst.name = entity_name_t(c->get_peer_type(), c->get_peer_global_id());
     }
   }
   const ConnectionRef& get_connection() const {

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -96,8 +96,11 @@ public:
     }
   }
 
+  void dump(Formatter *f) const;
+
 private:
   int state = STATE_CLOSED;
+  bool reconnecting = false;
   uint64_t state_seq = 0;
   int importing_count = 0;
   friend class SessionMap;
@@ -155,6 +158,9 @@ public:
       state_seq++;
     }
   }
+
+  void set_reconnecting(bool s) { reconnecting = s; }
+
   void decode(bufferlist::const_iterator &p);
   template<typename T>
   void set_client_metadata(T&& meta)

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -606,8 +606,8 @@ public:
   }
 
   bool is_any_state(int state) const {
-    map<int,xlist<Session*>* >::const_iterator p = by_state.find(state);
-    if (p == by_state.end() || p->second->empty())
+    auto it = by_state.find(state);
+    if (it == by_state.end() || it->second->empty())
       return false;
     return true;
   }

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -601,8 +601,7 @@ public:
   // sessions
   void decode_legacy(bufferlist::const_iterator& blp) override;
   bool empty() const { return session_map.empty(); }
-  const ceph::unordered_map<entity_name_t, Session*>& get_sessions() const
-  {
+  const auto& get_sessions() const {
     return session_map;
   }
 

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -463,8 +463,8 @@ void client_metadata_t::decode(bufferlist::const_iterator& p)
 void client_metadata_t::dump(Formatter *f) const
 {
   f->dump_stream("features") << features;
-  for (const auto& p : kv_map)
-    f->dump_string(p.first.c_str(), p.second);
+  for (const auto& [name, val] : kv_map)
+    f->dump_string(name.c_str(), val);
 }
 
 /*
@@ -521,41 +521,33 @@ void session_info_t::dump(Formatter *f) const
   f->dump_stream("inst") << inst;
 
   f->open_array_section("completed_requests");
-  for (map<ceph_tid_t,inodeno_t>::const_iterator p = completed_requests.begin();
-       p != completed_requests.end();
-       ++p) {
+  for (const auto& [tid, ino] : completed_requests) {
     f->open_object_section("request");
-    f->dump_unsigned("tid", p->first);
-    f->dump_stream("created_ino") << p->second;
+    f->dump_unsigned("tid", tid);
+    f->dump_stream("created_ino") << ino;
     f->close_section();
   }
   f->close_section();
 
   f->open_array_section("prealloc_inos");
-  for (interval_set<inodeno_t>::const_iterator p = prealloc_inos.begin();
-       p != prealloc_inos.end();
-       ++p) {
+  for (const auto& [start, len] : prealloc_inos) {
     f->open_object_section("ino_range");
-    f->dump_unsigned("start", p.get_start());
-    f->dump_unsigned("length", p.get_len());
+    f->dump_unsigned("start", start);
+    f->dump_unsigned("length", len);
     f->close_section();
   }
   f->close_section();
 
   f->open_array_section("used_inos");
-  for (interval_set<inodeno_t>::const_iterator p = used_inos.begin();
-       p != used_inos.end();
-       ++p) {
+  for (const auto& [start, len] : used_inos) {
     f->open_object_section("ino_range");
-    f->dump_unsigned("start", p.get_start());
-    f->dump_unsigned("length", p.get_len());
+    f->dump_unsigned("start", start);
+    f->dump_unsigned("length", len);
     f->close_section();
   }
   f->close_section();
 
-  f->open_array_section("client_metadata");
-  client_metadata.dump(f);
-  f->close_section();
+  f->dump_object("client_metadata", client_metadata);
 }
 
 void session_info_t::generate_test_instances(std::list<session_info_t*>& ls)


### PR DESCRIPTION
    This introduces two new config options [1,2] that dictate when a session
    is considered quiescent by the MDS. (Options are documented fully in
    options.cc.) When a session is quiescent, the MDS will preemptively
    recall caps to reduce the outstanding capabilities which optimizes for
    reducing work during failover.
    
    [1] mds_session_cache_liveness_magnitude
    [2] mds_session_cache_liveness_decay_rate
    
    Fixes: https://tracker.ceph.com/issues/22446
