### PR TITLE
nautilus: ceph-volume: use the Device.rotational property instead of sys_api 

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -31,7 +31,7 @@ def bluestore_single_type(device_facts):
     Detect devices that are just HDDs or solid state so that a 1:1
     device-to-osd provisioning can be done
     """
-    types = [device.sys_api['rotational'] for device in device_facts]
+    types = [device.rotational for device in device_facts]
     if len(set(types)) == 1:
         return strategies.bluestore.SingleType
 
@@ -41,7 +41,7 @@ def bluestore_mixed_type(device_facts):
     Detect if devices are HDDs as well as solid state so that block.db can be
     placed in solid devices while data is kept in the spinning drives.
     """
-    types = [device.sys_api['rotational'] for device in device_facts]
+    types = [device.rotational for device in device_facts]
     if len(set(types)) > 1:
         return strategies.bluestore.MixedType
 
@@ -51,7 +51,7 @@ def filestore_single_type(device_facts):
     Detect devices that are just HDDs or solid state so that a 1:1
     device-to-osd provisioning can be done, keeping the journal on the OSD
     """
-    types = [device.sys_api['rotational'] for device in device_facts]
+    types = [device.rotational for device in device_facts]
     if len(set(types)) == 1:
         return strategies.filestore.SingleType
 
@@ -61,7 +61,7 @@ def filestore_mixed_type(device_facts):
     Detect if devices are HDDs as well as solid state so that the journal can be
     placed in solid devices while data is kept in the spinning drives.
     """
-    types = [device.sys_api['rotational'] for device in device_facts]
+    types = [device.rotational for device in device_facts]
     if len(set(types)) > 1:
         return strategies.filestore.MixedType
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/strategies.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/strategies.py
@@ -20,8 +20,8 @@ class Strategy(object):
 
     @staticmethod
     def split_devices_rotational(devices):
-        data_devs = [device for device in devices if device.sys_api['rotational'] == '1']
-        db_or_journal_devs = [device for device in devices if device.sys_api['rotational'] == '0']
+        data_devs = [device for device in devices if device.rotational]
+        db_or_journal_devs = [device for device in devices if not device.rotational]
         return data_devs, db_or_journal_devs
 
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -8,7 +8,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        block_db_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         computed_osd = bluestore.SingleType.with_auto_devices(args, devices).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 100
@@ -20,7 +20,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        block_db_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
         ]
         computed_osd = bluestore.SingleType.with_auto_devices(args, devices).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 100
@@ -32,7 +32,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=3,
                        block_db_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             bluestore.SingleType.with_auto_devices(args, devices)
@@ -42,7 +42,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        block_db_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=True, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             bluestore.SingleType.with_auto_devices(args, devices)
@@ -54,8 +54,8 @@ class TestMixedType(object):
     def test_filter_all_data_devs(self, fakedevice, factory):
         # in this scenario the user passed a already used device to be used for
         # data and an unused device to be used as db device.
-        db_dev = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        data_dev = fakedevice(used_by_ceph=True, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        db_dev = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
+        data_dev = fakedevice(used_by_ceph=True, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         args = factory(filtered_devices=[data_dev], osds_per_device=1,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
@@ -72,8 +72,8 @@ class TestMixedTypeConfiguredSize(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType.with_auto_devices(args, devices).computed['osds'][0]
@@ -90,8 +90,8 @@ class TestMixedTypeConfiguredSize(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:
@@ -105,8 +105,8 @@ class TestMixedTypeConfiguredSize(object):
         args = factory(filtered_devices=[], osds_per_device=2,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=60737400000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:
@@ -122,8 +122,8 @@ class TestMixedTypeLargeAsPossible(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType.with_auto_devices(args, devices).computed['osds'][0]
@@ -140,8 +140,8 @@ class TestMixedTypeLargeAsPossible(object):
         args = factory(filtered_devices=[], osds_per_device=2,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=60073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=60073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=60073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType.with_auto_devices(args, devices).computed['osds'][0]
@@ -158,8 +158,8 @@ class TestMixedTypeLargeAsPossible(object):
         args = factory(filtered_devices=[], osds_per_device=2,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=60737400000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:
@@ -175,8 +175,8 @@ class TestMixedTypeWithExplicitDevices(object):
         args = factory(filtered_devices=[], osds_per_device=2,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60073740000))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=60073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=60073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=60073740000))
 
         osd = bluestore.MixedType(args, [hdd], [], [ssd]).computed['osds'][0]
         assert osd['data']['percentage'] == 50
@@ -192,8 +192,8 @@ class TestMixedTypeWithExplicitDevices(object):
         args = factory(filtered_devices=[], osds_per_device=2,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
-        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=1610612736))
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=60073740000))
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=1610612736))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=60073740000))
 
         with pytest.raises(RuntimeError) as error:
             bluestore.MixedType(args, [hdd], [], [ssd]).computed['osds'][0]

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
@@ -10,7 +10,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=12073740000))
         ]
         computed_osd = filestore.SingleType.with_auto_devices(args, devices).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 55
