### PR TITLE
crimson/osd: abort on unsupported objectstore type

### DIFF
--- a/src/crimson/common/assert.cc
+++ b/src/crimson/common/assert.cc
@@ -39,8 +39,9 @@ namespace ceph {
 
     seastar::logger& logger = ceph::get_logger(0);
     logger.error("{}:{} : In function '{}', ceph_assert(%s)\n"
-                 "{}",
+                 "{}\n{}\n",
                  file, line, func, assertion,
+                 buf,
                  seastar::current_backtrace());
     std::cout << std::flush;
     abort();
@@ -53,6 +54,26 @@ namespace ceph {
     logger.error("{}:{} : In function '{}', abort(%s)\n"
                  "{}",
                  file, line, func, msg,
+                 seastar::current_backtrace());
+    std::cout << std::flush;
+    abort();
+  }
+
+  [[gnu::cold]] void __ceph_abortf(const char* file, int line,
+                                   const char* func, const char* fmt,
+                                   ...)
+  {
+    char buf[8096];
+    va_list args;
+    va_start(args, fmt);
+    std::vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    seastar::logger& logger = ceph::get_logger(0);
+    logger.error("{}:{} : In function '{}', abort()\n"
+                 "{}\n{}\n",
+                 file, line, func,
+                 buf,
                  seastar::current_backtrace());
     std::cout << std::flush;
     abort();

--- a/src/crimson/os/cyan_store.cc
+++ b/src/crimson/os/cyan_store.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "cyan_store.h"
 
 #include <fmt/format.h>

--- a/src/crimson/os/futurized_store.cc
+++ b/src/crimson/os/futurized_store.cc
@@ -8,9 +8,10 @@ std::unique_ptr<FuturizedStore> FuturizedStore::create(const std::string& type,
 {
   if (type == "memstore") {
     return std::make_unique<ceph::os::CyanStore>(data);
+  } else {
+    ceph_abort_msgf("unsupported objectstore type: %s", type.c_str());
+    return {};
   }
-
-  return nullptr;
 }
 
 }

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -221,7 +221,7 @@ seastar::future<> PG::read_state(ceph::os::FuturizedStore* store)
       else
 	peering_state.set_role(-1);
 
-      epoch_t epoch = peering_state.get_osdmap()->get_epoch();
+      epoch_t epoch = get_osdmap_epoch();
       shard_services.start_operation<LocalPeeringEvent>(
 	this,
 	shard_services,

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -71,11 +71,11 @@ public:
 
   ~PG();
 
-  const pg_shard_t &get_pg_whoami() const {
+  const pg_shard_t& get_pg_whoami() const {
     return pg_whoami;
   }
 
-  const spg_t&get_pgid() const {
+  const spg_t& get_pgid() const {
     return pgid;
   }
 

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "pg_backend.h"
 
 #include <optional>


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

