### PR TITLE
crimson: make do_peering_event() reentrant

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -157,6 +157,14 @@ void PG::on_activate_complete()
 {
   active_promise.set_value();
   active_promise = {};
+
+  if (peering_state.needs_recovery()) {
+    do_peering_event(PeeringState::DoRecovery{}, nullptr);
+  } else if (peering_state.needs_backfill()) {
+    do_peering_event(PeeringState::RequestBackfill{}, nullptr);
+  } else {
+    do_peering_event(PeeringState::AllReplicasRecovered{}, nullptr);
+  }
 }
 
 void PG::log_state_enter(const char *state) {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -88,29 +88,7 @@ public:
     bool dirty_info,
     bool dirty_big_info,
     bool need_write_epoch,
-    ObjectStore::Transaction &t) final {
-    std::map<string,bufferlist> km;
-    if (dirty_big_info || dirty_info) {
-      int ret = prepare_info_keymap(
-	shard_services.get_cct(),
-	&km,
-	peering_state.get_osdmap()->get_epoch(),
-	info,
-	last_written_info,
-	past_intervals,
-	dirty_big_info,
-	need_write_epoch,
-	true,
-	nullptr,
-	this);
-      ceph_assert(ret == 0);
-    }
-    pglog.write_log_and_missing(
-      t, &km, coll, pgmeta_oid,
-      peering_state.get_pool().info.require_rollback());
-    if (!km.empty())
-      t.omap_setkeys(coll, pgmeta_oid, km);
-  }
+    ObjectStore::Transaction &t) final;
 
   void on_info_history_change() final {
     // Not needed yet -- mainly for scrub scheduling
@@ -236,10 +214,7 @@ public:
   void on_activate(interval_set<snapid_t> to_trim) final {
     // Not needed yet (will be needed for IO unblocking)
   }
-  void on_activate_complete() final {
-    active_promise.set_value();
-    active_promise = {};
-  }
+  void on_activate_complete() final;
   void on_new_interval() final {
     // Not needed yet
   }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -363,14 +363,16 @@ public:
   seastar::future<> read_state(ceph::os::FuturizedStore* store);
 
   void do_peering_event(
-    PGPeeringEvent& evt, PeeringCtx &rctx);
+    const PGPeeringEvent& evt,
+    PeeringCtx& rctx);
+
   void do_peering_event(
     std::unique_ptr<PGPeeringEvent> evt,
     PeeringCtx &rctx) {
     return do_peering_event(*evt, rctx);
   }
   void do_peering_event(
-    PGPeeringEventRef evt,
+    std::shared_ptr<PGPeeringEvent> evt,
     PeeringCtx &rctx) {
     return do_peering_event(*evt, rctx);
   }
@@ -385,7 +387,7 @@ public:
 private:
   void do_peering_event(
     const boost::statechart::event_base &evt,
-    PeeringCtx &rctx);
+    PeeringCtx *rctx);
   seastar::future<Ref<MOSDOpReply>> do_osd_ops(Ref<MOSDOp> m);
   seastar::future<> do_osd_op(
     ObjectState& os,
@@ -402,6 +404,9 @@ private:
   std::unique_ptr<PGBackend> backend;
 
   PeeringState peering_state;
+
+  using event_ptr = boost::intrusive_ptr<const boost::statechart::event_base>;
+  std::queue<event_ptr> pending_peering_events;
 
   seastar::shared_promise<> active_promise;
   seastar::future<> wait_for_active();

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -53,16 +53,16 @@ public:
     }
     desc = out.str();
   }
-  epoch_t get_epoch_sent() {
+  epoch_t get_epoch_sent() const {
     return epoch_sent;
   }
-  epoch_t get_epoch_requested() {
+  epoch_t get_epoch_requested() const {
     return epoch_requested;
   }
-  const boost::statechart::event_base &get_event() {
+  const boost::statechart::event_base &get_event() const {
     return *evt;
   }
-  const std::string& get_desc() {
+  const std::string& get_desc() const {
     return desc;
   }
 };

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1476,10 +1476,21 @@ public:
     PeeringListener *pl);
 
   /// Process evt
+  void process_event(const boost::statechart::event_base& evt) {
+    machine.process_event(evt);
+  }
+
+  template<typename Func>
+  void with_peering_context(PeeringCtx* rctx, Func&& func) {
+    start_handle(rctx);
+    std::move(func)();
+    end_handle();
+  }
+
   void handle_event(const boost::statechart::event_base &evt,
 		    PeeringCtx *rctx) {
     start_handle(rctx);
-    machine.process_event(evt);
+    process_event(evt);
     end_handle();
   }
 
@@ -1487,7 +1498,7 @@ public:
   void handle_event(PGPeeringEventRef evt,
 		    PeeringCtx *rctx) {
     start_handle(rctx);
-    machine.process_event(evt->get_event());
+    process_event(evt->get_event());
     end_handle();
   }
 


### PR DESCRIPTION
along with #28689, this change allows crimson-osd to mark the created PGs clean after they are activated.

it's another step to enable us to run cbt tests against crimson-osd.