### PR TITLE
nautilus: ceph-volume tests add a sleep in tox for slow OSDs after booting

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -58,6 +58,9 @@ commands=
   # reboot all vms - attempt
   bash {toxinidir}/../scripts/vagrant_reload.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
 
+  # after a reboot, osds may take about 20 seconds to come back up
+  sleep 30
+
   # retest to ensure cluster came back up correctly after rebooting
   py.test -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -62,6 +62,9 @@ commands=
   # reboot all vms - attempt
   bash {toxinidir}/../scripts/vagrant_reload.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
 
+  # after a reboot, osds may take about 20 seconds to come back up
+  sleep 30
+
   # retest to ensure cluster came back up correctly after rebooting
   py.test -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>
(cherry picked from commit b398f99f810d97c94af6d943aed4c11a5fd69c19)

backport of #28836