### PR TITLE
mgr/rbd_support: support scheduling long-running background operations

### DIFF
--- a/qa/suites/rbd/singleton/all/rbd_tasks.yaml
+++ b/qa/suites/rbd/singleton/all/rbd_tasks.yaml
@@ -1,0 +1,13 @@
+roles:
+- [mon.a, mgr.x, osd.0, osd.1, client.0]
+tasks:
+- install:
+- ceph:
+    fs: xfs
+    log-whitelist:
+      - overall HEALTH_
+      - \(CACHE_POOL_NO_HIT_SET\)
+      - \(POOL_APP_NOT_ENABLED\)
+- workunit:
+    clients:
+      all: [rbd/test_rbd_tasks.sh]

--- a/qa/workunits/rbd/test_rbd_tasks.sh
+++ b/qa/workunits/rbd/test_rbd_tasks.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -ex
+
+POOL=rbd_tasks
+POOL_NS=ns1
+
+setup() {
+  trap 'cleanup' INT TERM EXIT
+
+  ceph osd pool create ${POOL} 128
+  rbd pool init ${POOL}
+  rbd namespace create ${POOL}/${POOL_NS}
+
+  TEMPDIR=`mktemp -d`
+}
+
+cleanup() {
+  ceph osd pool rm ${POOL} ${POOL} --yes-i-really-really-mean-it
+
+  rm -rf ${TEMPDIR}
+}
+
+wait_for() {
+  local TEST_FN=$1
+  shift 1
+  local TEST_FN_ARGS=("$@")
+
+  for s in 1 2 4 8 8 8 8 8 8 8 8 16 16; do
+    sleep ${s}
+
+    ${TEST_FN} "${TEST_FN_ARGS[@]}" || continue
+    return 0
+  done
+  return 1
+}
+
+task_exists() {
+  local TASK_ID=$1
+  [[ -z "${TASK_ID}" ]] && exit 1
+
+  ceph rbd task list ${TASK_ID} || return 1
+  return 0
+}
+
+task_dne() {
+  local TASK_ID=$1
+  [[ -z "${TASK_ID}" ]] && exit 1
+
+  ceph rbd task list ${TASK_ID} || return 0
+  return 1
+}
+
+task_in_progress() {
+  local TASK_ID=$1
+  [[ -z "${TASK_ID}" ]] && exit 1
+
+  [[ $(ceph rbd task list ${TASK_ID} | jq '.in_progress') == 'true' ]]
+}
+
+test_remove() {
+  echo "test_remove"
+
+  local IMAGE=`uuidgen`
+  rbd create --size 1 --image-shared ${POOL}/${IMAGE}
+
+  # MGR might require some time to discover the OSD map w/ new pool
+  wait_for ceph rbd task add remove ${POOL}/${IMAGE}
+}
+
+test_flatten() {
+  echo "test_flatten"
+
+  local PARENT_IMAGE=`uuidgen`
+  local CHILD_IMAGE=`uuidgen`
+
+  rbd create --size 1 --image-shared ${POOL}/${PARENT_IMAGE}
+  rbd snap create ${POOL}/${PARENT_IMAGE}@snap
+  rbd clone ${POOL}/${PARENT_IMAGE}@snap ${POOL}/${POOL_NS}/${CHILD_IMAGE} --rbd-default-clone-format=2
+  [[ "$(rbd info --format json ${POOL}/${POOL_NS}/${CHILD_IMAGE} | jq 'has("parent")')" == "true" ]]
+
+  local TASK_ID=`ceph rbd task add flatten ${POOL}/${POOL_NS}/${CHILD_IMAGE} | jq --raw-output ".id"`
+  wait_for task_dne ${TASK_ID}
+
+  [[ "$(rbd info --format json ${POOL}/${POOL_NS}/${CHILD_IMAGE} | jq 'has("parent")')" == "false" ]]
+}
+
+test_trash_remove() {
+  echo "test_trash_remove"
+
+  local IMAGE=`uuidgen`
+  rbd create --size 1 --image-shared ${POOL}/${IMAGE}
+  local IMAGE_ID=`rbd info --format json ${POOL}/${IMAGE} | jq --raw-output ".id"`
+  rbd trash mv ${POOL}/${IMAGE}
+  [[ -n "$(rbd trash list ${POOL})" ]] || exit 1
+
+  local TASK_ID=`ceph rbd task add trash remove ${POOL}/${IMAGE_ID} | jq --raw-output ".id"`
+  wait_for task_dne ${TASK_ID}
+
+  [[ -z "$(rbd trash list ${POOL})" ]] || exit 1
+}
+
+test_migration_execute() {
+  echo "test_migration_execute"
+
+  local SOURCE_IMAGE=`uuidgen`
+  local TARGET_IMAGE=`uuidgen`
+  rbd create --size 1 --image-shared ${POOL}/${SOURCE_IMAGE}
+  rbd migration prepare ${POOL}/${SOURCE_IMAGE} ${POOL}/${TARGET_IMAGE}
+  [[ "$(rbd status --format json ${POOL}/${TARGET_IMAGE} | jq --raw-output '.migration.state')" == "prepared" ]]
+
+  local TASK_ID=`ceph rbd task add migration execute ${POOL}/${TARGET_IMAGE} | jq --raw-output ".id"`
+  wait_for task_dne ${TASK_ID}
+
+  [[ "$(rbd status --format json ${POOL}/${TARGET_IMAGE} | jq --raw-output '.migration.state')" == "executed" ]]
+}
+
+test_migration_commit() {
+  echo "test_migration_commit"
+
+  local SOURCE_IMAGE=`uuidgen`
+  local TARGET_IMAGE=`uuidgen`
+  rbd create --size 1 --image-shared ${POOL}/${SOURCE_IMAGE}
+  rbd migration prepare ${POOL}/${SOURCE_IMAGE} ${POOL}/${TARGET_IMAGE}
+  [[ "$(rbd status --format json ${POOL}/${TARGET_IMAGE} | jq --raw-output '.migration.state')" == "prepared" ]]
+
+  local TASK_ID=`ceph rbd task add migration execute ${POOL}/${TARGET_IMAGE} | jq --raw-output ".id"`
+  wait_for task_dne ${TASK_ID}
+
+  TASK_ID=`ceph rbd task add migration commit ${POOL}/${TARGET_IMAGE} | jq --raw-output ".id"`
+  wait_for task_dne ${TASK_ID}
+
+  [[ "$(rbd status --format json ${POOL}/${TARGET_IMAGE} | jq 'has("migration")')" == "false" ]]
+  (rbd info ${POOL}/${SOURCE_IMAGE} && return 1) || true
+  rbd info ${POOL}/${TARGET_IMAGE}
+}
+
+test_migration_abort() {
+  echo "test_migration_abort"
+
+  local SOURCE_IMAGE=`uuidgen`
+  local TARGET_IMAGE=`uuidgen`
+  rbd create --size 1 --image-shared ${POOL}/${SOURCE_IMAGE}
+  rbd migration prepare ${POOL}/${SOURCE_IMAGE} ${POOL}/${TARGET_IMAGE}
+  [[ "$(rbd status --format json ${POOL}/${TARGET_IMAGE} | jq --raw-output '.migration.state')" == "prepared" ]]
+
+  local TASK_ID=`ceph rbd task add migration execute ${POOL}/${TARGET_IMAGE} | jq --raw-output ".id"`
+  wait_for task_dne ${TASK_ID}
+
+  TASK_ID=`ceph rbd task add migration abort ${POOL}/${TARGET_IMAGE} | jq --raw-output ".id"`
+  wait_for task_dne ${TASK_ID}
+
+  [[ "$(rbd status --format json ${POOL}/${SOURCE_IMAGE} | jq 'has("migration")')" == "false" ]]
+  rbd info ${POOL}/${SOURCE_IMAGE}
+  (rbd info ${POOL}/${TARGET_IMAGE} && return 1) || true
+}
+
+test_list() {
+  echo "test_list"
+
+  local IMAGE_1=`uuidgen`
+  local IMAGE_2=`uuidgen`
+
+  rbd create --size 1T --image-shared ${POOL}/${IMAGE_1}
+  rbd create --size 1T --image-shared ${POOL}/${IMAGE_2}
+
+  local TASK_ID_1=`ceph rbd task add remove ${POOL}/${IMAGE_1} | jq --raw-output ".id"`
+  local TASK_ID_2=`ceph rbd task add remove ${POOL}/${IMAGE_2} | jq --raw-output ".id"`
+
+  local LIST_FILE="${TEMPDIR}/list_file"
+  ceph rbd task list > ${LIST_FILE}
+  cat ${LIST_FILE}
+
+  [[ $(jq "[.[] | .id] | contains([\"${TASK_ID_1}\", \"${TASK_ID_2}\"])" ${LIST_FILE}) == "true" ]]
+
+  ceph rbd task cancel ${TASK_ID_1}
+  ceph rbd task cancel ${TASK_ID_2}
+}
+
+test_cancel() {
+  echo "test_cancel"
+
+  local IMAGE=`uuidgen`
+  rbd create --size 1T --image-shared ${POOL}/${IMAGE}
+  local TASK_ID=`ceph rbd task add remove ${POOL}/${IMAGE} | jq --raw-output ".id"`
+
+  wait_for task_exists ${TASK_ID}
+
+  ceph rbd task cancel ${TASK_ID}
+  wait_for task_dne ${TASK_ID}
+}
+
+test_duplicate_task() {
+  echo "test_duplicate_task"
+
+  local IMAGE=`uuidgen`
+  rbd create --size 1T --image-shared ${POOL}/${IMAGE}
+  local IMAGE_ID=`rbd info --format json ${POOL}/${IMAGE} | jq --raw-output ".id"`
+  rbd trash mv ${POOL}/${IMAGE}
+
+  local TASK_ID_1=`ceph rbd task add trash remove ${POOL}/${IMAGE_ID} | jq --raw-output ".id"`
+  local TASK_ID_2=`ceph rbd task add trash remove ${POOL}/${IMAGE_ID} | jq --raw-output ".id"`
+
+  [[ "${TASK_ID_1}" == "${TASK_ID_2}" ]]
+
+  ceph rbd task cancel ${TASK_ID_1}
+}
+
+test_progress() {
+  echo "test_progress"
+
+  local IMAGE_1=`uuidgen`
+  local IMAGE_2=`uuidgen`
+
+  rbd create --size 1 --image-shared ${POOL}/${IMAGE_1}
+  local TASK_ID_1=`ceph rbd task add remove ${POOL}/${IMAGE_1} | jq --raw-output ".id"`
+
+  wait_for task_dne ${TASK_ID_1}
+
+  local PROGRESS_FILE="${TEMPDIR}/progress_file"
+  ceph progress json > ${PROGRESS_FILE}
+  cat ${PROGRESS_FILE}
+
+  [[ $(jq "[.completed | .[].id] | contains([\"${TASK_ID_1}\"])" ${PROGRESS_FILE}) == "true" ]]
+
+  rbd create --size 1T --image-shared ${POOL}/${IMAGE_2}
+  local TASK_ID_2=`ceph rbd task add remove ${POOL}/${IMAGE_2} | jq --raw-output ".id"`
+
+  wait_for task_in_progress ${TASK_ID_2}
+  ceph progress json > ${PROGRESS_FILE}
+  cat ${PROGRESS_FILE}
+
+  [[ $(jq "[.events | .[].id] | contains([\"${TASK_ID_2}\"])" ${PROGRESS_FILE}) == "true" ]]
+
+  ceph rbd task cancel ${TASK_ID_2}
+  wait_for task_dne ${TASK_ID_2}
+
+  ceph progress json > ${PROGRESS_FILE}
+  cat ${PROGRESS_FILE}
+
+  [[ $(jq "[.completed | map(select(.failed)) | .[].id] | contains([\"${TASK_ID_2}\"])" ${PROGRESS_FILE}) == "true" ]]
+}
+
+setup
+test_remove
+test_flatten
+test_trash_remove
+test_migration_execute
+test_migration_commit
+test_migration_abort
+test_list
+test_cancel
+test_duplicate_task
+test_progress
+
+echo OK

