### PR TITLE
rgw: Silence warning: control reaches end of non-void function

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3579,13 +3579,19 @@ RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
 
    // Non-website mode    // Non-website mode
   if (get_data) {   
-    if (list_type == 1) {
-       return new RGWListBucket_ObjStore_S3;     
-    } else if(list_type == 2) {
-      return new RGWListBucket_ObjStore_S3v2;
-    } } else {
-    return new RGWStatBucket_ObjStore_S3;    
-  }   }
+    switch (list_type) {
+      case 1:
+        return new RGWListBucket_ObjStore_S3;
+      case 2:
+        return new RGWListBucket_ObjStore_S3v2;
+      default:
+        ldpp_dout(s, 5) << __func__ << ": unsupported list-type " << list_type << dendl;
+        return new RGWListBucket_ObjStore_S3;
+    }
+  } else {
+    return new RGWStatBucket_ObjStore_S3;
+  }
+}
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_get()
 {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3574,11 +3574,9 @@ RGWOp *RGWHandler_REST_Service_S3::op_post()
 RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
 {
   // Non-website mode
-  int list_type = 1;
-  s->info.args.get_int("list-type", &list_type, 1);
-
-   // Non-website mode    // Non-website mode
   if (get_data) {   
+    int list_type = 1;
+    s->info.args.get_int("list-type", &list_type, 1);
     switch (list_type) {
       case 1:
         return new RGWListBucket_ObjStore_S3;


### PR DESCRIPTION
Build shows:
```
[ 53%] Building CXX object src/mds/CMakeFiles/mds.dir/JournalPointer.cc.o
ceph/src/rgw/rgw_rest_s3.cc: In member function ‘RGWOp* RGWHandler_REST_Bucket_S3::get_obj_op(bool)’:
ceph/src/rgw/rgw_rest_s3.cc:3588:5: warning: control reaches end of non-void function [-Wreturn-type]
   }   }
     ^
```

Found during the testing of https://github.com/ceph/ceph/pull/20160.

---

Fixes: 4ffc765c4c5debc665ade7769c4647c3a7278fd2
Fixes: http://tracker.ceph.com/issues/40747