### PR TITLE
common/options: Set concurrent bluestore rocksdb compactions to 2

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4628,7 +4628,7 @@ std::vector<Option> get_global_options() {
     .set_description("Max transactions with deferred writes that can accumulate before we force flush deferred writes"),
 
     Option("bluestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152")
+    .set_default("compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152,max_background_compactions=2")
     .set_description("Rocksdb options"),
 
     Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
This PR sets the number of concurrent background compactions to 2.  This improved performance in OMAP heavy write workload tests by about 50% at the expense of potentially having overlapping compactions events take longer.  Setting the number of concurrent compactions too high can hurt performance, but setting this conservatively to 2 doesn't appear to significantly hurt while improving OMAP throughput.  As we will eventually be sharding the DB, we may not want to set this higher (and may in fact want to set this back to 1 after that PR lands).  Also, on older versions of rocksdb we should be mindful of:

https://github.com/facebook/rocksdb/pull/3926

That bug was fixed by the version of RocksDB used in master/nautilus however.

Performance test results:

**4K RBD Random Write IOPS**

| Compaction Threads | master | wip-rocksdb-v6.1.2 | wip-rocksdb-v6.1.2+28597 |
| -- | -- | -- | -- |
| 1 | 28002.2 | 26810.7 | **38636.3** |
| 2 | X | 27500.6 | **37748.8** |
| 4 | X | 28546.2 | **38008** |

**16K RADOS Object Write MB/s**

| Compaction Threads | master | wip-rocksdb-v6.1.2 | wip-rocksdb-v6.1.2+28597 |
| -- | -- | -- | -- |
| 1 | 383.048 | 403.231 | **464.988** |
| 2 | X | 401.873 | **454.048** |
| 4 | X | 398.089 | **459.217** |

**4K RADOS OMAP Write MB/s**

| Compaction Threads | master | wip-rocksdb-v6.1.2 | wip-rocksdb-v6.1.2+28597 |
| -- | -- | -- | -- |
| 1 | 37.586 | 47.5135 | 47.3075 |
| 2 | X | **63.3403** | **62.32** |
| 4 | X | **63.143** | **63.4607** |

Additional testing data along with compaction event latency is available here:

https://docs.google.com/spreadsheets/d/10IuxqW0oRD2AzPLD4AUbZzIcoS_1_4UWFUg4cgxsJjs/edit?usp=sharing

Signed-off-by: Mark Nelson <mnelson@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug


