### PR TITLE
crimson/osd: add "--help-seastar" command line option

### DIFF
--- a/doc/dev/crimson.rst
+++ b/doc/dev/crimson.rst
@@ -92,9 +92,19 @@ using ``vstart.sh``,
 ``--redirect-output``
     redirect the stdout and stderr of service to ``out/$type.$num.stdout``.
 
+``--osd-args``
+    pass extra command line options to crimson-osd or ceph-osd. It's quite
+    useful for passing Seastar options to crimson-osd.
+
 So, a typical command to start a single-crimson-node cluster is::
 
-  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x --without-dashboard --memstore --crimson --nodaemon --redirect-output
+  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x --without-dashboard --memstore \
+    --crimson --nodaemon --redirect-output \
+    --osd-args "--memory 4G --smp 1 --cpuset 0"
+
+Where we assign 4 GiB memory, a single thread running on core-0 to crimson-osd.
+Please refer ``crimson-osd --help-seastar`` for more Seastar specific command
+line options.
 
 You could stop the vstart cluster using::
 


### PR DESCRIPTION
so we can

* have access to the available command line options offered by Seastar.
* tell if the executable we are playing around is ceph-osd or crimson-osd.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

