### PR TITLE
tools/rbd_nbd: use POSIX basename()

### DIFF
--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -18,6 +18,7 @@
 
 #include "include/int_types.h"
 
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -562,7 +563,7 @@ private:
     ifs >> cmdline;
 
     for (unsigned i = 0; i < cmdline.size(); i++) {
-      const char *arg = &cmdline[i];
+      char *arg = &cmdline[i];
       if (i == 0) {
         if (strcmp(basename(arg) , "rbd-nbd") != 0) {
           return -EINVAL;


### PR DESCRIPTION
* glibc offers two variants of basename(). one modifies the content of
  `path`, the other does not. to be standard compliant, and to fix
  the FTBFS with musl-libc, we need to use the POSIX variant.
* #include <libgen.h> for basename(3), the POSIX compliant one.

see
http://pubs.opengroup.org/onlinepubs/009695399/functions/basename.html

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

