### PR TITLE
client: support for printing a single inode cache

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -909,7 +909,7 @@ protected:
   void _trim_negative_child_dentries(InodeRef& in);
 
   void dump_inode(Formatter *f, Inode *in, set<Inode*>& did, bool disconnected);
-  void dump_cache(Formatter *f);  // debug
+  void dump_cache(Formatter *f,uint64_t inode_no = 0);  // debug
 
   // force read-only
   void force_session_readonly(MetaSession *s);


### PR DESCRIPTION
client: query a single cache information, for example print a single inode cache information

Fixes:http://tracker.ceph.com/issues/40563
Signed-off-by:  wenpengLi  liwenpeng@inspur.com


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

