### PR TITLE
mgr/dashboard: Fix form validation problems in RGW user form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -202,7 +202,7 @@
           <div class="row">
             <div class="offset-sm-3 col-sm-9">
               <span *ngIf="subusers.length === 0"
-                    class="form-control no-border">
+                    class="no-border">
                 <span class="form-text text-muted"
                       i18n>There are no subusers.</span>
               </span>
@@ -215,7 +215,7 @@
                     </span>
                   </div>
                   <input type="text"
-                         class="form-control"
+                         class="cd-form-control"
                          value="{{ subuser.id }}"
                          readonly>
                   <div class="input-group-prepend"
@@ -225,7 +225,7 @@
                     </span>
                   </div>
                   <input type="text"
-                         class="form-control"
+                         class="cd-form-control"
                          value="{{ ('full-control' === subuser.permissions) ? 'full' : subuser.permissions }}"
                          readonly>
                   <span class="input-group-append">
@@ -274,7 +274,7 @@
                    i18n>S3</label>
             <div class="col-sm-9">
               <span *ngIf="s3Keys.length === 0"
-                    class="form-control no-border">
+                    class="no-border">
                 <span class="form-text text-muted"
                       i18n>There are no keys.</span>
               </span>
@@ -287,7 +287,7 @@
                     </div>
                   </div>
                   <input type="text"
-                         class="form-control"
+                         class="cd-form-control"
                          value="{{ key.user }}"
                          readonly>
                   <span class="input-group-append">
@@ -335,7 +335,7 @@
 
             <div class="col-sm-9">
               <span *ngIf="swiftKeys.length === 0"
-                    class="form-control no-border">
+                    class="no-border">
                 <span class="form-text text-muted"
                       i18n>There are no keys.</span>
               </span>
@@ -348,7 +348,7 @@
                     </span>
                   </div>
                   <input type="text"
-                         class="form-control"
+                         class="cd-form-control"
                          value="{{ key.user }}"
                          readonly>
                   <span class="input-group-append">
@@ -374,7 +374,7 @@
           <div class="form-group row">
             <div class="offset-sm-3 col-sm-9">
               <span *ngIf="capabilities.length === 0"
-                    class="form-control no-border">
+                    class="no-border">
                 <span class="form-text text-muted"
                       i18n>There are no capabilities.</span>
               </span>
@@ -387,7 +387,7 @@
                     </div>
                   </span>
                   <input type="text"
-                         class="form-control"
+                         class="cd-form-control"
                          value="{{ cap.type }}:{{ cap.perm }}"
                          readonly>
                   <span class="input-group-append">


### PR DESCRIPTION
ng-bootstrap-form-validation requires that every "form-control" has
an associated "formControlName".

Since these didn't had one, we had to either removed the "form-control" class
or rename it to "cd-form-control" (which will apply the same style without
triggering the validation).

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

