### PR TITLE
mon,osd: deprecate forward and readforward cache modes

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -360,12 +360,15 @@ function test_tiering_1()
   expect_false ceph osd tier add slow2 cache
   # test some state transitions
   ceph osd tier cache-mode cache writeback
+  # forward is removed/deprecated
   expect_false ceph osd tier cache-mode cache forward
-  ceph osd tier cache-mode cache forward --yes-i-really-mean-it
+  expect_false ceph osd tier cache-mode cache forward --yes-i-really-mean-it
   expect_false ceph osd tier cache-mode cache readonly
+  ceph osd tier cache-mode cache proxy
+  ceph osd tier cache-mode cache none
   ceph osd tier cache-mode cache readonly --yes-i-really-mean-it
   expect_false ceph osd tier cache-mode cache forward
-  ceph osd tier cache-mode cache forward --yes-i-really-mean-it
+  expect_false ceph osd tier cache-mode cache forward --yes-i-really-mean-it
   ceph osd tier cache-mode cache none
   ceph osd tier cache-mode cache writeback
   ceph osd tier cache-mode cache proxy

--- a/qa/workunits/rados/test_cache_pool.sh
+++ b/qa/workunits/rados/test_cache_pool.sh
@@ -137,7 +137,7 @@ rados -p base put testclone /etc/hosts
 rados -p cache cache-flush-evict-all
 rados -p cache ls - | wc -l | grep 0
 
-ceph osd tier cache-mode cache forward --yes-i-really-mean-it
+ceph osd tier cache-mode cache proxy --yes-i-really-mean-it
 rados -p base -s snap get testclone testclone.txt
 diff -q testclone.txt /etc/passwd
 rados -p base get testclone testclone.txt


### PR DESCRIPTION
Map these to proxy and readproxy, which actually work.