### PR TITLE
mimic: common: Keyrings created by ceph auth get are not suitable for ceph auth import

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <sstream>
 #include <algorithm>
+#include <boost/algorithm/string/replace.hpp>
 #include "auth/KeyRing.h"
 #include "common/config.h"
 #include "common/debug.h"
@@ -256,6 +257,7 @@ void KeyRing::print(ostream& out)
       string caps;
       using ceph::decode;
       decode(caps, dataiter);
+      boost::replace_all(caps, "\"", "\\\"");
       out << "\tcaps " << q->first << " = \"" << caps << '"' << std::endl;
     }
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/40547