### PR TITLE
doc/dev/corpus.rst: minor tweaks

### DIFF
--- a/doc/dev/corpus.rst
+++ b/doc/dev/corpus.rst
@@ -26,7 +26,7 @@ We can generate an object corpus for a particular version of ceph like so.
 	cd ceph
 	git submodule update --init --recursive
 
-#. Build with flag to dump objects to /tmp/foo::
+#. Build with flag to dump objects to ``/tmp/foo``::
 
 	rm -rf /tmp/foo ; mkdir /tmp/foo
 	do_cmake.sh -DCMAKE_CXX_FLAGS="-DENCODE_DUMP_PATH=/tmp/foo"
@@ -76,9 +76,9 @@ Do some more stuff with rgw if you know how.
 
 	pushd ../ceph-object-corpus
 	git checkout -b wip-new
-	git add archive/`../src/ceph-dencoder version`
-	git commit -m `../src/ceph-dencoder version`
-	git remote add cc ceph.com:/git/ceph-object-corpus.git
+	git add archive/`../build/bin/ceph-dencoder version`
+	git commit -m `../build/bin/ceph-dencoder version`
+	git remote add cc git@github.com:ceph/ceph-object-corpus.git
 	git push cc wip-new
 	popd
 


### PR DESCRIPTION
the executables are located in build/bin after we switched to cmake

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

