### PR TITLE
mgr/dashboard: Add nolockdep option to e2e-script

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -43,7 +43,7 @@ cd ../../../../build
 BUILD_DIR=`pwd`
 
 if [ "$BASE_URL" == "" ]; then
-    MGR=2 RGW=1 ../src/vstart.sh -n -d
+    MGR=2 RGW=1 ../src/vstart.sh -n -d --nolockdep
     sleep 10
 
     # Create an Object Gateway User


### PR DESCRIPTION
Adding the --nolockdep option to the vstart command
seems to fix the current issue where vstart just
hangs at the dashboard ac-user-create command.
Hopefully we can get the e2e tests to run again
in Jenkins by applying this change.
Note that this might be a workaround only.
Note no. 2: This change will be reverted as soon as PR #28987 has been merged.

Fixes: https://tracker.ceph.com/issues/40688

Signed-off-by: Laura Paduano <lpaduano@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

