### PR TITLE
cephfs-shell: cd with no args must change CWD to root

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -184,6 +184,9 @@ class CephFSMount(object):
 
     def run_shell(self, args, wait=True, stdin=None, check_status=True,
                   omit_sudo=True):
+        if isinstance(args, str):
+            args = args.split()
+
         args = ["cd", self.mountpoint, run.Raw('&&'), "sudo"] + args
         return self.client_remote.run(args=args, stdout=StringIO(),
                                       stderr=StringIO(), wait=wait,

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -280,6 +280,19 @@ class TestCD(TestCephFSShell):
         output = self.get_cephfs_shell_script_output(script)
         self.assertEqual(output, expected_cwd)
 
+    def test_cd_with_args(self):
+        """
+        Test that when cd is issued with an argument, CWD is changed
+        to the path passed in the argument.
+        """
+        path = 'dir1/dir2/dir3'
+        self.mount_a.run_shell('mkdir -p ' + path)
+        expected_cwd = '/dir1/dir2/dir3'
+
+        script = 'cd {}\ncwd\n'.format(path)
+        output = self.get_cephfs_shell_script_output(script)
+        self.assertEqual(output, expected_cwd)
+
 #    def test_ls(self):
 #        """
 #        Test that ls passes

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -44,15 +44,7 @@ class TestCephFSShell(CephFSTestCase):
         return mount_x.client_remote.run(args=args, stdout=StringIO(),
                                          stderr=StringIO(), stdin=stdin)
 
-    def test_help(self):
-        """
-        Test that help outputs commands.
-        """
-
-        o = self._cephfs_shell("help")
-
-        log.info("output:\n{}".format(o))
-
+class TestMkdir(TestCephFSShell):
     def test_mkdir(self):
         """
         Test that mkdir creates directory
@@ -141,18 +133,8 @@ class TestCephFSShell(CephFSTestCase):
         o = self.mount_a.stat('d5/d6/d7')
         log.info("mount_a output:\n{}".format(o))
 
-    def validate_stat_output(self, s):
-        l = s.split('\n')
-        log.info("lines:\n{}".format(l))
-        rv = l[-1] # get last line; a failed stat will have "1" as the line
-        log.info("rv:{}".format(rv))
-        r = 0
-        try:
-            r = int(rv) # a non-numeric line will cause an exception
-        except:
-            pass
-        assert(r == 0)
-
+class TestGetAndPut(TestCephFSShell):
+    # the 'put' command gets tested as well with the 'get' comamnd
     def test_put_and_get_without_target_directory(self):
         """
         Test that put fails without target path
@@ -195,7 +177,18 @@ class TestCephFSShell(CephFSTestCase):
         log.info("cephfs-shell output:\n{}".format(o))
         self.validate_stat_output(o)
 
-    # the 'put' command gets tested as well with the 'get' comamnd
+    def validate_stat_output(self, s):
+        l = s.split('\n')
+        log.info("lines:\n{}".format(l))
+        rv = l[-1] # get last line; a failed stat will have "1" as the line
+        log.info("rv:{}".format(rv))
+        r = 0
+        try:
+            r = int(rv) # a non-numeric line will cause an exception
+        except:
+            pass
+        assert(r == 0)
+
     def test_get_with_target_name(self):
         """
         Test that get passes with target name
@@ -301,3 +294,13 @@ class TestCephFSShell(CephFSTestCase):
 #            log.info('ls -a succeeded')
 #        else:
 #            log.info('ls -a failed')
+
+class TestMisc(TestCephFSShell):
+    def test_help(self):
+        """
+        Test that help outputs commands.
+        """
+
+        o = self._cephfs_shell("help")
+
+        log.info("output:\n{}".format(o))

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -264,6 +264,22 @@ class TestGetAndPut(TestCephFSShell):
         log.info("o_hash:{}".format(o_hash))
         assert(s_hash == o_hash)
 
+class TestCD(TestCephFSShell):
+    CLIENTS_REQUIRED = 1
+
+    def test_cd_with_no_args(self):
+        """
+        Test that when cd is issued without any arguments, CWD is changed
+        to root directory.
+        """
+        path = 'dir1/dir2/dir3'
+        self.mount_a.run_shell('mkdir -p ' + path)
+        expected_cwd = '/'
+
+        script = 'cd {}\ncd\ncwd\n'.format(path)
+        output = self.get_cephfs_shell_script_output(script)
+        self.assertEqual(output, expected_cwd)
+
 #    def test_ls(self):
 #        """
 #        Test that ls passes

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -24,6 +24,10 @@ class TestCephFSShell(CephFSTestCase):
                                                 stdin=stdin)
         return status.stdout.getvalue().strip()
 
+    def get_cephfs_shell_script_output(self, script, mount_x=None, stdin=None):
+        return self.run_cephfs_shell_script(script, mount_x, stdin).stdout.\
+            getvalue().strip()
+
     def run_cephfs_shell_script(self, script, mount_x=None, stdin=None):
         if mount_x is None:
             mount_x = self.mount_a

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -231,8 +231,22 @@ class LocalRemote(object):
         shutil.copy(path, tmpfile)
         return tmpfile
 
+    # XXX: This method ignores the error raised when src and dst are
+    # holding same path. For teuthology, same path still represents
+    # different locations as they lie on different machines.
     def put_file(self, src, dst, sudo=False):
-        shutil.copy(src, dst)
+        if sys.version_info.major < 3:
+            exception = shutil.Error
+        elif sys.version_info.major >= 3:
+            exception = shutil.SameFileError
+
+        try:
+            shutil.copy(src, dst)
+        except exception as e:
+            if sys.version_info.major < 3 and e.message.find('are the same '
+               'file') != -1:
+                return
+            raise e
 
     def _perform_checks_and_return_list_of_args(self, args, omit_sudo):
         # Since Python's shell simulation can only work when commands are

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -896,7 +896,8 @@ sub-directories, files')
         return self.complete_filenames(text, line, begidx, endidx)
 
     cd_parser = argparse.ArgumentParser(description='Change working directory')
-    cd_parser.add_argument('path', type=str, help='Name of the directory.', default='/')
+    cd_parser.add_argument('path', type=str, help='Name of the directory.',
+                           nargs='?', default='/')
 
     @with_argparser(cd_parser)
     def do_cd(self, args):


### PR DESCRIPTION
This PR -

* makes cd change CWD to root when no arguments is passed
* adds tests for cd's behaviour in case argument is and is not provided
* adds a new method to `test_cephfs_shell.py` that can run a CephFS shell script




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug