### PR TITLE
Documentation: Add missing ceph-volume lvm batch argument to ceph-volume.rst

### DIFF
--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -85,12 +85,10 @@ Optional arguments:
 * [--dmcrypt]           Enable encryption for the underlying OSD devices
 * [--crush-device-class] Define a CRUSH device class to assign the OSD to
 * [--no-systemd]         Do not enable or create any systemd units
-* [--report]         Report what the potential outcome would be for the
-                     current input (requires devices to be passed in)
-* [--format]         Output format when reporting (used along with
-                     --report), can be one of 'pretty' (default) or 'json'
-* [--block-db-size]     Set (or override) the "bluestore_block_db_size" value,
-                        in bytes
+* [--osds-per-device]   Provision more than 1 (the default) OSD per device
+* [--report]         Report what the potential outcome would be for the current input (requires devices to be passed in)
+* [--format]         Output format when reporting (used along with --report), can be one of 'pretty' (default) or 'json'
+* [--block-db-size]     Set (or override) the "bluestore_block_db_size" value, in bytes
 * [--journal-size]      Override the "osd_journal_size" value, in megabytes
 
 Required positional arguments:


### PR DESCRIPTION
doc: The optional argument '--osds-per-device' is missing. Since this is quite helpful when creating NVMe based OSDs, it should be documented.

Signed-off-by: Andreas Krebs <wintamute@gmail.com>