### PR TITLE
mgr/progress: added the time an event has been in progress

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1202,8 +1202,8 @@ class MgrModule(ceph_module.BaseMgrModule):
 
         return self._ceph_have_mon_connection()
 
-    def update_progress_event(self, evid, desc, progress):
-        return self._ceph_update_progress_event(str(evid), str(desc), float(progress))
+    def update_progress_event(self, evid, desc, progress, duration):
+        return self._ceph_update_progress_event(str(evid), str(desc+" "+duration), float(progress))
 
     def complete_progress_event(self, evid):
         return self._ceph_complete_progress_event(str(evid))

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -20,9 +20,9 @@ class Event(object):
     """
 
     def __init__(self, message, refs):
-        self._message = message
         self._refs = refs
-
+        self._duration_str = "(since 0h 0m 0s)"
+        self._message = message
         self.started_at = datetime.datetime.utcnow()
 
         self.id = None
@@ -31,6 +31,7 @@ class Event(object):
         global _module
         _module.log.debug('refreshing mgr for %s (%s) at %f' % (self.id, self._message,
                                                                 self.progress))
+        self.update_duration_event()
         _module.update_progress_event(self.id, self._message, self.progress)
 
     @property
@@ -44,9 +45,13 @@ class Event(object):
     @property
     def progress(self):
         raise NotImplementedError()
+    
+    @property
+    def duration_str(self):
+        return self._duration_str
 
     def summary(self):
-        return "{0} {1}".format(self.progress, self.message)
+        return "{0} {1} {2}".format(self.progress, self.message, self.duration_str)
 
     def _progress_str(self, width):
         inner_width = width - 2
@@ -66,16 +71,26 @@ class Event(object):
             [===============..............]
 
         """
-        return "{0}\n    {1}".format(
-            self._message, self._progress_str(30))
+        return "{0} {1}\n    {2}".format(
+            self._message, self._duration_str, self._progress_str(30))
 
     def to_json(self):
         return {
             "id": self.id,
             "message": self.message,
+            "duration": self.duration_str,
             "refs": self._refs
         }
 
+    def update_duration_event(self):
+        # Update duration of event in seconds/minutes/hours
+
+        duration = (datetime.datetime.utcnow() - self.started_at)
+        duration_sec = duration.seconds
+        duration_min = duration_sec //60
+        duration_hr = duration_min // 60
+
+        self._duration_str = "(since {0}h {1}m {2}s)".format(duration_hr, duration_min, duration_sec)
 
 class GhostEvent(Event):
     """
@@ -216,26 +231,14 @@ class PgRecoveryEvent(Event):
                         ratio = 0.5
                     complete_accumulate += ratio
         
-        # Update duration of event in seconds/minutes/hours
-        duration = (datetime.datetime.utcnow() - self.started_at)
-        duration_sec = duration.seconds
-        duration_min = duration_sec //60
-        duration_hr = duration_min // 60
-
         self._pgs = list(set(self._pgs) ^ complete)
         completed_pgs = self._original_pg_count - len(self._pgs)
         self._progress = (completed_pgs + complete_accumulate)\
             / self._original_pg_count
 
-        # Because the spacing of 'in' and 'out' characters are different
-        if self._message[31] == "i":
-            self._message = self._message[:34] + "(since {0}h {1}m {2}s)".format(duration_hr, duration_min, duration_sec)
-        else:
-            self._message = self._message[:34] + " (since {0}h {1}m {2}s)".format(duration_hr, duration_min, duration_sec)
-        self._refresh()
-        
-        log.info("Updated progress to {0} ({1})".format(
-            self._progress, self._message
+        self._refresh()    
+        log.info("Updated progress to {0} ({1} {2})".format(
+            self._progress, self._message, self._duration_str
         ))
 
     @property

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -2,7 +2,7 @@ from mgr_module import MgrModule
 import threading
 import datetime
 import uuid
-
+import time
 import json
 
 
@@ -19,9 +19,9 @@ class Event(object):
     objects (osds, pools) this relates to.
     """
 
-    def __init__(self, message, refs):
+    def __init__(self, message, refs, duration="(since 00h 00m 00s)"):
         self._refs = refs
-        self._duration_str = "(since 0h 0m 0s)"
+        self._duration_str = duration
         self._message = message
         self.started_at = datetime.datetime.utcnow()
 
