### PR TITLE
nautilus: qa/ceph-ansible: ceph-ansible requires ansible 2.8

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/2-ceph/ceph_ansible.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/2-ceph/ceph_ansible.yaml
@@ -3,7 +3,7 @@ meta:
 
 overrides:
    ceph_ansible:
-     ansible-version: "2.7"
+     ansible-version: "2.8"
      vars:
         ceph_conf_overrides:
           global:


### PR DESCRIPTION
http://tracker.ceph.com/issues/40669