### PR TITLE
mgr: return perf_counters data timestamps in nanosecs

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -702,7 +702,7 @@ PyObject* ActivePyModules::get_counter_python(
       const auto &avg_data = counter_instance.get_data_avg();
       for (const auto &datapoint : avg_data) {
         f.open_array_section("datapoint");
-        f.dump_unsigned("t", datapoint.t.sec());
+        f.dump_unsigned("t", datapoint.t.to_nsec());
         f.dump_unsigned("s", datapoint.s);
         f.dump_unsigned("c", datapoint.c);
         f.close_section();
@@ -711,7 +711,7 @@ PyObject* ActivePyModules::get_counter_python(
       const auto &data = counter_instance.get_data();
       for (const auto &datapoint : data) {
         f.open_array_section("datapoint");
-        f.dump_unsigned("t", datapoint.t.sec());
+        f.dump_unsigned("t", datapoint.t.to_nsec());
         f.dump_unsigned("v", datapoint.v);
         f.close_section();
       }
@@ -732,12 +732,12 @@ PyObject* ActivePyModules::get_latest_counter_python(
   {
     if (counter_type.type & PERFCOUNTER_LONGRUNAVG) {
       const auto &datapoint = counter_instance.get_latest_data_avg();
-      f.dump_unsigned("t", datapoint.t.sec());
+      f.dump_unsigned("t", datapoint.t.to_nsec());
       f.dump_unsigned("s", datapoint.s);
       f.dump_unsigned("c", datapoint.c);
     } else {
       const auto &datapoint = counter_instance.get_latest_data();
-      f.dump_unsigned("t", datapoint.t.sec());
+      f.dump_unsigned("t", datapoint.t.to_nsec());
       f.dump_unsigned("v", datapoint.v);
     }
   };


### PR DESCRIPTION
When the mgr modules request the information of a perf_counter they receive a time series of the values of the perf_counter. The timestamp of each data point is now being returned in nanoseconds (opposed to seconds).
We are changing the precision to nanoseconds because sometimes we would get two consecutive data points with the same timestamp, which would cause a python exception when calculating the derivative of the sequence of data points. See: https://github.com/ceph/ceph/pull/26270#discussion_r299901814

By looking at the code of the mgr modules that query the perf_counters from the manager, I don't think this code breaks existing modules, the timestamps are only being used to calculate the derivative of the time series.

Signed-off-by: Ricardo Dias <rdias@suse.com>

