### PR TITLE
os/bluestore: avoid length overflow in extents returned by Stupid

### DIFF
--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -193,6 +193,8 @@ int64_t StupidAllocator::allocate(
   if (max_alloc_size == 0) {
     max_alloc_size = want_size;
   }
+  // cap with 32-bit val
+  max_alloc_size = std::min(max_alloc_size, 0x10000000 - alloc_unit);
 
   while (allocated_size < want_size) {
     res = allocate_int(std::min(max_alloc_size, (want_size - allocated_size)),

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -206,10 +206,13 @@ int64_t StupidAllocator::allocate(
     bool can_append = true;
     if (!extents->empty()) {
       bluestore_pextent_t &last_extent  = extents->back();
-      if ((last_extent.end() == offset) &&
-	  ((last_extent.length + length) <= max_alloc_size)) {
-	can_append = false;
-	last_extent.length += length;
+      if (last_extent.end() == offset) {
+        uint64_t l64 = last_extent.length;
+        l64 += length;
+        if (l64 < 0x100000000 && l64 <= max_alloc_size) {
+	  can_append = false;
+	  last_extent.length += length;
+        }
       }
     }
     if (can_append) {

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -326,6 +326,27 @@ TEST_P(AllocTest, test_alloc_bug_24598)
   EXPECT_EQ(0x200000u, tmp[0].length);
 }
 
+//Verifies issue from
+//http://tracker.ceph.com/issues/40703
+//
+TEST_P(AllocTest, test_alloc_big2)
+{
+  int64_t block_size = 4096;
+  int64_t blocks = 1048576 * 2;
+  int64_t mas = 1024*1024;
+  init_alloc(blocks*block_size, block_size);
+  alloc->init_add_free(0, blocks * block_size);
+  
+  PExtentVector extents;
+  uint64_t need = block_size * blocks / 4; // 2GB
+  EXPECT_EQ(need,
+      alloc->allocate(need, mas, 0, &extents));
+  need = block_size * blocks / 4; // 2GB
+  EXPECT_EQ(need,
+      alloc->allocate(need, mas, 0, &extents));
+  EXPECT_TRUE(extents[0].length > 0);
+}
+
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -336,12 +336,30 @@ TEST_P(AllocTest, test_alloc_big2)
   int64_t mas = 1024*1024;
   init_alloc(blocks*block_size, block_size);
   alloc->init_add_free(0, blocks * block_size);
-  
+
   PExtentVector extents;
   uint64_t need = block_size * blocks / 4; // 2GB
   EXPECT_EQ(need,
       alloc->allocate(need, mas, 0, &extents));
   need = block_size * blocks / 4; // 2GB
+  EXPECT_EQ(need,
+      alloc->allocate(need, mas, 0, &extents));
+  EXPECT_TRUE(extents[0].length > 0);
+}
+
+//Verifies stuck 4GB chunk allocation
+//in StupidAllocator
+//
+TEST_P(AllocTest, test_alloc_big3)
+{
+  int64_t block_size = 4096;
+  int64_t blocks = 1048576 * 2;
+  int64_t mas = 1024*1024;
+  init_alloc(blocks*block_size, block_size);
+  alloc->init_add_free(0, blocks * block_size);
+
+  PExtentVector extents;
+  uint64_t need = block_size * blocks / 2; // 4GB
   EXPECT_EQ(need,
       alloc->allocate(need, mas, 0, &extents));
   EXPECT_TRUE(extents[0].length > 0);


### PR DESCRIPTION
Allocator.

Extent merge could overflow 32-bit length.

Fixes: http://tracker.ceph.com/issues/40703

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