@@ -23,7 +23,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
@@ -35,7 +35,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=12073740000))
         ]
         computed_osd = filestore.SingleType.with_auto_devices(args, devices).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 55
@@ -48,7 +48,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
@@ -60,7 +60,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=4,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=16073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
@@ -72,7 +72,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=4,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=16073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
@@ -84,7 +84,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=True, rotational=True, sys_api=dict(size=12073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
@@ -95,7 +95,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
@@ -107,7 +107,7 @@ class TestSingleType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType.with_auto_devices(args, devices)
@@ -122,8 +122,8 @@ class TestMixedType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
@@ -135,8 +135,8 @@ class TestMixedType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
@@ -148,8 +148,8 @@ class TestMixedType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=True, rotational=True, sys_api=dict(size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
@@ -159,9 +159,9 @@ class TestMixedType(object):
         # fast PV, because ssd is an LVM member
         CephPV = lvm.PVolume(vg_name='fast', pv_name='/dev/sda', pv_tags='')
         ssd = fakedevice(
-            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV]
+            used_by_ceph=False, is_lvm_member=True, rotational=False, sys_api=dict(size=6073740000), pvs_api=[CephPV]
         )
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         # when get_api_vgs() gets called, it will return this one VG
         stub_vgs([
             dict(
@@ -184,12 +184,12 @@ class TestMixedType(object):
         CephPV1 = lvm.PVolume(vg_name='fast1', pv_name='/dev/sda', pv_tags='')
         CephPV2 = lvm.PVolume(vg_name='fast2', pv_name='/dev/sdb', pv_tags='')
         ssd1 = fakedevice(
-            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV1]
+            used_by_ceph=False, is_lvm_member=True, rotational=False, sys_api=dict(size=6073740000), pvs_api=[CephPV1]
         )
         ssd2 = fakedevice(
-            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV2]
+            used_by_ceph=False, is_lvm_member=True, rotational=False, sys_api=dict(size=6073740000), pvs_api=[CephPV2]
         )
-        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         # when get_api_vgs() gets called, it will return this one VG
         stub_vgs([
             dict(
@@ -216,8 +216,8 @@ class TestMixedType(object):
         args = factory(filtered_devices=[], osds_per_device=2,
                        journal_size=None, osd_ids=[])
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000)),
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
+            fakedevice(is_lvm_member=False, rotational=False, sys_api=dict(size=16073740000)),
+            fakedevice(is_lvm_member=False, rotational=True, sys_api=dict(size=16073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
@@ -227,8 +227,8 @@ class TestMixedType(object):
     def test_filter_all_data_devs(self, fakedevice, factory):
         # in this scenario the user passed a already used device to be used for
         # data and an unused device to be used as db device.
-        db_dev = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        data_dev = fakedevice(used_by_ceph=True, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        db_dev = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
+        data_dev = fakedevice(used_by_ceph=True, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
         args = factory(filtered_devices=[data_dev], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         filestore.MixedType(args, [], [db_dev])

--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27, py35, py36, flake8
+skip_missing_interpreters = true
 
 [testenv]
 deps=


### PR DESCRIPTION
backport of #28060
