### PR TITLE
luminous: os/bluestore: load OSD all compression settings unconditionally.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3854,12 +3854,6 @@ void BlueStore::_set_compression()
 
   compressor = nullptr;
 
-  if (comp_mode == Compressor::COMP_NONE) {
-    dout(10) << __func__ << " compression mode set to 'none', "
-             << "ignore other compression setttings" << dendl;
-    return;
-  }
-
   if (cct->_conf->bluestore_compression_min_blob_size) {
     comp_min_blob_size = cct->_conf->bluestore_compression_min_blob_size;
   } else {


### PR DESCRIPTION
https://tracker.ceph.com/issues/40534