### PR TITLE
crimson/osd: implement replicated write

### DIFF
--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -12,9 +12,10 @@ add_executable(crimson-osd
   shard_services.cc
   osd_operation.cc
   osd_operations/client_request.cc
-  osd_operations/peering_event.cc
   osd_operations/compound_peering_request.cc
+  osd_operations/peering_event.cc
   osd_operations/pg_advance_map.cc
+  osd_operations/replicated_request.cc
   osdmap_gate.cc
   pg_map.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PeeringState.cc

--- a/src/crimson/osd/acked_peers.h
+++ b/src/crimson/osd/acked_peers.h
@@ -1,0 +1,25 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106900
+#include <boost/container/small_vector.hpp>
+#else
+#include <vector>
+#endif
+
+namespace ceph::osd {
+  struct peer_shard_t {
+    pg_shard_t shard;
+    eversion_t last_complete_ondisk;
+  };
+#if BOOST_VERSION >= 106900
+  // small_vector is is_nothrow_move_constructible<> since 1.69
+  // 2 + 1 = 3, which is the default value of "osd_pool_default_size"
+  using acked_peers_t = boost::container::small_vector<peer_shard_t, 2>;
+#else
+  using acked_peers_t = std::vector<peer_shard_t>;
+#endif
+}

--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -1,12 +1,14 @@
 #include "ec_backend.h"
+
 #include "crimson/os/cyan_collection.h"
+#include "crimson/osd/shard_services.h"
 
 ECBackend::ECBackend(shard_id_t shard,
                      ECBackend::CollectionRef coll,
-                     ceph::os::FuturizedStore* store,
+                     ceph::osd::ShardServices& shard_services,
                      const ec_profile_t&,
                      uint64_t)
-  : PGBackend{shard, coll, store}
+  : PGBackend{shard, coll, &shard_services.get_store()}
 {
   // todo
 }
@@ -18,4 +20,16 @@ seastar::future<bufferlist> ECBackend::_read(const hobject_t& hoid,
 {
   // todo
   return seastar::make_ready_future<bufferlist>();
+}
+
+seastar::future<ceph::osd::acked_peers_t>
+ECBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
+                               const hobject_t& hoid,
+                               ceph::os::Transaction&& txn,
+                               osd_reqid_t req_id,
+                               epoch_t min_epoch, epoch_t max_epoch,
+                               eversion_t ver)
+{
+  // todo
+  return seastar::make_ready_future<ceph::osd::acked_peers_t>();
 }

--- a/src/crimson/osd/ec_backend.h
+++ b/src/crimson/osd/ec_backend.h
@@ -13,7 +13,8 @@ class ECBackend : public PGBackend
 {
 public:
   ECBackend(shard_id_t shard,
-	    CollectionRef, ceph::os::FuturizedStore*,
+	    CollectionRef coll,
+	    ceph::osd::ShardServices& shard_services,
 	    const ec_profile_t& ec_profile,
 	    uint64_t stripe_width);
 private:
@@ -21,6 +22,13 @@ private:
 					  uint64_t off,
 					  uint64_t len,
 					  uint32_t flags) override;
+  seastar::future<ceph::osd::acked_peers_t>
+  _submit_transaction(std::set<pg_shard_t>&& pg_shards,
+		      const hobject_t& hoid,
+		      ceph::os::Transaction&& txn,
+		      osd_reqid_t req_id,
+		      epoch_t min_epoch, epoch_t max_epoch,
+		      eversion_t ver) final;
   CollectionRef coll;
   ceph::os::FuturizedStore* store;
 };

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -34,10 +34,11 @@
 #include "crimson/osd/pg.h"
 #include "crimson/osd/pg_backend.h"
 #include "crimson/osd/pg_meta.h"
+#include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_operations/compound_peering_request.h"
 #include "crimson/osd/osd_operations/peering_event.h"
 #include "crimson/osd/osd_operations/pg_advance_map.h"
