### PR TITLE
cephfs-shell: Fix TypeError in poutput()

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -55,7 +55,7 @@ shell = None
 
 
 def poutput(s, end='\n'):
-    shell.poutput(s, end)
+    shell.poutput(s, end=end)
 
 
 def setup_cephfs(config_file):
@@ -725,12 +725,12 @@ exists.')
                 if dirs:
                     paths.extend(dirs)
                 else:
-                    self.poutput(path, ':\n')
+                    self.poutput(path, end=':\n')
                 items = sorted(items, key=lambda item: item.d_name)
             else:
                 if path != '' and path != cephfs.getcwd().decode(
                         'utf-8') and len(paths) > 1:
-                    self.poutput(path, ':\n')
+                    self.poutput(path, end=':\n')
                 items = sorted(ls(path),
                                key=lambda item: item.d_name)
             if not args.all:
@@ -769,7 +769,7 @@ exists.')
             if not args.long:
                 print_list(values, shutil.get_terminal_size().columns)
                 if path != paths[-1]:
-                    self.poutput('\n')
+                    self.poutput('')
 
     def complete_rmdir(self, text, line, begidx, endidx):
         """


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/40679
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

