### PR TITLE
mgr/telemetry: channels

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -7,18 +7,33 @@ The telemetry module sends anonymous data about the cluster back to the Ceph
 developers to help understand how Ceph is used and what problems users may
 be experiencing.
 
-Reported telemetry includes:
+Channels
+--------
 
-  * capacity of the cluster 
-  * number of monitors, managers, OSDs, MDSs, radosgws, or other daemons
-  * software version currently being used
-  * number and types of RADOS pools and CephFS file systems
-  * information about daemon crashes, including
+The telemetry report is broken down into several "channels," each with
+a different type of information.  Assuming telemetry has been enabled,
+individual channels can be turned on and off.  (If telemetry is off,
+the per-channel setting has no effect.)
+
+* **basic** (default: on): Basic information about the cluster
+
+    - capacity of the cluster
+    - number of monitors, managers, OSDs, MDSs, radosgws, or other daemons
+    - software version currently being used
+    - number and types of RADOS pools and CephFS file systems
+
+* **crash** (default: on): Information about daemon crashes, including
 
     - type of daemon
     - version of the daemon
     - operating system (OS distribution, kernel version)
     - stack trace identifying where in the Ceph code the crash occurred
+
+* **ident** (default: on): User-provided identifying information about
+  the cluster
+
+    - cluster description
+    - contact email address
 
 The data being reported does *not* contain any sensitive
 data like pool names, object names, object contents, or hostnames.
@@ -30,26 +45,43 @@ the way Ceph is used.
 
 Data is sent over HTTPS to *telemetry.ceph.com*.
 
+Enabling the module
+-------------------
+
+The module must first be enabled.  Note that even if the module is
+enabled, telemetry is still "off" by default, so simply enabling the
+module will *NOT* result in any data being shared.::
+
+  ceph mgr module enable telemetry
+
 Sample report
 -------------
 
 You can look at what data is reported at any time with the command::
 
-  ceph mgr module enable telemetry
   ceph telemetry show
 
 If you have any concerns about privacy with regard to the information included in
 this report, please contact the Ceph developers.
 
-Enabling
+Channels
 --------
 
-The *telemetry* module is enabled with::
+Individual channels can be enabled or disabled with::
 
-  ceph mgr module enable telemetry
+  ceph config set mgr mgr/telemetry/channel_ident false
+  ceph config set mgr mgr/telemetry/channel_basic false
+  ceph config set mgr mgr/telemetry/channel_crash false
+  ceph telemetry show
+
+Enabling Telemetry
+------------------
+
+To allow the *telemetry* module to start sharing data,::
+
   ceph telemetry on
 
-Telemetry can be disabled with::
+Telemetry can be disabled at any time with::
 
   ceph telemetry off
 
@@ -64,16 +96,10 @@ You can adjust this interval with::
 Contact and Description
 -----------------------
 
-A contact and description can be added to the report.  This is completely optional.::
+A contact and description can be added to the report.  This is
+completely optional, and disabled by default.::
 
   ceph config set mgr mgr/telemetry/contact 'John Doe <john.doe@example.com>'
   ceph config set mgr mgr/telemetry/description 'My first Ceph cluster'
+  ceph config set mgr mgr/telemetry/channel_ident true
 
-Show report
------------
-
-The report is sent in JSON format, and can be printed::
-
-  ceph telemetry show
-
-So you can inspect the content if you have privacy concerns.

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -631,3 +631,7 @@ class Module(MgrModule):
                 return self.remote(plugin_name, 'predict_all_devices')
         except:
             return -1, '', 'unable to invoke diskprediction local or remote plugin'
+
+    def gather_device_report(self):
+        # write me
+        return {}

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -333,9 +333,7 @@ class Module(MgrModule):
             )
 
         elif command['prefix'] == 'telemetry show':
-            report = self.last_report
-            if not report:
-                report = self.compile_report()
+            report = self.compile_report()
             return 0, json.dumps(report, indent=4), ''
         else:
             return (-errno.EINVAL, '',

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 from mgr_module import MgrModule
 
+ALL_CHANNELS = ['basic', 'crash', 'device']
 
 class Module(MgrModule):
     config = dict()
@@ -105,7 +106,8 @@ class Module(MgrModule):
             "perm": "rw"
         },
         {
-            "cmd": "telemetry show",
+            "cmd": "telemetry show "
+                   "name=channels,type=CephString,n=N,req=False",
             "desc": "Show last report or report to be sent",
             "perm": "r"
         },
@@ -215,13 +217,16 @@ class Module(MgrModule):
         except:
             return None
 
