### PR TITLE
mgr/progress: fix dictionary change during iteration error

### DIFF
--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -364,7 +364,8 @@ class Module(MgrModule):
         # In the case of the osd coming back in, we might need to cancel 
         # previous recovery event for that osd
         if marked == "in":
-            for ev_id, ev in self._events.items():
+            for ev_id in list(self._events):
+                ev = self._events[ev_id]
                 if isinstance(ev, PgRecoveryEvent) and osd_id in ev.evacuating_osds:
                     self.log.info("osd.{0} came back in, cancelling event".format(
                         osd_id
@@ -416,7 +417,8 @@ class Module(MgrModule):
             self._osdmap_changed(old_osdmap, self._latest_osdmap)
         elif notify_type == "pg_summary":
             data = self.get("pg_dump")
-            for ev_id, ev in self._events.items():
+            for ev_id in list(self._events):
+                ev = self._events[ev_id]
                 if isinstance(ev, PgRecoveryEvent):
                     ev.pg_update(data, self.log)
                     self.maybe_complete(ev)


### PR DESCRIPTION
Provide a fix for the bug where
there is runtime error for when
dictionary change during iteration.
Fix by just making a copy of the
dictionary using list()

Fixes: http://tracker.ceph.com/issues/40618
Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

