### PR TITLE
ceph-volume: manually specified osd id legality check

### DIFF
--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -201,6 +201,10 @@ def osd_id_available(osd_id):
     osd = [osd for osd in osds if str(osd['id']) == str(osd_id)]
     if osd and osd[0].get('status') == "destroyed":
         return True
+    
+    if not osd:
+        return True
+    
     return False
 
 


### PR DESCRIPTION
Sometimes we need to deploy osd concurrently, in which case you need to manually specify the {osd-id} in the Prepare step. I think the specified {osd-id} does not have to be in the `osd tree`. As long as we guarantee that the manually specified {osd-id} is available in the cluster.What do you think?

Signed-off-by: ypdai <self19900924@gmail.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

