### PR TITLE
pybind: use current interpreter for cflags

### DIFF
--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -55,7 +55,7 @@ def get_python_flags():
     if os.environ.get('VIRTUAL_ENV', None):
         python = "python"
     else:
-        python = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
+        python = sys.executable
 
     python_config = python + '-config'
 

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -55,7 +55,7 @@ def get_python_flags():
     if os.environ.get('VIRTUAL_ENV', None):
         python = "python"
     else:
-        python = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
+        python = sys.executable
 
     python_config = python + '-config'
 

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -55,7 +55,7 @@ def get_python_flags():
     if os.environ.get('VIRTUAL_ENV', None):
         python = "python"
     else:
-        python = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
+        python = sys.executable
 
     python_config = python + '-config'
 

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -57,7 +57,7 @@ def get_python_flags():
     if os.environ.get('VIRTUAL_ENV', None):
         python = "python"
     else:
-        python = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
+        python = sys.executable
 
     python_config = python + '-config'
 


### PR DESCRIPTION
when doing cross compilation, we should not rely on "$PATH" to find the
the path to used python interpreter executable, instead we should use
the *current* python interpreter for the cflags

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

