### PR TITLE
rgw-website: fix FTBFS in OpenSUSE Build Service

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3566,15 +3566,14 @@ RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
   int list_type = 1;
   s->info.args.get_int("list-type", &list_type, 1);
 
-   // Non-website mode    // Non-website mode
   if (get_data) {   
-    if (list_type == 1) {
-       return new RGWListBucket_ObjStore_S3;     
-    } else if(list_type == 2) {
+    if (list_type == 1)
+      return new RGWListBucket_ObjStore_S3;     
+    if (list_type == 2)
       return new RGWListBucket_ObjStore_S3v2;
-    } } else {
-    return new RGWStatBucket_ObjStore_S3;    
-  }   }
+  }
+  return new RGWStatBucket_ObjStore_S3;    
+}
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_get()
 {


### PR DESCRIPTION
This code, with lots of curly braces combined with improper indentation,
confused one of the static-analysis checks implemented by the OpenSUSE Build
Service.

Fixes: http://tracker.ceph.com/issues/40747
Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

