### PR TITLE
rgw: fix a bug lead to a 403 return code in chunked upload mode

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -665,6 +665,7 @@ protected:
   off_t copy_source_range_lst;
   string etag;
   bool chunked_upload;
+  bufferlist chunk_data_remains;
   RGWAccessControlPolicy policy;
   const char *dlo_manifest;
   RGWSLOInfo *slo_info;


### PR DESCRIPTION
When uploading data in chunked upload mode, there may be
a truncated header at the end of receiving buffer in some
extreme cases. This will cause the get_padding_last_aws4_chunk_encoded()
function to return ERR_SIGNATURE_NO_MATCH which leads to an
upload failure. Stash the incomplete header and splice it
at the head of the receive buffer in the next round of reading.

Fixes: https://tracker.ceph.com/issues/40552
Signed-off-by: Yang Chen <ax.victor@outlook.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

