### PR TITLE
nautilus: os/bluestore: more smart allocator dump when lacking space for bluefs

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5686,7 +5686,7 @@ int BlueStore::allocate_bluefs_freespace(
 	      << " available 0x " << alloc->get_free()
 	      << std::dec << dendl;
 
-	alloc->dump();
+	_dump_alloc_on_failure();
 	alloc->release(*extents);
 	extents->clear();
 	return -ENOSPC;


### PR DESCRIPTION
http://tracker.ceph.com/issues/40675