### PR TITLE
mds: display scrub status in ceph status

### DIFF
--- a/doc/cephfs/scrub.rst
+++ b/doc/cephfs/scrub.rst
@@ -70,8 +70,20 @@ initiate the scrub.
    }
 
 `status` shows the number of inodes that are scheduled to be scrubbed at any point in time,
-hence, can change on subsequent `scrub status` invocations.
+hence, can change on subsequent `scrub status` invocations. Also, a high level summary of
+scrub operation (which includes the operation state and paths on which scrub is triggered)
+gets displayed in `ceph status`.
 
+::
+
+   ceph status
+   [...]
+
+   task status:
+     scrub status:
+         mds.0: active [paths:/]
+
+   [...]
 
 Control (ongoing) Filesystem Scrubs
 ===================================

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -2695,6 +2695,24 @@ class CephManager:
         remote.run(args=['sudo',
                          'install', '-d', '-m0777', '--', '/var/run/ceph', ], )
 
+    def get_service_task_status(self, service, status_key):
+        """
+        Return daemon task status for a given ceph service.
+
+        :param service: ceph service (mds, osd, etc...)
+        :param status_key: matching task status key
+        """
+        task_status = {}
+        status = self.raw_cluster_status()
+        try:
+            for k,v in status['servicemap']['services'][service]['daemons'].items():
+                ts = dict(v).get('task_status', None)
+                if ts:
+                    task_status[k] = ts[status_key]
+        except KeyError: # catches missing service and status key
+            return {}
+        self.log(task_status)
+        return task_status
 
 def utility_task(name):
     """

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -430,6 +430,9 @@ class Filesystem(MDSCluster):
         if not hasattr(self._ctx, "filesystem"):
             self._ctx.filesystem = self
 
+    def get_task_status(self, status_key):
+        return self.mon_manager.get_service_task_status("mds", status_key)
+
     def getinfo(self, refresh = False):
         status = self.status()
         if self.id is not None:

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -30,6 +30,9 @@ class TestScrubControls(CephFSTestCase):
         self.assertEqual(res['return_code'], expected)
     def _get_scrub_status(self):
         return self.fs.rank_tell(["scrub", "status"])
+    def _check_task_status(self, expected_status):
+        task_status = self.fs.get_task_status("scrub status")
+        self.assertTrue(task_status['0'].startswith(expected_status))
 
     def test_scrub_abort(self):
         test_dir = "scrub_control_test_path"
@@ -50,6 +53,10 @@ class TestScrubControls(CephFSTestCase):
         out_json = self._get_scrub_status()
         self.assertTrue("no active" in out_json['status'])
 
+        # sleep enough to fetch updated task status
+        time.sleep(10)
+        self._check_task_status("idle")
+
     def test_scrub_pause_and_resume(self):
         test_dir = "scrub_control_test_path"
         abs_test_path = "/{0}".format(test_dir)
@@ -68,6 +75,10 @@ class TestScrubControls(CephFSTestCase):
         self._pause_scrub(0)
         out_json = self._get_scrub_status()
         self.assertTrue("PAUSED" in out_json['status'])
+
+        # sleep enough to fetch updated task status
+        time.sleep(10)
+        self._check_task_status("paused")
 
         # resume and verify
         self._resume_scrub(0)
@@ -93,16 +104,28 @@ class TestScrubControls(CephFSTestCase):
         out_json = self._get_scrub_status()
         self.assertTrue("PAUSED" in out_json['status'])
 
+        # sleep enough to fetch updated task status
+        time.sleep(10)
+        self._check_task_status("paused")
+
         # abort and verify
         self._abort_scrub(0)
         out_json = self._get_scrub_status()
         self.assertTrue("PAUSED" in out_json['status'])
         self.assertTrue("0 inodes" in out_json['status'])
 
+        # sleep enough to fetch updated task status
+        time.sleep(10)
+        self._check_task_status("paused")
+
         # resume and verify
         self._resume_scrub(0)
         out_json = self._get_scrub_status()
         self.assertTrue("no active" in out_json['status'])
+
+        # sleep enough to fetch updated task status
+        time.sleep(10)
+        self._check_task_status("idle")
 
 class TestScrubChecks(CephFSTestCase):
     """

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8140,6 +8140,11 @@ std::vector<Option> get_mds_options() {
      .set_default(0)
      .set_description("threshold for cache usage to disallow \"dump cache\" operation to file")
      .set_long_description("Disallow MDS from dumping caches to file via \"dump cache\" command if cache usage exceeds this threshold."),
+
+    Option("mds_task_status_update_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+     .set_default(2.0)
+     .set_description("task status update interval to manager")
+     .set_long_description("interval (in seconds) for sending mds task status to ceph manager"),
   });
 }
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -871,7 +871,7 @@ void MDSDaemon::handle_mds_map(const cref_t<MMDSMap> &m)
     // Did I previously not hold a rank?  Initialize!
     if (mds_rank == NULL) {
       mds_rank = new MDSRankDispatcher(whoami, mds_lock, clog,
-          timer, beacon, mdsmap, messenger, monc,
+          timer, beacon, mdsmap, messenger, monc, &mgrc,
           new FunctionContext([this](int r){respawn();}),
           new FunctionContext([this](int r){suicide();}));
       dout(10) <<  __func__ << ": initializing MDS rank "

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -529,7 +529,7 @@ MDSRank::MDSRank(
   mdlog = new MDLog(this);
   balancer = new MDBalancer(this, messenger, monc);
 
-  scrubstack = new ScrubStack(mdcache, finisher);
+  scrubstack = new ScrubStack(mdcache, clog, finisher);
 
   inotable = new InoTable(this);
   snapserver = new SnapServer(this, monc);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -21,6 +21,8 @@
 #include "messages/MMDSLoadTargets.h"
 #include "messages/MMDSTableRequest.h"
 
+#include "mgr/MgrClient.h"
+
 #include "MDSDaemon.h"
 #include "MDSMap.h"
 #include "SnapClient.h"
@@ -479,6 +481,7 @@ MDSRank::MDSRank(
     std::unique_ptr<MDSMap>& mdsmap_,
     Messenger *msgr,
     MonClient *monc_,
+    MgrClient *mgrc,
     Context *respawn_hook_,
     Context *suicide_hook_)
   :
@@ -508,7 +511,7 @@ MDSRank::MDSRank(
     hb(NULL), last_tid(0), osd_epoch_barrier(0), beacon(beacon_),
     mds_slow_req_count(0),
     last_client_mdsmap_bcast(0),
-    messenger(msgr), monc(monc_),
+    messenger(msgr), monc(monc_), mgrc(mgrc),
     respawn_hook(respawn_hook_),
     suicide_hook(suicide_hook_),
     standby_replaying(false),
@@ -539,6 +542,15 @@ MDSRank::MDSRank(
                                          cct->_conf->mds_op_log_threshold);
   op_tracker.set_history_size_and_duration(cct->_conf->mds_op_history_size,
                                            cct->_conf->mds_op_history_duration);
+
+  std::string rank_str = stringify(get_nodeid());
+  std::map<std::string, std::string> service_metadata = {{"rank", rank_str}};
+  int r = mgrc->service_daemon_register("mds", rank_str, service_metadata);
+  if (r < 0) {
+    derr << ": failed to register with manager for service status update" << dendl;
+  }
+
+  schedule_update_timer_task();
 }
 
 MDSRank::~MDSRank()
@@ -3507,12 +3519,13 @@ MDSRankDispatcher::MDSRankDispatcher(
     std::unique_ptr<MDSMap> &mdsmap_,
     Messenger *msgr,
     MonClient *monc_,
+    MgrClient *mgrc,
     Context *respawn_hook_,
     Context *suicide_hook_)
   : MDSRank(whoami_, mds_lock_, clog_, timer_, beacon_, mdsmap_,
-      msgr, monc_, respawn_hook_, suicide_hook_)
+            msgr, monc_, mgrc, respawn_hook_, suicide_hook_)
 {
-  g_conf().add_observer(this);
+    g_conf().add_observer(this);
 }
 
 bool MDSRankDispatcher::handle_command(
@@ -3729,4 +3742,37 @@ void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::s
     mdcache->handle_conf_change(changed, *mdsmap);
     purge_queue.handle_conf_change(changed, *mdsmap);
   }));
