### PR TITLE
rpm,etc/sysconfig: remove SuSEfirewall2 support

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1256,8 +1256,6 @@ install -m 0644 -D etc/sysctl/90-ceph-osd.conf %{buildroot}%{_sysctldir}/90-ceph
 
 # firewall templates and /sbin/mount.ceph symlink
 %if 0%{?suse_version}
-install -m 0644 -D etc/sysconfig/SuSEfirewall2.d/services/ceph-mon %{buildroot}%{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/ceph-mon
-install -m 0644 -D etc/sysconfig/SuSEfirewall2.d/services/ceph-osd-mds %{buildroot}%{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/ceph-osd-mds
 mkdir -p %{buildroot}/sbin
 ln -sf %{_sbindir}/mount.ceph %{buildroot}/sbin/mount.ceph
 %endif
@@ -1336,8 +1334,6 @@ rm -rf %{buildroot}
 %endif
 %if 0%{?suse_version}
 %{_fillupdir}/sysconfig.*
-%config %{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/ceph-mon
-%config %{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/ceph-osd-mds
 %endif
 %{_unitdir}/ceph.target
 %if 0%{with python2}

--- a/etc/sysconfig/SuSEfirewall2.d/services/ceph-mon
+++ b/etc/sysconfig/SuSEfirewall2.d/services/ceph-mon
@@ -1,5 +1,0 @@
-## Name: Ceph MON
-## Description: Open port for Ceph Monitor
-
-# space separated list of allowed TCP ports
-TCP="6789"

--- a/etc/sysconfig/SuSEfirewall2.d/services/ceph-osd-mds
+++ b/etc/sysconfig/SuSEfirewall2.d/services/ceph-osd-mds
@@ -1,5 +1,0 @@
-## Name: Ceph OSD/MDS
-## Description: Open ports for Ceph OSDs and Metadata Servers (max: 166 per node)
-
-# space separated list of allowed TCP ports
-TCP="6800:7300"


### PR DESCRIPTION
removal of SuSEfirewall2 service, since SuSEfirewall2 has been replaced
by firewalld, see [1].

[1]: https://lists.opensuse.org/opensuse-factory/2019-01/msg00490.html

Fixes: http://tracker.ceph.com/issues/40738
Signed-off-by: Matthias Gerstner <matthias.gerstner@suse.de>