### PR TITLE
ceph-crash: use open(..,'rb') to read bytes for Python3

### DIFF
--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -32,7 +32,7 @@ def post_crash(path):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    f = open(os.path.join(path, 'meta'), 'r')
+    f = open(os.path.join(path, 'meta'), 'rb')
     stdout, stderr = pr.communicate(input=f.read())
     rc = pr.wait()
     f.close()


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/40781
Signed-off-by: Dan Mick <dan.mick@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

