### PR TITLE
os/bluestore: cleanup around allocator calls

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2497,8 +2497,8 @@ int BlueFS::_allocate_without_fallback(uint8_t id, uint64_t len,
   }
   extents->reserve(4);  // 4 should be (more than) enough for most allocations
   int64_t alloc_len = alloc[id]->allocate(left, min_alloc_size, 0, extents);
-  if (alloc_len < (int64_t)left) {
-    if (alloc_len != 0) {
+  if (alloc_len < 0 || alloc_len < (int64_t)left) {
+    if (alloc_len > 0) {
       alloc[id]->release(*extents);
     }
     if (bdev[id])
@@ -2536,7 +2536,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
     extents.reserve(4);  // 4 should be (more than) enough for most allocations
     alloc_len = alloc[id]->allocate(left, min_alloc_size, hint, &extents);
   }
-  if (alloc_len < (int64_t)left) {
+  if (alloc_len < 0 || alloc_len < (int64_t)left) {
     if (alloc_len > 0) {
       alloc[id]->release(extents);
     }
@@ -2566,7 +2566,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
       ceph_assert(last_alloc);
       // try again
       alloc_len = last_alloc->allocate(left, min_alloc_size, hint, &extents);
-      if (alloc_len < (int64_t)left) {
+      if (alloc_len < 0 || alloc_len < (int64_t)left) {
 	if (alloc_len > 0) {
 	  last_alloc->release(extents);
 	}

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5615,18 +5615,19 @@ int BlueStore::allocate_bluefs_freespace(
 
       alloc_len = alloc->allocate(gift, cct->_conf->bluefs_alloc_size,
 				  0, 0, extents);
-      if (alloc_len) {
+      if (alloc_len > 0) {
 	allocated += alloc_len;
 	size -= alloc_len;
       }
 
-      if (alloc_len < (int64_t)gift && (min_size > allocated)) {
+      if (alloc_len < 0 || 
+          (alloc_len < (int64_t)gift && (min_size > allocated))) {
 	derr << __func__
 	      << " failed to allocate on 0x" << std::hex << gift
 	      << " min_size 0x" << min_size
 	      << " > allocated total 0x" << allocated
 	      << " bluefs_alloc_size 0x" << cct->_conf->bluefs_alloc_size
-	      << " allocated 0x" << alloc_len
+	      << " allocated 0x" << (alloc_len < 0 ? 0 : alloc_len)
 	      << " available 0x " << alloc->get_free()
 	      << std::dec << dendl;
 
@@ -7579,10 +7580,10 @@ int BlueStore::_fsck(bool deep, bool repair)
 	    PExtentVector exts;
 	    int64_t alloc_len = alloc->allocate(e->length, min_alloc_size,
 						0, 0, &exts);
-	    if (alloc_len < (int64_t)e->length) {
+	    if (alloc_len < 0 || alloc_len < (int64_t)e->length) {
 	      derr << __func__
 	           << " failed to allocate 0x" << std::hex << e->length
-		   << " allocated 0x " << alloc_len
+		   << " allocated 0x " << (alloc_len < 0 ? 0 : alloc_len)
 		   << " min_alloc_size 0x" << min_alloc_size
 		   << " available 0x " << alloc->get_free()
 		   << std::dec << dendl;
@@ -12129,9 +12130,9 @@ int BlueStore::_do_alloc_write(
   prealloc_left = alloc->allocate(
     need, min_alloc_size, need,
     0, &prealloc);
-  if (prealloc_left < (int64_t)need) {
+  if (prealloc_left < 0 || prealloc_left < (int64_t)need) {
     derr << __func__ << " failed to allocate 0x" << std::hex << need
-         << " allocated 0x " << prealloc_left
+         << " allocated 0x " << (prealloc_left < 0 ? 0 : prealloc_left)
          << " min_alloc_size 0x" << min_alloc_size
          << " available 0x " << alloc->get_free()
          << std::dec << dendl;


### PR DESCRIPTION
Both stupid and bitmap allocator returs -ENOSPC if they're
unable to allocate any space. Existing callers aren't always
respect this - hence doing some cleanup.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

