### PR TITLE
os/bluestore: fix pmem osd build problem

### DIFF
--- a/src/os/bluestore/PMEMDevice.cc
+++ b/src/os/bluestore/PMEMDevice.cc
@@ -143,7 +143,7 @@ int PMEMDevice::collect_metadata(const string& prefix, map<string,string> *pm) c
   if (S_ISBLK(st.st_mode)) {
     (*pm)[prefix + "access_mode"] = "blk";
     char buffer[1024] = {0};
-    BlkDev blkdev(fd_buffered);
+    BlkDev blkdev(fd);
 
     blkdev.model(buffer, sizeof(buffer));
     (*pm)[prefix + "model"] = buffer;
@@ -184,7 +184,7 @@ void PMEMDevice::aio_submit(IOContext *ioc)
   return;
 }
 
-int PMEMDevice::write(uint64_t off, bufferlist& bl, bool buffered, int write_hint = WRITE_LIFE_NOT_SET)
+int PMEMDevice::write(uint64_t off, bufferlist& bl, bool buffered, int write_hint)
 {
   uint64_t len = bl.length();
   dout(20) << __func__ << " " << off << "~" << len  << dendl;
@@ -219,7 +219,7 @@ int PMEMDevice::aio_write(
   bufferlist &bl,
   IOContext *ioc,
   bool buffered,
-  int write_hint = WRITE_LIFE_NOT_SET)
+  int write_hint)
 {
   return write(off, bl, buffered);
 }


### PR DESCRIPTION
Signed-off-by: Peterson, Scott <scott.d.peterson@intel.com>
Signed-off-by: Li, Xiaoyan <xiaoyan.li@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

