### PR TITLE
qa/tasks/ceph_manager.py: ignore errors in test_pool_min_size

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -95,6 +95,11 @@ def mount_osd_data(ctx, remote, cluster, osd):
             )
 
 
+class PoolType:
+    REPLICATED = 1
+    ERASURE_CODED = 3
+
+
 class Thrasher:
     """
     Object used to thrash Ceph
@@ -1174,9 +1179,6 @@ class CephManager:
     the same name.
     """
 
-    REPLICATED_POOL = 1
-    ERASURE_CODED_POOL = 3
-
     def __init__(self, controller, ctx=None, config=None, logger=None,
                  cluster='ceph'):
         self.lock = threading.RLock()
@@ -2060,7 +2062,7 @@ class CephManager:
         """
         pool_dump = self.get_pool_dump(pool)
         object_map = self.get_object_map(pool, name)
-        if pool_dump["type"] == CephManager.ERASURE_CODED_POOL:
+        if pool_dump["type"] == PoolType.ERASURE_CODED:
             shard = object_map['acting'].index(osdid)
             return "{pgid}s{shard}".format(pgid=object_map['pgid'],
                                            shard=shard)

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -713,8 +713,10 @@ class Thrasher:
                 pool_type = pool_json['type']  # 1 for rep, 3 for ec
                 min_size = pool_json['min_size']
                 self.log("pool {pool} min_size is {min_size}".format(pool=pool,min_size=min_size))
-                ec_profile = self.ceph_manager.get_pool_property(pool, "erasure_code_profile")
-                if pool_type == 3:
+                try:
+                    ec_profile = self.ceph_manager.get_pool_property(pool, 'erasure_code_profile')
+                    if pool_type != PoolType.ERASURE_CODED:
+                        continue
                     ec_profile = pool_json['erasure_code_profile']
                     ec_profile_json = self.ceph_manager.raw_cluster_cmd(
                         'osd',
@@ -726,13 +728,16 @@ class Thrasher:
                     local_k = int(ec_json['k'])
                     local_m = int(ec_json['m'])
                     self.log("pool {pool} local_k={k} local_m={m}".format(pool=pool,
-                                                                      k=local_k, m=local_m))
+                                                                          k=local_k, m=local_m))
                     if local_k > k:
                         self.log("setting k={local_k} from previous {k}".format(local_k=local_k, k=k))
                         k = local_k
                     if local_m < m:
                         self.log("setting m={local_m} from previous {m}".format(local_m=local_m, m=m))
                         m = local_m
+                except CommandFailedError:
+                    self.log("failed to read erasure_code_profile. %s was likely removed", pool)
+                    continue
 
             if has_pools :
                 self.log("using k={k}, m={m}".format(k=k,m=m))

--- a/qa/tasks/ceph_objectstore_tool.py
+++ b/qa/tasks/ceph_objectstore_tool.py
@@ -250,10 +250,10 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
     for stats in manager.get_pg_stats():
         if stats["pgid"].find(str(REPID) + ".") != 0:
             continue
-        if pool_dump["type"] == ceph_manager.CephManager.REPLICATED_POOL:
+        if pool_dump["type"] == ceph_manager.PoolType.REPLICATED:
             for osd in stats["acting"]:
                 pgs.setdefault(osd, []).append(stats["pgid"])
-        elif pool_dump["type"] == ceph_manager.CephManager.ERASURE_CODED_POOL:
+        elif pool_dump["type"] == ceph_manager.PoolType.ERASURE_CODED:
             shard = 0
             for osd in stats["acting"]:
                 pgs.setdefault(osd, []).append("{pgid}s{shard}".
@@ -311,7 +311,7 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
     log.info(pgswithobjects)
     log.info(objsinpg)
 
-    if pool_dump["type"] == ceph_manager.CephManager.REPLICATED_POOL:
+    if pool_dump["type"] == ceph_manager.PoolType.REPLICATED:
         # Test get-bytes
         log.info("Test get-bytes and set-bytes")
         for basename in db.keys():


### PR DESCRIPTION
to be specific, ignore errors when querying erasure coded pool's
erasure-code-profile. the pool might be removed after
"test_pool_min_size" lists all pools and before queries the pools'
erasure-code-profile. in that case, we should just continue on with the
next pool.

normally, the pools are created by the "radosbench" tasks. and they
don't delete the ec profiles after removing the ec pools using them, but
i don't want to rely on this fact. so, in this change, the `try` block
guards both `ceph osd pool get <pool_name> erasure_code_profile`
and `ceph osd erasure-code-profile get <profile>` calls.

Fixes: http://tracker.ceph.com/issues/40533
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

