### PR TITLE
[RFC][WIP]os/bluestore: framework for more intelligent DB space usage

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1068,6 +1068,7 @@ OPTION(bluestore_warn_on_legacy_statfs, OPT_BOOL)
 OPTION(bluestore_log_op_age, OPT_DOUBLE)
 OPTION(bluestore_log_omap_iterator_age, OPT_DOUBLE)
 OPTION(bluestore_debug_enforce_settings, OPT_STR)
+OPTION(bluestore_volume_selection_policy, OPT_STR)
 
 OPTION(kstore_max_ops, OPT_U64)
 OPTION(kstore_max_bytes, OPT_U64)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4834,6 +4834,11 @@ std::vector<Option> get_global_options() {
     .set_description("Enforces specific hw profile settings")
     .set_long_description("'hdd' enforces settings intended for BlueStore above a rotational drive. 'ssd' enforces settings intended for BlueStore above a solid drive. 'default' - using settings for the actual hardware."),
 
+    Option("bluestore_volume_selection_policy", Option::TYPE_STR, Option::LEVEL_DEV)
+    .set_default("rocksdb_original")
+    .set_enum_allowed({ "rocksdb_original", "use_some_extra" })
+    .set_description("Determines bluefs volume selection policy")
+    .set_long_description("Determines bluefs volume selection policy"),
 
     // -----------------------------------------
     // kstore

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -128,7 +128,11 @@ public:
   }
 
   int tryInterpret(const string& key, const string& val, rocksdb::Options &opt);
-  int ParseOptionsFromString(const string& opt_str, rocksdb::Options &opt);
+  int ParseOptionsFromString(const string& opt_str, rocksdb::Options& opt);
+  static int ParseOptionsFromStringStatic(
+    CephContext* cct,
+    const string& opt_str,
+    rocksdb::Options &opt);
   static int _test_init(const string& dir);
   int init(string options_str) override;
   /// compact rocksdb for all keys with a given prefix

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -65,6 +65,50 @@ public:
     PExtentVector& extents) = 0;
 };
 
