### PR TITLE
rgw: shard number must be non-negative when resharding the bucket

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2598,6 +2598,11 @@ int check_reshard_bucket_params(RGWRados *store,
     return -EINVAL;
   }
 
+  if (num_shards < 0) {
+    cerr << "ERROR: num_shards must be non-negative integer" << std::endl;
+    return -EINVAL;
+  }
+
   int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket, &attrs);
   if (ret < 0) {
     cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;


### PR DESCRIPTION
Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>




