### PR TITLE
mimic: mgr/crash: fix python3 invalid syntax problems

### DIFF
--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -45,13 +45,14 @@ class Module(MgrModule):
         :param f: f(time) return true to keep crash report
         :returns: crash reports for which f(time) returns true
         """
-        def inner((_, meta)):
+        def inner(pair):
+            _, meta = pair
             meta = json.loads(meta)
             time = self.time_from_string(meta["timestamp"])
             return f(time)
         matches = filter(inner, six.iteritems(
             self.get_store_prefix("crash/")))
-        return map(lambda (k, m): (k, json.loads(m)), matches)
+        return [(k, json.loads(m)) for k, m in matches]
 
     # command handlers
 


### PR DESCRIPTION
Signed-off-by: Ricardo Dias <rdias@suse.com>
(cherry picked from commit bcf0f4df2db8b51c58e5ca4d411d05e2a4d081ab)