### PR TITLE
ceph.in: do not preload asan even if not needed

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -115,9 +115,8 @@ def get_cmake_variables(*names):
 
 if os.path.exists(os.path.join(MYPDIR, "CMakeCache.txt")) \
      and os.path.exists(os.path.join(MYPDIR, "bin/init-ceph")):
-    src_path, build_type, with_seastar, with_asan, asan_lib_path = \
-        get_cmake_variables("ceph_SOURCE_DIR", "CMAKE_BUILD_TYPE",
-                            "WITH_SEASTAR", "WITH_ASAN", "ASAN_LIBRARY")
+    src_path, with_asan, asan_lib_path = \
+        get_cmake_variables("ceph_SOURCE_DIR", "WITH_ASAN", "ASAN_LIBRARY")
     if src_path is None:
         # Huh, maybe we're not really in a cmake environment?
         pass
@@ -129,9 +128,6 @@ if os.path.exists(os.path.join(MYPDIR, "CMakeCache.txt")) \
         pythonlib_path = os.path.join(lib_path,
                                       "cython_modules",
                                       get_pythonlib_dir())
-        if (with_seastar and build_type == 'Debug' and
-            not asan_lib_path.endswith('NOTFOUND')):
-            with_asan = True
         respawn_in_path(lib_path, pybind_path, pythonlib_path,
                         asan_lib_path if with_asan else None)
 


### PR DESCRIPTION
if ceph python bindings are compiled with ASan enabled has nothing to do
with Seastar. so no need to check for Seastar related compiling
settings.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