+}
+
+void MDSRank::get_task_status(std::map<std::string, std::string> *status) {
+  dout(20) << __func__ << dendl;
+
+  // scrub summary for now..
+  std::string_view scrub_summary = scrubstack->scrub_summary();
+  status->emplace(SCRUB_STATUS_KEY, std::move(scrub_summary));
+}
+
+void MDSRank::schedule_update_timer_task() {
+  dout(20) << __func__ << dendl;
+
+  timer.add_event_after(g_conf().get_val<double>("mds_task_status_update_interval"),
+                        new FunctionContext([this](int _) {
+                            send_task_status();
+                          }));
+}
+
+void MDSRank::send_task_status() {
+  std::map<std::string, std::string> status;
+  get_task_status(&status);
+
+  if (!status.empty()) {
+    dout(20) << __func__ << ": updating " << status.size() << " status keys" << dendl;
+
+    int r = mgrc->service_daemon_update_task_status(std::move(status));
+    if (r < 0) {
+      derr << ": failed to update service daemon status: " << cpp_strerror(r) << dendl;
+    }
+  }
+
+  schedule_update_timer_task();
 }

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -116,6 +116,7 @@ class MDSTableClient;
 class Messenger;
 class Objecter;
 class MonClient;
+class MgrClient;
 class Finisher;
 class ScrubStack;
 class C_MDS_Send_Command_Reply;