-    def compile_report(self):
+    def compile_report(self, channels=[]):
+        if not channels:
+            channels = self.get_active_channels()
         report = {
             'leaderboard': False,
             'report_version': 1,
             'report_timestamp': datetime.utcnow().isoformat(),
             'report_id': self.report_id,
-            'channels': self.get_active_channels(),
+            'channels': channels,
+            'channels_available': ALL_CHANNELS,
         }
 
         if self.leaderboard:
@@ -230,7 +235,7 @@ class Module(MgrModule):
         for option in ['description', 'contact', 'organization']:
             report[option] = getattr(self, option)
 
-        if self.channel_basic:
+        if 'basic' in channels:
             mon_map = self.get('mon_map')
             osd_map = self.get('osd_map')
             service_map = self.get('service_map')
@@ -286,10 +291,10 @@ class Module(MgrModule):
             for key, value in service_map['services'].items():
                 report['services'][key] += 1
 
-        if self.channel_crash:
+        if 'crash' in channels:
             report['crashes'] = self.gather_crashinfo()
 
-        if self.channel_devices:
+        if 'device' in channels:
             report['devices'] = self.gather_device_report()
 
         return report
@@ -333,7 +338,9 @@ class Module(MgrModule):
             )
 
         elif command['prefix'] == 'telemetry show':
-            report = self.compile_report()
+            report = self.compile_report(
+                channels=command.get('channels', None)
+            )
             return 0, json.dumps(report, indent=4), ''
         else:
             return (-errno.EINVAL, '',

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -72,7 +72,19 @@ class Module(MgrModule):
             'type': 'int',
             'default': 24,
             'min': 8
-        }
+        },
+        {
+            'name': 'channel_basic',
+            'type': 'bool',
+            'default': True,
+            'description': 'Share basic cluster information (size, version)',
+        },
+        {
+            'name': 'channel_crash',
+            'type': 'bool',
+            'default': True,
+            'description': 'Share metadata about Ceph daemon crashes (version, stack straces, etc)',
+        },
     ]
 
     COMMANDS = [
@@ -181,11 +193,21 @@ class Module(MgrModule):
             crashlist.append(c)
         return crashlist
 
+    def get_active_channels(self):
+        r = []
+        if self.channel_basic:
+            r.append('basic')
+        if self.channel_crash:
+            r.append('crash')
+        return r
+
     def compile_report(self):
         report = {
             'leaderboard': False,
             'report_version': 1,
-            'report_timestamp': datetime.utcnow().isoformat()
+            'report_timestamp': datetime.utcnow().isoformat(),
+            'report_id': self.report_id,
+            'channels': self.get_active_channels(),
         }
 
         if self.leaderboard:
@@ -194,63 +216,64 @@ class Module(MgrModule):
         for option in ['description', 'contact', 'organization']:
             report[option] = getattr(self, option)
 
-        mon_map = self.get('mon_map')
-        osd_map = self.get('osd_map')
-        service_map = self.get('service_map')
-        fs_map = self.get('fs_map')
-        df = self.get('df')
+        if self.channel_basic:
+            mon_map = self.get('mon_map')
+            osd_map = self.get('osd_map')
+            service_map = self.get('service_map')
+            fs_map = self.get('fs_map')
+            df = self.get('df')
 
-        report['report_id'] = self.report_id
-        report['created'] = mon_map['created']
+            report['created'] = mon_map['created']
 
-        report['mon'] = {
-            'count': len(mon_map['mons']),
-            'features': mon_map['features']
-        }
+            report['mon'] = {
+                'count': len(mon_map['mons']),
+                'features': mon_map['features']
+            }
 
-        num_pg = 0
-        report['pools'] = list()
-        for pool in osd_map['pools']:
-            num_pg += pool['pg_num']
-            report['pools'].append(
-                {
-                    'pool': pool['pool'],
-                    'type': pool['type'],
-                    'pg_num': pool['pg_num'],
-                    'pgp_num': pool['pg_placement_num'],
-                    'size': pool['size'],
-                    'min_size': pool['min_size'],
-                    'crush_rule': pool['crush_rule']
-                }
-            )
+            num_pg = 0
+            report['pools'] = list()
+            for pool in osd_map['pools']:
+                num_pg += pool['pg_num']
+                report['pools'].append(
+                    {
+                        'pool': pool['pool'],
+                        'type': pool['type'],
+                        'pg_num': pool['pg_num'],
+                        'pgp_num': pool['pg_placement_num'],
+                        'size': pool['size'],
+                        'min_size': pool['min_size'],
+                        'crush_rule': pool['crush_rule']
+                    }
+                )
 
-        report['osd'] = {
-            'count': len(osd_map['osds']),
-            'require_osd_release': osd_map['require_osd_release'],
-            'require_min_compat_client': osd_map['require_min_compat_client']
-        }
+            report['osd'] = {
+                'count': len(osd_map['osds']),
+                'require_osd_release': osd_map['require_osd_release'],
+                'require_min_compat_client': osd_map['require_min_compat_client']
+            }
 
-        report['fs'] = {
-            'count': len(fs_map['filesystems'])
-        }
+            report['fs'] = {
+                'count': len(fs_map['filesystems'])
+            }
 
-        report['metadata'] = dict()
-        report['metadata']['osd'] = self.gather_osd_metadata(osd_map)
-        report['metadata']['mon'] = self.gather_mon_metadata(mon_map)
+            report['metadata'] = dict()
+            report['metadata']['osd'] = self.gather_osd_metadata(osd_map)
+            report['metadata']['mon'] = self.gather_mon_metadata(mon_map)
 
-        report['usage'] = {
-            'pools': len(df['pools']),
-            'pg_num:': num_pg,
-            'total_used_bytes': df['stats']['total_used_bytes'],
-            'total_bytes': df['stats']['total_bytes'],
-            'total_avail_bytes': df['stats']['total_avail_bytes']
-        }
+            report['usage'] = {
+                'pools': len(df['pools']),
+                'pg_num:': num_pg,
+                'total_used_bytes': df['stats']['total_used_bytes'],
+                'total_bytes': df['stats']['total_bytes'],
+                'total_avail_bytes': df['stats']['total_avail_bytes']
+            }
 
-        report['services'] = defaultdict(int)
-        for key, value in service_map['services'].items():
-            report['services'][key] += 1
+            report['services'] = defaultdict(int)
+            for key, value in service_map['services'].items():
+                report['services'][key] += 1
 
-        report['crashes'] = self.gather_crashinfo()
+        if self.channel_crash:
+            report['crashes'] = self.gather_crashinfo()
 
         return report
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 
 from mgr_module import MgrModule
 
-ALL_CHANNELS = ['basic', 'crash', 'device']
+ALL_CHANNELS = ['basic', 'ident', 'crash', 'device']
 
 class Module(MgrModule):
     config = dict()
@@ -79,6 +79,12 @@ class Module(MgrModule):
             'type': 'bool',
             'default': True,
             'description': 'Share basic cluster information (size, version)',
+        },
+        {
+            'name': 'channel_ident',
+            'type': 'bool',
+            'default': False,
+            'description': 'Share a user-provided description and/or contact email for the cluster',
         },
         {
             'name': 'channel_crash',
@@ -229,11 +235,11 @@ class Module(MgrModule):
             'channels_available': ALL_CHANNELS,
         }
 
