### PR TITLE
osdc/Striper: specialize std::min<>

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1354,7 +1354,7 @@ void BlueFS::_drop_link(FileRef file)
 int BlueFS::_read_random(
   FileReader *h,         ///< [in] read from here
   uint64_t off,          ///< [in] offset
-  size_t len,            ///< [in] this many bytes
+  uint64_t len,          ///< [in] this many bytes
   char *out)             ///< [out] optional: or copy it here
 {
   auto* buf = &h->buf;
@@ -1384,7 +1384,7 @@ int BlueFS::_read_random(
       s_lock.unlock();
       uint64_t x_off = 0;
       auto p = h->file->fnode.seek(off, &x_off);
-      uint64_t l = std::min(p->length - x_off, static_cast<uint64_t>(len));
+      uint64_t l = std::min(p->length - x_off, len);
       dout(20) << __func__ << " read random 0x"
 	       << std::hex << x_off << "~" << l << std::dec
 	       << " of " << *p << dendl;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -375,7 +375,7 @@ private:
   int _read_random(
     FileReader *h,   ///< [in] read from here
     uint64_t offset, ///< [in] offset
-    size_t len,      ///< [in] this many bytes
+    uint64_t len,    ///< [in] this many bytes
     char *out);      ///< [out] optional: or copy it here
 
   void _invalidate_cache(FileRef f, uint64_t offset, uint64_t length);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4159,7 +4159,7 @@ public:
     return head.version == 0 && head.epoch == 0;
   }
 
-  size_t approx_size() const {
+  uint64_t approx_size() const {
     return head.version - tail.version;
   }
 

--- a/src/osdc/Striper.cc
+++ b/src/osdc/Striper.cc
@@ -406,7 +406,7 @@ void Striper::StripedReadResult::add_partial_sparse_result(
 
     ceph_assert(s->first <= *bl_off);
     size_t left = (s->first + s->second) - *bl_off;
-    size_t actual = std::min(left, tlen);
+    size_t actual = std::min<size_t>(left, tlen);
 
     if (actual > 0) {
       ldout(cct, 20) << "  s has " << actual << ", copying" << dendl;


### PR DESCRIPTION
on armhf, `unsigned int` is 32bit, and `size_t` is defined as `unsigned
int`, so `std::min(a_size_t, a_uint32_t)` is not able to deduce the
template parameter, so we need to either use a single type or specialize
this template.

because `actual` will eventually used as a parameter of
`buffer::list::splice(unsigned, unsigned, buffer::list)`, it's at least
not worse to use `std::min<size_t>()` on a 32-bit system. on a LP64
system, `actual` will be casted to `unsigned` when calling
`bl.splice()` with or without this change.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

