### PR TITLE
osd/PGLog: Avoid rmissing index value conflicts

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -80,7 +80,7 @@ public:
 
     // recovery pointers
     list<pg_log_entry_t>::iterator complete_to; // not inclusive of referenced item
-    version_t last_requested = 0;               // last object requested by primary
+    eversion_t last_requested = eversion_t();               // last object requested by primary
 
     //
   private:
@@ -132,7 +132,7 @@ public:
   public:
     IndexedLog() :
       complete_to(log.end()),
-      last_requested(0),
+      last_requested(0, 0),
       indexed_data(0),
       rollback_info_trimmed_to_riter(log.rbegin())
     { }
@@ -141,7 +141,7 @@ public:
     explicit IndexedLog(Args&&... args) :
       pg_log_t(std::forward<Args>(args)...),
       complete_to(log.end()),
-      last_requested(0),
+      last_requested(0, 0),
       indexed_data(0),
       rollback_info_trimmed_to_riter(log.rbegin())
     {
@@ -240,7 +240,7 @@ public:
     }
     void reset_recovery_pointers() {
       complete_to = log.end();
-      last_requested = 0;
+      last_requested = eversion_t();
     }
 
     bool logged_object(const hobject_t& oid) const {
@@ -708,7 +708,7 @@ public:
 
   void set_head(eversion_t head) { log.head = head; }
 
-  void set_last_requested(version_t last_requested) {
+  void set_last_requested(eversion_t last_requested) {
     log.last_requested = last_requested;
   }
 
@@ -846,7 +846,7 @@ public:
 
   void activate_not_complete(pg_info_t &info) {
     reset_complete_to(&info);
-    log.last_requested = 0;
+    log.last_requested = eversion_t();
   }
 
   void proc_replica_log(pg_info_t &oinfo,

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3735,7 +3735,7 @@ void PeeringState::force_object_missing(
       peer_missing[peer].add(soid, version, eversion_t(), false);
     } else {
       pg_log.missing_add(soid, version, eversion_t());
-      pg_log.set_last_requested(0);
+      pg_log.set_last_requested(eversion_t());
     }
   }
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1850,7 +1850,7 @@ public:
   }
 
   /// Update last_requested pointer to v
-  void set_last_requested(version_t v) {
+  void set_last_requested(eversion_t v) {
     pg_log.set_last_requested(v);
   }
 

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1048,7 +1048,7 @@ TEST(pg_missing_t, add_next_event)
     missing.add_next_event(e);
     EXPECT_TRUE(missing.is_missing(oid));
     EXPECT_EQ(eversion_t(), missing.get_items().at(oid).have);
-    EXPECT_EQ(oid, missing.get_rmissing().at(e.version.version));
+    EXPECT_EQ(oid, missing.get_rmissing().at(e.version));
     EXPECT_EQ(1U, missing.num_missing());
     EXPECT_EQ(1U, missing.get_rmissing().size());
 
@@ -1073,7 +1073,7 @@ TEST(pg_missing_t, add_next_event)
     missing.add_next_event(e);
     EXPECT_TRUE(missing.is_missing(oid));
     EXPECT_EQ(eversion_t(), missing.get_items().at(oid).have);
-    EXPECT_EQ(oid, missing.get_rmissing().at(e.version.version));
+    EXPECT_EQ(oid, missing.get_rmissing().at(e.version));
     EXPECT_EQ(1U, missing.num_missing());
     EXPECT_EQ(1U, missing.get_rmissing().size());
 
@@ -1098,7 +1098,7 @@ TEST(pg_missing_t, add_next_event)
     missing.add_next_event(e);
     EXPECT_TRUE(missing.is_missing(oid));
     EXPECT_EQ(eversion_t(), missing.get_items().at(oid).have);
-    EXPECT_EQ(oid, missing.get_rmissing().at(e.version.version));
+    EXPECT_EQ(oid, missing.get_rmissing().at(e.version));
     EXPECT_EQ(1U, missing.num_missing());
     EXPECT_EQ(1U, missing.get_rmissing().size());
 
@@ -1125,7 +1125,7 @@ TEST(pg_missing_t, add_next_event)
     EXPECT_TRUE(missing.is_missing(oid));
     EXPECT_EQ(prior_version, missing.get_items().at(oid).have);
     EXPECT_EQ(version, missing.get_items().at(oid).need);
-    EXPECT_EQ(oid, missing.get_rmissing().at(e.version.version));
+    EXPECT_EQ(oid, missing.get_rmissing().at(e.version));
     EXPECT_EQ(1U, missing.num_missing());
     EXPECT_EQ(1U, missing.get_rmissing().size());
   }
@@ -1150,7 +1150,7 @@ TEST(pg_missing_t, add_next_event)
     EXPECT_TRUE(missing.get_items().at(oid).is_delete());
     EXPECT_EQ(prior_version, missing.get_items().at(oid).have);
     EXPECT_EQ(version, missing.get_items().at(oid).need);
-    EXPECT_EQ(oid, missing.get_rmissing().at(e.version.version));
+    EXPECT_EQ(oid, missing.get_rmissing().at(e.version));
     EXPECT_EQ(1U, missing.num_missing());
     EXPECT_EQ(1U, missing.get_rmissing().size());
   }
@@ -1177,7 +1177,7 @@ TEST(pg_missing_t, add_next_event)
     EXPECT_TRUE(missing.get_items().at(oid).is_delete());
     EXPECT_EQ(prior_version, missing.get_items().at(oid).have);
     EXPECT_EQ(e.version, missing.get_items().at(oid).need);
-    EXPECT_EQ(oid, missing.get_rmissing().at(e.version.version));
+    EXPECT_EQ(oid, missing.get_rmissing().at(e.version));
     EXPECT_EQ(1U, missing.num_missing());
     EXPECT_EQ(1U, missing.get_rmissing().size());
   }


### PR DESCRIPTION
missing log: 5124'4491(5115'4489) 1000002101d.00000000:head by client.684196.0:77304
master log:  5141'4491(5115'4490) 10000020c32.00000002:head by client.629257.0:16618
1. osd extending head to 5141'4491, add 10000020c32.00000002:head to rmissing
2. osd merge divergent log, remove 1000002101d.00000000:head from missing & rmissing
Both objects have the same version_t, the rmissing collection is empty

Signed-off-by: Tao Ning <ningtao@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

