### PR TITLE
osd: add duration field to dump_historic_ops method

### DIFF
--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -190,10 +190,9 @@ public:
   {
     typename T::Ref retval(new T(params, this));
     retval->tracking_start();
-
     if (is_tracking()) {
-      retval->mark_event("header_read", params->get_recv_stamp());
       retval->mark_event("throttled", params->get_throttle_stamp());
+      retval->mark_event("header_read", params->get_recv_stamp());
       retval->mark_event("all_read", params->get_recv_complete_stamp());
       retval->mark_event("dispatched", params->get_dispatch_stamp());
     }
@@ -201,7 +200,6 @@ public:
     return retval;
   }
 };
-
 
 class TrackedOp : public boost::intrusive::list_base_hook<> {
 private:


### PR DESCRIPTION
To make dump_historic_ops more human readable, add duration along
with event and stamp fields to dump_historic_ops method.

Signed-off-by: Deepika Upadhyay <deepikaupadhyay01@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

