### PR TITLE
Revert "mgr/DaemonServer: log pgmap usage to cluster log"

### DIFF
--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -91,6 +91,20 @@ public:
         ceph_abort();
     }
   }
+
+  OstreamTemp verbose() {
+    return OstreamTemp(CLOG_VERBOSE, this);
+  }
+  void verbose(std::stringstream &s) {
+    do_log(CLOG_VERBOSE, s);
+  }
+  OstreamTemp verb() {
+    return verbose();
+  }
+  void verb(std::stringstream &s) {
+    verbose(s);
+  }
+
   OstreamTemp info() {
     return OstreamTemp(CLOG_INFO, this);
   }

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -32,6 +32,8 @@ clog_type LogEntry::str_to_level(std::string const &str)
 
   if (level_str == "debug") {
     return CLOG_DEBUG;
+  } else if (level_str == "verbose") {
+    return CLOG_VERBOSE;
   } else if (level_str == "info") {
     return CLOG_INFO;
   } else if (level_str == "sec") {
@@ -52,6 +54,8 @@ int clog_type_to_syslog_level(clog_type t)
   switch (t) {
     case CLOG_DEBUG:
       return LOG_DEBUG;
+    case CLOG_VERBOSE:
+      return LOG_INFO;
     case CLOG_INFO:
       return LOG_INFO;
     case CLOG_WARN:
@@ -69,42 +73,60 @@ int clog_type_to_syslog_level(clog_type t)
 clog_type string_to_clog_type(const string& s)
 {
   if (boost::iequals(s, "debug") ||
-      boost::iequals(s, "dbg"))
+      boost::iequals(s, "dbg")) {
     return CLOG_DEBUG;
+  }
+  if (boost::iequals(s, "verbose") ||
+      boost::iequals(s, "verb")) {
+    return CLOG_VERBOSE;
+  }
   if (boost::iequals(s, "info") ||
-      boost::iequals(s, "inf"))
+      boost::iequals(s, "inf")) {
     return CLOG_INFO;
+  }
   if (boost::iequals(s, "warning") ||
       boost::iequals(s, "warn") ||
-      boost::iequals(s, "wrn"))
+      boost::iequals(s, "wrn")) {
     return CLOG_WARN;
+  }
   if (boost::iequals(s, "error") ||
-      boost::iequals(s, "err"))
+      boost::iequals(s, "err")) {
     return CLOG_ERROR;
+  }
   if (boost::iequals(s, "security") ||
-      boost::iequals(s, "sec"))
+      boost::iequals(s, "sec")) {
     return CLOG_SEC;
+  }
 
   return CLOG_UNKNOWN;
 }
 
 int string_to_syslog_level(string s)
 {
-  if (boost::iequals(s, "debug"))
+  if (boost::iequals(s, "debug")) {
     return LOG_DEBUG;
-  if (boost::iequals(s, "info") ||
-      boost::iequals(s, "notice"))
+  }
+  if (boost::iequals(s, "verbose") ||
+      boost::iequals(s, "verb")) {
     return LOG_INFO;
+  }
+  if (boost::iequals(s, "info") ||
+      boost::iequals(s, "notice")) {
+    return LOG_INFO;
+  }
   if (boost::iequals(s, "warning") ||
-      boost::iequals(s, "warn"))
+      boost::iequals(s, "warn")) {
     return LOG_WARNING;
+  }
   if (boost::iequals(s, "error") ||
-      boost::iequals(s, "err"))
+      boost::iequals(s, "err")) {
     return LOG_ERR;
+  }
   if (boost::iequals(s, "crit") ||
       boost::iequals(s, "critical") ||
-      boost::iequals(s, "emerg"))
+      boost::iequals(s, "emerg")) {
     return LOG_CRIT;
+  }
 
   // err on the side of noise!
   return LOG_DEBUG;
@@ -162,6 +184,8 @@ string clog_type_to_string(clog_type t)
   switch (t) {
     case CLOG_DEBUG:
       return "debug";
+    case CLOG_VERBOSE:
+      return "verbose";
     case CLOG_INFO:
       return "info";
     case CLOG_WARN:

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -57,7 +57,7 @@ int clog_type_to_syslog_level(clog_type t)
     case CLOG_VERBOSE:
       return LOG_INFO;
     case CLOG_INFO:
-      return LOG_INFO;
+      return LOG_NOTICE;
     case CLOG_WARN:
       return LOG_WARNING;
     case CLOG_ERROR:
@@ -112,7 +112,7 @@ int string_to_syslog_level(string s)
   }
   if (boost::iequals(s, "info") ||
       boost::iequals(s, "notice")) {
-    return LOG_INFO;
+    return LOG_NOTICE;
   }
   if (boost::iequals(s, "warning") ||
       boost::iequals(s, "warn")) {

--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -148,6 +148,8 @@ inline std::ostream& operator<<(std::ostream& out, const clog_type t)
   switch (t) {
   case CLOG_DEBUG:
     return out << "[DBG]";
+  case CLOG_VERBOSE:
+    return out << "[VERB]";
   case CLOG_INFO:
     return out << "[INF]";
   case CLOG_SEC:

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -714,7 +714,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("mon_cluster_log_to_file"),
 
     Option("mon_cluster_log_file_level", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("debug")
+    .set_default("info")
     .set_flag(Option::FLAG_RUNTIME)
     .add_service("mon")
     .set_description("Lowest level to include is cluster log file")

--- a/src/common/ostream_temp.h
+++ b/src/common/ostream_temp.h
@@ -11,6 +11,8 @@ typedef enum {
   CLOG_SEC = 2,
   CLOG_WARN = 3,
   CLOG_ERROR = 4,
+  // VERBOSE is actually to be an intermediate state between DEBUG and INFO
+  CLOG_VERBOSE = 5,
   CLOG_UNKNOWN = -1,
 } clog_type;
 

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -277,7 +277,7 @@ void Log::_flush(EntryVector& t, bool requeue, bool crash)
       ceph_assert((used + 1 /* '\n' */) < allocated);
 
       if (do_syslog) {
-        syslog(LOG_USER|LOG_INFO, "%s", pos);
+        syslog(LOG_USER|LOG_INFO|LOG_NOTICE, "%s", pos);
       }
 
       if (do_stderr) {
@@ -324,7 +324,7 @@ void Log::_log_message(const char *s, bool crash)
       std::cerr << "problem writing to " << m_log_file << ": " << cpp_strerror(r) << std::endl;
   }
   if ((crash ? m_syslog_crash : m_syslog_log) >= 0) {
-    syslog(LOG_USER|LOG_INFO, "%s", s);
+    syslog(LOG_USER|LOG_INFO|LOG_NOTICE, "%s", s);
   }
 
   if ((crash ? m_stderr_crash : m_stderr_log) >= 0) {

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2327,7 +2327,7 @@ void DaemonServer::send_report()
 	  jf.flush(*_dout);
 	  *_dout << dendl;
           if (osdmap.require_osd_release >= ceph_release_t::luminous) {
-              clog->debug() << "pgmap v" << pg_map.version << ": " << pg_map;
+              clog->verbose() << "pgmap v" << pg_map.version << ": " << pg_map;
           }
 	});
     });


### PR DESCRIPTION
This partially reverts commit f64a69e5054fb319e9f717bbcb7ddd8541e01c6f.

Having clog, by default, logging on debug causes a lot of noise to
unsuspecting users.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>