-#include "crimson/osd/osd_operations/client_request.h"
+#include "crimson/osd/osd_operations/replicated_request.h"
 
 namespace {
   seastar::logger& logger() {
@@ -479,6 +480,8 @@ seastar::future<> OSD::ms_dispatch(ceph::net::Connection* conn, MessageRef m)
     return seastar::now();
   case MSG_OSD_PG_LOG:
     return handle_pg_log(conn, boost::static_pointer_cast<MOSDPGLog>(m));
+  case MSG_OSD_REPOP:
+    return handle_rep_op(conn, boost::static_pointer_cast<MOSDRepOp>(m));
   case MSG_OSD_REPOPREPLY:
     return handle_rep_op_reply(conn, boost::static_pointer_cast<MOSDRepOpReply>(m));
   default:
@@ -856,11 +859,23 @@ seastar::future<> OSD::handle_osd_op(ceph::net::Connection* conn,
   return seastar::now();
 }
 
+seastar::future<> OSD::handle_rep_op(ceph::net::Connection* conn,
+				     Ref<MOSDRepOp> m)
+{
+  m->finish_decode();
+  shard_services.start_operation<RepRequest>(
+    *this,
+    conn->get_shared(),
+    std::move(m));
+  return seastar::now();
+}
+
 seastar::future<> OSD::handle_rep_op_reply(ceph::net::Connection* conn,
 					   Ref<MOSDRepOpReply> m)
 {
   const auto& pgs = pg_map.get_pgs();
   if (auto pg = pgs.find(m->get_spg()); pg != pgs.end()) {
+    m->finish_decode();
     pg->second->handle_rep_op_reply(conn, *m);
   } else {
     logger().warn("stale reply: {}", *m);

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -35,6 +35,7 @@
 class MOSDMap;
 class MOSDOp;
 class MOSDRepOpReply;
+class MOSDRepOp;
 class OSDMap;
 class OSDMeta;
 class Heartbeat;
@@ -165,6 +166,8 @@ private:
                                    Ref<MOSDMap> m);
   seastar::future<> handle_osd_op(ceph::net::Connection* conn,
 				  Ref<MOSDOp> m);
+  seastar::future<> handle_rep_op(ceph::net::Connection* conn,
+				  Ref<MOSDRepOp> m);
   seastar::future<> handle_rep_op_reply(ceph::net::Connection* conn,
 					Ref<MOSDRepOpReply> m);
   seastar::future<> handle_pg_log(ceph::net::Connection* conn,

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -34,6 +34,7 @@
 
 class MOSDMap;
 class MOSDOp;
+class MOSDRepOpReply;
 class OSDMap;
 class OSDMeta;
 class Heartbeat;
@@ -164,6 +165,8 @@ private:
                                    Ref<MOSDMap> m);
   seastar::future<> handle_osd_op(ceph::net::Connection* conn,
 				  Ref<MOSDOp> m);
+  seastar::future<> handle_rep_op_reply(ceph::net::Connection* conn,
+					Ref<MOSDRepOpReply> m);
   seastar::future<> handle_pg_log(ceph::net::Connection* conn,
 				  Ref<MOSDPGLog> m);
 

--- a/src/crimson/osd/osd_connection_priv.h
+++ b/src/crimson/osd/osd_connection_priv.h
@@ -7,12 +7,14 @@
 #include "crimson/osd/osd_operation.h"
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_operations/peering_event.h"
+#include "crimson/osd/osd_operations/replicated_request.h"
 
 namespace ceph::osd {
 
 struct OSDConnectionPriv : public ceph::net::Connection::user_private_t {
   ClientRequest::ConnectionPipeline client_request_conn_pipeline;
   RemotePeeringEvent::ConnectionPipeline peering_request_conn_pipeline;
+  RepRequest::ConnectionPipeline replicated_request_conn_pipeline;
 };
 
 static OSDConnectionPriv &get_osd_priv(ceph::net::Connection *conn) {

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -24,7 +24,8 @@ enum class OperationTypeCode {
   compound_peering_request = 2,
   pg_advance_map = 3,
   pg_creation = 4,
-  last_op = 5
+  replicated_request = 5,
+  last_op = 6
 };
 
 static constexpr const char* const OP_NAMES[] = {
@@ -33,6 +34,7 @@ static constexpr const char* const OP_NAMES[] = {
   "compound_peering_request",
   "pg_advance_map",
   "pg_creation",
+  "replicated_request",
 };
 
 // prevent the addition of OperationTypeCode-s with no matching OP_NAMES entry:

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -1,0 +1,74 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "replicated_request.h"
+
+#include "common/Formatter.h"
+#include "messages/MOSDRepOp.h"
+
+#include "crimson/osd/osd.h"
+#include "crimson/osd/osd_connection_priv.h"
+#include "crimson/osd/pg.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace ceph::osd {
+
+RepRequest::RepRequest(OSD &osd,
+		       ceph::net::ConnectionRef&& conn,
+		       Ref<MOSDRepOp> &&req)
+  : osd{osd},
+    conn{std::move(conn)},
+    req{req}
+{}
+
+void RepRequest::print(std::ostream& os) const
+{
+  os << "RepRequest("
+     << "from=" << req->from
+     << " req=" << *req
+     << ")";
+}
+
+void RepRequest::dump_detail(Formatter *f) const
+{
+  f->open_object_section("RepRequest");
+  f->dump_stream("reqid") << req->reqid;
+  f->dump_stream("pgid") << req->get_spg();
+  f->dump_unsigned("map_epoch", req->get_map_epoch());
+  f->dump_unsigned("min_epoch", req->get_min_epoch());
+  f->dump_stream("oid") << req->poid;
+  f->dump_stream("from") << req->from;
+  f->close_section();
+}
+
+RepRequest::ConnectionPipeline &RepRequest::cp()
+{
+  return get_osd_priv(conn.get()).replicated_request_conn_pipeline;
+}
+
+RepRequest::PGPipeline &RepRequest::pp(PG &pg)
+{
+  return pg.replicated_request_pg_pipeline;
+}
+
+seastar::future<> RepRequest::start()
+{
+  logger().info("{} start", *this);
+  IRef ref = this;
+  return with_blocking_future(handle.enter(cp().await_map))
+    .then([this]() {
+      return with_blocking_future(osd.osdmap_gate.wait_for_map(req->get_min_epoch()));
+    }).then([this](epoch_t epoch) {
+      return with_blocking_future(handle.enter(cp().get_pg));
+    }).then([this] {
+      return with_blocking_future(osd.wait_for_pg(req->get_spg()));
+    }).then([this, ref=std::move(ref)](Ref<PG> pg) {
+      return pg->handle_rep_op(std::move(req));
+    });
+}
+}

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/net/Connection.h"
+#include "crimson/osd/osd_operation.h"
+#include "crimson/common/type_helpers.h"
+
+class MOSDRepOp;
+
+namespace ceph::osd {
+
+class OSD;
+class PG;
+
+class RepRequest final : public OperationT<RepRequest> {
+public:
+  class ConnectionPipeline {
+    OrderedPipelinePhase await_map = {
+      "RepRequest::ConnectionPipeline::await_map"
+    };
+    OrderedPipelinePhase get_pg = {
+      "RepRequest::ConnectionPipeline::get_pg"
+    };
+    friend RepRequest;
+  };
+  class PGPipeline {
+    OrderedPipelinePhase await_map = {
+      "RepRequest::PGPipeline::await_map"
+    };
+    OrderedPipelinePhase process = {
+      "RepRequest::PGPipeline::process"
+    };
+    friend RepRequest;
+  };
+  static constexpr OperationTypeCode type = OperationTypeCode::replicated_request;
+  RepRequest(OSD&, ceph::net::ConnectionRef&&, Ref<MOSDRepOp>&&);
+
+  void print(std::ostream &) const final;
+  void dump_detail(Formatter *f) const final;
+  seastar::future<> start();
+
+private:
+  ConnectionPipeline &cp();
+  PGPipeline &pp(PG &pg);
+
+  OSD &osd;
+  ceph::net::ConnectionRef conn;
+  Ref<MOSDRepOp> req;
+  OrderedPipelinePhase::Handle handle;
+};
+
+}

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -260,6 +260,7 @@ void PG::do_peering_event(
   peering_state.handle_event(
     evt,
     &rctx);
+  peering_state.write_if_dirty(rctx.transaction);
 }
 
 void PG::do_peering_event(

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -124,6 +124,11 @@ bool PG::try_flush_or_schedule_async() {
   return false;
 }
 
+void PG::on_activate(interval_set<snapid_t>)
+{
+  projected_last_update = peering_state.get_info().last_update;
+}
+
 void PG::on_activate_complete()
 {
   active_promise.set_value();

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -268,7 +268,7 @@ void PG::do_peering_event(
 {
   if (!peering_state.pg_has_reset_since(evt.get_epoch_requested())) {
     logger().debug("{} handling {}", __func__, evt.get_desc());
-    return do_peering_event(evt.get_event(), rctx);
+    do_peering_event(evt.get_event(), rctx);
   } else {
     logger().debug("{} ignoring {} -- pg has reset", __func__, evt.get_desc());
   }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -417,6 +417,9 @@ public:
   void handle_initialize(PeeringCtx &rctx);
   seastar::future<> handle_op(ceph::net::Connection* conn,
 			      Ref<MOSDOp> m);
+  void handle_rep_op_reply(ceph::net::Connection* conn,
+			   const MOSDRepOpReply& m);
+
   void print(std::ostream& os) const;
 
 private:
@@ -431,6 +434,9 @@ private:
   seastar::future<ceph::bufferlist> do_pgnls(ceph::bufferlist& indata,
 					     const std::string& nspace,
 					     uint64_t limit);
+  seastar::future<> submit_transaction(boost::local_shared_ptr<ObjectState>&& os,
+				       ceph::os::Transaction&& txn,
+				       const MOSDOp& req);
 
 private:
   OSDMapGate osdmap_gate;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -257,9 +257,7 @@ public:
   void on_change(ObjectStore::Transaction &t) final {
     // Not needed yet
   }
-  void on_activate(interval_set<snapid_t> to_trim) final {
-    // Not needed yet (will be needed for IO unblocking)
-  }
+  void on_activate(interval_set<snapid_t> to_trim) final;
   void on_activate_complete() final;
   void on_new_interval() final {
     // Not needed yet
@@ -442,6 +440,7 @@ private:
   std::unique_ptr<PGBackend> backend;
 
   PeeringState peering_state;
+  eversion_t projected_last_update;
 
   seastar::shared_promise<> active_promise;
   seastar::future<> wait_for_active();

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -21,6 +21,7 @@
 #include "crimson/common/type_helpers.h"
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_operations/peering_event.h"
+#include "crimson/osd/osd_operations/replicated_request.h"
 #include "crimson/osd/shard_services.h"
 #include "crimson/osd/osdmap_gate.h"
 
@@ -54,6 +55,7 @@ class PG : public boost::intrusive_ref_counter<
 
   ClientRequest::PGPipeline client_request_pg_pipeline;
   PeeringEvent::PGPipeline peering_request_pg_pipeline;
+  RepRequest::PGPipeline replicated_request_pg_pipeline;
 
   spg_t pgid;
   pg_shard_t pg_whoami;
@@ -417,6 +419,7 @@ public:
   void handle_initialize(PeeringCtx &rctx);
   seastar::future<> handle_op(ceph::net::Connection* conn,
 			      Ref<MOSDOp> m);
+  seastar::future<> handle_rep_op(Ref<MOSDRepOp> m);
   void handle_rep_op_reply(ceph::net::Connection* conn,
 			   const MOSDRepOpReply& m);
 
@@ -453,8 +456,9 @@ private:
 
   friend std::ostream& operator<<(std::ostream&, const PG& pg);
   friend class ClientRequest;
-  friend class PeeringEvent;
   friend class PGAdvanceMap;
+  friend class PeeringEvent;
+  friend class RepRequest;
 };
 
 std::ostream& operator<<(std::ostream&, const PG& pg);

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -1,13 +1,27 @@
 #include "replicated_backend.h"
 
+#include "messages/MOSDRepOpReply.h"
+
+#include "crimson/common/log.h"
 #include "crimson/os/cyan_collection.h"
 #include "crimson/os/cyan_object.h"
 #include "crimson/os/futurized_store.h"
+#include "crimson/osd/shard_services.h"
 
-ReplicatedBackend::ReplicatedBackend(shard_id_t shard,
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+ReplicatedBackend::ReplicatedBackend(pg_t pgid,
+                                     pg_shard_t whoami,
                                      ReplicatedBackend::CollectionRef coll,
-                                     ceph::os::FuturizedStore* store)
-  : PGBackend{shard, coll, store}
+                                     ceph::osd::ShardServices& shard_services)
+  : PGBackend{whoami.shard, coll, &shard_services.get_store()},
+    pgid{pgid},
+    whoami{whoami},
+    shard_services{shard_services}
 {}
 
 seastar::future<bufferlist> ReplicatedBackend::_read(const hobject_t& hoid,
@@ -16,4 +30,66 @@ seastar::future<bufferlist> ReplicatedBackend::_read(const hobject_t& hoid,
                                                      uint32_t flags)
 {
   return store->read(coll, ghobject_t{hoid}, off, len, flags);
+}
+
+seastar::future<ceph::osd::acked_peers_t>
+ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
+                                       const hobject_t& hoid,
+                                       ceph::os::Transaction&& txn,
+                                       osd_reqid_t req_id,
+                                       epoch_t min_epoch, epoch_t map_epoch,
+                                       eversion_t ver)
+{
+  const ceph_tid_t tid = next_txn_id++;
+  auto pending_txn =
+    pending_trans.emplace(tid, pending_on_t{pg_shards.size()}).first;
+  bufferlist encoded_txn;
+  encode(txn, encoded_txn);
+
+  return seastar::parallel_for_each(std::move(pg_shards),
+    [=, encoded_txn=std::move(encoded_txn), txn=std::move(txn)]
+    (auto pg_shard) mutable {
+      if (pg_shard == whoami) {
+        return shard_services.get_store().do_transaction(coll,std::move(txn));
+      } else {
+        auto m = make_message<MOSDRepOp>(req_id, whoami,
+                                         spg_t{pgid, pg_shard.shard}, hoid,
+                                         CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK,
+                                         map_epoch, min_epoch,
+                                         tid, ver);
+        m->set_data(encoded_txn);
+        pending_txn->second.acked_peers.push_back({pg_shard, eversion_t{}});
+        // TODO: set more stuff. e.g., pg_states
+        return shard_services.send_to_osd(pg_shard.osd, std::move(m), map_epoch);
+      }
+    }).then([&peers=pending_txn->second] {
+      if (--peers.pending == 0) {
+        peers.all_committed.set_value();
+      }
+      return peers.all_committed.get_future();
+    }).then([tid, pending_txn, this] {
+      pending_txn->second.all_committed = {};
+      auto acked_peers = std::move(pending_txn->second.acked_peers);
+      pending_trans.erase(pending_txn);
+      return seastar::make_ready_future<ceph::osd::acked_peers_t>(std::move(acked_peers));
+    });
+}
+
+void ReplicatedBackend::got_rep_op_reply(const MOSDRepOpReply& reply)
+{
+  auto found = pending_trans.find(reply.get_tid());
+  if (found == pending_trans.end()) {
+    logger().warn("{}: no matched pending rep op: {}", __func__, reply);
+    return;
+  }
+  auto& peers = found->second;
+  for (auto& peer : peers.acked_peers) {
+    if (peer.shard == reply.from) {
+      peer.last_complete_ondisk = reply.get_last_complete_ondisk();
+      if (--peers.pending == 0) {
+        peers.all_committed.set_value();    
+      }
+      return;
+    }
+  }
 }

--- a/src/crimson/osd/replicated_backend.h
+++ b/src/crimson/osd/replicated_backend.h
@@ -7,17 +7,45 @@
 #include <seastar/core/future.hh>
 #include "include/buffer_fwd.h"
 #include "osd/osd_types.h"
+
+#include "acked_peers.h"
 #include "pg_backend.h"
+
+namespace ceph::osd {
+  class ShardServices;
+}
 
 class ReplicatedBackend : public PGBackend
 {
 public:
-  ReplicatedBackend(shard_id_t shard,
+  ReplicatedBackend(pg_t pgid, pg_shard_t whoami,
 		    CollectionRef coll,
-		    ceph::os::FuturizedStore* store);
+		    ceph::osd::ShardServices& shard_services);
+  void got_rep_op_reply(const MOSDRepOpReply& reply) final;
 private:
   seastar::future<ceph::bufferlist> _read(const hobject_t& hoid,
 					  uint64_t off,
 					  uint64_t len,
 					  uint32_t flags) override;
+  seastar::future<ceph::osd::acked_peers_t>
+  _submit_transaction(std::set<pg_shard_t>&& pg_shards,
+		      const hobject_t& hoid,
+		      ceph::os::Transaction&& txn,
+		      osd_reqid_t req_id,
+		      epoch_t min_epoch, epoch_t max_epoch,
+		      eversion_t ver) final;
+  const pg_t pgid;
+  const pg_shard_t whoami;
+  ceph::osd::ShardServices& shard_services;
+  ceph_tid_t next_txn_id = 0;
+  struct pending_on_t {
+    pending_on_t(size_t pending)
+      : pending{static_cast<unsigned>(pending)}
+    {}
+    unsigned pending;
+    ceph::osd::acked_peers_t acked_peers;
+    seastar::promise<> all_committed;
+  };
+  using pending_transactions_t = std::map<ceph_tid_t, pending_on_t>;
+  pending_transactions_t pending_trans;
 };

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -49,7 +49,12 @@ ShardServices::ShardServices(
 
 seastar::future<> ShardServices::send_to_osd(
   int peer, Ref<Message> m, epoch_t from_epoch) {
-  if (osdmap->is_down(peer) || osdmap->get_info(peer).up_from > from_epoch) {
+  if (osdmap->is_down(peer)) {
+    logger().info("{}: osd.{} is_down", __func__, peer);
+    return seastar::now();
+  } else if (osdmap->get_info(peer).up_from > from_epoch) {
+    logger().info("{}: osd.{} {} > {}", __func__, peer,
+		    osdmap->get_info(peer).up_from, from_epoch);
     return seastar::now();
   } else {
     return cluster_msgr.connect(osdmap->get_cluster_addrs(peer).front(),


### PR DESCRIPTION
- [x] `bin/rados -p foo put test-object /etc/passwd` works with 3-replica crimson cluster.
- [x] run perf test against this change
- [ ] will add pipe line support in a follow-up PR.