### PR TITLE
mgr/prometheus: redirect metrics request sent to standby mgr to active mgr

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1060,7 +1060,12 @@ class StandbyModule(MgrStandbyModule):
             @cherrypy.expose
             def metrics(self):
                 cherrypy.response.headers['Content-Type'] = 'text/plain'
-                return ''
+                active_uri = module.get_active_uri()
+                if active_uri:
+                    module.log.info("Redirecting to active '%s'", active_uri)
+                    raise cherrypy.HTTPRedirect(active_uri + "metrics")
+                else:
+                    raise cherrypy.HTTPError(503, 'No active ceph-mgr instance is currently running the prometheus')
 
         cherrypy.tree.mount(Root(), '/', {})
         self.log.info('Starting engine...')


### PR DESCRIPTION
mgr/prometheus: redirect metrics request sent to standby mgr to active mgr

Fixes: https://tracker.ceph.com/issues/40671

Signed-off-by: Jiahui Zeng <jhzeng93@foxmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

