### PR TITLE
mgr/dashboard: Upgrade ceph-iscsi config to version 10

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -25,7 +25,7 @@ from ..tools import TaskManager
 @UiApiController('/iscsi', Scope.ISCSI)
 class IscsiUi(BaseController):
 
-    REQUIRED_CEPH_ISCSI_CONFIG_VERSION = 9
+    REQUIRED_CEPH_ISCSI_CONFIG_VERSION = 10
 
     @Endpoint()
     @ReadPermission


### PR DESCRIPTION
This PR will upgrade the required `ceph-iscsi` config version from `v9` to `v10`.

iSCSI gateways name will be automatically renamed from host short name to FQDN.

Fixes: https://tracker.ceph.com/issues/40566

~~Note that `ceph-iscsi` config `v10` uses FQDNs instead of short names, so if Ceph Dashboard was already configured with a previous version of `ceph-iscsi` you should perform the following steps:~~

~~1) List all iSCSI gateways on Ceph Dashboard~~

~~$ ceph dashboard iscsi-gateway-list~~
~~{"gateways": {"node1": {"service_url": "https://admin:admin@192.168.100.201:5001"} ...}~~


~~2) Remove all your gateways from Ceph Dashboard~~
~~$ ceph dashboard iscsi-gateway-rm node1~~
~~...~~


~~3) Re-add all iSCSI gateways~~
~~$ ceph dashboard iscsi-gateway-add https://admin:admin@192.168.100.201:5001~~
~~...~~

~~4) Check that iSCSI gateways ids are now the FQDNs~~
~~$ ceph dashboard iscsi-gateway-list~~
~~{"gateways": {"node1.ceph.local": {"service_url": "https://admin:admin@192.168.100.201:5001"} ...}~~

~~**IMPORTANT**~~
~~Note that iSCSI configuration will **NOT** be lost.~~
~~These steps will just update the iSCSI gateways "ids" used by Ceph Dashboard.~~


See https://github.com/ceph/ceph-iscsi/pull/84

Signed-off-by: Ricardo Marques <rimarques@suse.com>
