### PR TITLE
rgw: add check for index entry's existing when adding bucket stats during bucket reshard.

### DIFF
--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -261,6 +261,7 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
       {
         rgw_bucket_dir_entry entry;
         decode(entry, iter);
+        account = (account && entry.exists);
         *key = entry.key;
         *category = entry.meta.category;
         accounted_stats->num_entries++;


### PR DESCRIPTION
If we  reshard versioning bucket, bucket stats will contain extra information `rgw.none`.
Before reshard：
```
"mtime": "2019-07-16T09:39:07.175539Z",
    "max_marker": "0#,1#,2#",
    "usage": {
        "rgw.main": {
            "size": 2,
            "size_actual": 4096,
            "size_utilized": 2,
            "size_kb": 1,
            "size_kb_actual": 4,
            "size_kb_utilized": 1,
            "num_objects": 1
        }
    },
```
After reshard：
```
"mtime": "2019-07-17T02:36:12.490795Z",
    "max_marker": "0#,1#,2#,3#,4#",
    "usage": {
        "rgw.none": {
            "size": 0,
            "size_actual": 0,
            "size_utilized": 0,
            "size_kb": 0,
            "size_kb_actual": 0,
            "size_kb_utilized": 0,
            "num_objects": 1
        },
        "rgw.main": {
            "size": 2,
            "size_actual": 4096,
            "size_utilized": 2,
            "size_kb": 1,
            "size_kb_actual": 4,
            "size_kb_utilized": 1,
            "num_objects": 1
        }
    },
```

Versioning bucket has idx like below and it's counted in stats while resharding bucket.
```
"type": "plain",
        "idx": "obj10",
        "entry": {
            "name": "obj10",
            "instance": "",
            "ver": {
                "pool": -1,
                "epoch": 0
            },
            "locator": "",
            "exists": "false",
            "meta": {
                "category": 0,
                "size": 0,
                "mtime": "0.000000",
                "etag": "",
                "storage_class": "",
                "owner": "",
                "owner_display_name": "",
                "content_type": "",
                "accounted_size": 0,
                "user_data": "",
                "appendable": "false"
            },
            "tag": "",
            "flags": 8,
            "pending_map": [],
            "versioned_epoch": 0
        }

```

Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>



