### PR TITLE
common/TrackedOP: make slow_op_threshold work on ms or us.

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -78,7 +78,7 @@ void OpHistory::_insert_delayed(const utime_t& now, TrackedOpRef op)
   double opduration = op->get_duration();
   duration.insert(make_pair(opduration, op));
   arrived.insert(make_pair(op->get_initiated(), op));
-  if (opduration >= history_slow_op_threshold.load())
+  if (opduration >= (double)history_slow_op_threshold.load()/(double)1000.0)
     slow_op.insert(make_pair(op->get_initiated(), op));
   cleanup(now);
 }
@@ -183,7 +183,7 @@ void OpHistory::dump_slow_ops(utime_t now, Formatter *f, set<string> filters)
   cleanup(now);
   f->open_object_section("OpHistory slow ops");
   f->dump_int("num to keep", history_slow_op_size.load());
-  f->dump_int("threshold to keep", history_slow_op_threshold.load());
+  f->dump_unsigned("threshold to keep(millisecond)", history_slow_op_threshold.load());
   {
     f->open_array_section("Ops");
     for (set<pair<utime_t, TrackedOpRef> >::const_iterator i =

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -779,7 +779,7 @@ OPTION(osd_num_op_tracker_shard, OPT_U32) // The number of shards for holding th
 OPTION(osd_op_history_size, OPT_U32)    // Max number of completed ops to track
 OPTION(osd_op_history_duration, OPT_U32) // Oldest completed op to track
 OPTION(osd_op_history_slow_op_size, OPT_U32)           // Max number of slow ops to track
-OPTION(osd_op_history_slow_op_threshold, OPT_DOUBLE) // track the op if over this threshold
+OPTION(osd_op_history_slow_op_threshold, OPT_U32) // track the op if over this threshold
 OPTION(osd_target_transaction_size, OPT_INT)     // to adjust various transactions that batch smaller items
 OPTION(osd_failsafe_full_ratio, OPT_FLOAT) // what % full makes an OSD "full" (failsafe)
 OPTION(osd_fast_fail_on_connection_refused, OPT_BOOL) // immediately mark OSDs as down once they refuse to accept connections

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1258,10 +1258,10 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description("max number of slow historical MON OPS to keep"),
 
-    Option("mon_op_history_slow_op_threshold", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
-    .set_default(10)
+    Option("mon_op_history_slow_op_threshold", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(10000)
     .add_service("mon")
-    .set_description("duration of an op to be considered as a historical slow op"),
+    .set_description("duration (millisecond)of an op to be considered as a historical slow op"),
 
     Option("mon_data", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_flag(Option::FLAG_NO_MON_UPDATE)
@@ -3783,9 +3783,9 @@ std::vector<Option> get_global_options() {
     .set_default(20)
     .set_description(""),
 
-    Option("osd_op_history_slow_op_threshold", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(10.0)
-    .set_description(""),
+    Option("osd_op_history_slow_op_threshold", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(10000)
+    .set_description("duration (milliseconds) of an op to be considered as a historical slow op"),
 
     Option("osd_target_transaction_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(30)

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -25,21 +25,6 @@ struct Option {
     TYPE_SECS = 9,
   };
 
-  static const char *type_to_c_type_str(type_t t) {
-    switch (t) {
-    case TYPE_UINT: return "uint64_t";
-    case TYPE_INT: return "int64_t";
-    case TYPE_STR: return "std::string";
-    case TYPE_FLOAT: return "double";
-    case TYPE_BOOL: return "bool";
-    case TYPE_ADDR: return "entity_addr_t";
-    case TYPE_ADDRVEC: return "entity_addrvec_t";
-    case TYPE_UUID: return "uuid_d";
-    case TYPE_SIZE: return "size_t";
-    case TYPE_SECS: return "secs";
-    default: return "unknown";
-    }
-  }
   static const char *type_to_str(type_t t) {
     switch (t) {
     case TYPE_UINT: return "uint";

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -212,7 +212,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
       g_conf().get_val<std::chrono::seconds>("mon_op_history_duration").count());
   op_tracker.set_history_slow_op_size_and_threshold(
       g_conf().get_val<uint64_t>("mon_op_history_slow_op_size"),
-      g_conf().get_val<std::chrono::seconds>("mon_op_history_slow_op_threshold").count());
+      g_conf().get_val<uint64_t>("mon_op_history_slow_op_threshold"));
 
   paxos = new Paxos(this, "paxos");
 


### PR DESCRIPTION
For all-nvme-ssd Ceph cluster, dupration of Op is ms or us. So we
need make slow_op_threshold in this range.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

