### PR TITLE
[RFC] ceph-volume: DriveGroups in ceph-volume

### DIFF
--- a/doc/ceph-volume/drivegroups/README.rst
+++ b/doc/ceph-volume/drivegroups/README.rst
@@ -1,0 +1,155 @@
+.. _ceph-volume-drivegroups:
+
+``Concept``
+============
+
+Creating OSDs in ceph is a mostly manual process. DriveGroups are aiming to change that.
+
+Instead of targeting drives individually we try to describe them by using attributes.
+
+.. note:: Valid attributes are `vendor`, `model`, `size`, `rotational`
+          (Attributes are compared to what ceph-volume inventory --format json-pretty reports)
+
+
+
+``Example``
+===========
+
+Imagine a node with 10HDDs and 2SSDs.
+
+HDD:
+
+- Vendor: Example_vendor_A
+- Model: Slow_rusty_spinner_123
+- Size: 2TB
+
+SSD:
+
+- Vendor: Example_vendor_B
+- Model: Fast_thing_987
+- Size: 512GB
+
+
+We'd like to have the two SSDs as dedicated DB/WAL devices.
+
+In a traditional deployment procedure we'd find the device names of these drives and pass them
+to ceph-volume (given we follow the manual deployment process)::
+
+:: ref to ceph-volume docs
+
+With DriveGroups we just create one yaml file::
+
+
+    touch example_drive_groups.yaml
+
+
+Now we add try to describe these drives using their attributes.
+
+The easiest way to differentiate the drives is by their ``rotational`` flag.
+Hence our DriveGroups would look as simple as:
+
+
+.. code-block:: yaml
+
+        default:
+            data_devices:
+              rotational: 0
+            db_devices:
+              rotational: 1
+
+
+If for whatever reason we can't rely on the rotational flag, we may just use any other property.
+
+
+.. code-block:: yaml
+
+        default:
+            data_devices:
+              size: 2TB # high:low notation is also implemented (:N, N:, MIN:MAX)
+            db_devices:
+              size: 512MB # MB or M is fine
+
+We can also mix attributes:
+
+
+.. code-block:: yaml
+
+        default:
+            data_devices:
+              model: Slow_rusty_spinner_123  # model and vendor are implemented as a substring matcher
+            db_devices:
+              vendor: Example_vendor_B
+
+
+We can also define properties like ``block_wal_size`` or ``encryption`` by adding it to the DriveGroup file.
+
+
+.. code-block:: yaml
+
+        default:
+            data_devices:
+              model: Slow_rusty_spinner_123  # model and vendor are implemented as a substring matcher
+            db_devices:
+              vendor: Example_vendor_B
+            encryption: True
+
+
+
+``show``
+============
+
+How that we described our setup, we can pass this to ceph-volume and validate it::
+
+
+    ceph-volume drivegroups show /path/to/example_drive_groups.yaml
+
+
+Internally this re-uses the reporting functionality of ceph-volume. So we'd get back something like this (my example output is with 5xHDD 2xPseudo SSDs)
+
+::
+
+
+    data1:/ceph-volume drivegroups show /path/to/example_drive_groups.yaml
+
+    --> Processing DriveGroup <default>
+    --> Initializing filter <size> with value <20G>
+    --> Initializing filter <size> with value <10G>
+
+    Total OSDs: 5
+
+
+    Solid State VG:
+      Targets:   block.db                  Total size: 18.00 GB
+      Total LVs: 5                         Size per LV: 3.60 GB
+      Devices:   /dev/vdg, /dev/vdh
+
+      Type            Path                                                    LV Size         % of device
+    ----------------------------------------------------------------------------------------------------
+      [data]          /dev/vdb                                                19.00 GB        100.0%
+      [block.db]      vg: vg/lv                                               3.60 GB         20%
+    ----------------------------------------------------------------------------------------------------
+      [data]          /dev/vdc                                                19.00 GB        100.0%
+      [block.db]      vg: vg/lv                                               3.60 GB         20%
+    ----------------------------------------------------------------------------------------------------
+      [data]          /dev/vdd                                                19.00 GB        100.0%
+      [block.db]      vg: vg/lv                                               3.60 GB         20%
+    ----------------------------------------------------------------------------------------------------
+      [data]          /dev/vde                                                19.00 GB        100.0%
+      [block.db]      vg: vg/lv                                               3.60 GB         20%
+    ----------------------------------------------------------------------------------------------------
+      [data]          /dev/vdf                                                19.00 GB        100.0%
+      [block.db]      vg: vg/lv                                               3.60 GB         20%
+
+
+
+``apply``
+============
+
+If we're satisfied with the results we can continue with the deployment process by ``applying`` the DriveGroups.::
+
+    ceph-volume drivegroups apply /path/to/example_drive_groups.yaml
+
+
+We get prompted with the summary above again, but for automated deployments there is a ``-n`` (non-interactive) switch.
+
+From there on ceph-volume (specifically Batch()) takes care of the deployment.

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -136,6 +136,11 @@ class Batch(object):
     """)
 
     def __init__(self, argv):
+
+
+        if __name__ != '__main__':
+            print("#TODO Implement a common interface for module<->module calls")
+
         parser = argparse.ArgumentParser(
             prog='ceph-volume lvm batch',
             formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/ceph-volume/ceph_volume/drivegroups/__init__.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/__init__.py
@@ -1,0 +1,1 @@
+from .main import DriveGroups #noqa

--- a/src/ceph-volume/ceph_volume/drivegroups/actions.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/actions.py
@@ -1,0 +1,127 @@
+import logging
+import argparse
+import yaml
+from textwrap import dedent
+from ceph_volume import terminal
+from .selector import DriveSelection
+from ceph_volume.devices.lvm.batch import Batch
+
+mlogger = terminal.MultiLogger(__name__)
+logger = logging.getLogger(__name__)
+
+
+class DriveGroupsCommand(object):
+    """ Parent class for DriveGroup commands """
+
+    def __init__(self, argv, report_only=False, non_interative=False):
+        self.argv = argv
+        self.non_interative = non_interative
+        self.report = report_only
+
+    @staticmethod
+    def _load_drive_group_file(filename):
+        with open(filename, 'rb') as _fd:
+            return yaml.load(_fd)
+
+    def apply(self, drive_selector):
+        data = drive_selector.data_devices()
+        db = drive_selector.db_devices()
+        wal = drive_selector.wal_devices()
+        journal = drive_selector.journal_devices()
+
+        if not data:
+            return "Nothing matched #TODO message"
+
+        data_strings = [dev.path for dev in data]
+
+        argv_string = data_strings
+
+        if db:
+            db_strings = [dev.path for dev in db]
+            argv_string.extend(['--db-devices'])
+            argv_string.extend(db_strings)
+
+        if wal:
+            wal_strings = [dev.path for dev in wal]
+            argv_string.extend(['--wal-devices'])
+            argv_string.extend(wal_strings)
+
+        if journal:
+            journal_strings = [dev.path for dev in journal]
+            argv_string.extend(['--journal-devices'])
+            argv_string.extend(journal_strings)
+
+        if self.report:
+            argv_string.extend(["--report"])
+
+        if self.non_interative:
+            argv_string.extend(["--yes"])
+
+        #TODO: Improve this! Bare string passing is a hack!
+        Batch(argv_string).main()
+
+    def _run(self, _args):
+        drive_group_def = self._load_drive_group_file(_args.filename)
+        for drive_group_name, drive_group_spec in drive_group_def.items():
+            mlogger.info(f"Processing DriveGroup <{drive_group_name}>")
+            self.apply(DriveSelection(drive_group_spec))
+
+
+class DriveGroupsApply(DriveGroupsCommand):
+    def __init__(self, argv):
+        DriveGroupsCommand.__init__(self, argv, report_only=False)
+
+    def main(self):
+        sub_command_help = dedent("""
+
+        Dummy text for DriveGroup foo.
+
+            ceph-volume drivegroup apply <example_drivegroup_file.yaml>
+
+        When you apply DriveGroups, ceph-volume will apply foo #TODO.
+        # TODO: re-write
+        """)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume drivegroups apply',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=sub_command_help,
+        )
+
+        parser.add_argument(
+            'filename', help='A file containing the DriveGroups spec')
+        if len(self.argv) == 0:
+            print(sub_command_help)
+            return
+
+        args = parser.parse_args(self.argv)
+        self._run(args)
+
+
+class DriveGroupsShow(DriveGroupsCommand):
+    def __init__(self, argv):
+        DriveGroupsCommand.__init__(self, argv, report_only=True)
+
+    def main(self):
+        sub_command_help = dedent("""
+
+        Dummy text for DriveGroup foo.
+
+            ceph-volume drivegroup show <example_drivegroup_file.yaml>
+
+        When you apply DriveGroups, ceph-volume will show foo #TODO.
+        # TODO: re-write
+        """)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume drivegroups show',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=sub_command_help,
+        )
+
+        parser.add_argument(
+            'filename', help='A file containing the DriveGroups spec')
+        if len(self.argv) == 0:
+            print(sub_command_help)
+            return
+
+        args = parser.parse_args(self.argv)
+        self._run(args)

--- a/src/ceph-volume/ceph_volume/drivegroups/example.yaml
+++ b/src/ceph-volume/ceph_volume/drivegroups/example.yaml
@@ -1,0 +1,21 @@
+# default:
+#   target: 'data*'
+#   data_devices:
+#     size: 20G
+#   db_devices:
+#     size: 10G
+#     rotational: 1
+# allflash:
+#   target: 'fast_nodes*'
+#   data_devices:
+#     size: 100G
+#   db_devices:
+#     size: 50G
+#     rotational: 0
+
+# This is the default configuration and
+# will create an OSD on all available drives
+default:
+  target: 'fnmatch_target'
+  data_devices:
+    all: true

--- a/src/ceph-volume/ceph_volume/drivegroups/exceptions.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/exceptions.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+
+class FilterNotSupported(Exception):
+    """ A critical error when the user specified filter is unsupported
+    """
+    pass
+
+
+class FeatureNotSupported(Exception):
+    """ A critical error when the user specified feature is unsupported
+    """
+    pass
+
+
+class UnitNotSupported(Exception):
+    """ A critical error which encouters when a unit is parsed which
+    isn't supported.
+    """
+    pass
+
+
+class ConfigError(Exception):
+    """ A critical error which is encountered when a configuration is not supported
+    or is invalid.
+    """
+    pass

--- a/src/ceph-volume/ceph_volume/drivegroups/filter.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/filter.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+import logging
+from .matchers import SubstringMatcher, AllMatcher, SizeMatcher, EqualityMatcher
+from ceph_volume import terminal
+
+mlogger = terminal.MultiLogger(__name__)
+logger = logging.getLogger(__name__)
+
+
+class Filter(object):
+    """ Filter class to assign properties to bare filters.
+
+    This is a utility class that tries to simplify working
+    with information comming from a textfile (drive_group.yaml)
+
+    """
+
+    def __init__(self, **kwargs):
+        self.name: str = str(kwargs.get('name', None))
+        self.matcher = kwargs.get('matcher', None)
+        self.value: str = str(kwargs.get('value', None))
+        self._assign_matchers()
+        mlogger.debug("Initializing filter <{}> with value <{}>".format(
+            self.name, self.value))
+
+    @property
+    def is_matchable(self) -> bool:
+        """ A property to indicate if a Filter has a matcher
+
+        Some filter i.e. 'limit' or 'osd_per_device' are valid filter
+        attributes but cannot be applied to a disk set. In this case
+        we return 'None'
+        :return: If a matcher is present True/Flase
+        :rtype: bool
+        """
+        return self.matcher is not None
+
+    def _assign_matchers(self) -> None:
+        """ Assign a matcher based on filter_name
+
+        This method assigns an individual Matcher based
+        on `self.name` and returns it.
+        """
+        if self.name == "size":
+            self.matcher = SizeMatcher(self.name, self.value)
+        elif self.name == "model":
+            self.matcher = SubstringMatcher(self.name, self.value)
+        elif self.name == "vendor":
+            self.matcher = SubstringMatcher(self.name, self.value)
+        elif self.name == "rotational":
+            self.matcher = EqualityMatcher(self.name, self.value)
+        elif self.name == "all":
+            self.matcher = AllMatcher(self.name, self.value)
+        else:
+            logger.debug(f"No suitable matcher for <{self.name}> could be found.")
+
+    def __repr__(self) -> str:
+        """ Visual representation of the filter
+        """
+        return 'Filter<{}>'.format(self.name)
+
+
+class FilterGenerator(object):
+    def __init__(self, device_filter):
+        self.device_filter = device_filter
+
+    def __iter__(self):
+        for name, val in self.device_filter.items():
+            yield Filter(name=name, value=val)

--- a/src/ceph-volume/ceph_volume/drivegroups/main.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/main.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import argparse
+
+import logging
+from textwrap import dedent
+from ceph_volume import terminal
+from .actions import DriveGroupsApply, DriveGroupsShow
+
+mlogger = terminal.MultiLogger(__name__)
+logger = logging.getLogger(__name__)
+
+
+class DriveGroups(object):
+
+    help = 'foo'
+
+    _help = dedent("""
+
+    show [reports the resulting changes]
+    apply [applies the drivegroup, creates OSDs if needed #TODO re-write]
+
+    {sub_help}
+    """)
+
+    mapper = {'show': DriveGroupsShow, 'apply': DriveGroupsApply}
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def print_help(self, sub_help):
+        return self._help.format(sub_help=sub_help)
+
+    def main(self):
+        terminal.dispatch(self.mapper, self.argv)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume drivegroup',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.print_help(terminal.subhelp(self.mapper)),
+        )
+        parser.parse_args(self.argv)
+        if len(self.argv) <= 1:
+            return parser.print_help()

--- a/src/ceph-volume/ceph_volume/drivegroups/matchers.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/matchers.py
@@ -1,0 +1,378 @@
+# -*- coding: utf-8 -*-
+
+from typing import Tuple
+from .exceptions import UnitNotSupported
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class Matcher(object):
+    """ The base class to all Matchers
+
+    It holds utility methods such as _get_disk_key
+    and handles the initialization.
+
+    """
+
+    def __init__(self, key: str, value: str) -> None:
+        """ Initialization of Base class
+
+        :param str key: Attribute like 'model, size or vendor'
+        :param str value: Value of attribute like 'X123, 5G or samsung'
+        """
+        self.key: str = key
+        self.value: str = value
+        self.fallback_key: str = ''
+
+    # pylint: disable=inconsistent-return-statements
+    def _get_disk_key(self, disk: dict) -> str:
+        """ Helper method to safely extract values form the disk dict
+
+        There is a 'key' and a _optional_ 'fallback' key that can be used.
+        The reason for this is that the output of ceph-volume is not always
+        consistent (due to a bug currently, but you never know).
+        There is also a safety measure for a disk_key not existing on
+        virtual environments. ceph-volume apparently sources its information
+        from udev which seems to not populate certain fields on VMs.
+
+        :param dict disk: A disk representation
+        :raises: A generic Exception when no disk_key could be found.
+        :return: A disk value
+        :rtype: str
+        """
+        # TODO: Actually you get a Disk() object back which can be accessed
+        # using the . notation, but some keys are nested, and hidden behind
+        # a different hierarchy, which makes it harder to access programatically
+        # hence, make it a dict.
+        disk = disk.json_report()
+
+        def findkeys(node, key_val):
+            """ Find keys in non-flat dict recursively """
+            if isinstance(node, list):
+                for i in node:
+                    for key in findkeys(i, key_val):
+                        yield key
+            elif isinstance(node, dict):
+                if key_val in node:
+                    yield node[key_val]
+                for j in node.values():
+                    for key in findkeys(j, key_val):
+                        yield key
+
+        disk_value: str = list(findkeys(disk, self.key))
+        if not disk_value and self.fallback_key:
+            disk_value = list(findkeys(disk, self.fallback_key))
+
+        if disk_value:
+            return disk_value[0]
+        else:
+            raise Exception("No value found for {} or {}".format(
+                self.key, self.fallback_key))
+
+    def compare(self, disk: dict):
+        """ Implements a valid comparison method for a SubMatcher
+        This will get overwritten by the individual classes
+
+        :param dict disk: A disk representation
+        """
+        pass
+
+
+# pylint: disable=too-few-public-methods
+class SubstringMatcher(Matcher):
+    """ Substring matcher subclass
+    """
+
+    def __init__(self, key: str, value: str, fallback_key=None) -> None:
+        Matcher.__init__(self, key, value)
+        self.fallback_key = fallback_key
+
+    def compare(self, disk: dict) -> bool:
+        """ Overwritten method to match substrings
+
+        This matcher does substring matching
+        :param dict disk: A disk representation (see base for examples)
+        :return: True/False if the match succeeded
+        :rtype: bool
+        """
+        if not disk:
+            return False
+        disk_value: str = self._get_disk_key(disk)
+        if str(self.value) in str(disk_value):
+            return True
+        return False
+
+
+# pylint: disable=too-few-public-methods
+class AllMatcher(Matcher):
+    """ All matcher subclass
+    """
+
+    def __init__(self, key: str, value: str, fallback_key=None) -> None:
+        Matcher.__init__(self, key, value)
+        self.fallback_key = fallback_key
+
+    def compare(self, disk: dict) -> bool:
+        """ Overwritten method to match all
+
+        A rather dumb matcher that just accepts all disks
+        (regardless of the value)
+        :param dict disk: A disk representation (see base for examples)
+        :return: always True
+        :rtype: bool
+        """
+        if not disk:
+            return False
+        return True
+
+
+# pylint: disable=too-few-public-methods
+class EqualityMatcher(Matcher):
+    """ Equality matcher subclass
+    """
+
+    def __init__(self, key: str, value: str) -> None:
+        Matcher.__init__(self, key, value)
+
+    def compare(self, disk: dict) -> bool:
+        """ Overwritten method to match equality
+
+        This matcher does value comparison
+        :param dict disk: A disk representation
+        :return: True/False if the match succeeded
+        :rtype: bool
+        """
+        if not disk:
+            return False
+        disk_value: str = self._get_disk_key(disk)
+        if int(disk_value) == int(self.value):
+            return True
+        return False
+
+
+class SizeMatcher(Matcher):
+    """ Size matcher subclass
+    """
+
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, key: str, value: str) -> None:
+        # The 'key' value is overwritten here because
+        # the user_defined attribute does not neccessarily
+        # correspond to the desired attribute
+        # requested from the inventory output
+        Matcher.__init__(self, key, value)
+        self.key: str = "human_readable_size"
+        self.fallback_key: str = "size"
+        self._high = None
+        self._high_suffix = None
+        self._low = None
+        self._low_suffix = None
+        self._exact = None
+        self._exact_suffix = None
+        self._parse_filter()
+
+    @property
+    def low(self) -> Tuple:
+        """ Getter for 'low' matchers
+        """
+        return self._low, self._low_suffix
+
+    @low.setter
+    def low(self, low: Tuple) -> None:
+        """ Setter for 'low' matchers
+        """
+        self._low, self._low_suffix = low
+
+    @property
+    def high(self) -> Tuple:
+        """ Getter for 'high' matchers
+        """
+        return self._high, self._high_suffix
+
+    @high.setter
+    def high(self, high: Tuple) -> None:
+        """ Setter for 'high' matchers
+        """
+        self._high, self._high_suffix = high
+
+    @property
+    def exact(self) -> Tuple:
+        """ Getter for 'exact' matchers
+        """
+        return self._exact, self._exact_suffix
+
+    @exact.setter
+    def exact(self, exact: Tuple) -> None:
+        """ Setter for 'exact' matchers
+        """
+        self._exact, self._exact_suffix = exact
+
+    @property
+    def supported_suffixes(self) -> list:
+        """ Only power of 10 notation is supported
+        """
+        return ["MB", "GB", "TB", "M", "G", "T"]
+
+    def _normalize_suffix(self, suffix: str) -> str:
+        """ Normalize any supported suffix
+
+        Since the Drive Groups are user facing, we simply
+        can't make sure that all users type in the requested
+        form. That's why we have to internally agree on one format.
+        It also checks if any of the supported suffixes was used
+        and raises an Exception otherwise.
+
+        :param str suffix: A suffix ('G') or ('M')
+        :return: A normalized output
+        :rtype: str
+        """
+        if suffix not in self.supported_suffixes:
+            raise UnitNotSupported("Unit '{}' not supported".format(suffix))
+        if suffix == "G":
+            return "GB"
+        if suffix == "T":
+            return "TB"
+        if suffix == "M":
+            return "MB"
+        return suffix
+
+    def _parse_suffix(self, obj: str) -> str:
+        """ Wrapper method to find and normalize a prefix
+
+        :param str obj: A size filtering string ('10G')
+        :return: A normalized unit ('GB')
+        :rtype: str
+        """
+        return self._normalize_suffix(re.findall(r"[a-zA-Z]+", obj)[0])
+
+    def _get_k_v(self, data: str) -> Tuple:
+        """ Helper method to extract data from a string
+
+        It uses regex to extract all digits and calls _parse_suffix
+        which also uses a regex to extract all letters and normalizes
+        the resulting suffix.
+
+        :param str data: A size filtering string ('10G')
+        :return: A Tuple with normalized output (10, 'GB')
+        :rtype: tuple
+        """
+        return (re.findall(r"\d+", data)[0], self._parse_suffix(data))
+
+    def _parse_filter(self):
+        """ Identifies which type of 'size' filter is applied
+
+        There are four different filtering modes:
+
+        1) 10G:50G (high-low)
+           At least 10G but at max 50G of size
+
+        2) :60G
+           At max 60G of size
+
+        3) 50G:
+           At least 50G of size
+
+        4) 20G
+           Exactly 20G in size
+
+        This method uses regex to identify and extract this information
+        and raises if none could be found.
+        """
+        low_high = re.match(r"\d+[A-Z]{1,2}:\d+[A-Z]{1,2}", self.value)
+        if low_high:
+            low, high = low_high.group().split(":")
+            self.low = self._get_k_v(low)
+            self.high = self._get_k_v(high)
+
+        low = re.match(r"\d+[A-Z]{1,2}:$", self.value)
+        if low:
+            self.low = self._get_k_v(low.group())
+
+        high = re.match(r"^:\d+[A-Z]{1,2}", self.value)
+        if high:
+            self.high = self._get_k_v(high.group())
+
+        exact = re.match(r"^\d+[A-Z]{1,2}$", self.value)
+        if exact:
+            self.exact = self._get_k_v(exact.group())
+
+        if not self.low and not self.high and not self.exact:
+            raise Exception("Couldn't parse {}".format(self.value))
+
+    @staticmethod
+    # pylint: disable=inconsistent-return-statements
+    def to_byte(tpl: Tuple) -> float:
+        """ Convert any supported unit to bytes
+
+        :param tuple tpl: A tuple with ('10', 'GB')
+        :return: The converted byte value
+        :rtype: float
+        """
+        value = float(tpl[0])
+        suffix = tpl[1]
+        if suffix == "MB":
+            return value * 1e+6
+        elif suffix == "GB":
+            return value * 1e+9
+        elif suffix == "TB":
+            return value * 1e+12
+        # checkers force me to return something, although
+        # it's not quite good to return something here.. ignore?
+        return 0.00
+
+    # pylint: disable=inconsistent-return-statements, too-many-return-statements
+    def compare(self, disk: dict) -> bool:
+        """ Convert MB/GB/TB down to bytes and compare
+
+        1) Extracts information from the to-be-inspected disk.
+        2) Depending on the mode, apply checks and return
+
+        # This doesn't seem very solid and _may_
+        be re-factored
+
+
+        """
+        if not disk:
+            return False
+        disk_value = self._get_disk_key(disk)
+        # This doesn't neccessarily have to be a float.
+        # The current output from ceph-volume gives a float..
+        # This may change in the future..
+        # todo: harden this paragraph
+        if not disk_value:
+            logger.warning("Could not retrieve value for disk")
+            return False
+
+        disk_size = float(re.findall(r"\d+\.\d+", disk_value)[0])
+        disk_suffix = self._parse_suffix(disk_value)
+        disk_size_in_byte = self.to_byte((disk_size, disk_suffix))
+
+        if all(self.high) and all(self.low):
+            if disk_size_in_byte <= self.to_byte(
+                    self.high) and disk_size_in_byte >= self.to_byte(self.low):
+                return True
+            # is a else: return False neccessary here?
+            # (and in all other branches)
+            logger.debug("Disk didn't match for 'high/low' filter")
+
+        elif all(self.low) and not all(self.high):
+            if disk_size_in_byte >= self.to_byte(self.low):
+                return True
+            logger.debug("Disk didn't match for 'low' filter")
+
+        elif all(self.high) and not all(self.low):
+            if disk_size_in_byte <= self.to_byte(self.high):
+                return True
+            logger.debug("Disk didn't match for 'high' filter")
+
+        elif all(self.exact):
+            if disk_size_in_byte == self.to_byte(self.exact):
+                return True
+            logger.debug("Disk didn't match for 'exact' filter")
+        else:
+            logger.debug("Neither high, low, nor exact was given")
+            raise Exception("No filters applied")
+        return False

--- a/src/ceph-volume/ceph_volume/drivegroups/selector.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/selector.py
@@ -1,0 +1,118 @@
+import logging
+from ceph_volume import terminal
+from ceph_volume.util.device import Devices, Device
+from .specs import DriveGroupSpecs
+from .filter import Filter, FilterGenerator
+
+mlogger = terminal.MultiLogger(__name__)
+logger = logging.getLogger(__name__)
+
+
+class DriveSelection(object):
+    def __init__(self, spec_obj):
+        self.disks = self._load_disks()
+        self.spec = DriveGroupSpecs(spec_obj)
+
+    def _load_disks(self):
+        return Devices().devices
+
+    def data_devices(self):
+        return self.assign_devices(self.spec.data_device_attrs)
+
+    def wal_devices(self):
+        return self.assign_devices(self.spec.wal_device_attrs)
+
+    def db_devices(self):
+        return self.assign_devices(self.spec.db_device_attrs)
+
+    def journal_devices(self):
+        return self.assign_devices(self.spec.journal_device_attrs)
+
+    @staticmethod
+    def _limit_reached(device_filter: dict, len_devices: int,
+                       disk_path: str) -> bool:
+        """ Check for the <limit> property and apply logic
+
+        If a limit is set in 'device_attrs' we have to stop adding
+        disks at some point.
+
+        If limit is set (>0) and len(devices) >= limit
+
+        :param int len_devices: Length of the already populated device set/list
+        :param str disk_path: The disk identifier (for logging purposes)
+        :return: True/False if the device should be added to the list of devices
+        :rtype: bool
+        """
+        limit = int(device_filter.get('limit', 0))
+
+        if limit > 0 and len_devices >= limit:
+            mlogger.info("Refuse to add {} due to limit policy of <{}>".format(
+                disk_path, limit))
+            return True
+        return False
+
+    @staticmethod
+    def _has_mandatory_idents(disk: dict) -> bool:
+        """ Check for mandatory indentification fields
+        """
+        if disk.path:
+            logger.debug("Found matching disk: {}".format(disk.path))
+            return True
+        else:
+            raise Exception(
+                "Disk {} doesn't have a 'path' identifier".format(disk))
+
+    def assign_devices(self, device_filter: dict) -> list:
+        """ Assign drives based on used filters
+
+        Do not add disks when:
+
+        1) Filter didn't match
+        2) Disk doesn't have a mandatory identification item (path)
+        3) The set :limit was reached
+
+        After the disk was added we make sure not to re-assign this disk
+        for another defined type[wal/db/journal devices]
+
+        return a sorted(by path) list of devices
+        """
+        devices: list = list()
+        for _filter in FilterGenerator(device_filter):
+            if not _filter.is_matchable:
+                logger.debug(
+                    "Ignoring disk {}. Filter is not matchable".format(
+                        disk.path))
+                continue
+
+            for disk in self.disks:
+                logger.debug("Processing disk {}".format(disk.path))
+
+                # continue criterias
+                if not _filter.matcher.compare(disk):
+                    logger.debug(
+                        "Ignoring disk {}. Filter did not match".format(
+                            disk.path))
+                    continue
+
+                if not self._has_mandatory_idents(disk):
+                    logger.debug(
+                        "Ignoring disk {}. Missing mandatory idents".format(
+                            disk.path))
+                    continue
+
+                # break on this condition.
+                if self._limit_reached(device_filter, len(devices), disk.path):
+                    logger.debug("Ignoring disk {}. Limit reached".format(
+                        disk.path))
+                    break
+
+                if disk not in devices:
+                    logger.debug('Adding disk {}'.format(disk.path))
+                    devices.append(disk)
+
+        # This disk is already taken and must not be re-assigned.
+        for taken_device in devices:
+            if taken_device in self.disks:
+                self.disks.remove(taken_device)
+
+        return sorted([x for x in devices], key=lambda dev: dev.path)

--- a/src/ceph-volume/ceph_volume/drivegroups/specs.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/specs.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+from .validate import DriveGroupValidator
+
+
+class DriveGroupSpecs(object):
+    def __init__(self, specs):
+        assert isinstance(specs, dict)
+        self.specs = specs
+        DriveGroupValidator(self).validate()
+
+    @property
+    def db_slots(self) -> dict:
+        """ Property of db_slots
+
+        db_slots are essentially ratio indicators
+        """
+        return self.specs.get("db_slots", False)
+
+    @property
+    def wal_slots(self) -> dict:
+        """ Property of wal_slots
+
+        wal_slots are essentially ratio indicators
+        """
+        return self.specs.get("wal_slots", False)
+
+    @property
+    def encryption(self) -> dict:
+        """ Property of encryption
+
+        True/Flase if encryption is enabled
+        """
+        return self.specs.get("encryption", False)
+
+    @property
+    def data_device_attrs(self) -> dict:
+        """ Data Device attributes
+        """
+        return self.specs.get("data_devices", dict())
+
+    @property
+    def db_device_attrs(self) -> dict:
+        """ Db Device attributes
+        """
+        return self.specs.get("db_devices", dict())
+
+    @property
+    def wal_device_attrs(self) -> dict:
+        """ Wal Device attributes
+        """
+        return self.specs.get("wal_devices", dict())
+
+    @property
+    def journal_device_attrs(self) -> dict:
+        """ Journal Device attributes
+        """
+        return self.specs.get("journal_devices", dict())
+
+    @property
+    def block_wal_size(self) -> int:
+        """ Wal Device attributes
+        """
+        return self.specs.get("block_wal_size", 0)
+
+    @property
+    def block_db_size(self) -> int:
+        """ Wal Device attributes
+        """
+        return self.specs.get("block_db_size", 0)
+
+    @property
+    def format(self) -> str:
+        """
+        On-disk-format - Filestore/Bluestore
+        """
+        return self.specs.get("format", "bluestore")
+
+    @property
+    def journal_size(self) -> int:
+        """
+        Journal size
+        """
+        return self.specs.get("journal_size", 0)

--- a/src/ceph-volume/ceph_volume/drivegroups/validate.py
+++ b/src/ceph-volume/ceph_volume/drivegroups/validate.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+from .exceptions import FilterNotSupported, FeatureNotSupported
+
+
+class DriveGroupValidator(object):
+    def __init__(self, spec_obj):
+        self.spec = spec_obj
+
+    @property
+    def _supported_filters(self) -> list:
+        """ List of supported filters
+        """
+        return [
+            "size", "vendor", "model", "rotational", "limit",
+            "osds_per_device", "all"
+        ]
+
+    @property
+    def _supported_features(self) -> list:
+        """ List of supported features """
+        return [
+            "encrypted", "block_wal_size", "osd_per_device", "format",
+            "db_slots", "wal_slots", "block_db_size", "target"
+        ]
+
+    def _check_filter(self, attr: dict) -> None:
+        """ Check if the used filters are supported
+
+        :param dict attr: A dict of filters
+        :raises: FilterNotSupported if not supported
+        :return: None
+        """
+        for applied_filter in list(attr.keys()):
+            if applied_filter not in self._supported_filters:
+                raise FilterNotSupported("Filtering for <{}> is not supported".
+                                         format(applied_filter))
+
+    def _check_filter_support(self) -> None:
+        """ Iterates over attrs to check support
+        """
+        for attr in [
+                self.spec.data_device_attrs,
+                self.spec.wal_device_attrs,
+                self.spec.db_device_attrs,
+        ]:
+            self._check_filter(attr)
+
+    def _check_feature_support(self) -> None:
+        """ Iterates over attrs to check support
+
+        Check every key of this dict that is no dict itself.
+        This would indicate a section(like data_devices, etc. which can't have features)
+        """
+        dict_spec = self.spec.__dict__.get('specs', dict())
+        for feature, value in dict_spec.items():
+            if isinstance(value, dict):
+                continue
+            if feature not in self._supported_features:
+                raise FeatureNotSupported(
+                    "<{}> is not supported".format(feature))
+
+    def validate(self):
+        self._check_feature_support()
+        self._check_filter_support()

--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -6,7 +6,7 @@ import sys
 import logging
 
 from ceph_volume.decorators import catches
-from ceph_volume import log, devices, configuration, conf, exceptions, terminal, inventory
+from ceph_volume import log, devices, configuration, conf, exceptions, terminal, inventory, drivegroups
 
 
 class Volume(object):
@@ -28,6 +28,7 @@ Ceph Conf: {ceph_path}
             'lvm': devices.lvm.LVM,
             'simple': devices.simple.Simple,
             'inventory': inventory.Inventory,
+            'drivegroups': drivegroups.DriveGroups
         }
         self.plugin_help = "No plugins found/loaded"
         if argv is None:
@@ -99,7 +100,8 @@ Ceph Conf: {ceph_path}
         # early
         configuration.load_ceph_conf_path()
         self.load_log_path()
-        self.enable_plugins()
+        # FIXME: Uncommet later, Do not merge this
+        #self.enable_plugins()
         main_args, subcommand_args = self._get_split_args()
         # no flags where passed in, return the help menu instead of waiting for
         # argparse which will end up complaning that there are no args

--- a/src/ceph-volume/ceph_volume/tests/drivegroups/test_drivegroups.py
+++ b/src/ceph-volume/ceph_volume/tests/drivegroups/test_drivegroups.py
@@ -1,0 +1,14 @@
+import pytest
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+class TestDriveGroupGenerator(object):
+    """ DriveGroups Testclass """
+
+    def test_dummy(self):
+        """ Test """
+        pass


### PR DESCRIPTION
This pullrequest is supposed to be a reference implementation of the DriveGroup concept in ceph-volume.

ceph-volume would be a well suited place to host the logic since all the needed data comes from ceph-volume's inventory function `Devices().devices`

We can also re-use the `Batch()` module to apply DriveGroups to the cluster.

<details><summary>ceph-volume drivegroups show/apply <path_to_drivegroups.yml></summary>



```
data1:/ceph-volume # ceph-volume drivegroups show ceph_volume/drivegroups/example.yaml
--> Processing DriveGroup <default>
--> Initializing filter <all> with value <True>
#TODO Implement a common interface for module<->module calls

Total OSDs: 8

  Type            Path                                                    LV Size         % of device
----------------------------------------------------------------------------------------------------
  [data]          /dev/vda                                                19.00 GB        100.0%
----------------------------------------------------------------------------------------------------
  [data]          /dev/vdb                                                19.00 GB        100.0%
----------------------------------------------------------------------------------------------------
  [data]          /dev/vdc                                                19.00 GB        100.0%
----------------------------------------------------------------------------------------------------
  [data]          /dev/vdd                                                19.00 GB        100.0%
----------------------------------------------------------------------------------------------------
  [data]          /dev/vde                                                19.00 GB        100.0%
----------------------------------------------------------------------------------------------------
  [data]          /dev/vdf                                                19.00 GB        100.0%
----------------------------------------------------------------------------------------------------
  [data]          /dev/vdg                                                9.00 GB         100.0%
----------------------------------------------------------------------------------------------------
  [data]          /dev/vdh                                                9.00 GB         100.0%


```


</details>


<details><summary>drivegroups.yaml</summary>

``` yaml
default:
  target: 'fnmatch_target'
  data_devices:
    all: true
```


</details>


This is the most basic DriveGroup possible. The current specification allows to describe all kinds of drives and drive combinations. Please find the spec here:

<details><summary>DriveGroup Specification</summary>



``` yaml
drive_group_default_name:
  target: *
  data_devices:
    device_spec: arg 
  db_devices:
    device_spec: arg
  wal_devices:
    device_spec: arg
  block_wal_size: '5G' (optional)
  block_db_size: '5G' (optional)
  osds_per_device: 1 # number of osd daemons per device. To fully utilize nvme devices multiple osds are required.  # not implemented
  format: bluestore/filestore (defaults to bluestore)
  encrypted: True/False (defaults to False)
  db_slots: 5 (optional)
  wal_slots: 1 (optional)

```
</details>

`device_spec` is a placeholder for drive matchers like `model`, `vendor`, `size` and `rotational`.
Please see the [  DriveGroups wiki on the DeepSea github page](https://github.com/SUSE/DeepSea/wiki/Drive-Groups) for a more detailed description (and examples)


--------------------

There is a incomplete implementation for DriveGroups in https://github.com/ceph/ceph/blob/2ea3df19679adcdc4834e2c0ea6d748b40fdfd2d/src/pybind/mgr/orchestrator.py#L552

which is arguably the right place for the specification, but not for the selection/filtering logic.


-----------------
Unittests are in the pipeline and will be added once we reached consensus.
Obviously this PR is not well rounded and contains issues. It will be overhauled after a later stage.


Signed-off-by: Joshua Schmid <jschmid@suse.de>

~- [ ] References tracker ticket~
~- [ ] Updates documentation if necessary~
~- [ ] Includes tests for new functionality or reproducer for bug~

