### PR TITLE
qa: vstart_runner fails because of string index out of range

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -257,7 +257,7 @@ class LocalRemote(object):
             if isinstance(arg, Raw):
                 continue
 
-            if (arg[0] in ['"', "'"] or arg[-1] in ['"', "'"]) and \
+            if arg and (arg[0] in ['"', "'"] or arg[-1] in ['"', "'"]) and \
                (arg.find(' ') != -1 and 0 < arg.find(' ') < len(arg) - 1):
                 raise RuntimeError(errmsg)
 


### PR DESCRIPTION
Fix problem in ``LocalRemote::_perform_checks_and_return_list_of_args()`` when ``LocalCephManager::raw_cluster_cmd()`` is called with an empty command parameter.

Fixes: https://tracker.ceph.com/issues/40729

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

