### PR TITLE
script,doc: add gen-corpus.sh

### DIFF
--- a/doc/dev/corpus.rst
+++ b/doc/dev/corpus.rst
@@ -18,7 +18,8 @@ decode old objects across that $version (this is normally the case).
 How to generate an object corpus
 --------------------------------
 
-We can generate an object corpus for a particular version of ceph like so.
+We can generate an object corpus for a particular version of ceph using the
+script of ``script/gen-corpus.sh``, or by following the instructions below:
 
 #. Checkout a clean repo (best not to do this where you normally work)::
 
@@ -50,8 +51,7 @@ We can generate an object corpus for a particular version of ceph like so.
 	bin/ceph_test_librbd
 	bin/ceph_test_libcephfs
 	bin/init-ceph restart mds.a
-
-Do some more stuff with rgw if you know how.
+    ../qa/workunits/rgw/run-s3tests.sh
 
 #. Stop::
 

--- a/src/script/gen-corpus.sh
+++ b/src/script/gen-corpus.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# -*- mode:sh; tab-width:4; sh-basic-offset:4; indent-tabs-mode:nil -*-
+# vim: softtabstop=4 shiftwidth=4 expandtab
+
+set -ex
+
+function get_jobs() {
+    local jobs=$(nproc)
+    if [ $jobs -ge 8 ] ; then
+        echo 8
+    else
+        echo $jobs
+    fi
+}
+
+function build() {
+    local encode_dump_path=$1
+    shift
+
+    ./do_cmake.sh \
+        -DWITH_MGR_DASHBOARD_FRONTEND=OFF \
+        -DWITH_DPDK=OFF \
+        -DWITH_SPDK=OFF \
+        -DCMAKE_CXX_FLAGS="-DENCODE_DUMP_PATH=${encode_dump_path}"
+    cd build
+    cmake --build . -- -j$(get_jobs)
+}
+
+function run() {
+    MON=3 MGR=2 OSD=3 MDS=3 RGW=1 ../src/vstart.sh -n -x
+
+    local old_path="$PATH"
+    export PATH="bin:$PATH"
+    ceph osd pool create mypool 8
+    rados -p mypool bench 10 write -b 123
+    ceph osd out 0
+    ceph osd in 0
+    init-ceph restart osd.1
+    for f in ../qa/workunits/cls/*.sh ; do
+        $f
+    done
+    ../qa/workunits/rados/test.sh
+    ceph_test_librbd
+    ceph_test_libcephfs
+    init-ceph restart mds.a
+    ../qa/workunits/rgw/run-s3tests.sh
+    PATH="$old_path"
+
+    ../src/stop.sh
+}
+
+function import_corpus() {
+    local encode_dump_path=$1
+    shift
+    local version=$1
+    shift
+
+    # import the corpus
+    ../src/test/encoding/import.sh \
+        ${encode_dump_path} \
+        ${version} \
+        ../ceph-object-corpus/archive
+    ../src/test/encoding/import-generated.sh \
+        ../ceph-object-corpus/archive
+    # prune it
+    pushd ../ceph-object-corpus
+    bin/prune-archive.sh
+    popd
+}
+
+function verify() {
+    ctest -R readable.sh
+}
+
+function commit_and_push() {
+    local version=$1
+    shift
+
+    pushd ../ceph-object-corpus
+    git checkout -b wip-${version}
+    git add archive/${version}
+    git commit --signoff --message=${version}
+    git remote add cc git@github.com:ceph/ceph-object-corpus.git
+    git push cc wip-${version}
+    popd
+}
+
+encode_dump_path=$(mktemp -d)
+build $encode_dump_path
+echo "generating corpus objects.."
+run
+version=$(bin/ceph-dencoder version)
+echo "importing corpus. it may take over 30 minutes.."
+import_corpus $encode_dump_path $version
+echo "verifying imported corpus.."
+verify
+echo "all good, pushing to remote repo.."
+commit_and_push ${version}
+rm -rf encode_dump_path


### PR DESCRIPTION
to automate generation of ceph-object-corpus objects. it facilitate the
process of cutting a new release

see also https://pad.ceph.com/p/downgrades

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