@@ -32,7 +32,7 @@ class Event(object):
         _module.log.debug('refreshing mgr for %s (%s) at %f' % (self.id, self._message,
                                                                 self.progress))
         self.update_duration_event()
-        _module.update_progress_event(self.id, self._message, self.progress)
+        _module.update_progress_event(self.id, self._message, self.progress, self._duration_str)
 
     @property
     def message(self):
@@ -85,12 +85,8 @@ class Event(object):
     def update_duration_event(self):
         # Update duration of event in seconds/minutes/hours
 
-        duration = (datetime.datetime.utcnow() - self.started_at)
-        duration_sec = duration.seconds
-        duration_min = duration_sec //60
-        duration_hr = duration_min // 60
-
-        self._duration_str = "(since {0}h {1}m {2}s)".format(duration_hr, duration_min, duration_sec)
+        duration = (datetime.datetime.utcnow() - self.started_at).seconds
+        self._duration_str = time.strftime("(since %Hh %Mm %Ss)", time.gmtime(duration))
 
 class GhostEvent(Event):
     """
@@ -98,8 +94,8 @@ class GhostEvent(Event):
     after the event is complete.
     """
 
-    def __init__(self, my_id, message, refs):
-        super(GhostEvent, self).__init__(message, refs)
+    def __init__(self, my_id, message, refs, duration="(since 00h 00m 00s)"):
+        super(GhostEvent, self).__init__(message, refs, duration)
         self.id = my_id
 
     @property
@@ -114,8 +110,8 @@ class RemoteEvent(Event):
     progress information as it emerges.
     """
 
-    def __init__(self, my_id, message, refs):
-        super(RemoteEvent, self).__init__(message, refs)
+    def __init__(self, my_id, message, refs, duration="(since 00h 00m 00s)"):
+        super(RemoteEvent, self).__init__(message, refs, duration)
         self.id = my_id
         self._progress = 0.0
         self._refresh()
@@ -230,16 +226,14 @@ class PgRecoveryEvent(Event):
                         # as half done.
                         ratio = 0.5
                     complete_accumulate += ratio
-        
+
         self._pgs = list(set(self._pgs) ^ complete)
         completed_pgs = self._original_pg_count - len(self._pgs)
         self._progress = (completed_pgs + complete_accumulate)\
             / self._original_pg_count
 
-        self._refresh()    
-        log.info("Updated progress to {0} ({1} {2})".format(
-            self._progress, self._message, self._duration_str
-        ))
+        self._refresh()
+        log.info("Updated progress to %s", self.summary())
 
     @property
     def progress(self):
@@ -530,7 +524,7 @@ class Module(MgrModule):
         self.complete_progress_event(ev.id)
 
         self._completed_events.append(
-            GhostEvent(ev.id, ev.message, ev.refs))
+            GhostEvent(ev.id, ev.message, ev.refs, ev.duration_str))
         del self._events[ev.id]
         self._prune_completed_events()
         self._dirty = True

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -215,13 +215,25 @@ class PgRecoveryEvent(Event):
                         # as half done.
                         ratio = 0.5
                     complete_accumulate += ratio
+        
+        # Update duration of event in seconds/minutes/hours
+        duration = (datetime.datetime.utcnow() - self.started_at)
+        duration_sec = duration.seconds
+        duration_min = duration_sec //60
+        duration_hr = duration_min // 60
 
         self._pgs = list(set(self._pgs) ^ complete)
         completed_pgs = self._original_pg_count - len(self._pgs)
         self._progress = (completed_pgs + complete_accumulate)\
             / self._original_pg_count
-        self._refresh()
 
+        # Because the spacing of 'in' and 'out' characters are different
+        if self._message[31] == "i":
+            self._message = self._message[:34] + "(since {0}h {1}m {2}s)".format(duration_hr, duration_min, duration_sec)
+        else:
+            self._message = self._message[:34] + " (since {0}h {1}m {2}s)".format(duration_hr, duration_min, duration_sec)
+        self._refresh()
+        
         log.info("Updated progress to {0} ({1})".format(
             self._progress, self._message
         ))


### PR DESCRIPTION
In ceph -s and out/mgr.x.log
now can see how long event has been in
progress for when osd is marked in and out.

Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

