### PR TITLE
rgw: add missing close_section in send_versioned_response

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -934,9 +934,12 @@ void RGWListBucket_ObjStore_S3::send_versioned_response()
       } else {
         s->formatter->dump_string("Type", "Normal");
       }
-      s->formatter->close_section();
+      s->formatter->close_section(); // Version/DeleteMarker
     }
-    s->formatter->close_section();
+    if (objs_container) {
+      s->formatter->close_section(); // Entries
+    }
+    s->formatter->close_section(); // ListVersionsResult
   }
   rgw_flush_formatter_and_reset(s, s->formatter);
 }


### PR DESCRIPTION
multisite requests use a '?objs-container' extension to wrap the entries in an array section for json decoding. send_versioned_response() was missing the close_section() to match the conditional open_array_section("Entries")