### PR TITLE
luminous: rgw: conditionally allow builtin users with non-unique email addresses

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5494,6 +5494,14 @@ std::vector<Option> get_rgw_options() {
         "server static websites if s3website hostnames are configured, and unrelated to "
         "this configurable."),
 
+     Option("rgw_user_unique_email", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(true)
+    .set_description("Require local RGW users to have unique email addresses")
+    .set_long_description(
+        "Enforce builtin user accounts to have unique email addresses.  This "
+	"setting is historical.  In future, non-enforcement of email address "
+        "uniqueness is likely to become the default."),
+
     Option("rgw_log_http_headers", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_default("")
     .set_description("List of HTTP headers to log")

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1789,9 +1789,11 @@ int RGWUser::init(RGWUserAdminOpState& op_state)
     found = (rgw_get_user_info_by_uid(store, user_id, user_info, &op_state.objv) >= 0);
     op_state.found_by_uid = found;
   }
-  if (!user_email.empty() && !found) {
-    found = (rgw_get_user_info_by_email(store, user_email, user_info, &op_state.objv) >= 0);
-    op_state.found_by_email = found;
+  if (store->ctx()->_conf->get_val<bool>("rgw_user_unique_email")) {
+    if (!user_email.empty() && !found) {
+      found = (rgw_get_user_info_by_email(store, user_email, user_info, &op_state.objv) >= 0);
+      op_state.found_by_email = found;
+    }
   }
   if (!swift_user.empty() && !found) {
     found = (rgw_get_user_info_by_swift(store, swift_user, user_info, &op_state.objv) >= 0);


### PR DESCRIPTION
http://tracker.ceph.com/issues/40506