### PR TITLE
test/cli/ceph-conf: fix test

### DIFF
--- a/src/test/cli/ceph-conf/env-vs-args.t
+++ b/src/test/cli/ceph-conf/env-vs-args.t
@@ -2,9 +2,9 @@
   $ env CEPH_CONF=from-env ceph-conf -s foo bar
   did not load config file, using default settings.
   .* \-1 Errors while parsing config file! (re)
-  .* \-1 parse_file: filesystem error: cannot get file size: No such file or directory \[from-env\] (re)
+  .* \-1 parse_file: filesystem error: cannot get file size: (No such file or directory )?\[from-env\] (re)
   .* \-1 Errors while parsing config file! (re)
-  .* \-1 parse_file: filesystem error: cannot get file size: No such file or directory \[from-env\] (re)
+  .* \-1 parse_file: filesystem error: cannot get file size: (No such file or directory )?\[from-env\] (re)
   [1]
 
 # command-line arguments should override environment


### PR DESCRIPTION
turns out the libstdc++ on fc30 does not include error_code.message() in
filesystem_error.what(). let's make it optional

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

