### PR TITLE
common/OpTracker: [RFC] Event Optimzation

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -434,15 +434,14 @@ void OpTracker::get_age_ms_histogram(pow2_hist_t *h)
 #undef dout_context
 #define dout_context tracker->cct
 
-void TrackedOp::mark_event_string(const string &event, utime_t stamp)
+void TrackedOp::mark_event_string(std::string_view event, utime_t stamp)
 {
   if (!state)
     return;
 
   {
-    std::lock_guard l(lock);
     events.emplace_back(stamp, event);
-    current = events.back().c_str();
+    current = events.back()->c_str();
   }
   dout(6) << " seq: " << seq
 	  << ", time: " << stamp
@@ -458,7 +457,6 @@ void TrackedOp::mark_event(const char *event, utime_t stamp)
     return;
 
   {
-    std::lock_guard l(lock);
     events.emplace_back(stamp, event);
     current = event;
   }

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -390,7 +390,7 @@ bool OpTracker::check_ops_in_flight(std::string* summary,
     ss << "slow request " << age << " seconds old, received at "
        << op.get_initiated() << ": " << op.get_desc()
        << " currently "
-       << op.state_string();
+       << (op.current ? op.current : op.state_string());
     warnings.push_back(ss.str());
     // only those that have been shown will backoff
     op.warn_interval_multiplier *= 2;
@@ -434,7 +434,7 @@ void OpTracker::get_age_ms_histogram(pow2_hist_t *h)
 #undef dout_context
 #define dout_context tracker->cct
 
-void TrackedOp::mark_event(std::string_view event, utime_t stamp)
+void TrackedOp::mark_event_string(const string &event, utime_t stamp)
 {
   if (!state)
     return;
@@ -442,6 +442,25 @@ void TrackedOp::mark_event(std::string_view event, utime_t stamp)
   {
     std::lock_guard l(lock);
     events.emplace_back(stamp, event);
+    current = events.back().c_str();
+  }
+  dout(6) << " seq: " << seq
+	  << ", time: " << stamp
+	  << ", event: " << event
+	  << ", op: " << get_desc()
+	  << dendl;
+  _event_marked();
+}
+
+void TrackedOp::mark_event(const char *event, utime_t stamp)
+{
+  if (!state)
+    return;
+
+  {
+    std::lock_guard l(lock);
+    events.emplace_back(stamp, event);
+    current = event;
   }
   dout(6) << " seq: " << seq
 	  << ", time: " << stamp

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -15,6 +15,7 @@
 #define TRACKEDREQUEST_H_
 
 #include <atomic>
+#include <stdexcept>
 #include "common/histogram.h"
 #include "common/RWLock.h"
 #include "common/Thread.h"
@@ -22,8 +23,7 @@
 #include "common/ceph_mutex.h"
 #include "include/spinlock.h"
 #include "msg/Message.h"
-
-#define OPTRACKER_PREALLOC_EVENTS 20
+#include "include/ceph_assert.h"
 
 class TrackedOp;
 class OpHistory;
@@ -233,34 +233,121 @@ protected:
   utime_t initiated_at;
 
   struct Event {
-    utime_t stamp;
-    string str;
-    const char *cstr = nullptr;
+    utime_t stamp_;
+    string str_;
+    const char *cstr_ = nullptr;
 
-    Event(utime_t t, const string& s) : stamp(t), str(s) {}
-    Event(utime_t t, const char *s) : stamp(t), cstr(s) {}
+    Event() {};
+    Event(utime_t t, std::string_view s) : stamp_(t), str_(s) {}
+    Event(utime_t t, const char *s) : stamp_(t), cstr_(s) {}
 
-    int compare(const char *s) const {
-      if (cstr)
-	return strcmp(cstr, s);
+    void set(utime_t t, std::string_view s) {
+      stamp_ = t;
+      str_ = s;
+    }
+
+    void set(utime_t t, const char* s) {
+      stamp_ = t;
+      cstr_ = s;
+    }
+
+    const utime_t stamp() const {
+      return stamp_;
+    }
+
+    const int compare(const char *s) const {
+      if (cstr_)
+	return strcmp(cstr_, s);
       else
-	return str.compare(s);
+	return str_.compare(s);
     }
 
     const char *c_str() const {
-      if (cstr)
-	return cstr;
+      if (cstr_)
+	return cstr_;
       else
-	return str.c_str();
+	return str_.c_str();
     }
 
     void dump(ceph::Formatter *f) const {
-      f->dump_stream("time") << stamp;
+      f->dump_stream("time") << stamp_;
       f->dump_string("event", c_str());
     }
   };
 
-  std::vector<Event> events;    ///< std::list of events and their times
+  // Semi-Lockless append only list with reserved items
+  template<class T>
+  class AppendList {
+    static constexpr size_t RESERVED_ITEMS = 16;
+
+  private:
+    // pre-initialized array with atomic index
+    std::array<T, RESERVED_ITEMS> arr;
+    std::atomic<size_t> reservation_ = 0;
+    std::atomic<size_t> size_ = 0;
+    // Expansion storage with lock
+    std::vector<T> vec;
+    mutable ceph::mutex lock = ceph::make_mutex("AppendList::lock");
+
+  public:
+    AppendList() {};
+
+    template<class... Args>
+    void emplace_back(Args&&... args) {
+      size_t r = reservation_++;
+
+      // Someone else got a prior reservation so wait until they've written it.
+      while (r > size_) {
+        continue;
+      }
+      
+      if (r < size_) {
+        ceph_assert("Trying to insert element before existing element.");
+      }
+
+      // It's our time to write
+      if (r < RESERVED_ITEMS) {
+        arr[r].set(std::forward<Args>(args)...);
+      } else {
+        std::lock_guard l(lock);
+        // Initialize vec to double capacity when we first start using it.
+        if (r == RESERVED_ITEMS)
+          vec.reserve(RESERVED_ITEMS);
+        vec.emplace_back(std::forward<Args>(args)...);
+      }
+      size_++;
+    }
+
+    const size_t size() const {
+      return size_;
+    }
+
+    const bool empty() const {
+      return (size_ == 0) ? true : false;
+    }
+
+    const T* at(size_t index) const {
+      if (index > size_)
+        return nullptr;
+      if (index < RESERVED_ITEMS)
+        return &arr[index];
+      std::lock_guard l(lock);
+      return &vec[index - RESERVED_ITEMS];
+    }
+
+    const T* back() const {
+      size_t s = size_;
+      if (s == 0)
+        return nullptr;
+      size_t index = s - 1;
+      if (index < RESERVED_ITEMS)
+        return &arr[index];
+      std::lock_guard l(lock);
+      return &vec[index - RESERVED_ITEMS];
+    }
+  };
+
+  AppendList<Event> events;
   mutable ceph::mutex lock = ceph::make_mutex("TrackedOp::lock"); ///< to protect the events list
   const char *current = 0; ///< the current state the event is in
   uint64_t seq = 0;        ///< a unique value set by the OpTracker
@@ -282,7 +369,6 @@ protected:
     tracker(_tracker),
     initiated_at(initiated)
   {
-    events.reserve(OPTRACKER_PREALLOC_EVENTS);
   }
 
   /// output any type-specific data you want to get when dump() is called
@@ -367,14 +453,15 @@ public:
   }
 
   double get_duration() const {
-    std::lock_guard l(lock);
-    if (!events.empty() && events.rbegin()->compare("done") == 0)
-      return events.rbegin()->stamp - get_initiated();
-    else
-      return ceph_clock_now() - get_initiated();
+    if (!events.empty()) {
+      const Event* e = events.back();
+      if (e->compare("done") == 0)
+        return e->stamp() - get_initiated();
+    }
+    return ceph_clock_now() - get_initiated();
   }
 
-  void mark_event_string(const string &event,
+  void mark_event_string(std::string_view event,
 			 utime_t stamp=ceph_clock_now());
   void mark_event(const char *event,
 		  utime_t stamp=ceph_clock_now());
@@ -384,8 +471,7 @@ public:
   }
 
   virtual const char *state_string() const {
-    std::lock_guard l(lock);
-    return events.rbegin()->c_str();
+    return (events.empty()) ? "" : events.back()->c_str();
   }
 
   void dump(utime_t now, ceph::Formatter *f) const;

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -124,7 +124,7 @@ public:
     linkage.remote_d_type = dt;
   }
 
-  std::string_view pin_name(int p) const override {
+  const char *pin_name(int p) const override {
     switch (p) {
     case PIN_INODEPIN: return "inodepin";
     case PIN_FRAGMENTING: return "fragmenting";

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -62,7 +62,7 @@ public:
   static const int PIN_EXPORTBOUND = 10;
   static const int PIN_STICKY =      11;
   static const int PIN_SUBTREETEMP = 12;  // used by MDCache::trim_non_auth()
-  std::string_view pin_name(int p) const override {
+  const char *pin_name(int p) const override {
     switch (p) {
     case PIN_DNWAITER: return "dnwaiter";
     case PIN_INOWAITER: return "inowaiter";
@@ -469,6 +469,9 @@ protected:
  public:
   CDentry* lookup_exact_snap(std::string_view dname, snapid_t last);
   CDentry* lookup(std::string_view n, snapid_t snap=CEPH_NOSNAP);
+  CDentry* lookup(const char *n, snapid_t snap=CEPH_NOSNAP) {
+    return lookup(std::string_view(n), snap);
+  }
 
   CDentry* add_null_dentry(std::string_view dname,
 			   snapid_t first=2, snapid_t last=CEPH_NOSNAP);

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1077,12 +1077,10 @@ struct C_IO_Inode_Stored : public CInodeIOContext {
   }
 };
 
-object_t InodeStoreBase::get_object_name(inodeno_t ino, frag_t fg, std::string_view suffix)
+object_t InodeStoreBase::get_object_name(inodeno_t ino, frag_t fg, const char *suffix)
 {
   char n[60];
-  snprintf(n, sizeof(n), "%llx.%08llx", (long long unsigned)ino, (long long unsigned)fg);
-  ceph_assert(strlen(n) + suffix.size() < sizeof n);
-  strncat(n, suffix.data(), suffix.size());
+  snprintf(n, sizeof(n), "%llx.%08llx%s", (long long unsigned)ino, (long long unsigned)fg, suffix ? suffix : "");
   return object_t(n);
 }
 
@@ -2062,7 +2060,7 @@ void CInode::finish_scatter_update(ScatterLock *lock, CDir *dir,
       mempool_inode *pi = get_projected_inode();
       fnode_t *pf = dir->project_fnode();
 
-      std::string_view ename;
+      const char *ename = 0;
       switch (lock->get_type()) {
       case CEPH_LOCK_IFILE:
 	pf->fragstat.version = pi->dirstat.version;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -94,7 +94,7 @@ public:
   bool is_file() const    { return inode.is_file(); }
   bool is_symlink() const { return inode.is_symlink(); }
   bool is_dir() const     { return inode.is_dir(); }
-  static object_t get_object_name(inodeno_t ino, frag_t fg, std::string_view suffix);
+  static object_t get_object_name(inodeno_t ino, frag_t fg, const char *suffix);
 
   /* Full serialization for use in ".inode" root inode objects */
   void encode(bufferlist &bl, uint64_t features, const bufferlist *snap_blob=NULL) const;
@@ -175,7 +175,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int PIN_DIRWAITER =        24;
   static const int PIN_SCRUBQUEUE =       25;
 
-  std::string_view pin_name(int p) const override {
+  const char *pin_name(int p) const override {
     switch (p) {
     case PIN_DIRFRAG: return "dirfrag";
     case PIN_CAPS: return "caps";

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -193,9 +193,9 @@ void Locker::include_snap_rdlocks_wlayout(CInode *in, MutationImpl::LockOpVec& l
 
 struct MarkEventOnDestruct {
   MDRequestRef& mdr;
-  std::string_view message;
+  const char* message;
   bool mark_event;
-  MarkEventOnDestruct(MDRequestRef& _mdr, std::string_view _message) :
+  MarkEventOnDestruct(MDRequestRef& _mdr, const char *_message) :
       mdr(_mdr),
       message(_message),
       mark_event(true) {}
@@ -5278,7 +5278,7 @@ void Locker::handle_file_lock(ScatterLock *lock, const cref_t<MLock> &m)
     }
   }
 
-  dout(7) << "handle_file_lock a=" << lock->get_lock_action_name(m->get_action())
+  dout(7) << "handle_file_lock a=" << get_lock_action_name(m->get_action())
 	  << " on " << *lock
 	  << " from mds." << from << " " 
 	  << *in << dendl;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -496,7 +496,7 @@ struct C_MDC_CreateSystemFile : public MDCacheLogContext {
   }
 };
 
-void MDCache::_create_system_file(CDir *dir, std::string_view name, CInode *in, MDSContext *fin)
+void MDCache::_create_system_file(CDir *dir, const char *name, CInode *in, MDSContext *fin)
 {
   dout(10) << "_create_system_file " << name << " in " << *dir << dendl;
   CDentry *dn = dir->add_null_dentry(name);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -978,7 +978,7 @@ public:
   void open_mydir_frag(MDSContext *c);
   void populate_mydir();
 
-  void _create_system_file(CDir *dir, std::string_view name, CInode *in, MDSContext *fin);
+  void _create_system_file(CDir *dir, const char *name, CInode *in, MDSContext *fin);
   void _create_system_file_finish(MutationRef& mut, CDentry *dn,
                                   version_t dpv, MDSContext *fin);
 

--- a/src/mds/MDSCacheObject.cc
+++ b/src/mds/MDSCacheObject.cc
@@ -48,7 +48,7 @@ void MDSCacheObject::dump(Formatter *f) const
 #ifdef MDS_REF_SET
     f->open_object_section("pins");
     for(const auto& p : ref_map) {
-      f->dump_int(pin_name(p.first).data(), p.second);
+      f->dump_int(pin_name(p.first), p.second);
     }
     f->close_section();
 #endif

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -2,7 +2,6 @@
 #define CEPH_MDSCACHEOBJECT_H
 
 #include <ostream>
-#include <string_view>
 
 #include "common/config.h"
 
@@ -70,7 +69,7 @@ class MDSCacheObject {
   static const int PIN_CLIENTLEASE = 1009;
   static const int PIN_DISCOVERBASE = 1010;
 
-  std::string_view generic_pin_name(int p) const {
+  const char *generic_pin_name(int p) const {
     switch (p) {
     case PIN_REPLICATED: return "replicated";
     case PIN_DIRTY: return "dirty";
@@ -83,7 +82,7 @@ class MDSCacheObject {
     case PIN_TEMPEXPORTING: return "tempexporting";
     case PIN_CLIENTLEASE: return "clientlease";
     case PIN_DISCOVERBASE: return "discoverbase";
-    default: ceph_abort(); return std::string_view();
+    default: ceph_abort(); return 0;
     }
   }
 
@@ -158,7 +157,7 @@ protected:
 #endif
     return ref;
   }
-  virtual std::string_view pin_name(int by) const = 0;
+  virtual const char *pin_name(int by) const = 0;
   //bool is_pinned_by(int by) { return ref_set.count(by); }
   //multiset<int>& get_ref_set() { return ref_set; }
 

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -144,9 +144,9 @@ object_t MDSTable::get_object_name() const
 {
   char n[50];
   if (per_mds)
-    snprintf(n, sizeof(n), "mds%d_%s", int(rank), table_name.c_str());
+    snprintf(n, sizeof(n), "mds%d_%s", int(rank), table_name);
   else
-    snprintf(n, sizeof(n), "mds_%s", table_name.c_str());
+    snprintf(n, sizeof(n), "mds_%s", table_name);
   return object_t(n);
 }
 

--- a/src/mds/MDSTable.h
+++ b/src/mds/MDSTable.h
@@ -27,7 +27,7 @@ class MDSTable {
 public:
   MDSRank *mds;
 protected:
-  std::string table_name;
+  const char *table_name;
   bool per_mds;
   mds_rank_t rank;
 
@@ -43,7 +43,7 @@ protected:
   map<version_t, MDSContext::vec > waitfor_save;
   
 public:
-  MDSTable(MDSRank *m, std::string_view n, bool is_per_mds) :
+  MDSTable(MDSRank *m, const char *n, bool is_per_mds) :
     mds(m), table_name(n), per_mds(is_per_mds), rank(MDS_RANK_NONE),
     state(STATE_UNDEF),
     version(0), committing_version(0), committed_version(0), projected_version(0) {}

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -24,7 +24,6 @@
 #include <map>
 #include <list>
 #include <set>
-#include <string_view>
 
 class MDSRank;
 class CDir;
@@ -61,7 +60,7 @@ public:
   const static int EXPORT_EXPORTING	= 7;  // sent actual export, waiting for ack
   const static int EXPORT_LOGGINGFINISH	= 8;  // logging EExportFinish
   const static int EXPORT_NOTIFYING	= 9;  // waiting for notifyacks
-  static std::string_view get_export_statename(int s) {
+  static const char *get_export_statename(int s) {
     switch (s) {
     case EXPORT_CANCELLING: return "cancelling";
     case EXPORT_LOCKING: return "locking";
@@ -72,7 +71,7 @@ public:
     case EXPORT_EXPORTING: return "exporting";
     case EXPORT_LOGGINGFINISH: return "loggingfinish";
     case EXPORT_NOTIFYING: return "notifying";
-    default: ceph_abort(); return std::string_view();
+    default: ceph_abort(); return 0;
     }
   }
 
@@ -85,7 +84,7 @@ public:
   const static int IMPORT_ACKING        = 6; // logged EImportStart, sent ack, waiting for finish
   const static int IMPORT_FINISHING     = 7; // sent cap imports, waiting for finish
   const static int IMPORT_ABORTING      = 8; // notifying bystanders of an abort before unfreezing
-  static std::string_view get_import_statename(int s) {
+  static const char *get_import_statename(int s) {
     switch (s) {
     case IMPORT_DISCOVERING: return "discovering";
     case IMPORT_DISCOVERED: return "discovered";
@@ -95,7 +94,7 @@ public:
     case IMPORT_ACKING: return "acking";
     case IMPORT_FINISHING: return "finishing";
     case IMPORT_ABORTING: return "aborting";
-    default: ceph_abort(); return std::string_view();
+    default: ceph_abort(); return 0;
     }
   }
 

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -439,9 +439,8 @@ void MDRequestImpl::_dump(Formatter *f) const
   }
   {
     f->open_array_section("events");
-    std::lock_guard l(lock);
-    for (auto& i : events) {
-      f->dump_object("event", i);
+    for (size_t i = 0; i < events.size(); i++) {
+      f->dump_object("event", *events.at(i));
     }
     f->close_section(); // events
   }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1740,12 +1740,12 @@ void Server::journal_and_reply(MDRequestRef& mdr, CInode *in, CDentry *dn, LogEv
 }
 
 void Server::submit_mdlog_entry(LogEvent *le, MDSLogContextBase *fin, MDRequestRef& mdr,
-                                std::string_view event)
+                                const char *event)
 {
   if (mdr) {
     string event_str("submit entry: ");
     event_str += event;
-    mdr->mark_event(event_str);
+    mdr->mark_event_string(event_str);
   } 
   mdlog->submit_entry(le, fin);
 }

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -183,7 +183,7 @@ public:
   void journal_and_reply(MDRequestRef& mdr, CInode *tracei, CDentry *tracedn,
 			 LogEvent *le, MDSLogContextBase *fin);
   void submit_mdlog_entry(LogEvent *le, MDSLogContextBase *fin,
-                          MDRequestRef& mdr, std::string_view event);
+                          MDRequestRef& mdr, const char *evt);
   void dispatch_client_request(MDRequestRef& mdr);
   void perf_gather_op_latency(const cref_t<MClientRequest> &req, utime_t lat);
   void early_reply(MDRequestRef& mdr, CInode *tracei, CDentry *tracedn);

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -84,7 +84,7 @@ public:
     STATE_KILLING = 5
   };
 
-  static std::string_view get_state_name(int s) {
+  const char *get_state_name(int s) const {
     switch (s) {
     case STATE_CLOSED: return "closed";
     case STATE_OPENING: return "opening";
@@ -226,7 +226,7 @@ public:
     return info.get_client();
   }
 
-  std::string_view get_state_name() const { return get_state_name(state); }
+  const char *get_state_name() const { return get_state_name(state); }
   uint64_t get_state_seq() const { return state_seq; }
   bool is_closed() const { return state == STATE_CLOSED; }
   bool is_opening() const { return state == STATE_OPENING; }

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -24,6 +24,24 @@
 // -- lock types --
 // see CEPH_LOCK_*
 
+inline const char *get_lock_type_name(int t) {
+  switch (t) {
+    case CEPH_LOCK_DN: return "dn";
+    case CEPH_LOCK_DVERSION: return "dversion";
+    case CEPH_LOCK_IVERSION: return "iversion";
+    case CEPH_LOCK_IFILE: return "ifile";
+    case CEPH_LOCK_IAUTH: return "iauth";
+    case CEPH_LOCK_ILINK: return "ilink";
+    case CEPH_LOCK_IDFT: return "idft";
+    case CEPH_LOCK_INEST: return "inest";
+    case CEPH_LOCK_IXATTR: return "ixattr";
+    case CEPH_LOCK_ISNAP: return "isnap";
+    case CEPH_LOCK_INO: return "ino";
+    case CEPH_LOCK_IFLOCK: return "iflock";
+    case CEPH_LOCK_IPOLICY: return "ipolicy";
+    default: ceph_abort(); return 0;
+  }
+}
 
 struct MutationImpl;
 typedef boost::intrusive_ptr<MutationImpl> MutationRef;
@@ -75,7 +93,7 @@ class SimpleLock {
 public:
   LockType *type;
   
-  static std::string_view get_state_name(int n) {
+  const char *get_state_name(int n) const {
     switch (n) {
     case LOCK_UNDEF: return "UNDEF";
     case LOCK_SYNC: return "sync";
@@ -126,45 +144,7 @@ public:
 
     case LOCK_SNAP_SYNC: return "snap->sync";
 
-    default: ceph_abort(); return std::string_view();
-    }
-  }
-
-  static std::string_view get_lock_type_name(int t) {
-    switch (t) {
-      case CEPH_LOCK_DN: return "dn";
-      case CEPH_LOCK_DVERSION: return "dversion";
-      case CEPH_LOCK_IVERSION: return "iversion";
-      case CEPH_LOCK_IFILE: return "ifile";
-      case CEPH_LOCK_IAUTH: return "iauth";
-      case CEPH_LOCK_ILINK: return "ilink";
-      case CEPH_LOCK_IDFT: return "idft";
-      case CEPH_LOCK_INEST: return "inest";
-      case CEPH_LOCK_IXATTR: return "ixattr";
-      case CEPH_LOCK_ISNAP: return "isnap";
-      case CEPH_LOCK_INO: return "ino";
-      case CEPH_LOCK_IFLOCK: return "iflock";
-      case CEPH_LOCK_IPOLICY: return "ipolicy";
-      default: ceph_abort(); return std::string_view();
-    }
-  }
-
-  static std::string_view get_lock_action_name(int a) {
-    switch (a) {
-      case LOCK_AC_SYNC: return "sync";
-      case LOCK_AC_MIX: return "mix";
-      case LOCK_AC_LOCK: return "lock";
-      case LOCK_AC_LOCKFLUSHED: return "lockflushed";
-
-      case LOCK_AC_SYNCACK: return "syncack";
-      case LOCK_AC_MIXACK: return "mixack";
-      case LOCK_AC_LOCKACK: return "lockack";
-
-      case LOCK_AC_REQSCATTER: return "reqscatter";
-      case LOCK_AC_REQUNSCATTER: return "requnscatter";
-      case LOCK_AC_NUDGE: return "nudge";
-      case LOCK_AC_REQRDLOCK: return "reqrdlock";
-      default: return "???";
+    default: ceph_abort(); return 0;
     }
   }
 

--- a/src/mds/events/EFragment.h
+++ b/src/mds/events/EFragment.h
@@ -51,7 +51,7 @@ public:
     OP_ROLLBACK = 3,
     OP_FINISH = 4 // finish deleting orphan dirfrags
   };
-  static std::string_view op_name(int o) {
+  static const char *op_name(int o) {
     switch (o) {
     case OP_PREPARE: return "prepare";
     case OP_COMMIT: return "commit";

--- a/src/mds/events/ESlaveUpdate.h
+++ b/src/mds/events/ESlaveUpdate.h
@@ -15,8 +15,6 @@
 #ifndef CEPH_MDS_ESLAVEUPDATE_H
 #define CEPH_MDS_ESLAVEUPDATE_H
 
-#include <string_view>
-
 #include "../LogEvent.h"
 #include "EMetaBlob.h"
 
@@ -125,7 +123,7 @@ public:
   __u8 origop; // link | rename
 
   ESlaveUpdate() : LogEvent(EVENT_SLAVEUPDATE), master(0), op(0), origop(0) { }
-  ESlaveUpdate(MDLog *mdlog, std::string_view s, metareqid_t ri, int mastermds, int o, int oo) :
+  ESlaveUpdate(MDLog *mdlog, const char *s, metareqid_t ri, int mastermds, int o, int oo) :
     LogEvent(EVENT_SLAVEUPDATE),
     type(s),
     reqid(ri),

--- a/src/mds/events/EUpdate.h
+++ b/src/mds/events/EUpdate.h
@@ -15,8 +15,6 @@
 #ifndef CEPH_MDS_EUPDATE_H
 #define CEPH_MDS_EUPDATE_H
 
-#include <string_view>
-
 #include "../LogEvent.h"
 #include "EMetaBlob.h"
 
@@ -30,7 +28,7 @@ public:
   bool had_slaves;
 
   EUpdate() : LogEvent(EVENT_UPDATE), cmapv(0), had_slaves(false) { }
-  EUpdate(MDLog *mdlog, std::string_view s) :
+  EUpdate(MDLog *mdlog, const char *s) :
     LogEvent(EVENT_UPDATE),
     type(s), cmapv(0), had_slaves(false) { }
   

--- a/src/mds/locks.h
+++ b/src/mds/locks.h
@@ -122,5 +122,23 @@ enum {
 #define LOCK_AC_FOR_REPLICA(a)  ((a) < 0)
 #define LOCK_AC_FOR_AUTH(a)     ((a) > 0)
 
+static inline const char *get_lock_action_name(int a) {
+  switch (a) {
+    case LOCK_AC_SYNC: return "sync";
+    case LOCK_AC_MIX: return "mix";
+    case LOCK_AC_LOCK: return "lock";
+    case LOCK_AC_LOCKFLUSHED: return "lockflushed";
+
+    case LOCK_AC_SYNCACK: return "syncack";
+    case LOCK_AC_MIXACK: return "mixack";
+    case LOCK_AC_LOCKACK: return "lockack";
+
+    case LOCK_AC_REQSCATTER: return "reqscatter";
+    case LOCK_AC_REQUNSCATTER: return "requnscatter";
+    case LOCK_AC_NUDGE: return "nudge";
+    case LOCK_AC_REQRDLOCK: return "reqrdlock";
+    default: return "???";
+  }
+}
 
 #endif

--- a/src/mds/mds_table_types.h
+++ b/src/mds/mds_table_types.h
@@ -17,18 +17,16 @@
 
 // MDS TABLES
 
-#include <string_view>
-
 enum {
   TABLE_ANCHOR,
   TABLE_SNAP,
 };
 
-inline std::string_view get_mdstable_name(int t) {
+inline const char *get_mdstable_name(int t) {
   switch (t) {
   case TABLE_ANCHOR: return "anchortable";
   case TABLE_SNAP: return "snaptable";
-  default: ceph_abort(); return std::string_view();
+  default: ceph_abort();
   }
 }
 
@@ -46,7 +44,7 @@ enum {
   TABLESERVER_OP_NOTIFY_PREP  = -11,
 };
 
-inline std::string_view get_mdstableserver_opname(int op) {
+inline const char *get_mdstableserver_opname(int op) {
   switch (op) {
   case TABLESERVER_OP_QUERY: return "query";
   case TABLESERVER_OP_QUERY_REPLY: return "query_reply";
@@ -59,7 +57,7 @@ inline std::string_view get_mdstableserver_opname(int op) {
   case TABLESERVER_OP_SERVER_READY: return "server_ready";
   case TABLESERVER_OP_NOTIFY_ACK: return "notify_ack";
   case TABLESERVER_OP_NOTIFY_PREP: return "notify_prep";
-  default: ceph_abort(); return std::string_view();
+  default: ceph_abort(); return 0;
   }
 }
 
@@ -69,12 +67,12 @@ enum {
   TABLE_OP_DESTROY,
 };
 
-inline std::string_view get_mdstable_opname(int op) {
+inline const char *get_mdstable_opname(int op) {
   switch (op) {
   case TABLE_OP_CREATE: return "create";
   case TABLE_OP_UPDATE: return "update";
   case TABLE_OP_DESTROY: return "destroy";
-  default: ceph_abort(); return std::string_view();
+  default: ceph_abort(); return 0;
   }
 }
 

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1269,6 +1269,7 @@ struct string_snap_t {
   snapid_t snapid;
   string_snap_t() {}
   string_snap_t(std::string_view n, snapid_t s) : name(n), snapid(s) {}
+  string_snap_t(const char *n, snapid_t s) : name(n), snapid(s) {}
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& p);

--- a/src/messages/MLock.h
+++ b/src/messages/MLock.h
@@ -65,8 +65,8 @@ protected:
 public:
   std::string_view get_type_name() const override { return "ILock"; }
   void print(ostream& out) const override {
-    out << "lock(a=" << SimpleLock::get_lock_action_name(action)
-	<< " " << SimpleLock::get_lock_type_name(lock_type)
+    out << "lock(a=" << get_lock_action_name(action)
+	<< " " << get_lock_type_name(lock_type)
 	<< " " << object_info
 	<< ")";
   }

--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -104,9 +104,8 @@ private:
   void _dump(Formatter *f) const override {
     {
       f->open_array_section("events");
-      std::lock_guard l(lock);
-      for (auto& i : events) {
-	f->dump_object("event", i);
+      for (size_t i = 0; i < events.size(); i++) {
+        f->dump_object("event", *events.at(i));
       }
       f->close_section();
       f->open_object_section("info");
@@ -215,7 +214,7 @@ struct C_MonOp : public Context
     _finish(r);
   }
 
-  void mark_op_event(const string &event) {
+  void mark_op_event(std::string_view event) {
     if (op)
       op->mark_event_string(event);
   }

--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -41,7 +41,7 @@ struct MonOpRequest : public TrackedOp {
   void mark_svc_event(const string &service, const string &event) {
     string s = service;
     s.append(":").append(event);
-    mark_event(s);
+    mark_event_string(s);
   }
 
   void mark_logmon_event(const string &event) {
@@ -217,7 +217,7 @@ struct C_MonOp : public Context
 
   void mark_op_event(const string &event) {
     if (op)
-      op->mark_event(event);
+      op->mark_event_string(event);
   }
 
   virtual void _finish(int r) = 0;

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -543,7 +543,7 @@ public:
    */
   void wait_for_finished_proposal(MonOpRequestRef op, Context *c) {
     if (op)
-      op->mark_event(service_name + ":wait_for_finished_proposal");
+      op->mark_event_string(service_name + ":wait_for_finished_proposal");
     waiting_for_finished_proposal.push_back(c);
   }
   void wait_for_finished_proposal_ctx(Context *c) {
@@ -558,7 +558,7 @@ public:
    */
   void wait_for_active(MonOpRequestRef op, Context *c) {
     if (op)
-      op->mark_event(service_name + ":wait_for_active");
+      op->mark_event_string(service_name + ":wait_for_active");
 
     if (!is_proposing()) {
       paxos->wait_for_active(op, c);
@@ -585,7 +585,7 @@ public:
      * happens to be readable at that specific point in time.
      */
     if (op)
-      op->mark_event(service_name + ":wait_for_readable");
+      op->mark_event_string(service_name + ":wait_for_readable");
 
     if (is_proposing() ||
 	ver > get_last_committed() ||
@@ -593,7 +593,7 @@ public:
       wait_for_finished_proposal(op, c);
     else {
       if (op)
-        op->mark_event(service_name + ":wait_for_readable/paxos");
+        op->mark_event_string(service_name + ":wait_for_readable/paxos");
 
       paxos->wait_for_readable(op, c);
     }
@@ -611,7 +611,7 @@ public:
    */
   void wait_for_writeable(MonOpRequestRef op, Context *c) {
     if (op)
-      op->mark_event(service_name + ":wait_for_writeable");
+      op->mark_event_string(service_name + ":wait_for_writeable");
 
     if (is_proposing())
       wait_for_finished_proposal(op, c);

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -66,9 +66,8 @@ void OpRequest::_dump(Formatter *f) const
   }
   {
     f->open_array_section("events");
-    std::lock_guard l(lock);
-    for (auto& i : events) {
-      f->dump_object("event", i);
+    for (size_t i = 0; i < events.size(); i++) {
+      f->dump_object("event", *events.at(i));
     }
     f->close_section();
   }
@@ -154,7 +153,7 @@ void OpRequest::mark_flag_point(uint8_t flag, const char *s) {
 	     flag, s, old_flags, hit_flag_points);
 }
 
-void OpRequest::mark_flag_point_string(uint8_t flag, const string& s) {
+void OpRequest::mark_flag_point_string(uint8_t flag, const string &s) {
 #ifdef WITH_LTTNG
   uint8_t old_flags = hit_flag_points;
 #endif

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -158,7 +158,7 @@ void OpRequest::mark_flag_point_string(uint8_t flag, const string& s) {
 #ifdef WITH_LTTNG
   uint8_t old_flags = hit_flag_points;
 #endif
-  mark_event(s);
+  mark_event_string(s);
   hit_flag_points |= flag;
   latest_flag_point = flag;
   tracepoint(oprequest, mark_flag_point, reqid.name._type,

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -121,7 +121,7 @@ public:
     }
   }
 
-  std::string_view state_string() const override {
+  const char *state_string() const override {
     switch(latest_flag_point) {
     case flag_queued_for_pg: return "queued for pg";
     case flag_reached_pg: return "reached pg";

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -140,7 +140,7 @@ public:
   void mark_reached_pg() {
     mark_flag_point(flag_reached_pg, "reached_pg");
   }
-  void mark_delayed(const std::string& s) {
+  void mark_delayed(const string& s) {
     mark_flag_point_string(flag_delayed, s);
   }
   void mark_started() {
@@ -169,7 +169,7 @@ public:
 private:
   void set_rmw_flags(int flags);
   void mark_flag_point(uint8_t flag, const char *s);
-  void mark_flag_point_string(uint8_t flag, const std::string& s);
+  void mark_flag_point_string(uint8_t flag, const string &s);
 };
 
 typedef OpRequest::Ref OpRequestRef;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -573,7 +573,7 @@ void ReplicatedBackend::do_repop_reply(OpRequestRef op)
       ceph_assert(ip_op.waiting_for_commit.count(from));
       ip_op.waiting_for_commit.erase(from);
       if (ip_op.op) {
-	ip_op.op->mark_event("sub_op_commit_rec");
+	ip_op.op->mark_event_string("sub_op_commit_rec");
 	ip_op.op->pg_trace.event("sub_op_commit_rec");
       }
     } else {


### PR DESCRIPTION
This PR is a first pass at improving the OpTracker to help with performance issues seen in #28708. This PR starts by reverting most of the changes in #25921. The idea to replace string references with string_view is good, but unfortunately TrackedOps are hot enough that always storing a copy of the string for each Event is expensive. Instead, this PR reverts to using const char* where possible and only uses string_view when we must store a copy of a string. That saves significant wallclock time both in the hot path and in the OpHistorySvc thread when deleting TrackedOps.

The second change in this PR is implementing an append-only small-vector-like data structure for storing Events. The fist N elements are stored in a std::array with atomic reservation and size counters to ensure that writes are ordered and committed before reads can take place.  After the first N elements the structure falls back to a traditional vector+locking approach since the counter approach isn't sufficient to ensure reads are safe during vector write operations.

Another approach using a Harris inspired compare-and-swap lockless linkedlist (still using std::array for the first N elements) was attempted with mixed results. The bookkeeping overhead was higher for the first N elements and safely deleting heap allocated elements was trickier than the vector-locking fallback approach.

Ultimately with unconstrained CPU resources, this PR does not actually appear to have a significant effect on performance. When testing with #28597 performance results for small random IO workloads on Incerta were nearly identical.  When CPU constrained, there may be a small performance improvement.

| Test Config | Before IOPS | After IOPS |
| -- | -- | -- |
| 4K RandWrite (2 Cores) | 7810 | 7946 |
| 4K RandRead (2 Cores) | 19103 | 20573 |
| 4K RandWrite (All Cores) | 39613 | 39555 |
| 4K RandRead (All Cores) | 71781 | 71738 |

Wallclock profiles however show significantly less time spent both in the OpHistorySvc thread deleting strings and in Event lock contention:

**before (4k randreads):**
```
Thread: 60 (OpHistorySvc) - 1000 samples 

+ 100.00% clone
  + 100.00% start_thread
    + 100.00% OpHistoryServiceThread::entry
      + 79.90% usleep
      | + 79.90% nanosleep
      + 14.00% ~pair
      | + 14.00% ~intrusive_ptr
      |   + 14.00% intrusive_ptr_release
      |     + 14.00% put
      |       + 13.90% ~intrusive_ptr
      |         + 13.90% intrusive_ptr_release
      |           + 13.90% put
      |             + 13.70% OpRequest::~OpRequest
      |             | + 13.70% ~OpRequest
      |             |   + 6.80% RefCountedObject::put
      |             |   | + 4.90% MOSDOp::~MOSDOp
      |             |   | + 1.00% operator--
      |             |   | + 0.20% tcmalloc::ThreadCache::ListTooLong
      |             |   | + 0.20% tc_free
      |             |   + 6.30% ~TrackedOp
      |             |   | + 6.30% ~vector
      |             |   |   + 6.10% _Destroy<TrackedOp::Event*, TrackedOp::Event>
      |             |   |   | + 6.10% _Destroy<TrackedOp::Event*>
      |             |   |   |   + 6.10% __destroy<TrackedOp::Event*>
      |             |   |   |     + 6.10% _Destroy<TrackedOp::Event>
      |             |   |   |       + 6.10% ~Event
      |             |   |   |         + 6.10% ~basic_string
      |             |   |   |           + 5.90% _M_dispose
      |             |   |   |           | + 5.90% std::string::_Rep::_M_dispose
      |             |   |   |           |   + 1.00% _M_destroy
      |             |   |   |           |   + 0.20% __exchange_and_add_dispatch
      |             |   |   |           + 0.20% _M_rep
      |             |   |   + 0.20% ~_Vector_base
      |             |   + 0.50% ~vector
      |             + 0.10% tcmalloc::ThreadCache::ListTooLong
      |             + 0.10% tc_free
      + 4.00% OpHistory::_insert_delayed
      + 1.50% pop_front
      + 0.50% pair
```

**After (4k randreads):**
```
Thread: 60 (OpHistorySvc) - 1000 samples 

+ 100.00% clone
  + 100.00% start_thread
    + 100.00% OpHistoryServiceThread::entry
      + 98.70% usleep
      | + 98.70% nanosleep
      + 0.70% ~pair
      + 0.30% OpHistory::_insert_delayed
      + 0.20% pair
      + 0.10% pop_front
```

And in msgr-worker-2:


**Before (4K randreads):**
```
+ 15.60% OpTracker::create_request<OpRequest, Message*>
| + 5.10% TrackedOp::mark_event
| | + 2.80% emplace_back<utime_t&, std::basic_string_view<char, std::char_traits<char> >&>
| | + 2.00% ~lock_guard
| | + 0.20% lock_guard
| + 4.60% OpRequest::OpRequest
| | + 1.40% TrackedOp
| | + 0.20% get_source_inst
| + 3.70% tracking_start
| | + 3.20% OpTracker::register_inflight_op
| | | + 1.00% RLocker
| | | + 0.60% ~RLocker
| | | + 0.60% lock_guard
| | | + 0.30% ~lock_guard
| | + 0.50% emplace_back<utime_t&, char const (&) [10]>
| + 1.00% tc_new
| + 0.40% is_tracking
| + 0.30% basic_string_view
| + 0.20% operator->
```

**After (4K randreads):**
```
| + 7.70% OpTracker::create_request<OpRequest, Message*>
| | + 4.40% OpRequest::OpRequest
| | | + 0.50% TrackedOp
| | | + 0.10% get_source_inst
| | + 1.90% tracking_start
| | + 0.60% TrackedOp::mark_event
| | + 0.50% tc_new
| | + 0.30% operator->
```

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

