### PR TITLE
rgw: fix MalformedXML errors in PutBucketObjectLock/PutObjRetention

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7568,7 +7568,10 @@ void RGWPutBucketObjectLock::execute()
     op_ret = -EINVAL;
     return;
   }
-
+  op_ret = get_params();
+  if (op_ret < 0) {
+    return;
+  }
   if (!parser.parse(data.c_str(), data.length(), 1)) {
     op_ret = -ERR_MALFORMED_XML;
     return;
@@ -7656,10 +7659,6 @@ void RGWPutObjRetention::execute()
     op_ret = -EINVAL;
     return;
   }
-
-  op_ret = get_params();
-  if (op_ret < 0)
-    return;
 
   if (!parser.parse(data.c_str(), data.length(), 1)) {
     op_ret = -ERR_MALFORMED_XML;


### PR DESCRIPTION
RGWPutBucketObjectLock was not calling get_params(), so the 'data' it was trying to parse was empty

RGWPutObjRetention was calling get_params() a second time, which overwrote the 'data' from the first call