### PR TITLE
rgw: fix the bug of rgw not doing necessary checking to website configuration

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1400,6 +1400,21 @@ int RGWSetBucketWebsite_ObjStore_S3::get_params()
     return -EINVAL;
   }
 
+  if (website_conf.is_redirect_all && website_conf.redirect_all.hostname.empty()) {
+    s->err.message = "A host name must be provided to redirect all requests (e.g. \"example.com\").";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    return -EINVAL;
+  } else if (!website_conf.is_redirect_all && !website_conf.is_set_index_doc) {
+    s->err.message = "A value for IndexDocument Suffix must be provided if RedirectAllRequestsTo is empty";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    return -EINVAL;
+  } else if (!website_conf.is_redirect_all && website_conf.is_set_index_doc &&
+             website_conf.index_doc_suffix.empty()) {
+    s->err.message = "The IndexDocument Suffix is not well formed";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    return -EINVAL;
+  }
+
 #define WEBSITE_ROUTING_RULES_MAX_NUM      50
   int max_num = s->cct->_conf->rgw_website_routing_rules_max_num;
   if (max_num < 0) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4186,7 +4186,13 @@ int RGWHandler_REST_S3Website::retarget(RGWOp* op, RGWOp** new_op) {
   }
 
   rgw_obj_key new_obj;
-  s->bucket_info.website_conf.get_effective_key(s->object.name, &new_obj.name, web_dir());
+  bool get_res = s->bucket_info.website_conf.get_effective_key(s->object.name, &new_obj.name, web_dir());
+  if (!get_res) {
+    s->err.message = "The IndexDocument Suffix is not configurated or not well formed!";
+    ldpp_dout(s, 5) << s->err.message << dendl;
+    return -EINVAL;
+  }
+
   ldpp_dout(s, 10) << "retarget get_effective_key " << s->object << " -> "
 		    << new_obj << dendl;
 

--- a/src/rgw/rgw_website.cc
+++ b/src/rgw/rgw_website.cc
@@ -107,8 +107,11 @@ bool RGWBucketWebsiteConf::should_redirect(const string& key, const int http_err
   return true;
 }
 
-void RGWBucketWebsiteConf::get_effective_key(const string& key, string *effective_key, bool is_file) const
+bool RGWBucketWebsiteConf::get_effective_key(const string& key, string *effective_key, bool is_file) const
 {
+  if (index_doc_suffix.empty()) {
+    return false;
+  }
 
   if (key.empty()) {
     *effective_key = index_doc_suffix;
@@ -119,4 +122,6 @@ void RGWBucketWebsiteConf::get_effective_key(const string& key, string *effectiv
   } else {
     *effective_key = key;
   }
+
+  return true;
 }

--- a/src/rgw/rgw_website.h
+++ b/src/rgw/rgw_website.h
@@ -226,7 +226,7 @@ struct RGWBucketWebsiteConf
                        const int http_error_code,
                        RGWBWRoutingRule *redirect);
 
