### PR TITLE
mimic: mgr/dashboard: Fix run-frontend-e2e-tests.sh

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -7,7 +7,7 @@ stop() {
         cd $BUILD_DIR
         ../src/stop.sh
     fi
-    exit
+    exit $1
 }
 
 BASE_URL=''
@@ -18,7 +18,10 @@ while getopts 'd:r:' flag; do
   case "${flag}" in
     d) DEVICE=$OPTARG;;
     r) REMOTE='true'
-       BASE_URL=$OPTARG;;
+       # jq is expecting a string literal, otherwise it will fail on the url ':'.
+       # We need to ensure that jq gets a json string for assignment; we achieve
+       # that by introducing literal double quotes (i.e., '"').
+       BASE_URL='"'$OPTARG'"';;
   esac
 done
 
@@ -30,7 +33,7 @@ if [ "$DEVICE" == "" ]; then
     else
         echo "ERROR: Chrome and Docker not found. You need to install one of  \
 them to run the e2e frontend tests."
-        stop
+        stop 1
     fi
 fi
 
@@ -44,23 +47,26 @@ if [ "$BASE_URL" == "" ]; then
     sleep 10
 
     BASE_URL=`./bin/ceph mgr services | jq .dashboard`
-    BASE_URL=${BASE_URL//\"}
 fi
 
 cd $DASH_DIR/frontend
+jq .[].target=$BASE_URL proxy.conf.json.sample > proxy.conf.json
+
 . $BUILD_DIR/src/pybind/mgr/dashboard/node-env/bin/activate
 npm ci
 npm run build -- --prod
 
 if [ $DEVICE == "chrome" ]; then
-    npm run e2e -- --serve=false --base-href $BASE_URL || stop
+    npm run e2e || stop 1
+    stop 0
 elif [ $DEVICE == "docker" ]; then
-    docker run -d -v $(pwd):/workdir --net=host --name angular-e2e-container rogargon/angular-e2e || stop
-    docker exec angular-e2e-container npm run e2e -- --serve=false --base-href $BASE_URL
+    failed=0
+    docker run -d -v $(pwd):/workdir --net=host --name angular-e2e-container rogargon/angular-e2e || failed=1
+    docker exec angular-e2e-container npm run e2e || failed=1
     docker stop angular-e2e-container
     docker rm angular-e2e-container
+    stop $failed
 else
     echo "ERROR: Device not recognized. Valid devices are 'chrome' and 'docker'."
+    stop 1
 fi
-
-stop


### PR DESCRIPTION
e2e tests were always returning positive result, even when they failed.

Fixed problem with jq, where it was failing when it was not receiving a string.

Fixes: http://tracker.ceph.com/issues/40707

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>
Signed-off-by: Tiago Melo <tmelo@suse.com>
(cherry picked from commit ad293e1961065ea4b92244c8f059dff0ef73a016)

Conflicts:
	src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

