### PR TITLE
Return an error, for Bluestore OSD, if WAL or DB are defined in the tags of the OSD but not present on the system

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -109,14 +109,16 @@ def get_osd_device_path(osd_lv, lvs, device_type, dmcrypt_secret=None):
             encryption_utils.luks_open(dmcrypt_secret, device_lv.lv_path, device_uuid)
             return '/dev/mapper/%s' % device_uuid
         return device_lv.lv_path
-    else:
-        # this could be a regular device, so query it with blkid
-        physical_device = disk.get_device_from_partuuid(device_uuid)
-        if physical_device and is_encrypted:
+
+    # this could be a regular device, so query it with blkid
+    physical_device = disk.get_device_from_partuuid(device_uuid)
+    if physical_device:
+        if is_encrypted:
             encryption_utils.luks_open(dmcrypt_secret, physical_device, device_uuid)
             return '/dev/mapper/%s' % device_uuid
-        return physical_device or None
-    return None
+        return physical_device
+
+    raise RuntimeError('could not find %s with uuid %s' % (device_type, device_uuid))
 
 
 def activate_bluestore(lvs, no_systemd=False):


### PR DESCRIPTION
In the first merge request, we were waiting for the WAL and DB devices to be present. But only if these are lv.

Here, the proposal is to return an error during Bluestore activation, if WAL and DB are defined in the device block but not present on the system.

Fixes: https://tracker.ceph.com/issues/40100
Signed-off-by: David Casier <david.casier@aevoo.fr>
