### PR TITLE
 crimson/osd: update peering_state in PG::on_activate_complete()

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -124,6 +124,41 @@ bool PG::try_flush_or_schedule_async() {
   return false;
 }
 
+void PG::on_activate_complete()
+{
+  active_promise.set_value();
+  active_promise = {};
+
+  if (peering_state.needs_recovery()) {
+    shard_services.start_operation<LocalPeeringEvent>(
+      this,
+      shard_services,
+      pg_whoami,
+      pgid,
+      get_osdmap_epoch(),
+      get_osdmap_epoch(),
+      PeeringState::DoRecovery{});
+  } else if (peering_state.needs_backfill()) {
+    shard_services.start_operation<LocalPeeringEvent>(
+      this,
+      shard_services,
+      pg_whoami,
+      pgid,
+      get_osdmap_epoch(),
+      get_osdmap_epoch(),
+      PeeringState::RequestBackfill{});
+  } else {
+    shard_services.start_operation<LocalPeeringEvent>(
+      this,
+      shard_services,
+      pg_whoami,
+      pgid,
+      get_osdmap_epoch(),
+      get_osdmap_epoch(),
+      PeeringState::AllReplicasRecovered{});
+  }
+}
+
 void PG::log_state_enter(const char *state) {
   logger().info("Entering state: {}", state);
 }

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -111,7 +111,7 @@ bool PG::try_flush_or_schedule_async() {
   shard_services.get_store().do_transaction(
     coll_ref,
     ObjectStore::Transaction()).then(
-      [this, epoch=peering_state.get_osdmap()->get_epoch()]() {
+      [this, epoch=get_osdmap_epoch()]() {
 	return shard_services.start_operation<LocalPeeringEvent>(
 	  this,
 	  shard_services,

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -114,7 +114,7 @@ public:
       int ret = prepare_info_keymap(
 	shard_services.get_cct(),
 	&km,
-	peering_state.get_osdmap()->get_epoch(),
+	get_osdmap_epoch(),
 	info,
 	last_written_info,
 	past_intervals,

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -256,10 +256,7 @@ public:
   void on_activate(interval_set<snapid_t> to_trim) final {
     // Not needed yet (will be needed for IO unblocking)
   }
-  void on_activate_complete() final {
-    active_promise.set_value();
-    active_promise = {};
-  }
+  void on_activate_complete() final;
   void on_new_interval() final {
     // Not needed yet
   }


### PR DESCRIPTION
along with #28689, this change allows crimson-osd to mark the created PGs clean after they are activated.

it's another step to enable us to run cbt tests against crimson-osd.