-        if self.leaderboard:
-            report['leaderboard'] = True
-
-        for option in ['description', 'contact', 'organization']:
-            report[option] = getattr(self, option)
+        if 'ident' in channels:
+            if self.leaderboard:
+                report['leaderboard'] = True
+            for option in ['description', 'contact', 'organization']:
+                report[option] = getattr(self, option)
 
         if 'basic' in channels:
             mon_map = self.get('mon_map')

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -209,6 +209,12 @@ class Module(MgrModule):
             r.append('device')
         return r
 
+    def gather_device_report(self):
+        try:
+            return self.remote('devicehealth', 'gather_device_report')
+        except:
+            return None
+
     def compile_report(self):
         report = {
             'leaderboard': False,
@@ -282,6 +288,9 @@ class Module(MgrModule):
 
         if self.channel_crash:
             report['crashes'] = self.gather_crashinfo()
+
+        if self.channel_devices:
+            report['devices'] = self.gather_device_report()
 
         return report
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -85,6 +85,12 @@ class Module(MgrModule):
             'default': True,
             'description': 'Share metadata about Ceph daemon crashes (version, stack straces, etc)',
         },
+        {
+            'name': 'channel_device',
+            'type': 'bool',
+            'default': True,
+            'description': 'Share device health metrics (e.g., SMART data)',
+        },
     ]
 
     COMMANDS = [
@@ -199,6 +205,8 @@ class Module(MgrModule):
             r.append('basic')
         if self.channel_crash:
             r.append('crash')
+        if self.channel_device:
+            r.append('device')
         return r
 
     def compile_report(self):


### PR DESCRIPTION
The main idea here is to separate phone-home telemetry into a number of different channels that can be enabled and disabled independently.

- *basic* is the basic stuff about the cluster (size, version, etc.)
- *crash* is the crash dumps
- *ident* includes the optional contact information, and is off by default
- *device* will eventually be health (SMART) metrics, but is not yet implemented.
