### PR TITLE
mgr/volumes: allow/deny access to fs subvolumes and subvolume groups

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -297,3 +297,25 @@ class CephFSTestCase(CephTestCase):
                 return subtrees
             time.sleep(pause)
         raise RuntimeError("rank {0} failed to reach desired subtree state".format(rank))
+
+    @staticmethod
+    def _sudo_write_file(remote, path, data):
+        """
+        Write data to a remote file as super user
+
+        :param remote: Remote site.
+        :param path: Path on the remote being written to.
+        :param data: Data to be written.
+
+        Both perms and owner are passed directly to chmod.
+        """
+        remote.run(
+            args=[
+                'sudo',
+                'python',
+                '-c',
+                'import shutil, sys; shutil.copyfileobj(sys.stdin, file(sys.argv[1], "wb"))',
+                path,
+            ],
+            stdin=data,
+        )

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -46,27 +46,6 @@ vc.disconnect()
                    vol_prefix=vol_prefix, ns_prefix=ns_prefix),
         self.py_version)
 
-    def _sudo_write_file(self, remote, path, data):
-        """
-        Write data to a remote file as super user
-
-        :param remote: Remote site.
-        :param path: Path on the remote being written to.
-        :param data: Data to be written.
-
-        Both perms and owner are passed directly to chmod.
-        """
-        remote.run(
-            args=[
-                'sudo',
-                'python',
-                '-c',
-                'import shutil, sys; shutil.copyfileobj(sys.stdin, file(sys.argv[1], "wb"))',
-                path,
-            ],
-            stdin=data,
-        )
-
     def _configure_vc_auth(self, mount, id_name):
         """
         Set up auth credentials for the VolumeClient user

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -214,7 +214,7 @@ void MonCapGrant::expand_profile_mon(const EntityName& name) const
     profile_grants.push_back(MonCapGrant("mds", MON_CAP_R | MON_CAP_W));
     profile_grants.push_back(MonCapGrant("fs", MON_CAP_R | MON_CAP_W));
     profile_grants.push_back(MonCapGrant("osd", MON_CAP_R | MON_CAP_W));
-    profile_grants.push_back(MonCapGrant("auth", MON_CAP_R | MON_CAP_X));
+    profile_grants.push_back(MonCapGrant("auth", MON_CAP_R | MON_CAP_W | MON_CAP_X));
     profile_grants.push_back(MonCapGrant("config-key", MON_CAP_R | MON_CAP_W));
     profile_grants.push_back(MonCapGrant("config", MON_CAP_R | MON_CAP_W));
   }

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -149,6 +149,23 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'desc': "Deny a cephx auth ID access to a subvolume",
             'perm': 'rw'
         },
+        {
+            'cmd': 'fs subvolumegroup authorize '
+                   'name=vol_name,type=CephString '
+                   'name=group_name,type=CephString '
+                   'name=auth_id,type=CephString '
+                   'name=access_level,type=CephString,req=false ',
+            'desc': "Allow a cephx auth ID access to a subvolumegroup",
+            'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolumegroup deauthorize '
+                   'name=vol_name,type=CephString '
+                   'name=group_name,type=CephString '
+                   'name=auth_id,type=CephString ',
+            'desc': "Deny a cephx auth ID access to a subvolumegroup",
+            'perm': 'rw'
+        },
 
 
         # volume ls [recursive]
@@ -315,3 +332,18 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         group_name = cmd.get('group_name', None)
 
         return self.vc.deauthorize_subvolume(vol_name, sub_name, auth_id, group_name)
+
+    def _cmd_fs_subvolumegroup_authorize(self, inbuf, cmd):
+        vol_name = cmd['vol_name']
+        group_name = cmd['group_name']
+        auth_id = cmd['auth_id']
+        access_level = cmd.get('access_level', 'rw')
+
+        return self.vc.authorize_subvolumegroup(vol_name, group_name, auth_id, access_level)
+
+    def _cmd_fs_subvolumegroup_deauthorize(self, inbuf, cmd):
+        vol_name = cmd['vol_name']
+        group_name = cmd['group_name']
+        auth_id = cmd['auth_id']
+
+        return self.vc.deauthorize_subvolumegroup(vol_name, group_name, auth_id)

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -130,6 +130,26 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                     "and optionally, in a specific subvolume group",
             'perm': 'rw'
         },
+        {
+            'cmd': 'fs subvolume authorize '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=auth_id,type=CephString '
+                   'name=group_name,type=CephString,req=false '
+                   'name=access_level,type=CephString,req=false ',
+            'desc': "Allow a cephx auth ID access to a subvolume",
+            'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolume deauthorize '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=auth_id,type=CephString '
+                   'name=group_name,type=CephString,req=false ',
+            'desc': "Deny a cephx auth ID access to a subvolume",
+            'perm': 'rw'
+        },
+
 
         # volume ls [recursive]
         # subvolume ls <volume>
@@ -278,3 +298,20 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         group_name = cmd.get('group_name', None)
 
         return self.vc.remove_subvolume_snapshot(vol_name, sub_name, snap_name, group_name, force)
+
+    def _cmd_fs_subvolume_authorize(self, inbuf, cmd):
+        vol_name = cmd['vol_name']
+        sub_name = cmd['sub_name']
+        auth_id = cmd['auth_id']
+        access_level = cmd.get('access_level', 'rw')
+        group_name = cmd.get('group_name', None)
+
+        return self.vc.authorize_subvolume(vol_name, sub_name, auth_id, group_name, access_level)
+
+    def _cmd_fs_subvolume_deauthorize(self, inbuf, cmd):
+        vol_name = cmd['vol_name']
+        sub_name = cmd['sub_name']
+        auth_id = cmd['auth_id']
+        group_name = cmd.get('group_name', None)
+
+        return self.vc.deauthorize_subvolume(vol_name, sub_name, auth_id, group_name)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40401

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

