### PR TITLE
ceph-volume: reject disks smaller then 5GB in inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -401,7 +401,7 @@ class TestCephDiskDevice(object):
         assert not disk.available
 
     def test_accept_non_removable_device(self, device_info):
-        data = {"/dev/sdb": {"removable": 0}}
+        data = {"/dev/sdb": {"removable": 0, "size": 5368709120}}
         device_info(devices=data)
         disk = device.Device("/dev/sdb")
         assert disk.available
@@ -412,8 +412,14 @@ class TestCephDiskDevice(object):
         disk = device.Device("/dev/cdrom")
         assert not disk.available
 
+    def test_reject_smaller_than_5gb(self, device_info):
+        data = {"/dev/sda": {"size": 5368709119}}
+        device_info(devices=data)
+        disk = device.Device("/dev/sda")
+        assert not disk.available, 'too small device is available'
+
     def test_accept_non_readonly_device(self, device_info):
-        data = {"/dev/sda": {"ro": 0}}
+        data = {"/dev/sda": {"ro": 0, "size": 5368709120}}
         device_info(devices=data)
         disk = device.Device("/dev/sda")
         assert disk.available

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -389,6 +389,9 @@ class Device(object):
         ]
         rejected = [reason for (k, v, reason) in reasons if
                     self.sys_api.get(k, '') == v]
+        # reject disks small than 5GB
+        if int(self.sys_api.get('size', 0)) < 5368709120:
+            rejected.append('Insufficient space (<5GB)')
         if self.is_ceph_disk_member:
             rejected.append("Used by ceph-disk")
 


### PR DESCRIPTION
Volumes smaller than 5GB won't be created anyway. This also guards
against drives with size 0, as can happen in mdraid setups.

Fixes: http://tracker.ceph.com/issues/40776

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

