### PR TITLE
mgr/dashboard: controllers/grafana is not Python3 compatible

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/grafana.py
+++ b/src/pybind/mgr/dashboard/controllers/grafana.py
@@ -36,7 +36,7 @@ class Grafana(BaseController):
             response['success'] = push_local_dashboards()
         except Exception as e:  # pylint: disable=broad-except
             raise DashboardException(
-                msg=e.message,
+                msg=str(e),
                 component='grafana',
                 http_status_code=500,
             )


### PR DESCRIPTION
An exception would have caused another exception and possibly hidden the
real cause of the exception when the dashboard is run with Python 2.

Fixes: http://tracker.ceph.com/issues/40428

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

