### PR TITLE
mgr/status: fix 'ceph osd status' ZeroDivisionError

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -43,7 +43,7 @@ class Module(MgrModule):
         data = self.get_counter(daemon_type, daemon_name, stat)[stat]
 
         #self.log.error("get_latest {0} data={1}".format(stat, data))
-        if data and len(data) > 1:
+        if data and len(data) > 1 and data[-1][0] != data[-2][0]:
             return (data[-1][1] - data[-2][1]) / float(data[-1][0] - data[-2][0])
         else:
             return 0


### PR DESCRIPTION
Signed-off-by: simon gao <simon29rock@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

