### PR TITLE
rgw: get_obj_op should return nullptr if got invalid list-type params.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3569,11 +3569,15 @@ RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
   if (get_data) {   
     if (list_type == 1) {
        return new RGWListBucket_ObjStore_S3;     
-    } else if(list_type == 2) {
+    } else if (list_type == 2) {
       return new RGWListBucket_ObjStore_S3v2;
-    } } else {
+    } else {
+      return nullptr;
+    }
+  } else {
     return new RGWStatBucket_ObjStore_S3;    
-  }   }
+  }
+}
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_get()
 {


### PR DESCRIPTION
Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


