### PR TITLE
mimic: librbd: properly track in-flight flush requests

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -661,25 +661,6 @@ public:
     return len;
   }
 
-  void ImageCtx::flush_async_operations() {
-    C_SaferCond ctx;
-    flush_async_operations(&ctx);
-    ctx.wait();
-  }
-
-  void ImageCtx::flush_async_operations(Context *on_finish) {
-    {
-      Mutex::Locker l(async_ops_lock);
-      if (!async_ops.empty()) {
-        ldout(cct, 20) << "flush async operations: " << on_finish << " "
-                       << "count=" << async_ops.size() << dendl;
-        async_ops.front()->add_flush_context(on_finish);
-        return;
-      }
-    }
-    on_finish->complete(0);
-  }
-
   void ImageCtx::cancel_async_requests() {
     C_SaferCond ctx;
     cancel_async_requests(&ctx);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -292,9 +292,6 @@ namespace librbd {
     uint64_t prune_parent_extents(vector<pair<uint64_t,uint64_t> >& objectx,
 				  uint64_t overlap);
 
-    void flush_async_operations();
-    void flush_async_operations(Context *on_finish);
-
     void cancel_async_requests();
     void cancel_async_requests(Context *on_finish);
 

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -242,8 +242,8 @@ int DiffIterate<I>::diff_iterate(I *ictx,
   C_SaferCond flush_ctx;
   {
     RWLock::RLocker owner_locker(ictx->owner_lock);
-    auto aio_comp = io::AioCompletion::create(&flush_ctx, ictx,
-                                              io::AIO_TYPE_FLUSH);
+    auto aio_comp = io::AioCompletion::create_and_start(&flush_ctx, ictx,
+                                                        io::AIO_TYPE_FLUSH);
     auto req = io::ImageDispatchSpec<I>::create_flush_request(
       *ictx, aio_comp, io::FLUSH_SOURCE_INTERNAL, {});
     req->send();

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -165,8 +165,8 @@ void CloseRequest<I>::send_flush() {
   RWLock::RLocker owner_locker(m_image_ctx->owner_lock);
   auto ctx = create_context_callback<
     CloseRequest<I>, &CloseRequest<I>::handle_flush>(this);
-  auto aio_comp = io::AioCompletion::create(ctx, m_image_ctx,
-                                            io::AIO_TYPE_FLUSH);
+  auto aio_comp = io::AioCompletion::create_and_start(ctx, m_image_ctx,
+                                                      io::AIO_TYPE_FLUSH);
   auto req = io::ImageDispatchSpec<I>::create_flush_request(
     *m_image_ctx, aio_comp, io::FLUSH_SOURCE_INTERNAL, {});
   req->send();

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -1081,7 +1081,7 @@ Context *RefreshRequest<I>::send_flush_aio() {
     RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
     auto ctx = create_context_callback<
       RefreshRequest<I>, &RefreshRequest<I>::handle_flush_aio>(this);
-    auto aio_comp = io::AioCompletion::create(
+    auto aio_comp = io::AioCompletion::create_and_start(
       ctx, util::get_image_ctx(&m_image_ctx), io::AIO_TYPE_FLUSH);
     auto req = io::ImageDispatchSpec<I>::create_flush_request(
       m_image_ctx, aio_comp, io::FLUSH_SOURCE_INTERNAL, {});

--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -115,14 +115,17 @@ void AioCompletion::init_time(ImageCtx *i, aio_type_t t) {
   }
 }
 
-void AioCompletion::start_op(bool ignore_type) {
+void AioCompletion::start_op() {
   Mutex::Locker locker(lock);
   assert(ictx != nullptr);
-  assert(!async_op.started());
-  if (state == AIO_STATE_PENDING &&
-      (ignore_type || aio_type != AIO_TYPE_FLUSH)) {
-    async_op.start_op(*ictx);
+
+  if (aio_type == AIO_TYPE_OPEN || aio_type == AIO_TYPE_CLOSE) {
+    // no need to track async open/close operations
+    return;
   }
+
+  assert(!async_op.started());
+  async_op.start_op(*ictx);
 }
 
 void AioCompletion::fail(int r)

--- a/src/librbd/io/AioCompletion.h
+++ b/src/librbd/io/AioCompletion.h
@@ -89,16 +89,10 @@ struct AioCompletion {
   }
 
   template <typename T, void (T::*MF)(int) = &T::complete>
-  static AioCompletion *create(T *obj, ImageCtx *image_ctx, aio_type_t type) {
-    AioCompletion *comp = create<T, MF>(obj);
-    comp->init_time(image_ctx, type);
-    return comp;
-  }
-
-  template <typename T, void (T::*MF)(int) = &T::complete>
   static AioCompletion *create_and_start(T *obj, ImageCtx *image_ctx,
                                          aio_type_t type) {
-    AioCompletion *comp = create<T, MF>(obj, image_ctx, type);
+    AioCompletion *comp = create<T, MF>(obj);
+    comp->init_time(image_ctx, type);
     comp->start_op();
     return comp;
   }
@@ -129,7 +123,7 @@ struct AioCompletion {
   }
 
   void init_time(ImageCtx *i, aio_type_t t);
-  void start_op(bool ignore_type = false);
+  void start_op();
   void fail(int r);
 
   void complete();

--- a/src/librbd/io/AsyncOperation.cc
+++ b/src/librbd/io/AsyncOperation.cc
@@ -20,7 +20,8 @@ struct C_CompleteFlushes : public Context {
   ImageCtx *image_ctx;
   std::list<Context *> flush_contexts;
 
-  explicit C_CompleteFlushes(ImageCtx *image_ctx, std::list<Context *> &&flush_contexts)
+  explicit C_CompleteFlushes(ImageCtx *image_ctx,
+                             std::list<Context *> &&flush_contexts)
     : image_ctx(image_ctx), flush_contexts(std::move(flush_contexts)) {
   }
   void finish(int r) override {
@@ -73,11 +74,20 @@ void AsyncOperation::finish_op() {
   }
 }
 
-void AsyncOperation::add_flush_context(Context *on_finish) {
-  assert(m_image_ctx->async_ops_lock.is_locked());
-  ldout(m_image_ctx->cct, 20) << this << " " << __func__ << ": "
-                              << "flush=" << on_finish << dendl;
-  m_flush_contexts.push_back(on_finish);
+void AsyncOperation::flush(Context* on_finish) {
+  {
+    Mutex::Locker locker(m_image_ctx->async_ops_lock);
+    xlist<AsyncOperation *>::iterator iter(&m_xlist_item);
+    ++iter;
+
+    // linked list stored newest -> oldest ops
+    if (!iter.end()) {
+      (*iter)->m_flush_contexts.push_back(on_finish);
+      return;
+    }
+  }
+
+  m_image_ctx->op_work_queue->queue(on_finish);
 }
 
 } // namespace io

--- a/src/librbd/io/AsyncOperation.h
+++ b/src/librbd/io/AsyncOperation.h
@@ -36,7 +36,7 @@ public:
   void start_op(ImageCtx &image_ctx);
   void finish_op();
 
-  void add_flush_context(Context *on_finish);
+  void flush(Context *on_finish);
 
 private:
 

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -488,8 +488,8 @@ void ImageFlushRequest<I>::send_request() {
   }
 
   // ensure all in-flight IOs are settled if non-user flush request
-  image_ctx.flush_async_operations(ctx);
   aio_comp->start_op(true);
+  aio_comp->async_op.flush(ctx);
   aio_comp->put();
 
   // might be flushing during image shutdown

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -95,7 +95,7 @@ template <typename I>
 void ImageRequest<I>::send() {
   I &image_ctx = this->m_image_ctx;
   assert(m_aio_comp->is_initialized(get_aio_type()));
-  assert(m_aio_comp->is_started() ^ (get_aio_type() == AIO_TYPE_FLUSH));
+  assert(m_aio_comp->is_started());
 
   CephContext *cct = image_ctx.cct;
   AioCompletion *aio_comp = this->m_aio_comp;
@@ -488,7 +488,6 @@ void ImageFlushRequest<I>::send_request() {
   }
 
   // ensure all in-flight IOs are settled if non-user flush request
-  aio_comp->start_op(true);
   aio_comp->async_op.flush(ctx);
   aio_comp->put();
 

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -28,7 +28,7 @@ namespace {
 
 template <typename I>
 void flush_image(I& image_ctx, Context* on_finish) {
-  auto aio_comp = librbd::io::AioCompletion::create(
+  auto aio_comp = librbd::io::AioCompletion::create_and_start(
     on_finish, util::get_image_ctx(&image_ctx), librbd::io::AIO_TYPE_FLUSH);
   auto req = librbd::io::ImageDispatchSpec<I>::create_flush_request(
     image_ctx, aio_comp, librbd::io::FLUSH_SOURCE_INTERNAL, {});
@@ -385,6 +385,7 @@ void ImageRequestWQ<I>::aio_flush(AioCompletion *c, bool native_async) {
     queue(ImageDispatchSpec<I>::create_flush_request(
             m_image_ctx, c, FLUSH_SOURCE_USER, trace));
   } else {
+    c->start_op();
     ImageRequest<I>::aio_flush(&m_image_ctx, c, FLUSH_SOURCE_USER, trace);
     finish_in_flight_io();
   }

--- a/src/librbd/operation/ResizeRequest.cc
+++ b/src/librbd/operation/ResizeRequest.cc
@@ -193,7 +193,7 @@ void ResizeRequest<I>::send_flush_cache() {
   RWLock::RLocker owner_locker(image_ctx.owner_lock);
   auto ctx = create_context_callback<
     ResizeRequest<I>, &ResizeRequest<I>::handle_flush_cache>(this);
-  auto aio_comp = io::AioCompletion::create(
+  auto aio_comp = io::AioCompletion::create_and_start(
     ctx, util::get_image_ctx(&image_ctx), io::AIO_TYPE_FLUSH);
   auto req = io::ImageDispatchSpec<I>::create_flush_request(
     image_ctx, aio_comp, io::FLUSH_SOURCE_INTERNAL, {});

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -81,11 +81,6 @@ struct TestMockIoImageRequest : public TestMockFixture {
                   mock_image_ctx.image_ctx->op_work_queue->queue(&spec->dispatcher_ctx, r);
                 }));
   }
-
-  void expect_flush_async_operations(MockImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(mock_image_ctx, flush_async_operations(_))
-      .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
-  }
 };
 
 TEST_F(TestMockIoImageRequest, AioWriteJournalAppendDisabled) {
@@ -159,7 +154,6 @@ TEST_F(TestMockIoImageRequest, AioFlushJournalAppendDisabled) {
 
   InSequence seq;
   expect_is_journal_appending(mock_journal, false);
-  expect_flush_async_operations(mock_image_ctx, 0);
   expect_object_request_send(mock_image_ctx, 0);
 
   C_SaferCond aio_comp_ctx;

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -857,7 +857,7 @@ TEST_F(TestJournalReplay, ObjectPosition) {
 
   // user flush requests are ignored when journaling + cache are enabled
   C_SaferCond flush_ctx;
-  aio_comp = librbd::io::AioCompletion::create(
+  aio_comp = librbd::io::AioCompletion::create_and_start(
     &flush_ctx, ictx, librbd::io::AIO_TYPE_FLUSH);
   auto req = librbd::io::ImageDispatchSpec<>::create_flush_request(
     *ictx, aio_comp, librbd::io::FLUSH_SOURCE_INTERNAL, {});

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -186,7 +186,6 @@ struct MockImageCtx {
 			     librados::snap_t id));
 
   MOCK_METHOD0(user_flushed, void());
-  MOCK_METHOD1(flush_async_operations, void(Context *));
   MOCK_METHOD1(flush_copyup, void(Context *));
 
   MOCK_CONST_METHOD1(test_features, bool(uint64_t test_features));

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -30,7 +30,7 @@ namespace {
 
 int flush(librbd::ImageCtx *image_ctx) {
   C_SaferCond ctx;
-  auto aio_comp = librbd::io::AioCompletion::create(
+  auto aio_comp = librbd::io::AioCompletion::create_and_start(
     &ctx, image_ctx, librbd::io::AIO_TYPE_FLUSH);
   auto req = librbd::io::ImageDispatchSpec<>::create_flush_request(
     *image_ctx, aio_comp, librbd::io::FLUSH_SOURCE_INTERNAL, {});


### PR DESCRIPTION
http://tracker.ceph.com/issues/40573