### PR TITLE
osd: some prelim changes

### DIFF
--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -100,7 +100,20 @@ namespace ceph {
   }
 
   std::ostream& operator<<(std::ostream& m, const timespan& t) {
-    return m << std::chrono::duration<double>(t).count() << "s";
+    int64_t ns = t.count();
+    if (ns < 0) {
+      ns = -ns;
+      m << "-";
+    }
+    m << (ns / 1000000000ll);
+    ns %= 1000000000ll;
+    if (ns) {
+      char oldfill = m.fill();
+      m.fill('0');
+      m << '.' << std::setw(9) << ns;
+      m.fill(oldfill);
+    }
+    return m << "s";
   }
 
   template<typename Clock,

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -132,6 +132,11 @@ OPTION(ms_inject_delay_msg_type, OPT_STR)      // the type of message to delay).
 OPTION(ms_inject_delay_max, OPT_DOUBLE)         // seconds
 OPTION(ms_inject_delay_probability, OPT_DOUBLE) // range [0, 1]
 OPTION(ms_inject_internal_delays, OPT_DOUBLE)   // seconds
+OPTION(ms_blackhole_osd, OPT_BOOL)
+OPTION(ms_blackhole_mon, OPT_BOOL)
+OPTION(ms_blackhole_mds, OPT_BOOL)
+OPTION(ms_blackhole_mgr, OPT_BOOL)
+OPTION(ms_blackhole_client, OPT_BOOL)
 OPTION(ms_dump_on_send, OPT_BOOL)           // hexdump msg to log on send
 OPTION(ms_dump_corrupt_message_level, OPT_INT)  // debug level to hexdump undecodeable messages at
 OPTION(ms_async_op_threads, OPT_U64)            // number of worker processing threads for async messenger created on init

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1066,6 +1066,26 @@ std::vector<Option> get_global_options() {
     .set_default(0)
     .set_description("Inject various internal delays to induce races (seconds)"),
 
+    Option("ms_blackhole_osd", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description(""),
+
+    Option("ms_blackhole_mon", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description(""),
+
+    Option("ms_blackhole_mds", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description(""),
+
+    Option("ms_blackhole_mgr", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description(""),
+
+    Option("ms_blackhole_client", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description(""),
+
     Option("ms_dump_on_send", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description("Hexdump message to debug log on message send"),

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -312,8 +312,8 @@ template<typename Rep, typename Period,
 void encode(const std::chrono::duration<Rep, Period>& d,
 	    ceph::bufferlist &bl) {
   using namespace std::chrono;
-  uint32_t s = duration_cast<seconds>(d).count();
-  uint32_t ns = (duration_cast<nanoseconds>(d) % seconds(1)).count();
+  int32_t s = duration_cast<seconds>(d).count();
+  int32_t ns = (duration_cast<nanoseconds>(d) % seconds(1)).count();
   encode(s, bl);
   encode(ns, bl);
 }
@@ -322,8 +322,8 @@ template<typename Rep, typename Period,
          typename std::enable_if_t<std::is_integral_v<Rep>>* = nullptr>
 void decode(std::chrono::duration<Rep, Period>& d,
 	    bufferlist::const_iterator& p) {
-  uint32_t s;
-  uint32_t ns;
+  int32_t s;
+  int32_t ns;
   decode(s, p);
   decode(ns, p);
   d = std::chrono::seconds(s) + std::chrono::nanoseconds(ns);

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1007,15 +1007,28 @@ CtPtr ProtocolV1::handle_message_footer(char *buffer, int r) {
 
   state = OPENED;
 
+  ceph::mono_time fast_dispatch_time;
+
+  auto& conf = cct->_conf;
+  if ((conf->ms_blackhole_mon && connection->peer_type == CEPH_ENTITY_TYPE_MON)||
+      (conf->ms_blackhole_osd && connection->peer_type == CEPH_ENTITY_TYPE_OSD)||
+      (conf->ms_blackhole_mds && connection->peer_type == CEPH_ENTITY_TYPE_MDS)||
+      (conf->ms_blackhole_client &&
+       connection->peer_type == CEPH_ENTITY_TYPE_CLIENT)) {
+    ldout(cct, 10) << __func__ << " blackhole " << *message << dendl;
+    message->put();
+    goto out;
+  }
+
   connection->logger->inc(l_msgr_recv_messages);
   connection->logger->inc(
       l_msgr_recv_bytes,
       cur_msg_size + sizeof(ceph_msg_header) + sizeof(ceph_msg_footer));
 
   messenger->ms_fast_preprocess(message);
-  auto fast_dispatch_time = ceph::mono_clock::now();
+  fast_dispatch_time = ceph::mono_clock::now();
   connection->logger->tinc(l_msgr_running_recv_time,
-                           fast_dispatch_time - connection->recv_start_time);
+			   fast_dispatch_time - connection->recv_start_time);
   if (connection->delay_state) {
     double delay_period = 0;
     if (rand() % 10000 < cct->_conf->ms_inject_delay_probability * 10000.0) {
@@ -1038,6 +1051,7 @@ CtPtr ProtocolV1::handle_message_footer(char *buffer, int r) {
                                         connection->conn_id);
   }
 
+ out:
   // clean up local buffer references
   data_buf.clear();
   front.clear();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8071,8 +8071,6 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 	client_messenger->get_myaddrs().get_ports(&avoid_ports);
 #endif
 	cluster_messenger->get_myaddrs().get_ports(&avoid_ports);
-	hb_back_server_messenger->get_myaddrs().get_ports(&avoid_ports);
-	hb_front_server_messenger->get_myaddrs().get_ports(&avoid_ports);
 
 	int r = cluster_messenger->rebind(avoid_ports);
 	if (r != 0) {
@@ -8082,22 +8080,8 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
                   << " rebind cluster_messenger failed" << dendl;
         }
 
-	r = hb_back_server_messenger->rebind(avoid_ports);
-	if (r != 0) {
-	  do_shutdown = true;  // FIXME: do_restart?
-          network_error = true;
-          dout(0) << __func__ << " marked down:"
-                  << " rebind hb_back_server_messenger failed" << dendl;
-        }
-
-	r = hb_front_server_messenger->rebind(avoid_ports);
-	if (r != 0) {
-	  do_shutdown = true;  // FIXME: do_restart?
-          network_error = true;
-          dout(0) << __func__ << " marked down:" 
-                  << " rebind hb_front_server_messenger failed" << dendl;
-        }
-
+	hb_back_server_messenger->mark_down_all();
+	hb_front_server_messenger->mark_down_all();
 	hb_front_client_messenger->mark_down_all();
 	hb_back_client_messenger->mark_down_all();
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -693,7 +693,8 @@ void PeeringState::init_primary_up_acting(
   const vector<int> &newup,
   const vector<int> &newacting,
   int new_up_primary,
-  int new_acting_primary) {
+  int new_acting_primary)
+{
   actingset.clear();
   acting = newacting;
   for (uint8_t i = 0; i < acting.size(); ++i) {
@@ -713,26 +714,28 @@ void PeeringState::init_primary_up_acting(
 	  pool.info.is_erasure() ? shard_id_t(i) : shard_id_t::NO_SHARD));
   }
   if (!pool.info.is_erasure()) {
+    // replicated
     up_primary = pg_shard_t(new_up_primary, shard_id_t::NO_SHARD);
     primary = pg_shard_t(new_acting_primary, shard_id_t::NO_SHARD);
-    return;
-  }
-  up_primary = pg_shard_t();
-  primary = pg_shard_t();
-  for (uint8_t i = 0; i < up.size(); ++i) {
-    if (up[i] == new_up_primary) {
-      up_primary = pg_shard_t(up[i], shard_id_t(i));
-      break;
+  } else {
+    // erasure
+    up_primary = pg_shard_t();
+    primary = pg_shard_t();
+    for (uint8_t i = 0; i < up.size(); ++i) {
+      if (up[i] == new_up_primary) {
+	up_primary = pg_shard_t(up[i], shard_id_t(i));
+	break;
+      }
     }
-  }
-  for (uint8_t i = 0; i < acting.size(); ++i) {
-    if (acting[i] == new_acting_primary) {
-      primary = pg_shard_t(acting[i], shard_id_t(i));
-      break;
+    for (uint8_t i = 0; i < acting.size(); ++i) {
+      if (acting[i] == new_acting_primary) {
+	primary = pg_shard_t(acting[i], shard_id_t(i));
+	break;
+      }
     }
+    ceph_assert(up_primary.osd == new_up_primary);
+    ceph_assert(primary.osd == new_acting_primary);
   }
-  ceph_assert(up_primary.osd == new_up_primary);
-  ceph_assert(primary.osd == new_acting_primary);
 }
 
 void PeeringState::clear_recovery_state()

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2738,13 +2738,11 @@ WRITE_CLASS_ENCODER(pg_history_t)
 
 inline std::ostream& operator<<(std::ostream& out, const pg_history_t& h) {
   return out << "ec=" << h.epoch_created << "/" << h.epoch_pool_created
-	     << " lis/c " << h.last_interval_started
+	     << " lis/c=" << h.last_interval_started
 	     << "/" << h.last_interval_clean
-	     << " les/c/f " << h.last_epoch_started << "/" << h.last_epoch_clean
+	     << " les/c/f=" << h.last_epoch_started << "/" << h.last_epoch_clean
 	     << "/" << h.last_epoch_marked_full
-	     << " " << h.same_up_since
-	     << "/" << h.same_interval_since
-	     << "/" << h.same_primary_since;
+	     << " sis=" << h.same_interval_since;
 }
 
 

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -17,6 +17,22 @@ install(TARGETS
   ceph_test_rados
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+# test_stale_read
+add_executable(ceph_test_osd_stale_read
+  ceph_test_osd_stale_read.cc
+  )
+target_link_libraries(ceph_test_osd_stale_read
+  librados
+  global
+  ${CMAKE_DL_LIBS}
+  ${EXTRALIBS}
+  ${CMAKE_DL_LIBS}
+  ${UNITTEST_LIBS}
+  )
+install(TARGETS
+  ceph_test_osd_stale_read
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 # scripts
 add_ceph_test(safe-to-destroy.sh ${CMAKE_CURRENT_SOURCE_DIR}/safe-to-destroy.sh)
 

--- a/src/test/osd/ceph_test_osd_stale_read.cc
+++ b/src/test/osd/ceph_test_osd_stale_read.cc
@@ -1,0 +1,178 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#include "gtest/gtest.h"
+
+#include "mds/mdstypes.h"
+#include "include/buffer.h"
+#include "include/rbd_types.h"
+#include "include/rados/librados.h"
+#include "include/rados/librados.hpp"
+#include "include/stringify.h"
+#include "include/types.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include "common/common_init.h"
+#include "common/Cond.h"
+#include "json_spirit/json_spirit.h"
+
+#include <errno.h>
+#include <map>
+#include <sstream>
+#include <string>
+
+using namespace librados;
+using std::map;
+using std::ostringstream;
+using std::string;
+
+int get_primary_osd(Rados& rados, const string& pool_name,
+		    const string& oid, int *pprimary)
+{
+  bufferlist inbl;
+  string cmd = string("{\"prefix\": \"osd map\",\"pool\":\"")
+    + pool_name
+    + string("\",\"object\": \"")
+    + oid
+    + string("\",\"format\": \"json\"}");
+  bufferlist outbl;
+  int r = rados.mon_command(cmd, inbl, &outbl, NULL);
+  assert(r >= 0);
+  string outstr(outbl.c_str(), outbl.length());
+  json_spirit::Value v;
+  if (!json_spirit::read(outstr, v)) {
+    cerr <<" unable to parse json " << outstr << std::endl;
+    return -1;
+  }
+
+  json_spirit::Object& o = v.get_obj();
+  for (json_spirit::Object::size_type i=0; i<o.size(); i++) {
+    json_spirit::Pair& p = o[i];
+    if (p.name_ == "acting_primary") {
+      cout << "primary = " << p.value_.get_int() << std::endl;
+      *pprimary = p.value_.get_int();
+      return 0;
+    }
+  }
+  cerr << "didn't find primary in " << outstr << std::endl;
+  return -1;
+}
+
+int fence_osd(Rados& rados, int osd)
+{
+  bufferlist inbl, outbl;
+  string cmd("{\"prefix\": \"injectargs\",\"injected_args\":["
+	     "\"--ms-blackhole-osd\", "
+	     "\"--ms-blackhole-mon\"]}");
+  return rados.osd_command(osd, cmd, inbl, &outbl, NULL);
+}
+
+int mark_down_osd(Rados& rados, int osd)
+{
+  bufferlist inbl, outbl;
+  string cmd("{\"prefix\": \"osd down\",\"ids\":[\"" +
+	     stringify(osd) + "\"]}");
+  return rados.mon_command(cmd, inbl, &outbl, NULL);
+}
+
+TEST(OSD, StaleRead) {
+  // create two rados instances, one pool
+  Rados rados1, rados2;
+  IoCtx ioctx1, ioctx2;
+  int r;
+
+  r = rados1.init_with_context(g_ceph_context);
+  ASSERT_EQ(0, r);
+  r = rados1.connect();
+  ASSERT_EQ(0, r);
+
+  srand(time(0));
+  string pool_name = "read-hole-test-" + stringify(rand());
+  r = rados1.pool_create(pool_name.c_str());
+  ASSERT_EQ(0, r);
+
+  r = rados1.ioctx_create(pool_name.c_str(), ioctx1);
+  ASSERT_EQ(0, r);
+
+  r = rados2.init_with_context(g_ceph_context);
+  ASSERT_EQ(0, r);
+  r = rados2.connect();
+  ASSERT_EQ(0, r);
+  r = rados2.ioctx_create(pool_name.c_str(), ioctx2);
+  ASSERT_EQ(0, r);
+
+  string oid = "foo";
+  bufferlist one;
+  one.append("one");
+  {
+    cout << "client1: writing 'one'" << std::endl;
+    r = ioctx1.write_full(oid, one);
+    ASSERT_EQ(0, r);
+  }
+
+  // make sure 2 can read it
+  {
+    cout << "client2: reading 'one'" << std::endl;
+    bufferlist bl;
+    r = ioctx2.read(oid, bl, 3, 0);
+    ASSERT_EQ(3, r);
+    ASSERT_EQ('o', bl[0]);
+    ASSERT_EQ('n', bl[1]);
+    ASSERT_EQ('e', bl[2]);
+  }
+
+  // find the primary
+  int primary;
+  r = get_primary_osd(rados1, pool_name, oid, &primary);
+  ASSERT_EQ(0, r);
+
+  // fence it
+  cout << "client1: fencing primary" << std::endl;
+  fence_osd(rados1, primary);
+  mark_down_osd(rados1, primary);
+  rados1.wait_for_latest_osdmap();
+
+  // should still be able to read the old value on 2
+  {
+    cout << "client2: reading 'one' again from old primary" << std::endl;
+    bufferlist bl;
+    r = ioctx2.read(oid, bl, 3, 0);
+    ASSERT_EQ(3, r);
+    ASSERT_EQ('o', bl[0]);
+    ASSERT_EQ('n', bl[1]);
+    ASSERT_EQ('e', bl[2]);
+  }
+
+  // update object on 1
+  bufferlist two;
+  two.append("two");
+  {
+    cout << "client1: writing 'two' to new acting set" << std::endl;
+    r = ioctx1.write_full(oid, two);
+    ASSERT_EQ(0, r);
+  }
+
+  // make sure we can't still read the old value on 2
+  {
+    cout << "client2: reading again from old primary" << std::endl;
+    bufferlist bl;
+    r = ioctx2.read(oid, bl, 3, 0);
+    ASSERT_EQ(3, r);
+    ASSERT_EQ('t', bl[0]);
+    ASSERT_EQ('w', bl[1]);
+    ASSERT_EQ('o', bl[2]);
+  }
+
+  rados1.shutdown();
+  rados2.shutdown();
+}
+
+int main(int argc, char **argv) {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
A few misc fixes and cleanups that precede the read hole fix series.

- change handling of heartbeat messengers a bit
- fix ceph time duration encode/decode, operator<<
- ms_blackhole_* infra for testing
- a test program to reproduce the real hole problem (not yet part of test suite, since it fails)