### PR TITLE
mon: always enable pg_autoscaler

### DIFF
--- a/qa/releases/nautilus.yaml
+++ b/qa/releases/nautilus.yaml
@@ -3,4 +3,5 @@ tasks:
     osd.0:
       - ceph osd require-osd-release nautilus
       - ceph osd set-require-min-compat-client nautilus
+      - for p in `ceph osd pool ls`; do ceph osd pool set $p pg_autoscale_mode off; done
 - ceph.healthy:

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -18,6 +18,9 @@
 	mon max pg per osd = 10000        # >= luminous
 	mon pg warn max object skew = 0
 
+	# disable pg_autoscaler by default for new pools
+        osd_pool_default_pg_autoscale_mode = off
+
 	osd pool default size = 2
 
 	mon osd allow primary affinity = true

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -60,6 +60,7 @@ const static std::map<uint32_t, std::set<std::string>> always_on_modules = {
       "devicehealth",
       "orchestrator_cli",
       "volumes",
+      "pg_autoscaler",
     }
   }
 };


### PR DESCRIPTION
This different from https://github.com/ceph/ceph/pull/29049 in that the module can't be turned off, and there is no additional step to take during upgrade.

FWIW I think this is a better path.  The autoscaler was introduced in nautilus and in octopus it will be on by default. If users don't like it, they can set each pool's pg_autoscale_mode to off. The only upgrade "pain" is that by default they will get PG count warnings when the current pg_num differs from the module's recommendation by >3x.  I think that's what we want..