### PR TITLE
osd: move getloadavg out of time sensitive thread OSD::heartbeat

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -658,6 +658,7 @@ OPTION(osd_snap_trim_sleep, OPT_DOUBLE)
 OPTION(osd_scrub_invalid_stats, OPT_BOOL)
 OPTION(osd_command_thread_timeout, OPT_INT)
 OPTION(osd_command_thread_suicide_timeout, OPT_INT)
+OPTION(osd_update_daily_loadavg_interval, OPT_INT)       // (seconds) how often we update daily_loadavg
 OPTION(osd_heartbeat_interval, OPT_INT)       // (seconds) how often we ping peers
 
 // (seconds) how long before we decide a peer has failed

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3260,6 +3260,11 @@ std::vector<Option> get_global_options() {
     .set_default(15_min)
     .set_description(""),
 
+    Option("osd_update_daily_loadavg_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(6)
+    .set_min_max(1, 86400)
+    .set_description("Interval (in seconds) to update daily loadavg"),
+    
     Option("osd_heartbeat_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(6)
     .set_min_max(1, 86400)

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1151,6 +1151,7 @@ protected:
   void create_recoverystate_perf();
   void tick();
   void tick_without_osd_lock();
+  void update_daily_loadavg();
   void _dispatch(Message *m);
   void dispatch_op(OpRequestRef op);
 


### PR DESCRIPTION
getloadavg could potentially take long time to get back, it is not good to call it
at time sensitive thread which is heartbeat thread, and it will also cause
heartbeat thread holding the heartbeat_lock for too long, which will cause
OSD::heartbeat_check unable to process osd_ping reply message in time.
And this will cause the osd wongly reporting other osds failure.
This patch tries to call getloadavg() at OSD::tick_without_osd_lock and it
also introduce a new option osd_update_daily_loadavg_interval to specify how often
the daily_loadavg will be updated.

However, the reason that causes procfs got stuck and cause getloadavg taking long time to get back
will need to be further addressed.

Fixes: https://tracker.ceph.com/issues/40601

Signed-off-by: dongdong tao <dongdong.tao@canonical.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

