### PR TITLE
cmake: fix WITH_UBSAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,7 @@ endif()
 
 option(WITH_UBSAN "build with UBSAN" OFF)
 if(WITH_UBSAN)
-  list(APPEND sanitizers "undefined-behavior")
+  list(APPEND sanitizers "undefined_behavior")
 endif()
 
 if(sanitizers)


### PR DESCRIPTION
```
CMake Error at cmake/modules/FindSanitizers.cmake:28 (message):
  Unsupported sanitizer: undefined-behavior
```