### PR TITLE
qa/tasks: add exception in do_thrash()

### DIFF
--- a/qa/tasks/mon_thrash.py
+++ b/qa/tasks/mon_thrash.py
@@ -89,6 +89,7 @@ class MonitorThrasher:
         self.manager = manager
         self.manager.wait_for_clean()
 
+        self.e = None
         self.stopping = False
         self.logger = logger
         self.config = config
@@ -220,6 +221,19 @@ class MonitorThrasher:
             return m
 
     def do_thrash(self):
+        """
+        _do_thrash() wrapper.
+        """
+        try:
+            self._do_thrash()
+        except Exception as e:
+            # See _run exception comment for MDSThrasher
+            self.e = e
+            self.logger.exception("exception:")
+            # Allow successful completion so gevent doesn't see an exception.
+            # The DaemonWatchdog will observe the error and tear down the test.
+
+    def _do_thrash(self):
         """
         Continuously loop and thrash the monitors.
         """


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/teuthworker/src/github.com_ceph_ceph-c_wip-daemonwatchdog-testing13/qa/tasks/daemonwatchdog.py", line 38, in _run
    self.watch()
  File "/home/teuthworker/src/github.com_ceph_ceph-c_wip-daemonwatchdog-testing13/qa/tasks/daemonwatchdog.py", line 112, in watch
    if thrasher.e is not None:
AttributeError: MonitorThrasher instance has no attribute 'e'
```

This happens in the DaemonWatchdog testing simulating OSD Segfaults [1]. 
[1] http://qa-proxy.ceph.com/teuthology/jcollin-2019-07-09_10:16:36-fs-wip-daemonwatchdog-testing13-distro-basic-smithi/4105469/teuthology.log

Additionally, mon_thrash.py doesn't have the `_run()` function as in `mds_thrash.py`. I think it's better rewrite `mon_thrash.py`, introduce a `_run()` and make it similar to `mds_thrash.py`.