### PR TITLE
doc/rados/operations/erasure-code.rst: allow recovery below min_size

### DIFF
--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -163,6 +163,14 @@ the *hot-storage* and benefit from its flexibility and speed.
 More information can be found in the `cache tiering
 <../cache-tiering>`_ documentation.
 
+Erasure coded pool recovery
+---------------------------
+
+Erasure coded pools could not recover when there were less than min_size
+shards available. This restriction has been removed in Octopus, which means
+that as long as there are enough shards available for data to be recovered,
+we will allow recovery to proceed below min_size.
+
 Glossary
 --------
 

--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -172,7 +172,8 @@ In Octopus, erasure coded pools can recover as long as there are at least *K* sh
 available. (With fewer than *K* shards, you have actually lost data!)
 
 Prior to Octopus, erasure coded pools required at least *min_size* shards to be
-available. (We generally recommend min_size be *K+2* or more to prevent loss of writes and data.)
+available, even if *min_size* is greater than *K*. (We generally recommend min_size
+be *K+2* or more to prevent loss of writes and data.)
 This conservative decision was made out of an abundance of caution when designing the new pool
 mode but also meant pools with lost OSDs but no data loss were unable to recover and go active
 without manual intervention to change the *min_size*.

--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -165,11 +165,17 @@ More information can be found in the `cache tiering
 
 Erasure coded pool recovery
 ---------------------------
+If an erasure coded pool loses some shards, it must recover them from the others.
+This generally involves reading from the remaining shards, reconstructing the data, and
+writing it to the new peer.
+In Octopus, erasure coded pools can recover as long as there are at least *K* shards
+available. (With fewer than *K* shards, you have actually lost data!)
 
-Erasure coded pools could not recover when there were less than min_size
-shards available. This restriction has been removed in Octopus, which means
-that as long as there are enough shards available for data to be recovered,
-we will allow recovery to proceed below min_size.
+Prior to Octopus, erasure coded pools required at least *min_size* shards to be
+available. (We generally recommend min_size be *K+2* or more to prevent loss of writes and data.)
+This conservative decision was made out of an abundance of caution when designing the new pool
+mode but also meant pools with lost OSDs but no data loss were unable to recover and go active
+without manual intervention to change the *min_size*.
 
 Glossary
 --------


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/17619 allows recovery below min_size
for EC pools starting in Octopus. Also mention that this wasn't allowed
earlier.

Fixes: https://tracker.ceph.com/issues/40488
Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

