### PR TITLE
[DNM][RFC][WIP] Add automation to move RocksDB files between BlueFS devices.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4296,6 +4296,18 @@ std::vector<Option> get_global_options() {
     .set_default(1)
     .set_description("How frequently (in seconds) to balance free space between BlueFS and BlueStore"),
 
+    Option("bluestore_bluefs_placement_check_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(10)
+    .set_description("How frequently (in seconds) to check for optimal RocksDB files placement (db/slow)"),
+
+    Option("bluestore_bluefs_placement_all_on_db", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.8)
+    .set_description("Level on which all RocksDB files are placed on db"),
+
+    Option("bluestore_bluefs_placement_no_slow_on_db", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.9)
+    .set_description("Level on which no RocksDB files marked slow are allowed on db"),
+
     Option("bluestore_bluefs_alloc_failure_dump_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description("How frequently (in seconds) to dump allocator on"

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -48,9 +48,9 @@ public:
   explicit SocketHook(BlueFS *m) : bluefs(m) {}
   bool call(std::string_view command, const cmdmap_t& cmdmap,
             std::string_view format, bufferlist& out) override {
-    stringstream ss;
     bool r = true;
     if (command == "bluefs files move") {
+      stringstream ss;
       string file_name;
       cmd_getval(g_ceph_context, cmdmap, "file", file_name);
       string device;
@@ -75,14 +75,17 @@ public:
                 break;
               }
             }
+	    if (file)
+	      break;
           }
         }
         if (file)
           bluefs->file_move_start(file, dev_id);
       }
+      out.append(ss);
     } else if (command == "bluefs files list") {
+      stringstream ss;
       Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
-
       std::lock_guard l(bluefs->lock);
       f->open_array_section("files");
       for (auto &d : bluefs->dir_map) {
@@ -112,6 +115,7 @@ public:
       f->close_section();
       f->flush(ss);
       delete f;
+      out.append(ss);
     } else if (command == "bluefs files get") {
       string file_name;
       cmd_getval(g_ceph_context, cmdmap, "file", file_name);
@@ -136,10 +140,11 @@ public:
         out.append(p);
       }
     } else {
+      stringstream ss;
       ss << "Invalid command" << std::endl;
+      out.append(ss);
       r = false;
     }
-    out.append(ss);
     return r;
   }
 };

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -93,7 +93,7 @@ public:
     boost::intrusive::list_member_hook<> dirty_item;
 
     std::atomic_int num_readers, num_writers;
-    shared_mutex num_reading;
+    ceph::shared_mutex num_reading;
 
     File()
       : RefCountedObject(NULL, 0),

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10583,6 +10583,9 @@ void BlueStore::_kv_sync_thread()
 	int r = _balance_bluefs_freespace();
 	ceph_assert(r >= 0);
       }
+      if (bluefs) {
+	bluefs->consider_move();
+      }
 
       // cleanup sync deferred keys
       for (auto b : deferred_stable) {

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -56,6 +56,7 @@ struct bluefs_fnode_t {
   void recalc_allocated() {
     allocated = 0;
     extents_index.reserve(extents.size());
+    extents_index.clear();
     for (auto& p : extents) {
       extents_index.emplace_back(allocated);
       allocated += p.length;


### PR DESCRIPTION
This PR tries to combat spillover from fast db to slow db.
During compaction sometimes there is huge spike of database size, like in https://bugzilla.redhat.com/show_bug.cgi?id=1708711 .
While this state is only temporary, files left on db.slow will remain there.

The idea of this PR is to allow moving of RocksDB files between BlueFS devices, without any change noticeable by RocksDB.
This rebalancing has 3 modes, dependent on % free space on fast device:
- when fast device has a lot of free space, try moving all files to fast
- when fast device is reasonably full, keep all files tagged "fast" on fast device
- when fast device is almost full, move files tagged "slow" to slow device

This seems to be related to PR #28960 and its modifications.
