### PR TITLE
mgr: enable pg_autoscale by default on new clusters

### DIFF
--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -18,6 +18,9 @@
 	mon max pg per osd = 10000        # >= luminous
 	mon pg warn max object skew = 0
 
+	# disable pg_autoscaler by default for new pools
+        osd_pool_default_pg_autoscale_mode = off
+
 	osd pool default size = 2
 
 	mon osd allow primary affinity = true

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5325,7 +5325,7 @@ std::vector<Option> get_global_options() {
     .set_description("Filesystem path to manager modules."),
 
     Option("mgr_initial_modules", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("restful iostat")
+    .set_default("restful iostat pg_autoscaler")
     .set_flag(Option::FLAG_NO_MON_UPDATE)
     .set_flag(Option::FLAG_CLUSTER_CREATE)
     .add_service("mon")


### PR DESCRIPTION
Alternatively, we could put pg_autoscaler in the always_on modules for octopus... not sure which is better?