### PR TITLE
journal: return error after first corruption detected

### DIFF
--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -180,8 +180,7 @@ int ObjectPlayer::handle_fetch_complete(int r, const bufferlist &bl,
         break;
       }
 
-      if (!invalid &&
-          !advance_to_last_pad_byte(m_read_bl_off + iter.get_off(), &iter,
+      if (!advance_to_last_pad_byte(m_read_bl_off + iter.get_off(), &iter,
                                     &pad_len, &partial_entry)) {
         invalid_start_off = m_read_bl_off + bl_off;
         invalid = true;
@@ -193,10 +192,11 @@ int ObjectPlayer::handle_fetch_complete(int r, const bufferlist &bl,
             ldout(m_cct, 20) << ": partial pad detected, will re-fetch"
                              << dendl;
           }
-          break;
+        } else {
+          lderr(m_cct) << ": detected corrupt journal entry at offset "
+                       << invalid_start_off << dendl;
         }
-        lderr(m_cct) << ": detected corrupt journal entry at offset "
-                     << invalid_start_off << dendl;
+        break;
       }
       ++iter;
       continue;

--- a/src/test/journal/test_ObjectPlayer.cc
+++ b/src/test/journal/test_ObjectPlayer.cc
@@ -155,25 +155,21 @@ TYPED_TEST(TestObjectPlayer, FetchCorrupt) {
 
   journal::Entry entry1(234, 123, this->create_payload(std::string(24, '1')));
   journal::Entry entry2(234, 124, this->create_payload(std::string(24, '2')));
-  journal::Entry entry3(234, 125, this->create_payload(std::string(24, '3')));
 
   bufferlist bl;
   encode(entry1, bl);
   encode(this->create_payload("corruption" + std::string(1024, 'X')), bl);
   encode(entry2, bl);
-  encode(this->create_payload("corruption" + std::string(1024, 'Y')), bl);
-  encode(entry3, bl);
   ASSERT_EQ(0, this->append(this->get_object_name(oid), bl));
 
   journal::ObjectPlayerPtr object = this->create_object(oid, 14);
   ASSERT_EQ(-EBADMSG, this->fetch(object));
-  ASSERT_EQ(0, this->fetch(object));
 
   journal::ObjectPlayer::Entries entries;
   object->get_entries(&entries);
-  ASSERT_EQ(3U, entries.size());
+  ASSERT_EQ(1U, entries.size());
 
-  journal::ObjectPlayer::Entries expected_entries = {entry1, entry2, entry3};
+  journal::ObjectPlayer::Entries expected_entries = {entry1};
   ASSERT_EQ(expected_entries, entries);
 }
 


### PR DESCRIPTION
No need for the ObjectPlayer to try to decode other entries if
it is going to return -EBADMSG anyway.

This also fixes the ObjectPlayer behaviour when it did not return
error if the corrurption was at the object end.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

