### PR TITLE
mimic: core: should report EINVAL in ErasureCode::parse() if m<=0

### DIFF
--- a/qa/standalone/erasure-code/test-erasure-code.sh
+++ b/qa/standalone/erasure-code/test-erasure-code.sh
@@ -308,7 +308,7 @@ function TEST_chunk_mapping() {
 
     ceph osd erasure-code-profile set remap-profile \
         plugin=lrc \
-        layers='[ [ "_DD", "" ] ]' \
+        layers='[ [ "cDD", "" ] ]' \
         mapping='_DD' \
         crush-steps='[ [ "choose", "osd", 0 ] ]' || return 1
     ceph osd erasure-code-profile get remap-profile

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -2220,6 +2220,16 @@ function test_mon_osd_erasure_code()
   # clean up
   ceph osd erasure-code-profile rm fooprofile
   ceph osd erasure-code-profile rm barprofile
+
+  # try weird k and m values
+  expect_false ceph osd erasure-code-profile set badk k=1 m=1
+  expect_false ceph osd erasure-code-profile set badk k=1 m=2
+  expect_false ceph osd erasure-code-profile set badk k=0 m=2
+  expect_false ceph osd erasure-code-profile set badk k=-1 m=2
+  expect_false ceph osd erasure-code-profile set badm k=2 m=0
+  expect_false ceph osd erasure-code-profile set badm k=2 m=-1
+  ceph osd erasure-code-profile set good k=2 m=1
+  ceph osd erasure-code-profile rm good
 }
 
 function test_mon_osd_misc()

--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -72,14 +72,17 @@ int ErasureCode::create_rule(
   return ruleid;
 }
 
-int ErasureCode::sanity_check_k(int k, ostream *ss)
+int ErasureCode::sanity_check_k_m(int k, int m, ostream *ss)
 {
   if (k < 2) {
     *ss << "k=" << k << " must be >= 2" << std::endl;
     return -EINVAL;
-  } else {
-    return 0;
   }
+  if (m < 1) {
+    *ss << "m=" << m << " must be >= 1" << std::endl;
+    return -EINVAL;
+  }
+  return 0;
 }
 
 int ErasureCode::chunk_index(unsigned int i) const

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -50,7 +50,7 @@ namespace ceph {
 		    CrushWrapper &crush,
 		    std::ostream *ss) const;
 
-    int sanity_check_k(int k, std::ostream *ss);
+    int sanity_check_k_m(int k, int m, std::ostream *ss);
 
     unsigned int get_coding_chunk_count() const override {
       return get_chunk_count() - get_data_chunk_count();

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -325,7 +325,7 @@ int ErasureCodeIsaDefault::parse(ErasureCodeProfile &profile,
   int err = ErasureCode::parse(profile, ss);
   err |= to_int("k", profile, &k, DEFAULT_K, ss);
   err |= to_int("m", profile, &m, DEFAULT_M, ss);
-  err |= sanity_check_k(k, ss);
+  err |= sanity_check_k_m(k, m, ss);
 
   if (matrixtype == kVandermonde) {
     // these are verified safe values evaluated using the

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -66,7 +66,7 @@ int ErasureCodeJerasure::parse(ErasureCodeProfile &profile,
     chunk_mapping.clear();
     err = -EINVAL;
   }
-  err |= sanity_check_k(k, ss);
+  err |= sanity_check_k_m(k, m, ss);
   return err;
 }
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6295,7 +6295,11 @@ int OSDMonitor::prepare_pool_size(const unsigned pool_type,
       err = get_erasure_code(erasure_code_profile, &erasure_code, ss);
       if (err == 0) {
 	*size = erasure_code->get_chunk_count();
-	*min_size = std::min(erasure_code->get_data_chunk_count() + 1, *size);
+	*min_size =
+	  erasure_code->get_data_chunk_count() +
+	  std::min<int>(1, erasure_code->get_coding_chunk_count() - 1);
+	assert(*min_size <= *size);
+	assert(*min_size >= erasure_code->get_data_chunk_count());
       }
     }
     break;

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -392,7 +392,7 @@ TEST(ErasureCodeLrc, layers_sanity_checks)
       "  [ \"DD\", \"\" ], "
       "]";
     profile["layers"] = description_string;
-    EXPECT_EQ(ERROR_LRC_MAPPING_SIZE, lrc.init(profile, &cerr));
+    EXPECT_EQ(-EINVAL, lrc.init(profile, &cerr));
   }
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38751