### PR TITLE
qa: stop testing on 16.04 xenial

### DIFF
--- a/qa/distros/supported-all-distro/ubuntu_16.04.yaml
+++ b/qa/distros/supported-all-distro/ubuntu_16.04.yaml
@@ -1,1 +1,0 @@
-../all/ubuntu_16.04.yaml

--- a/qa/distros/supported-random-distro$/ubuntu_16.04.yaml
+++ b/qa/distros/supported-random-distro$/ubuntu_16.04.yaml
@@ -1,1 +1,0 @@
-../all/ubuntu_16.04.yaml

--- a/qa/suites/rados/thrash-old-clients/distro$/ubuntu_16.04.yaml
+++ b/qa/suites/rados/thrash-old-clients/distro$/ubuntu_16.04.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_16.04.yaml


### PR DESCRIPTION
After this merges we can also stop building xenial packages for master/octopus.