### PR TITLE
rgw: Project Zipper part 1

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -117,6 +117,7 @@ set(librgw_common_srcs
   rgw_rest_role.cc
   rgw_rest_s3.cc
   rgw_role.cc
+  rgw_sal.cc
   rgw_string.cc
   rgw_tag.cc
   rgw_tag_s3.cc

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -236,7 +236,7 @@ namespace rgw {
 
     RGWObjectCtx rados_ctx(store, s); // XXX holds std::map
 
-    auto sysobj_ctx = store->svc.sysobj->init_obj_ctx();
+    auto sysobj_ctx = store->svc()->sysobj->init_obj_ctx();
     s->sysobj_ctx = &sysobj_ctx;
 
     /* XXX and -then- stash req_state pointers everywhere they are needed */
@@ -336,7 +336,7 @@ namespace rgw {
               << e.what() << dendl;
     }
     if (should_log) {
-      rgw_log_op(store, nullptr /* !rest */, s,
+      rgw_log_op(store->getRados(), nullptr /* !rest */, s,
 		 (op ? op->name() : "unknown"), olog);
     }
 
@@ -527,7 +527,7 @@ namespace rgw {
 
     r = rgw_perf_start(g_ceph_context);
 
-    rgw_rest_init(g_ceph_context, store, store->svc.zone->get_zonegroup());
+    rgw_rest_init(g_ceph_context, store->svc()->zone->get_zonegroup());
 
     mutex.lock();
     init_timer.cancel_all_events();
@@ -550,7 +550,7 @@ namespace rgw {
     ldh->init();
     ldh->bind();
 
-    rgw_log_usage_init(g_ceph_context, store);
+    rgw_log_usage_init(g_ceph_context, store->getRados());
 
     // XXX ex-RGWRESTMgr_lib, mgr->set_logging(true)
 
@@ -582,7 +582,7 @@ namespace rgw {
 
     fe->run();
 
-    r = store->register_to_service_map("rgw-nfs", service_map_meta);
+    r = store->getRados()->register_to_service_map("rgw-nfs", service_map_meta);
     if (r < 0) {
       derr << "ERROR: failed to register to service map: " << cpp_strerror(-r) << dendl;
       /* ignore error */
@@ -625,9 +625,9 @@ namespace rgw {
     return 0;
   } /* RGWLib::stop() */
 
-  int RGWLibIO::set_uid(RGWRados *store, const rgw_user& uid)
+  int RGWLibIO::set_uid(rgw::sal::RGWRadosStore *store, const rgw_user& uid)
   {
-    int ret = store->ctl.user->get_info_by_uid(uid, &user_info, null_yield);
+    int ret = store->ctl()->user->get_info_by_uid(uid, &user_info, null_yield);
     if (ret < 0) {
       derr << "ERROR: failed reading user info: uid=" << uid << " ret="
 	   << ret << dendl;

--- a/src/rgw/rgw_admin_user.h
+++ b/src/rgw/rgw_admin_user.h
@@ -20,18 +20,17 @@
 #include "common/config.h"
 
 #include <boost/intrusive_ptr.hpp>
-
-class RGWRados;
+#include "rgw_sal.h"
 
 namespace rgw {
 
   class RGWLibAdmin
   {
-    RGWRados *store;
+    rgw::sal::RGWRadosStore *store;
     boost::intrusive_ptr<CephContext> cct;
 
   public:
-    RGWRados* get_store()
+    rgw::sal::RGWRadosStore* get_store()
     {
       return store;
     }

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -143,7 +143,7 @@ void handle_connection(boost::asio::io_context& context,
       }
 
       // process the request
-      RGWRequest req{env.store->get_new_req_id()};
+      RGWRequest req{env.store->getRados()->get_new_req_id()};
 
       auto& socket = stream.lowest_layer();
       StreamIO real_client{cct, stream, parser, yield, buffer, is_ssl,
@@ -292,7 +292,7 @@ class AsioFrontend {
   void stop();
   void join();
   void pause();
-  void unpause(RGWRados* store, rgw_auth_registry_ptr_t);
+  void unpause(rgw::sal::RGWRadosStore* store, rgw_auth_registry_ptr_t);
 };
 
 unsigned short parse_port(const char *input, boost::system::error_code& ec)
@@ -695,7 +695,7 @@ void AsioFrontend::pause()
   }
 }
 
-void AsioFrontend::unpause(RGWRados* const store,
+void AsioFrontend::unpause(rgw::sal::RGWRadosStore* const store,
                            rgw_auth_registry_ptr_t auth_registry)
 {
   env.store = store;
@@ -759,7 +759,7 @@ void RGWAsioFrontend::pause_for_new_config()
 }
 
 void RGWAsioFrontend::unpause_with_new_config(
-  RGWRados* const store,
+  rgw::sal::RGWRadosStore* const store,
   rgw_auth_registry_ptr_t auth_registry
 ) {
   impl->unpause(store, std::move(auth_registry));

--- a/src/rgw/rgw_asio_frontend.h
+++ b/src/rgw/rgw_asio_frontend.h
@@ -21,7 +21,7 @@ public:
   void join() override;
 
   void pause_for_new_config() override;
-  void unpause_with_new_config(RGWRados *store,
+  void unpause_with_new_config(rgw::sal::RGWRadosStore *store,
                                rgw_auth_registry_ptr_t auth_registry) override;
 };
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -26,6 +26,7 @@ class RGWSI_Meta;
 class RGWBucketMetadataHandler;
 class RGWBucketInstanceMetadataHandler;
 class RGWUserCtl;
+namespace rgw { namespace sal { class RGWRadosStore; } }
 
 extern int rgw_bucket_parse_bucket_instance(const string& bucket_instance, string *bucket_name, string *bucket_id, int *shard_id);
 extern int rgw_bucket_parse_bucket_key(CephContext *cct, const string& key,
@@ -208,7 +209,7 @@ public:
  * Get all the buckets owned by a user and fill up an RGWUserBuckets with them.
  * Returns: 0 on success, -ERR# on failure.
  */
-extern int rgw_read_user_buckets(RGWRados *store,
+extern int rgw_read_user_buckets(rgw::sal::RGWRadosStore *store,
                                  const rgw_user& user_id,
                                  RGWUserBuckets& buckets,
                                  const string& marker,
@@ -218,15 +219,15 @@ extern int rgw_read_user_buckets(RGWRados *store,
 				 bool* is_truncated,
                                  uint64_t default_amount = 1000);
 
-extern int rgw_remove_object(RGWRados *store, const RGWBucketInfo& bucket_info, const rgw_bucket& bucket, rgw_obj_key& key);
-extern int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children, optional_yield y);
-extern int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket, int concurrent_max, optional_yield y);
+extern int rgw_remove_object(rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info, const rgw_bucket& bucket, rgw_obj_key& key);
+extern int rgw_remove_bucket(rgw::sal::RGWRadosStore *store, rgw_bucket& bucket, bool delete_children, optional_yield y);
+extern int rgw_remove_bucket_bypass_gc(rgw::sal::RGWRadosStore *store, rgw_bucket& bucket, int concurrent_max, optional_yield y);
 
-extern int rgw_object_get_attr(RGWRados* store, const RGWBucketInfo& bucket_info,
+extern int rgw_object_get_attr(rgw::sal::RGWRadosStore* store, const RGWBucketInfo& bucket_info,
                                const rgw_obj& obj, const char* attr_name,
                                bufferlist& out_bl, optional_yield y);
 
-extern void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id, bool fix);
+extern void check_bad_user_bucket_mapping(rgw::sal::RGWRadosStore *store, const rgw_user& user_id, bool fix);
 
 struct RGWBucketAdminOpState {
   rgw_user uid;
@@ -310,7 +311,7 @@ struct RGWBucketAdminOpState {
 class RGWBucket
 {
   RGWUserBuckets buckets;
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWAccessHandle handle;
 
   RGWUserInfo user_info;
@@ -323,7 +324,7 @@ class RGWBucket
 
 public:
   RGWBucket() : store(NULL), handle(NULL), failure(false) {}
-  int init(RGWRados *storage, RGWBucketAdminOpState& op_state, optional_yield y,
+  int init(rgw::sal::RGWRadosStore *storage, RGWBucketAdminOpState& op_state, optional_yield y,
               std::string *err_msg = NULL, map<string, bufferlist> *pattrs = NULL);
 
   int check_bad_index_multipart(RGWBucketAdminOpState& op_state,
@@ -359,37 +360,37 @@ public:
 class RGWBucketAdminOp
 {
 public:
-  static int get_policy(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int get_policy(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher);
-  static int get_policy(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int get_policy(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
                   RGWAccessControlPolicy& policy);
-  static int dump_s3_policy(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int dump_s3_policy(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
                   ostream& os);
 
-  static int unlink(RGWRados *store, RGWBucketAdminOpState& op_state);
-  static int link(RGWRados *store, RGWBucketAdminOpState& op_state, string *err_msg = NULL);
-  static int chown(RGWRados *store, RGWBucketAdminOpState& op_state, const string& marker, string *err_msg = NULL);
+  static int unlink(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state);
+  static int link(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state, string *err_msg = NULL);
+  static int chown(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state, const string& marker, string *err_msg = NULL);
 
-  static int check_index(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int check_index(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, optional_yield y);
 
-  static int remove_bucket(RGWRados *store, RGWBucketAdminOpState& op_state, optional_yield y, bool bypass_gc = false, bool keep_index_consistent = true);
-  static int remove_object(RGWRados *store, RGWBucketAdminOpState& op_state);
-  static int info(RGWRados *store, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher);
-  static int limit_check(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int remove_bucket(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state, optional_yield y, bool bypass_gc = false, bool keep_index_consistent = true);
+  static int remove_object(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state);
+  static int info(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher);
+  static int limit_check(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
 			 const std::list<std::string>& user_ids,
 			 RGWFormatterFlusher& flusher,
 			 bool warnings_only = false);
-  static int set_quota(RGWRados *store, RGWBucketAdminOpState& op_state);
+  static int set_quota(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state);
 
-  static int list_stale_instances(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int list_stale_instances(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
 				  RGWFormatterFlusher& flusher);
 
-  static int clear_stale_instances(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int clear_stale_instances(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher);
-  static int fix_lc_shards(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int fix_lc_shards(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
                            RGWFormatterFlusher& flusher);
-  static int fix_obj_expiry(RGWRados *store, RGWBucketAdminOpState& op_state,
+  static int fix_obj_expiry(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
 			    RGWFormatterFlusher& flusher, bool dry_run = false);
 };
 
@@ -830,7 +831,7 @@ public:
 		    optional_yield y,
                     bool update_entrypoint = true);
 
-  int chown(RGWRados *store, RGWBucketInfo& bucket_info,
+  int chown(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_info,
             const rgw_user& user_id, const std::string& display_name,
             const std::string& marker, optional_yield y);
 

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -65,7 +65,7 @@ int RGWCivetWebFrontend::process(struct mg_connection*  const conn)
                                 &cw_client))));
   RGWRestfulIO client_io(dout_context, &real_client_io);
 
-  RGWRequest req(env.store->get_new_req_id());
+  RGWRequest req(env.store->getRados()->get_new_req_id());
   int http_ret = 0;
   //assert (scheduler != nullptr);
   int ret = process_request(env.store, env.rest, &req, env.uri_prefix,

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -11,6 +11,7 @@
 
 #include "rgw_coroutine.h"
 #include "rgw_http_client.h"
+#include "rgw_sal.h"
 
 #include "rgw_sync_module.h"
 #include "rgw_sync_trace.h"
@@ -234,7 +235,7 @@ class RGWRESTConn;
 struct RGWDataSyncEnv {
   const DoutPrefixProvider *dpp{nullptr};
   CephContext *cct{nullptr};
-  RGWRados *store{nullptr};
+  rgw::sal::RGWRadosStore *store{nullptr};
   RGWRESTConn *conn{nullptr};
   RGWAsyncRadosProcessor *async_rados{nullptr};
   RGWHTTPManager *http_manager{nullptr};
@@ -246,7 +247,7 @@ struct RGWDataSyncEnv {
 
   RGWDataSyncEnv() {}
 
-  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, RGWRados *_store, RGWRESTConn *_conn,
+  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RGWRadosStore *_store, RGWRESTConn *_conn,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
             RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer,
             const string& _source_zone, RGWSyncModuleInstanceRef& _sync_module,
@@ -273,7 +274,7 @@ class RGWDataChangesLogInfo;
 
 class RGWRemoteDataLog : public RGWCoroutinesManager {
   const DoutPrefixProvider *dpp;
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWAsyncRadosProcessor *async_rados;
   RGWHTTPManager http_manager;
 
@@ -287,7 +288,7 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
   bool initialized;
 
 public:
-  RGWRemoteDataLog(const DoutPrefixProvider *dpp, RGWRados *_store,
+  RGWRemoteDataLog(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *_store,
                    RGWAsyncRadosProcessor *async_rados);
   int init(const string& _source_zone, RGWRESTConn *_conn, RGWSyncErrorLogger *_error_logger,
            RGWSyncTraceManager *_sync_tracer, RGWSyncModuleInstanceRef& module,
@@ -307,7 +308,7 @@ public:
 };
 
 class RGWDataSyncStatusManager : public DoutPrefixProvider {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
 
   string source_zone;
   RGWRESTConn *conn;
@@ -325,12 +326,12 @@ class RGWDataSyncStatusManager : public DoutPrefixProvider {
   int num_shards;
 
 public:
-  RGWDataSyncStatusManager(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
+  RGWDataSyncStatusManager(rgw::sal::RGWRadosStore *_store, RGWAsyncRadosProcessor *async_rados,
                            const string& _source_zone, PerfCounters* counters)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
       sync_module(nullptr), counters(counters),
       source_log(this, store, async_rados), num_shards(0) {}
-  RGWDataSyncStatusManager(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
+  RGWDataSyncStatusManager(rgw::sal::RGWRadosStore *_store, RGWAsyncRadosProcessor *async_rados,
                            const string& _source_zone, PerfCounters* counters,
                            const RGWSyncModuleInstanceRef& _sync_module)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
@@ -495,7 +496,7 @@ struct rgw_bucket_index_marker_info {
 
 class RGWRemoteBucketLog : public RGWCoroutinesManager {
   const DoutPrefixProvider *dpp;
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWRESTConn *conn{nullptr};
   string source_zone;
   rgw_bucket_shard bs;
@@ -510,7 +511,7 @@ class RGWRemoteBucketLog : public RGWCoroutinesManager {
   RGWBucketSyncCR *sync_cr{nullptr};
 
 public:
-  RGWRemoteBucketLog(const DoutPrefixProvider *_dpp, RGWRados *_store,
+  RGWRemoteBucketLog(const DoutPrefixProvider *_dpp, rgw::sal::RGWRadosStore *_store,
                      RGWBucketSyncStatusManager *_sm,
                      RGWAsyncRadosProcessor *_async_rados,
                      RGWHTTPManager *_http_manager);
@@ -530,7 +531,7 @@ public:
 };
 
 class RGWBucketSyncStatusManager : public DoutPrefixProvider {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
 
   RGWCoroutinesManager cr_mgr;
 
@@ -554,7 +555,7 @@ class RGWBucketSyncStatusManager : public DoutPrefixProvider {
   int num_shards;
 
 public:
-  RGWBucketSyncStatusManager(RGWRados *_store, const string& _source_zone,
+  RGWBucketSyncStatusManager(rgw::sal::RGWRadosStore *_store, const string& _source_zone,
                              const rgw_bucket& bucket);
   ~RGWBucketSyncStatusManager();
 
@@ -576,7 +577,7 @@ public:
 };
 
 /// read the sync status of all bucket shards from the given source zone
-int rgw_bucket_sync_status(const DoutPrefixProvider *dpp, RGWRados *store, const std::string& source_zone,
+int rgw_bucket_sync_status(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, const std::string& source_zone,
                            const RGWBucketInfo& bucket_info,
                            std::vector<rgw_bucket_shard_sync_info> *status);
 

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1515,7 +1515,7 @@ namespace rgw {
     struct req_state* s = get_state();
 
     auto compression_type =
-      get_store()->svc.zone->get_zone_params().get_compression_type(
+      get_store()->svc()->zone->get_zone_params().get_compression_type(
 	s->bucket_info.placement_rule);
 
     /* not obviously supportable */
@@ -1551,7 +1551,7 @@ namespace rgw {
       if (!version_id.empty()) {
         obj.key.set_instance(version_id);
       } else {
-        get_store()->gen_rand_obj_instance_name(&obj);
+        get_store()->getRados()->gen_rand_obj_instance_name(&obj);
         version_id = obj.key.instance;
       }
     }
@@ -1597,7 +1597,7 @@ namespace rgw {
       return -EIO;
     }
 
-    op_ret = get_store()->check_quota(s->bucket_owner.get_id(), s->bucket,
+    op_ret = get_store()->getRados()->check_quota(s->bucket_owner.get_id(), s->bucket,
                                       user_quota, bucket_quota, real_ofs, true);
     /* max_size exceed */
     if (op_ret < 0)
@@ -1640,14 +1640,14 @@ namespace rgw {
       goto done;
     }
 
-    op_ret = get_store()->check_quota(s->bucket_owner.get_id(), s->bucket,
+    op_ret = get_store()->getRados()->check_quota(s->bucket_owner.get_id(), s->bucket,
 				      user_quota, bucket_quota, s->obj_size, true);
     /* max_size exceed */
     if (op_ret < 0) {
       goto done;
     }
 
-    op_ret = get_store()->check_bucket_shards(s->bucket_info, s->bucket,
+    op_ret = get_store()->getRados()->check_bucket_shards(s->bucket_info, s->bucket,
 					      bucket_quota);
     if (op_ret < 0) {
       goto done;

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -972,8 +972,8 @@ namespace rgw {
       (void) fh_lru.unref(fh, cohort::lru::FLAG_NONE);
     }
 
-    int authorize(RGWRados* store) {
-      int ret = store->ctl.user->get_info_by_access_key(key.id, &user, null_yield);
+    int authorize(rgw::sal::RGWRadosStore* store) {
+      int ret = store->ctl()->user->get_info_by_access_key(key.id, &user, null_yield);
       if (ret == 0) {
 	RGWAccessKey* k = user.get_key(key.id);
 	if (!k || (k->key != key.key))
@@ -992,8 +992,8 @@ namespace rgw {
 	}
 	if (token.valid() && (ldh->auth(token.id, token.key) == 0)) {
 	  /* try to store user if it doesn't already exist */
-	  if (store->ctl.user->get_info_by_uid(token.id, &user, null_yield) < 0) {
-	    int ret = store->ctl.user->store_info(user, null_yield,
+	  if (store->ctl()->user->get_info_by_uid(token.id, &user, null_yield) < 0) {
+	    int ret = store->ctl()->user->store_info(user, null_yield,
                                                   RGWUserCtl::PutParams()
                                                   .set_exclusive(true));
 	    if (ret < 0) {
@@ -1277,7 +1277,7 @@ namespace rgw {
 
     void update_user() {
       RGWUserInfo _user = user;
-      auto user_ctl = rgwlib.get_store()->ctl.user;
+      auto user_ctl = rgwlib.get_store()->ctl()->user;
       int ret = user_ctl->get_info_by_access_key(key.id, &user, null_yield);
       if (ret != 0)
         user = _user;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -20,6 +20,7 @@
 #include "rgw_rados.h"
 #include "cls/rgw/cls_rgw_types.h"
 #include "rgw_tag.h"
+#include "rgw_sal.h"
 
 #include <atomic>
 #include <tuple>
@@ -451,7 +452,7 @@ WRITE_CLASS_ENCODER(RGWLifecycleConfiguration)
 
 class RGWLC : public DoutPrefixProvider {
   CephContext *cct;
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   int max_objs{0};
   string *obj_names{nullptr};
   std::atomic<bool> down_flag = { false };
@@ -480,7 +481,7 @@ class RGWLC : public DoutPrefixProvider {
     finalize();
   }
 
-  void initialize(CephContext *_cct, RGWRados *_store);
+  void initialize(CephContext *_cct, rgw::sal::RGWRadosStore *_store);
   void finalize();
 
   int process();
@@ -511,7 +512,7 @@ class RGWLC : public DoutPrefixProvider {
 
 namespace rgw::lc {
 
-int fix_lc_shard_entry(RGWRados *store, const RGWBucketInfo& bucket_info,
+int fix_lc_shard_entry(rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info,
 		       const map<std::string,bufferlist>& battrs);
 
 std::string s3_expiration_header(

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -107,7 +107,7 @@ void RGWLoadGenProcess::gen_request(const string& method,
 				    int content_length, std::atomic<bool>* fail_flag)
 {
   RGWLoadGenRequest* req =
-    new RGWLoadGenRequest(store->get_new_req_id(), method, resource,
+    new RGWLoadGenRequest(store->getRados()->get_new_req_id(), method, resource,
 			  content_length, fail_flag);
   dout(10) << "allocated request req=" << hex << req << dec << dendl;
   req_throttle.get(1);

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -11,6 +11,7 @@
 #include "rgw_zone.h"
 #include "rgw_tools.h"
 #include "rgw_mdlog.h"
+#include "rgw_sal.h"
 
 #include "rgw_cr_rados.h"
 
@@ -23,6 +24,8 @@
 #include "include/ceph_assert.h"
 
 #include <boost/asio/yield.hpp>
+
+using namespace rgw::sal;
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -389,11 +392,11 @@ int RGWMetadataHandler::attach(RGWMetadataManager *manager)
 }
 
 RGWMetadataHandler_GenericMetaBE::Put::Put(RGWMetadataHandler_GenericMetaBE *_handler,
-                                           RGWSI_MetaBackend_Handler::Op *_op,
-                                           string& _entry, RGWMetadataObject *_obj,
-                                           RGWObjVersionTracker& _objv_tracker,
-                                           optional_yield _y,
-                                           RGWMDLogSyncType _type) :
+					   RGWSI_MetaBackend_Handler::Op *_op,
+					   string& _entry, RGWMetadataObject *_obj,
+					   RGWObjVersionTracker& _objv_tracker,
+					   optional_yield _y,
+					   RGWMDLogSyncType _type):
   handler(_handler), op(_op),
   entry(_entry), obj(_obj),
   objv_tracker(_objv_tracker),

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -16,11 +16,12 @@
 #include "cls/log/cls_log_types.h"
 #include "common/RefCountedObj.h"
 #include "common/ceph_time.h"
-
 #include "services/svc_meta_be.h"
 
 
-class RGWRados;
+namespace rgw { namespace sal {
+class RGWRadosStore;
+} }
 class RGWCoroutine;
 class JSONObj;
 struct RGWObjVersionTracker;
@@ -136,7 +137,7 @@ public:
       return handler->do_get(op, entry, obj, y);
     }
   public:
-    Put(RGWMetadataHandler_GenericMetaBE *handler, RGWSI_MetaBackend_Handler::Op *_op,
+    Put(RGWMetadataHandler_GenericMetaBE *_handler, RGWSI_MetaBackend_Handler::Op *_op,
         string& _entry, RGWMetadataObject *_obj,
         RGWObjVersionTracker& _objv_tracker, optional_yield _y,
         RGWMDLogSyncType _type);

--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -9,6 +9,10 @@
 #include "rgw_obj_manifest.h"
 #include "rgw_compression_types.h"
 
+namespace rgw { namespace sal {
+  class RGWRadosStore;
+} }
+
 #define MULTIPART_UPLOAD_ID_PREFIX_LEGACY "2/"
 #define MULTIPART_UPLOAD_ID_PREFIX "2~" // must contain a unique char that may not come up in gen_rand_alpha()
 
@@ -104,7 +108,7 @@ public:
 
 extern bool is_v2_upload_id(const string& upload_id);
 
-extern int list_multipart_parts(RGWRados *store, RGWBucketInfo& bucket_info,
+extern int list_multipart_parts(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_info,
 				CephContext *cct,
                                 const string& upload_id,
                                 const string& meta_oid, int num_parts,
@@ -112,17 +116,17 @@ extern int list_multipart_parts(RGWRados *store, RGWBucketInfo& bucket_info,
                                 int *next_marker, bool *truncated,
                                 bool assume_unsorted = false);
 
-extern int list_multipart_parts(RGWRados *store, struct req_state *s,
+extern int list_multipart_parts(rgw::sal::RGWRadosStore *store, struct req_state *s,
                                 const string& upload_id,
                                 const string& meta_oid, int num_parts,
                                 int marker, map<uint32_t, RGWUploadPartInfo>& parts,
                                 int *next_marker, bool *truncated,
                                 bool assume_unsorted = false);
 
-extern int abort_multipart_upload(RGWRados *store, CephContext *cct, RGWObjectCtx *obj_ctx,
+extern int abort_multipart_upload(rgw::sal::RGWRadosStore *store, CephContext *cct, RGWObjectCtx *obj_ctx,
                                 RGWBucketInfo& bucket_info, RGWMPObj& mp_obj);
 
-extern int list_bucket_multiparts(RGWRados *store, RGWBucketInfo& bucket_info,
+extern int list_bucket_multiparts(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_info,
 				  const string& prefix,
 				  const string& marker,
 				  const string& delim,
@@ -130,6 +134,6 @@ extern int list_bucket_multiparts(RGWRados *store, RGWBucketInfo& bucket_info,
 				  vector<rgw_bucket_dir_entry> *objs,
 				  map<string, bool> *common_prefixes, bool *is_truncated);
 
-extern int abort_bucket_multiparts(RGWRados *store, CephContext *cct, RGWBucketInfo& bucket_info,
+extern int abort_bucket_multiparts(rgw::sal::RGWRadosStore *store, CephContext *cct, RGWBucketInfo& bucket_info,
                                 string& prefix, string& delim);
 #endif

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -21,6 +21,7 @@
 class RGWSI_Zone;
 struct RGWZoneGroup;
 struct RGWZoneParams;
+class RGWRados;
 
 class rgw_obj_select {
   rgw_placement_rule placement_rule;

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -33,13 +33,13 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-static RGWRados *store = NULL;
+static rgw::sal::RGWRadosStore *store = NULL;
 
 class StoreDestructor {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
 
 public:
-  explicit StoreDestructor(RGWRados *_s) : store(_s) {}
+  explicit StoreDestructor(rgw::sal::RGWRadosStore *_s) : store(_s) {}
   ~StoreDestructor() {
     if (store) {
       RGWStoreManager::close_storage(store);

--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -28,10 +28,11 @@
 #include "include/utime.h"
 #include "include/str_list.h"
 
+#include "rgw_sal.h"
+
 class CephContext;
 class RGWSI_RADOS;
 class RGWSI_Zone;
-class RGWRados;
 class RGWBucketInfo;
 class cls_timeindex_entry;
 
@@ -68,7 +69,7 @@ public:
 
 class RGWObjectExpirer {
 protected:
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWObjExpStore exp_store;
 
   int init_bucket_info(const std::string& tenant_name,
@@ -97,9 +98,9 @@ protected:
   std::atomic<bool> down_flag = { false };
 
 public:
-  explicit RGWObjectExpirer(RGWRados *_store)
+  explicit RGWObjectExpirer(rgw::sal::RGWRadosStore *_store)
     : store(_store),
-      exp_store(_store->ctx(), _store->svc.rados, _store->svc.zone),
+      exp_store(_store->getRados()->ctx(), _store->svc()->rados, _store->svc()->zone),
       worker(NULL) {
   }
   ~RGWObjectExpirer() {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -79,7 +79,7 @@ int rgw_op_get_bucket_policy_from_attr(CephContext *cct,
 
 class RGWHandler {
 protected:
-  RGWRados *store{nullptr};
+  rgw::sal::RGWRadosStore* store{nullptr};
   struct req_state *s{nullptr};
 
   int do_init_permissions();
@@ -89,7 +89,7 @@ public:
   RGWHandler() {}
   virtual ~RGWHandler();
 
-  virtual int init(RGWRados *store,
+  virtual int init(rgw::sal::RGWRadosStore* store,
                    struct req_state* _s,
                    rgw::io::BasicClient* cio);
 
@@ -126,7 +126,7 @@ class RGWOp : public DoutPrefixProvider {
 protected:
   struct req_state *s;
   RGWHandler *dialect_handler;
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWCORSConfiguration bucket_cors;
   bool cors_exist;
   RGWQuotaInfo bucket_quota;
@@ -159,7 +159,7 @@ public:
     return 0;
   }
 
-  virtual void init(RGWRados *store, struct req_state *s, RGWHandler *dialect_handler) {
+  virtual void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *dialect_handler) {
     this->store = store;
     this->s = s;
     this->dialect_handler = dialect_handler;
@@ -483,11 +483,11 @@ public:
     unsigned int num_unfound;
     std::list<fail_desc_t> failures;
 
-    RGWRados * const store;
+    rgw::sal::RGWRadosStore * const store;
     req_state * const s;
 
   public:
-    Deleter(const DoutPrefixProvider* dpp, RGWRados * const str, req_state * const s)
+    Deleter(const DoutPrefixProvider* dpp, rgw::sal::RGWRadosStore * const str, req_state * const s)
       : dpp(dpp),
         num_deleted(0),
         num_unfound(0),
@@ -596,7 +596,7 @@ public:
     : num_created(0) {
   }
 
-  void init(RGWRados* const store,
+  void init(rgw::sal::RGWRadosStore* const store,
             struct req_state* const s,
             RGWHandler* const h) override;
 
@@ -983,7 +983,7 @@ public:
   int verify_permission() override;
   void pre_exec() override;
   void execute() override;
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
     relaxed_region_enforcement =
@@ -1136,7 +1136,7 @@ public:
     delete obj_legal_hold;
   }
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1206,7 +1206,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1247,7 +1247,7 @@ public:
       has_policy(false) {
   }
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1286,7 +1286,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1313,7 +1313,7 @@ public:
     : dlo_manifest(NULL)
   {}
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1435,7 +1435,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl));
   }
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     dest_policy.set_ctx(s->cct);
   }
@@ -1488,7 +1488,7 @@ public:
   void pre_exec() override;
   void execute() override;
 
-  virtual int get_policy_from_state(RGWRados *store, struct req_state *s, stringstream& ss) { return 0; }
+  virtual int get_policy_from_state(rgw::sal::RGWRadosStore *store, struct req_state *s, stringstream& ss) { return 0; }
   virtual int get_params() = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_acls"; }
@@ -1525,7 +1525,7 @@ public:
   }
   ~RGWPutLC() override {}
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *dialect_handler) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *dialect_handler) override {
 #define COOKIE_LEN 16
     char buf[COOKIE_LEN + 1];
 
@@ -1683,7 +1683,7 @@ protected:
 public:
   RGWInitMultipart() {}
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1773,7 +1773,7 @@ public:
     truncated = false;
   }
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy = RGWAccessControlPolicy(s->cct);
   }
@@ -1812,7 +1812,7 @@ public:
     default_max = 0;
   }
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     max_uploads = default_max;
   }
@@ -1916,13 +1916,13 @@ public:
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
 
-extern int rgw_build_bucket_policies(RGWRados* store, struct req_state* s);
-extern int rgw_build_object_policies(RGWRados *store, struct req_state *s,
+extern int rgw_build_bucket_policies(rgw::sal::RGWRadosStore* store, struct req_state* s);
+extern int rgw_build_object_policies(rgw::sal::RGWRadosStore *store, struct req_state *s,
 				     bool prefetch_data);
-extern void rgw_build_iam_environment(RGWRados* store,
+extern void rgw_build_iam_environment(rgw::sal::RGWRadosStore* store,
 						                          struct req_state* s);
 extern vector<rgw::IAM::Policy> get_iam_user_policy_from_attr(CephContext* cct,
-                        RGWRados* store,
+                        rgw::sal::RGWRadosStore* store,
                         map<string, bufferlist>& attrs,
                         const string& tenant);
 
@@ -2338,7 +2338,7 @@ protected:
 public:
   RGWGetClusterStat() {}
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
   }
   int verify_permission() override {return 0;}

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -20,7 +20,7 @@
 #include "common/Formatter.h"
 #include "common/errno.h"
 
-#include "rgw_rados.h"
+#include "rgw_sal.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -124,13 +124,13 @@ struct RGWOrphanSearchState {
 WRITE_CLASS_ENCODER(RGWOrphanSearchState)
 
 class RGWOrphanStore {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   librados::IoCtx ioctx;
 
   string oid;
 
 public:
-  explicit RGWOrphanStore(RGWRados *_store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
+  explicit RGWOrphanStore(rgw::sal::RGWRadosStore *_store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
 
   librados::IoCtx& get_ioctx() { return ioctx; }
 
@@ -148,7 +148,7 @@ public:
 
 
 class RGWOrphanSearch {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
 
   RGWOrphanStore orphan_store;
 
@@ -186,7 +186,7 @@ class RGWOrphanSearch {
 
   int remove_index(map<int, string>& index);
 public:
-  RGWOrphanSearch(RGWRados *_store, int _max_ios, uint64_t _stale_secs) : store(_store), orphan_store(store), max_concurrent_ios(_max_ios), stale_secs(_stale_secs) {}
+  RGWOrphanSearch(rgw::sal::RGWRadosStore *_store, int _max_ios, uint64_t _stale_secs) : store(_store), orphan_store(store), max_concurrent_ios(_max_ios), stale_secs(_stale_secs) {}
 
   int save_state() {
     RGWOrphanSearchState state;

--- a/src/rgw/rgw_otp.h
+++ b/src/rgw/rgw_otp.h
@@ -4,6 +4,10 @@
 #ifndef CEPH_RGW_OTP_H
 #define CEPH_RGW_OTP_H
 
+namespace rgw { namespace sal {
+class RGWRadosStore;
+} }
+
 #include "cls/otp/cls_otp_types.h"
 #include "services/svc_meta_be_otp.h"
 

--- a/src/rgw/rgw_period_pusher.cc
+++ b/src/rgw/rgw_period_pusher.cc
@@ -7,6 +7,7 @@
 #include "rgw_period_pusher.h"
 #include "rgw_cr_rest.h"
 #include "rgw_zone.h"
+#include "rgw_sal.h"
 
 #include "services/svc_zone.h"
 
@@ -156,17 +157,17 @@ class RGWPeriodPusher::CRThread {
 };
 
 
-RGWPeriodPusher::RGWPeriodPusher(RGWRados* store)
+RGWPeriodPusher::RGWPeriodPusher(rgw::sal::RGWRadosStore* store)
   : cct(store->ctx()), store(store)
 {
-  const auto& realm = store->svc.zone->get_realm();
+  const auto& realm = store->svc()->zone->get_realm();
   auto& realm_id = realm.get_id();
   if (realm_id.empty()) // no realm configuration
     return;
 
   // always send out the current period on startup
   RGWPeriod period;
-  int r = period.init(cct, store->svc.sysobj, realm_id, realm.get_name());
+  int r = period.init(cct, store->svc()->sysobj, realm_id, realm.get_name());
   if (r < 0) {
     lderr(cct) << "failed to load period for realm " << realm_id << dendl;
     return;
@@ -221,7 +222,7 @@ void RGWPeriodPusher::handle_notify(RGWZonesNeedPeriod&& period)
 
   // find our zonegroup in the new period
   auto& zonegroups = period.get_map().zonegroups;
-  auto i = zonegroups.find(store->svc.zone->get_zonegroup().get_id());
+  auto i = zonegroups.find(store->svc()->zone->get_zonegroup().get_id());
   if (i == zonegroups.end()) {
     lderr(cct) << "The new period does not contain my zonegroup!" << dendl;
     return;
@@ -229,7 +230,7 @@ void RGWPeriodPusher::handle_notify(RGWZonesNeedPeriod&& period)
   auto& my_zonegroup = i->second;
 
   // if we're not a master zone, we're not responsible for pushing any updates
-  if (my_zonegroup.master_zone != store->svc.zone->get_zone_params().get_id())
+  if (my_zonegroup.master_zone != store->svc()->zone->get_zone_params().get_id())
     return;
 
   // construct a map of the zones that need this period. the map uses the same
@@ -238,11 +239,11 @@ void RGWPeriodPusher::handle_notify(RGWZonesNeedPeriod&& period)
   auto hint = conns.end();
 
   // are we the master zonegroup in this period?
-  if (period.get_map().master_zonegroup == store->svc.zone->get_zonegroup().get_id()) {
+  if (period.get_map().master_zonegroup == store->svc()->zone->get_zonegroup().get_id()) {
     // update other zonegroup endpoints
     for (auto& zg : zonegroups) {
       auto& zonegroup = zg.second;
-      if (zonegroup.get_id() == store->svc.zone->get_zonegroup().get_id())
+      if (zonegroup.get_id() == store->svc()->zone->get_zonegroup().get_id())
         continue;
       if (zonegroup.endpoints.empty())
         continue;
@@ -250,14 +251,14 @@ void RGWPeriodPusher::handle_notify(RGWZonesNeedPeriod&& period)
       hint = conns.emplace_hint(
           hint, std::piecewise_construct,
           std::forward_as_tuple(zonegroup.get_id()),
-          std::forward_as_tuple(cct, store->svc.zone, zonegroup.get_id(), zonegroup.endpoints));
+          std::forward_as_tuple(cct, store->svc()->zone, zonegroup.get_id(), zonegroup.endpoints));
     }
   }
 
   // update other zone endpoints
   for (auto& z : my_zonegroup.zones) {
     auto& zone = z.second;
-    if (zone.id == store->svc.zone->get_zone_params().get_id())
+    if (zone.id == store->svc()->zone->get_zone_params().get_id())
       continue;
     if (zone.endpoints.empty())
       continue;
@@ -265,7 +266,7 @@ void RGWPeriodPusher::handle_notify(RGWZonesNeedPeriod&& period)
     hint = conns.emplace_hint(
         hint, std::piecewise_construct,
         std::forward_as_tuple(zone.id),
-        std::forward_as_tuple(cct, store->svc.zone, zone.id, zone.endpoints));
+        std::forward_as_tuple(cct, store->svc()->zone, zone.id, zone.endpoints));
   }
 
   if (conns.empty()) {
@@ -291,7 +292,7 @@ void RGWPeriodPusher::pause()
   store = nullptr;
 }
 
-void RGWPeriodPusher::resume(RGWRados* store)
+void RGWPeriodPusher::resume(rgw::sal::RGWRadosStore* store)
 {
   std::lock_guard<std::mutex> lock(mutex);
   this->store = store;

--- a/src/rgw/rgw_period_pusher.h
+++ b/src/rgw/rgw_period_pusher.h
@@ -10,7 +10,12 @@
 
 #include "rgw_realm_reloader.h"
 
-class RGWRados;
+namespace rgw {
+namespace sal {
+class RGWRadosStore;
+}
+}
+
 class RGWPeriod;
 
 // RGWRealmNotify payload for push coordination
@@ -23,7 +28,7 @@ using RGWZonesNeedPeriod = RGWPeriod;
 class RGWPeriodPusher final : public RGWRealmWatcher::Watcher,
                               public RGWRealmReloader::Pauser {
  public:
-  explicit RGWPeriodPusher(RGWRados* store);
+  explicit RGWPeriodPusher(rgw::sal::RGWRadosStore* store);
   ~RGWPeriodPusher() override;
 
   /// respond to realm notifications by pushing new periods to other zones
@@ -34,13 +39,13 @@ class RGWPeriodPusher final : public RGWRealmWatcher::Watcher,
   void pause() override;
 
   /// continue processing notifications with a new RGWRados instance
-  void resume(RGWRados* store) override;
+  void resume(rgw::sal::RGWRadosStore* store) override;
 
  private:
   void handle_notify(RGWZonesNeedPeriod&& period);
 
   CephContext *const cct;
-  RGWRados* store;
+  rgw::sal::RGWRadosStore* store;
 
   std::mutex mutex;
   epoch_t realm_epoch{0}; //< the current realm epoch being sent

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -166,7 +166,7 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
   return 0;
 }
 
-int process_request(RGWRados* const store,
+int process_request(rgw::sal::RGWRadosStore* const store,
                     RGWREST* const rest,
                     RGWRequest* const req,
                     const std::string& frontend_prefix,
@@ -193,7 +193,7 @@ int process_request(RGWRados* const store,
   RGWObjectCtx rados_ctx(store, s);
   s->obj_ctx = &rados_ctx;
 
-  auto sysobj_ctx = store->svc.sysobj->init_obj_ctx();
+  auto sysobj_ctx = store->svc()->sysobj->init_obj_ctx();
   s->sysobj_ctx = &sysobj_ctx;
 
   if (ret < 0) {
@@ -202,9 +202,9 @@ int process_request(RGWRados* const store,
     return ret;
   }
 
-  s->req_id = store->svc.zone_utils->unique_id(req->id);
-  s->trans_id = store->svc.zone_utils->unique_trans_id(req->id);
-  s->host_id = store->host_id;
+  s->req_id = store->svc()->zone_utils->unique_id(req->id);
+  s->trans_id = store->svc()->zone_utils->unique_trans_id(req->id);
+  s->host_id = store->getRados()->host_id;
   s->yield = yield;
 
   ldpp_dout(s, 2) << "initializing for trans_id = " << s->trans_id << dendl;
@@ -294,7 +294,7 @@ done:
   }
 
   if (should_log) {
-    rgw_log_op(store, rest, s, (op ? op->name() : "unknown"), olog);
+    rgw_log_op(store->getRados(), rest, s, (op ? op->name() : "unknown"), olog);
   }
 
   if (http_ret != nullptr) {

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -33,7 +33,7 @@ namespace rgw::dmclock {
 }
 
 struct RGWProcessEnv {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWREST *rest;
   OpsLogSocket *olog;
   int port;
@@ -47,7 +47,7 @@ class RGWProcess {
   deque<RGWRequest*> m_req_queue;
 protected:
   CephContext *cct;
-  RGWRados* store;
+  rgw::sal::RGWRadosStore* store;
   rgw_auth_registry_ptr_t auth_registry;
   OpsLogSocket* olog;
   ThreadPool m_tp;
@@ -114,7 +114,7 @@ public:
     m_tp.pause();
   }
 
-  void unpause_with_new_config(RGWRados* const store,
+  void unpause_with_new_config(rgw::sal::RGWRadosStore* const store,
                                rgw_auth_registry_ptr_t auth_registry) {
     this->store = store;
     this->auth_registry = std::move(auth_registry);
@@ -173,7 +173,7 @@ public:
   void set_access_key(RGWAccessKey& key) { access_key = key; }
 };
 /* process stream request */
-extern int process_request(RGWRados* store,
+extern int process_request(rgw::sal::RGWRadosStore* store,
                            RGWREST* rest,
                            RGWRequest* req,
                            const std::string& frontend_prefix,

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -422,7 +422,7 @@ class RGWUserPubSub
 {
   friend class Bucket;
 
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   rgw_user user;
   RGWSysObjectCtx obj_ctx;
 
@@ -452,7 +452,7 @@ class RGWUserPubSub
   int write_user_topics(const rgw_pubsub_user_topics& topics, RGWObjVersionTracker *objv_tracker);
 
 public:
-  RGWUserPubSub(RGWRados *_store, const rgw_user& _user);
+  RGWUserPubSub(rgw::sal::RGWRadosStore *_store, const rgw_user& _user);
 
   class Bucket {
     friend class RGWUserPubSub;
@@ -616,7 +616,7 @@ int RGWUserPubSub::write(const rgw_raw_obj& obj, const T& info, RGWObjVersionTra
   bufferlist bl;
   encode(info, bl);
 
-  auto obj_ctx = store->svc.sysobj->init_obj_ctx();
+  auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
   int ret = rgw_put_system_obj(obj_ctx, obj.pool, obj.oid,
                            bl, false, objv_tracker,
                            real_time());

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -79,7 +79,7 @@ using RawObjSet = std::set<rgw_raw_obj>;
 // a data sink that writes to rados objects and deletes them on cancelation
 class RadosWriter : public DataProcessor {
   Aio *const aio;
-  RGWRados *const store;
+  rgw::sal::RGWRadosStore *const store;
   const RGWBucketInfo& bucket_info;
   RGWObjectCtx& obj_ctx;
   const rgw_obj head_obj;
@@ -89,7 +89,8 @@ class RadosWriter : public DataProcessor {
   optional_yield y;
 
  public:
-  RadosWriter(Aio *aio, RGWRados *store, const RGWBucketInfo& bucket_info,
+  RadosWriter(Aio *aio, rgw::sal::RGWRadosStore *store,
+	      const RGWBucketInfo& bucket_info,
               RGWObjectCtx& obj_ctx, const rgw_obj& head_obj,
               const DoutPrefixProvider *dpp, optional_yield y)
     : aio(aio), store(store), bucket_info(bucket_info),
@@ -118,7 +119,7 @@ class RadosWriter : public DataProcessor {
 class ManifestObjectProcessor : public HeadObjectProcessor,
                                 public StripeGenerator {
  protected:
-  RGWRados *const store;
+  rgw::sal::RGWRadosStore *const store;
   const RGWBucketInfo& bucket_info;
   rgw_placement_rule tail_placement_rule;
   const rgw_user& owner;
@@ -136,7 +137,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
   int next(uint64_t offset, uint64_t *stripe_size) override;
 
  public:
-  ManifestObjectProcessor(Aio *aio, RGWRados *store,
+  ManifestObjectProcessor(Aio *aio, rgw::sal::RGWRadosStore *store,
                           const RGWBucketInfo& bucket_info,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,
@@ -169,7 +170,7 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 
   int process_first_chunk(bufferlist&& data, DataProcessor **processor) override;
  public:
-  AtomicObjectProcessor(Aio *aio, RGWRados *store,
+  AtomicObjectProcessor(Aio *aio, rgw::sal::RGWRadosStore *store,
                         const RGWBucketInfo& bucket_info,
                         const rgw_placement_rule *ptail_placement_rule,
                         const rgw_user& owner,
@@ -213,7 +214,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
   // prepare the head stripe and manifest
   int prepare_head();
  public:
-  MultipartObjectProcessor(Aio *aio, RGWRados *store,
+  MultipartObjectProcessor(Aio *aio, rgw::sal::RGWRadosStore *store,
                            const RGWBucketInfo& bucket_info,
                            const rgw_placement_rule *ptail_placement_rule,
                            const rgw_user& owner, RGWObjectCtx& obj_ctx,
@@ -256,7 +257,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
     int process_first_chunk(bufferlist&& data, DataProcessor **processor) override;
 
   public:
-    AppendObjectProcessor(Aio *aio, RGWRados *store, const RGWBucketInfo& bucket_info,
+    AppendObjectProcessor(Aio *aio, rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,const rgw_obj& head_obj,
                           const std::string& unique_tag, uint64_t position,

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -27,8 +27,10 @@ static inline int64_t rgw_rounded_kb(int64_t bytes)
   return (bytes + 1023) / 1024;
 }
 
-class RGWRados;
 class JSONObj;
+namespace rgw { namespace sal {
+  class RGWRadosStore;
+} }
 
 struct RGWQuotaInfo {
   template<class T> friend class RGWQuotaCache;
@@ -112,7 +114,7 @@ public:
 
   virtual void update_stats(const rgw_user& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
 
-  static RGWQuotaHandler *generate_handler(RGWRados *store, bool quota_threads);
+  static RGWQuotaHandler *generate_handler(rgw::sal::RGWRadosStore *store, bool quota_threads);
   static void free_handler(RGWQuotaHandler *handler);
 };
 

--- a/src/rgw/rgw_realm_reloader.h
+++ b/src/rgw/rgw_realm_reloader.h
@@ -7,7 +7,11 @@
 #include "rgw_realm_watcher.h"
 #include "common/Cond.h"
 
-class RGWRados;
+namespace rgw {
+namespace sal {
+class RGWRadosStore;
+}
+}
 
 /**
  * RGWRealmReloader responds to new period notifications by recreating RGWRados
@@ -29,10 +33,10 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
     /// pause all frontends while realm reconfiguration is in progress
     virtual void pause() = 0;
     /// resume all frontends with the given RGWRados instance
-    virtual void resume(RGWRados* store) = 0;
+    virtual void resume(rgw::sal::RGWRadosStore* store) = 0;
   };
 
-  RGWRealmReloader(RGWRados*& store, std::map<std::string, std::string>& service_map_meta,
+  RGWRealmReloader(rgw::sal::RGWRadosStore*& store, std::map<std::string, std::string>& service_map_meta,
                    Pauser* frontends);
   ~RGWRealmReloader() override;
 
@@ -45,8 +49,8 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
 
   class C_Reload; //< Context that calls reload()
 
-  /// main()'s RGWRados pointer as a reference, modified by reload()
-  RGWRados*& store;
+  /// main()'s RGWRadosStore pointer as a reference, modified by reload()
+  rgw::sal::RGWRadosStore*& store;
   std::map<std::string, std::string>& service_map_meta;
   Pauser *const frontends;
 

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -8,6 +8,7 @@
 #include "rgw_zone.h"
 #include "rgw_bucket.h"
 #include "rgw_reshard.h"
+#include "rgw_sal.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/lock/cls_lock_client.h"
 #include "common/errno.h"
@@ -27,7 +28,7 @@ const string bucket_instance_lock_name = "bucket_instance_lock";
 
 
 class BucketReshardShard {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   const RGWBucketInfo& bucket_info;
   int num_shard;
   RGWRados::BucketShard bs;
@@ -69,10 +70,10 @@ class BucketReshardShard {
   }
 
 public:
-  BucketReshardShard(RGWRados *_store, const RGWBucketInfo& _bucket_info,
+  BucketReshardShard(rgw::sal::RGWRadosStore *_store, const RGWBucketInfo& _bucket_info,
                      int _num_shard,
                      deque<librados::AioCompletion *>& _completions) :
-    store(_store), bucket_info(_bucket_info), bs(store),
+    store(_store), bucket_info(_bucket_info), bs(store->getRados()),
     aio_completions(_completions)
   {
     num_shard = (bucket_info.num_shards > 0 ? _num_shard : -1);
@@ -115,7 +116,7 @@ public:
 
     librados::ObjectWriteOperation op;
     for (auto& entry : entries) {
-      store->bi_put(op, bs, entry);
+      store->getRados()->bi_put(op, bs, entry);
     }
     cls_rgw_bucket_update_stats(op, false, stats);
 
@@ -148,14 +149,14 @@ public:
 
 
 class BucketReshardManager {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   const RGWBucketInfo& target_bucket_info;
   deque<librados::AioCompletion *> completions;
   int num_target_shards;
   vector<BucketReshardShard *> target_shards;
 
 public:
-  BucketReshardManager(RGWRados *_store,
+  BucketReshardManager(rgw::sal::RGWRadosStore *_store,
 		       const RGWBucketInfo& _target_bucket_info,
 		       int _num_target_shards) :
     store(_store), target_bucket_info(_target_bucket_info),
@@ -213,7 +214,7 @@ public:
   }
 }; // class BucketReshardManager
 
-RGWBucketReshard::RGWBucketReshard(RGWRados *_store,
+RGWBucketReshard::RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
 				   const RGWBucketInfo& _bucket_info,
 				   const map<string, bufferlist>& _bucket_attrs,
 				   RGWBucketReshardLock* _outer_reshard_lock) :
@@ -222,7 +223,7 @@ RGWBucketReshard::RGWBucketReshard(RGWRados *_store,
   outer_reshard_lock(_outer_reshard_lock)
 { }
 
-int RGWBucketReshard::set_resharding_status(RGWRados* store,
+int RGWBucketReshard::set_resharding_status(rgw::sal::RGWRadosStore* store,
 					    const RGWBucketInfo& bucket_info,
 					    const string& new_instance_id,
 					    int32_t num_shards,
@@ -236,7 +237,7 @@ int RGWBucketReshard::set_resharding_status(RGWRados* store,
   cls_rgw_bucket_instance_entry instance_entry;
   instance_entry.set_status(new_instance_id, num_shards, status);
 
-  int ret = store->bucket_set_reshard(bucket_info, instance_entry);
+  int ret = store->getRados()->bucket_set_reshard(bucket_info, instance_entry);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "RGWReshard::" << __func__ << " ERROR: error setting bucket resharding flag on bucket index: "
 		  << cpp_strerror(-ret) << dendl;
@@ -246,7 +247,7 @@ int RGWBucketReshard::set_resharding_status(RGWRados* store,
 }
 
 // reshard lock assumes lock is held
-int RGWBucketReshard::clear_resharding(RGWRados* store,
+int RGWBucketReshard::clear_resharding(rgw::sal::RGWRadosStore* store,
 				       const RGWBucketInfo& bucket_info)
 {
   int ret = clear_index_shard_reshard_status(store, bucket_info);
@@ -258,7 +259,7 @@ int RGWBucketReshard::clear_resharding(RGWRados* store,
   }
 
   cls_rgw_bucket_instance_entry instance_entry;
-  ret = store->bucket_set_reshard(bucket_info, instance_entry);
+  ret = store->getRados()->bucket_set_reshard(bucket_info, instance_entry);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "RGWReshard::" << __func__ <<
       " ERROR: error setting bucket resharding flag on bucket index: " <<
@@ -269,7 +270,7 @@ int RGWBucketReshard::clear_resharding(RGWRados* store,
   return 0;
 }
 
-int RGWBucketReshard::clear_index_shard_reshard_status(RGWRados* store,
+int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* store,
 						       const RGWBucketInfo& bucket_info)
 {
   uint32_t num_shards = bucket_info.num_shards;
@@ -290,7 +291,7 @@ int RGWBucketReshard::clear_index_shard_reshard_status(RGWRados* store,
   return 0;
 }
 
-static int create_new_bucket_instance(RGWRados *store,
+static int create_new_bucket_instance(rgw::sal::RGWRadosStore *store,
 				      int new_num_shards,
 				      const RGWBucketInfo& bucket_info,
 				      map<string, bufferlist>& attrs,
@@ -298,7 +299,7 @@ static int create_new_bucket_instance(RGWRados *store,
 {
   new_bucket_info = bucket_info;
 
-  store->create_bucket_id(&new_bucket_info.bucket.bucket_id);
+  store->getRados()->create_bucket_id(&new_bucket_info.bucket.bucket_id);
 
   new_bucket_info.num_shards = new_num_shards;
   new_bucket_info.objv_tracker.clear();
@@ -306,13 +307,13 @@ static int create_new_bucket_instance(RGWRados *store,
   new_bucket_info.new_bucket_instance_id.clear();
   new_bucket_info.reshard_status = 0;
 
-  int ret = store->svc.bi->init_index(new_bucket_info);
+  int ret = store->svc()->bi->init_index(new_bucket_info);
   if (ret < 0) {
     cerr << "ERROR: failed to init new bucket indexes: " << cpp_strerror(-ret) << std::endl;
     return ret;
   }
 
-  ret = store->put_bucket_instance_info(new_bucket_info, true, real_time(), &attrs);
+  ret = store->getRados()->put_bucket_instance_info(new_bucket_info, true, real_time(), &attrs);
   if (ret < 0) {
     cerr << "ERROR: failed to store new bucket instance info: " << cpp_strerror(-ret) << std::endl;
     return ret;
@@ -343,7 +344,7 @@ int RGWBucketReshard::cancel()
 
 class BucketInfoReshardUpdate
 {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWBucketInfo bucket_info;
   std::map<string, bufferlist> bucket_attrs;
 
@@ -351,7 +352,7 @@ class BucketInfoReshardUpdate
 
   int set_status(cls_rgw_reshard_status s) {
     bucket_info.reshard_status = s;
-    int ret = store->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
+    int ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: failed to write bucket info, ret=" << ret << dendl;
       return ret;
@@ -360,7 +361,7 @@ class BucketInfoReshardUpdate
   }
 
 public:
-  BucketInfoReshardUpdate(RGWRados *_store,
+  BucketInfoReshardUpdate(rgw::sal::RGWRadosStore *_store,
 			  RGWBucketInfo& _bucket_info,
                           map<string, bufferlist>& _bucket_attrs,
 			  const string& new_bucket_id) :
@@ -405,7 +406,7 @@ public:
 };
 
 
-RGWBucketReshardLock::RGWBucketReshardLock(RGWRados* _store,
+RGWBucketReshardLock::RGWBucketReshardLock(rgw::sal::RGWRadosStore* _store,
 					   const std::string& reshard_lock_oid,
 					   bool _ephemeral) :
   store(_store),
@@ -430,10 +431,10 @@ int RGWBucketReshardLock::lock() {
   internal_lock.set_must_renew(false);
   int ret;
   if (ephemeral) {
-    ret = internal_lock.lock_exclusive_ephemeral(&store->reshard_pool_ctx,
+    ret = internal_lock.lock_exclusive_ephemeral(&store->getRados()->reshard_pool_ctx,
 						 lock_oid);
   } else {
-    ret = internal_lock.lock_exclusive(&store->reshard_pool_ctx, lock_oid);
+    ret = internal_lock.lock_exclusive(&store->getRados()->reshard_pool_ctx, lock_oid);
   }
   if (ret < 0) {
     ldout(store->ctx(), 0) << "RGWReshardLock::" << __func__ <<
@@ -446,7 +447,7 @@ int RGWBucketReshardLock::lock() {
 }
 
 void RGWBucketReshardLock::unlock() {
-  int ret = internal_lock.unlock(&store->reshard_pool_ctx, lock_oid);
+  int ret = internal_lock.unlock(&store->getRados()->reshard_pool_ctx, lock_oid);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "WARNING: RGWBucketReshardLock::" << __func__ <<
       " failed to drop lock on " << lock_oid << " ret=" << ret << dendl;
@@ -457,10 +458,10 @@ int RGWBucketReshardLock::renew(const Clock::time_point& now) {
   internal_lock.set_must_renew(true);
   int ret;
   if (ephemeral) {
-    ret = internal_lock.lock_exclusive_ephemeral(&store->reshard_pool_ctx,
+    ret = internal_lock.lock_exclusive_ephemeral(&store->getRados()->reshard_pool_ctx,
 						 lock_oid);
   } else {
-    ret = internal_lock.lock_exclusive(&store->reshard_pool_ctx, lock_oid);
+    ret = internal_lock.lock_exclusive(&store->getRados()->reshard_pool_ctx, lock_oid);
   }
   if (ret < 0) { /* expired or already locked by another processor */
     std::stringstream error_s;
@@ -546,7 +547,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
     marker.clear();
     while (is_truncated) {
       entries.clear();
-      ret = store->bi_list(bucket, i, string(), marker, max_entries, &entries, &is_truncated);
+      ret = store->getRados()->bi_list(bucket, i, string(), marker, max_entries, &entries, &is_truncated);
       if (ret < 0 && ret != -ENOENT) {
 	derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
 	return ret;
@@ -572,7 +573,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	bool account = entry.get_info(&cls_key, &category, &stats);
 	rgw_obj_key key(cls_key);
 	rgw_obj obj(new_bucket_info.bucket, key);
-	int ret = store->get_target_shard_id(new_bucket_info, obj.get_hash_object(), &target_shard_id);
+	int ret = store->getRados()->get_target_shard_id(new_bucket_info, obj.get_hash_object(), &target_shard_id);
 	if (ret < 0) {
 	  lderr(store->ctx()) << "ERROR: get_target_shard_id() returned ret=" << ret << dendl;
 	  return ret;
@@ -630,7 +631,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
     return -EIO;
   }
 
-  ret = store->ctl.bucket->link_bucket(new_bucket_info.owner, new_bucket_info.bucket, bucket_info.creation_time, null_yield);
+  ret = store->ctl()->bucket->link_bucket(new_bucket_info.owner, new_bucket_info.bucket, bucket_info.creation_time, null_yield);
   if (ret < 0) {
     lderr(store->ctx()) << "failed to link new bucket instance (bucket_id=" << new_bucket_info.bucket.bucket_id << ": " << cpp_strerror(-ret) << ")" << dendl;
     return ret;
@@ -648,7 +649,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
 
 int RGWBucketReshard::get_status(list<cls_rgw_bucket_instance_entry> *status)
 {
-  return store->svc.bi_rados->get_reshard_status(bucket_info, status);
+  return store->svc()->bi_rados->get_reshard_status(bucket_info, status);
 }
 
 
@@ -701,14 +702,14 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
   // best effort and don't report out an error; the lock isn't needed
   // at this point since all we're using a best effor to to remove old
   // shard objects
-  ret = store->svc.bi->clean_index(bucket_info);
+  ret = store->svc()->bi->clean_index(bucket_info);
   if (ret < 0) {
     lderr(store->ctx()) << "Error: " << __func__ <<
       " failed to clean up old shards; " <<
       "RGWRados::clean_bucket_index returned " << ret << dendl;
   }
 
-  ret = store->ctl.bucket->remove_bucket_instance_info(bucket_info.bucket,
+  ret = store->ctl()->bucket->remove_bucket_instance_info(bucket_info.bucket,
                                                        bucket_info, null_yield);
   if (ret < 0) {
     lderr(store->ctx()) << "Error: " << __func__ <<
@@ -731,14 +732,14 @@ error_out:
   // since the real problem is the issue that led to this error code
   // path, we won't touch ret and instead use another variable to
   // temporarily error codes
-  int ret2 = store->svc.bi->clean_index(new_bucket_info);
+  int ret2 = store->svc()->bi->clean_index(new_bucket_info);
   if (ret2 < 0) {
     lderr(store->ctx()) << "Error: " << __func__ <<
       " failed to clean up shards from failed incomplete resharding; " <<
       "RGWRados::clean_bucket_index returned " << ret2 << dendl;
   }
 
-  ret2 = store->ctl.bucket->remove_bucket_instance_info(new_bucket_info.bucket,
+  ret2 = store->ctl()->bucket->remove_bucket_instance_info(new_bucket_info.bucket,
                                                         new_bucket_info,
 							null_yield);
   if (ret2 < 0) {
@@ -752,7 +753,7 @@ error_out:
 } // execute
 
 
-RGWReshard::RGWReshard(RGWRados* _store, bool _verbose, ostream *_out,
+RGWReshard::RGWReshard(rgw::sal::RGWRadosStore* _store, bool _verbose, ostream *_out,
                        Formatter *_formatter) :
   store(_store), instance_lock(bucket_instance_lock_name),
   verbose(_verbose), out(_out), formatter(_formatter)
@@ -781,7 +782,7 @@ void RGWReshard::get_bucket_logshard_oid(const string& tenant, const string& buc
 
 int RGWReshard::add(cls_rgw_reshard_entry& entry)
 {
-  if (!store->svc.zone->can_reshard()) {
+  if (!store->svc()->zone->can_reshard()) {
     ldout(store->ctx(), 20) << __func__ << " Resharding is disabled"  << dendl;
     return 0;
   }
@@ -793,7 +794,7 @@ int RGWReshard::add(cls_rgw_reshard_entry& entry)
   librados::ObjectWriteOperation op;
   cls_rgw_reshard_add(op, entry);
 
-  int ret = store->reshard_pool_ctx.operate(logshard_oid, &op);
+  int ret = store->getRados()->reshard_pool_ctx.operate(logshard_oid, &op);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed to add entry to reshard log, oid=" << logshard_oid << " tenant=" << entry.tenant << " bucket=" << entry.bucket_name << dendl;
     return ret;
@@ -831,7 +832,7 @@ int RGWReshard::list(int logshard_num, string& marker, uint32_t max, std::list<c
 
   get_logshard_oid(logshard_num, &logshard_oid);
 
-  int ret = cls_rgw_reshard_list(store->reshard_pool_ctx, logshard_oid, marker, max, entries, is_truncated);
+  int ret = cls_rgw_reshard_list(store->getRados()->reshard_pool_ctx, logshard_oid, marker, max, entries, is_truncated);
 
   if (ret < 0) {
     if (ret == -ENOENT) {
@@ -840,7 +841,7 @@ int RGWReshard::list(int logshard_num, string& marker, uint32_t max, std::list<c
     }
     lderr(store->ctx()) << "ERROR: failed to list reshard log entries, oid=" << logshard_oid << dendl;
     if (ret == -EACCES) {
-      lderr(store->ctx()) << "access denied to pool " << store->svc.zone->get_zone_params().reshard_pool
+      lderr(store->ctx()) << "access denied to pool " << store->svc()->zone->get_zone_params().reshard_pool
                           << ". Fix the pool access permissions of your client" << dendl;
     }
   }
@@ -854,7 +855,7 @@ int RGWReshard::get(cls_rgw_reshard_entry& entry)
 
   get_bucket_logshard_oid(entry.tenant, entry.bucket_name, &logshard_oid);
 
-  int ret = cls_rgw_reshard_get(store->reshard_pool_ctx, logshard_oid, entry);
+  int ret = cls_rgw_reshard_get(store->getRados()->reshard_pool_ctx, logshard_oid, entry);
   if (ret < 0) {
     if (ret != -ENOENT) {
       lderr(store->ctx()) << "ERROR: failed to get entry from reshard log, oid=" << logshard_oid << " tenant=" << entry.tenant <<
@@ -875,7 +876,7 @@ int RGWReshard::remove(cls_rgw_reshard_entry& entry)
   librados::ObjectWriteOperation op;
   cls_rgw_reshard_remove(op, entry);
 
-  int ret = store->reshard_pool_ctx.operate(logshard_oid, &op);
+  int ret = store->getRados()->reshard_pool_ctx.operate(logshard_oid, &op);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed to remove entry from reshard log, oid=" << logshard_oid << " tenant=" << entry.tenant << " bucket=" << entry.bucket_name << dendl;
     return ret;
@@ -886,7 +887,7 @@ int RGWReshard::remove(cls_rgw_reshard_entry& entry)
 
 int RGWReshard::clear_bucket_resharding(const string& bucket_instance_oid, cls_rgw_reshard_entry& entry)
 {
-  int ret = cls_rgw_clear_bucket_resharding(store->reshard_pool_ctx, bucket_instance_oid);
+  int ret = cls_rgw_clear_bucket_resharding(store->getRados()->reshard_pool_ctx, bucket_instance_oid);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed to clear bucket resharding, bucket_instance_oid=" << bucket_instance_oid << dendl;
     return ret;
@@ -978,12 +979,12 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	ldout(store->ctx(), 20) << __func__ << " resharding " <<
 	  entry.bucket_name  << dendl;
 
-        auto obj_ctx = store->svc.sysobj->init_obj_ctx();
+        auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
 	rgw_bucket bucket;
 	RGWBucketInfo bucket_info;
 	map<string, bufferlist> attrs;
 
-	ret = store->get_bucket_info(obj_ctx, entry.tenant, entry.bucket_name,
+	ret = store->getRados()->get_bucket_info(obj_ctx, entry.tenant, entry.bucket_name,
 				     bucket_info, nullptr, null_yield, &attrs);
 	if (ret < 0) {
 	  ldout(cct, 0) <<  __func__ << ": Error in get_bucket_info: " <<
@@ -1044,7 +1045,7 @@ void  RGWReshard::get_logshard_oid(int shard_num, string *logshard)
 
 int RGWReshard::process_all_logshards()
 {
-  if (!store->svc.zone->can_reshard()) {
+  if (!store->svc()->zone->can_reshard()) {
     ldout(store->ctx(), 20) << __func__ << " Resharding is disabled"  << dendl;
     return 0;
   }

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -20,13 +20,15 @@
 
 
 class CephContext;
-class RGWRados;
 class RGWReshard;
+namespace rgw { namespace sal {
+  class RGWRadosStore;
+} }
 
 class RGWBucketReshardLock {
   using Clock = ceph::coarse_mono_clock;
 
-  RGWRados* store;
+  rgw::sal::RGWRadosStore* store;
   const std::string lock_oid;
   const bool ephemeral;
   rados::cls::lock::Lock internal_lock;
@@ -41,10 +43,10 @@ class RGWBucketReshardLock {
   }
 
 public:
-  RGWBucketReshardLock(RGWRados* _store,
+  RGWBucketReshardLock(rgw::sal::RGWRadosStore* _store,
 		       const std::string& reshard_lock_oid,
 		       bool _ephemeral);
-  RGWBucketReshardLock(RGWRados* _store,
+  RGWBucketReshardLock(rgw::sal::RGWRadosStore* _store,
 		       const RGWBucketInfo& bucket_info,
 		       bool _ephemeral) :
     RGWBucketReshardLock(_store, bucket_info.bucket.get_key(':'), _ephemeral)
@@ -68,7 +70,7 @@ public:
 
 private:
 
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWBucketInfo bucket_info;
   std::map<string, bufferlist> bucket_attrs;
 
@@ -87,7 +89,7 @@ public:
 
   // pass nullptr for the final parameter if no outer reshard lock to
   // manage
-  RGWBucketReshard(RGWRados *_store, const RGWBucketInfo& _bucket_info,
+  RGWBucketReshard(rgw::sal::RGWRadosStore *_store, const RGWBucketInfo& _bucket_info,
                    const std::map<string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
   int execute(int num_shards, int max_op_entries,
@@ -96,17 +98,17 @@ public:
 	      RGWReshard *reshard_log = nullptr);
   int get_status(std::list<cls_rgw_bucket_instance_entry> *status);
   int cancel();
-  static int clear_resharding(RGWRados* store,
+  static int clear_resharding(rgw::sal::RGWRadosStore* store,
 			      const RGWBucketInfo& bucket_info);
   int clear_resharding() {
     return clear_resharding(store, bucket_info);
   }
-  static int clear_index_shard_reshard_status(RGWRados* store,
+  static int clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* store,
 					      const RGWBucketInfo& bucket_info);
   int clear_index_shard_reshard_status() {
     return clear_index_shard_reshard_status(store, bucket_info);
   }
-  static int set_resharding_status(RGWRados* store,
+  static int set_resharding_status(rgw::sal::RGWRadosStore* store,
 				   const RGWBucketInfo& bucket_info,
 				   const string& new_instance_id,
 				   int32_t num_shards,
@@ -124,7 +126,7 @@ public:
     using Clock = ceph::coarse_mono_clock;
 
 private:
-    RGWRados *store;
+    rgw::sal::RGWRadosStore *store;
     string lock_name;
     rados::cls::lock::Lock instance_lock;
     int num_logshards;
@@ -159,7 +161,7 @@ protected:
   void get_bucket_logshard_oid(const string& tenant, const string& bucket_name, string *oid);
 
 public:
-  RGWReshard(RGWRados* _store, bool _verbose = false, ostream *_out = nullptr, Formatter *_formatter = nullptr);
+  RGWReshard(rgw::sal::RGWRadosStore* _store, bool _verbose = false, ostream *_out = nullptr, Formatter *_formatter = nullptr);
   int add(cls_rgw_reshard_entry& entry);
   int update(const RGWBucketInfo& bucket_info, const RGWBucketInfo& new_bucket_info);
   int get(cls_rgw_reshard_entry& entry);

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -176,7 +176,7 @@ string uppercase_underscore_http_attr(const string& orig)
 static set<string> hostnames_set;
 static set<string> hostnames_s3website_set;
 
-void rgw_rest_init(CephContext *cct, RGWRados *store, const RGWZoneGroup& zone_group)
+void rgw_rest_init(CephContext *cct, const RGWZoneGroup& zone_group)
 {
   for (const auto& rgw2http : base_rgw_to_http_attrs)  {
     rgw_to_http_attrs[rgw2http.rgw_attr] = rgw2http.http_attr;
@@ -1638,7 +1638,7 @@ int RGWRESTOp::verify_permission()
   return check_caps(s->user->caps);
 }
 
-RGWOp* RGWHandler_REST::get_op(RGWRados* store)
+RGWOp* RGWHandler_REST::get_op(rgw::sal::RGWRadosStore* store)
 {
   RGWOp *op;
   switch (s->op) {
@@ -1838,7 +1838,7 @@ int RGWHandler_REST::init_permissions(RGWOp* op)
     if (! s->user->user_id.empty() && s->auth.identity->get_identity_type() != TYPE_ROLE) {
       try {
         map<string, bufferlist> uattrs;
-        if (auto ret = store->ctl.user->get_attrs_by_uid(s->user->user_id, &uattrs, null_yield); ! ret) {
+        if (auto ret = store->ctl()->user->get_attrs_by_uid(s->user->user_id, &uattrs, null_yield); ! ret) {
           if (s->iam_user_policies.empty()) {
             s->iam_user_policies = get_iam_user_policy_from_attr(s->cct, store, uattrs, s->user->user_id.tenant);
           } else {
@@ -2253,7 +2253,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
 }
 
 RGWHandler_REST* RGWREST::get_handler(
-  RGWRados * const store,
+  rgw::sal::RGWRadosStore * const store,
   struct req_state* const s,
   const rgw::auth::StrategyRegistry& auth_registry,
   const std::string& frontend_prefix,

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -17,7 +17,7 @@
 
 extern std::map<std::string, std::string> rgw_to_http_attrs;
 
-extern void rgw_rest_init(CephContext *cct, RGWRados *store, const RGWZoneGroup& zone_group);
+extern void rgw_rest_init(CephContext *cct, const RGWZoneGroup& zone_group);
 
 extern void rgw_flush_formatter_and_reset(struct req_state *s,
 					 ceph::Formatter *formatter);
@@ -163,7 +163,7 @@ protected:
 public:
   RGWGetObj_ObjStore() : sent_header(false) {}
 
-  void init(RGWRados *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWGetObj::init(store, s, h);
     sent_header = false;
   }
@@ -529,7 +529,7 @@ protected:
   RGWRESTFlusher flusher;
 public:
   RGWRESTOp() : http_ret(0) {}
-  void init(RGWRados *store, struct req_state *s,
+  void init(rgw::sal::RGWRadosStore *store, struct req_state *s,
             RGWHandler *dialect_handler) override {
     RGWOp::init(store, s, dialect_handler);
     flusher.init(s, this);
@@ -570,7 +570,7 @@ public:
   int init_permissions(RGWOp* op) override;
   int read_permissions(RGWOp* op) override;
 
-  virtual RGWOp* get_op(RGWRados* store);
+  virtual RGWOp* get_op(rgw::sal::RGWRadosStore* store);
   virtual void put_op(RGWOp* op);
 };
 
@@ -655,7 +655,7 @@ class RGWREST {
   static int preprocess(struct req_state *s, rgw::io::BasicClient* rio);
 public:
   RGWREST() {}
-  RGWHandler_REST *get_handler(RGWRados *store,
+  RGWHandler_REST *get_handler(rgw::sal::RGWRadosStore *store,
                                struct req_state *s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix,

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -267,8 +267,8 @@ void RGWOp_Set_Bucket_Quota::execute()
   if (use_http_params) {
     RGWBucketInfo bucket_info;
     map<string, bufferlist> attrs;
-    auto obj_ctx = store->svc.sysobj->init_obj_ctx();
-    http_ret = store->get_bucket_info(obj_ctx, uid.tenant, bucket, bucket_info, NULL, s->yield, &attrs);
+    auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
+    http_ret = store->getRados()->get_bucket_info(obj_ctx, uid.tenant, bucket, bucket_info, NULL, s->yield, &attrs);
     if (http_ret < 0) {
       return;
     }

--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -30,7 +30,7 @@
 #define dout_subsys ceph_subsys_rgw
 
 void RGWOp_ZoneGroupMap_Get::execute() {
-  http_ret = zonegroup_map.read(g_ceph_context, store->svc.sysobj);
+  http_ret = zonegroup_map.read(g_ceph_context, store->svc()->sysobj);
   if (http_ret < 0) {
     dout(5) << "failed to read zone_group map" << dendl;
   }
@@ -58,7 +58,7 @@ void RGWOp_ZoneGroupMap_Get::send_response() {
 }
 
 void RGWOp_ZoneConfig_Get::send_response() {
-  const RGWZoneParams& zone_params = store->svc.zone->get_zone_params();
+  const RGWZoneParams& zone_params = store->svc()->zone->get_zone_params();
 
   set_req_state_err(s, http_ret);
   dump_errno(s);

--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -77,7 +77,7 @@ RGWOp *RGWHandler_REST_IAM::op_post()
   return nullptr;
 }
 
-int RGWHandler_REST_IAM::init(RGWRados *store,
+int RGWHandler_REST_IAM::init(rgw::sal::RGWRadosStore *store,
                               struct req_state *s,
                               rgw::io::BasicClient *cio)
 {

--- a/src/rgw/rgw_rest_iam.h
+++ b/src/rgw/rgw_rest_iam.h
@@ -22,7 +22,7 @@ public:
       post_body(post_body) {}
   ~RGWHandler_REST_IAM() override = default;
 
-  int init(RGWRados *store,
+  int init(rgw::sal::RGWRadosStore *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider* dpp) override;

--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -53,7 +53,7 @@ void RGWOp_Metadata_Get::execute() {
 
   frame_metadata_key(s, metadata_key);
 
-  auto meta_mgr = store->ctl.meta.mgr;
+  auto meta_mgr = store->ctl()->meta.mgr;
 
   /* Get keys */
   http_ret = meta_mgr->get(metadata_key, s->formatter, s->yield);
@@ -122,7 +122,7 @@ void RGWOp_Metadata_List::execute() {
      marker = "3:bf885d8f:root::sorry_janefonda_665:head";
   */
 
-  http_ret = store->ctl.meta.mgr->list_keys_init(metadata_key, marker, &handle);
+  http_ret = store->ctl()->meta.mgr->list_keys_init(metadata_key, marker, &handle);
   if (http_ret < 0) {
     dout(5) << "ERROR: can't get key: " << cpp_strerror(http_ret) << dendl;
     return;
@@ -137,7 +137,7 @@ void RGWOp_Metadata_List::execute() {
 
   s->formatter->open_array_section("keys");
 
-  auto meta_mgr = store->ctl.meta.mgr;
+  auto meta_mgr = store->ctl()->meta.mgr;
 
   uint64_t left;
   do {
@@ -262,7 +262,7 @@ void RGWOp_Metadata_Put::execute() {
     }
   }
 
-  http_ret = store->ctl.meta.mgr->put(metadata_key, bl, s->yield, sync_type,
+  http_ret = store->ctl()->meta.mgr->put(metadata_key, bl, s->yield, sync_type,
 				  &ondisk_version);
   if (http_ret < 0) {
     dout(5) << "ERROR: can't put key: " << cpp_strerror(http_ret) << dendl;
@@ -293,7 +293,7 @@ void RGWOp_Metadata_Delete::execute() {
   string metadata_key;
 
   frame_metadata_key(s, metadata_key);
-  http_ret = store->ctl.meta.mgr->remove(metadata_key, s->yield);
+  http_ret = store->ctl()->meta.mgr->remove(metadata_key, s->yield);
   if (http_ret < 0) {
     dout(5) << "ERROR: can't remove key: " << cpp_strerror(http_ret) << dendl;
     return;

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -25,7 +25,7 @@ int RGWRestRole::verify_permission()
   }
 
   string role_name = s->info.args.get("RoleName");
-  RGWRole role(s->cct, store->pctl, role_name, s->user->user_id.tenant);
+  RGWRole role(s->cct, store->getRados()->pctl, role_name, s->user->user_id.tenant);
   if (op_ret = role.get(); op_ret < 0) {
     if (op_ret == -ENOENT) {
       op_ret = -ERR_NO_ROLE_FOUND;
@@ -129,7 +129,7 @@ void RGWCreateRole::execute()
   if (op_ret < 0) {
     return;
   }
-  RGWRole role(s->cct, store->pctl, role_name, role_path, trust_policy,
+  RGWRole role(s->cct, store->getRados()->pctl, role_name, role_path, trust_policy,
                 s->user->user_id.tenant, max_session_duration);
   op_ret = role.create(true);
 
@@ -228,7 +228,7 @@ void RGWGetRole::execute()
   if (op_ret < 0) {
     return;
   }
-  RGWRole role(s->cct, store->pctl, role_name, s->user->user_id.tenant);
+  RGWRole role(s->cct, store->getRados()->pctl, role_name, s->user->user_id.tenant);
   op_ret = role.get();
 
   if (op_ret == -ENOENT) {
@@ -321,7 +321,7 @@ void RGWListRoles::execute()
     return;
   }
   vector<RGWRole> result;
-  op_ret = RGWRole::get_roles_by_path_prefix(store, s->cct, path_prefix, s->user->user_id.tenant, result);
+  op_ret = RGWRole::get_roles_by_path_prefix(store->getRados(), s->cct, path_prefix, s->user->user_id.tenant, result);
 
   if (op_ret == 0) {
     s->formatter->open_array_section("ListRolesResponse");

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -28,6 +28,7 @@
 #include "rgw_auth.h"
 #include "rgw_auth_filters.h"
 #include "rgw_sts.h"
+#include "rgw_sal.h"
 
 struct rgw_http_error {
   int http_ret;
@@ -326,7 +327,7 @@ public:
   RGWPutACLs_ObjStore_S3() {}
   ~RGWPutACLs_ObjStore_S3() override {}
 
-  int get_policy_from_state(RGWRados *store, struct req_state *s, stringstream& ss) override;
+  int get_policy_from_state(rgw::sal::RGWRadosStore *store, struct req_state *s, stringstream& ss) override;
   void send_response() override;
   int get_params() override;
 };
@@ -547,7 +548,7 @@ public:
 class RGW_Auth_S3 {
 public:
   static int authorize(const DoutPrefixProvider *dpp,
-                       RGWRados *store,
+                       rgw::sal::RGWRadosStore *store,
                        const rgw::auth::StrategyRegistry& auth_registry,
                        struct req_state *s);
 };
@@ -567,7 +568,7 @@ public:
   static int validate_bucket_name(const string& bucket);
   static int validate_object_name(const string& bucket);
 
-  int init(RGWRados *store,
+  int init(rgw::sal::RGWRadosStore *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp) override {
@@ -589,7 +590,7 @@ public:
     }
   ~RGWHandler_REST_S3() override = default;
 
-  int init(RGWRados *store,
+  int init(rgw::sal::RGWRadosStore *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp) override;

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -41,7 +41,7 @@ public:
   using RGWHandler_REST_S3::RGWHandler_REST_S3;
   ~RGWHandler_REST_S3Website() override = default;
 
-  int init(RGWRados *store, req_state *s, rgw::io::BasicClient* cio) override;
+  int init(rgw::sal::RGWRadosStore *store, req_state *s, rgw::io::BasicClient* cio) override;
   int error_handler(int err_no, string *error_content) override;
 };
 

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -335,7 +335,7 @@ void RGWSTSAssumeRole::execute()
 }
 
 int RGW_Auth_STS::authorize(const DoutPrefixProvider *dpp,
-                            RGWRados *store,
+                            rgw::sal::RGWRadosStore *store,
                             const rgw::auth::StrategyRegistry& auth_registry,
                             struct req_state *s)
 {
@@ -385,7 +385,7 @@ RGWOp *RGWHandler_REST_STS::op_post()
   return nullptr;
 }
 
-int RGWHandler_REST_STS::init(RGWRados *store,
+int RGWHandler_REST_STS::init(rgw::sal::RGWRadosStore *store,
                               struct req_state *s,
                               rgw::io::BasicClient *cio)
 {

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -158,7 +158,7 @@ public:
 class RGW_Auth_STS {
 public:
   static int authorize(const DoutPrefixProvider *dpp,
-                       RGWRados *store,
+                       rgw::sal::RGWRadosStore *store,
                        const rgw::auth::StrategyRegistry& auth_registry,
                        struct req_state *s);
 };
@@ -178,7 +178,7 @@ public:
       post_body(post_body) {}
   ~RGWHandler_REST_STS() override = default;
 
-  int init(RGWRados *store,
+  int init(rgw::sal::RGWRadosStore *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider* dpp) override;

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -273,7 +273,7 @@ public:
   RGWFormPost() = default;
   ~RGWFormPost() = default;
 
-  void init(RGWRados* store,
+  void init(rgw::sal::RGWRadosStore* store,
             req_state* s,
             RGWHandler* dialect_handler) override;
 
@@ -344,7 +344,7 @@ public:
 
 
 class RGWSwiftWebsiteHandler {
-  RGWRados* const store;
+  rgw::sal::RGWRadosStore* const store;
   req_state* const s;
   RGWHandler_REST* const handler;
 
@@ -359,7 +359,7 @@ class RGWSwiftWebsiteHandler {
   RGWOp* get_ws_index_op();
   RGWOp* get_ws_listing_op();
 public:
-  RGWSwiftWebsiteHandler(RGWRados* const store,
+  RGWSwiftWebsiteHandler(rgw::sal::RGWRadosStore* const store,
                          req_state* const s,
                          RGWHandler_REST* const handler)
     : store(store),
@@ -394,7 +394,7 @@ public:
 
   int validate_bucket_name(const string& bucket);
 
-  int init(RGWRados *store, struct req_state *s, rgw::io::BasicClient *cio) override;
+  int init(rgw::sal::RGWRadosStore *store, struct req_state *s, rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp) override;
   int postauth_init() override;
 
@@ -442,7 +442,7 @@ public:
     return website_handler->retarget_bucket(op, new_op);
   }
 
-  int init(RGWRados* const store,
+  int init(rgw::sal::RGWRadosStore* const store,
            struct req_state* const s,
            rgw::io::BasicClient* const cio) override {
     website_handler = boost::in_place<RGWSwiftWebsiteHandler>(store, s, this);
@@ -480,7 +480,7 @@ public:
     return website_handler->retarget_object(op, new_op);
   }
 
-  int init(RGWRados* const store,
+  int init(rgw::sal::RGWRadosStore* const store,
            struct req_state* const s,
            rgw::io::BasicClient* const cio) override {
     website_handler = boost::in_place<RGWSwiftWebsiteHandler>(store, s, this);
@@ -533,7 +533,7 @@ public:
     return new RGWGetCrossDomainPolicy_ObjStore_SWIFT();
   }
 
-  int init(RGWRados* const store,
+  int init(rgw::sal::RGWRadosStore* const store,
            struct req_state* const state,
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";
@@ -589,7 +589,7 @@ public:
     return new RGWGetHealthCheck_ObjStore_SWIFT();
   }
 
-  int init(RGWRados* const store,
+  int init(rgw::sal::RGWRadosStore* const store,
            struct req_state* const state,
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";
@@ -645,7 +645,7 @@ public:
     return new RGWInfo_ObjStore_SWIFT();
   }
 
-  int init(RGWRados* const store,
+  int init(rgw::sal::RGWRadosStore* const store,
            struct req_state* const state,
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -52,7 +52,7 @@ void RGWOp_Usage_Get::execute() {
     }
   }
 
-  http_ret = RGWUsage::show(store, uid, bucket_name, start, end, show_entries, show_summary, &categories, flusher);
+  http_ret = RGWUsage::show(store->getRados(), uid, bucket_name, start, end, show_entries, show_summary, &categories, flusher);
 }
 
 class RGWOp_Usage_Delete : public RGWRESTOp {
@@ -92,7 +92,7 @@ void RGWOp_Usage_Delete::execute() {
     }
   }
 
-  http_ret = RGWUsage::trim(store, uid, bucket_name, start, end);
+  http_ret = RGWUsage::trim(store->getRados(), uid, bucket_name, start, end);
 }
 
 RGWOp *RGWHandler_Usage::op_get()

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -118,14 +118,14 @@ void RGWPutUserPolicy::execute()
 
   RGWUserInfo info;
   rgw_user user_id(user_name);
-  op_ret = store->ctl.user->get_info_by_uid(user_id, &info, s->yield);
+  op_ret = store->ctl()->user->get_info_by_uid(user_id, &info, s->yield);
   if (op_ret < 0) {
     op_ret = -ERR_NO_SUCH_ENTITY;
     return;
   }
 
   map<string, bufferlist> uattrs;
-  op_ret = store->ctl.user->get_attrs_by_uid(user_id, &uattrs, s->yield);
+  op_ret = store->ctl()->user->get_attrs_by_uid(user_id, &uattrs, s->yield);
   if (op_ret == -ENOENT) {
     op_ret = -ERR_NO_SUCH_ENTITY;
     return;
@@ -144,7 +144,7 @@ void RGWPutUserPolicy::execute()
     uattrs[RGW_ATTR_USER_POLICY] = in_bl;
 
     RGWObjVersionTracker objv_tracker;
-    op_ret = store->ctl.user->store_info(info, s->yield,
+    op_ret = store->ctl()->user->store_info(info, s->yield,
                                          RGWUserCtl::PutParams()
                                          .set_objv_tracker(&objv_tracker)
                                          .set_attrs(&uattrs));
@@ -193,7 +193,7 @@ void RGWGetUserPolicy::execute()
 
   rgw_user user_id(user_name);
   map<string, bufferlist> uattrs;
-  op_ret = store->ctl.user->get_attrs_by_uid(user_id, &uattrs, s->yield);
+  op_ret = store->ctl()->user->get_attrs_by_uid(user_id, &uattrs, s->yield);
   if (op_ret == -ENOENT) {
     ldout(s->cct, 0) << "ERROR: attrs not found for user" << user_name << dendl;
     op_ret = -ERR_NO_SUCH_ENTITY;
@@ -257,7 +257,7 @@ void RGWListUserPolicies::execute()
 
   rgw_user user_id(user_name);
   map<string, bufferlist> uattrs;
-  op_ret = store->ctl.user->get_attrs_by_uid(user_id, &uattrs, s->yield);
+  op_ret = store->ctl()->user->get_attrs_by_uid(user_id, &uattrs, s->yield);
   if (op_ret == -ENOENT) {
     ldout(s->cct, 0) << "ERROR: attrs not found for user" << user_name << dendl;
     op_ret = -ERR_NO_SUCH_ENTITY;
@@ -320,7 +320,7 @@ void RGWDeleteUserPolicy::execute()
   RGWUserInfo info;
   map<string, bufferlist> uattrs;
   rgw_user user_id(user_name);
-  op_ret = store->ctl.user->get_info_by_uid(user_id, &info, s->yield,
+  op_ret = store->ctl()->user->get_info_by_uid(user_id, &info, s->yield,
                                             RGWUserCtl::GetParams()
                                             .set_attrs(&uattrs));
   if (op_ret < 0) {
@@ -340,7 +340,7 @@ void RGWDeleteUserPolicy::execute()
       uattrs[RGW_ATTR_USER_POLICY] = in_bl;
 
       RGWObjVersionTracker objv_tracker;
-      op_ret = store->ctl.user->store_info(info, s->yield,
+      op_ret = store->ctl()->user->store_info(info, s->yield,
                                            RGWUserCtl::PutParams()
                                            .set_old_info(&info)
                                            .set_objv_tracker(&objv_tracker)

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -1,0 +1,119 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <system_error>
+#include <unistd.h>
+#include <sstream>
+
+#include "common/errno.h"
+
+#include "rgw_sal.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::sal {
+
+RGWObject *RGWRadosBucket::create_object(const rgw_obj_key &key)
+{
+  if (!object) {
+    object = new RGWRadosObject(store, key);
+  }
+
+  return object;
+}
+
+RGWUser *RGWRadosStore::get_user(const rgw_user &u)
+{
+  if (!user) {
+    user = new RGWRadosUser(this, u);
+  }
+
+  return user;
+}
+
+RGWSalBucket *RGWRadosStore::create_bucket(RGWUser &u, const cls_user_bucket &b)
+{
+  if (!bucket) {
+    bucket = new RGWRadosBucket(this, u, b);
+  }
+
+  return bucket;
+}
+
+void RGWRadosStore::finalize(void) {
+  if (rados)
+    rados->finalize();
+}
+
+} // namespace rgw::sal
+
+rgw::sal::RGWRadosStore *RGWStoreManager::init_storage_provider(CephContext *cct, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_cache)
+{
+  RGWRados *rados = new RGWRados;
+  rgw::sal::RGWRadosStore *store = new rgw::sal::RGWRadosStore();
+
+  store->setRados(rados);
+  rados->set_store(store);
+
+  if ((*rados).set_use_cache(use_cache)
+              .set_run_gc_thread(use_gc_thread)
+              .set_run_lc_thread(use_lc_thread)
+              .set_run_quota_threads(quota_threads)
+              .set_run_sync_thread(run_sync_thread)
+              .set_run_reshard_thread(run_reshard_thread)
+              .initialize(cct) < 0) {
+    delete store;
+    return NULL;
+  }
+
+  return store;
+}
+
+rgw::sal::RGWRadosStore *RGWStoreManager::init_raw_storage_provider(CephContext *cct)
+{
+  RGWRados *rados = new RGWRados;
+  rgw::sal::RGWRadosStore *store = new rgw::sal::RGWRadosStore();
+
+  store->setRados(rados);
+  rados->set_store(store);
+
+  rados->set_context(cct);
+
+  int ret = rados->init_svc(true);
+  if (ret < 0) {
+    ldout(cct, 0) << "ERROR: failed to init services (ret=" << cpp_strerror(-ret) << ")" << dendl;
+    delete store;
+    return nullptr;
+  }
+
+  if (rados->init_rados() < 0) {
+    delete store;
+    return nullptr;
+  }
+
+  return store;
+}
+
+void RGWStoreManager::close_storage(rgw::sal::RGWRadosStore *store)
+{
+  if (!store)
+    return;
+
+  store->finalize();
+
+  delete store;
+}

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1,0 +1,230 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "rgw_rados.h"
+#include "rgw_user.h"
+
+namespace rgw { namespace sal {
+
+#define RGW_SAL_VERSION 1
+
+class RGWUser;
+class RGWSalBucket;
+class RGWObject;
+
+typedef std::vector<RGWSalBucket> RGWBucketList;
+typedef std::map<string, string> RGWAttrs;
+
+class RGWStore {
+  public:
+    RGWStore() {}
+    virtual ~RGWStore() = default;
+
+    virtual RGWUser* get_user(const rgw_user &u) = 0;
+    virtual RGWSalBucket* get_bucket(RGWUser &u, const cls_user_bucket &b) = 0;
+    virtual RGWSalBucket* create_bucket(RGWUser &u, const cls_user_bucket &b) = 0;
+    virtual RGWBucketList* list_buckets(void) = 0;
+
+    virtual void finalize(void)=0;
+
+    virtual CephContext *ctx(void)=0;
+};
+
+class RGWUser {
+  protected:
+    rgw_user user;
+
+  public:
+    RGWUser() : user() {}
+    RGWUser(const rgw_user &_u) : user(_u) {}
+    virtual ~RGWUser() = default;
+
+    virtual RGWBucketList* list_buckets(void) = 0;
+};
+
+class RGWSalBucket {
+  protected:
+    cls_user_bucket ub;
+
+  public:
+    RGWSalBucket() : ub() {}
+    RGWSalBucket(const cls_user_bucket &_b) : ub(_b) {}
+    virtual ~RGWSalBucket() = default;
+
+    virtual RGWObject* get_object(const rgw_obj_key &key) = 0;
+    virtual RGWBucketList* list(void) = 0;
+    virtual RGWObject* create_object(const rgw_obj_key &key /* Attributes */) = 0;
+    virtual RGWAttrs& get_attrs(void) = 0;
+    virtual int set_attrs(RGWAttrs &attrs) = 0;
+    virtual int delete_bucket(void) = 0;
+    virtual RGWAccessControlPolicy& get_acl(void) = 0;
+    virtual int set_acl(const RGWAccessControlPolicy &acl) = 0;
+};
+
+class RGWObject {
+  protected:
+    rgw_obj_key key;
+
+  public:
+    RGWObject() : key() {}
+    RGWObject(const rgw_obj_key &_k) : key(_k) {}
+    virtual ~RGWObject() = default;
+
+    virtual int read(off_t offset, off_t length, std::iostream &stream) = 0;
+    virtual int write(off_t offset, off_t length, std::iostream &stream) = 0;
+    virtual RGWAttrs& get_attrs(void) = 0;
+    virtual int set_attrs(RGWAttrs &attrs) = 0;
+    virtual int delete_object(void) = 0;
+    virtual RGWAccessControlPolicy& get_acl(void) = 0;
+    virtual int set_acl(const RGWAccessControlPolicy &acl) = 0;
+};
+
+
+class RGWRadosStore;
+
+class RGWRadosUser : public RGWUser {
+  private:
+    RGWRadosStore *store;
+
+  public:
+    RGWRadosUser(RGWRadosStore *_st, const rgw_user &_u) : RGWUser(_u), store(_st) { }
+    RGWRadosUser() {}
+
+    RGWBucketList* list_buckets(void) { return new RGWBucketList(); }
+};
+
+class RGWRadosObject : public RGWObject {
+  private:
+    RGWRadosStore *store;
+    RGWAttrs attrs;
+    RGWAccessControlPolicy acls;
+
+  public:
+    RGWRadosObject()
+      : attrs(),
+        acls() {
+    }
+
+    RGWRadosObject(RGWRadosStore *_st, const rgw_obj_key &_k)
+      : RGWObject(_k),
+	store(_st),
+	attrs(),
+        acls() {
+    }
+
+    int read(off_t offset, off_t length, std::iostream &stream) { return length; }
+    int write(off_t offset, off_t length, std::iostream &stream) { return length; }
+    RGWAttrs& get_attrs(void) { return attrs; }
+    int set_attrs(RGWAttrs &a) { attrs = a; return 0; }
+    int delete_object(void) { return 0; }
+    RGWAccessControlPolicy& get_acl(void) { return acls; }
+    int set_acl(const RGWAccessControlPolicy &acl) { acls = acl; return 0; }
+};
+
+class RGWRadosBucket : public RGWSalBucket {
+  private:
+    RGWRadosStore *store;
+    RGWRadosObject *object;
+    RGWAttrs attrs;
+    RGWAccessControlPolicy acls;
+    RGWRadosUser user;
+
+  public:
+    RGWRadosBucket()
+      : object(nullptr),
+        attrs(),
+        acls(),
+	user() {
+    }
+
+    RGWRadosBucket(RGWRadosStore *_st, RGWUser &_u, const cls_user_bucket &_b)
+      : RGWSalBucket(_b),
+	store(_st),
+	object(nullptr),
+        attrs(),
+        acls(),
+	user(dynamic_cast<RGWRadosUser&>(_u)) {
+    }
+
+    RGWObject* get_object(const rgw_obj_key &key) { return object; }
+    RGWBucketList* list(void) { return new RGWBucketList(); }
+    RGWObject* create_object(const rgw_obj_key &key /* Attributes */) override;
+    RGWAttrs& get_attrs(void) { return attrs; }
+    int set_attrs(RGWAttrs &a) { attrs = a; return 0; }
+    int delete_bucket(void) { return 0; }
+    RGWAccessControlPolicy& get_acl(void) { return acls; }
+    int set_acl(const RGWAccessControlPolicy &acl) { acls = acl; return 0; }
+};
+
+class RGWRadosStore : public RGWStore {
+  private:
+    RGWRados *rados;
+    RGWRadosUser *user;
+    RGWRadosBucket *bucket;
+
+  public:
+    RGWRadosStore()
+      : rados(nullptr),
+        user(nullptr),
+        bucket(nullptr) {
+      }
+    ~RGWRadosStore() {
+	if (bucket)
+	    delete bucket;
+	if (user)
+	    delete user;
+	if (rados)
+	    delete rados;
+    }
+
+    virtual RGWUser* get_user(const rgw_user &u);
+    virtual RGWSalBucket* get_bucket(RGWUser &u, const cls_user_bucket &b) { return bucket; }
+    virtual RGWSalBucket* create_bucket(RGWUser &u, const cls_user_bucket &b);
+    virtual RGWBucketList* list_buckets(void) { return new RGWBucketList(); }
+
+    void setRados(RGWRados * st) { rados = st; }
+    RGWRados *getRados(void) { return rados; }
+
+    RGWServices *svc() { return &rados->svc; }
+    RGWCtl *ctl() { return &rados->ctl; }
+
+    void finalize(void) override;
+
+    virtual CephContext *ctx(void) { return rados->ctx(); }
+};
+
+} } // namespace rgw::sal
+
+
+class RGWStoreManager {
+public:
+  RGWStoreManager() {}
+  static rgw::sal::RGWRadosStore *get_storage(CephContext *cct, bool use_gc_thread, bool use_lc_thread, bool quota_threads,
+			       bool run_sync_thread, bool run_reshard_thread, bool use_cache = true) {
+    rgw::sal::RGWRadosStore *store = init_storage_provider(cct, use_gc_thread, use_lc_thread,
+	quota_threads, run_sync_thread, run_reshard_thread, use_cache);
+    return store;
+  }
+  static rgw::sal::RGWRadosStore *get_raw_storage(CephContext *cct) {
+    rgw::sal::RGWRadosStore *rados = init_raw_storage_provider(cct);
+    return rados;
+  }
+  static rgw::sal::RGWRadosStore *init_storage_provider(CephContext *cct, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_metadata_cache);
+  static rgw::sal::RGWRadosStore *init_raw_storage_provider(CephContext *cct);
+  static void close_storage(rgw::sal::RGWRadosStore *store);
+
+};

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -26,6 +26,7 @@
 #include "rgw_user.h"
 #include "rgw_iam_policy.h"
 #include "rgw_sts.h"
+#include "rgw_sal.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -140,7 +141,7 @@ void AssumedRoleUser::dump(Formatter *f) const
 }
 
 int AssumedRoleUser::generateAssumedRoleUser(CephContext* cct,
-                                              RGWRados *store,
+                                              rgw::sal::RGWRadosStore *store,
                                               const string& roleId,
                                               const rgw::ARN& roleArn,
                                               const string& roleSessionName)
@@ -251,7 +252,7 @@ std::tuple<int, RGWRole> STSService::getRoleInfo(const string& arn)
   if (auto r_arn = rgw::ARN::parse(arn); r_arn) {
     auto pos = r_arn->resource.find_last_of('/');
     string roleName = r_arn->resource.substr(pos + 1);
-    RGWRole role(cct, store->pctl, roleName, r_arn->account);
+    RGWRole role(cct, store->getRados()->pctl, roleName, r_arn->account);
     if (int ret = role.get(); ret < 0) {
       if (ret == -ENOENT) {
         ret = -ERR_NO_ROLE_FOUND;
@@ -270,14 +271,14 @@ int STSService::storeARN(string& arn)
 {
   int ret = 0;
   RGWUserInfo info;
-  if (ret = rgw_get_user_info_by_uid(store->ctl.user, user_id, info); ret < 0) {
+  if (ret = rgw_get_user_info_by_uid(store->ctl()->user, user_id, info); ret < 0) {
     return -ERR_NO_SUCH_ENTITY;
   }
 
   info.assumed_role_arn = arn;
 
   RGWObjVersionTracker objv_tracker;
-  if (ret = rgw_store_user_info(store->ctl.user, info, &info, &objv_tracker, real_time(),
+  if (ret = rgw_store_user_info(store->ctl()->user, info, &info, &objv_tracker, real_time(),
           false); ret < 0) {
     return -ERR_INTERNAL_ERROR;
   }

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -107,7 +107,7 @@ class AssumedRoleUser {
   string assumeRoleId;
 public:
   int generateAssumedRoleUser( CephContext* cct,
-                                RGWRados *store,
+                                rgw::sal::RGWRadosStore *store,
                                 const string& roleId,
                                 const rgw::ARN& roleArn,
                                 const string& roleSessionName);
@@ -203,14 +203,14 @@ using AssumeRoleWithWebIdentityResponse = struct AssumeRoleWithWebIdentityRespon
 
 class STSService {
   CephContext* cct;
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   rgw_user user_id;
   RGWRole role;
   rgw::auth::Identity* identity;
   int storeARN(string& arn);
 public:
   STSService() = default;
-  STSService(CephContext* cct, RGWRados *store, rgw_user user_id, rgw::auth::Identity* identity) : cct(cct), store(store), user_id(user_id), identity(identity) {}
+  STSService(CephContext* cct, rgw::sal::RGWRadosStore *store, rgw_user user_id, rgw::auth::Identity* identity) : cct(cct), store(store), user_id(user_id), identity(identity) {}
   std::tuple<int, RGWRole> getRoleInfo(const string& arn);
   AssumeRoleResponse assumeRole(AssumeRoleRequest& req);
   GetSessionTokenResponse getSessionToken(GetSessionTokenRequest& req);

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -684,7 +684,7 @@ void RGW_SWIFT_Auth_Get::execute()
 
   user_str = user;
 
-  if ((ret = store->ctl.user->get_info_by_swift(user_str, &info, s->yield)) < 0)
+  if ((ret = store->ctl()->user->get_info_by_swift(user_str, &info, s->yield)) < 0)
   {
     ret = -EACCES;
     goto done;
@@ -738,7 +738,7 @@ done:
   end_header(s);
 }
 
-int RGWHandler_SWIFT_Auth::init(RGWRados *store, struct req_state *state,
+int RGWHandler_SWIFT_Auth::init(rgw::sal::RGWRadosStore *store, struct req_state *state,
 				rgw::io::BasicClient *cio)
 {
   state->dialect = "swift-auth";

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -9,6 +9,7 @@
 #include "rgw_auth.h"
 #include "rgw_auth_keystone.h"
 #include "rgw_auth_filters.h"
+#include "rgw_sal.h"
 
 #define RGW_SWIFT_TOKEN_EXPIRATION (15 * 60)
 
@@ -298,7 +299,7 @@ public:
   ~RGWHandler_SWIFT_Auth() override {}
   RGWOp *op_get() override;
 
-  int init(RGWRados *store, struct req_state *state, rgw::io::BasicClient *cio) override;
+  int init(rgw::sal::RGWRadosStore *store, struct req_state *state, rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp) override;
   int postauth_init() override { return 0; }
   int read_permissions(RGWOp *op) override { return 0; }

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -42,7 +42,7 @@ static string mdlog_sync_status_oid = "mdlog.sync-status";
 static string mdlog_sync_status_shard_prefix = "mdlog.sync-status.shard";
 static string mdlog_sync_full_sync_index_prefix = "meta.full-sync.index";
 
-RGWSyncErrorLogger::RGWSyncErrorLogger(RGWRados *_store, const string &oid_prefix, int _num_shards) : store(_store), num_shards(_num_shards) {
+RGWSyncErrorLogger::RGWSyncErrorLogger(rgw::sal::RGWRadosStore *_store, const string &oid_prefix, int _num_shards) : store(_store), num_shards(_num_shards) {
   for (int i = 0; i < num_shards; i++) {
     oids.push_back(get_shard_oid(oid_prefix, i));
   }
@@ -59,7 +59,7 @@ RGWCoroutine *RGWSyncErrorLogger::log_error_cr(const string& source_zone, const 
   rgw_sync_error_info info(source_zone, error_code, message);
   bufferlist bl;
   encode(info, bl);
-  store->svc.cls->timelog.prepare_entry(entry, real_clock::now(), section, name, bl);
+  store->svc()->cls->timelog.prepare_entry(entry, real_clock::now(), section, name, bl);
 
   uint32_t shard_id = ++counter % num_shards;
 
@@ -258,7 +258,7 @@ int RGWRemoteMetaLog::read_log_info(rgw_mdlog_info *log_info)
 
 int RGWRemoteMetaLog::read_master_log_shards_info(const string &master_period, map<int, RGWMetadataLogInfo> *shards_info)
 {
-  if (store->svc.zone->is_meta_master()) {
+  if (store->svc()->zone->is_meta_master()) {
     return 0;
   }
 
@@ -273,7 +273,7 @@ int RGWRemoteMetaLog::read_master_log_shards_info(const string &master_period, m
 
 int RGWRemoteMetaLog::read_master_log_shards_next(const string& period, map<int, string> shard_markers, map<int, rgw_mdlog_shard_data> *result)
 {
-  if (store->svc.zone->is_meta_master()) {
+  if (store->svc()->zone->is_meta_master()) {
     return 0;
   }
 
@@ -282,7 +282,7 @@ int RGWRemoteMetaLog::read_master_log_shards_next(const string& period, map<int,
 
 int RGWRemoteMetaLog::init()
 {
-  conn = store->svc.zone->get_master_conn();
+  conn = store->svc()->zone->get_master_conn();
 
   int ret = http_manager.start();
   if (ret < 0) {
@@ -309,18 +309,18 @@ void RGWRemoteMetaLog::finish()
 
 int RGWMetaSyncStatusManager::init()
 {
-  if (store->svc.zone->is_meta_master()) {
+  if (store->svc()->zone->is_meta_master()) {
     return 0;
   }
 
-  if (!store->svc.zone->get_master_conn()) {
+  if (!store->svc()->zone->get_master_conn()) {
     lderr(store->ctx()) << "no REST connection to master zone" << dendl;
     return -EIO;
   }
 
-  int r = rgw_init_ioctx(store->get_rados_handle(), store->svc.zone->get_zone_params().log_pool, ioctx, true);
+  int r = rgw_init_ioctx(store->getRados()->get_rados_handle(), store->svc()->zone->get_zone_params().log_pool, ioctx, true);
   if (r < 0) {
-    lderr(store->ctx()) << "ERROR: failed to open log pool (" << store->svc.zone->get_zone_params().log_pool << " ret=" << r << dendl;
+    lderr(store->ctx()) << "ERROR: failed to open log pool (" << store->svc()->zone->get_zone_params().log_pool << " ret=" << r << dendl;
     return r;
   }
 
@@ -342,7 +342,7 @@ int RGWMetaSyncStatusManager::init()
   int num_shards = sync_status.sync_info.num_shards;
 
   for (int i = 0; i < num_shards; i++) {
-    shard_objs[i] = rgw_raw_obj(store->svc.zone->get_zone_params().log_pool, sync_env.shard_obj_name(i));
+    shard_objs[i] = rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env.shard_obj_name(i));
   }
 
   std::unique_lock wl{ts_to_shard_lock};
@@ -366,7 +366,7 @@ std::ostream&  RGWMetaSyncStatusManager::gen_prefix(std::ostream& out) const
   return out << "meta sync: ";
 }
 
-void RGWMetaSyncEnv::init(const DoutPrefixProvider *_dpp, CephContext *_cct, RGWRados *_store, RGWRESTConn *_conn,
+void RGWMetaSyncEnv::init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RGWRadosStore *_store, RGWRESTConn *_conn,
                           RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
                           RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer) {
   dpp = _dpp;
@@ -393,7 +393,7 @@ string RGWMetaSyncEnv::shard_obj_name(int shard_id)
 }
 
 class RGWAsyncReadMDLogEntries : public RGWAsyncRadosRequest {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   RGWMetadataLog *mdlog;
   int shard_id;
   string *marker;
@@ -417,7 +417,7 @@ protected:
     return ret;
   }
 public:
-  RGWAsyncReadMDLogEntries(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
+  RGWAsyncReadMDLogEntries(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
                            RGWMetadataLog* mdlog, int _shard_id,
                            string* _marker, int _max_entries,
                            list<cls_log_entry> *_entries, bool *_truncated)
@@ -487,7 +487,7 @@ public:
 
   int operate() override {
     auto store = env->store;
-    RGWRESTConn *conn = store->svc.zone->get_master_conn();
+    RGWRESTConn *conn = store->svc()->zone->get_master_conn();
     reenter(this) {
       yield {
 	char buf[16];
@@ -655,9 +655,9 @@ public:
         set_status("acquiring sync lock");
 	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
         string lock_name = "sync_lock";
-        RGWRados *store = sync_env->store;
+	rgw::sal::RGWRadosStore *store = sync_env->store;
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
-                                                rgw_raw_obj(store->svc.zone->get_zone_params().log_pool, sync_env->status_oid()),
+                                                rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                 lock_name, lock_duration, this));
         lease_stack.reset(spawn(lease_cr.get(), false));
       }
@@ -672,9 +672,9 @@ public:
       }
       yield {
         set_status("writing sync status");
-        RGWRados *store = sync_env->store;
-        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store->svc.sysobj,
-                                                           rgw_raw_obj(store->svc.zone->get_zone_params().log_pool, sync_env->status_oid()),
+	rgw::sal::RGWRadosStore *store = sync_env->store;
+        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store->svc()->sysobj,
+                                                           rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                            status));
       }
 
@@ -702,19 +702,19 @@ public:
           RGWMetadataLogInfo& info = shards_info[i];
 	  marker.next_step_marker = info.marker;
 	  marker.timestamp = info.last_update;
-          RGWRados *store = sync_env->store;
+	  rgw::sal::RGWRadosStore *store = sync_env->store;
           spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados,
-                                                                store->svc.sysobj,
-                                                                rgw_raw_obj(store->svc.zone->get_zone_params().log_pool, sync_env->shard_obj_name(i)),
+                                                                store->svc()->sysobj,
+                                                                rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->shard_obj_name(i)),
                                                                 marker), true);
         }
       }
       yield {
         set_status("changing sync state: build full sync maps");
 	status.state = rgw_meta_sync_info::StateBuildingFullSyncMaps;
-        RGWRados *store = sync_env->store;
-        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store->svc.sysobj,
-                                                           rgw_raw_obj(store->svc.zone->get_zone_params().log_pool, sync_env->status_oid()),
+	rgw::sal::RGWRadosStore *store = sync_env->store;
+        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store->svc()->sysobj,
+                                                           rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                            status));
       }
       set_status("drop lock lease");
@@ -755,9 +755,9 @@ bool RGWReadSyncStatusMarkersCR::spawn_next()
     return false;
   }
   using CR = RGWSimpleRadosReadCR<rgw_meta_sync_marker>;
-  rgw_raw_obj obj{env->store->svc.zone->get_zone_params().log_pool,
+  rgw_raw_obj obj{env->store->svc()->zone->get_zone_params().log_pool,
                   env->shard_obj_name(shard_id)};
-  spawn(new CR(env->async_rados, env->store->svc.sysobj, obj, &markers[shard_id]), false);
+  spawn(new CR(env->async_rados, env->store->svc()->sysobj, obj, &markers[shard_id]), false);
   shard_id++;
   return true;
 }
@@ -781,9 +781,9 @@ int RGWReadSyncStatusCoroutine::operate()
     using ReadInfoCR = RGWSimpleRadosReadCR<rgw_meta_sync_info>;
     yield {
       bool empty_on_enoent = false; // fail on ENOENT
-      rgw_raw_obj obj{sync_env->store->svc.zone->get_zone_params().log_pool,
+      rgw_raw_obj obj{sync_env->store->svc()->zone->get_zone_params().log_pool,
                       sync_env->status_oid()};
-      call(new ReadInfoCR(sync_env->async_rados, sync_env->store->svc.sysobj, obj,
+      call(new ReadInfoCR(sync_env->async_rados, sync_env->store->svc()->sysobj, obj,
                           &sync_status->sync_info, empty_on_enoent));
     }
     if (retcode < 0) {
@@ -892,7 +892,7 @@ public:
         string lock_name = "sync_lock";
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados,
                                                 sync_env->store,
-                                                rgw_raw_obj(sync_env->store->svc.zone->get_zone_params().log_pool, sync_env->status_oid()),
+                                                rgw_raw_obj(sync_env->store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                 lock_name, lock_duration, this));
         lease_stack.reset(spawn(lease_cr.get(), false));
       }
@@ -906,7 +906,7 @@ public:
         yield;
       }
       entries_index.reset(new RGWShardedOmapCRManager(sync_env->async_rados, sync_env->store, this, num_shards,
-                                                      sync_env->store->svc.zone->get_zone_params().log_pool,
+                                                      sync_env->store->svc()->zone->get_zone_params().log_pool,
                                                       mdlog_sync_full_sync_index_prefix));
       yield {
 	call(new RGWReadRESTResourceCR<list<string> >(cct, conn, sync_env->http_manager,
@@ -956,8 +956,8 @@ public:
             tn->log(20, SSTR("list metadata: section=" << *sections_iter << " key=" << *iter));
             string s = *sections_iter + ":" + *iter;
             int shard_id;
-            RGWRados *store = sync_env->store;
-            int ret = store->ctl.meta.mgr->get_shard_id(*sections_iter, *iter, &shard_id);
+	    rgw::sal::RGWRadosStore *store = sync_env->store;
+            int ret = store->ctl()->meta.mgr->get_shard_id(*sections_iter, *iter, &shard_id);
             if (ret < 0) {
               tn->log(0, SSTR("ERROR: could not determine shard id for " << *sections_iter << ":" << *iter));
               ret_status = ret;
@@ -979,8 +979,8 @@ public:
           int shard_id = (int)iter->first;
           rgw_meta_sync_marker& marker = iter->second;
           marker.total_entries = entries_index->get_total_entries(shard_id);
-          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados, sync_env->store->svc.sysobj,
-                                                                rgw_raw_obj(sync_env->store->svc.zone->get_zone_params().log_pool, sync_env->shard_obj_name(shard_id)),
+          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados, sync_env->store->svc()->sysobj,
+                                                                rgw_raw_obj(sync_env->store->svc()->zone->get_zone_params().log_pool, sync_env->shard_obj_name(shard_id)),
                                                                 marker), true);
         }
       }
@@ -1082,12 +1082,12 @@ public:
 };
 
 class RGWAsyncMetaStoreEntry : public RGWAsyncRadosRequest {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   string raw_key;
   bufferlist bl;
 protected:
   int _send_request() override {
-    int ret = store->ctl.meta.mgr->put(raw_key, bl, null_yield, RGWMDLogSyncType::APPLY_ALWAYS);
+    int ret = store->ctl()->meta.mgr->put(raw_key, bl, null_yield, RGWMDLogSyncType::APPLY_ALWAYS);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: can't store key: " << raw_key << " ret=" << ret << dendl;
       return ret;
@@ -1095,7 +1095,7 @@ protected:
     return 0;
   }
 public:
-  RGWAsyncMetaStoreEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
+  RGWAsyncMetaStoreEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
                        const string& _raw_key,
                        bufferlist& _bl) : RGWAsyncRadosRequest(caller, cn), store(_store),
                                           raw_key(_raw_key), bl(_bl) {}
@@ -1135,11 +1135,11 @@ public:
 };
 
 class RGWAsyncMetaRemoveEntry : public RGWAsyncRadosRequest {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   string raw_key;
 protected:
   int _send_request() override {
-    int ret = store->ctl.meta.mgr->remove(raw_key, null_yield);
+    int ret = store->ctl()->meta.mgr->remove(raw_key, null_yield);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: can't remove key: " << raw_key << " ret=" << ret << dendl;
       return ret;
@@ -1147,7 +1147,7 @@ protected:
     return 0;
   }
 public:
-  RGWAsyncMetaRemoveEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
+  RGWAsyncMetaRemoveEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
                        const string& _raw_key) : RGWAsyncRadosRequest(caller, cn), store(_store),
                                           raw_key(_raw_key) {}
 };
@@ -1234,10 +1234,10 @@ public:
 
     ldpp_dout(sync_env->dpp, 20) << __func__ << "(): updating marker marker_oid=" << marker_oid << " marker=" << new_marker << " realm_epoch=" << sync_marker.realm_epoch << dendl;
     tn->log(20, SSTR("new marker=" << new_marker));
-    RGWRados *store = sync_env->store;
+    rgw::sal::RGWRadosStore *store = sync_env->store;
     return new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados,
-                                                           store->svc.sysobj,
-                                                           rgw_raw_obj(store->svc.zone->get_zone_params().log_pool, marker_oid),
+                                                           store->svc()->sysobj,
+                                                           rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, marker_oid),
                                                            sync_marker);
   }
 
@@ -1555,7 +1555,7 @@ public:
       yield {
 	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
         string lock_name = "sync_lock";
-        RGWRados *store = sync_env->store;
+	rgw::sal::RGWRadosStore *store = sync_env->store;
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                                 rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                 lock_name, lock_duration, this));
@@ -1647,7 +1647,7 @@ public:
 	  ldpp_dout(sync_env->dpp, 4) << *this << ": saving marker pos=" << temp_marker->marker << " realm_epoch=" << realm_epoch << dendl;
 
 	  using WriteMarkerCR = RGWSimpleRadosWriteCR<rgw_meta_sync_marker>;
-	  yield call(new WriteMarkerCR(sync_env->async_rados, sync_env->store->svc.sysobj,
+	  yield call(new WriteMarkerCR(sync_env->async_rados, sync_env->store->svc()->sysobj,
 				       rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
 				       *temp_marker));
         }
@@ -1701,7 +1701,7 @@ public:
         yield {
           uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
           string lock_name = "sync_lock";
-          RGWRados *store = sync_env->store;
+	  rgw::sal::RGWRadosStore *store = sync_env->store;
           lease_cr.reset( new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                                    rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                    lock_name, lock_duration, this));
@@ -1890,8 +1890,8 @@ public:
   }
 
   RGWCoroutine *alloc_finisher_cr() override {
-    RGWRados *store = sync_env->store;
-    return new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->async_rados, store->svc.sysobj,
+    rgw::sal::RGWRadosStore *store = sync_env->store;
+    return new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->async_rados, store->svc()->sysobj,
                                                           rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                           &sync_marker);
   }
@@ -1920,7 +1920,7 @@ public:
   RGWMetaSyncCR(RGWMetaSyncEnv *_sync_env, const RGWPeriodHistory::Cursor &cursor,
                 const rgw_meta_sync_status& _sync_status, RGWSyncTraceNodeRef& _tn)
     : RGWCoroutine(_sync_env->cct), sync_env(_sync_env),
-      pool(sync_env->store->svc.zone->get_zone_params().log_pool),
+      pool(sync_env->store->svc()->zone->get_zone_params().log_pool),
       cursor(cursor), sync_status(_sync_status), tn(_tn) {}
 
   ~RGWMetaSyncCR() {
@@ -1931,7 +1931,7 @@ public:
       // loop through one period at a time
       tn->log(1, "start");
       for (;;) {
-        if (cursor == sync_env->store->svc.mdlog->get_period_history()->get_current()) {
+        if (cursor == sync_env->store->svc()->mdlog->get_period_history()->get_current()) {
           next = RGWPeriodHistory::Cursor{};
           if (cursor) {
             ldpp_dout(sync_env->dpp, 10) << "RGWMetaSyncCR on current period="
@@ -1951,7 +1951,7 @@ public:
           // get the mdlog for the current period (may be empty)
           auto& period_id = sync_status.sync_info.period;
           auto realm_epoch = sync_status.sync_info.realm_epoch;
-          auto mdlog = sync_env->store->svc.mdlog->get_log(period_id);
+          auto mdlog = sync_env->store->svc()->mdlog->get_log(period_id);
 
           tn->log(1, SSTR("realm epoch=" << realm_epoch << " period id=" << period_id));
 
@@ -2005,7 +2005,7 @@ public:
         sync_status.sync_info.period = cursor.get_period().get_id();
         sync_status.sync_info.realm_epoch = cursor.get_epoch();
         yield call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados,
-                                                                 sync_env->store->svc.sysobj,
+                                                                 sync_env->store->svc()->sysobj,
                                                                  rgw_raw_obj(pool, sync_env->status_oid()),
                                                                  sync_status.sync_info));
       }
@@ -2031,16 +2031,16 @@ void RGWRemoteMetaLog::init_sync_env(RGWMetaSyncEnv *env) {
   env->async_rados = async_rados;
   env->http_manager = &http_manager;
   env->error_logger = error_logger;
-  env->sync_tracer = store->get_sync_tracer();
+  env->sync_tracer = store->getRados()->get_sync_tracer();
 }
 
 int RGWRemoteMetaLog::read_sync_status(rgw_meta_sync_status *sync_status)
 {
-  if (store->svc.zone->is_meta_master()) {
+  if (store->svc()->zone->is_meta_master()) {
     return 0;
   }
   // cannot run concurrently with run_sync(), so run in a separate manager
-  RGWCoroutinesManager crs(store->ctx(), store->get_cr_registry());
+  RGWCoroutinesManager crs(store->ctx(), store->getRados()->get_cr_registry());
   RGWHTTPManager http_manager(store->ctx(), crs.get_completion_mgr());
   int ret = http_manager.start();
   if (ret < 0) {
@@ -2057,7 +2057,7 @@ int RGWRemoteMetaLog::read_sync_status(rgw_meta_sync_status *sync_status)
 
 int RGWRemoteMetaLog::init_sync_status()
 {
-  if (store->svc.zone->is_meta_master()) {
+  if (store->svc()->zone->is_meta_master()) {
     return 0;
   }
 
@@ -2070,7 +2070,7 @@ int RGWRemoteMetaLog::init_sync_status()
 
   rgw_meta_sync_info sync_info;
   sync_info.num_shards = mdlog_info.num_shards;
-  auto cursor = store->svc.mdlog->get_period_history()->get_current();
+  auto cursor = store->svc()->mdlog->get_period_history()->get_current();
   if (cursor) {
     sync_info.period = cursor.get_period().get_id();
     sync_info.realm_epoch = cursor.get_epoch();
@@ -2082,13 +2082,13 @@ int RGWRemoteMetaLog::init_sync_status()
 int RGWRemoteMetaLog::store_sync_info(const rgw_meta_sync_info& sync_info)
 {
   tn->log(20, "store sync info");
-  return run(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(async_rados, store->svc.sysobj,
-                                                           rgw_raw_obj(store->svc.zone->get_zone_params().log_pool, sync_env.status_oid()),
+  return run(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(async_rados, store->svc()->sysobj,
+                                                           rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env.status_oid()),
                                                            sync_info));
 }
 
 // return a cursor to the period at our sync position
-static RGWPeriodHistory::Cursor get_period_at(RGWRados* store,
+static RGWPeriodHistory::Cursor get_period_at(rgw::sal::RGWRadosStore* store,
                                               const rgw_meta_sync_info& info)
 {
   if (info.period.empty()) {
@@ -2097,7 +2097,7 @@ static RGWPeriodHistory::Cursor get_period_at(RGWRados* store,
   }
 
   // look for an existing period in our history
-  auto cursor = store->svc.mdlog->get_period_history()->lookup(info.realm_epoch);
+  auto cursor = store->svc()->mdlog->get_period_history()->lookup(info.realm_epoch);
   if (cursor) {
     // verify that the period ids match
     auto& existing = cursor.get_period().get_id();
@@ -2112,14 +2112,14 @@ static RGWPeriodHistory::Cursor get_period_at(RGWRados* store,
 
   // read the period from rados or pull it from the master
   RGWPeriod period;
-  int r = store->svc.mdlog->pull_period(info.period, period);
+  int r = store->svc()->mdlog->pull_period(info.period, period);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed to read period id "
         << info.period << ": " << cpp_strerror(r) << dendl;
     return RGWPeriodHistory::Cursor{r};
   }
   // attach the period to our history
-  cursor = store->svc.mdlog->get_period_history()->attach(std::move(period));
+  cursor = store->svc()->mdlog->get_period_history()->attach(std::move(period));
   if (!cursor) {
     r = cursor.get_error();
     lderr(store->ctx()) << "ERROR: failed to read period history back to "
@@ -2130,7 +2130,7 @@ static RGWPeriodHistory::Cursor get_period_at(RGWRados* store,
 
 int RGWRemoteMetaLog::run_sync()
 {
-  if (store->svc.zone->is_meta_master()) {
+  if (store->svc()->zone->is_meta_master()) {
     return 0;
   }
 
@@ -2193,7 +2193,7 @@ int RGWRemoteMetaLog::run_sync()
     if (sync_status.sync_info.state == rgw_meta_sync_info::StateInit) {
       ldpp_dout(dpp, 20) << __func__ << "(): init" << dendl;
       sync_status.sync_info.num_shards = mdlog_info.num_shards;
-      auto cursor = store->svc.mdlog->get_period_history()->get_current();
+      auto cursor = store->svc()->mdlog->get_period_history()->get_current();
       if (cursor) {
         // run full sync, then start incremental from the current period/epoch
         sync_status.sync_info.period = cursor.get_period().get_id();

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -563,11 +563,11 @@ struct AWSSyncConfig {
   void expand_target(RGWDataSyncEnv *sync_env, const string& sid, const string& path, string *dest) {
       apply_meta_param(path, "sid", sid, dest);
 
-      const RGWZoneGroup& zg = sync_env->store->svc.zone->get_zonegroup();
+      const RGWZoneGroup& zg = sync_env->store->svc()->zone->get_zonegroup();
       apply_meta_param(path, "zonegroup", zg.get_name(), dest);
       apply_meta_param(path, "zonegroup_id", zg.get_id(), dest);
 
-      const RGWZone& zone = sync_env->store->svc.zone->get_zone();
+      const RGWZone& zone = sync_env->store->svc()->zone->get_zone();
       apply_meta_param(path, "zone", zone.name, dest);
       apply_meta_param(path, "zone_id", zone.id, dest);
   }
@@ -642,7 +642,7 @@ struct AWSSyncConfig {
     auto& root_conf = root_profile->conn_conf;
 
     root_profile->conn.reset(new S3RESTConn(sync_env->cct,
-                                           sync_env->store->svc.zone,
+                                           sync_env->store->svc()->zone,
                                            id,
                                            { root_conf->endpoint },
                                            root_conf->key,
@@ -652,7 +652,7 @@ struct AWSSyncConfig {
       auto& c = i.second;
 
       c->conn.reset(new S3RESTConn(sync_env->cct,
-                                   sync_env->store->svc.zone,
+                                   sync_env->store->svc()->zone,
                                    id,
                                    { c->conn_conf->endpoint },
                                    c->conn_conf->key,
@@ -1426,14 +1426,14 @@ public:
                                                    obj_size(_obj_size),
                                                    src_properties(_src_properties),
                                                    rest_obj(_rest_obj),
-                                                   status_obj(sync_env->store->svc.zone->get_zone_params().log_pool,
+                                                   status_obj(sync_env->store->svc()->zone->get_zone_params().log_pool,
                                                               RGWBucketSyncStatusManager::obj_status_oid(sync_env->source_zone, src_obj)) {
   }
 
 
   int operate() override {
     reenter(this) {
-      yield call(new RGWSimpleRadosReadCR<rgw_sync_aws_multipart_upload_info>(sync_env->async_rados, sync_env->store->svc.sysobj,
+      yield call(new RGWSimpleRadosReadCR<rgw_sync_aws_multipart_upload_info>(sync_env->async_rados, sync_env->store->svc()->sysobj,
                                                                  status_obj, &status, false));
 
       if (retcode < 0 && retcode != -ENOENT) {
@@ -1496,7 +1496,7 @@ public:
           return set_cr_error(ret_err);
         }
 
-        yield call(new RGWSimpleRadosWriteCR<rgw_sync_aws_multipart_upload_info>(sync_env->async_rados, sync_env->store->svc.sysobj, status_obj, status));
+        yield call(new RGWSimpleRadosWriteCR<rgw_sync_aws_multipart_upload_info>(sync_env->async_rados, sync_env->store->svc()->sysobj, status_obj, status));
         if (retcode < 0) {
           ldout(sync_env->cct, 0) << "ERROR: failed to store multipart upload state, retcode=" << retcode << dendl;
           /* continue with upload anyway */
@@ -1604,8 +1604,7 @@ public:
                               << " zone_short_id=" << src_zone_short_id << " pg_ver=" << src_pg_ver
                               << dendl;
 
-
-      source_conn = sync_env->store->svc.zone->get_zone_conn_by_id(sync_env->source_zone);
+      source_conn = sync_env->store->svc()->zone->get_zone_conn_by_id(sync_env->source_zone);
       if (!source_conn) {
         ldout(sync_env->cct, 0) << "ERROR: cannot find http connection to zone " << sync_env->source_zone << dendl;
         return set_cr_error(-EINVAL);

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -800,7 +800,7 @@ public:
   ~RGWElasticDataSyncModule() override {}
 
   void init(RGWDataSyncEnv *sync_env, uint64_t instance_id) override {
-    conf->init_instance(sync_env->store->svc.zone->get_realm(), instance_id);
+    conf->init_instance(sync_env->store->svc()->zone->get_realm(), instance_id);
   }
 
   RGWCoroutine *init_sync(RGWDataSyncEnv *sync_env) override {

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -379,7 +379,7 @@ class RGWHandler_REST_MDSearch_S3 : public RGWHandler_REST_S3 {
 protected:
   RGWOp *op_get() override {
     if (s->info.args.exists("query")) {
-      return new RGWMetadataSearch_ObjStore_S3(store->get_sync_module());
+      return new RGWMetadataSearch_ObjStore_S3(store->getRados()->get_sync_module());
     }
     if (!s->init_state.url_bucket.empty() &&
         s->info.args.exists("mdsearch")) {

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -959,7 +959,7 @@ class PSManager
             rgw_raw_obj obj;
             ups.get_sub_meta_obj(sub_name, &obj);
             bool empty_on_enoent = false;
-            call(new ReadInfoCR(sync_env->async_rados, sync_env->store->svc.sysobj,
+            call(new ReadInfoCR(sync_env->async_rados, sync_env->store->svc()->sysobj,
                                 obj,
                                 &user_sub_conf, empty_on_enoent));
           }
@@ -1141,7 +1141,7 @@ public:
       using ReadInfoCR = RGWSimpleRadosReadCR<rgw_pubsub_bucket_topics>;
       yield {
         bool empty_on_enoent = true;
-        call(new ReadInfoCR(sync_env->async_rados, sync_env->store->svc.sysobj,
+        call(new ReadInfoCR(sync_env->async_rados, sync_env->store->svc()->sysobj,
                             bucket_obj,
                             &bucket_topics, empty_on_enoent));
       }
@@ -1155,7 +1155,7 @@ public:
 	using ReadUserTopicsInfoCR = RGWSimpleRadosReadCR<rgw_pubsub_user_topics>;
 	yield {
 	  bool empty_on_enoent = true;
-	  call(new ReadUserTopicsInfoCR(sync_env->async_rados, sync_env->store->svc.sysobj,
+	  call(new ReadUserTopicsInfoCR(sync_env->async_rados, sync_env->store->svc()->sysobj,
 					user_obj,
 					&user_topics, empty_on_enoent));
 	}
@@ -1518,7 +1518,7 @@ public:
 
   void init(RGWDataSyncEnv *sync_env, uint64_t instance_id) override {
     PSManagerRef mgr = PSManager::get_shared(sync_env, env);
-    env->init_instance(sync_env->store->svc.zone->get_realm(), instance_id, mgr);
+    env->init_instance(sync_env->store->svc()->zone->get_realm(), instance_id, mgr);
   }
 
   RGWCoroutine *start_sync(RGWDataSyncEnv *sync_env) override {

--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -70,7 +70,7 @@ public:
     dest.arn_topic = topic_name;
     // the topic ARN will be sent in the reply
     const rgw::ARN arn(rgw::Partition::aws, rgw::Service::sns, 
-        store->svc.zone->get_zonegroup().get_name(),
+        store->svc()->zone->get_zonegroup().get_name(),
         s->user->user_id.tenant, topic_name);
     topic_arn = arn.to_string();
     return 0;
@@ -348,7 +348,7 @@ public:
       return -EINVAL;
     }
 
-    const auto psmodule = static_cast<RGWPSSyncModuleInstance*>(store->get_sync_module().get());
+    const auto psmodule = static_cast<RGWPSSyncModuleInstance*>(store->getRados()->get_sync_module().get());
     const auto& conf = psmodule->get_effective_conf();
 
     dest.push_endpoint = s->info.args.get("push-endpoint");
@@ -701,7 +701,7 @@ public:
 
     const auto& id = s->owner.get_id();
 
-    ret = store->get_bucket_info(*s->sysobj_ctx, id.tenant, bucket_name,
+    ret = store->getRados()->get_bucket_info(*s->sysobj_ctx, id.tenant, bucket_name,
                                  bucket_info, nullptr, null_yield, nullptr);
     if (ret < 0) {
       ldout(s->cct, 1) << "failed to get bucket info, cannot verify ownership" << dendl;
@@ -872,7 +872,7 @@ void RGWPSCreateNotif_ObjStore_S3::execute() {
   ups = make_unique<RGWUserPubSub>(store, s->owner.get_id());
   auto b = ups->get_bucket(bucket_info.bucket);
   ceph_assert(b);
-  const auto psmodule = static_cast<RGWPSSyncModuleInstance*>(store->get_sync_module().get());
+  const auto psmodule = static_cast<RGWPSSyncModuleInstance*>(store->getRados()->get_sync_module().get());
   const auto& conf = psmodule->get_effective_conf();
 
   for (const auto& c : configurations.list) {
@@ -964,7 +964,7 @@ public:
       return ret;
     }
 
-    ret = store->get_bucket_info(*s->sysobj_ctx, s->owner.get_id().tenant, bucket_name,
+    ret = store->getRados()->get_bucket_info(*s->sysobj_ctx, s->owner.get_id().tenant, bucket_name,
                                  bucket_info, nullptr, null_yield, nullptr);
     if (ret < 0) {
       return ret;
@@ -1124,7 +1124,7 @@ public:
       return ret;
     }
 
-    ret = store->get_bucket_info(*s->sysobj_ctx, s->owner.get_id().tenant, bucket_name,
+    ret = store->getRados()->get_bucket_info(*s->sysobj_ctx, s->owner.get_id().tenant, bucket_name,
                                  bucket_info, nullptr, null_yield, nullptr);
     if (ret < 0) {
       return ret;

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -19,6 +19,9 @@ class RGWRados;
 class RGWSysObjectCtx;
 struct RGWObjVersionTracker;
 class optional_yield;
+namespace rgw { namespace sal {
+  class RGWRadosStore;
+} }
 
 struct obj_version;
 
@@ -132,11 +135,11 @@ using RGWMD5Etag = RGWEtag<MD5, CEPH_CRYPTO_MD5_DIGESTSIZE>;
 
 class RGWDataAccess
 {
-  RGWRados *store;
+  rgw::sal::RGWRadosStore *store;
   std::unique_ptr<RGWSysObjectCtx> sysobj_ctx;
 
 public:
-  RGWDataAccess(RGWRados *_store);
+  RGWDataAccess(rgw::sal::RGWRadosStore *_store);
 
   class Object;
   class Bucket;

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "rgw_torrent.h"
+#include "rgw_sal.h"
 #include "include/str_list.h"
 #include "include/rados/librados.hpp"
 
@@ -35,7 +36,7 @@ seed::~seed()
   store = NULL;
 }
 
-void seed::init(struct req_state *p_req, RGWRados *p_store)
+void seed::init(struct req_state *p_req, rgw::sal::RGWRadosStore *p_store)
 {
   s = p_req;
   store = p_store;
@@ -245,9 +246,9 @@ int seed::save_torrent_file()
   rgw_obj obj(s->bucket, s->object.name);    
 
   rgw_raw_obj raw_obj;
-  store->obj_to_raw(s->bucket_info.placement_rule, obj, &raw_obj);
+  store->getRados()->obj_to_raw(s->bucket_info.placement_rule, obj, &raw_obj);
 
-  auto obj_ctx = store->svc.sysobj->init_obj_ctx();
+  auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(raw_obj);
 
   op_ret = sysobj.omap().set(key, bl, null_yield);

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -108,7 +108,7 @@ private:
   bufferlist bl;  // bufflist ready to send
 
   struct req_state *s{nullptr};
-  RGWRados *store{nullptr};
+  rgw::sal::RGWRadosStore *store{nullptr};
   SHA1 h;
 
   TorrentBencode dencode;
@@ -117,7 +117,7 @@ public:
   ~seed();
 
   int get_params();
-  void init(struct req_state *p_req, RGWRados *p_store);
+  void init(struct req_state *p_req, rgw::sal::RGWRadosStore *p_store);
   int get_torrent_file(RGWRados::Object::Read &read_op,
                        uint64_t &total_len,
                        ceph::bufferlist &bl_data,

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -26,7 +26,7 @@
 #include "rgw_cr_rest.h"
 #include "rgw_data_sync.h"
 #include "rgw_metadata.h"
-#include "rgw_rados.h"
+#include "rgw_sal.h"
 #include "rgw_zone.h"
 #include "rgw_sync.h"
 #include "rgw_bucket.h"
@@ -237,7 +237,7 @@ void TrimComplete::Handler::handle(bufferlist::const_iterator& input,
 
 /// rados watcher for bucket trim notifications
 class BucketTrimWatcher : public librados::WatchCtx2 {
-  RGWRados *const store;
+  rgw::sal::RGWRadosStore *const store;
   const rgw_raw_obj& obj;
   rgw_rados_ref ref;
   uint64_t handle{0};
@@ -246,7 +246,7 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
   boost::container::flat_map<TrimNotifyType, HandlerPtr> handlers;
 
  public:
-  BucketTrimWatcher(RGWRados *store, const rgw_raw_obj& obj,
+  BucketTrimWatcher(rgw::sal::RGWRadosStore *store, const rgw_raw_obj& obj,
                     TrimCounters::Server *counters)
     : store(store), obj(obj) {
     handlers.emplace(NotifyTrimCounters, new TrimCounters::Handler(counters));
@@ -258,7 +258,7 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
   }
 
   int start() {
-    int r = store->get_raw_obj_ref(obj, &ref);
+    int r = store->getRados()->get_raw_obj_ref(obj, &ref);
     if (r < 0) {
       return r;
     }
@@ -380,12 +380,12 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
 /// concurrent requests
 class BucketTrimShardCollectCR : public RGWShardCollectCR {
   static constexpr int MAX_CONCURRENT_SHARDS = 16;
-  RGWRados *const store;
+  rgw::sal::RGWRadosStore *const store;
   const RGWBucketInfo& bucket_info;
   const std::vector<std::string>& markers; //< shard markers to trim
   size_t i{0}; //< index of current shard marker
  public:
-  BucketTrimShardCollectCR(RGWRados *store, const RGWBucketInfo& bucket_info,
+  BucketTrimShardCollectCR(rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info,
                            const std::vector<std::string>& markers)
     : RGWShardCollectCR(store->ctx(), MAX_CONCURRENT_SHARDS),
       store(store), bucket_info(bucket_info), markers(markers)
@@ -414,7 +414,7 @@ bool BucketTrimShardCollectCR::spawn_next()
 
 /// trim the bilog of all of the given bucket instance's shards
 class BucketTrimInstanceCR : public RGWCoroutine {
-  RGWRados *const store;
+  rgw::sal::RGWRadosStore *const store;
   RGWHTTPManager *const http;
   BucketTrimObserver *const observer;
   std::string bucket_instance;
@@ -428,14 +428,14 @@ class BucketTrimInstanceCR : public RGWCoroutine {
   std::vector<std::string> min_markers; //< min marker per shard
 
  public:
-  BucketTrimInstanceCR(RGWRados *store, RGWHTTPManager *http,
+  BucketTrimInstanceCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
                        BucketTrimObserver *observer,
                        const std::string& bucket_instance)
     : RGWCoroutine(store->ctx()), store(store),
       http(http), observer(observer),
       bucket_instance(bucket_instance),
-      zone_id(store->svc.zone->get_zone().id),
-      peer_status(store->svc.zone->get_zone_data_notify_to_map().size()) {
+      zone_id(store->svc()->zone->get_zone().id),
+      peer_status(store->svc()->zone->get_zone_data_notify_to_map().size()) {
     rgw_bucket_parse_bucket_key(cct, bucket_instance, &bucket, nullptr);
   }
 
@@ -460,14 +460,14 @@ int BucketTrimInstanceCR::operate()
       };
 
       auto p = peer_status.begin();
-      for (auto& c : store->svc.zone->get_zone_data_notify_to_map()) {
+      for (auto& c : store->svc()->zone->get_zone_data_notify_to_map()) {
         using StatusCR = RGWReadRESTResourceCR<StatusShards>;
         spawn(new StatusCR(cct, c.second, http, "/admin/log/", params, &*p),
               false);
         ++p;
       }
       // in parallel, read the local bucket instance info
-      spawn(new RGWGetBucketInstanceInfoCR(store->svc.rados->get_async_processor(), store,
+      spawn(new RGWGetBucketInstanceInfoCR(store->svc()->rados->get_async_processor(), store,
                                            bucket, &bucket_info),
             false);
     }
@@ -517,13 +517,13 @@ int BucketTrimInstanceCR::operate()
 
 /// trim each bucket instance while limiting the number of concurrent operations
 class BucketTrimInstanceCollectCR : public RGWShardCollectCR {
-  RGWRados *const store;
+  rgw::sal::RGWRadosStore *const store;
   RGWHTTPManager *const http;
   BucketTrimObserver *const observer;
   std::vector<std::string>::const_iterator bucket;
   std::vector<std::string>::const_iterator end;
  public:
-  BucketTrimInstanceCollectCR(RGWRados *store, RGWHTTPManager *http,
+  BucketTrimInstanceCollectCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
                               BucketTrimObserver *observer,
                               const std::vector<std::string>& buckets,
                               int max_concurrent)
@@ -718,7 +718,7 @@ class MetadataListCR : public RGWSimpleCoroutine {
 };
 
 class BucketTrimCR : public RGWCoroutine {
-  RGWRados *const store;
+  rgw::sal::RGWRadosStore *const store;
   RGWHTTPManager *const http;
   const BucketTrimConfig& config;
   BucketTrimObserver *const observer;
@@ -733,7 +733,7 @@ class BucketTrimCR : public RGWCoroutine {
 
   static const std::string section; //< metadata section for bucket instances
  public:
-  BucketTrimCR(RGWRados *store, RGWHTTPManager *http,
+  BucketTrimCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
                const BucketTrimConfig& config, BucketTrimObserver *observer,
                const rgw_raw_obj& obj)
     : RGWCoroutine(store->ctx()), store(store), http(http), config(config),
@@ -789,7 +789,7 @@ int BucketTrimCR::operate()
       // read BucketTrimStatus for marker position
       set_status("reading trim status");
       using ReadStatus = RGWSimpleRadosReadCR<BucketTrimStatus>;
-      yield call(new ReadStatus(store->svc.rados->get_async_processor(), store->svc.sysobj, obj,
+      yield call(new ReadStatus(store->svc()->rados->get_async_processor(), store->svc()->sysobj, obj,
                                 &status, true, &objv));
       if (retcode < 0) {
         ldout(cct, 10) << "failed to read bilog trim status: "
@@ -824,8 +824,8 @@ int BucketTrimCR::operate()
           return buckets.size() < config.buckets_per_interval;
         };
 
-        call(new MetadataListCR(cct, store->svc.rados->get_async_processor(),
-                                store->ctl.meta.mgr,
+        call(new MetadataListCR(cct, store->svc()->rados->get_async_processor(),
+                                store->ctl()->meta.mgr,
                                 section, status.marker, cb));
       }
       if (retcode < 0) {
@@ -848,7 +848,7 @@ int BucketTrimCR::operate()
       status.marker = std::move(last_cold_marker);
       ldout(cct, 20) << "writing bucket trim marker=" << status.marker << dendl;
       using WriteStatus = RGWSimpleRadosWriteCR<BucketTrimStatus>;
-      yield call(new WriteStatus(store->svc.rados->get_async_processor(), store->svc.sysobj, obj,
+      yield call(new WriteStatus(store->svc()->rados->get_async_processor(), store->svc()->sysobj, obj,
                                  status, &objv));
       if (retcode < 0) {
         ldout(cct, 4) << "failed to write updated trim status: "
@@ -881,7 +881,7 @@ int BucketTrimCR::operate()
 }
 
 class BucketTrimPollCR : public RGWCoroutine {
-  RGWRados *const store;
+  rgw::sal::RGWRadosStore *const store;
   RGWHTTPManager *const http;
   const BucketTrimConfig& config;
   BucketTrimObserver *const observer;
@@ -890,7 +890,7 @@ class BucketTrimPollCR : public RGWCoroutine {
   const std::string cookie;
 
  public:
-  BucketTrimPollCR(RGWRados *store, RGWHTTPManager *http,
+  BucketTrimPollCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
                    const BucketTrimConfig& config,
                    BucketTrimObserver *observer, const rgw_raw_obj& obj)
     : RGWCoroutine(store->ctx()), store(store), http(http),
@@ -910,7 +910,7 @@ int BucketTrimPollCR::operate()
 
       // prevent others from trimming for our entire wait interval
       set_status("acquiring trim lock");
-      yield call(new RGWSimpleRadosLockCR(store->svc.rados->get_async_processor(), store,
+      yield call(new RGWSimpleRadosLockCR(store->svc()->rados->get_async_processor(), store,
                                           obj, name, cookie,
                                           config.trim_interval_sec));
       if (retcode < 0) {
@@ -923,7 +923,7 @@ int BucketTrimPollCR::operate()
       if (retcode < 0) {
         // on errors, unlock so other gateways can try
         set_status("unlocking");
-        yield call(new RGWSimpleRadosUnlockCR(store->svc.rados->get_async_processor(), store,
+        yield call(new RGWSimpleRadosUnlockCR(store->svc()->rados->get_async_processor(), store,
                                               obj, name, cookie));
       }
     }
@@ -1004,7 +1004,7 @@ void configure_bucket_trim(CephContext *cct, BucketTrimConfig& config)
 class BucketTrimManager::Impl : public TrimCounters::Server,
                                 public BucketTrimObserver {
  public:
-  RGWRados *const store;
+   rgw::sal::RGWRadosStore *const store;
   const BucketTrimConfig config;
 
   const rgw_raw_obj status_obj;
@@ -1023,9 +1023,9 @@ class BucketTrimManager::Impl : public TrimCounters::Server,
   /// protect data shared between data sync, trim, and watch/notify threads
   std::mutex mutex;
 
-  Impl(RGWRados *store, const BucketTrimConfig& config)
+  Impl(rgw::sal::RGWRadosStore *store, const BucketTrimConfig& config)
     : store(store), config(config),
-      status_obj(store->svc.zone->get_zone_params().log_pool, BucketTrimStatus::oid),
+      status_obj(store->svc()->zone->get_zone_params().log_pool, BucketTrimStatus::oid),
       counter(config.counter_size),
       trimmed(config.recent_size, config.recent_duration),
       watcher(store, status_obj, this)
@@ -1061,7 +1061,7 @@ class BucketTrimManager::Impl : public TrimCounters::Server,
   }
 };
 
-BucketTrimManager::BucketTrimManager(RGWRados *store,
+BucketTrimManager::BucketTrimManager(rgw::sal::RGWRadosStore *store,
                                      const BucketTrimConfig& config)
   : impl(new Impl(store, config))
 {

--- a/src/rgw/rgw_trim_bilog.h
+++ b/src/rgw/rgw_trim_bilog.h
@@ -25,9 +25,12 @@
 class CephContext;
 class RGWCoroutine;
 class RGWHTTPManager;
-class RGWRados;
 
 namespace rgw {
+
+namespace sal {
+  class RGWRadosStore;
+}
 
 /// Interface to inform the trim process about which buckets are most active
 struct BucketChangeObserver {
@@ -69,7 +72,7 @@ class BucketTrimManager : public BucketChangeObserver {
   class Impl;
   std::unique_ptr<Impl> impl;
  public:
-  BucketTrimManager(RGWRados *store, const BucketTrimConfig& config);
+  BucketTrimManager(sal::RGWRadosStore *store, const BucketTrimConfig& config);
   ~BucketTrimManager();
 
   int init();

--- a/src/rgw/rgw_trim_datalog.h
+++ b/src/rgw/rgw_trim_datalog.h
@@ -7,14 +7,17 @@ class RGWCoroutine;
 class RGWRados;
 class RGWHTTPManager;
 class utime_t;
+namespace rgw { namespace sal {
+  class RGWRadosStore;
+} }
 
 // DataLogTrimCR factory function
-extern RGWCoroutine* create_data_log_trim_cr(RGWRados *store,
+extern RGWCoroutine* create_data_log_trim_cr(rgw::sal::RGWRadosStore *store,
                                              RGWHTTPManager *http,
                                              int num_shards, utime_t interval);
 
 // factory function for datalog trim via radosgw-admin
-RGWCoroutine* create_admin_data_log_trim_cr(RGWRados *store,
+RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RGWRadosStore *store,
                                             RGWHTTPManager *http,
                                             int num_shards,
                                             std::vector<std::string>& markers);

--- a/src/rgw/rgw_trim_mdlog.h
+++ b/src/rgw/rgw_trim_mdlog.h
@@ -8,15 +8,18 @@ class DoutPrefixProvider;
 class RGWRados;
 class RGWHTTPManager;
 class utime_t;
+namespace rgw { namespace sal {
+  class RGWRadosStore;
+} }
 
 // MetaLogTrimCR factory function
 RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp,
-                                      RGWRados *store,
+                                      rgw::sal::RGWRadosStore *store,
                                       RGWHTTPManager *http,
                                       int num_shards, utime_t interval);
 
 // factory function for mdlog trim via radosgw-admin
 RGWCoroutine* create_admin_meta_log_trim_cr(const DoutPrefixProvider *dpp,
-                                            RGWRados *store,
+                                            rgw::sal::RGWRadosStore *store,
                                             RGWHTTPManager *http,
                                             int num_shards);

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -26,12 +26,14 @@
 
 #define XMLNS_AWS_S3 "http://s3.amazonaws.com/doc/2006-03-01/"
 
-class RGWRados;
 class RGWUserCtl;
 class RGWBucketCtl;
 class RGWUserBuckets;
 
 class RGWGetUserStats_CB;
+namespace rgw { namespace sal {
+class RGWRadosStore;
+} }
 
 /**
  * A string wrapper that includes encode/decode functions
@@ -55,8 +57,8 @@ struct RGWUID
 };
 WRITE_CLASS_ENCODER(RGWUID)
 
-extern int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id);
-extern int rgw_user_get_all_buckets_stats(RGWRados *store, const rgw_user& user_id, map<string, cls_user_bucket_entry>&buckets_usage_map);
+extern int rgw_user_sync_all_stats(rgw::sal::RGWRadosStore *store, const rgw_user& user_id);
+extern int rgw_user_get_all_buckets_stats(rgw::sal::RGWRadosStore *store, const rgw_user& user_id, map<string, cls_user_bucket_entry>&buckets_usage_map);
 
 /**
  * Get the anonymous (ie, unauthenticated) user info.
@@ -552,7 +554,7 @@ class RGWAccessKeyPool
 
   std::map<std::string, int, ltstr_nocase> key_type_map;
   rgw_user user_id;
-  RGWRados *store{nullptr};
+  rgw::sal::RGWRadosStore *store{nullptr};
   RGWUserCtl *user_ctl{nullptr};
 
   map<std::string, RGWAccessKey> *swift_keys{nullptr};
@@ -595,7 +597,7 @@ class RGWSubUserPool
   RGWUser *user{nullptr};
 
   rgw_user user_id;
-  RGWRados *store{nullptr};
+  rgw::sal::RGWRadosStore *store{nullptr};
   RGWUserCtl *user_ctl{nullptr};
   bool subusers_allowed{false};
 
@@ -653,7 +655,7 @@ class RGWUser
 
 private:
   RGWUserInfo old_info;
-  RGWRados *store{nullptr};
+  rgw::sal::RGWRadosStore *store{nullptr};
   RGWUserCtl *user_ctl{nullptr};
 
   rgw_user user_id;
@@ -679,13 +681,13 @@ private:
 public:
   RGWUser();
 
-  int init(RGWRados *storage, RGWUserAdminOpState& op_state);
+  int init(rgw::sal::RGWRadosStore *storage, RGWUserAdminOpState& op_state);
 
-  int init_storage(RGWRados *storage);
+  int init_storage(rgw::sal::RGWRadosStore *storage);
   int init(RGWUserAdminOpState& op_state);
   int init_members(RGWUserAdminOpState& op_state);
 
-  RGWRados *get_store() { return store; }
+  rgw::sal::RGWRadosStore *get_store() { return store; }
   RGWUserCtl *get_user_ctl() { return user_ctl; }
 
   /* API Contracted Members */
@@ -724,52 +726,52 @@ public:
 class RGWUserAdminOp_User
 {
 public:
-  static int list(RGWRados *store,
+  static int list(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
-  static int info(RGWRados *store,
+  static int info(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
-  static int create(RGWRados *store,
+  static int create(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
-  static int modify(RGWRados *store,
+  static int modify(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
-  static int remove(RGWRados *store,
+  static int remove(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y);
 };
 
 class RGWUserAdminOp_Subuser
 {
 public:
-  static int create(RGWRados *store,
+  static int create(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
-  static int modify(RGWRados *store,
+  static int modify(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
-  static int remove(RGWRados *store,
+  static int remove(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 };
 
 class RGWUserAdminOp_Key
 {
 public:
-  static int create(RGWRados *store,
+  static int create(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
-  static int remove(RGWRados *store,
+  static int remove(rgw::sal::RGWRadosStore *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 };
 
 class RGWUserAdminOp_Caps
 {
 public:
-  static int add(RGWRados *store,
+  static int add(rgw::sal::RGWRadosStore *store,
 		  RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
-  static int remove(RGWRados *store,
+  static int remove(rgw::sal::RGWRadosStore *store,
 		  RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 };
 

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1340,10 +1340,10 @@ void RGWPeriod::fork()
   realm_epoch++;
 }
 
-static int read_sync_status(RGWRados *store, rgw_meta_sync_status *sync_status)
+static int read_sync_status(rgw::sal::RGWRadosStore *store, rgw_meta_sync_status *sync_status)
 {
   // initialize a sync status manager to read the status
-  RGWMetaSyncStatusManager mgr(store, store->svc.rados->get_async_processor());
+  RGWMetaSyncStatusManager mgr(store, store->svc()->rados->get_async_processor());
   int r = mgr.init();
   if (r < 0) {
     return r;
@@ -1353,7 +1353,7 @@ static int read_sync_status(RGWRados *store, rgw_meta_sync_status *sync_status)
   return r;
 }
 
-int RGWPeriod::update_sync_status(RGWRados *store, /* for now */
+int RGWPeriod::update_sync_status(rgw::sal::RGWRadosStore *store, /* for now */
 				  const RGWPeriod &current_period,
                                   std::ostream& error_stream,
                                   bool force_if_stale)
@@ -1403,7 +1403,7 @@ int RGWPeriod::update_sync_status(RGWRados *store, /* for now */
   return 0;
 }
 
-int RGWPeriod::commit(RGWRados *store,
+int RGWPeriod::commit(rgw::sal::RGWRadosStore *store,
 		      RGWRealm& realm, const RGWPeriod& current_period,
                       std::ostream& error_stream, bool force_if_stale)
 {

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -1026,7 +1026,7 @@ class RGWPeriod
   const std::string get_period_oid_prefix() const;
 
   // gather the metadata sync status for each shard; only for use on master zone
-  int update_sync_status(RGWRados *store,
+  int update_sync_status(rgw::sal::RGWRadosStore *store,
                          const RGWPeriod &current_period,
                          std::ostream& error_stream, bool force_if_stale);
 
@@ -1120,7 +1120,7 @@ public:
   int update();
 
   // commit a staging period; only for use on master zone
-  int commit(RGWRados *store,
+  int commit(rgw::sal::RGWRadosStore *store,
              RGWRealm& realm, const RGWPeriod &current_period,
              std::ostream& error_stream, bool force_if_stale = false);
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -820,11 +820,11 @@ TEST_F(IPPolicyTest, IPEnvironment) {
   // Unfortunately RGWCivetWeb is too tightly tied to civetweb to test RGWCivetWeb::init_env.
   RGWEnv rgw_env;
   RGWUserInfo user;
-  RGWRados rgw_rados;
+  rgw::sal::RGWRadosStore store;
   rgw_env.set("REMOTE_ADDR", "192.168.1.1");
   rgw_env.set("HTTP_HOST", "1.2.3.4");
   req_state rgw_req_state(cct.get(), &rgw_env, &user, 0);
-  rgw_build_iam_environment(&rgw_rados, &rgw_req_state);
+  rgw_build_iam_environment(&store, &rgw_req_state);
   auto ip = rgw_req_state.env.find("aws:SourceIp");
   ASSERT_NE(ip, rgw_req_state.env.end());
   EXPECT_EQ(ip->second, "192.168.1.1");
@@ -832,13 +832,13 @@ TEST_F(IPPolicyTest, IPEnvironment) {
   ASSERT_EQ(cct.get()->_conf.set_val("rgw_remote_addr_param", "SOME_VAR"), 0);
   EXPECT_EQ(cct.get()->_conf->rgw_remote_addr_param, "SOME_VAR");
   rgw_req_state.env.clear();
-  rgw_build_iam_environment(&rgw_rados, &rgw_req_state);
+  rgw_build_iam_environment(&store, &rgw_req_state);
   ip = rgw_req_state.env.find("aws:SourceIp");
   EXPECT_EQ(ip, rgw_req_state.env.end());
 
   rgw_env.set("SOME_VAR", "192.168.1.2");
   rgw_req_state.env.clear();
-  rgw_build_iam_environment(&rgw_rados, &rgw_req_state);
+  rgw_build_iam_environment(&store, &rgw_req_state);
   ip = rgw_req_state.env.find("aws:SourceIp");
   ASSERT_NE(ip, rgw_req_state.env.end());
   EXPECT_EQ(ip->second, "192.168.1.2");
@@ -846,14 +846,14 @@ TEST_F(IPPolicyTest, IPEnvironment) {
   ASSERT_EQ(cct.get()->_conf.set_val("rgw_remote_addr_param", "HTTP_X_FORWARDED_FOR"), 0);
   rgw_env.set("HTTP_X_FORWARDED_FOR", "192.168.1.3");
   rgw_req_state.env.clear();
-  rgw_build_iam_environment(&rgw_rados, &rgw_req_state);
+  rgw_build_iam_environment(&store, &rgw_req_state);
   ip = rgw_req_state.env.find("aws:SourceIp");
   ASSERT_NE(ip, rgw_req_state.env.end());
   EXPECT_EQ(ip->second, "192.168.1.3");
 
   rgw_env.set("HTTP_X_FORWARDED_FOR", "192.168.1.4, 4.3.2.1, 2001:db8:85a3:8d3:1319:8a2e:370:7348");
   rgw_req_state.env.clear();
-  rgw_build_iam_environment(&rgw_rados, &rgw_req_state);
+  rgw_build_iam_environment(&store, &rgw_req_state);
   ip = rgw_req_state.env.find("aws:SourceIp");
   ASSERT_NE(ip, rgw_req_state.env.end());
   EXPECT_EQ(ip->second, "192.168.1.4");


### PR DESCRIPTION
This is the first part of Project Zipper, the Store Abstraction Layer.
It introduces the basic framework, and wraps RGWRados in RGWRadosStore.
The goal over the next few weeks is to do the same for user, bucket, and
object.  This will make most of the remaining users of RGWRados wrapped
in SAL classes, allowing it to be completely absorbed into the private
RGWRadosStore.  This will also expose all the APIs that need to be
pusheg up to higher layers in the SAL.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>