### PR TITLE
nautilus: ceph.spec.in: Drop systemd BuildRequires in case of building for SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -226,7 +226,6 @@ BuildRequires:  yaml-cpp-devel
 %if 0%{?suse_version}
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:	systemd-rpm-macros
-BuildRequires:	systemd
 %{?systemd_requires}
 PreReq:		%fillup_prereq
 BuildRequires:	net-tools


### PR DESCRIPTION
Nautilus backport of https://github.com/ceph/ceph/pull/28884

No tracker