### PR TITLE
[DNM] crimson/net: introduce read_exactly2 interface

### DIFF
--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -79,7 +79,7 @@ class ProtocolV2 final : public Protocol {
   ceph::bufferlist txbuf;
 
   void enable_recording();
-  seastar::future<Socket::tmp_buf> read_exactly(size_t bytes);
+  seastar::future<Socket::tmp_buf> read_exactly(size_t bytes, __le16 alignment = alignof(char));
   seastar::future<bufferlist> read(size_t bytes);
   seastar::future<> write(bufferlist&& buf);
   seastar::future<> write_flush(bufferlist&& buf);

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -68,11 +68,11 @@ seastar::future<bufferlist> Socket::read(size_t bytes)
 }
 
 seastar::future<seastar::temporary_buffer<char>>
-Socket::read_exactly(size_t bytes) {
+Socket::read_exactly(size_t bytes, __le16 alignment) {
   if (bytes == 0) {
     return seastar::make_ready_future<seastar::temporary_buffer<char>>();
   }
-  return in.read_exactly(bytes)
+  return in.read_exactly2(bytes, alignment)
     .then([this](auto buf) {
       if (buf.empty()) {
         throw std::system_error(make_error_code(error::read_eof));

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -67,7 +67,7 @@ class Socket
   seastar::future<bufferlist> read(size_t bytes);
   using tmp_buf = seastar::temporary_buffer<char>;
   using packet = seastar::net::packet;
-  seastar::future<tmp_buf> read_exactly(size_t bytes);
+  seastar::future<tmp_buf> read_exactly(size_t bytes, __le16 alignment = alignof(char));
 
   seastar::future<> write(packet&& buf) {
     return out.write(std::move(buf));


### PR DESCRIPTION
This PR works with https://github.com/ceph/seastar/pull/5

Test summary:

BS (2-way) | Controlled | Fixed prefetch (8K) | Prefetch up to 512K
----- | ----- | ----- | -----
256B | 62.56 MB/s | 63.74 MB/s | 68.03 MB/s
4K | 776.3 MB/s | 780.9 MB/s | 842.2 MB/s
64K | 2215 MB/s | 2839 MB/s | 2819 MB/s
1M | 2277 MB/s | 3328 MB/s | 2785 MB/s


From the result, how to set prefetch size properly is tricky because:
- Too small prefetch size introduces more syscalls for small reads;
- Too large prefetch size introduces more user-space memcpy for large reads with memory layout requirements.

See https://gist.github.com/cyx1231st/807c2b3ae12b264d1a5727dd81d3da4b for details.