### PR TITLE
mgr/progress & mgr/pg_autoscaler: Added Pg Autoscaler Event

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -351,7 +351,7 @@ class PgAutoscaler(MgrModule):
         total_bytes = dict([(r, 0) for r in iter(root_map)])
         total_target_bytes = dict([(r, 0.0) for r in iter(root_map)])
         target_bytes_pools = dict([(r, []) for r in iter(root_map)])
- 
+
         for p in ps:
             pool_id = str(p['pool_id'])
             total_ratio[p['crush_root_id']] += max(p['actual_capacity_ratio'],

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -242,7 +242,7 @@ class PgAutoscaler(MgrModule):
             pools,
             threshold=3.0,
     ):
-        assert threshold >= 3.0
+        assert threshold >= 2.0
 
         crush_map = osdmap.get_crush()
 

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -351,7 +351,7 @@ class PgAutoscaler(MgrModule):
         total_bytes = dict([(r, 0) for r in iter(root_map)])
         total_target_bytes = dict([(r, 0.0) for r in iter(root_map)])
         target_bytes_pools = dict([(r, []) for r in iter(root_map)])
-        
+ 
         for p in ps:
             pool_id = str(p['pool_id'])
             total_ratio[p['crush_root_id']] += max(p['actual_capacity_ratio'],
@@ -366,6 +366,8 @@ class PgAutoscaler(MgrModule):
                 total_target_bytes[p['crush_root_id']] += p['target_bytes'] * p['raw_used_rate']
                 target_bytes_pools[p['crush_root_id']].append(p['pool_name'])
             if not p['would_adjust']:
+                # Means that we no need to adjust the pg any longer
+                # Therefore complete event if it still exists
                 if pool_id in self._event:
                     self.remote('progress', 'complete', self._event[pool_id])
                     del self._event[pool_id]

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -48,11 +48,11 @@ class PgAdjustmentProgress(object):
     """
     Keeps the initial and target pg_num values
     """
-    def __init__(self, pg_num, pg_num_target, ev_id):
+    def __init__(self, pg_num, pg_num_target, ev_id, increase_decrease):
         self._ev_id = ev_id
         self._pg_num = pg_num
         self._pg_num_target = pg_num_target
-        
+        self._increase_decrease = increase_decrease
    
 
 class PgAutoscaler(MgrModule):
@@ -352,27 +352,21 @@ class PgAutoscaler(MgrModule):
             pg_num_target = pool_data['pg_num_target']
             initial_pg_num = ev._pg_num
             initial_pg_num_target = ev._pg_num_target
-            progress = (pg_num - initial_pg_num)/(pg_num_target - initial_pg_num)
+            progress = (pg_num - initial_pg_num) / (pg_num_target - initial_pg_num)
             if pg_num == pg_num_target:
                 self.remote('progress', 'complete', ev._ev_id)
                 del self._event[pool_id]
                 continue
             elif pg_num == initial_pg_num:
+                # Means no change
                 continue
 
-            elif pg_num_target > pg_num:
+            else: 
                 self.remote('progress', 'update', ev._ev_id, 
-                                    ev_msg="PG autoscaler increasing pool %s PGs from %d to %d" % 
-                                    (pool_id, pg_num, pg_num_target), 
-                                    ev_progress=progress,
-                                    refs=[("pool", int(pool_id))])
-
-            elif pg_num_target < pg_num:
-                 self.remote('progress', 'update', ev._ev_id, 
-                                    ev_msg="PG autoscaler decreasing pool %s PGs from %d to %d" % 
-                                    (pool_id, pg_num, pg_num_target), 
-                                    ev_progress=progress,
-                                    refs=[("pool", int(pool_id))])
+                        ev_msg="PG autoscaler %s pool %s PGs from %d to %d" % 
+                        (ev._increase_decrease, pool_id, pg_num, pg_num_target), 
+                        ev_progress=progress,
+                        refs=[("pool", int(pool_id))])
 
     def _maybe_adjust(self):
         self.log.info('_maybe_adjust')
@@ -439,20 +433,20 @@ class PgAutoscaler(MgrModule):
                     pg_num = pool_data['pg_num']
                     pg_num_target = pool_data['pg_num_target']
                     ev_id = str(uuid.uuid4())
-                    pg_adj_obj = PgAdjustmentProgress(pg_num, pg_num_target, ev_id)
-                    self._event[pool_id] = pg_adj_obj
+                    pg_adj_obj = None
                     if pg_num < pg_num_target:
-                        self.remote('progress', 'update', ev_id, 
-                                    ev_msg="PG autoscaler increasing pool %s PGs from %d to %d" % 
-                                    (pool_id, pg_num, pg_num_target), 
-                                    ev_progress=0.0,
-                                    refs=[("pool", int(pool_id))])
+                        pg_adj_obj = PgAdjustmentProgress(pg_num, pg_num_target, ev_id, 'increasing')
+                        self._event[pool_id] = pg_adj_obj
+
                     else:
-                        self.remote('progress', 'update', ev_id, 
-                                    ev_msg="PG autoscaler decreasing pool %s PGs from %d to %d" % 
-                                    (pool_id, pg_num, pg_num_target), 
-                                    ev_progress=0.0,
-                                    refs=[("pool", int(pool_id))])
+                        pg_adj_obj = PgAdjustmentProgress(pg_num, pg_num_target, ev_id, 'decreasing')
+                        self._event[pool_id] = pg_adj_obj
+
+                    self.remote('progress', 'update', ev_id, 
+                    ev_msg="PG autoscaler %s pool %s PGs from %d to %d" % 
+                    (pg_adj_obj._increase_decrease, pool_id, pg_num, pg_num_target), 
+                    ev_progress=0.0,
+                    refs=[("pool", int(pool_id))])
 
                 if r[0] != 0:
                     # FIXME: this is a serious and unexpected thing,

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -10,7 +10,6 @@ import uuid
 from six import itervalues, iteritems
 from collections import defaultdict
 from prettytable import PrettyTable, PLAIN_COLUMNS
