### PR TITLE
ceph-volume broken assertion errors after pytest changes

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -67,8 +67,13 @@ def _splitname_parser(line):
 
     :returns: dictionary with stripped prefixes
     """
-    parts = line[0].split(';')
     parsed = {}
+    try:
+        parts = line[0].split(';')
+    except IndexError:
+        logger.exception('Unable to parse mapper device: %s', line)
+        return parsed
+
     for part in parts:
         part = part.replace("'", '')
         key, value = part.split('=')

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -384,7 +384,7 @@ class TestVolumeGroupFree(object):
         vg = api.VolumeGroup(vg_name='nosize', vg_free='F')
         with pytest.raises(RuntimeError) as error:
             vg.free
-        assert "Unable to convert vg size to integer: 'F'" in str(error)
+        assert "Unable to convert vg size to integer: 'F'" in str(error.value)
 
     def test_invalid_float(self):
         vg = api.VolumeGroup(vg_name='nosize', vg_free=' g')
@@ -464,7 +464,7 @@ class TestVolumeGroupSizing(object):
     def test_parts_and_size_errors(self):
         with pytest.raises(ValueError) as error:
             self.vg.sizing(parts=4, size=10)
-        assert "Cannot process sizing" in str(error)
+        assert "Cannot process sizing" in str(error.value)
 
     def test_zero_parts_produces_100_percent(self):
         result = self.vg.sizing(parts=0)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -36,7 +36,7 @@ class TestSingleType(object):
         ]
         with pytest.raises(RuntimeError) as error:
             bluestore.SingleType.with_auto_devices(args, devices)
-        assert 'Unable to use device 5.66 GB /dev/sda' in str(error)
+        assert 'Unable to use device 5.66 GB /dev/sda' in str(error.value)
 
     def test_device_is_lvm_member_fails(self, fakedevice, factory):
         args = factory(filtered_devices=[], osds_per_device=1,
@@ -46,7 +46,7 @@ class TestSingleType(object):
         ]
         with pytest.raises(RuntimeError) as error:
             bluestore.SingleType.with_auto_devices(args, devices)
-        assert 'Unable to use device, already a member of LVM' in str(error)
+        assert 'Unable to use device, already a member of LVM' in str(error.value)
 
 
 class TestMixedType(object):
@@ -97,7 +97,7 @@ class TestMixedTypeConfiguredSize(object):
         with pytest.raises(RuntimeError) as error:
             bluestore.MixedType.with_auto_devices(args, devices).computed['osds'][0]
         expected = 'Not enough space in fast devices (5.66 GB) to create 1 x 7.22 GB block.db LV'
-        assert expected in str(error)
+        assert expected in str(error.value)
 
     def test_multi_hdd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         # 3GB block.db in ceph.conf
@@ -112,7 +112,7 @@ class TestMixedTypeConfiguredSize(object):
         with pytest.raises(RuntimeError) as error:
             bluestore.MixedType.with_auto_devices(args, devices)
         expected = 'Unable to use device 5.66 GB /dev/sda, LVs would be smaller than 5GB'
-        assert expected in str(error)
+        assert expected in str(error.value)
 
 
 class TestMixedTypeLargeAsPossible(object):
@@ -165,7 +165,7 @@ class TestMixedTypeLargeAsPossible(object):
         with pytest.raises(RuntimeError) as error:
             bluestore.MixedType.with_auto_devices(args, devices)
         expected = 'Unable to use device 5.66 GB /dev/sda, LVs would be smaller than 5GB'
-        assert expected in str(error)
+        assert expected in str(error.value)
 
 
 class TestMixedTypeWithExplicitDevices(object):
@@ -198,4 +198,4 @@ class TestMixedTypeWithExplicitDevices(object):
         with pytest.raises(RuntimeError) as error:
             bluestore.MixedType(args, [hdd], [], [ssd]).computed['osds'][0]
         expected = 'Unable to use device 1.50 GB /dev/sda, LVs would be smaller than 1GB'
-        assert expected in str(error), str(error)
+        assert expected in str(error.value), str(error)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
@@ -28,7 +28,7 @@ class TestSingleType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
         msg = "Unable to use device 5.66 GB /dev/sda, LVs would be smaller than 5GB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_ssd_device_is_large_enough(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
@@ -53,7 +53,7 @@ class TestSingleType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
         msg = "Unable to use device 5.66 GB /dev/sda, LVs would be smaller than 5GB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_ssd_device_multi_osd(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
@@ -65,7 +65,7 @@ class TestSingleType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
         msg = "Unable to use device 14.97 GB /dev/sda, LVs would be smaller than 5GB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_hdd_device_multi_osd(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
@@ -77,7 +77,7 @@ class TestSingleType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
         msg = "Unable to use device 14.97 GB /dev/sda, LVs would be smaller than 5GB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_device_is_lvm_member_fails(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
@@ -88,7 +88,7 @@ class TestSingleType(object):
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
-        assert 'Unable to use device, already a member of LVM' in str(error)
+        assert 'Unable to use device, already a member of LVM' in str(error.value)
 
     def test_hdd_device_with_small_configured_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '120')
@@ -100,7 +100,7 @@ class TestSingleType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
         msg = "journal sizes must be larger than 2GB, detected: 120.00 MB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_ssd_device_with_small_configured_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '120')
@@ -112,7 +112,7 @@ class TestSingleType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
         msg = "journal sizes must be larger than 2GB, detected: 120.00 MB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
 
 class TestMixedType(object):
@@ -128,7 +128,7 @@ class TestMixedType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
         msg = "journal sizes must be larger than 2GB, detected: 120.00 MB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_ssd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '7120')
@@ -141,7 +141,7 @@ class TestMixedType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
         msg = "Not enough space in fast devices (5.66 GB) to create 1 x 6.95 GB journal LV"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_hdd_device_is_lvm_member_fails(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
@@ -153,7 +153,7 @@ class TestMixedType(object):
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
-        assert 'Unable to use device, already a member of LVM' in str(error)
+        assert 'Unable to use device, already a member of LVM' in str(error.value)
 
     def test_ssd_is_lvm_member_doesnt_fail(self, volumes, stub_vgs, fakedevice, factory, conf_ceph):
         # fast PV, because ssd is an LVM member
@@ -209,7 +209,7 @@ class TestMixedType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
 
-        assert 'Could not find a common VG between devices' in str(error)
+        assert 'Could not find a common VG between devices' in str(error.value)
 
     def test_ssd_device_fails_multiple_osds(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '15120')
@@ -222,7 +222,7 @@ class TestMixedType(object):
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
         msg = "Not enough space in fast devices (14.97 GB) to create 2 x 14.77 GB journal LV"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_filter_all_data_devs(self, fakedevice, factory):
         # in this scenario the user passed a already used device to be used for

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_validate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_validate.py
@@ -14,7 +14,7 @@ class TestMinimumDeviceSize(object):
         with pytest.raises(RuntimeError) as error:
             validators.minimum_device_size(devices)
         msg = "LVs would be smaller than 5GB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_large_device_multiple_osds_fails(self, fakedevice):
         devices = [fakedevice(sys_api=dict(size=6073740000))]
@@ -23,7 +23,7 @@ class TestMinimumDeviceSize(object):
                 devices, osds_per_device=4
             )
         msg = "LVs would be smaller than 5GB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
 
 class TestMinimumCollocatedDeviceSize(object):
@@ -40,7 +40,7 @@ class TestMinimumCollocatedDeviceSize(object):
         with pytest.raises(RuntimeError) as error:
             validators.minimum_device_collocated_size(devices, self.journal_size)
         msg = "LVs would be smaller than 5GB"
-        assert msg in str(error)
+        assert msg in str(error.value)
 
     def test_large_device_multiple_osds_fails(self, fakedevice):
         devices = [fakedevice(sys_api=dict(size=16073740000))]
@@ -49,4 +49,4 @@ class TestMinimumCollocatedDeviceSize(object):
                 devices, self.journal_size, osds_per_device=3
             )
         msg = "LVs would be smaller than 5GB"
-        assert msg in str(error)
+        assert msg in str(error.value)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -28,8 +28,8 @@ class TestPrepareDevice(object):
         with pytest.raises(RuntimeError) as error:
             lvm.prepare.Prepare([]).prepare_device(
                     '/dev/var/foo', 'data', 'asdf', '0')
-        assert 'Cannot use device (/dev/var/foo)' in str(error)
-        assert 'A vg/lv path or an existing device is needed' in str(error)
+        assert 'Cannot use device (/dev/var/foo)' in str(error.value)
+        assert 'A vg/lv path or an existing device is needed' in str(error.value)
 
 
 class TestGetClusterFsid(object):
@@ -98,7 +98,7 @@ class TestPrepare(object):
         with pytest.raises(SystemExit) as error:
             lvm.prepare.Prepare(argv=['--filestore', '--data', '/dev/sdfoo']).main()
         expected = '--journal is required when using --filestore'
-        assert expected in str(error)
+        assert expected in str(error.value)
 
 
 class TestGetJournalLV(object):

--- a/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
@@ -15,7 +15,7 @@ class TestActivate(object):
         os.environ['CEPH_VOLUME_SIMPLE_JSON_DIR'] = '/non/existing/path'
         with pytest.raises(RuntimeError) as error:
             activate.Activate(['1', 'asdf']).main()
-        assert 'RuntimeError: Expected JSON config path not found' in str(error)
+        assert 'Expected JSON config path not found' in str(error.value)
 
     def test_main_spits_help_with_no_arguments(self, capsys):
         activate.Activate([]).main()
@@ -132,13 +132,13 @@ class TestValidateDevices(object):
         activation = activate.Activate([])
         with pytest.raises(RuntimeError) as error:
             activation.validate_devices({'type': 'filestore', 'data': {}})
-        assert 'Unable to activate filestore OSD due to missing devices' in str(error)
+        assert 'Unable to activate filestore OSD due to missing devices' in str(error.value)
 
     def test_filestore_missing_data(self):
         activation = activate.Activate([])
         with pytest.raises(RuntimeError) as error:
             activation.validate_devices({'type': 'filestore', 'journal': {}})
-        assert 'Unable to activate filestore OSD due to missing devices' in str(error)
+        assert 'Unable to activate filestore OSD due to missing devices' in str(error.value)
 
     def test_filestore_journal_device_found(self, capsys):
         activation = activate.Activate([])
@@ -180,7 +180,7 @@ class TestValidateDevices(object):
         activation = activate.Activate([])
         with pytest.raises(RuntimeError) as error:
             activation.validate_devices({'type': 'bluestore', 'block': {}})
-        assert 'Unable to activate bluestore OSD due to missing devices' in str(error)
+        assert 'Unable to activate bluestore OSD due to missing devices' in str(error.value)
 
     def test_bluestore_block_device_found(self, capsys):
         activation = activate.Activate([])

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -25,7 +25,7 @@ class TestOSDPath(object):
         validator = arg_validators.OSDPath()
         with pytest.raises(argparse.ArgumentError) as error:
             validator(tmppath)
-        assert 'Required file (ceph_fsid) was not found in OSD' in str(error)
+        assert 'Required file (ceph_fsid) was not found in OSD' in str(error.value)
 
 
 class TestExcludeGroupOptions(object):

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -319,7 +319,7 @@ class TestMkfsFilestore(object):
         stub_call(([], [], 1))
         with pytest.raises(RuntimeError) as error:
             prepare.osd_mkfs_filestore('1', 'asdf-1234', 'keyring')
-        assert "Command failed with exit code 1" in str(error)
+        assert "Command failed with exit code 1" in str(error.value)
 
     def test_non_zero_exit_formats_command_correctly(self, stub_call, monkeypatch):
         conf.cluster = 'ceph'
@@ -337,7 +337,7 @@ class TestMkfsFilestore(object):
             '--osd-journal', '/var/lib/ceph/osd/ceph-1/journal',
             '--osd-uuid', 'asdf-1234',
             '--setuser', 'ceph', '--setgroup', 'ceph'])
-        assert expected in str(error)
+        assert expected in str(error.value)
 
 
 class TestMkfsBluestore(object):
@@ -348,7 +348,7 @@ class TestMkfsBluestore(object):
         stub_call(([], [], 1))
         with pytest.raises(RuntimeError) as error:
             prepare.osd_mkfs_bluestore('1', 'asdf-1234', keyring='keyring')
-        assert "Command failed with exit code 1" in str(error)
+        assert "Command failed with exit code 1" in str(error.value)
 
     def test_non_zero_exit_formats_command_correctly(self, stub_call, monkeypatch):
         conf.cluster = 'ceph'
@@ -365,7 +365,7 @@ class TestMkfsBluestore(object):
             '--keyfile', '-', '--osd-data', '/var/lib/ceph/osd/ceph-1/',
             '--osd-uuid', 'asdf-1234',
             '--setuser', 'ceph', '--setgroup', 'ceph'])
-        assert expected in str(error)
+        assert expected in str(error.value)
 
 
 class TestGetJournalSize(object):
@@ -418,5 +418,5 @@ class TestGetJournalSize(object):
         """))
         with pytest.raises(RuntimeError) as error:
             prepare.get_journal_size()
-        assert 'journal sizes must be larger' in str(error)
-        assert 'detected: 1024.00 MB' in str(error)
+        assert 'journal sizes must be larger' in str(error.value)
+        assert 'detected: 1024.00 MB' in str(error.value)


### PR DESCRIPTION
pytest has changed its exception handling on pytest.raises to require error.value instead of str(error) for comparison.

All tests need to be updated for this.

This PR also makes a change to the dmmapper parser because it was catching an exception on my local tests because it was picking up a local LV. Catching IndexError here is safe, and returning the empty dictionary while logging is good enough.


Fixes: http://tracker.ceph.com/issues/40665