### PR TITLE
crimson: use given osd_fsid when mkfs

### DIFF
--- a/src/crimson/os/cyan_store.h
+++ b/src/crimson/os/cyan_store.h
@@ -41,7 +41,7 @@ public:
   seastar::future<> mount() final;
   seastar::future<> umount() final;
 
-  seastar::future<> mkfs() final;
+  seastar::future<> mkfs(uuid_d new_osd_fsid) final;
   store_statfs_t stat() const final;
 
   seastar::future<ceph::bufferlist> read(CollectionRef c,

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -61,7 +61,7 @@ public:
   virtual seastar::future<> mount() = 0;
   virtual seastar::future<> umount() = 0;
 
-  virtual seastar::future<> mkfs() = 0;
+  virtual seastar::future<> mkfs(uuid_d new_osd_fsid) = 0;
   virtual store_statfs_t stat() const = 0;
 
   using CollectionRef = boost::intrusive_ptr<Collection>;

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -110,11 +110,11 @@ CompatSet get_osd_initial_compat_set()
 
 seastar::future<> OSD::mkfs(uuid_d osd_uuid, uuid_d cluster_fsid)
 {
-  return store->mkfs().then([this] {
+  return store->mkfs(osd_uuid).then([this] {
     return store->mount();
-  }).then([cluster_fsid, osd_uuid, this] {
+  }).then([cluster_fsid, this] {
     superblock.cluster_fsid = cluster_fsid;
-    superblock.osd_fsid = osd_uuid;
+    superblock.osd_fsid = store->get_fsid();
     superblock.whoami = whoami;
     superblock.compat_features = get_osd_initial_compat_set();
 


### PR DESCRIPTION
MemStore does not have this feature, but CyanStore needs it. because
`qa/tasks/ceph.py` uses following steps when creating/starting an OSD

1. ceph-osd --mkfs --mkkey -i <osd_id> --monmap <monmap>
2. read the osd_fsid of osd.<osd_id>
3. ceph osd new <osd_fsid> <osd_id>

when we mkfs for the OSD, the osd_fsid is still unknown. so we cannot
use the configured one, as it is always empty. in that case, we need to
use a random uuid, and persist it to both ${osd_data}/fsid and
superblock.osd_fsid

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