-
 from mgr_module import MgrModule
 
 """
@@ -73,6 +72,7 @@ class PgAutoscaler(MgrModule):
     def __init__(self, *args, **kwargs):
         super(PgAutoscaler, self).__init__(*args, **kwargs)
         self._shutdown = threading.Event()
+        self._event = {}
 
         # So much of what we do peeks at the osdmap that it's easiest
         # to just keep a copy of the pythonized version.
@@ -242,7 +242,7 @@ class PgAutoscaler(MgrModule):
             pools,
             threshold=3.0,
     ):
-        assert threshold >= 2.0
+        assert threshold >= 3.0
 
         crush_map = osdmap.get_crush()
 
@@ -303,7 +303,7 @@ class PgAutoscaler(MgrModule):
 
             adjust = False
             if (final_pg_target > p['pg_num_target'] * threshold or \
-                final_pg_target <= p['pg_num_target'] / threshold) and \
+                final_pg_target < p['pg_num_target'] / threshold) and \
                 final_ratio >= 0.0 and \
                 final_ratio <= 1.0:
                 adjust = True
@@ -351,8 +351,9 @@ class PgAutoscaler(MgrModule):
         total_bytes = dict([(r, 0) for r in iter(root_map)])
         total_target_bytes = dict([(r, 0.0) for r in iter(root_map)])
         target_bytes_pools = dict([(r, []) for r in iter(root_map)])
-
+        
         for p in ps:
+            pool_id = str(p['pool_id'])
             total_ratio[p['crush_root_id']] += max(p['actual_capacity_ratio'],
                                                    p['target_ratio'])
             if p['target_ratio'] > 0:
@@ -365,6 +366,9 @@ class PgAutoscaler(MgrModule):
                 total_target_bytes[p['crush_root_id']] += p['target_bytes'] * p['raw_used_rate']
                 target_bytes_pools[p['crush_root_id']].append(p['pool_name'])
             if not p['would_adjust']:
+                if pool_id in self._event:
+                    self.remote('progress', 'complete', self._event[pool_id])
+                    del self._event[pool_id]
                 continue
             if p['pg_autoscale_mode'] == 'warn':
                 msg = 'Pool %s has %d placement groups, should have %d' % (
@@ -385,6 +389,45 @@ class PgAutoscaler(MgrModule):
                     'var': 'pg_num',
                     'val': str(p['pg_num_final'])
                 })
+                
+                # Create new event for each pool
+                # and update existing events
+                # Call Progress Module to create progress event
+
+                if pool_id not in self._event:
+                    self._event[pool_id] = str(uuid.uuid4())
+                    if p['pg_num_target'] < p['pg_num_final']:
+                        self.remote('progress', 'update', self._event[pool_id], 
+                                ev_msg=" PgAutoscaler growing PGs in pool: {0}".format(
+                                    pool_id), 
+                                ev_progress=0.0, 
+                                refs=[("pool", int(pool_id))])
+                    else:
+                        self.remote('progress', 'update', self._event[pool_id], 
+                                ev_msg=" PgAutoscaler shrinking PGs in pool: {0}".format(
+                                    pool_id), 
+                                ev_progress=0.0, 
+                                refs=[("pool", int(pool_id))])
+
+                else:
+                    new_progress = p['pg_num_target']/p['pg_num_final']
+                    if new_progress == 1.0:
+                        self.remote('progress', 'complete', self._event[pool_id])
+                        del self._event[pool_id]
+                    elif new_progress > 1.0:
+                        new_progress = p['pg_num_final']/p['pg_num_target']
+                        self.remote('progress', 'update', self._event[pool_id],   
+                                ev_msg=" PgAutoscaler shrinking PGs in pool: {0}".format(
+                                    pool_id), 
+                                ev_progress=new_progress,
+                                refs=[("pool", int(pool_id))])
+                    else:
+                        self.remote('progress', 'update', self._event[pool_id],   
+                                ev_msg=" PgAutoscaler growing PGs in pool: {0}".format(
+                                    pool_id), 
+                                ev_progress=new_progress,
+                                refs=[("pool", int(pool_id))])
+
 
                 if r[0] != 0:
                     # FIXME: this is a serious and unexpected thing,

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -168,6 +168,7 @@ class RemoteEvent(Event):
         self._progress = 1.0
         self._failed = True
         self._failure_message = message
+        self._refresh()
 
     def set_message(self, message):
         self._message = message

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -168,6 +168,9 @@ class RemoteEvent(Event):
         self._progress = 1.0
         self._failed = True
         self._failure_message = message
+
+    def set_message(self, message):
+        self._message = message
         self._refresh()
 
     @property
@@ -384,7 +387,6 @@ class Module(MgrModule):
                 # data from the json dump
                 old_up_acting = old_map.pg_to_up_acting_osds(pool['pool'], ps)
                 old_osds = set(old_up_acting['acting'])
-
                 new_up_acting = new_map.pg_to_up_acting_osds(pool['pool'], ps)
                 new_osds = set(new_up_acting['acting'])
 
@@ -587,7 +589,7 @@ class Module(MgrModule):
                 ev_progress, ev_msg))
 
         ev.set_progress(ev_progress)
-        ev._refresh()
+        ev.set_message(ev_msg)
 
     def _complete(self, ev):
         duration = (time.time() - ev.started_at)


### PR DESCRIPTION
Creates a progress event in progress module
when the pool need pg_num adjusting to match
target pg_num. Also made a bit of change to
the logic of trigerring pg adjusting.

Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