+class BlueFSVolumeSelector {
+public:
+  typedef std::vector<std::pair<std::string, uint64_t>> paths;
+
+  virtual ~BlueFSVolumeSelector() {
+  }
+  virtual void* get_hint_by_device(uint8_t dev) const = 0;
+  virtual void* get_hint_by_dir(const string& dirname) const = 0;
+
+  virtual void add_usage(void* file_hint, const bluefs_fnode_t& fnode) = 0;
+  virtual void sub_usage(void* file_hint, const bluefs_fnode_t& fnode) = 0;
+  virtual void add_usage(void* file_hint, uint64_t fsize) = 0;
+  virtual void sub_usage(void* file_hint, uint64_t fsize) = 0;
+  virtual uint8_t select_prefer_bdev(void* hint) = 0;
+  virtual void get_paths(const std::string& base, paths& res) const = 0;
+  virtual void dump(CephContext* cct) = 0;
+};
+class BlueFS;
+class OriginalVolumeSelector : public BlueFSVolumeSelector {
+  BlueFS* bluefs = nullptr;
+public:
+  OriginalVolumeSelector(BlueFS* _bluefs) : bluefs(_bluefs) {}
+
+  void* get_hint_by_device(uint8_t dev) const override;
+  void* get_hint_by_dir(const string& dirname) const override;
+
+  void add_usage(void* file_hint, const bluefs_fnode_t& fnode) override {
+    // do nothing
+  }
+  void sub_usage(void* file_hint, const bluefs_fnode_t& fnode) override {
+    // do nothing
+  }
+  void add_usage(void* file_hint, uint64_t fsize) override {
+    // do nothing
+  }
+  void sub_usage(void* file_hint, uint64_t fsize) override {
+    // do nothing
+  }
+  uint8_t select_prefer_bdev(void* hint) override;
+  void get_paths(const std::string& base, paths& res) const override;
+  void dump(CephContext* cct) override;
+
+};
+
 class BlueFS {
 public:
   CephContext* cct;
@@ -94,6 +138,8 @@ public:
     std::atomic_int num_readers, num_writers;
     std::atomic_int num_reading;
 
+    void* vselector_hint = nullptr;
+
     File()
       : RefCountedObject(NULL, 0),
 	refs(0),
@@ -102,7 +148,8 @@ public:
 	deleted(false),
 	num_readers(0),
 	num_writers(0),
-	num_reading(0)
+	num_reading(0),
+        vselector_hint(nullptr)
       {}
     ~File() override {
       ceph_assert(num_readers.load() == 0);
@@ -304,6 +351,7 @@ private:
   BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
 
   BlueFSDeviceExpander* slow_dev_expander = nullptr;
+  std::unique_ptr<BlueFSVolumeSelector> vselector;
 
   void _init_logger();
   void _shutdown_logger();
@@ -477,6 +525,14 @@ public:
   void set_slow_device_expander(BlueFSDeviceExpander* a) {
     slow_dev_expander = a;
   }
+  void set_volume_selector(BlueFSVolumeSelector* s) {
+    vselector.reset(s);
+  }
+  void get_vselector_paths(const std::string& base,
+                           BlueFSVolumeSelector::paths& res) const {
+    return vselector->get_paths(base, res);
+  }
+
   int add_block_device(unsigned bdev, const string& path, bool trim,
 		       bool shared_with_bluestore=false);
   bool bdev_support_label(unsigned id);

--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -6,10 +6,12 @@
 #include <memory>
 #include <string>
 
+#include "rocksdb/options.h"
 #include "rocksdb/status.h"
 #include "rocksdb/utilities/env_mirror.h"
 
 #include "include/ceph_assert.h"
+#include "kv/RocksDBStore.h"
 
 class BlueFS;
 

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -115,7 +115,6 @@ void bluefs_fnode_t::dump(Formatter *f) const
   f->dump_unsigned("ino", ino);
   f->dump_unsigned("size", size);
   f->dump_stream("mtime") << mtime;
-  f->dump_unsigned("prefer_bdev", prefer_bdev);
   f->open_array_section("extents");
   for (auto& p : extents)
     f->dump_object("extent", p);
@@ -130,7 +129,7 @@ void bluefs_fnode_t::generate_test_instances(list<bluefs_fnode_t*>& ls)
   ls.back()->size = 1048576;
   ls.back()->mtime = utime_t(123,45);
   ls.back()->extents.push_back(bluefs_extent_t(0, 1048576, 4096));
-  ls.back()->prefer_bdev = 1;
+  ls.back()->__unused__ = 1;
 }
 
 ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
@@ -138,7 +137,6 @@ ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
   return out << "file(ino " << file.ino
 	     << " size 0x" << std::hex << file.size << std::dec
 	     << " mtime " << file.mtime
-	     << " bdev " << (int)file.prefer_bdev
 	     << " allocated " << std::hex << file.allocated << std::dec
 	     << " extents " << file.extents
 	     << ")";

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -33,12 +33,11 @@ WRITE_CLASS_DENC(bluefs_extent_t)
 
 ostream& operator<<(ostream& out, const bluefs_extent_t& e);
 
-
 struct bluefs_fnode_t {
   uint64_t ino;
   uint64_t size;
   utime_t mtime;
-  uint8_t prefer_bdev;
+  uint8_t __unused__; // was prefer_bdev
   mempool::bluefs::vector<bluefs_extent_t> extents;
 
   // precalculated logical offsets for extents vector entries
@@ -47,7 +46,7 @@ struct bluefs_fnode_t {
 
   uint64_t allocated;
 
-  bluefs_fnode_t() : ino(0), size(0), prefer_bdev(0), allocated(0) {}
+  bluefs_fnode_t() : ino(0), size(0), __unused__(0), allocated(0) {}
 
   uint64_t get_allocated() const {
     return allocated;
@@ -81,7 +80,7 @@ struct bluefs_fnode_t {
     denc_varint(v.ino, p);
     denc_varint(v.size, p);
     denc(v.mtime, p);
-    denc(v.prefer_bdev, p);
+    denc(v.__unused__, p);
     denc(v.extents, p);
     DENC_FINISH(p);
   }


### PR DESCRIPTION
The idea is to force RocksDB to "hint" corresponding DB level when opening a file.
Which is implemented via passing level size aligned folders when opening a DB. RocksDB opens files using these folders hence denoting DB level this file belongs to.  The accuracy of such hints looks pretty good.
As a result one is able to build volume usage matrix (DEVICE x DB_LEVEL) which allows to make more intelligent decisions where allocate bluefs extents for specific file from.
Currently this patch is mainly about infrastructure rather than taking such a decision except some improvement for levels 4+ which allows partial DB space usage even when the whole L4 doesn't fit into DB.
One more improvement we can consider is using WAL device for L0/L1 when WAL is underused...

Here is an example for DB levels and bluefs volume usage statistics collected by both the new framework and existing methods. In fact new framework keeps two DEVICE x LEVEL  matrices:
a) current values
b) maximum observed values
In the reports below one can check the matching between REAL column in current values matrix and rocksdb per-level stats.
Or TOTALS row values vs. bluefs-bdev-sizes output

Case 1: Original allocation policy:

2019-07-10T15:40:13.791+0300 7f32bb255700  1 RocksDBBlueFSVolumeSelector: wal_total:5368709120, db_total:96636764160, slow_total:107374182400, db_cut_level:4, policy:0 usage matrix:
**** current values matrix starts here ****
LEVEL, WAL, DB, SLOW, ****, ****, REAL
L0-1 0,0,0,0,0,0
L2 0,1009778688,0,0,0,1002696637
L3 0,15006171136,0,0,0,14928509229
L4+ 0,0,78671511552,0,0,78313236820
WAL 530579456,1048576,0,0,0,345309959
UNSORTED 0,6291456,0,0,0,1285822
TOTALS 530579456,16023289856,78671511552,0,0,0
^^^^^ current values matrix ends here, maximums matrix follow
MAXIMUMS:
0,3279945728,0,0,0,3264581164
0,10412359680,0,0,0,10369342915
0,48643440640,0,0,0,48425182335
0,0,93072654336,0,0,92586709652
538968064,1048576,0,0,0,528943749
0,7340032,0,0,0,1285822
538968064,55071211520,93072654336,0,0,0
2019-07-10T15:40:13.791+0300 7f32bb255700  1 bluestore(/home/if/ceph/build/dev/osd0)  bluefs bdev sizes: bluefs bdev sizes: bluefs bdev sizes:
0 : device size 0x140000000 : own 0x[1000~13ffff000] = 0x13ffff000 : using 0x1faff000(507 MiB)
1 : device size 0x1680000000 : own 0x[2000~167fffe000] = 0x167fffe000 : using 0x3bb1fe000(15 GiB)
2 : device size 0x1900000000 : own 0x[3600000~300000,3a00000~52ac00000,52ea00000~600d00000,b33d00000~a60d00000,1595000000~3dc00000] = 0x15ca500000 : using 0x1251300000(73 GiB)
db_statistics {
    "rocksdb_compaction_statistics": "",
    "": "",
    "": "** Compaction Stats [default] **",
    "": "Level    Files   Size  
    "": "---------------------
    "": "  L0      0/0    0.00 KB   ...
    "": "  L1      0/0    0.00 KB   ...
    "": "  L2     19/1   956.25 MB ...
    "": "  L3    234/27  13.00 GB   ...
    "": "  L4   1161/0   72.93 GB   ...
    "": " Sum   1414/28  86.87 GB  ...
 
Case 2: Use some extra space for L4+ policy:
2019-07-10T16:21:45.827+0300 7f5f6f6d7700  1 RocksDBBlueFSVolumeSelector: wal_total:5368709120, db_total:96636764160, slow_total:107374182400, db_cut_level:4, policy:1 usage matrix:
LEVEL, WAL, DB, SLOW, ****, ****, REAL
L0-1 0,419430400,0,0,0,417663585
L2 0,2645557248,0,0,0,2634051067
L3 0,26923237376,0,0,0,26823171800
L4+ 0,21681405952,0,0,0,21550869858
WAL 530579456,1048576,0,0,0,524066537
UNSORTED 0,5242880,0,0,0,511651
TOTALS 530579456,51675922432,0,0,0,0
MAXIMUMS:
0,6149898240,0,0,0,6121377338
0,19858980864,0,0,0,19782445877
0,46491762688,0,0,0,46268971009
0,21681405952,0,0,0,21550869858
538968064,1048576,0,0,0,531368421
0,7340032,0,0,0,511651
538968064,53198454784,0,0,0,0
2019-07-10T16:21:45.831+0300 7f5f6f6d7700  1 bluestore(/home/if/ceph/build/dev/osd0)  bluefs bdev sizes: bluefs bdev sizes: bluefs bdev sizes:
0 : device size 0x140000000 : own 0x[1000~13ffff000] = 0x13ffff000 : using 0x1faff000(507 MiB)
1 : device size 0x1680000000 : own 0x[2000~167fffe000] = 0x167fffe000 : using 0xc0c3fe000(48 GiB)
2 : device size 0x1900000000 : own 0x[c00000000~100000000] = 0x100000000 : using 0x0(0 B)
db_statistics {
    "rocksdb_compaction_statistics": "",
    "": "",
    "": "** Compaction Stats [default] **",
    "": "Level    Files   Size     
    "": "-----------------------",
    "": "  L0      1/0   204.04 MB  ...
    "": "  L1      3/0   194.28 MB  ...  
    "": "  L2     41/0    2.45 GB    ...
    "": "  L3    396/0   24.98 GB  ...
    "": "  L4    317/0   20.07 GB   ... 
 

Relates to: http://tracker.ceph.com/issues/38745



Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

