### PR TITLE
mon/AuthMonitor: fix initial creation of rotating keys

### DIFF
--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -78,7 +78,10 @@ struct KeyServerData {
   }
 
   void clear_secrets() {
+    version = 0;
     secrets.clear();
+    rotating_ver = 0;
+    rotating_secrets.clear();
   }
 
   void add_auth(const EntityName& name, EntityAuth& auth) {

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -211,6 +211,7 @@ void AuthMonitor::create_initial()
   dout(10) << "create_initial -- creating initial map" << dendl;
 
   // initialize rotating keys
+  mon->key_server.clear_secrets();
   last_rotating_ver = 0;
   check_rotate();
   ceph_assert(pending_auth.size() == 1);


### PR DESCRIPTION
http://tracker.ceph.com/issues/40634