### PR TITLE
nautilus: os/bluestore/bluefs_types: consolidate contiguous extents

### DIFF
--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -88,8 +88,14 @@ struct bluefs_fnode_t {
   }
 
   void append_extent(const bluefs_extent_t& ext) {
-    extents_index.emplace_back(allocated);
-    extents.push_back(ext);
+    if (!extents.empty() &&
+	extents.back().end() == ext.offset &&
+	(uint64_t)extents.back().length + (uint64_t)ext.length < 0xffffffff) {
+      extents.back().length += ext.length;
+    } else {
+      extents_index.emplace_back(allocated);
+      extents.push_back(ext);
+    }
     allocated += ext.length;
   }
 


### PR DESCRIPTION
If we allocate a new extent that is contiguous with the last extent,
just extend it.  This avoids having long vectors of continguous extents
when a single large extent would suffice--especially with log files.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 4f3ce9bc201c20d10d739d42e3f7018408f110a6)
