### PR TITLE
mgr/dashboard: Write E2E tests for pool creation, deletion and verification

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/helper.po.ts
@@ -1,4 +1,5 @@
 import { browser } from 'protractor';
+import { PoolPageHelper } from './pools/pools.po';
 import { BucketsPageHelper } from './rgw/buckets.po';
 
 export class Helper {
@@ -6,9 +7,11 @@ export class Helper {
   static TIMEOUT = 30000;
 
   buckets: BucketsPageHelper;
+  pools: PoolPageHelper;
 
   constructor() {
     this.buckets = new BucketsPageHelper();
+    this.pools = new PoolPageHelper();
   }
 
   /**

--- a/src/pybind/mgr/dashboard/frontend/e2e/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/page-helper.po.ts
@@ -1,4 +1,4 @@
-import { $, $$, browser, by, element } from 'protractor';
+import { $, $$, browser, by, element, ElementFinder, promise } from 'protractor';
 
 interface Pages {
   index: string;
@@ -47,14 +47,73 @@ export abstract class PageHelper {
     return element.all(by.cssContainingText('.datatable-body-cell-label', content)).first();
   }
 
-  // Used for instances where a modal container recieved the click rather than the
-  // desired element
+  /**
+   * Used for instances where a modal container received the click rather than the desired element.
+   *
+   * https://stackoverflow.com/questions/26211751/protractor-chrome-driver-element-is-not-clickable-at-point
+   */
   static moveClick(object) {
     return browser
       .actions()
       .mouseMove(object)
       .click()
       .perform();
+  }
+
+  /**
+   * Returns the cell with the content given in `content`. Will not return a
+   * rejected Promise if the table cell hasn't been found. It behaves this way
+   * to enable to wait for visiblity/invisiblity/precense of the returned
+   * element.
+   *
+   * It will return a rejected Promise if the result is ambigous, though. That
+   * means if after the search for content has been completed, but more than a
+   * single row is shown in the data table.
+   */
+  static getTableCellByContent(content: string): promise.Promise<ElementFinder> {
+    const searchInput = $('#pool-list > div .search input');
+    const rowAmountInput = $('#pool-list > div > div > .dataTables_paginate input');
+    const footer = $('#pool-list > div datatable-footer');
+
+    rowAmountInput.clear();
+    rowAmountInput.sendKeys('10');
+    searchInput.clear();
+    searchInput.sendKeys(content);
+
+    return footer.getAttribute('ng-reflect-row-count').then((rowCount: string) => {
+      const count = Number(rowCount);
+      if (count !== 0 && count > 1) {
+        return Promise.reject('getTableCellByContent: Result is ambigous');
+      } else {
+        return element(
+          by.cssContainingText('.datatable-body-cell-label', new RegExp(`^\\s${content}\\s$`))
+        );
+      }
+    });
+  }
+
+  /**
+   * Decorator to be used on Helper methods to restrict access to one
+   * particular URL.  This shall help developers to prevent and highlight
+   * mistakes.  It also reduces boilerplate code and by thus, increases
+   * readability.
+   */
+  static restrictTo(page): any {
+    return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+      const fn: Function = descriptor.value;
+      descriptor.value = function(...args) {
+        return browser
+          .getCurrentUrl()
+          .then((url) =>
+            url.endsWith(page)
+              ? fn.apply(this, args)
+              : promise.Promise.reject(
+                  `Method ${target.constructor.name}::${propertyKey} is supposed to be ` +
+                    `run on path "${page}", but was run on URL "${url}"`
+                )
+          );
+      };
+    };
   }
 
   navigateTo(page = null) {

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
@@ -3,9 +3,13 @@ import { PoolPageHelper } from './pools.po';
 
 describe('Pools page', () => {
   let page: PoolPageHelper;
+  let helper: Helper;
+  const poolName = 'pool_e2e_pool_test';
 
   beforeAll(() => {
     page = new PoolPageHelper();
+    helper = new Helper();
+    page.navigateTo();
   });
 
   afterEach(() => {
@@ -13,10 +17,6 @@ describe('Pools page', () => {
   });
 
   describe('breadcrumb and tab tests', () => {
-    beforeAll(() => {
-      page.navigateTo();
-    });
-
     it('should open and show breadcrumb', () => {
       expect(PoolPageHelper.getBreadcrumbText()).toEqual('Pools');
     });
@@ -31,6 +31,24 @@ describe('Pools page', () => {
 
     it('should show overall performance as a second tab', () => {
       expect(PoolPageHelper.getTabText(1)).toEqual('Overall Performance');
+    });
+  });
+
+  it('should create a pool', () => {
+    helper.pools.exist(poolName, false).then(() => {
+      helper.pools.navigateTo('create');
+      helper.pools.create(poolName, 8).then(() => {
+        helper.pools.navigateTo();
+        helper.pools.exist(poolName, true);
+      });
+    });
+  });
+
+  it('should delete a pool', () => {
+    helper.pools.exist(poolName);
+    helper.pools.delete(poolName).then(() => {
+      helper.pools.navigateTo();
+      helper.pools.exist(poolName, false);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.po.ts
@@ -1,8 +1,77 @@
+import { $, browser, by, element, ElementFinder, promise, protractor } from 'protractor';
+import { Helper } from '../helper.po';
 import { PageHelper } from '../page-helper.po';
 
+const EC = protractor.ExpectedConditions;
+const pages = {
+  index: '/#/pool',
+  create: '/#/pool/create'
+};
+
 export class PoolPageHelper extends PageHelper {
-  pages = {
-    index: '/#/pool',
-    create: '/#/pool/create'
-  };
+  pages = pages;
+
+  private isPowerOf2(n: number): boolean {
+    // tslint:disable-next-line: no-bitwise
+    return (n & (n - 1)) === 0;
+  }
+
+  @PageHelper.restrictTo(pages.index)
+  exist(name: string, oughtToBePresent = true): promise.Promise<any> {
+    return PageHelper.getTableCellByContent(name).then((elem) => {
+      const waitFn = oughtToBePresent ? EC.visibilityOf(elem) : EC.invisibilityOf(elem);
+      return browser.wait(waitFn, Helper.TIMEOUT).catch(() => {
+        const visibility = oughtToBePresent ? 'invisible' : 'visible';
+        const msg = `Pool "${name}" is ${visibility}, but should not be. Waiting for a change timed out`;
+        return promise.Promise.reject(msg);
+      });
+    });
+  }
+
+  @PageHelper.restrictTo(pages.create)
+  create(name: string, placement_groups: number): promise.Promise<any> {
+    const nameInput = $('input[name=name]');
+    nameInput.clear();
+    if (!this.isPowerOf2(placement_groups)) {
+      return Promise.reject(`Placement groups ${placement_groups} are not a power of 2`);
+    }
+    return nameInput.sendKeys(name).then(() => {
+      element(by.cssContainingText('select[name=poolType] option', 'replicated'))
+        .click()
+        .then(() => {
+          expect(element(by.css('select[name=poolType] option:checked')).getText()).toBe(
+            ' replicated '
+          );
+          $('input[name=pgNum]')
+            .sendKeys(protractor.Key.CONTROL, 'a', protractor.Key.NULL, placement_groups)
+            .then(() => {
+              return element(by.css('cd-submit-button')).click();
+            });
+        });
+    });
+  }
+
+  @PageHelper.restrictTo(pages.index)
+  delete(name: string): promise.Promise<any> {
+    return PoolPageHelper.getTableCellByContent(name).then((tableCell: ElementFinder) => {
+      return tableCell.click().then(() => {
+        return $('.table-actions button.dropdown-toggle') // open submenu
+          .click()
+          .then(() => {
+            return $('li.delete a') // click on "delete" menu item
+              .click()
+              .then(() => {
+                const getConfirmationCheckbox = () => $('#confirmation');
+                browser
+                  .wait(() => EC.visibilityOf(getConfirmationCheckbox()), Helper.TIMEOUT)
+                  .then(() => {
+                    PageHelper.moveClick(getConfirmationCheckbox()).then(() => {
+                      return element(by.cssContainingText('button', 'Delete Pool')).click(); // Click Delete item
+                    });
+                  });
+              });
+          });
+      });
+    });
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
@@ -5,16 +5,19 @@
                    [statusFor]="viewCacheStatus.statusFor"></cd-view-cache>
 
     <cd-table #table
+              id="pool-list"
               [data]="pools"
               [columns]="columns"
               selectionType="single"
               (updateSelection)="updateSelection($event)">
-      <cd-table-actions class="table-actions"
+      <cd-table-actions id="pool-list-actions"
+                        class="table-actions"
                         [permission]="permissions.pool"
                         [selection]="selection"
                         [tableActions]="tableActions">
       </cd-table-actions>
       <cd-pool-details cdTableDetail
+                       id="pool-list-details"
                        [selection]="selection"
                        [permissions]="permissions"
                        [cacheTiers]="selectionCacheTiers">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -15,7 +15,7 @@
     <!-- end filters -->
 
     <!-- search -->
-    <div class="input-group">
+    <div class="input-group search">
       <span class="input-group-prepend">
         <span class="input-group-text">
         <i [ngClass]="[icons.search]"></i>


### PR DESCRIPTION
~~Please let me know if you think these changes deserve some documentation in our `HACKING.rst`.~~

---

The focus of this implementation is performance (no sleeps have been used) and reliability. The creation and deletion tests, including two verficiations inside each test, have run in about 5 seconds on my system. 

The creation of pools is (currently) very rudimentary. Actually, it wouldn't be possible to create more than one pool with this implementation on a vstart cluster, as the second pool wouldn't have enough placement groups left. The deletion and verification however don't need any more elaboration.

I faced one problem repeatedly and found a solution to it, which I have put in the `PageHelper` class, so that it can be used on other suites and by other developers. This is `checkCheckbox`. I don't think it's the only or best solution, but it works very reliably.

As we decided to be a little bit more explicit when writing these tests, resulting in the necessity to browse to the correct page before calling a helper method, I added a check to the helper methods (create/delete/exist) which verify that the current page is the correct one. That code was more or less duplicated three times, so I wrote a `restrictTo` decorator which eases the restriction of any helper method of any suite to a certain page. It also provides a meaningful error message to developers if they find themselves using a helper method on the wrong page.

Limitations:

`getTableCellByContent` does not work reliably for tables with more than 10 entries. The method will, however, detect if it has been used on a table with more than 10 entries and fail with a meaningful error message.

Recommended improvements (tracker issues are about to be created):

- I'd really like to refactor the code to use async/await keywords, as that would not only remove the indentation through the extensive use of callbacks, but also allow for a simpler implementation of `checkCheckbox`. When doing that, it might make sense to (and might also be necessary) to change the whole E2E tests to use async/await, as Selenium's `Control Flow` feature would need to be disabled for async/await to work reliably.
  http://tracker.ceph.com/issues/40693
- It would be a good idea to replace `getTableCellByContent` with something like `findInTableColumn(column, content)`.
- `PoolHelper::create` needs way more options to choose from.
- `getTableCellByContent` needs an extension to work on tables with more entries.

TODO

- [x] Write corresponding documentation
- [x] Improve `getTableCellByContent` to work for at least 100 entries
---

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

