### PR TITLE
mgr/dashboard: integrate progress mgr module events into dashboard tasks list

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/summary.py
+++ b/src/pybind/mgr/dashboard/controllers/summary.py
@@ -9,6 +9,7 @@ from ..security import Permission, Scope
 from ..controllers.rbd_mirroring import get_daemons_and_pools
 from ..exceptions import ViewCacheNoDataException
 from ..tools import TaskManager
+from ..services import progress
 
 
 @ApiController('/summary')
@@ -72,6 +73,13 @@ class Summary(BaseController):
         exe_t, fin_t = TaskManager.list_serializable()
         executing_tasks = [task for task in exe_t if self._task_permissions(task['name'])]
         finished_tasks = [task for task in fin_t if self._task_permissions(task['name'])]
+
+        e, f = progress.get_progress_tasks()
+        executing_tasks.extend(e)
+        finished_tasks.extend(f)
+
+        executing_tasks.sort(key=lambda t: t['begin_time'], reverse=True)
+        finished_tasks.sort(key=lambda t: t['end_time'], reverse=True)
 
         result = {
             'health_status': self._health_status(),

--- a/src/pybind/mgr/dashboard/controllers/task.py
+++ b/src/pybind/mgr/dashboard/controllers/task.py
@@ -3,12 +3,21 @@ from __future__ import absolute_import
 
 from . import ApiController, RESTController
 from ..tools import TaskManager
+from ..services import progress
 
 
 @ApiController('/task')
 class Task(RESTController):
     def list(self, name=None):
         executing_t, finished_t = TaskManager.list_serializable(name)
+
+        e, f = progress.get_progress_tasks()
+        executing_t.extend(e)
+        finished_t.extend(f)
+
+        executing_t.sort(key=lambda t: t['begin_time'], reverse=True)
+        finished_t.sort(key=lambda t: t['end_time'], reverse=True)
+
         return {
             'executing_tasks': executing_t,
             'finished_tasks': finished_t

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -369,6 +369,18 @@ export class TaskMessageService {
   }
 
   _getTaskTitle(task: Task) {
+    if (task.name && task.name.startsWith('progress/')) {
+      // we don't fill the failure string because, at least for now, all
+      // progress module tasks will be considered successful
+      return this.newTaskMessage(
+        new TaskMessageOperation(
+          task.name.replace('progress/', ''),
+          '',
+          task.name.replace('progress/', '')
+        ),
+        (_metadata) => ''
+      );
+    }
     return this.messages[task.name] || this.defaultMessage;
   }
 

--- a/src/pybind/mgr/dashboard/services/progress.py
+++ b/src/pybind/mgr/dashboard/services/progress.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+'''
+Progress Mgr Module Helper
+
+This python module implements helper methods to retrieve the
+executing and completed tasks tacked by the progress mgr module
+using the same structure of dashboard tasks
+'''
+
+from __future__ import absolute_import
+
+from datetime import datetime
+
+from .. import mgr, logger
+
+
+def get_progress_tasks():
+    executing_t = []
+    finished_t = []
+    progress_events = mgr.remote('progress', "_json")
+
+    for ev in progress_events['events']:
+        logger.debug("[Progress] event=%s", ev)
+        executing_t.append({
+            # we're prepending the "progress/" prefix to tag tasks that come
+            # from the progress module
+            'name': "progress/{}".format(ev['message']),
+            'metadata': dict(ev['refs']),
+            'begin_time': "{}Z".format(datetime.fromtimestamp(ev["started_at"])
+                                       .isoformat()),
+            'progress': int(100 * ev['progress'])
+        })
+
+    for ev in progress_events['completed']:
+        logger.debug("[Progress] finished event=%s", ev)
+        finished_t.append({
+            'name': "progress/{}".format(ev['message']),
+            'metadata': dict(ev['refs']),
+            'begin_time': "{}Z".format(datetime.fromtimestamp(ev["started_at"])
+                                       .isoformat()),
+            'end_time': "{}Z".format(datetime.fromtimestamp(ev['finished_at'])
+                                     .isoformat()),
+            'duration': ev['finished_at'] - ev['started_at'],
+            'progress': 100,
+            'success': True,
+            'ret_value': None,
+            'exception': None
+        })
+
+    return executing_t, finished_t

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -7,6 +7,7 @@ from . import ControllerTestCase
 from .. import mgr
 from ..controllers.summary import Summary
 from ..controllers.rbd_mirroring import RbdMirroringSummary
+from ..services import progress
 
 
 mock_list_servers = [{
@@ -66,6 +67,9 @@ class RbdMirroringSummaryControllerTest(ControllerTestCase):
         mgr.version = 'ceph version 13.1.0-534-g23d3751b89 ' \
                       '(23d3751b897b31d2bda57aeaf01acb5ff3c4a9cd) ' \
                       'nautilus (dev)'
+
+        progress.get_progress_tasks = mock.MagicMock()
+        progress.get_progress_tasks.return_value = ([], [])
 
         # pylint: disable=protected-access
         RbdMirroringSummary._cp_config['tools.authenticate.on'] = False

--- a/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
+++ b/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
@@ -3,9 +3,12 @@
 
 import time
 
+import mock
+
 from . import ControllerTestCase
 from ..controllers import Controller, RESTController, Task
 from ..controllers.task import Task as TaskController
+from ..services import progress
 from ..tools import NotificationQueue, TaskManager
 
 
@@ -48,6 +51,9 @@ class TaskControllerTest(ControllerTestCase):
     @classmethod
     def setup_server(cls):
         # pylint: disable=protected-access
+        progress.get_progress_tasks = mock.MagicMock()
+        progress.get_progress_tasks.return_value = ([], [])
+
         NotificationQueue.start_queue()
         TaskManager.init()
         TaskTest._cp_config['tools.authenticate.on'] = False

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -4,10 +4,11 @@ import threading
 import datetime
 import uuid
 import time
+
 import json
 
 
-ENCODING_VERSION = 1
+ENCODING_VERSION = 2
 
 # keep a global reference to the module so we can use it from Event methods
 _module = None
@@ -23,13 +24,12 @@ class Event(object):
     objects (osds, pools) this relates to.
     """
 
-    def __init__(self, message, refs, duration="(since 00h 00m 00s)"):
-        self._refs = refs
-        self._duration_str = duration
+    def __init__(self, message, refs, started_at=None):
         self._message = message
-        self.started_at = datetime.datetime.utcnow()
-
+        self._refs = refs
+        self.started_at = started_at if started_at else time.time()
         self.id = None
+        self.update_duration_event()
 
     def _refresh(self):
         global _module
@@ -49,7 +49,7 @@ class Event(object):
     @property
     def progress(self):
         raise NotImplementedError()
-    
+
     @property
     def duration_str(self):
         return self._duration_str
@@ -91,7 +91,7 @@ class Event(object):
     def update_duration_event(self):
         # Update duration of event in seconds/minutes/hours
 
-        duration = (datetime.datetime.utcnow() - self.started_at).seconds
+        duration = time.time() - self.started_at
         self._duration_str = time.strftime("(since %Hh %Mm %Ss)", time.gmtime(duration))
 
 class GhostEvent(Event):
@@ -100,8 +100,9 @@ class GhostEvent(Event):
     after the event is complete.
     """
 
-    def __init__(self, my_id, message, refs, duration="(since 00h 00m 00s)"):
-        super(GhostEvent, self).__init__(message, refs, duration)
+    def __init__(self, my_id, message, refs, started_at, finished_at=None):
+        super(GhostEvent, self).__init__(message, refs, started_at)
+        self.finished_at = finished_at if finished_at else time.time()
         self.id = my_id
 
     @property
@@ -112,7 +113,9 @@ class GhostEvent(Event):
         return {
             "id": self.id,
             "message": self.message,
-            "refs": self._refs
+            "refs": self._refs,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at
         }
 
 
@@ -123,8 +126,8 @@ class RemoteEvent(Event):
     progress information as it emerges.
     """
 
-    def __init__(self, my_id, message, refs, duration="(since 00h 00m 00s)"):
-        super(RemoteEvent, self).__init__(message, refs, duration)
+    def __init__(self, my_id, message, refs):
+        super(RemoteEvent, self).__init__(message, refs)
         self.id = my_id
         self._progress = 0.0
         self._refresh()
@@ -159,7 +162,7 @@ class PgRecoveryEvent(Event):
 
         self._progress = 0.0
 
-        # self._start_epoch = _module.get_osdmap().get_epoch() 
+        # self._start_epoch = _module.get_osdmap().get_epoch()
         self._start_epoch = start_epoch
 
         self.id = str(uuid.uuid4())
@@ -325,7 +328,7 @@ class Module(MgrModule):
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
     def _osd_in_out(self, old_map, old_dump, new_map, osd_id, marked):
-        # A function that will create or complete an event when an 
+        # A function that will create or complete an event when an
         # OSD is marked in or out according to the affected PGs
         affected_pgs = []
         unmoved_pgs = []
@@ -341,13 +344,13 @@ class Module(MgrModule):
 
                 new_up_acting = new_map.pg_to_up_acting_osds(pool['pool'], ps)
                 new_osds = set(new_up_acting['acting'])
-                
+
                 # Check the osd_id being in the acting set for both old
                 # and new maps to cover both out and in cases
                 was_on_out_or_in_osd = osd_id in old_osds or osd_id in new_osds
                 if not was_on_out_or_in_osd:
                     continue
-                
+
                 self.log.debug("pool_id, ps = {0}, {1}".format(
                     pool_id, ps
                 ))
@@ -366,7 +369,7 @@ class Module(MgrModule):
                 self.log.debug(
                     "new_up_acting: {0}".format(json.dumps(new_up_acting,
                                                            indent=2)))
-                
+
                 if was_on_out_or_in_osd and is_relocated:
                     # This PG is now in motion, track its progress
                     affected_pgs.append(PgId(pool_id, ps))
@@ -383,8 +386,8 @@ class Module(MgrModule):
         self.log.warn("{0} PGs affected by osd.{1} being marked {2}".format(
             len(affected_pgs), osd_id, marked))
 
-           
-        # In the case of the osd coming back in, we might need to cancel 
+
+        # In the case of the osd coming back in, we might need to cancel
         # previous recovery event for that osd
         if marked == "in":
             for ev_id, ev in self._events.items():
@@ -400,11 +403,11 @@ class Module(MgrModule):
                     refs=[("osd", osd_id)],
                     which_pgs=affected_pgs,
                     evacuate_osds=[osd_id],
-                    start_epoch=self.get_osdmap().get_epoch() 
+                    start_epoch=self.get_osdmap().get_epoch()
                     )
             ev.pg_update(self.get("pg_dump"), self.log)
             self._events[ev.id] = ev
-                 
+
     def _osdmap_changed(self, old_osdmap, new_osdmap):
         old_dump = old_osdmap.dump()
         new_dump = new_osdmap.dump()
@@ -473,8 +476,16 @@ class Module(MgrModule):
             raise RuntimeError("Cannot decode version {0}".format(
                                decoded['compat_version']))
 
+        if decoded['compat_version'] < ENCODING_VERSION:
+            # we need to add the "started_at" and "finished_at" attributes to the events
+            for ev in decoded['events']:
+                ev['started_at'] = None
+                ev['finished_at'] = None
+
         for ev in decoded['events']:
-            self._completed_events.append(GhostEvent(ev['id'], ev['message'], ev['refs']))
+            self._completed_events.append(GhostEvent(ev['id'], ev['message'],
+                                                     ev['refs'], ev['started_at'],
+                                                     ev['finished_at']))
 
         self._prune_completed_events()
 
@@ -532,14 +543,14 @@ class Module(MgrModule):
         ev._refresh()
 
     def _complete(self, ev):
-        duration = (datetime.datetime.utcnow() - ev.started_at)
+        duration = (time.time() - ev.started_at)
         self.log.info("Completed event {0} ({1}) in {2} seconds".format(
-            ev.id, ev.message, duration.seconds
+            ev.id, ev.message, int(round(duration))
         ))
         self.complete_progress_event(ev.id)
 
         self._completed_events.append(
-            GhostEvent(ev.id, ev.message, ev.refs, ev.duration_str))
+            GhostEvent(ev.id, ev.message, ev.refs, ev.started_at))
         del self._events[ev.id]
         self._prune_completed_events()
         self._dirty = True

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -83,7 +83,9 @@ class Event(object):
             "id": self.id,
             "message": self.message,
             "duration": self.duration_str,
-            "refs": self._refs
+            "refs": self._refs,
+            "progress": self.progress,
+            "started_at": self.started_at
         }
 
     def update_duration_event(self):
@@ -105,6 +107,13 @@ class GhostEvent(Event):
     @property
     def progress(self):
         return 1.0
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "message": self.message,
+            "refs": self._refs
+        }
 
 
 class RemoteEvent(Event):


### PR DESCRIPTION
This PR integrates the executing and finished events from the progress mgr module into the list of dashboard tasks.
The progress module events are retrieved by the dashboard using the inter-module calls provided by ceph-mgr.

This allows to show in the dashboard frontend the long-running asynchronous actions registered in the progress module alongside with the dashboard tasks.

We also add to extend the information stored for the completed events in the progress module to allow them to be more "compatible" with the dashboard events.
See commits 7904b9e and 87469c0

Fixes: https://tracker.ceph.com/issues/38202

Signed-off-by: Ricardo Dias <rdias@suse.com>
