### PR TITLE
librbd: prevent concurrent AIO callbacks to external clients

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -163,7 +163,9 @@ function(do_build_boost version)
   include(ExternalProject)
   ExternalProject_Add(Boost
     ${source_dir}
-    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 < ${CMAKE_MODULE_PATH}/boost_context_asm_arm_syntax_unified.patch
+    PATCH_COMMAND
+      patch -d <SOURCE_DIR> -p1 < ${CMAKE_MODULE_PATH}/boost_context_asm_arm_syntax_unified.patch &&
+      patch -d <SOURCE_DIR> -p1 < ${CMAKE_MODULE_PATH}/boost_lockfree_queue_valgrind_error.patch
     CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${configure_command}
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${build_command}
     BUILD_IN_SOURCE 1

--- a/cmake/modules/boost_lockfree_queue_valgrind_error.patch
+++ b/cmake/modules/boost_lockfree_queue_valgrind_error.patch
@@ -1,0 +1,11 @@
+--- a/boost/lockfree/queue.hpp
++++ b/boost/lockfree/queue.hpp
+@@ -108,7 +108,7 @@
+         typedef typename detail::select_tagged_handle<node, node_based>::handle_type handle_type;
+ 
+         node(T const & v, handle_type null_handle):
+-            data(v)//, next(tagged_node_handle(0, 0))
++            next(tagged_node_handle(null_handle, 0)), data(v)
+         {
+             /* increment tag to avoid ABA problem */
+             tagged_node_handle old_next = next.load(memory_order_relaxed);

--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -611,14 +611,3 @@
    fun:_ZN11EventCenter14process_eventsEjPNSt6chrono8durationImSt5ratioILl1ELl1000000000EEEE
    ...
 }
-
-{
-   boost::lockfree::queue uninitialized variable
-   Memcheck:Cond
-   ...
-   fun:*do_push*
-   fun:*push*
-   fun:_ZN6librbd2io13AioCompletion8completeEv
-   fun:_ZN6librbd2io13AioCompletion16complete_requestEl
-   ...
-}

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -122,7 +122,8 @@ public:
       operations(new Operations<>(*this)),
       exclusive_lock(nullptr), object_map(nullptr),
       io_work_queue(nullptr), op_work_queue(nullptr),
-      completed_reqs(32),
+      external_callback_completions(32),
+      event_socket_completions(32),
       asok_hook(nullptr),
       trace_endpoint("librbd")
   {

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -172,9 +172,14 @@ namespace librbd {
 
     ContextWQ *op_work_queue;
 
-    boost::lockfree::queue<
+    typedef boost::lockfree::queue<
       io::AioCompletion*,
-      boost::lockfree::allocator<ceph::allocator<void>>> completed_reqs;
+      boost::lockfree::allocator<ceph::allocator<void>>> Completions;
+
+    Completions external_callback_completions;
+    std::atomic<bool> external_callback_in_progress = {false};
+
+    Completions event_socket_completions;
     EventSocket event_socket;
 
     bool ignore_migrating = false;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1839,7 +1839,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     ldout(cct, 20) << __func__ << " " << ictx << " numcomp = " << numcomp
                    << dendl;
     int i = 0;
-    while (i < numcomp && ictx->completed_reqs.pop(comps[i])) {
+    while (i < numcomp && ictx->event_socket_completions.pop(comps[i])) {
       ++i;
     }
 

--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -99,11 +99,15 @@ void AioCompletion::complete() {
 
   state = AIO_STATE_CALLBACK;
   if (complete_cb) {
-    complete_cb(rbd_comp, complete_arg);
+    if (external_callback) {
+      complete_external_callback();
+    } else {
+      complete_cb(rbd_comp, complete_arg);
+    }
   }
 
   if (ictx != nullptr && event_notify && ictx->event_socket.is_valid()) {
-    ictx->completed_reqs.push(this);
+    ictx->event_socket_completions.push(this);
     ictx->event_socket.notify();
   }
   state = AIO_STATE_COMPLETE;
@@ -240,6 +244,31 @@ ssize_t AioCompletion::get_return_value() {
   ssize_t r = rval;
   tracepoint(librbd, aio_get_return_value_exit, r);
   return r;
+}
+
+void AioCompletion::complete_external_callback() {
+  // ensure librbd external users never experience concurrent callbacks
+  // from multiple librbd-internal threads.
+  ictx->external_callback_completions.push(this);
+
+  while (true) {
+    if (ictx->external_callback_in_progress.exchange(true)) {
+      // another thread is concurrently invoking external callbacks
+      break;
+    }
+
+    AioCompletion* aio_comp;
+    while (ictx->external_callback_completions.pop(aio_comp)) {
+      aio_comp->complete_cb(aio_comp->rbd_comp, aio_comp->complete_arg);
+    }
+
+    ictx->external_callback_in_progress.store(false);
+    if (ictx->external_callback_completions.empty()) {
+      // queue still empty implies we didn't have a race between the last failed
+      // pop and resetting the in-progress state
+      break;
+    }
+  }
 }
 
 } // namespace io

--- a/src/librbd/io/AioCompletion.h
+++ b/src/librbd/io/AioCompletion.h
@@ -70,6 +70,7 @@ struct AioCompletion {
 
   bool event_notify = false;
   bool was_armed = false;
+  bool external_callback = false;
 
   template <typename T, void (T::*MF)(int)>
   static void callback_adapter(completion_t cb, void *arg) {
@@ -176,6 +177,7 @@ struct AioCompletion {
 
 private:
   void queue_complete();
+  void complete_external_callback();
 
 };
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1155,8 +1155,10 @@ namespace librbd {
 
   RBD::AioCompletion::AioCompletion(void *cb_arg, callback_t complete_cb)
   {
-    pc = reinterpret_cast<void*>(librbd::io::AioCompletion::create(
-      cb_arg, complete_cb, this));
+    auto aio_comp = librbd::io::AioCompletion::create(
+      cb_arg, complete_cb, this);
+    aio_comp->external_callback = true;
+    pc = reinterpret_cast<void*>(aio_comp);
   }
 
   bool RBD::AioCompletion::is_complete()


### PR DESCRIPTION
With the various threads and conditional IO paths within librbd, it was
possible for external AIO callbacks to be concurrently executed from
different librbd threads. These callbacks should be serialized to reduce
the unexpected potential for data corruption.

Fixes: http://tracker.ceph.com/issues/40417
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

