### PR TITLE
rgw: solve warning: control reaches end of non-void function

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3581,7 +3581,7 @@ RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
   if (get_data) {   
     if (list_type == 1) {
        return new RGWListBucket_ObjStore_S3;     
-    } else if(list_type == 2) {
+    } else { /* list_type: 2 */
       return new RGWListBucket_ObjStore_S3v2;
     } } else {
     return new RGWStatBucket_ObjStore_S3;    


### PR DESCRIPTION
src/rgw/rgw_rest_s3.cc: In member function ‘RGWOp* RGWHandler_REST_Bucket_S3::get_obj_op(bool)’:
src/rgw/rgw_rest_s3.cc:3588:7: warning: control reaches end of non-void function [-Wreturn-type]

Fixes: 4ffc765c4c5d (rgw:listobjectsv2)

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

