### PR TITLE
luminous: os/bluestore: avoid length overflow in extents returned by Stupid Alloc

### DIFF
--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -205,10 +205,13 @@ int64_t StupidAllocator::allocate(
     bool can_append = true;
     if (!extents->empty()) {
       bluestore_pextent_t &last_extent  = extents->back();
-      if ((last_extent.end() == offset) &&
-	  ((last_extent.length + length) <= max_alloc_size)) {
-	can_append = false;
-	last_extent.length += length;
+      if (last_extent.end() == offset) {
+        uint64_t l64 = last_extent.length;
+        l64 += length;
+        if (l64 < 0x100000000 && l64 <= max_alloc_size) {
+	  can_append = false;
+	  last_extent.length += length;
+        }
       }
     }
     if (can_append) {

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -316,6 +316,27 @@ TEST_P(AllocTest, test_alloc_bug_24598)
   EXPECT_EQ(tmp.size(), 1);
 }
 
+//Verifies issue from
+//http://tracker.ceph.com/issues/40703
+//
+TEST_P(AllocTest, test_alloc_big2)
+{
+  int64_t block_size = 4096;
+  int64_t blocks = 1048576 * 2;
+  int64_t mas = 1024*1024;
+  init_alloc(blocks*block_size, block_size);
+  alloc->init_add_free(0, blocks * block_size);
+  
+  PExtentVector extents;
+  uint64_t need = block_size * blocks / 4; // 2GB
+  EXPECT_EQ(need,
+      alloc->allocate(need, mas, 0, &extents));
+  need = block_size * blocks / 4; // 2GB
+  EXPECT_EQ(need,
+      alloc->allocate(need, mas, 0, &extents));
+  EXPECT_TRUE(extents[0].length > 0);
+}
+
 INSTANTIATE_TEST_CASE_P(
   Allocator,
   AllocTest,


### PR DESCRIPTION
https://tracker.ceph.com/issues/40756