### PR TITLE
luminous: journal: properly advance read offset after skipping invalid range

### DIFF
--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -172,6 +172,8 @@ int ObjectPlayer::handle_fetch_complete(int r, const bufferlist &bl,
       m_invalid_ranges.insert(invalid_start_off,
                               invalid_end_off - invalid_start_off);
       invalid = false;
+
+      m_read_bl_off = invalid_end_off;
     }
 
     EntryKey entry_key(std::make_pair(entry.get_tag_tid(),


### PR DESCRIPTION
Backport ticket: https://tracker.ceph.com/issues/40463

Fixes: https://tracker.ceph.com/issues/40409
Signed-off-by: Mykola Golub <mgolub@suse.com>
(cherry picked from commit 7b8fd11fc6f49ca69a8484ee4b175b530b2dd2a3)

Conflicts:
	src/test/journal/test_ObjectPlayer.cc (encode func namespace)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

