### PR TITLE
docs: rgw: fix bucket operation spelling: ListBucketMultipartUploads

### DIFF
--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -66,7 +66,7 @@ Currently, we support only the following actions:
 - s3:GetObjectVersionTorrent
 - s3:GetReplicationConfiguration
 - s3:ListAllMyBuckets
-- s3:ListBucketMultiPartUploads
+- s3:ListBucketMultipartUploads
 - s3:ListBucket
 - s3:ListBucketVersions
 - s3:ListMultipartUploadParts

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6951,7 +6951,7 @@ std::vector<Option> get_rgw_options() {
     .set_long_description("This caps the maximum permitted value for listing-like operations in RGW S3. "
 			  "Affects ListBucket(max-keys), "
 			  "ListBucketVersions(max-keys), "
-			  "ListBucketMultiPartUploads(max-uploads), "
+			  "ListBucketMultipartUploads(max-uploads), "
 			  "ListMultipartUploadParts(max-parts)"),
 
     Option("rgw_sts_token_introspection_url", Option::TYPE_STR, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
The S3 action `s3:ListBucketMultipartUploads` is case-sensitive and was fixed in #21916, but there were two more occurrences left. The `p` in `Multipart` must be lower-case.