### PR TITLE
mgr/dashboard: Fix the table mouseenter event handling test

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -80,10 +80,18 @@ describe('TableComponent', () => {
   });
 
   it('should prevent propagation of mouseenter event', (done) => {
-    fixture.detectChanges();
+    let wasCalled = false;
     const mouseEvent = new MouseEvent('mouseenter');
-    mouseEvent.stopPropagation = () => done();
-    fixture.debugElement.nativeElement.dispatchEvent(mouseEvent);
+    mouseEvent.stopPropagation = () => {
+      wasCalled = true;
+    };
+    spyOn(window, 'addEventListener').and.callFake((eventName, fn) => {
+      fn(mouseEvent);
+      expect(eventName).toBe('mouseenter');
+      expect(wasCalled).toBe(true);
+      done();
+    });
+    component.ngOnInit();
   });
 
   describe('test search', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -179,14 +179,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   ngOnInit() {
     // ngx-datatable triggers calculations each time mouse enters a row,
     // this will prevent that.
-    window.addEventListener(
-      'mouseenter',
-      function(event) {
-        event.stopPropagation();
-      },
-      true
-    );
-
+    window.addEventListener('mouseenter', (event) => event.stopPropagation(), true);
     this._addTemplates();
     if (!this.sorts) {
       // Check whether the specified identifier exists.


### PR DESCRIPTION
This test only failed if all suites were run, for some reason the window
object got replaced with a mock window. The workaround is not to use
the window object, but mock the called function in order to call the
values as expected by window.

Fixes: https://tracker.ceph.com/issues/40580
Signed-off-by: Stephan Müller <smueller@suse.com>