### PR TITLE
cephfs-shell: Remove undefined variable 'files' in do_rm()

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -843,9 +843,10 @@ sub-directories, files')
         """
         Remove a specific file
         """
-        for path in args.paths:
+        file_paths = args.paths
+        for path in file_paths:
             if path.count('*') > 0:
-                files.extend([i for i in get_all_possible_paths(
+                file_paths.extend([i for i in get_all_possible_paths(
                     path) if is_file_exists(i)])
             else:
                 try:


### PR DESCRIPTION
Instead of args.paths list use file_paths.

Fixes: https://tracker.ceph.com/issues/40489
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

