### PR TITLE
mgr/dashboard: set python binary for teuthology venv

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -68,8 +68,7 @@ EOF
 
 
     cd $TEMP_DIR
-
-    virtualenv --python=/usr/bin/python venv
+    virtualenv --python=${TEUTHOLOGY_PYTHON_BIN:-/usr/bin/python} venv
     source venv/bin/activate
     eval pip install $TEUTHOLOGY_PY_REQS
     pip install -r $CURR_DIR/requirements.txt
@@ -103,7 +102,6 @@ EOF
 run_teuthology_tests() {
     cd "$BUILD_DIR"
     find ../src/pybind/mgr/dashboard/ -name '*.pyc' -exec rm -f {} \;
-    source $TEMP_DIR/venv/bin/activate
 
     OPTIONS=''
     TEST_CASES=''
@@ -120,11 +118,10 @@ run_teuthology_tests() {
     fi
 
     export PATH=$BUILD_DIR/bin:$PATH
+    source $TEMP_DIR/venv/bin/activate # Run after setting PATH as it does the last PATH export.
     export LD_LIBRARY_PATH=$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$BUILD_DIR/lib
     export PYTHONPATH=$TEMP_DIR/teuthology:$BUILD_DIR/../qa:$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$BUILD_DIR/../src/pybind
-    if [[ -z "$RGW" ]]; then
-        export RGW=1
-    fi
+    export RGW=${RGW:-1}
 
     export COVERAGE_ENABLED=true
     export COVERAGE_FILE=.coverage.mgr.dashboard


### PR DESCRIPTION
* Added env. var. to set python binary when creating teuthology venv.

Signed-off-by: alfonsomthd <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

