### PR TITLE
qa/standalone/scrub/osd-scrub-snaps: misc fixes for removed_snaps change

### DIFF
--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -343,12 +343,7 @@ EOF
       "locator": "",
       "snap": "head",
       "snapset": {
-        "snap_context": {
-          "seq": 1,
-          "snaps": [
-            1
-          ]
-        },
+        "seq": 1,
         "clones": [
           {
             "snap": 1,
@@ -374,12 +369,7 @@ EOF
       "nspace": "",
       "name": "obj11",
       "snapset": {
-        "snap_context": {
-          "seq": 1,
-          "snaps": [
-            1
-          ]
-        },
+        "seq": 1,
         "clones": []
       }
     },
@@ -389,12 +379,7 @@ EOF
       "locator": "",
       "snap": "head",
       "snapset": {
-        "snap_context": {
-          "seq": 1,
-          "snaps": [
-            1
-          ]
-        },
+        "seq": 1,
         "clones": [
           {
             "snap": 1,
@@ -440,14 +425,7 @@ EOF
       "nspace": "",
       "name": "obj3",
       "snapset": {
-        "snap_context": {
-          "seq": 3,
-          "snaps": [
-            3,
-            2,
-            1
-          ]
-        },
+        "seq": 3,
         "clones": [
           {
             "snap": 1,
@@ -481,18 +459,7 @@ EOF
       "nspace": "",
       "name": "obj4",
       "snapset": {
-        "snap_context": {
-          "seq": 7,
-          "snaps": [
-            7,
-            6,
-            5,
-            4,
-            3,
-            2,
-            1
-          ]
-        },
+        "seq": 7,
         "clones": [
           {
             "snap": 7,
@@ -528,17 +495,7 @@ EOF
       "nspace": "",
       "name": "obj5",
       "snapset": {
-        "snap_context": {
-          "seq": 6,
-          "snaps": [
-            6,
-            5,
-            4,
-            3,
-            2,
-            1
-          ]
-        },
+        "seq": 6,
         "clones": [
           {
             "snap": 1,
@@ -589,12 +546,7 @@ EOF
       "nspace": "",
       "name": "obj6",
       "snapset": {
-        "snap_context": {
-          "seq": 1,
-          "snaps": [
-            1
-          ]
-        },
+        "seq": 1,
         "clones": []
       }
     },
@@ -610,10 +562,7 @@ EOF
       "nspace": "",
       "name": "obj7",
       "snapset": {
-        "snap_context": {
-          "seq": 0,
-          "snaps": []
-        },
+        "seq": 0,
         "clones": []
       }
     },
@@ -626,12 +575,7 @@ EOF
       "nspace": "",
       "name": "obj8",
       "snapset": {
-        "snap_context": {
-          "seq": 0,
-          "snaps": [
-            1
-          ]
-        },
+        "seq": 0,
         "clones": [
           {
             "snap": 1,
@@ -650,12 +594,7 @@ EOF
       "locator": "",
       "snap": "head",
       "snapset": {
-        "snap_context": {
-          "seq": 1,
-          "snaps": [
-            1
-          ]
-        },
+        "seq": 1,
         "clones": [
           {
             "snap": 1,
@@ -919,12 +858,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
-                "snap_context": {
-                    "seq": 1,
-                    "snaps": [
-                        1
-                    ]
-                },
+                "seq": 1,
                 "clones": [
                     {
                         "snap": 1,
@@ -944,12 +878,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
-                "snap_context": {
-                    "seq": 1,
-                    "snaps": [
-                        1
-                    ]
-                },
+                "seq": 1,
                 "clones": []
             },
             "errors": [
@@ -965,12 +894,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
-                "snap_context": {
-                    "seq": 1,
-                    "snaps": [
-                        1
-                    ]
-                },
+                "seq": 1,
                 "clones": [
                     {
                         "snap": 1,
@@ -990,17 +914,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
-                "snap_context": {
-                    "seq": 6,
-                    "snaps": [
-                        6,
-                        5,
-                        4,
-                        3,
-                        2,
-                        1
-                    ]
-                },
+                "seq": 6,
                 "clones": [
                     {
                         "snap": 1,
@@ -1051,12 +965,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
-                "snap_context": {
-                    "seq": 1,
-                    "snaps": [
-                        1
-                    ]
-                },
+                "seq": 1,
                 "clones": []
             },
             "errors": [
@@ -1072,10 +981,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
-                "snap_context": {
-                    "seq": 0,
-                    "snaps": []
-                },
+                "seq": 0,
                 "clones": []
             },
             "errors": [
@@ -1091,12 +997,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
-                "snap_context": {
-                    "seq": 0,
-                    "snaps": [
-                        1
-                    ]
-                },
+                "seq": 0,
                 "clones": [
                     {
                         "snap": 1,
@@ -1118,12 +1019,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
-                "snap_context": {
-                    "seq": 1,
-                    "snaps": [
-                        1
-                    ]
-                },
+                "seq": 1,
                 "clones": [
                     {
                         "snap": 1,

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -101,11 +101,11 @@ function create_scenario() {
     OBJ5SAVE="$JSON"
     # Starts with a snapmap
     ceph-kvstore-tool bluestore-kv $dir/${osd} list 2> /dev/null > $dir/drk.log
-    grep "^M.*MAP_.*[.]1[.]obj5[.][.]$" $dir/drk.log || return 1
+    grep "^M.*SNA_.*[.]1[.]obj5[.][.]$" $dir/drk.log || return 1
     ceph-objectstore-tool --data-path $dir/${osd} --rmtype nosnapmap "$JSON" remove || return 1
     # Check that snapmap is stil there
     ceph-kvstore-tool bluestore-kv $dir/${osd} list 2> /dev/null > $dir/drk.log
-    grep "^M.*MAP_.*[.]1[.]obj5[.][.]$" $dir/drk.log || return 1
+    grep "^M.*SNA_.*[.]1[.]obj5[.][.]$" $dir/drk.log || return 1
     rm -f $dir/drk.log
 
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --op list obj5 | grep \"snapid\":4)"
@@ -121,12 +121,12 @@ function create_scenario() {
 
     # Starts with a snapmap
     ceph-kvstore-tool bluestore-kv $dir/${osd} list 2> /dev/null > $dir/drk.log
-    grep "^M.*MAP_.*[.]7[.]obj16[.][.]$" $dir/drk.log || return 1
+    grep "^M.*SNA_.*[.]7[.]obj16[.][.]$" $dir/drk.log || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --op list obj16 | grep \"snapid\":7)"
     ceph-objectstore-tool --data-path $dir/${osd} --rmtype snapmap "$JSON" remove || return 1
     # Check that snapmap is now removed
     ceph-kvstore-tool bluestore-kv $dir/${osd} list 2> /dev/null > $dir/drk.log
-    ! grep "^M.*MAP_.*[.]7[.]obj16[.][.]$" $dir/drk.log || return 1
+    ! grep "^M.*SNA_.*[.]7[.]obj16[.][.]$" $dir/drk.log || return 1
     rm -f $dir/drk.log
 
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj2)"

--- a/qa/standalone/special/ceph_objectstore_tool.py
+++ b/qa/standalone/special/ceph_objectstore_tool.py
@@ -618,7 +618,7 @@ def test_removeall(CFSD_PREFIX, db, OBJREPPGS, REP_POOL, CEPH_BIN, OSDDIR, REP_N
 
                     if int(basename.split(REP_NAME)[1]) <= int(NUM_CLONED_REP_OBJECTS):
                         cmd = (CFSD_PREFIX + "'{json}' remove").format(osd=osd, json=JSON)
-                        errors += test_failure(cmd, "Snapshots are present, use removeall to delete everything")
+                        errors += test_failure(cmd, "Clones are present, use removeall to delete everything")
 
                     cmd = (CFSD_PREFIX + " --force --dry-run '{json}' remove").format(osd=osd, json=JSON)
                     logging.debug(cmd)

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -102,7 +102,7 @@ string SnapMapper::get_prefix(int64_t pool, snapid_t snap)
 string SnapMapper::to_raw_key(
   const pair<snapid_t, hobject_t> &in)
 {
-  return get_prefix(pool, in.first) + shard_prefix + in.second.to_str();
+  return get_prefix(in.second.pool, in.first) + shard_prefix + in.second.to_str();
 }
 
 pair<string, bufferlist> SnapMapper::to_raw(


### PR DESCRIPTION
- expected output is different
- ceph-objectstore-tool fixes to use SnapSet::clone_snaps, not snaps
- SnapMapper fix to use hobject_t::pool, not SnapMapper::pool, since c-o-t doesn't set that up