### PR TITLE
nautilus: rgw: multisite: 'radosgw-admin bucket sync status' should call syncs_from(source.name) instead of id

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2398,7 +2398,7 @@ static int bucket_source_sync_status(RGWRados *store, const RGWZone& zone,
   out << indented{width, "source zone"} << source.id << " (" << source.name << ")\n";
 
   // syncing from this zone?
-  if (!zone.syncs_from(source.id)) {
+  if (!zone.syncs_from(source.name)) {
     out << indented{width} << "not in sync_from\n";
     return 0;
   }

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -613,8 +613,8 @@ struct RGWZone {
 
   bool is_read_only() const { return read_only; }
 
-  bool syncs_from(const std::string& zone_id) const {
-    return (sync_from_all || sync_from.find(zone_id) != sync_from.end());
+  bool syncs_from(const std::string& zone_name) const {
+    return (sync_from_all || sync_from.find(zone_name) != sync_from.end());
   }
 };
 WRITE_CLASS_ENCODER(RGWZone)


### PR DESCRIPTION
http://tracker.ceph.com/issues/40142