@@ -332,6 +333,7 @@ class MDSRank {
         std::unique_ptr<MDSMap> & mdsmap_,
         Messenger *msgr,
         MonClient *monc_,
+        MgrClient *mgrc,
         Context *respawn_hook_,
         Context *suicide_hook_);
 
@@ -498,6 +500,7 @@ class MDSRank {
   protected:
     Messenger    *messenger;
     MonClient    *monc;
+    MgrClient    *mgrc;
 
     Context *respawn_hook;
     Context *suicide_hook;
@@ -569,6 +572,13 @@ class MDSRank {
     void set_mdsmap_multimds_snaps_allowed();
 private:
     mono_time starttime = mono_clock::zero();
+
+    // "task" string that gets displayed in ceph status
+    inline static const std::string SCRUB_STATUS_KEY = "scrub status";
+
+    void get_task_status(std::map<std::string, std::string> *status);
+    void schedule_update_timer_task();
+    void send_task_status();
 
 protected:
   Context *create_async_exec_context(C_ExecAndReply *ctx);
@@ -646,6 +656,7 @@ public:
       std::unique_ptr<MDSMap> &mdsmap_,
       Messenger *msgr,
       MonClient *monc_,
+      MgrClient *mgrc,
       Context *respawn_hook_,
       Context *suicide_hook_);
 };

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -480,6 +480,7 @@ void ScrubStack::_validate_inode_done(CInode *in, int r,
 
   if (in == header->get_origin()) {
     scrub_origins.erase(in);
+    clog_scrub_summary(in);
     if (!header->get_recursive()) {
       if (r >= 0) { // we got into the scrubbing dump it
         result.dump(&(header->get_formatter()));
@@ -512,6 +513,7 @@ void ScrubStack::set_state(State next_state) {
       dout(20) << __func__ << ", from state=" << state << ", to state="
                << next_state << dendl;
       state = next_state;
+      clog_scrub_summary();
     }
 }
 
@@ -568,9 +570,7 @@ std::string_view ScrubStack::scrub_summary() {
         *cs << ",";
       }
 
-      std::string path;
-      (*inode)->make_path_string(path, true);
-      *cs << (path.empty() ? "/" : path.c_str());
+      *cs << scrub_inode_path(*inode);
     }
     *cs << "]";
   }
@@ -619,9 +619,7 @@ void ScrubStack::scrub_status(Formatter *f) {
     std::string tag(header->get_tag());
     f->open_object_section(tag.c_str()); // scrub id
 
-    std::string path;
-    inode->make_path_string(path, true);
-    f->dump_string("path", path.empty() ? "/" : path.c_str());
+    f->dump_string("path", scrub_inode_path(inode));
 
     std::stringstream optss;
     if (header->get_recursive()) {
@@ -657,6 +655,7 @@ void ScrubStack::abort_pending_scrubs() {
     CInode *in = *inode;
     if (in == in->scrub_info()->header->get_origin()) {
       scrub_origins.erase(in);
+      clog_scrub_summary(in);
     }
 
     MDSContext *ctx = nullptr;
@@ -734,4 +733,21 @@ bool ScrubStack::scrub_resume() {
   }
 
   return r;
+}
+
+// send current scrub summary to cluster log
+void ScrubStack::clog_scrub_summary(CInode *in) {
+  if (in) {
+    std::string what;
+    if (clear_inode_stack) {
+      what = "aborted";
+    } else if (scrub_origins.count(in)) {
+      what = "queued";
+    } else {
+      what = "completed";
+    }
+    clog->info() << "scrub " << what << " for path: " << scrub_inode_path(in);
+  }
+
+  clog->info() << "scrub summary: " << scrub_summary();
 }

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -528,6 +528,56 @@ bool ScrubStack::scrub_in_transition_state() {
   return false;
 }
 
+std::string_view ScrubStack::scrub_summary() {
+  ceph_assert(ceph_mutex_is_locked_by_me(mdcache->mds->mds_lock));
+
+  bool have_more = false;
+  CachedStackStringStream cs;
+
+  if (state == STATE_IDLE) {
+    return "idle";
+  }
+
+  if (state == STATE_RUNNING) {
+    if (clear_inode_stack) {
+      *cs << "aborting";
+    } else {
+      *cs << "active";
+    }
+  } else {
+    if (state == STATE_PAUSING) {
+      have_more = true;
+      *cs << "pausing";
+    } else if (state == STATE_PAUSED) {
+      have_more = true;
+      *cs << "paused";
+    }
+
+    if (clear_inode_stack) {
+      if (have_more) {
+        *cs << "+";
+      }
+      *cs << "aborting";
+    }
+  }
+
+  if (!scrub_origins.empty()) {
+    *cs << " [paths:";
+    for (auto inode = scrub_origins.begin(); inode != scrub_origins.end(); ++inode) {
+      if (inode != scrub_origins.begin()) {
+        *cs << ",";
+      }
+
+      std::string path;
+      (*inode)->make_path_string(path, true);
+      *cs << (path.empty() ? "/" : path.c_str());
+    }
+    *cs << "]";
+  }
+
+  return cs->strv();
+}
+
 void ScrubStack::scrub_status(Formatter *f) {
   ceph_assert(ceph_mutex_is_locked_by_me(mdcache->mds->mds_lock));
 

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -126,6 +126,12 @@ public:
    */
   void scrub_status(Formatter *f);
 
+  /**
+   * Get a high level scrub status summary such as current scrub state
+   * and scrub paths.
+   */
+  std::string_view scrub_summary();
+
 private:
   // scrub abort is _not_ a state, rather it's an operation that's
   // performed after in-progress scrubs are finished.

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -21,6 +21,7 @@
 #include "MDSContext.h"
 #include "ScrubHeader.h"
 
+#include "common/LogClient.h"
 #include "include/elist.h"
 
 class MDCache;
@@ -28,6 +29,9 @@ class Finisher;
 
 class ScrubStack {
 protected:
+  // reference to global cluster log client
+  LogChannelRef &clog;
+
   /// A finisher needed so that we don't re-enter kick_off_scrubs
   Finisher *finisher;
 
@@ -57,7 +61,8 @@ protected:
 
 public:
   MDCache *mdcache;
-  ScrubStack(MDCache *mdc, Finisher *finisher_) :
+  ScrubStack(MDCache *mdc, LogChannelRef &clog, Finisher *finisher_) :
+    clog(clog),
     finisher(finisher_),
     inode_stack(member_offset(CInode, item_scrub)),
     scrubs_in_progress(0),
@@ -81,6 +86,7 @@ public:
 			 MDSContext *on_finish) {
     enqueue_inode(in, header, on_finish, true);
     scrub_origins.emplace(in);
+    clog_scrub_summary(in);
   }
   /** Like enqueue_inode_top, but we wait for all pending scrubs before
    * starting this one.
@@ -89,6 +95,7 @@ public:
 			    MDSContext *on_finish) {
     enqueue_inode(in, header, on_finish, false);
     scrub_origins.emplace(in);
+    clog_scrub_summary(in);
   }
 
   /**
@@ -275,6 +282,23 @@ private:
    * Completion context is complete with -ECANCELED.
    */
   void abort_pending_scrubs();
+
+  /**
+   * Return path for a given inode.
+   * @param in inode to make path entry.
+   */
+  std::string scrub_inode_path(CInode *in) {
+    std::string path;
+    in->make_path_string(path, true);
+    return (path.empty() ? "/" : path.c_str());
+  }
+
+  /**
+   * Send scrub information (queued/finished scrub path and summary)
+   * to cluster log.
+   * @param in inode for which scrub has been queued or finished.
+   */
+  void clog_scrub_summary(CInode *in=nullptr);
 };
 
 #endif /* SCRUBSTACK_H_ */

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -73,7 +73,7 @@ WRITE_CLASS_ENCODER(PerfCounterType)
 
 class MMgrReport : public Message {
 private:
-  static constexpr int HEAD_VERSION = 7;
+  static constexpr int HEAD_VERSION = 8;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -98,6 +98,7 @@ public:
 
   // for service registration
   boost::optional<std::map<std::string,std::string>> daemon_status;
+  boost::optional<std::map<std::string,std::string>> task_status;
 
   std::vector<DaemonHealthMetric> daemon_health_metrics;
 
@@ -128,6 +129,9 @@ public:
     if (header.version >= 7) {
       decode(osd_perf_metric_reports, p);
     }
+    if (header.version >= 8) {
+      decode(task_status, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
@@ -141,6 +145,7 @@ public:
     encode(daemon_health_metrics, payload);
     encode(config_bl, payload);
     encode(osd_perf_metric_reports, payload);
+    encode(task_status, payload);
   }
 
   std::string_view get_type_name() const override { return "mgrreport"; }
@@ -160,6 +165,9 @@ public:
     }
     if (!daemon_health_metrics.empty()) {
       out << " daemon_metrics=" << daemon_health_metrics.size();
+    }
+    if (task_status) {
+      out << " task_status=" << task_status->size();
     }
     out << ")";
   }

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -42,7 +42,14 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr.server " << __func__ << " "
 
-
+namespace {
+  template <typename Map>
+  bool map_compare(Map const &lhs, Map const &rhs) {
+    return lhs.size() == rhs.size()
+      && std::equal(lhs.begin(), lhs.end(), rhs.begin(),
+                    [] (auto a, auto b) { return a.first == b.first && a.second == b.second; });
+  }
+}
 
 DaemonServer::DaemonServer(MonClient *monc_,
                            Finisher &finisher_,
@@ -415,6 +422,7 @@ bool DaemonServer::handle_open(const ref_t<MMgrOpen>& m)
     std::lock_guard l(daemon->lock);
     daemon->perf_counters.clear();
 
+    daemon->service_daemon = m->service_daemon;
     if (m->service_daemon) {
       daemon->set_metadata(m->daemon_metadata);
       daemon->service_status = m->daemon_status;
@@ -422,7 +430,7 @@ bool DaemonServer::handle_open(const ref_t<MMgrOpen>& m)
       utime_t now = ceph_clock_now();
       auto d = pending_service_map.get_daemon(m->service_name,
 					      m->daemon_name);
-      if (d->gid != (uint64_t)m->get_source().num()) {
+      if (!d->gid || d->gid != (uint64_t)m->get_source().num()) {
 	dout(10) << "registering " << key << " in pending_service_map" << dendl;
 	d->gid = m->get_source().num();
 	d->addr = m->get_source_addr();
@@ -506,98 +514,114 @@ bool DaemonServer::handle_report(const ref_t<MMgrReport>& m)
     return true;
   }
 
-  // Look up the DaemonState
-  DaemonStatePtr daemon;
-  if (daemon_state.exists(key)) {
-    dout(20) << "updating existing DaemonState for " << key << dendl;
-    daemon = daemon_state.get(key);
-  } else {
-    // we don't know the hostname at this stage, reject MMgrReport here.
-    dout(5) << "rejecting report from " << key << ", since we do not have its metadata now."
-	    << dendl;
 
-    // issue metadata request in background
-    if (!daemon_state.is_updating(key) && 
-	(key.first == "osd" || key.first == "mds" || key.first == "mon")) {
+  {
+    lock.lock();
 
-      std::ostringstream oss;
-      auto c = new MetadataUpdate(daemon_state, key);
-      if (key.first == "osd") {
-        oss << "{\"prefix\": \"osd metadata\", \"id\": "
-            << key.second<< "}";
+    DaemonStatePtr daemon;
+    // Look up the DaemonState
+    if (daemon_state.exists(key)) {
+      dout(20) << "updating existing DaemonState for " << key << dendl;
+      daemon = daemon_state.get(key);
+    } else {
+      lock.unlock();
 
-      } else if (key.first == "mds") {
-        c->set_default("addr", stringify(m->get_source_addr()));
-        oss << "{\"prefix\": \"mds metadata\", \"who\": \""
-            << key.second << "\"}";
+      // we don't know the hostname at this stage, reject MMgrReport here.
+      dout(5) << "rejecting report from " << key << ", since we do not have its metadata now."
+              << dendl;
+      // issue metadata request in background
+      if (!daemon_state.is_updating(key) && 
+          (key.first == "osd" || key.first == "mds" || key.first == "mon")) {
+
+        std::ostringstream oss;
+        auto c = new MetadataUpdate(daemon_state, key);
+        if (key.first == "osd") {
+          oss << "{\"prefix\": \"osd metadata\", \"id\": "
+              << key.second<< "}";
+
+        } else if (key.first == "mds") {
+          c->set_default("addr", stringify(m->get_source_addr()));
+          oss << "{\"prefix\": \"mds metadata\", \"who\": \""
+              << key.second << "\"}";
  
-      } else if (key.first == "mon") {
-        oss << "{\"prefix\": \"mon metadata\", \"id\": \""
-            << key.second << "\"}";
-      } else {
-	ceph_abort();
+        } else if (key.first == "mon") {
+          oss << "{\"prefix\": \"mon metadata\", \"id\": \""
+              << key.second << "\"}";
+        } else {
+          ceph_abort();
+        }
+
+        monc->start_mon_command({oss.str()}, {}, &c->outbl, &c->outs, c);
       }
 
-      monc->start_mon_command({oss.str()}, {}, &c->outbl, &c->outs, c);
-    }
-    
-    {
-      std::lock_guard l(lock);
+      lock.lock();
+
       // kill session
       auto priv = m->get_connection()->get_priv();
       auto session = static_cast<MgrSession*>(priv.get());
       if (!session) {
-	return false;
+        return false;
       }
       m->get_connection()->mark_down();
 
       dout(10) << "unregistering osd." << session->osd_id
-	       << "  session " << session << " con " << m->get_connection() << dendl;
+               << "  session " << session << " con " << m->get_connection() << dendl;
       
       if (osd_cons.find(session->osd_id) != osd_cons.end()) {
-	   osd_cons[session->osd_id].erase(m->get_connection());
-      } 
+        osd_cons[session->osd_id].erase(m->get_connection());
+      }
 
       auto iter = daemon_connections.find(m->get_connection());
       if (iter != daemon_connections.end()) {
-	daemon_connections.erase(iter);
+        daemon_connections.erase(iter);
+      }
+
+      lock.unlock();
+      return false;
+    }
+
+    // Update the DaemonState
+    ceph_assert(daemon != nullptr);
+    {
+      std::lock_guard l(daemon->lock);
+      auto &daemon_counters = daemon->perf_counters;
+      daemon_counters.update(*m.get());
+
+      auto p = m->config_bl.cbegin();
+      if (p != m->config_bl.end()) {
+        decode(daemon->config, p);
+        decode(daemon->ignored_mon_config, p);
+        dout(20) << " got config " << daemon->config
+                 << " ignored " << daemon->ignored_mon_config << dendl;
+      }
+
+      if (daemon->service_daemon) {
+        utime_t now = ceph_clock_now();
+        if (m->daemon_status) {
+          daemon->service_status_stamp = now;
+          daemon->service_status = *m->daemon_status;
+        }
+        if (m->task_status && !map_compare(daemon->task_status, *m->task_status)) {
+          auto d = pending_service_map.get_daemon(m->service_name, m->daemon_name);
+          if (d->gid) {
+            daemon->task_status = *m->task_status;
+            d->task_status = *m->task_status;
+            pending_service_map_dirty = pending_service_map.epoch;
+          }
+        }
+        daemon->last_service_beacon = now;
+      } else if (m->daemon_status) {
+        derr << "got status from non-daemon " << key << dendl;
+      }
+      if (m->get_connection()->peer_is_osd() || m->get_connection()->peer_is_mon()) {
+        // only OSD and MON send health_checks to me now
+        daemon->daemon_health_metrics = std::move(m->daemon_health_metrics);
+        dout(10) << "daemon_health_metrics " << daemon->daemon_health_metrics
+                 << dendl;
       }
     }
 
-    return false;
-  }
-
-  // Update the DaemonState
-  ceph_assert(daemon != nullptr);
-  {
-    std::lock_guard l(daemon->lock);
-    auto &daemon_counters = daemon->perf_counters;
-    daemon_counters.update(*m.get());
-
-    auto p = m->config_bl.cbegin();
-    if (p != m->config_bl.end()) {
-      decode(daemon->config, p);
-      decode(daemon->ignored_mon_config, p);
-      dout(20) << " got config " << daemon->config
-	       << " ignored " << daemon->ignored_mon_config << dendl;
-    }
-
-    if (daemon->service_daemon) {
-      utime_t now = ceph_clock_now();
-      if (m->daemon_status) {
-        daemon->service_status = *m->daemon_status;
-        daemon->service_status_stamp = now;
-      }
-      daemon->last_service_beacon = now;
-    } else if (m->daemon_status) {
-      derr << "got status from non-daemon " << key << dendl;
-    }
-    if (m->get_connection()->peer_is_osd() || m->get_connection()->peer_is_mon()) {
-      // only OSD and MON send health_checks to me now
-      daemon->daemon_health_metrics = std::move(m->daemon_health_metrics);
-      dout(10) << "daemon_health_metrics " << daemon->daemon_health_metrics
-	       << dendl;
-    }
+    lock.unlock();
   }
 
   // if there are any schema updates, notify the python modules

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -147,6 +147,7 @@ class DaemonState
   bool service_daemon = false;
   utime_t service_status_stamp;
   std::map<std::string, std::string> service_status;
+  std::map<std::string, std::string> task_status;
   utime_t last_service_beacon;
 
   // running config

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -349,6 +349,11 @@ void MgrClient::_send_report()
     daemon_dirty_status = false;
   }
 
+  if (task_dirty_status) {
+    report->task_status = task_status;
+    task_dirty_status = false;
+  }
+
   report->daemon_health_metrics = std::move(daemon_health_metrics);
 
   cct->_conf.get_config_bl(last_config_bl_version, &report->config_bl,
@@ -478,14 +483,6 @@ int MgrClient::service_daemon_register(
   const std::map<std::string,std::string>& metadata)
 {
   std::lock_guard l(lock);
-  if (service == "osd" ||
-      service == "mds" ||
-      service == "client" ||
-      service == "mon" ||
-      service == "mgr") {
-    // normal ceph entity types are not allowed!
-    return -EINVAL;
-  }
   if (service_daemon) {
     return -EEXIST;
   }
@@ -511,6 +508,15 @@ int MgrClient::service_daemon_update_status(
   ldout(cct,10) << status << dendl;
   daemon_status = std::move(status);
   daemon_dirty_status = true;
+  return 0;
+}
+
+int MgrClient::service_daemon_update_task_status(
+  std::map<std::string,std::string> &&status) {
+  std::lock_guard l(lock);
+  ldout(cct,10) << status << dendl;
+  task_status = std::move(status);
+  task_dirty_status = true;
   return 0;
 }
 

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -88,9 +88,11 @@ protected:
   // for service registration and beacon
   bool service_daemon = false;
   bool daemon_dirty_status = false;
+  bool task_dirty_status = false;
   std::string service_name, daemon_name;
   std::map<std::string,std::string> daemon_metadata;
   std::map<std::string,std::string> daemon_status;
+  std::map<std::string,std::string> task_status;
   std::vector<DaemonHealthMetric> daemon_health_metrics;
 
   void reconnect();
@@ -148,6 +150,8 @@ public:
     const std::map<std::string,std::string>& metadata);
   int service_daemon_update_status(
     std::map<std::string,std::string>&& status);
+  int service_daemon_update_task_status(
+    std::map<std::string,std::string> &&task_status);
   void update_daemon_health(std::vector<DaemonHealthMetric>&& metrics);
 
 private:

--- a/src/mgr/ServiceMap.cc
+++ b/src/mgr/ServiceMap.cc
@@ -12,23 +12,27 @@ using ceph::Formatter;
 
 void ServiceMap::Daemon::encode(bufferlist& bl, uint64_t features) const
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   encode(gid, bl);
   encode(addr, bl, features);
   encode(start_epoch, bl);
   encode(start_stamp, bl);
   encode(metadata, bl);
+  encode(task_status, bl);
   ENCODE_FINISH(bl);
 }
 
 void ServiceMap::Daemon::decode(bufferlist::const_iterator& p)
 {
-  DECODE_START(1, p);
+  DECODE_START(2, p);
   decode(gid, p);
   decode(addr, p);
   decode(start_epoch, p);
   decode(start_stamp, p);
   decode(metadata, p);
+  if (struct_v >= 2) {
+    decode(task_status, p);
+  }
   DECODE_FINISH(p);
 }
 
@@ -36,10 +40,15 @@ void ServiceMap::Daemon::dump(Formatter *f) const
 {
   f->dump_unsigned("start_epoch", start_epoch);
   f->dump_stream("start_stamp") << start_stamp;
-  f->dump_unsigned("gid", gid);
+  f->dump_unsigned("gid", *gid);
   f->dump_string("addr", addr.get_legacy_str());
   f->open_object_section("metadata");
   for (auto& p : metadata) {
+    f->dump_string(p.first.c_str(), p.second);
+  }
+  f->close_section();
+  f->open_object_section("task_status");
+  for (auto& p : task_status) {
     f->dump_string(p.first.c_str(), p.second);
   }
   f->close_section();
@@ -51,6 +60,7 @@ void ServiceMap::Daemon::generate_test_instances(std::list<Daemon*>& ls)
   ls.push_back(new Daemon);
   ls.back()->gid = 222;
   ls.back()->metadata["this"] = "that";
+  ls.back()->task_status["task1"] = "running";
 }
 
 // Service

--- a/src/mgr/ServiceMap.h
+++ b/src/mgr/ServiceMap.h
@@ -12,17 +12,20 @@
 #include "include/buffer.h"
 #include "msg/msg_types.h"
 
+#include <boost/optional.hpp>
+
 namespace ceph {
   class Formatter;
 }
 
 struct ServiceMap {
   struct Daemon {
-    uint64_t gid = 0;
+    boost::optional<uint64_t> gid;
     entity_addr_t addr;
     epoch_t start_epoch = 0;   ///< epoch first registered
     utime_t start_stamp;       ///< timestamp daemon started/registered
     std::map<std::string,std::string> metadata;  ///< static metadata
+    std::map<std::string,std::string> task_status; ///< running task status
 
     void encode(ceph::buffer::list& bl, uint64_t features) const;
     void decode(ceph::buffer::list::const_iterator& p);
@@ -59,6 +62,33 @@ struct ServiceMap {
 	  ss << p->first;
 	}
 	ss << ")";
+      }
+
+      return ss.str();
+    }
+
+    std::string get_task_summary(const std::string_view task_prefix) const {
+      // contruct a map similar to:
+      //     {"service1 status" -> {"service1.0" -> "running"}}
+      //     {"service2 status" -> {"service2.0" -> "idle"},
+      //                           {"service2.1" -> "running"}}
+      std::map<std::string, std::map<std::string, std::string>> by_task;
+      for (const auto &p : daemons) {
+        std::stringstream d;
+        d << task_prefix << "." << p.first;
+        for (const auto &q : p.second.task_status) {
+          auto p1 = by_task.emplace(q.first, std::map<std::string, std::string>{}).first;
+          auto p2 = p1->second.emplace(d.str(), std::string()).first;
+          p2->second = q.second;
+        }
+      }
+
+      std::stringstream ss;
+      for (const auto &p : by_task) {
+        ss << "\n    " << p.first << ":";
+        for (auto q : p.second) {
+          ss << "\n        " << q.first << ": " << q.second;
+        }
       }
 
       return ss.str();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3018,8 +3018,29 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
       osdmon()->osdmap.print_summary(NULL, ss, string(maxlen + 6, ' '));
       ss << "\n";
       for (auto& p : service_map.services) {
+        const std::string &service = p.first;
+        // filter out normal ceph entity types
+        if (service == "osd" ||
+            service == "client" ||
+            service == "mon" ||
+            service == "mds" ||
+            service == "mgr") {
+          continue;
+        }
 	ss << "    " << p.first << ": " << string(maxlen - p.first.size(), ' ')
 	   << p.second.get_summary() << "\n";
+      }
+    }
+
+    {
+      auto& service_map = mgrstatmon()->get_service_map();
+      if (!service_map.services.empty()) {
+        ss << "\n \n  task status:\n";
+        {
+          for (auto &p : service_map.services) {
+            ss << p.second.get_task_summary(p.first);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This introduces changes that allow normal ceph services (osd, mds, etc..) to register with ceph manager via `MgrClient::service_daemon_register()`. Also, services can forward the status of executing tasks to ceph manager. The `task status` makes its way upto the `ServiceMap`.

@batrick @liewegas please take a look.

Sample vstart display output when running mds scrub in a vstart cluster.
```
$ ceph -s
  cluster:                                                          
    id:     18a4f74f-7a1b-45bb-b971-4399c32797be                                                          
    health: HEALTH_ERR                                                                                    
            1 MDSs report damaged metadata                                                                 
                                                                                                           
  services:                                                                                               
    mon: 1 daemons, quorum a (age 3m)    
    mgr: x(active, since 3m)                    
    mds: a:1 {0=a=up:active} 2 up:standby
    osd: 3 osds: 3 up (since 92s), 3 in (since 12h)                 
                                                                    
  task status:                                                                                            
    scrub status:                                                                                         
        mds.0: active [paths:/]                     
                                                                    
  data:                                                                                                   
    pools:   2 pools, 24 pgs                                                                              
    objects: 66.79k objects, 1.4 GiB
    usage:   12 GiB used, 21 GiB / 33 GiB avail             
    pgs:     24 active+clean                                        
                                                                                                          
  io:                                                                                                     
    client:   1.5 MiB/s rd, 1.24k op/s rd, 0 op/s wr
```