### PR TITLE
build/ops: run "npm ci" with a one-hour timeout

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -90,7 +90,7 @@ build_dashboard_frontend() {
   $TEMP_DIR/bin/nodeenv -p --node=10.13.0
   cd src/pybind/mgr/dashboard/frontend
   . $TEMP_DIR/bin/activate
-  npm ci
+  timeout 1h npm ci
   npm run build -- --prod --progress=false
   deactivate
   cd $CURR_DIR

--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -63,7 +63,7 @@ cd $DASH_DIR/frontend
 jq .[].target=$BASE_URL proxy.conf.json.sample > proxy.conf.json
 
 . $BUILD_DIR/src/pybind/mgr/dashboard/node-env/bin/activate
-npm ci
+timeout 1h npm ci
 
 if [ $DEVICE == "chrome" ]; then
     npm run e2e || stop 1


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/40645
Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

