### PR TITLE
mgr/orchestrator: Fix disabling the orchestrator

### DIFF
--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -69,7 +69,7 @@ Disable the Orchestrator
 To disable the orchestrator again, use the empty string ``""``::
 
     ceph orchestrator set backend ""``
-    ceph mgr module disalbe rook
+    ceph mgr module disable rook
 
 Usage
 =====

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -49,7 +49,8 @@ The relation between the names is the following:
 Configuration
 =============
 
-You can select the orchestrator module to use with the ``set backend`` command::
+To enable the orchestrator, please select the orchestrator module to use
+with the ``set backend`` command::
 
     ceph orchestrator set backend <module>
 
@@ -61,6 +62,14 @@ For example, to enable the Rook orchestrator module and use it with the CLI::
 You can then check backend is properly configured::
 
     ceph orchestrator status
+
+Disable the Orchestrator
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To disable the orchestrator again, use the empty string ``""``::
+
+    ceph orchestrator set backend ""``
+    ceph mgr module disalbe rook
 
 Usage
 =====
@@ -223,11 +232,11 @@ services of a particular type via optional --type parameter
 
 ::
 
-    ceph orchestrator service ls [--host host] [--svc_type type] [--refresh|--no-cache]
+    ceph orchestrator service ls [--host host] [--svc_type type] [--refresh]
 
 Discover the status of a particular service::
 
-    ceph orchestrator service status <type> <name> [--refresh]
+    ceph orchestrator service ls --svc_type type --svc_id <name> [--refresh]
 
 
 Query the status of a particular service instance (mon, osd, mds, rgw).  For OSDs
@@ -280,13 +289,12 @@ This is an overview of the current implementation status of the orchestrators.
  host rm                             ✔️         ⚪       ⚪         ✔️
  mgr update                          ⚪         ⚪       ⚪         ✔️
  mon update                          ⚪         ✔️       ⚪         ✔️
- osd create                          ✔️          ✔️       ⚪         ✔️
+ osd create                          ✔️         ✔️       ⚪         ✔️
  osd device {ident,fault}-{on,off}   ⚪         ⚪       ⚪         ⚪
  osd rm                              ✔️         ⚪       ⚪         ⚪
  device {ident,fault}-(on,off}       ⚪         ⚪       ⚪         ⚪
  device ls                           ✔️         ✔️       ✔️         ✔️
  service ls                          ⚪         ✔️       ✔️         ⚪
- service status                      ⚪         ✔️       ✔️         ⚪
  service-instance status             ⚪         ⚪       ⚪         ⚪
  iscsi {stop,start,reload}           ⚪         ⚪       ⚪         ⚪
  iscsi add                           ⚪         ⚪       ⚪         ⚪

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -78,6 +78,10 @@ class TestModuleSelftest(MgrTestCase):
     def test_crash(self):
         self._selftest_plugin("crash")
 
+    def test_orchestrator_cli(self):
+        self._selftest_plugin("orchestrator_cli")
+
+
     def test_selftest_config_update(self):
         """
         That configuration updates are seen by running mgr modules

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1012,7 +1012,8 @@ class MgrModule(ceph_module.BaseMgrModule):
         return self._get_module_option(key, default, self.get_mgr_id())
 
     def _set_module_option(self, key, val):
-        return self._ceph_set_module_option(self.module_name, key, str(val))
+        return self._ceph_set_module_option(self.module_name, key,
+                                            None if val is None else str(val))
 
     def set_module_option(self, key, val):
         """

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -378,7 +378,7 @@ Usage:
         """
         mgr_map = self.get("mgr_map")
 
-        if module_name == "":
+        if module_name is None or module_name == "":
             self.set_module_option("orchestrator", None)
             return HandleCommandResult()
 
@@ -428,3 +428,9 @@ Usage:
                                            o, avail,
                                            " ({0})".format(why) if not avail else ""
                                        ))
+
+    def self_test(self):
+        old_orch = self._select_orchestrator()
+        self._set_backend('')
+        assert self._select_orchestrator() is None
+        self._set_backend(old_orch)


### PR DESCRIPTION
`_ceph_set_module_option` also accepts `None`, not just strings.

This fixes a bug introduced in 4872cc5aa32611e44705aebf93145a92d5df776a

Fixes: http://tracker.ceph.com/issues/40779

Also doc fixes:
* Remove old `service status` 
* Document disabling module.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