-  void get_effective_key(const std::string& key,
+  bool get_effective_key(const std::string& key,
                          std::string *effective_key, bool is_file) const;
 
   const std::string& get_index_doc() const {

--- a/src/rgw/rgw_website.h
+++ b/src/rgw/rgw_website.h
@@ -182,10 +182,14 @@ struct RGWBucketWebsiteConf
   std::string subdir_marker;
   std::string listing_css_doc;
   bool listing_enabled;
+  bool is_redirect_all;
+  bool is_set_index_doc;
   RGWBWRoutingRules routing_rules;
 
   RGWBucketWebsiteConf()
     : listing_enabled(false) {
+    is_redirect_all = false;
+    is_set_index_doc = false;
   }
 
   void encode(bufferlist& bl) const {

--- a/src/rgw/rgw_xml_enc.cc
+++ b/src/rgw/rgw_xml_enc.cc
@@ -116,11 +116,13 @@ void decode_xml_obj(list<RGWBWRoutingRule>& l, XMLObj *obj)
 void RGWBucketWebsiteConf::decode_xml(XMLObj *obj) {
   XMLObj *o = obj->find_first("RedirectAllRequestsTo");
   if (o) {
+    is_redirect_all = true;
     RGWXMLDecoder::decode_xml("HostName", redirect_all.hostname, o, true);
     RGWXMLDecoder::decode_xml("Protocol", redirect_all.protocol, o);
   } else {
     o = obj->find_first("IndexDocument");
     if (o) {
+      is_set_index_doc = true;
       RGWXMLDecoder::decode_xml("Suffix", index_doc_suffix, o);
     }
     o = obj->find_first("ErrorDocument");


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40678

According to AWS S3, https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html
- To redirect all website requests sent to the bucket's website endpoint, you add a website configuration with the following elements. Because all requests are sent to another website, you don't need to provide index document name for the bucket.
- If you want granular control over redirects, you can use the following elements to add routing rules that describe conditions for redirecting requests and information about the redirect destination. In this case, the website configuration must provide an index document for the bucket, because some requests might not be redirected.

But now, the RGW don't do the necessary checking to the IndexDocument field when the RedirectAllRequestsTo is not provided, which will lead the IndexDocument Suffix to be empty without any error being reported.

In this case，if we access the static website through the S3Website enabled RGW instance，the RGW instance will crash.

`   -84> 2019-07-09T23:17:54.272-0700 7f50565df700 20 HTTP_ACCEPT=*/*
   -83> 2019-07-09T23:17:54.272-0700 7f50565df700 20 HTTP_HOST=localhost
   -82> 2019-07-09T23:17:54.272-0700 7f50565df700 20 HTTP_USER_AGENT=curl/7.29.0
   -81> 2019-07-09T23:17:54.272-0700 7f50565df700 20 HTTP_VERSION=1.1
   -80> 2019-07-09T23:17:54.272-0700 7f50565df700 20 REMOTE_ADDR=127.0.0.1
   -79> 2019-07-09T23:17:54.272-0700 7f50565df700 20 REQUEST_METHOD=GET
   -78> 2019-07-09T23:17:54.272-0700 7f50565df700 20 REQUEST_URI=/webtest
   -77> 2019-07-09T23:17:54.272-0700 7f50565df700 20 SCRIPT_URI=/webtest
   -76> 2019-07-09T23:17:54.272-0700 7f50565df700 20 SERVER_PORT=80
   -75> 2019-07-09T23:17:54.272-0700 7f50565df700  1 ====== starting new request req=0x55b572034890 =====
   -74> 2019-07-09T23:17:54.272-0700 7f50565df700  1 lockdep reusing last freed id 55
   -73> 2019-07-09T23:17:54.272-0700 7f50565df700  1 lockdep using id 587
   -72> 2019-07-09T23:17:54.272-0700 7f50565df700  2 req 2 0.000s initializing for trans_id = tx000000000000000000002-005d258312-1065-default
   -71> 2019-07-09T23:17:54.272-0700 7f50565df700 10 rgw api priority: s3=-1 s3website=1
   -70> 2019-07-09T23:17:54.272-0700 7f50565df700 10 host=localhost
   -69> 2019-07-09T23:17:54.272-0700 7f50565df700 20 subdomain= domain= in_hosted_domain=0 in_hosted_domain_s3website=0
   -68> 2019-07-09T23:17:54.273-0700 7f50565df700 -1 res_query() failed
   -67> 2019-07-09T23:17:54.273-0700 7f50565df700 20 final domain/bucket subdomain= domain= in_hosted_domain=0 in_hosted_domain_s3website=1 s->info.domain= s->info.request_uri=/webtest
   -66> 2019-07-09T23:17:54.273-0700 7f50565df700 20 req 2 0.001s get_handler handler=32RGWHandler_REST_Bucket_S3Website
   -65> 2019-07-09T23:17:54.273-0700 7f50565df700 10 handler=32RGWHandler_REST_Bucket_S3Website
   -64> 2019-07-09T23:17:54.273-0700 7f50565df700  2 req 2 0.001s getting op 0
   -63> 2019-07-09T23:17:54.273-0700 7f50565df700 10 req 2 0.001s s3:get_obj scheduling with dmclock client=2 cost=1
   -62> 2019-07-09T23:17:54.273-0700 7f50565df700 10 op=28RGWGetObj_ObjStore_S3Website
   -61> 2019-07-09T23:17:54.273-0700 7f50565df700  2 req 2 0.001s s3:get_obj verifying requester
   -60> 2019-07-09T23:17:54.273-0700 7f50565df700 20 req 2 0.001s s3:get_obj rgw::auth::StrategyRegistry::s3_main_strategy_t: trying rgw::auth::s3::AWSAuthStrategy
   -59> 2019-07-09T23:17:54.273-0700 7f50565df700 20 req 2 0.001s s3:get_obj rgw::auth::s3::AWSAuthStrategy: trying rgw::auth::s3::S3AnonymousEngine
   -58> 2019-07-09T23:17:54.273-0700 7f50565df700 20 req 2 0.001s s3:get_obj rgw::auth::s3::S3AnonymousEngine granted access
   -57> 2019-07-09T23:17:54.273-0700 7f50565df700 20 req 2 0.001s s3:get_obj rgw::auth::s3::AWSAuthStrategy granted access
   -56> 2019-07-09T23:17:54.273-0700 7f50565df700  2 req 2 0.001s s3:get_obj normalizing buckets and tenants
   -55> 2019-07-09T23:17:54.273-0700 7f50565df700 10 s->object=<NULL> s->bucket=webtest
   -54> 2019-07-09T23:17:54.273-0700 7f50565df700  2 req 2 0.001s s3:get_obj init permissions
   -53> 2019-07-09T23:17:54.274-0700 7f50565df700 20 get_system_obj_state: rctx=0x55b5720336e0 obj=default.rgw.meta:root:webtest state=0x55b570f7f840 s->prefetch_data=0
   -52> 2019-07-09T23:17:54.274-0700 7f50565df700 10 cache get: name=default.rgw.meta+root+webtest : miss
   -51> 2019-07-09T23:17:54.274-0700 7f50565df700 20 WARNING: blocking librados call
   -50> 2019-07-09T23:17:54.274-0700 7f50565df700  1 lockdep using id 588
   -49> 2019-07-09T23:17:54.275-0700 7f50565df700 10 cache put: name=default.rgw.meta+root+webtest info.flags=0x16
   -48> 2019-07-09T23:17:54.275-0700 7f50565df700 10 adding default.rgw.meta+root+webtest to cache LRU end
   -47> 2019-07-09T23:17:54.275-0700 7f50565df700 10 updating xattr: name=ceph.objclass.version bl.length()=42
   -46> 2019-07-09T23:17:54.275-0700 7f50565df700 20 get_system_obj_state: s->obj_tag was set empty
   -45> 2019-07-09T23:17:54.275-0700 7f50565df700 20 Read xattr: user.rgw.idtag
   -44> 2019-07-09T23:17:54.275-0700 7f50565df700 10 cache get: name=default.rgw.meta+root+webtest : type miss (requested=0x13, cached=0x16)
   -43> 2019-07-09T23:17:54.276-0700 7f50565df700 20 rados->read ofs=0 len=0
   -42> 2019-07-09T23:17:54.276-0700 7f50565df700 20 WARNING: blocking librados call
   -41> 2019-07-09T23:17:54.276-0700 7f50565df700  1 lockdep reusing last freed id 588
   -40> 2019-07-09T23:17:54.277-0700 7f50565df700 20 rados_obj.operate() r=0 bl.length=171
   -39> 2019-07-09T23:17:54.277-0700 7f50565df700 10 cache put: name=default.rgw.meta+root+webtest info.flags=0x13
   -38> 2019-07-09T23:17:54.277-0700 7f50565df700 10 moving default.rgw.meta+root+webtest to cache LRU end
   -37> 2019-07-09T23:17:54.277-0700 7f50565df700 10 updating xattr: name=ceph.objclass.version bl.length()=42
   -36> 2019-07-09T23:17:54.277-0700 7f50565df700 20 rgw_get_bucket_info: bucket instance: :webtest[e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1])
   -35> 2019-07-09T23:17:54.277-0700 7f50565df700 20 reading from default.rgw.meta:root:.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1
   -34> 2019-07-09T23:17:54.277-0700 7f50565df700 20 get_system_obj_state: rctx=0x55b5720336e0 obj=default.rgw.meta:root:.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1 state=0x55b570f7fb40 s->prefetch_data=0
   -33> 2019-07-09T23:17:54.277-0700 7f50565df700 10 cache get: name=default.rgw.meta+root+.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1 : miss
   -32> 2019-07-09T23:17:54.278-0700 7f50529d9700 10 cache put: name=default.rgw.meta+root+.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1 info.flags=0x16
   -31> 2019-07-09T23:17:54.278-0700 7f50529d9700 10 adding default.rgw.meta+root+.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1 to cache LRU end
   -30> 2019-07-09T23:17:54.278-0700 7f50529d9700 10 updating xattr: name=ceph.objclass.version bl.length()=42
   -29> 2019-07-09T23:17:54.278-0700 7f50529d9700 10 updating xattr: name=user.rgw.acl bl.length()=147
   -28> 2019-07-09T23:17:54.278-0700 7f50529d9700 20 get_system_obj_state: s->obj_tag was set empty
   -27> 2019-07-09T23:17:54.278-0700 7f50529d9700 20 Read xattr: user.rgw.acl
   -26> 2019-07-09T23:17:54.278-0700 7f50529d9700 20 Read xattr: user.rgw.idtag
   -25> 2019-07-09T23:17:54.278-0700 7f50529d9700 10 cache get: name=default.rgw.meta+root+.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1 : type miss (requested=0x13, cached=0x16)
   -24> 2019-07-09T23:17:54.278-0700 7f50529d9700 20 rados->read ofs=0 len=0
   -23> 2019-07-09T23:17:54.280-0700 7f5051fd8700 20 rados_obj.operate() r=0 bl.length=331
   -22> 2019-07-09T23:17:54.280-0700 7f5051fd8700 10 cache put: name=default.rgw.meta+root+.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1 info.flags=0x13
   -21> 2019-07-09T23:17:54.280-0700 7f5051fd8700 10 moving default.rgw.meta+root+.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1 to cache LRU end
   -20> 2019-07-09T23:17:54.280-0700 7f5051fd8700 10 updating xattr: name=ceph.objclass.version bl.length()=42
   -19> 2019-07-09T23:17:54.280-0700 7f5051fd8700 10 updating xattr: name=user.rgw.acl bl.length()=147
   -18> 2019-07-09T23:17:54.280-0700 7f5051fd8700 10 chain_cache_entry: cache_locator=default.rgw.meta+root+webtest
   -17> 2019-07-09T23:17:54.280-0700 7f5051fd8700 10 chain_cache_entry: cache_locator=default.rgw.meta+root+.bucket.meta.webtest:e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1
   -16> 2019-07-09T23:17:54.280-0700 7f5051fd8700 15 decode_policy Read AccessControlPolicy<AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>emtest1</ID><DisplayName>emtest1</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>emtest1</ID><DisplayName>emtest1</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
   -15> 2019-07-09T23:17:54.280-0700 7f5051fd8700 20 get_system_obj_state: rctx=0x55b572033050 obj=default.rgw.meta:users.uid:anonymous state=0x55b570f7fe40 s->prefetch_data=0
   -14> 2019-07-09T23:17:54.280-0700 7f5051fd8700 10 cache get: name=default.rgw.meta+users.uid+anonymous : type miss (requested=0x6, cached=0x0)
   -13> 2019-07-09T23:17:54.280-0700 7f5051fd8700 20 WARNING: blocking librados call
   -12> 2019-07-09T23:17:54.280-0700 7f5051fd8700  1 lockdep reusing last freed id 588
   -11> 2019-07-09T23:17:54.281-0700 7f5051fd8700 10 cache put: name=default.rgw.meta+users.uid+anonymous info.flags=0x0
   -10> 2019-07-09T23:17:54.281-0700 7f5051fd8700 10 moving default.rgw.meta+users.uid+anonymous to cache LRU end
    -9> 2019-07-09T23:17:54.281-0700 7f5051fd8700  2 req 2 0.009s s3:get_obj recalculating target
    -8> 2019-07-09T23:17:54.281-0700 7f5051fd8700 10 req 2 0.009s retarget Starting retarget
    -7> 2019-07-09T23:17:54.281-0700 7f5051fd8700 10 req 2 0.009s retarget get_effective_key  ->
    -6> 2019-07-09T23:17:54.281-0700 7f5051fd8700  2 req 2 0.009s s3:get_obj reading permissions
    -5> 2019-07-09T23:17:54.281-0700 7f5051fd8700  2 req 2 0.009s s3:get_obj init op
    -4> 2019-07-09T23:17:54.281-0700 7f5051fd8700  2 req 2 0.009s s3:get_obj verifying op mask
    -3> 2019-07-09T23:17:54.281-0700 7f5051fd8700 20 req 2 0.009s s3:get_obj required_mask= 1 user.op_mask=7
    -2> 2019-07-09T23:17:54.281-0700 7f5051fd8700  2 req 2 0.009s s3:get_obj verifying op permissions
    -1> 2019-07-09T23:17:54.281-0700 7f5051fd8700  0 [debug by vampirem] bucket :webtest[e362fb6d-4c68-4de2-aeda-c010d08ca7a3.4169.1]) object
     0> 2019-07-09T23:17:54.296-0700 7f5051fd8700 -1 *** Caught signal (Aborted) **
 in thread 7f5051fd8700 thread_name:radosgw

 ceph version v15.0.0-2498-g9b967b4 (9b967b42f09f435cfabd0937f6a5c5912379d9a6) octopus (dev)
 1: (()+0xd8d974) [0x55b56e724974]
 2: (()+0xf5d0) [0x7f508af3b5d0]
 3: (gsignal()+0x37) [0x7f5089ca2207]
 4: (abort()+0x148) [0x7f5089ca38f8]
 5: (()+0x2f026) [0x7f5089c9b026]
 6: (()+0x2f0d2) [0x7f5089c9b0d2]
 7: (RGWObjectCtx::set_atomic(rgw_obj&)+0x69) [0x55b56e7b50ad]
 8: (RGWRados::set_atomic(void*, rgw_obj&)+0x2f) [0x55b56eb37d65]
 9: (RGWGetObj::verify_permission()+0x1e2) [0x55b56eaf314c]
 10: (rgw_process_authenticated(RGWHandler_REST*, RGWOp*&, RGWRequest*, req_state*, bool)+0xd1e) [0x55b56e76681f]
 11: (process_request(RGWRados*, RGWREST*, RGWRequest*, std::string const&, rgw::auth::StrategyRegistry const&, RGWRestfulIO*, OpsLogSocket*, optional_yield, rgw::dmclock::Scheduler*, int*)+0x1483) [0x55b56e768d47]
 12: (()+0xc81cf6) [0x55b56e618cf6]
 13: (()+0xc7d81a) [0x55b56e61481a]
 14: (()+0xc8949c) [0x55b56e62049c]
 15: (()+0xc8915a) [0x55b56e62015a]
 16: (()+0xc88e80) [0x55b56e61fe80]
 17: (make_fcontext()+0x2f) [0x55b56ede6b2f]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.`

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

