### PR TITLE
rgw/multisite: Don't allow certain radosgw-admin commands to run on non-master zone

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4996,6 +4996,12 @@ int main(int argc, const char **argv)
     }
     break;
   case OPT_USER_CREATE:
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "user created here will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
+
     if (!user_op.has_existing_user()) {
       user_op.set_generate_key(); // generate a new key by default
     }
@@ -5016,6 +5022,11 @@ int main(int argc, const char **argv)
     }
     break;
   case OPT_USER_RM:
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "user delete operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     ret = user.remove(user_op, &err_msg);
     if (ret < 0) {
       cerr << "could not remove user: " << err_msg << std::endl;
@@ -5027,6 +5038,11 @@ int main(int argc, const char **argv)
   case OPT_USER_ENABLE:
   case OPT_USER_SUSPEND:
   case OPT_USER_MODIFY:
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "user modify operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     ret = user.modify(user_op, &err_msg);
     if (ret < 0) {
       cerr << "could not modify user: " << err_msg << std::endl;
@@ -5506,6 +5522,11 @@ int main(int argc, const char **argv)
   }
 
   if (opt_cmd == OPT_BUCKET_LINK) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "link operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     bucket_op.set_bucket_id(bucket_id);
     string err;
     int r = RGWBucketAdminOp::link(store, bucket_op, &err);
@@ -5516,6 +5537,11 @@ int main(int argc, const char **argv)
   }
 
   if (opt_cmd == OPT_BUCKET_UNLINK) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "unlink operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     int r = RGWBucketAdminOp::unlink(store, bucket_op);
     if (r < 0) {
       cerr << "failure: " << cpp_strerror(-r) << std::endl;
@@ -6220,6 +6246,11 @@ next:
   }
 
   if (opt_cmd == OPT_BUCKET_RESHARD) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "resharding only applies to the local zone and will not be synced to master" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     rgw_bucket bucket;
     RGWBucketInfo bucket_info;
     map<string, bufferlist> attrs;
@@ -6406,6 +6437,11 @@ next:
   }
 
   if (opt_cmd == OPT_OBJECT_UNLINK) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "unlink operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     RGWBucketInfo bucket_info;
     int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
     if (ret < 0) {
@@ -6497,6 +6533,11 @@ next:
   }
 
   if (opt_cmd == OPT_BUCKET_RM) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "bucket remove operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     if (!inconsistent_index) {
       RGWBucketAdminOp::remove_bucket(store, bucket_op, bypass_gc, true);
     } else {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4891,6 +4891,28 @@ int main(int argc, const char **argv)
     return 0;
   }
 
+  bool non_master_cmd = (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it);
+  std::set<int> non_master_ops_list = {OPT_USER_CREATE, OPT_USER_RM, 
+                                        OPT_USER_MODIFY, OPT_USER_ENABLE,
+                                        OPT_USER_SUSPEND, OPT_SUBUSER_CREATE,
+                                        OPT_SUBUSER_MODIFY, OPT_SUBUSER_RM,
+                                        OPT_BUCKET_LINK, OPT_BUCKET_UNLINK,
+                                        OPT_BUCKET_RESHARD, OPT_BUCKET_RM,
+                                        OPT_METADATA_PUT, OPT_METADATA_RM,
+                                        OPT_RESHARD_CANCEL, OPT_RESHARD_ADD,
+                                        OPT_MFA_CREATE, OPT_MFA_REMOVE,
+                                        OPT_MFA_RESYNC, OPT_CAPS_ADD,
+                                        OPT_CAPS_RM};
+
+  bool print_warning_message = (non_master_ops_list.find(opt_cmd) != non_master_ops_list.end() &&
+                                non_master_cmd);
+
+  if (print_warning_message) {
+      cerr << "Please run the command on master zone. Performing this operation on non-master zone leads to inconsistent metadata between zones" << std::endl;
+      cerr << "Are you sure you want to go ahead? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+  }
+
   if (!user_id.empty()) {
     user_op.set_user_id(user_id);
     bucket_op.set_user_id(user_id);
@@ -4996,12 +5018,6 @@ int main(int argc, const char **argv)
     }
     break;
   case OPT_USER_CREATE:
-    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
-      cerr << "user created here will not be synced to master zone" << std::endl;
-      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
-      return EINVAL;
-    }
-
     if (!user_op.has_existing_user()) {
       user_op.set_generate_key(); // generate a new key by default
     }
@@ -5022,11 +5038,6 @@ int main(int argc, const char **argv)
     }
     break;
   case OPT_USER_RM:
-    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
-      cerr << "user delete operation will not be synced to master zone" << std::endl;
-      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
-      return EINVAL;
-    }
     ret = user.remove(user_op, &err_msg);
     if (ret < 0) {
       cerr << "could not remove user: " << err_msg << std::endl;
@@ -5038,11 +5049,6 @@ int main(int argc, const char **argv)
   case OPT_USER_ENABLE:
   case OPT_USER_SUSPEND:
   case OPT_USER_MODIFY:
-    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
-      cerr << "user modify operation will not be synced to master zone" << std::endl;
-      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
-      return EINVAL;
-    }
     ret = user.modify(user_op, &err_msg);
     if (ret < 0) {
       cerr << "could not modify user: " << err_msg << std::endl;
@@ -5522,11 +5528,6 @@ int main(int argc, const char **argv)
   }
 
   if (opt_cmd == OPT_BUCKET_LINK) {
-    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
-      cerr << "link operation will not be synced to master zone" << std::endl;
-      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
-      return EINVAL;
-    }
     bucket_op.set_bucket_id(bucket_id);
     string err;
     int r = RGWBucketAdminOp::link(store, bucket_op, &err);
@@ -5537,11 +5538,6 @@ int main(int argc, const char **argv)
   }
 
   if (opt_cmd == OPT_BUCKET_UNLINK) {
-    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
-      cerr << "unlink operation will not be synced to master zone" << std::endl;
-      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
-      return EINVAL;
-    }
     int r = RGWBucketAdminOp::unlink(store, bucket_op);
     if (r < 0) {
       cerr << "failure: " << cpp_strerror(-r) << std::endl;
@@ -6246,11 +6242,6 @@ next:
   }
 
   if (opt_cmd == OPT_BUCKET_RESHARD) {
-    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
-      cerr << "resharding only applies to the local zone and will not be synced to master" << std::endl;
-      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
-      return EINVAL;
-    }
     rgw_bucket bucket;
     RGWBucketInfo bucket_info;
     map<string, bufferlist> attrs;
@@ -6437,11 +6428,6 @@ next:
   }
 
   if (opt_cmd == OPT_OBJECT_UNLINK) {
-    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
-      cerr << "unlink operation will not be synced to master zone" << std::endl;
-      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
-      return EINVAL;
-    }
     RGWBucketInfo bucket_info;
     int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
     if (ret < 0) {
@@ -6533,11 +6519,6 @@ next:
   }
 
   if (opt_cmd == OPT_BUCKET_RM) {
-    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
-      cerr << "bucket remove operation will not be synced to master zone" << std::endl;
-      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
-      return EINVAL;
-    }
     if (!inconsistent_index) {
       RGWBucketAdminOp::remove_bucket(store, bucket_op, bypass_gc, true);
     } else {


### PR DESCRIPTION
These are commands that modify metadata. Can override with 'yes-i-really-mean-it' option to allow the changes only on the local zone. 

Fixes: http://tracker.ceph.com/issues/39548

Signed-off-by: Shilpa Jagannath <smanjara@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

