### PR TITLE
qa/rgw: more fixes for swift task

### DIFF
--- a/qa/tasks/swift.py
+++ b/qa/tasks/swift.py
@@ -247,6 +247,8 @@ def task(ctx, config):
                         },
                     }
                 )
+    # only take config for valid clients
+    config = {c: config[c] for c in clients}
 
     log.info('clients={c}'.format(c=config.keys()))
     with contextutil.nested(


### PR DESCRIPTION
swift task filters out runs against rhel 7.6 (see http://tracker.ceph.com/issues/40304) but this was breaking things elsewhere