### PR TITLE
mimic: doc: wrong value of usage log default in logging section 

### DIFF
--- a/doc/rados/troubleshooting/log-and-debug.rst
+++ b/doc/rados/troubleshooting/log-and-debug.rst
@@ -562,7 +562,7 @@ RADOS Gateway
 :Description: Enable logging of RGW's bandwidth usage.
 :Type: Boolean
 :Required: No
-:Default: ``true``
+:Default: ``false``
 
 
 ``rgw usage log flush threshold``


### PR DESCRIPTION
http://tracker.ceph.com/issues/37891