### PR TITLE
[AFTER: #28644] luminous: os/bluestore: default to bitmap allocator for bluestore/bluefs

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3314,7 +3314,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluefs_allocator", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("stupid")
+    .set_default("bitmap")
     .set_description(""),
 
     Option("bluefs_preextend_wal_files", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -3655,7 +3655,7 @@ std::vector<Option> get_global_options() {
     .set_description("Key value database to use for bluestore"),
 
     Option("bluestore_allocator", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("stupid")
+    .set_default("bitmap")
     .set_enum_allowed({"bitmap", "stupid"})
     .set_description("Allocator policy"),
 


### PR DESCRIPTION
Luminous backport of https://tracker.ceph.com/issues/40720