### PR TITLE
[RFC]common/option: let osd_enable_op_tracker default is false.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3723,7 +3723,7 @@ std::vector<Option> get_global_options() {
     .set_default(false),
 
     Option("osd_enable_op_tracker", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description(""),
 
     Option("osd_num_op_tracker_shard", Option::TYPE_UINT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
For my test w/ P3700, one osd:

runtime=3600S/QD=128		IOPS	avg(us)
enable-osd-op-tracker	4k-rr	37.9k	3375.39
			4k-rw	26.3k	4858.93
disable-osd-op-tracker	4k-rr	47K	2721
			4k-rw	33.4k	3835

This option seriously affect performance. So the defalt value is false.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