--- a/src/include/rbd_types.h
+++ b/src/include/rbd_types.h
@@ -42,6 +42,7 @@
 #define RBD_DIRECTORY           "rbd_directory"
 #define RBD_INFO                "rbd_info"
 #define RBD_NAMESPACE           "rbd_namespace"
+#define RBD_TASK                "rbd_task"
 
 /*
  * rbd_children object in each pool contains omap entries

--- a/src/librbd/AsyncObjectThrottle.cc
+++ b/src/librbd/AsyncObjectThrottle.cc
@@ -93,7 +93,10 @@ void AsyncObjectThrottle<T>::start_next_op() {
       done = true;
     }
     if (m_prog_ctx != NULL) {
-      m_prog_ctx->update_progress(ono, m_end_object_no);
+      r = m_prog_ctx->update_progress(ono, m_end_object_no);
+      if (r < 0) {
+        m_ret = r;
+      }
     }
   }
 }

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -152,8 +152,10 @@ void RemoveRequest<I>::handle_trim_image(int r) {
   ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
-    lderr(m_cct) << "warning: failed to remove some object(s): "
+    lderr(m_cct) << "failed to remove some object(s): "
                  << cpp_strerror(r) << dendl;
+    send_close_image(r);
+    return;
   }
 
   if (m_old_format) {

--- a/src/pybind/mgr/rbd_support/module.py
+++ b/src/pybind/mgr/rbd_support/module.py
@@ -2,16 +2,22 @@
 RBD support module
 """
 
+import errno
 import json
+import rados
+import rbd
+import re
 import time
 import traceback
+import uuid
 
 from mgr_module import MgrModule
 
+from contextlib import contextmanager
 from datetime import datetime, timedelta
-from rados import ObjectNotFound
-from rbd import RBD
+from functools import partial, wraps
 from threading import Condition, Lock, Thread
+
 
 GLOBAL_POOL_KEY = (None, None)
 
@@ -41,32 +47,57 @@ STATS_RATE_INTERVAL = timedelta(minutes=1)
 
 REPORT_MAX_RESULTS = 64
 
+RBD_TASK_OID = "rbd_task"
 
-class Module(MgrModule):
-    COMMANDS = [
-        {
-            "cmd": "rbd perf image stats "
-                   "name=pool_spec,type=CephString,req=false "
-                   "name=sort_by,type=CephChoices,strings="
-                   "write_ops|write_bytes|write_latency|"
-                   "read_ops|read_bytes|read_latency,"
-                   "req=false ",
-            "desc": "Retrieve current RBD IO performance stats",
-            "perm": "r"
-        },
-        {
-            "cmd": "rbd perf image counters "
-                   "name=pool_spec,type=CephString,req=false "
-                   "name=sort_by,type=CephChoices,strings="
-                   "write_ops|write_bytes|write_latency|"
-                   "read_ops|read_bytes|read_latency,"
-                   "req=false ",
-            "desc": "Retrieve current RBD IO performance counters",
-            "perm": "r"
-        }
-    ]
-    MODULE_OPTIONS = []
+TASK_SEQUENCE = "sequence"
+TASK_ID = "id"
+TASK_REFS = "refs"
+TASK_MESSAGE = "message"
+TASK_RETRY_TIME = "retry_time"
+TASK_IN_PROGRESS = "in_progress"
+TASK_PROGRESS = "progress"
+TASK_CANCELED = "canceled"
 
+TASK_REF_POOL_NAME = "pool_name"
+TASK_REF_POOL_NAMESPACE = "pool_namespace"
+TASK_REF_IMAGE_NAME = "image_name"
+TASK_REF_IMAGE_ID = "image_id"
+TASK_REF_ACTION = "action"
+
+TASK_REF_ACTION_FLATTEN = "flatten"
+TASK_REF_ACTION_REMOVE = "remove"
+TASK_REF_ACTION_TRASH_REMOVE = "trash remove"
+TASK_REF_ACTION_MIGRATION_EXECUTE = "migrate execute"
+TASK_REF_ACTION_MIGRATION_COMMIT = "migrate commit"
+TASK_REF_ACTION_MIGRATION_ABORT = "migrate abort"
+
+VALID_TASK_ACTIONS = [TASK_REF_ACTION_FLATTEN,
+                      TASK_REF_ACTION_REMOVE,
+                      TASK_REF_ACTION_TRASH_REMOVE,
+                      TASK_REF_ACTION_MIGRATION_EXECUTE,
+                      TASK_REF_ACTION_MIGRATION_COMMIT,
+                      TASK_REF_ACTION_MIGRATION_ABORT]
+
+TASK_RETRY_INTERVAL = timedelta(seconds=30)
+
+
+def extract_pool_key(pool_spec):
+    if not pool_spec:
+        return GLOBAL_POOL_KEY
+
+    match = re.match(r'^([^/]+)(?:/([^/]+))?$', pool_spec)
+    if not match:
+        raise ValueError("Invalid pool spec: {}".format(pool_spec))
+    return (match.group(1), match.group(2) or '')
+
+
+def get_rbd_pools(module):
+    osd_map = module.get('osd_map')
+    return {pool['pool']: pool['pool_name'] for pool in osd_map['pools']
+            if 'rbd' in pool.get('application_metadata', {})}
+
+
+class PerfHandler:
     user_queries = {}
     image_cache = {}
 
@@ -104,42 +135,35 @@ class Module(MgrModule):
         }
 
     @classmethod
-    def extract_pool_key(cls, pool_spec):
-        if not pool_spec:
-            return (None, None)
-        pool_spec = pool_spec.rsplit('/', 1)
-        if len(pool_spec) == 1 or not pool_spec[1]:
-            return (pool_spec[0], '')
-        return (pool_spec[0], pool_spec[1])
-
-    @classmethod
     def pool_spec_search_keys(cls, pool_key):
         return [pool_key[0:len(pool_key) - x]
                 for x in range(0, len(pool_key) + 1)]
 
     @classmethod
     def submatch_pool_key(cls, pool_key, search_key):
-        return ((pool_key[1] == search_key[1] or not search_key[1]) and
-                (pool_key[0] == search_key[0] or not search_key[0]))
+        return ((pool_key[1] == search_key[1] or not search_key[1])
+                and (pool_key[0] == search_key[0] or not search_key[0]))
 
-    def __init__(self, *args, **kwargs):
-        super(Module, self).__init__(*args, **kwargs)
+    def __init__(self, module):
+        self.module = module
+        self.log = module.log
+
         self.thread = Thread(target=self.run)
         self.thread.start()
 
     def run(self):
         try:
-            self.log.info("run: starting")
+            self.log.info("PerfHandler: starting")
             while True:
                 with self.lock:
                     self.scrub_expired_queries()
                     self.process_raw_osd_perf_counters()
                     self.refresh_condition.notify()
 
-                    stats_period = int(self.get_ceph_option("mgr_stats_period"))
+                    stats_period = int(self.module.get_ceph_option("mgr_stats_period"))
                     self.query_condition.wait(stats_period)
 
-                self.log.debug("run: tick")
+                self.log.debug("PerfHandler: tick")
 
         except Exception as ex:
             self.log.fatal("Fatal runtime error: {}\n{}".format(
@@ -152,7 +176,7 @@ class Module(MgrModule):
         # collect and combine the raw counters from all sort orders
         raw_pool_counters = query.setdefault(QUERY_RAW_POOL_COUNTERS, {})
         for query_id in query[QUERY_IDS]:
-            res = self.get_osd_perf_counters(query_id)
+            res = self.module.get_osd_perf_counters(query_id)
             for counter in res['counters']:
                 # replace pool id from object name if it exists
                 k = counter['k']
@@ -219,13 +243,12 @@ class Module(MgrModule):
         return sum_pool_counters
 
     def refresh_image_names(self, resolve_image_names):
-        rbd = RBD()
         for pool_id, namespace in resolve_image_names:
             image_key = (pool_id, namespace)
             images = self.image_name_cache.setdefault(image_key, {})
-            with self.rados.open_ioctx2(int(pool_id)) as ioctx:
+            with self.module.rados.open_ioctx2(int(pool_id)) as ioctx:
                 ioctx.set_namespace(namespace)
-                for image_meta in rbd.list2(ioctx):
+                for image_meta in rbd.RBD().list2(ioctx):
                     images[image_meta['id']] = image_meta['name']
             self.log.debug("resolve_image_names: {}={}".format(image_key, images))
 
@@ -275,15 +298,10 @@ class Module(MgrModule):
         elif not self.image_name_cache:
             self.scrub_missing_images()
 
-    def get_rbd_pools(self):
-        osd_map = self.get('osd_map')
-        return {pool['pool']: pool['pool_name'] for pool in osd_map['pools']
-                if 'rbd' in pool.get('application_metadata', {})}
-
     def resolve_pool_id(self, pool_name):
-        pool_id = self.rados.pool_lookup(pool_name)
+        pool_id = self.module.rados.pool_lookup(pool_name)
         if not pool_id:
-            raise ObjectNotFound("Pool '{}' not found".format(pool_name))
+            raise rados.ObjectNotFound("Pool '{}' not found".format(pool_name))
         return pool_id
 
     def scrub_expired_queries(self):
@@ -293,7 +311,7 @@ class Module(MgrModule):
         for pool_key in list(self.user_queries.keys()):
             user_query = self.user_queries[pool_key]
             if user_query[QUERY_LAST_REQUEST] < expire_time:
-                self.unregister_osd_perf_queries(pool_key, user_query[QUERY_IDS])
+                self.module.unregister_osd_perf_queries(pool_key, user_query[QUERY_IDS])
                 del self.user_queries[pool_key]
 
     def register_osd_perf_queries(self, pool_id, namespace):
@@ -303,14 +321,14 @@ class Module(MgrModule):
                 query = self.prepare_osd_perf_query(pool_id, namespace, counter)
                 self.log.debug("register_osd_perf_queries: {}".format(query))
 
-                query_id = self.add_osd_perf_query(query)
+                query_id = self.module.add_osd_perf_query(query)
                 if query_id is None:
                     raise RuntimeError('Failed to add OSD perf query: {}'.format(query))
                 query_ids.append(query_id)
 
         except Exception:
             for query_id in query_ids:
-                self.remove_osd_perf_query(query_id)
+                self.module.remove_osd_perf_query(query_id)
             raise
 
         return query_ids
@@ -319,7 +337,7 @@ class Module(MgrModule):
         self.log.info("unregister_osd_perf_queries: pool_key={}, query_ids={}".format(
             pool_key, query_ids))
         for query_id in query_ids:
-            self.remove_osd_perf_query(query_id)
+            self.module.remove_osd_perf_query(query_id)
         query_ids[:] = []
 
     def register_query(self, pool_key):
@@ -352,7 +370,7 @@ class Module(MgrModule):
                 # processing period
                 user_query[QUERY_POOL_ID_MAP] = {
                     pool_id: pool_name for pool_id, pool_name
-                    in self.get_rbd_pools().items()}
+                    in get_rbd_pools(self.module).items()}
 
         self.log.debug("register_query: pool_key={}, query_ids={}".format(
             pool_key, user_query[QUERY_IDS]))
@@ -459,7 +477,7 @@ class Module(MgrModule):
             report, pool_spec, sort_by))
         self.scrub_expired_queries()
 
-        pool_key = self.extract_pool_key(pool_spec)
+        pool_key = extract_pool_key(pool_spec)
         user_query = self.register_query(pool_key)
 
         now = datetime.now()
@@ -483,13 +501,730 @@ class Module(MgrModule):
         return self.get_perf_data(
             "counter", pool_spec, sort_by, self.extract_counter)
 
-    def handle_command(self, inbuf, cmd):
+    def handle_command(self, inbuf, prefix, cmd):
         with self.lock:
-            if cmd['prefix'] == 'rbd perf image stats':
+            if prefix == 'image stats':
                 return self.get_perf_stats(cmd.get('pool_spec', None),
                                            cmd.get('sort_by', OSD_PERF_QUERY_COUNTERS[0]))
-            elif cmd['prefix'] == 'rbd perf image counters':
+            elif prefix == 'image counters':
                 return self.get_perf_counters(cmd.get('pool_spec', None),
                                               cmd.get('sort_by', OSD_PERF_QUERY_COUNTERS[0]))
 
-            raise NotImplementedError(cmd['prefix'])
+        raise NotImplementedError(cmd['prefix'])
+
+
+class Throttle:
+    def __init__(self, throttle_period):
+        self.throttle_period = throttle_period
+        self.time_of_last_call = datetime.min
+
+    def __call__(self, fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            now = datetime.now()
+            if self.time_of_last_call + self.throttle_period <= now:
+                self.time_of_last_call = now
+                return fn(*args, **kwargs)
+        return wrapper
+
+
+class Task:
+    def __init__(self, sequence, task_id, message, refs):
+        self.sequence = sequence
+        self.task_id = task_id
+        self.message = message
+        self.refs = refs
+        self.retry_time = None
+        self.in_progress = False
+        self.progress = 0.0
+        self.canceled = False
+
+    def __str__(self):
+        return self.to_json()
+
+    @property
+    def sequence_key(self):
+        return "{0:016X}".format(self.sequence)
+
+    def cancel(self):
+        self.canceled = True
+
+    def to_dict(self):
+        d = {TASK_SEQUENCE: self.sequence,
+             TASK_ID: self.task_id,
+             TASK_MESSAGE: self.message,
+             TASK_REFS: self.refs
+             }
+        if self.retry_time:
+            d[TASK_RETRY_TIME] = self.retry_time.isoformat()
+        if self.in_progress:
+            d[TASK_IN_PROGRESS] = True
+            d[TASK_PROGRESS] = self.progress
+        if self.canceled:
+            d[TASK_CANCELED] = True
+        return d
+
+    def to_json(self):
+        return str(json.dumps(self.to_dict()))
+
+    @classmethod
+    def from_json(cls, val):
+        try:
+            d = json.loads(val)
+            action = d.get(TASK_REFS, {}).get(TASK_REF_ACTION)
+            if action not in VALID_TASK_ACTIONS:
+                raise ValueError("Invalid task action: {}".format(action))
+
+            return Task(d[TASK_SEQUENCE], d[TASK_ID], d[TASK_MESSAGE], d[TASK_REFS])
+        except json.JSONDecodeError as e:
+            raise ValueError("Invalid JSON ({})".format(str(e)))
+        except KeyError as e:
+            raise ValueError("Invalid task format (missing key {})".format(str(e)))
+
+
+class TaskHandler:
+    lock = Lock()
+    condition = Condition(lock)
+    thread = None
+
+    in_progress_task = None
+    tasks_by_sequence = dict()
+    tasks_by_id = dict()
+
+    sequence = 0
+
+    def __init__(self, module):
+        self.module = module
+        self.log = module.log
+
+        with self.lock:
+            self.init_task_queue()
+
+        self.thread = Thread(target=self.run)
+        self.thread.start()
+
+    @property
+    def default_pool_name(self):
+        return self.module.get_ceph_option("rbd_default_pool")
+
+    def extract_pool_spec(self, pool_spec):
+        pool_spec = extract_pool_key(pool_spec)
+        if pool_spec == GLOBAL_POOL_KEY:
+            pool_spec = (self.default_pool_name, '')
+        return pool_spec
+
+    def extract_image_spec(self, image_spec):
+        match = re.match(r'^(?:([^/]+)/(?:([^/]+)/)?)?([^/@]+)$',
+                         image_spec or '')
+        if not match:
+            raise ValueError("Invalid image spec: {}".format(image_spec))
+        return (match.group(1) or self.default_pool_name, match.group(2) or '',
+                match.group(3))
+
+    def run(self):
+        try:
+            self.log.info("TaskHandler: starting")
+            while True:
+                with self.lock:
+                    now = datetime.now()
+                    for sequence in sorted([sequence for sequence, task
+                                            in self.tasks_by_sequence.items()
+                                            if not task.retry_time or task.retry_time <= now]):
+                        self.execute_task(sequence)
+
+                    self.condition.wait(5)
+                    self.log.debug("TaskHandler: tick")
+
+        except Exception as ex:
+            self.log.fatal("Fatal runtime error: {}\n{}".format(
+                ex, traceback.format_exc()))
+
+    @contextmanager
+    def open_ioctx(self, spec):
+        try:
+            with self.module.rados.open_ioctx(spec[0]) as ioctx:
+                ioctx.set_namespace(spec[1])
+                yield ioctx
+        except rados.ObjectNotFound:
+            self.log.error("Failed to locate pool {}".format(spec[0]))
+            raise
+
+    @classmethod
+    def format_image_spec(cls, image_spec):
+        image = image_spec[2]
+        if image_spec[1]:
+            image = "{}/{}".format(image_spec[1], image)
+        if image_spec[0]:
+            image = "{}/{}".format(image_spec[0], image)
+        return image
+
+    def init_task_queue(self):
+        for pool_id, pool_name in get_rbd_pools(self.module).items():
+            try:
+                with self.module.rados.open_ioctx2(int(pool_id)) as ioctx:
+                    self.load_task_queue(ioctx, pool_name)
+
+                    for namespace in rbd.RBD().namespace_list(ioctx):
+                        ioctx.set_namespace(namespace)
+                        self.load_task_queue(ioctx, pool_name)
+            except rados.ObjectNotFound:
+                # pool DNE
+                pass
+
+        if self.tasks_by_sequence:
+            self.sequence = list(sorted(self.tasks_by_sequence.keys()))[-1]
+
+        self.log.debug("sequence={}, tasks_by_sequence={}, tasks_by_id={}".format(
+            self.sequence, str(self.tasks_by_sequence), str(self.tasks_by_id)))
+
+    def load_task_queue(self, ioctx, pool_name):
+        pool_spec = pool_name
+        if ioctx.nspace:
+            pool_spec += "/{}".format(ioctx.nspace)
+
+        start_after = ''
+        try:
+            while True:
+                with rados.ReadOpCtx() as read_op:
+                    self.log.info("load_task_task: {}, start_after={}".format(
+                        pool_spec, start_after))
+                    it, ret = ioctx.get_omap_vals(read_op, start_after, "", 128)
+                    ioctx.operate_read_op(read_op, RBD_TASK_OID)
+
+                    it = list(it)
+                    for k, v in it:
+                        start_after = k
+                        v = v.decode()
+                        self.log.info("load_task_task: task={}".format(v))
+
+                        try:
+                            task = Task.from_json(v)
+                            self.append_task(task)
+                        except ValueError:
+                            self.log.error("Failed to decode task: pool_spec={}, task={}".format(pool_spec, v))
+
+                    if not it:
+                        break
+
+        except StopIteration:
+            pass
+        except rados.ObjectNotFound:
+            # rbd_task DNE
+            pass
+
+    def append_task(self, task):
+        self.tasks_by_sequence[task.sequence] = task
+        self.tasks_by_id[task.task_id] = task
+
+    def add_task(self, ioctx, message, refs):
+        self.log.debug("add_task: message={}, refs={}".format(message, refs))
+
+        # search for dups and return the original
+        for task_id, task in self.tasks_by_id.items():
+            if task.refs == refs:
+                return json.dumps(task.to_dict())
+
+        # ensure unique uuid across all pools
+        while True:
+            task_id = str(uuid.uuid4())
+            if task_id not in self.tasks_by_id:
+                break
+
+        self.sequence += 1
+        task = Task(self.sequence, task_id, message, refs)
+
+        # add the task to the rbd_task omap
+        task_json = task.to_json()
+        omap_keys = (task.sequence_key, )
+        omap_vals = (str.encode(task_json), )
+        self.log.info("adding task: {} {}".format(omap_keys[0], omap_vals[0]))
+
+        with rados.WriteOpCtx() as write_op:
+            ioctx.set_omap(write_op, omap_keys, omap_vals)
+            ioctx.operate_write_op(write_op, RBD_TASK_OID)
+        self.append_task(task)
+
+        self.condition.notify()
+        return task_json
+
+    def remove_task(self, ioctx, task, remove_in_memory=True):
+        self.log.info("remove_task: task={}".format(str(task)))
+        omap_keys = (task.sequence_key, )
+        try:
+            with rados.WriteOpCtx() as write_op:
+                ioctx.remove_omap_keys(write_op, omap_keys)
+                ioctx.operate_write_op(write_op, RBD_TASK_OID)
+        except rados.ObjectNotFound:
+            pass
+
+        if remove_in_memory:
+            try:
+                del self.tasks_by_id[task.task_id]
+                del self.tasks_by_sequence[task.sequence]
+            except KeyError:
+                pass
+
+    def execute_task(self, sequence):
+        task = self.tasks_by_sequence[sequence]
+        self.log.info("execute_task: task={}".format(str(task)))
+
+        pool_valid = False
+        try:
+            with self.open_ioctx((task.refs[TASK_REF_POOL_NAME],
+                                  task.refs[TASK_REF_POOL_NAMESPACE])) as ioctx:
+                pool_valid = True
+
+                action = task.refs[TASK_REF_ACTION]
+                execute_fn = {TASK_REF_ACTION_FLATTEN: self.execute_flatten,
+                              TASK_REF_ACTION_REMOVE: self.execute_remove,
+                              TASK_REF_ACTION_TRASH_REMOVE: self.execute_trash_remove,
+                              TASK_REF_ACTION_MIGRATION_EXECUTE: self.execute_migration_execute,
+                              TASK_REF_ACTION_MIGRATION_COMMIT: self.execute_migration_commit,
+                              TASK_REF_ACTION_MIGRATION_ABORT: self.execute_migration_abort
+                              }.get(action)
+                if not execute_fn:
+                    self.log.error("Invalid task action: {}".format(action))
+                else:
+                    task.in_progress = True
+                    self.in_progress_task = task
+                    self.update_progress(task, 0)
+
+                    self.lock.release()
+                    try:
+                        execute_fn(ioctx, task)
+
+                    except rbd.OperationCanceled:
+                        self.log.info("Operation canceled: task={}".format(
+                            str(task)))
+
+                    finally:
+                        self.lock.acquire()
+
+                        task.in_progress = False
+                        self.in_progress_task = None
+
+                    self.complete_progress(task)
+                    self.remove_task(ioctx, task)
+
+        except rados.ObjectNotFound as e:
+            self.log.error("execute_task: {}".format(e))
+            if pool_valid:
+                self.update_progress(task, 0)
+            else:
+                # pool DNE -- remove the task
+                self.complete_progress(task)
+                self.remove_task(ioctx, task)
+
+        except (rados.Error, rbd.Error) as e:
+            self.log.error("execute_task: {}".format(e))
+            self.update_progress(task, 0)
+
+        finally:
+            task.in_progress = False
+            task.retry_time = datetime.now() + TASK_RETRY_INTERVAL
+
+    def progress_callback(self, task, current, total):
+        progress = float(current) / float(total)
+        self.log.debug("progress_callback: task={}, progress={}".format(
+            str(task), progress))
+
+        # avoid deadlocking when a new command comes in during a progress callback
+        if not self.lock.acquire(False):
+            return 0
+
+        try:
+            if not self.in_progress_task or self.in_progress_task.canceled:
+                return -rbd.ECANCELED
+            self.in_progress_task.progress = progress
+        finally:
+            self.lock.release()
+
+        self.throttled_update_progress(task, progress)
+        return 0
+
+    def execute_flatten(self, ioctx, task):
+        self.log.info("execute_flatten: task={}".format(str(task)))
+
+        try:
+            with rbd.Image(ioctx, task.refs[TASK_REF_IMAGE_NAME]) as image:
+                image.flatten(on_progress=partial(self.progress_callback, task))
+        except rbd.InvalidArgument:
+            self.log.info("Image does not have parent: task={}".format(str(task)))
+        except rbd.ImageNotFound:
+            self.log.info("Image does not exist: task={}".format(str(task)))
+
+    def execute_remove(self, ioctx, task):
+        self.log.info("execute_remove: task={}".format(str(task)))
+
+        try:
+            rbd.RBD().remove(ioctx, task.refs[TASK_REF_IMAGE_NAME],
+                             on_progress=partial(self.progress_callback, task))
+        except rbd.ImageNotFound:
+            self.log.info("Image does not exist: task={}".format(str(task)))
+
+    def execute_trash_remove(self, ioctx, task):
+        self.log.info("execute_trash_remove: task={}".format(str(task)))
+
+        try:
+            rbd.RBD().trash_remove(ioctx, task.refs[TASK_REF_IMAGE_ID],
+                                   on_progress=partial(self.progress_callback, task))
+        except rbd.ImageNotFound:
+            self.log.info("Image does not exist: task={}".format(str(task)))
+
+    def execute_migration_execute(self, ioctx, task):
+        self.log.info("execute_migration_execute: task={}".format(str(task)))
+
+        try:
+            rbd.RBD().migration_execute(ioctx, task.refs[TASK_REF_IMAGE_NAME],
+                                        on_progress=partial(self.progress_callback, task))
+        except rbd.ImageNotFound:
+            self.log.info("Image does not exist: task={}".format(str(task)))
+        except rbd.InvalidArgument:
+            self.log.info("Image is not migrating: task={}".format(str(task)))
+
+    def execute_migration_commit(self, ioctx, task):
+        self.log.info("execute_migration_commit: task={}".format(str(task)))
+
+        try:
+            rbd.RBD().migration_commit(ioctx, task.refs[TASK_REF_IMAGE_NAME],
+                                       on_progress=partial(self.progress_callback, task))
+        except rbd.ImageNotFound:
+            self.log.info("Image does not exist: task={}".format(str(task)))
+        except rbd.InvalidArgument:
+            self.log.info("Image is not migrating or migration not executed: task={}".format(str(task)))
+
+    def execute_migration_abort(self, ioctx, task):
+        self.log.info("execute_migration_abort: task={}".format(str(task)))
+
+        try:
+            rbd.RBD().migration_abort(ioctx, task.refs[TASK_REF_IMAGE_NAME],
+                                      on_progress=partial(self.progress_callback, task))
+        except rbd.ImageNotFound:
+            self.log.info("Image does not exist: task={}".format(str(task)))
+        except rbd.InvalidArgument:
+            self.log.info("Image is not migrating: task={}".format(str(task)))
+
+    def complete_progress(self, task):
+        self.log.debug("complete_progress: task={}".format(str(task)))
+        try:
+            self.module.remote("progress", "complete", task.task_id)
+        except ImportError:
+            # progress module is disabled
+            pass
+
+    def update_progress(self, task, progress):
+        self.log.debug("update_progress: task={}, progress={}".format(str(task), progress))
+        try:
+            self.module.remote("progress", "update", task.task_id,
+                               task.message, progress,
+                               ["rbd_support"])
+        except ImportError:
+            # progress module is disabled
+            pass
+
+    @Throttle(timedelta(seconds=1))
+    def throttled_update_progress(self, task, progress):
+        self.update_progress(task, progress)
+
+    def queue_flatten(self, image_spec):
+        image_spec = self.extract_image_spec(image_spec)
+        self.log.info("queue_flatten: {}".format(image_spec))
+
+        with self.open_ioctx(image_spec) as ioctx:
+            with rbd.Image(ioctx, image_spec[2]) as image:
+                try:
+                    image.parent_id()
+                except rbd.ImageNotFound:
+                    raise rbd.ImageNotFound("Image {} does not have a parent".format(
+                        self.format_image_spec(image_spec)), errno=errno.ENOENT)
+
+            return 0, self.add_task(ioctx,
+                                    "Flattening image {}".format(
+                                        self.format_image_spec(image_spec)),
+                                    {TASK_REF_ACTION: TASK_REF_ACTION_FLATTEN,
+                                     TASK_REF_POOL_NAME: image_spec[0],
+                                     TASK_REF_POOL_NAMESPACE: image_spec[1],
+                                     TASK_REF_IMAGE_NAME: image_spec[2]}), ""
+
+    def queue_remove(self, image_spec):
+        image_spec = self.extract_image_spec(image_spec)
+        self.log.info("queue_remove: {}".format(image_spec))
+
+        with self.open_ioctx(image_spec) as ioctx:
+            with rbd.Image(ioctx, image_spec[2]) as image:
+                if list(image.list_snaps()):
+                    raise rbd.ImageBusy("Image {} has snapshots".format(
+                        self.format_image_spec(image_spec)), errno=errno.EBUSY)
+
+            return 0, self.add_task(ioctx,
+                                    "Removing image {}".format(
+                                        self.format_image_spec(image_spec)),
+                                    {TASK_REF_ACTION: TASK_REF_ACTION_REMOVE,
+                                     TASK_REF_POOL_NAME: image_spec[0],
+                                     TASK_REF_POOL_NAMESPACE: image_spec[1],
+                                     TASK_REF_IMAGE_NAME: image_spec[2]}), ""
+
+    def queue_trash_remove(self, image_id_spec):
+        image_id_spec = self.extract_image_spec(image_id_spec)
+        self.log.info("queue_trash_remove: {}".format(image_id_spec))
+
+        # verify that image exists in trash
+        with self.open_ioctx(image_id_spec) as ioctx:
+            rbd.RBD().trash_get(ioctx, image_id_spec[2])
+
+            return 0, self.add_task(ioctx,
+                                    "Removing image {} from trash".format(
+                                        self.format_image_spec(image_id_spec)),
+                                    {TASK_REF_ACTION: TASK_REF_ACTION_TRASH_REMOVE,
+                                     TASK_REF_POOL_NAME: image_id_spec[0],
+                                     TASK_REF_POOL_NAMESPACE: image_id_spec[1],
+                                     TASK_REF_IMAGE_ID: image_id_spec[2]}), ""
+
+    def validate_image_migrating(self, ioctx, image_spec):
+        with rbd.Image(ioctx, image_spec[2]) as image:
+            features = image.features()
+            if features & rbd.RBD_FEATURE_MIGRATING == 0:
+                raise rbd.InvalidArgument("Image {} is not migrating".format(
+                    self.format_image_spec(image_spec)), errno=errno.EINVAL)
+
+    def resolve_pool_name(self, pool_id):
+        osd_map = self.module.get('osd_map')
+        for pool in osd_map['pools']:
+            if pool['pool'] == pool_id:
+                return pool['pool_name']
+        return '<unknown>'
+
+    def queue_migration_execute(self, image_spec):
+        image_spec = self.extract_image_spec(image_spec)
+        self.log.info("queue_migration_execute: {}".format(image_spec))
+
+        with self.open_ioctx(image_spec) as ioctx:
+            self.validate_image_migrating(ioctx, image_spec)
+
+            status = rbd.RBD().migration_status(ioctx, image_spec[2])
+            if status['state'] not in [rbd.RBD_IMAGE_MIGRATION_STATE_PREPARED,
+                                       rbd.RBD_IMAGE_MIGRATION_STATE_EXECUTING]:
+                raise rbd.InvalidArgument("Image {} is not in ready state".format(
+                    self.format_image_spec(image_spec)), errno=errno.EINVAL)
+
+            source_pool = self.resolve_pool_name(status['source_pool_id'])
+            dest_pool = self.resolve_pool_name(status['dest_pool_id'])
+            return 0, self.add_task(ioctx,
+                                    "Migrating image {} to {}".format(
+                                        self.format_image_spec((source_pool,
+                                                                status['source_pool_namespace'],
+                                                                status['source_image_name'])),
+                                        self.format_image_spec((dest_pool,
+                                                                status['dest_pool_namespace'],
+                                                                status['dest_image_name']))),
+                                    {TASK_REF_ACTION: TASK_REF_ACTION_MIGRATION_EXECUTE,
+                                     TASK_REF_POOL_NAME: image_spec[0],
+                                     TASK_REF_POOL_NAMESPACE: image_spec[1],
+                                     TASK_REF_IMAGE_NAME: image_spec[2]}), ""
+
+    def queue_migration_commit(self, image_spec):
+        image_spec = self.extract_image_spec(image_spec)
+        self.log.info("queue_migration_commit: {}".format(image_spec))
+
+        with self.open_ioctx(image_spec) as ioctx:
+            self.validate_image_migrating(ioctx, image_spec)
+
+            status = rbd.RBD().migration_status(ioctx, image_spec[2])
+            if status['state'] != rbd.RBD_IMAGE_MIGRATION_STATE_EXECUTED:
+                raise rbd.InvalidArgument("Image {} has not completed migration".format(
+                    self.format_image_spec(image_spec)), errno=errno.EINVAL)
+
+            return 0, self.add_task(ioctx,
+                                    "Committing image migration for {}".format(
+                                        self.format_image_spec(image_spec)),
+                                    {TASK_REF_ACTION: TASK_REF_ACTION_MIGRATION_COMMIT,
+                                     TASK_REF_POOL_NAME: image_spec[0],
+                                     TASK_REF_POOL_NAMESPACE: image_spec[1],
+                                     TASK_REF_IMAGE_NAME: image_spec[2]}), ""
+
+    def queue_migration_abort(self, image_spec):
+        image_spec = self.extract_image_spec(image_spec)
+        self.log.info("queue_migration_abort: {}".format(image_spec))
+
+        with self.open_ioctx(image_spec) as ioctx:
+            self.validate_image_migrating(ioctx, image_spec)
+
+            return 0, self.add_task(ioctx,
+                                    "Aborting image migration for {}".format(
+                                        self.format_image_spec(image_spec)),
+                                    {TASK_REF_ACTION: TASK_REF_ACTION_MIGRATION_ABORT,
+                                     TASK_REF_POOL_NAME: image_spec[0],
+                                     TASK_REF_POOL_NAMESPACE: image_spec[1],
+                                     TASK_REF_IMAGE_NAME: image_spec[2]}), ""
+
+    def task_cancel(self, task_id):
+        self.log.info("task_cancel: {}".format(task_id))
+
+        if task_id not in self.tasks_by_id:
+            self.log.debug("tasks: {}".format(str(self.tasks_by_id)))
+            raise KeyError("No such task {}".format(task_id))
+
+        task = self.tasks_by_id[task_id]
+        task.cancel()
+
+        remove_in_memory = True
+        if self.in_progress_task and self.in_progress_task.task_id == task_id:
+            self.log.info("Attempting to cancel in-progress task: {}".format(str(self.in_progress_task)))
+            remove_in_memory = False
+
+        # complete any associated event in the progress module
+        self.complete_progress(task)
+
+        # remove from rbd_task omap
+        with self.open_ioctx((task.refs[TASK_REF_POOL_NAME],
+                              task.refs[TASK_REF_POOL_NAMESPACE])) as ioctx:
+            self.remove_task(ioctx, task, remove_in_memory)
+
+        return 0, "", ""
+
+    def task_list(self, task_id):
+        self.log.info("task_list: {}".format(task_id))
+
+        if task_id:
+            if task_id not in self.tasks_by_id:
+                raise KeyError("No such task {}".format(task_id))
+
+            result = self.tasks_by_id[task_id].to_dict()
+        else:
+            result = []
+            for sequence in sorted(self.tasks_by_sequence.keys()):
+                task = self.tasks_by_sequence[sequence]
+                result.append(task.to_dict())
+
+        return 0, json.dumps(result), ""
+
+    def handle_command(self, inbuf, prefix, cmd):
+        with self.lock:
+            if prefix == 'add flatten':
+                return self.queue_flatten(cmd['image_spec'])
+            elif prefix == 'add remove':
+                return self.queue_remove(cmd['image_spec'])
+            elif prefix == 'add trash remove':
+                return self.queue_trash_remove(cmd['image_id_spec'])
+            elif prefix == 'add migration execute':
+                return self.queue_migration_execute(cmd['image_spec'])
+            elif prefix == 'add migration commit':
+                return self.queue_migration_commit(cmd['image_spec'])
+            elif prefix == 'add migration abort':
+                return self.queue_migration_abort(cmd['image_spec'])
+            elif prefix == 'cancel':
+                return self.task_cancel(cmd['task_id'])
+            elif prefix == 'list':
+                return self.task_list(cmd.get('task_id'))
+
+        raise NotImplementedError(cmd['prefix'])
+
+
+class Module(MgrModule):
+    COMMANDS = [
+        {
+            "cmd": "rbd perf image stats "
+                   "name=pool_spec,type=CephString,req=false "
+                   "name=sort_by,type=CephChoices,strings="
+                   "write_ops|write_bytes|write_latency|"
+                   "read_ops|read_bytes|read_latency,"
+                   "req=false ",
+            "desc": "Retrieve current RBD IO performance stats",
+            "perm": "r"
+        },
+        {
+            "cmd": "rbd perf image counters "
+                   "name=pool_spec,type=CephString,req=false "
+                   "name=sort_by,type=CephChoices,strings="
+                   "write_ops|write_bytes|write_latency|"
+                   "read_ops|read_bytes|read_latency,"
+                   "req=false ",
+            "desc": "Retrieve current RBD IO performance counters",
+            "perm": "r"
+        },
+        {
+            "cmd": "rbd task add flatten "
+                   "name=image_spec,type=CephString",
+            "desc": "Flatten a cloned image asynchronously in the background",
+            "perm": "w"
+        },
+        {
+            "cmd": "rbd task add remove "
+                   "name=image_spec,type=CephString",
+            "desc": "Remove an image asynchronously in the background",
+            "perm": "w"
+        },
+        {
+            "cmd": "rbd task add trash remove "
+                   "name=image_id_spec,type=CephString",
+            "desc": "Remove an image from the trash asynchronously in the background",
+            "perm": "w"
+        },
+        {
+            "cmd": "rbd task add migration execute "
+                   "name=image_spec,type=CephString",
+            "desc": "Execute an image migration asynchronously in the background",
+            "perm": "w"
+        },
+        {
+            "cmd": "rbd task add migration commit "
+                   "name=image_spec,type=CephString",
+            "desc": "Commit an executed migration asynchronously in the background",
+            "perm": "w"
+        },
+        {
+            "cmd": "rbd task add migration abort "
+                   "name=image_spec,type=CephString",
+            "desc": "Abort a prepared migration asynchronously in the background",
+            "perm": "w"
+        },
+        {
+            "cmd": "rbd task cancel "
+                   "name=task_id,type=CephString ",
+            "desc": "Cancel a pending or running asynchronous task",
+            "perm": "r"
+        },
+        {
+            "cmd": "rbd task list "
+                   "name=task_id,type=CephString,req=false ",
+            "desc": "List pending or running asynchronous tasks",
+            "perm": "r"
+        }
+    ]
+    MODULE_OPTIONS = []
+
+    perf = None
+    task = None
+
+    def __init__(self, *args, **kwargs):
+        super(Module, self).__init__(*args, **kwargs)
+        self.perf = PerfHandler(self)
+        self.task = TaskHandler(self)
+
+    def handle_command(self, inbuf, cmd):
+        prefix = cmd['prefix']
+        try:
+            try:
+                if prefix.startswith('rbd perf '):
+                    return self.perf.handle_command(inbuf, prefix[9:], cmd)
+                elif prefix.startswith('rbd task '):
+                    return self.task.handle_command(inbuf, prefix[9:], cmd)
+
+            except Exception as ex:
+                # log the full traceback but don't send it to the CLI user
+                self.log.fatal("Fatal runtime error: {}\n{}".format(
+                    ex, traceback.format_exc()))
+                raise
+
+        except rados.Error as ex:
+            return -ex.errno, "", str(ex)
+        except rbd.OSError as ex:
+            return -ex.errno, "", str(ex)
+        except rbd.Error as ex:
+            return -errno.EINVAL, "", str(ex)
+        except KeyError as ex:
+            return -errno.ENOENT, "", str(ex)
+        except ValueError as ex:
+            return -errno.EINVAL, "", str(ex)
+
+        raise NotImplementedError(cmd['prefix'])

--- a/src/pybind/mgr/rbd_support/module.py
+++ b/src/pybind/mgr/rbd_support/module.py
@@ -1134,8 +1134,7 @@ class TaskHandler:
         self.log.info("task_cancel: {}".format(task_id))
 
         if task_id not in self.tasks_by_id:
-            self.log.debug("tasks: {}".format(str(self.tasks_by_id)))
-            raise KeyError("No such task {}".format(task_id))
+            return -errno.ENOENT, '', "No such task {}".format(task_id)
 
         task = self.tasks_by_id[task_id]
         task.cancel()
@@ -1160,7 +1159,7 @@ class TaskHandler:
 
         if task_id:
             if task_id not in self.tasks_by_id:
-                raise KeyError("No such task {}".format(task_id))
+                return -errno.ENOENT, '', "No such task {}".format(task_id)
 
             result = self.tasks_by_id[task_id].to_dict()
         else:

--- a/src/pybind/mgr/rbd_support/module.py
+++ b/src/pybind/mgr/rbd_support/module.py
@@ -935,9 +935,11 @@ class TaskHandler:
     def update_progress(self, task, progress):
         self.log.debug("update_progress: task={}, progress={}".format(str(task), progress))
         try:
+            refs = {"origin": "rbd_support"}
+            refs.update(task.refs)
+
             self.module.remote("progress", "update", task.task_id,
-                               task.message, progress,
-                               ["rbd_support"])
+                               task.message, progress, refs)
         except ImportError:
             # progress module is disabled
             pass

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -53,6 +53,9 @@ cdef extern from "rados/librados.h":
     enum:
         _LIBRADOS_SNAP_HEAD "LIBRADOS_SNAP_HEAD"
 
+cdef extern from "rbd/librbd.h":
+    ctypedef int (*librbd_progress_fn_t)(uint64_t offset, uint64_t total, void* ptr)
+
 cdef extern from "rbd/librbd.h" nogil:
     enum:
         _RBD_FEATURE_LAYERING "RBD_FEATURE_LAYERING"
@@ -261,7 +264,6 @@ cdef extern from "rbd/librbd.h" nogil:
         _RBD_POOL_STAT_OPTION_TRASH_SNAPSHOTS "RBD_POOL_STAT_OPTION_TRASH_SNAPSHOTS"
 
     ctypedef void (*rbd_callback_t)(rbd_completion_t cb, void *arg)
-    ctypedef int (*librbd_progress_fn_t)(uint64_t offset, uint64_t total, void* ptr)
 
     void rbd_version(int *major, int *minor, int *extra)
 
@@ -295,7 +297,8 @@ cdef extern from "rbd/librbd.h" nogil:
     int rbd_clone3(rados_ioctx_t p_ioctx, const char *p_name,
                    const char *p_snapname, rados_ioctx_t c_ioctx,
                    const char *c_name, rbd_image_options_t c_opts)
-    int rbd_remove(rados_ioctx_t io, const char *name)
+    int rbd_remove_with_progress(rados_ioctx_t io, const char *name,
+                                 librbd_progress_fn_t cb, void *cbdata)
     int rbd_rename(rados_ioctx_t src_io_ctx, const char *srcname,
                    const char *destname)
 
@@ -308,15 +311,26 @@ cdef extern from "rbd/librbd.h" nogil:
     void rbd_trash_list_cleanup(rbd_trash_image_info_t *trash_entries,
                                 size_t num_entries)
     int rbd_trash_purge(rados_ioctx_t io, time_t expire_ts, float threshold)
-    int rbd_trash_remove(rados_ioctx_t io, const char *id, int force)
+    int rbd_trash_remove_with_progress(rados_ioctx_t io, const char *id,
+                                       int force, librbd_progress_fn_t cb,
+                                       void *cbdata)
     int rbd_trash_restore(rados_ioctx_t io, const char *id, const char *name)
 
     int rbd_migration_prepare(rados_ioctx_t io_ctx, const char *image_name,
-                              rados_ioctx_t dest_io_ctx, const char *dest_image_name,
+                              rados_ioctx_t dest_io_ctx,
+                              const char *dest_image_name,
                               rbd_image_options_t opts)
-    int rbd_migration_execute(rados_ioctx_t io_ctx, const char *image_name)
-    int rbd_migration_commit(rados_ioctx_t io_ctx, const char *image_name)
-    int rbd_migration_abort(rados_ioctx_t io_ctx, const char *image_name)
+    int rbd_migration_execute_with_progress(rados_ioctx_t io_ctx,
+                                            const char *image_name,
+                                            librbd_progress_fn_t cb,
+                                            void *cbdata)
+    int rbd_migration_commit_with_progress(rados_ioctx_t io_ctx,
+                                           const char *image_name,
+                                           librbd_progress_fn_t cb,
+                                           void *cbdata)
+    int rbd_migration_abort_with_progress(rados_ioctx_t io_ctx,
+                                          const char *image_name,
+                                          librbd_progress_fn_t cb, void *cbdata)
     int rbd_migration_status(rados_ioctx_t io_ctx, const char *image_name,
                              rbd_image_migration_status_t *status,
                              size_t status_size)
@@ -452,7 +466,8 @@ cdef extern from "rbd/librbd.h" nogil:
     int rbd_snap_get_trash_namespace(rbd_image_t image, uint64_t snap_id,
                                      char *original_name, size_t max_length)
 
-    int rbd_flatten(rbd_image_t image)
+    int rbd_flatten_with_progress(rbd_image_t image, librbd_progress_fn_t cb,
+                                  void *cbdata)
     int rbd_sparsify(rbd_image_t image, size_t sparse_size)
     int rbd_rebuild_object_map(rbd_image_t image, librbd_progress_fn_t cb,
                                void *cbdata)
@@ -861,7 +876,10 @@ cdef make_ex(ret, msg, exception_map=errno_to_exception):
 cdef rados_ioctx_t convert_ioctx(rados.Ioctx ioctx) except? NULL:
     return <rados_ioctx_t>ioctx.io
 
-cdef int no_op_progress_callback(uint64_t offset, uint64_t total, void* ptr) nogil:
+cdef int progress_callback(uint64_t offset, uint64_t total, void* ptr) with gil:
+    return (<object>ptr)(offset, total)
+
+cdef int no_op_progress_callback(uint64_t offset, uint64_t total, void* ptr):
     return 0
 
 def cstr(val, name, encoding="utf-8", opt=False):
@@ -1223,7 +1241,7 @@ class RBD(object):
         """
         return ImageIterator(ioctx)
 
-    def remove(self, ioctx, name):
+    def remove(self, ioctx, name, on_progress=None):
         """
         Delete an RBD image. This may take a long time, since it does
         not return until every object that comprises the image has
@@ -1237,6 +1255,8 @@ class RBD(object):
         :type ioctx: :class:`rados.Ioctx`
         :param name: the name of the image to remove
         :type name: str
+        :param on_progress: optional progress callback function
+        :type on_progress: callback function
         :raises: :class:`ImageNotFound`, :class:`ImageBusy`,
                  :class:`ImageHasSnapshots`
         """
@@ -1244,8 +1264,13 @@ class RBD(object):
         cdef:
             rados_ioctx_t _ioctx = convert_ioctx(ioctx)
             char *_name = name
+            librbd_progress_fn_t _prog_cb = &no_op_progress_callback
+            void *_prog_arg = NULL
+        if on_progress:
+            _prog_cb = &progress_callback
+            _prog_arg = <void *>on_progress
         with nogil:
-            ret = rbd_remove(_ioctx, _name)
+            ret = rbd_remove_with_progress(_ioctx, _name, _prog_cb, _prog_arg)
         if ret != 0:
             raise make_ex(ret, 'error removing image')
 
@@ -1327,7 +1352,7 @@ class RBD(object):
         if ret != 0:
             raise make_ex(ret, 'error purging images from trash')
 
-    def trash_remove(self, ioctx, image_id, force=False):
+    def trash_remove(self, ioctx, image_id, force=False, on_progress=None):
         """
         Delete an RBD image from trash. If image deferment time has not
         expired :class:`PermissionError` is raised.
@@ -1338,6 +1363,8 @@ class RBD(object):
         :type image_id: str
         :param force: force remove even if deferment time has not expired
         :type force: bool
+        :param on_progress: optional progress callback function
+        :type on_progress: callback function
         :raises: :class:`ImageNotFound`, :class:`PermissionError`
         """
         image_id = cstr(image_id, 'image_id')
@@ -1345,8 +1372,14 @@ class RBD(object):
             rados_ioctx_t _ioctx = convert_ioctx(ioctx)
             char *_image_id = image_id
             int _force = force
+            librbd_progress_fn_t _prog_cb = &no_op_progress_callback
+            void *_prog_arg = NULL
+        if on_progress:
+            _prog_cb = &progress_callback
+            _prog_arg = <void *>on_progress
         with nogil:
-            ret = rbd_trash_remove(_ioctx, _image_id, _force)
+            ret = rbd_trash_remove_with_progress(_ioctx, _image_id, _force,
+                                                 _prog_cb, _prog_arg)
         if ret != 0:
             raise make_ex(ret, 'error deleting image from trash')
 
@@ -1491,7 +1524,7 @@ class RBD(object):
         if ret < 0:
             raise make_ex(ret, 'error migrating image %s' % (image_name))
 
-    def migration_execute(self, ioctx, image_name):
+    def migration_execute(self, ioctx, image_name, on_progress=None):
         """
         Execute a prepared RBD image migration.
 
@@ -1499,18 +1532,26 @@ class RBD(object):
         :type ioctx: :class:`rados.Ioctx`
         :param image_name: the name of the image
         :type image_name: str
+        :param on_progress: optional progress callback function
+        :type on_progress: callback function
         :raises: :class:`ImageNotFound`
         """
         image_name = cstr(image_name, 'image_name')
         cdef:
             rados_ioctx_t _ioctx = convert_ioctx(ioctx)
             char *_image_name = image_name
+            librbd_progress_fn_t _prog_cb = &no_op_progress_callback
+            void *_prog_arg = NULL
+        if on_progress:
+            _prog_cb = &progress_callback
+            _prog_arg = <void *>on_progress
         with nogil:
-            ret = rbd_migration_execute(_ioctx, _image_name)
+            ret = rbd_migration_execute_with_progress(_ioctx, _image_name,
+                                                      _prog_cb, _prog_arg)
         if ret != 0:
             raise make_ex(ret, 'error aborting migration')
 
-    def migration_commit(self, ioctx, image_name):
+    def migration_commit(self, ioctx, image_name, on_progress=None):
         """
         Commit an executed RBD image migration.
 
@@ -1518,18 +1559,26 @@ class RBD(object):
         :type ioctx: :class:`rados.Ioctx`
         :param image_name: the name of the image
         :type image_name: str
+        :param on_progress: optional progress callback function
+        :type on_progress: callback function
         :raises: :class:`ImageNotFound`
         """
         image_name = cstr(image_name, 'image_name')
         cdef:
             rados_ioctx_t _ioctx = convert_ioctx(ioctx)
             char *_image_name = image_name
+            librbd_progress_fn_t _prog_cb = &no_op_progress_callback
+            void *_prog_arg = NULL
+        if on_progress:
+            _prog_cb = &progress_callback
+            _prog_arg = <void *>on_progress
         with nogil:
-            ret = rbd_migration_commit(_ioctx, _image_name)
+            ret = rbd_migration_commit_with_progress(_ioctx, _image_name,
+                                                     _prog_cb, _prog_arg)
         if ret != 0:
             raise make_ex(ret, 'error aborting migration')
 
-    def migration_abort(self, ioctx, image_name):
+    def migration_abort(self, ioctx, image_name, on_progress=None):
         """
         Cancel a previously started but interrupted migration.
 
@@ -1537,14 +1586,22 @@ class RBD(object):
         :type ioctx: :class:`rados.Ioctx`
         :param image_name: the name of the image
         :type image_name: str
+        :param on_progress: optional progress callback function
+        :type on_progress: callback function
         :raises: :class:`ImageNotFound`
         """
         image_name = cstr(image_name, 'image_name')
         cdef:
             rados_ioctx_t _ioctx = convert_ioctx(ioctx)
             char *_image_name = image_name
+            librbd_progress_fn_t _prog_cb = &no_op_progress_callback
+            void *_prog_arg = NULL
+        if on_progress:
+            _prog_cb = &progress_callback
+            _prog_arg = <void *>on_progress
         with nogil:
-            ret = rbd_migration_abort(_ioctx, _image_name)
+            ret = rbd_migration_abort_with_progress(_ioctx, _image_name,
+                                                    _prog_cb, _prog_arg)
         if ret != 0:
             raise make_ex(ret, 'error aborting migration')
 
@@ -3765,12 +3822,20 @@ written." % (self.name, ret, length))
             raise make_ex(ret, 'error getting modify timestamp for image: %s' % (self.name))
         return datetime.fromtimestamp(timestamp.tv_sec)
 
-    def flatten(self):
+    def flatten(self, on_progress=None):
         """
         Flatten clone image (copy all blocks from parent to child)
+        :param on_progress: optional progress callback function
+        :type on_progress: callback function
         """
+        cdef:
+            librbd_progress_fn_t _prog_cb = &no_op_progress_callback
+            void *_prog_arg = NULL
+        if on_progress:
+            _prog_cb = &progress_callback
+            _prog_arg = <void *>on_progress
         with nogil:
-            ret = rbd_flatten(self.image)
+            ret = rbd_flatten_with_progress(self.image, _prog_cb, _prog_arg)
         if ret < 0:
             raise make_ex(ret, "error flattening %s" % self.name)
 

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -49,6 +49,10 @@ cdef extern from "time.h":
         time_t tv_sec
         long tv_nsec
 
+cdef extern from "<errno.h>" nogil:
+    enum:
+        _ECANCELED "ECANCELED"
+
 cdef extern from "rados/librados.h":
     enum:
         _LIBRADOS_SNAP_HEAD "LIBRADOS_SNAP_HEAD"
@@ -613,6 +617,8 @@ cdef extern from "rbd/librbd.h" nogil:
                                          int stat_option, uint64_t* stat_val)
     int rbd_pool_stats_get(rados_ioctx_t io, rbd_pool_stats_t stats)
 
+ECANCELED = _ECANCELED
+
 RBD_FEATURE_LAYERING = _RBD_FEATURE_LAYERING
 RBD_FEATURE_STRIPINGV2 = _RBD_FEATURE_STRIPINGV2
 RBD_FEATURE_EXCLUSIVE_LOCK = _RBD_FEATURE_EXCLUSIVE_LOCK
@@ -821,6 +827,10 @@ class DiskQuotaExceeded(OSError):
         super(DiskQuotaExceeded, self).__init__(
                 "RBD disk quota exceeded (%s)" % message, errno)
 
+class OperationCanceled(OSError):
+    def __init__(self, message, errno=None):
+        super(OperationCanceled, self).__init__(
+                "RBD operation canceled (%s)" % message, errno)
 
 cdef errno_to_exception = {
     errno.EPERM     : PermissionError,
@@ -837,6 +847,7 @@ cdef errno_to_exception = {
     errno.ESHUTDOWN : ConnectionShutdown,
     errno.ETIMEDOUT : Timeout,
     errno.EDQUOT    : DiskQuotaExceeded,
+    ECANCELED       : OperationCanceled,
 }
 
 cdef group_errno_to_exception = {
@@ -854,6 +865,7 @@ cdef group_errno_to_exception = {
     errno.ESHUTDOWN : ConnectionShutdown,
     errno.ETIMEDOUT : Timeout,
     errno.EDQUOT    : DiskQuotaExceeded,
+    ECANCELED       : OperationCanceled,
 }
 
 cdef make_ex(ret, msg, exception_map=errno_to_exception):

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -1,4 +1,5 @@
 # vim: expandtab smarttab shiftwidth=4 softtabstop=4
+import errno
 import functools
 import socket
 import os
@@ -323,6 +324,24 @@ def test_list():
     with Image(ioctx, image_name) as image:
         image_id = image.id()
     eq([{'id': image_id, 'name': image_name}], list(RBD().list2(ioctx)))
+
+@with_setup(create_image)
+def test_remove_with_progress():
+    d = {'received_callback': False}
+    def progress_cb(current, total):
+        d['received_callback'] = True
+        return 0
+
+    RBD().remove(ioctx, image_name, on_progress=progress_cb)
+    eq(True, d['received_callback'])
+
+@with_setup(create_image)
+def test_remove_canceled():
+    def progress_cb(current, total):
+        return -errno.ESHUTDOWN
+
+    assert_raises(ConnectionShutdown, RBD().remove, ioctx, image_name,
+                  on_progress=progress_cb)
 
 @with_setup(create_image, remove_image)
 def test_rename():
@@ -1519,6 +1538,22 @@ class TestClone(object):
         self.clone.remove_snap('snap2')
         self.rbd.remove(ioctx, clone_name3)
 
+    def test_flatten_with_progress(self):
+        d = {'received_callback': False}
+        def progress_cb(current, total):
+            d['received_callback'] = True
+            return 0
+
+        global ioctx
+        global features
+        clone_name = get_temp_image_name()
+        self.rbd.clone(ioctx, image_name, 'snap1', ioctx, clone_name,
+                       features, 0)
+        with Image(ioctx, clone_name) as clone:
+            clone.flatten(on_progress=progress_cb)
+        self.rbd.remove(ioctx, clone_name)
+        eq(True, d['received_callback'])
+
     def test_resize_flatten_multi_level(self):
         self.clone.create_snap('snap2')
         self.clone.protect_snap('snap2')
@@ -1919,6 +1954,20 @@ class TestTrash(object):
         RBD().trash_move(ioctx, image_name, 0)
         RBD().trash_remove(ioctx, image_id)
 
+    def test_remove_with_progress(self):
+        d = {'received_callback': False}
+        def progress_cb(current, total):
+            d['received_callback'] = True
+            return 0
+
+        create_image()
+        with Image(ioctx, image_name) as image:
+            image_id = image.id()
+
+        RBD().trash_move(ioctx, image_name, 0)
+        RBD().trash_remove(ioctx, image_id, on_progress=progress_cb)
+        eq(True, d['received_callback'])
+
     def test_get(self):
         create_image()
         with Image(ioctx, image_name) as image:
@@ -2165,10 +2214,42 @@ class TestMigration(object):
         RBD().migration_commit(ioctx, image_name)
         remove_image()
 
+    def test_migration_with_progress(self):
+        d = {'received_callback': False}
+        def progress_cb(current, total):
+            d['received_callback'] = True
+            return 0
+
+        create_image()
+        RBD().migration_prepare(ioctx, image_name, ioctx, image_name, features=63,
+                                order=23, stripe_unit=1<<23, stripe_count=1,
+                                data_pool=None)
+        RBD().migration_execute(ioctx, image_name, on_progress=progress_cb)
+        eq(True, d['received_callback'])
+        d['received_callback'] = False
+
+        RBD().migration_commit(ioctx, image_name, on_progress=progress_cb)
+        eq(True, d['received_callback'])
+        remove_image()
+
     def test_migrate_abort(self):
         create_image()
         RBD().migration_prepare(ioctx, image_name, ioctx, image_name, features=63,
                                 order=23, stripe_unit=1<<23, stripe_count=1,
                                 data_pool=None)
         RBD().migration_abort(ioctx, image_name)
+        remove_image()
+
+    def test_migrate_abort_with_progress(self):
+        d = {'received_callback': False}
+        def progress_cb(current, total):
+            d['received_callback'] = True
+            return 0
+
+        create_image()
+        RBD().migration_prepare(ioctx, image_name, ioctx, image_name, features=63,
+                                order=23, stripe_unit=1<<23, stripe_count=1,
+                                data_pool=None)
+        RBD().migration_abort(ioctx, image_name, on_progress=progress_cb)
+        eq(True, d['received_callback'])
         remove_image()

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -16,6 +16,7 @@ from rados import (Rados,
 from rbd import (RBD, Group, Image, ImageNotFound, InvalidArgument, ImageExists,
                  ImageBusy, ImageHasSnapshots, ReadOnlyImage,
                  FunctionNotSupported, ArgumentOutOfRange,
+                 ECANCELED, OperationCanceled,
                  DiskQuotaExceeded, ConnectionShutdown, PermissionError,
                  RBD_FEATURE_LAYERING, RBD_FEATURE_STRIPINGV2,
                  RBD_FEATURE_EXCLUSIVE_LOCK, RBD_FEATURE_JOURNALING,
@@ -338,9 +339,9 @@ def test_remove_with_progress():
 @with_setup(create_image)
 def test_remove_canceled():
     def progress_cb(current, total):
-        return -errno.ESHUTDOWN
+        return -ECANCELED
 
-    assert_raises(ConnectionShutdown, RBD().remove, ioctx, image_name,
+    assert_raises(OperationCanceled, RBD().remove, ioctx, image_name,
                   on_progress=progress_cb)
 
 @with_setup(create_image, remove_image)


### PR DESCRIPTION
Certain RBD operations might take a long (blocking) amount of time so it would be preferable if we offered a way to schedule these tasks to run in the background. We would expose the ability to manage these background tasks via the MGR's "rbd_support" module via "ceph" CLI commands similar to the following:

    ceph rbd task add flatten <image-spec>
    ceph rbd task add remove <image-spec>
    ceph rbd task add trash remove <image-id-spec>
    ceph rbd task add migration execute <image-spec>
    ceph rbd task add migration commit <image-spec>
    ceph rbd task add migration abort <image-spec>
    ceph rbd task cancel <task-id>
    ceph rbd task list

The `ceph-csi` will be one of the first to utilize these new background tasks to offload its workload and support proper re-starting of in-progress events.