### PR TITLE
luminous: librbd: properly track in-flight flush requests

### DIFF
--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -127,20 +127,17 @@ void AioCompletion::init_time(ImageCtx *i, aio_type_t t) {
   }
 }
 
-void AioCompletion::start_op(bool ignore_type) {
+void AioCompletion::start_op() {
   Mutex::Locker locker(lock);
   assert(ictx != nullptr);
-  assert(!async_op.started());
 
   if (aio_type == AIO_TYPE_OPEN || aio_type == AIO_TYPE_CLOSE) {
     // no need to track async open/close operations
     return;
   }
 
-  if (state == AIO_STATE_PENDING &&
-      (ignore_type || aio_type != AIO_TYPE_FLUSH)) {
-    async_op.start_op(*ictx);
-  }
+  assert(!async_op.started());
+  async_op.start_op(*ictx);
 }
 
 void AioCompletion::fail(int r)

--- a/src/librbd/io/AioCompletion.h
+++ b/src/librbd/io/AioCompletion.h
@@ -123,7 +123,7 @@ struct AioCompletion {
   }
 
   void init_time(ImageCtx *i, aio_type_t t);
-  void start_op(bool ignore_type = false);
+  void start_op();
   void fail(int r);
 
   void complete();

--- a/src/librbd/io/AsyncOperation.h
+++ b/src/librbd/io/AsyncOperation.h
@@ -37,6 +37,7 @@ public:
   void finish_op();
 
   void add_flush_context(Context *on_finish);
+  void flush(Context *on_finish);
 
 private:
 

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -222,7 +222,7 @@ template <typename I>
 void ImageRequest<I>::send() {
   I &image_ctx = this->m_image_ctx;
   assert(m_aio_comp->is_initialized(get_aio_type()));
-  assert(m_aio_comp->is_started() ^ (get_aio_type() == AIO_TYPE_FLUSH));
+  assert(m_aio_comp->is_started());
 
   CephContext *cct = image_ctx.cct;
   AioCompletion *aio_comp = this->m_aio_comp;
@@ -715,7 +715,6 @@ void ImageFlushRequest<I>::send_request() {
   }
 
   // ensure all in-flight IOs are settled if non-user flush request
-  aio_comp->start_op(true);
   aio_comp->async_op.flush(ctx);
   aio_comp->put();
 

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -100,28 +100,6 @@ struct C_DiscardJournalCommit : public Context {
   }
 };
 
-template <typename ImageCtxT = ImageCtx>
-struct C_FlushJournalCommit : public Context {
-  ImageCtxT &image_ctx;
-  AioCompletion *aio_comp;
-
-  C_FlushJournalCommit(ImageCtxT &_image_ctx, AioCompletion *_aio_comp,
-                       uint64_t tid)
-    : image_ctx(_image_ctx), aio_comp(_aio_comp) {
-    CephContext *cct = image_ctx.cct;
-    ldout(cct, 20) << "delaying flush until journal tid " << tid << " "
-                   << "safe" << dendl;
-
-    aio_comp->add_request();
-  }
-
-  void finish(int r) override {
-    CephContext *cct = image_ctx.cct;
-    ldout(cct, 20) << "C_FlushJournalCommit: journal committed" << dendl;
-    aio_comp->complete_request(r);
-  }
-};
-
 } // anonymous namespace
 
 template <typename I>
@@ -710,36 +688,36 @@ void ImageFlushRequest<I>::send_request() {
   }
 
   AioCompletion *aio_comp = this->m_aio_comp;
+  aio_comp->set_request_count(1);
+
+  Context* ctx = new C_AioRequest(aio_comp);
+
+  // ensure no locks are held when flush is complete
+  ctx = util::create_async_context_callback(image_ctx, ctx);
+
   if (journaling) {
     // in-flight ops are flushed prior to closing the journal
     uint64_t journal_tid = image_ctx.journal->append_io_event(
       journal::EventEntry(journal::AioFlushEvent()),
       ObjectRequests(), 0, 0, false, 0);
 
-    aio_comp->set_request_count(1);
     aio_comp->associate_journal_event(journal_tid);
 
-    FunctionContext *flush_ctx = new FunctionContext(
-      [aio_comp, &image_ctx, journal_tid] (int r) {
-        auto ctx = new C_FlushJournalCommit<I>(image_ctx, aio_comp,
-                                               journal_tid);
-        image_ctx.journal->flush_event(journal_tid, ctx);
-
-        // track flush op for block writes
-        aio_comp->start_op(true);
-        aio_comp->put();
+    ctx = new FunctionContext([ctx, &image_ctx, journal_tid](int r) {
+      image_ctx.journal->flush_event(journal_tid, ctx);
     });
 
-    image_ctx.flush_async_operations(flush_ctx);
-  } else {
+  } else if (image_ctx.object_cacher != nullptr) {
     // flush rbd cache only when journaling is not enabled
-    aio_comp->set_request_count(1);
-    C_AioRequest *req_comp = new C_AioRequest(aio_comp);
-    image_ctx.flush(req_comp);
-
-    aio_comp->start_op(true);
-    aio_comp->put();
+    ctx = new FunctionContext([ctx, &image_ctx](int r) {
+      image_ctx.flush_cache(ctx);
+    });
   }
+
+  // ensure all in-flight IOs are settled if non-user flush request
+  aio_comp->start_op(true);
+  aio_comp->async_op.flush(ctx);
+  aio_comp->put();
 
   image_ctx.perfcounter->inc(l_librbd_aio_flush);
 }

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -335,6 +335,7 @@ void ImageRequestWQ<I>::aio_flush(AioCompletion *c, bool native_async) {
   if (m_image_ctx.non_blocking_aio || writes_blocked() || !writes_empty()) {
     queue(ImageRequest<I>::create_flush_request(m_image_ctx, c, trace));
   } else {
+    c->start_op();
     ImageRequest<I>::aio_flush(&m_image_ctx, c, trace);
     finish_in_flight_io();
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/40574