### PR TITLE
rgw: use get_val and observer api

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1250,10 +1250,8 @@ OPTION(rados_tracing, OPT_BOOL) // true if LTTng-UST tracepoints should be enabl
 
 
 OPTION(rgw_max_chunk_size, OPT_INT)
-OPTION(rgw_put_obj_min_window_size, OPT_INT)
 OPTION(rgw_put_obj_max_window_size, OPT_INT)
 OPTION(rgw_max_put_size, OPT_U64)
-OPTION(rgw_max_put_param_size, OPT_U64) // max input size for PUT requests accepting json/xml params
 
 /**
  * override max bucket index shards in zone configuration (if not zero)
@@ -1274,273 +1272,40 @@ OPTION(rgw_bucket_index_max_aio, OPT_U32)
 /**
  * whether or not the quota/gc threads should be started
  */
-OPTION(rgw_enable_quota_threads, OPT_BOOL)
-OPTION(rgw_enable_gc_threads, OPT_BOOL)
 OPTION(rgw_enable_lc_threads, OPT_BOOL)
 
 
 OPTION(rgw_data, OPT_STR)
 OPTION(rgw_enable_apis, OPT_STR)
-OPTION(rgw_cache_enabled, OPT_BOOL)   // rgw cache enabled
-OPTION(rgw_cache_lru_size, OPT_INT)   // num of entries in rgw cache
-OPTION(rgw_socket_path, OPT_STR)   // path to unix domain socket, if not specified, rgw will not run as external fcgi
 OPTION(rgw_host, OPT_STR)  // host for radosgw, can be an IP, default is 0.0.0.0
 OPTION(rgw_port, OPT_STR)  // port to listen, format as "8080" "5000", if not specified, rgw will not run external fcgi
-OPTION(rgw_dns_name, OPT_STR) // hostname suffix on buckets
-OPTION(rgw_dns_s3website_name, OPT_STR) // hostname suffix on buckets for s3-website endpoint
-OPTION(rgw_service_provider_name, OPT_STR) //service provider name which is contained in http response headers
-OPTION(rgw_content_length_compat, OPT_BOOL) // Check both HTTP_CONTENT_LENGTH and CONTENT_LENGTH in fcgi env
-OPTION(rgw_lifecycle_work_time, OPT_STR) //job process lc  at 00:00-06:00s
-OPTION(rgw_lc_lock_max_time, OPT_INT)  // total run time for a single lc processor work
-OPTION(rgw_lc_max_objs, OPT_INT)
-OPTION(rgw_lc_max_rules, OPT_U32)  // Max rules set on one bucket
-OPTION(rgw_lc_debug_interval, OPT_INT)  // Debug run interval, in seconds
-OPTION(rgw_script_uri, OPT_STR) // alternative value for SCRIPT_URI if not set in request
-OPTION(rgw_request_uri, OPT_STR) // alternative value for REQUEST_URI if not set in request
-OPTION(rgw_ignore_get_invalid_range, OPT_BOOL) // treat invalid (e.g., negative) range requests as full
-OPTION(rgw_swift_url, OPT_STR)             // the swift url, being published by the internal swift auth
-OPTION(rgw_swift_url_prefix, OPT_STR) // entry point for which a url is considered a swift url
-OPTION(rgw_swift_auth_url, OPT_STR)        // default URL to go and verify tokens for v1 auth (if not using internal swift auth)
-OPTION(rgw_swift_auth_entry, OPT_STR)  // entry point for which a url is considered a swift auth url
-OPTION(rgw_swift_tenant_name, OPT_STR)  // tenant name to use for swift access
-OPTION(rgw_swift_account_in_url, OPT_BOOL)  // assume that URL always contain the account (aka tenant) part
-OPTION(rgw_swift_enforce_content_length, OPT_BOOL)  // enforce generation of Content-Length even in cost of performance or scalability
-OPTION(rgw_keystone_url, OPT_STR)  // url for keystone server
-OPTION(rgw_keystone_admin_token, OPT_STR)  // keystone admin token (shared secret)
-OPTION(rgw_keystone_admin_token_path, OPT_STR)  // path to keystone admin token (shared secret)
-OPTION(rgw_keystone_admin_user, OPT_STR)  // keystone admin user name
-OPTION(rgw_keystone_admin_password, OPT_STR)  // keystone admin user password
-OPTION(rgw_keystone_admin_password_path, OPT_STR)  // path to keystone admin user password
-OPTION(rgw_keystone_admin_tenant, OPT_STR)  // keystone admin user tenant (for keystone v2.0)
-OPTION(rgw_keystone_admin_project, OPT_STR)  // keystone admin user project (for keystone v3)
-OPTION(rgw_keystone_admin_domain, OPT_STR)  // keystone admin user domain
-OPTION(rgw_keystone_barbican_user, OPT_STR)  // keystone user to access barbican secrets
-OPTION(rgw_keystone_barbican_password, OPT_STR)  // keystone password for barbican user
-OPTION(rgw_keystone_barbican_tenant, OPT_STR)  // keystone barbican user tenant (for keystone v2.0)
-OPTION(rgw_keystone_barbican_project, OPT_STR)  // keystone barbican user project (for keystone v3)
-OPTION(rgw_keystone_barbican_domain, OPT_STR)  // keystone barbican user domain
-OPTION(rgw_keystone_api_version, OPT_INT) // Version of Keystone API to use (2 or 3)
-OPTION(rgw_keystone_accepted_roles, OPT_STR)  // roles required to serve requests
-OPTION(rgw_keystone_accepted_admin_roles, OPT_STR) // list of roles allowing an user to gain admin privileges
-OPTION(rgw_keystone_token_cache_size, OPT_INT)  // max number of entries in keystone token cache
-OPTION(rgw_keystone_verify_ssl, OPT_BOOL) // should we try to verify keystone's ssl
-OPTION(rgw_keystone_implicit_tenants, OPT_BOOL)  // create new users in their own tenants of the same name
-OPTION(rgw_cross_domain_policy, OPT_STR)
-OPTION(rgw_healthcheck_disabling_path, OPT_STR) // path that existence causes the healthcheck to respond 503
-OPTION(rgw_s3_auth_use_rados, OPT_BOOL)  // should we try to use the internal credentials for s3?
-OPTION(rgw_s3_auth_use_keystone, OPT_BOOL)  // should we try to use keystone for s3?
-OPTION(rgw_s3_auth_order, OPT_STR) // s3 authentication order to try
-OPTION(rgw_barbican_url, OPT_STR)  // url for barbican server
-OPTION(rgw_opa_url, OPT_STR)  // url for OPA server
-OPTION(rgw_opa_token, OPT_STR)  // Bearer token OPA uses to authenticate client requests
-OPTION(rgw_opa_verify_ssl, OPT_BOOL) // should we try to verify OPA's ssl
-OPTION(rgw_use_opa_authz, OPT_BOOL) // should we use OPA to authorize client requests?
 
-/* OpenLDAP-style LDAP parameter strings */
-/* rgw_ldap_uri  space-separated list of LDAP servers in URI format */
-OPTION(rgw_ldap_uri, OPT_STR)
-/* rgw_ldap_binddn  LDAP entry RGW will bind with (user match) */
-OPTION(rgw_ldap_binddn, OPT_STR)
-/* rgw_ldap_searchdn  LDAP search base (basedn) */
-OPTION(rgw_ldap_searchdn, OPT_STR)
-/* rgw_ldap_dnattr  LDAP attribute containing RGW user names (to form binddns)*/
-OPTION(rgw_ldap_dnattr, OPT_STR)
-/* rgw_ldap_secret  file containing credentials for rgw_ldap_binddn */
-OPTION(rgw_ldap_secret, OPT_STR)
-/* rgw_s3_auth_use_ldap  use LDAP for RGW auth? */
-OPTION(rgw_s3_auth_use_ldap, OPT_BOOL)
-/* rgw_ldap_searchfilter  LDAP search filter */
-OPTION(rgw_ldap_searchfilter, OPT_STR)
 
-OPTION(rgw_admin_entry, OPT_STR)  // entry point for which a url is considered an admin request
-OPTION(rgw_enforce_swift_acls, OPT_BOOL)
-OPTION(rgw_swift_token_expiration, OPT_INT) // time in seconds for swift token expiration
-OPTION(rgw_print_continue, OPT_BOOL)  // enable if 100-Continue works
-OPTION(rgw_print_prohibited_content_length, OPT_BOOL) // violate RFC 7230 and send Content-Length in 204 and 304
 OPTION(rgw_remote_addr_param, OPT_STR)  // e.g. X-Forwarded-For, if you have a reverse proxy
-OPTION(rgw_op_thread_timeout, OPT_INT)
-OPTION(rgw_op_thread_suicide_timeout, OPT_INT)
-OPTION(rgw_thread_pool_size, OPT_INT)
-OPTION(rgw_num_control_oids, OPT_INT)
-OPTION(rgw_verify_ssl, OPT_BOOL) // should http_client try to verify ssl when sent https request
 
-/* The following are tunables for caches of RGW NFS (and other file
- * client) objects.
- *
- * The file handle cache is a partitioned hash table
- * (fhcache_partitions), each with a closed hash part and backing
- * b-tree mapping.  The number of partions is expected to be a small
- * prime, the cache size something larger but less than 5K, the total
- * size of the cache is n_part * cache_size.
- */
-OPTION(rgw_nfs_lru_lanes, OPT_INT)
-OPTION(rgw_nfs_lru_lane_hiwat, OPT_INT)
-OPTION(rgw_nfs_fhcache_partitions, OPT_INT)
-OPTION(rgw_nfs_fhcache_size, OPT_INT) /* 3*2017=6051 */
-OPTION(rgw_nfs_namespace_expire_secs, OPT_INT) /* namespace invalidate
-						     * timer */
-OPTION(rgw_nfs_max_gc, OPT_INT) /* max gc events per cycle */
-OPTION(rgw_nfs_write_completion_interval_s, OPT_INT) /* stateless (V3)
-							  * commit
-							  * delay */
-OPTION(rgw_nfs_s3_fast_attrs, OPT_BOOL) /* use fast S3 attrs from
-					 * bucket index--currently
-					 * assumes NFS mounts are
-					 * immutable */
 
 OPTION(rgw_zone, OPT_STR) // zone name
-OPTION(rgw_zone_root_pool, OPT_STR)    // pool where zone specific info is stored
-OPTION(rgw_default_zone_info_oid, OPT_STR)  // oid where default zone info is stored
-OPTION(rgw_region, OPT_STR) // region name
-OPTION(rgw_region_root_pool, OPT_STR)  // pool where all region info is stored
-OPTION(rgw_default_region_info_oid, OPT_STR)  // oid where default region info is stored
 OPTION(rgw_zonegroup, OPT_STR) // zone group name
 OPTION(rgw_zonegroup_root_pool, OPT_STR)  // pool where all zone group info is stored
-OPTION(rgw_default_zonegroup_info_oid, OPT_STR)  // oid where default zone group info is stored
 OPTION(rgw_realm, OPT_STR) // realm name
 OPTION(rgw_realm_root_pool, OPT_STR)  // pool where all realm info is stored
-OPTION(rgw_default_realm_info_oid, OPT_STR)  // oid where default realm info is stored
 OPTION(rgw_period_root_pool, OPT_STR)  // pool where all period info is stored
 OPTION(rgw_period_latest_epoch_info_oid, OPT_STR) // oid where current period info is stored
-OPTION(rgw_log_nonexistent_bucket, OPT_BOOL)
-OPTION(rgw_log_object_name, OPT_STR)      // man date to see codes (a subset are supported)
-OPTION(rgw_log_object_name_utc, OPT_BOOL)
-OPTION(rgw_usage_max_shards, OPT_INT)
-OPTION(rgw_usage_max_user_shards, OPT_INT)
-OPTION(rgw_enable_ops_log, OPT_BOOL) // enable logging every rgw operation
-OPTION(rgw_enable_usage_log, OPT_BOOL) // enable logging bandwidth usage
-OPTION(rgw_ops_log_rados, OPT_BOOL) // whether ops log should go to rados
-OPTION(rgw_ops_log_socket_path, OPT_STR) // path to unix domain socket where ops log can go
-OPTION(rgw_ops_log_data_backlog, OPT_INT) // max data backlog for ops log
-OPTION(rgw_fcgi_socket_backlog, OPT_INT) // socket  backlog for fcgi
-OPTION(rgw_usage_log_flush_threshold, OPT_INT) // threshold to flush pending log data
-OPTION(rgw_usage_log_tick_interval, OPT_INT) // flush pending log data every X seconds
-OPTION(rgw_init_timeout, OPT_INT) // time in seconds
-OPTION(rgw_mime_types_file, OPT_STR)
-OPTION(rgw_gc_max_objs, OPT_INT)
-OPTION(rgw_gc_obj_min_wait, OPT_INT)    // wait time before object may be handled by gc
-OPTION(rgw_gc_processor_max_time, OPT_INT)  // total run time for a single gc processor work
-OPTION(rgw_gc_processor_period, OPT_INT)  // gc processor cycle time
-OPTION(rgw_gc_max_concurrent_io, OPT_INT)  // gc processor cycle time
-OPTION(rgw_gc_max_trim_chunk, OPT_INT)  // gc trim chunk size
-OPTION(rgw_s3_success_create_obj_status, OPT_INT) // alternative success status response for create-obj (0 - default)
-OPTION(rgw_resolve_cname, OPT_BOOL)  // should rgw try to resolve hostname as a dns cname record
-OPTION(rgw_obj_stripe_size, OPT_INT)
-OPTION(rgw_extended_http_attrs, OPT_STR) // list of extended attrs that can be set on objects (beyond the default)
-OPTION(rgw_exit_timeout_secs, OPT_INT) // how many seconds to wait for process to go down before exiting unconditionally
-OPTION(rgw_get_obj_window_size, OPT_INT) // window size in bytes for single get obj request
-OPTION(rgw_get_obj_max_req_size, OPT_INT) // max length of a single get obj rados op
-OPTION(rgw_relaxed_s3_bucket_names, OPT_BOOL) // enable relaxed bucket name rules for US region buckets
-OPTION(rgw_defer_to_bucket_acls, OPT_STR) // if the user has bucket perms)
-OPTION(rgw_list_buckets_max_chunk, OPT_INT) // max buckets to retrieve in a single op when listing user buckets
-OPTION(rgw_md_log_max_shards, OPT_INT) // max shards for metadata log
-OPTION(rgw_curl_wait_timeout_ms, OPT_INT) // timeout for certain curl calls
-OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl calls
-OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
-OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
-OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
-OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep
+OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT)
                                                     // track of removed objects' mtime
-
-OPTION(rgw_data_log_window, OPT_INT) // data log entries window (in seconds)
-OPTION(rgw_data_log_changes_size, OPT_INT) // number of in-memory entries to hold for data changes log
-OPTION(rgw_data_log_num_shards, OPT_INT) // number of objects to keep data changes log on
-OPTION(rgw_data_log_obj_prefix, OPT_STR) //
-
-OPTION(rgw_bucket_quota_ttl, OPT_INT) // time for cached bucket stats to be cached within rgw instance
-OPTION(rgw_bucket_quota_soft_threshold, OPT_DOUBLE) // threshold from which we don't rely on cached info for quota decisions
-OPTION(rgw_bucket_quota_cache_size, OPT_INT) // number of entries in bucket quota cache
-OPTION(rgw_bucket_default_quota_max_objects, OPT_INT) // number of objects allowed
-OPTION(rgw_bucket_default_quota_max_size, OPT_LONGLONG) // Max size of object in bytes
-
-OPTION(rgw_expose_bucket, OPT_BOOL) // Return the bucket name in the 'Bucket' response header
-
 OPTION(rgw_frontends, OPT_STR) // rgw front ends
-
-OPTION(rgw_user_quota_bucket_sync_interval, OPT_INT) // time period for accumulating modified buckets before syncing stats
-OPTION(rgw_user_quota_sync_interval, OPT_INT) // time period for accumulating modified buckets before syncing entire user stats
-OPTION(rgw_user_quota_sync_idle_users, OPT_BOOL) // whether stats for idle users be fully synced
-OPTION(rgw_user_quota_sync_wait_time, OPT_INT) // min time between two full stats sync for non-idle users
-OPTION(rgw_user_default_quota_max_objects, OPT_INT) // number of objects allowed
-OPTION(rgw_user_default_quota_max_size, OPT_LONGLONG) // Max size of object in bytes
-
-OPTION(rgw_multipart_min_part_size, OPT_INT) // min size for each part (except for last one) in multipart upload
-OPTION(rgw_multipart_part_upload_limit, OPT_INT) // parts limit in multipart upload
-
-OPTION(rgw_max_slo_entries, OPT_INT) // default number of max entries in slo
-
-OPTION(rgw_olh_pending_timeout_sec, OPT_INT) // time until we retire a pending olh change
-OPTION(rgw_user_max_buckets, OPT_INT) // global option to set max buckets count for all user
-
-OPTION(rgw_objexp_gc_interval, OPT_U32) // maximum time between round of expired objects garbage collecting
-OPTION(rgw_objexp_hints_num_shards, OPT_U32) // maximum number of parts in which the hint index is stored in
-OPTION(rgw_objexp_chunk_size, OPT_U32) // maximum number of entries in a single operation when processing objexp data
-
-OPTION(rgw_enable_static_website, OPT_BOOL) // enable static website feature
-OPTION(rgw_log_http_headers, OPT_STR) // list of HTTP headers to log when seen, ignores case (e.g., http_x_forwarded_for
-
-OPTION(rgw_num_async_rados_threads, OPT_INT) // num of threads to use for async rados operations
-OPTION(rgw_md_notify_interval_msec, OPT_INT) // metadata changes notification interval to followers
-OPTION(rgw_run_sync_thread, OPT_BOOL) // whether radosgw (not radosgw-admin) spawns the sync thread
-OPTION(rgw_sync_lease_period, OPT_INT) // time in second for lease that rgw takes on a specific log (or log shard)
-OPTION(rgw_sync_log_trim_interval, OPT_INT) // time in seconds between attempts to trim sync logs
-
-OPTION(rgw_sync_data_inject_err_probability, OPT_DOUBLE) // range [0, 1]
-OPTION(rgw_sync_meta_inject_err_probability, OPT_DOUBLE) // range [0, 1]
-OPTION(rgw_sync_trace_history_size, OPT_INT) // max number of complete sync trace entries to keep
-OPTION(rgw_sync_trace_per_node_log_size, OPT_INT) // how many log entries to keep per node
-OPTION(rgw_sync_trace_servicemap_update_interval, OPT_INT) // interval in seconds between sync trace servicemap update
-
-
-OPTION(rgw_period_push_interval, OPT_DOUBLE) // seconds to wait before retrying "period push"
-OPTION(rgw_period_push_interval_max, OPT_DOUBLE) // maximum interval after exponential backoff
-
-OPTION(rgw_safe_max_objects_per_shard, OPT_INT) // safe max loading
-OPTION(rgw_shard_warning_threshold, OPT_DOUBLE) // pct of safe max
-						    // at which to warn
-
-OPTION(rgw_swift_versioning_enabled, OPT_BOOL) // whether swift object versioning feature is enabled
-
-OPTION(rgw_trust_forwarded_https, OPT_BOOL) // trust Forwarded and X-Forwarded-Proto headers for ssl termination
-OPTION(rgw_crypt_require_ssl, OPT_BOOL) // requests including encryption key headers must be sent over ssl
-OPTION(rgw_crypt_default_encryption_key, OPT_STR) // base64 encoded key for encryption of rgw objects
-OPTION(rgw_crypt_s3_kms_encryption_keys, OPT_STR) // extra keys that may be used for aws:kms
-                                                      // defined as map "key1=YmluCmJvb3N0CmJvb3N0LQ== key2=b3V0CnNyYwpUZXN0aW5nCg=="
-OPTION(rgw_crypt_suppress_logs, OPT_BOOL)   // suppress logs that might print customer key
-OPTION(rgw_list_bucket_min_readahead, OPT_INT) // minimum number of entries to read from rados for bucket listing
-
-OPTION(rgw_rest_getusage_op_compat, OPT_BOOL) // dump description of total stats for s3 GetUsage API
+OPTION(rgw_user_quota_sync_wait_time, OPT_INT)
+OPTION(rgw_bucket_quota_cache_size, OPT_INT)
+OPTION(rgw_user_quota_bucket_sync_interval, OPT_INT)
+OPTION(rgw_user_default_quota_max_objects, OPT_INT)
 
 OPTION(throttler_perf_counter, OPT_BOOL) // enable/disable throttler perf counter
-
-/* The following are tunables for torrent data */
-OPTION(rgw_torrent_flag, OPT_BOOL)    // produce torrent function flag
-OPTION(rgw_torrent_tracker, OPT_STR)    // torrent field announce and announce list
-OPTION(rgw_torrent_createby, OPT_STR)    // torrent field created by
-OPTION(rgw_torrent_comment, OPT_STR)    // torrent field comment
-OPTION(rgw_torrent_encoding, OPT_STR)    // torrent field encoding
-OPTION(rgw_torrent_origin, OPT_STR)    // torrent origin
-OPTION(rgw_torrent_sha_unit, OPT_INT)    // torrent field piece length 512K
 
 OPTION(event_tracing, OPT_BOOL) // true if LTTng-UST tracepoints should be enabled
 
 OPTION(debug_deliberately_leak_memory, OPT_BOOL)
 OPTION(debug_asok_assert_abort, OPT_BOOL)
 
-OPTION(rgw_swift_custom_header, OPT_STR) // option to enable swift custom headers
-
-OPTION(rgw_swift_need_stats, OPT_BOOL) // option to enable stats on bucket listing for swift
-
-OPTION(rgw_acl_grants_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), An ACL can have up to 100 grants.
-OPTION(rgw_cors_rules_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html), An cors can have up to 100 rules.
-OPTION(rgw_delete_multi_obj_max_num, OPT_INT) // According to AWS S3(https://docs.aws.amazon.com/AmazonS3/latest/dev/DeletingObjects.html), Amazon S3 also provides the Multi-Object Delete API that you can use to delete up to 1000 objects in a single HTTP request.
-OPTION(rgw_website_routing_rules_max_num, OPT_INT) // According to AWS S3, An website routing config can have up to 50 rules.
 OPTION(rgw_sts_entry, OPT_STR)
-OPTION(rgw_sts_key, OPT_STR)
-OPTION(rgw_s3_auth_use_sts, OPT_BOOL)  // should we try to use sts for s3?
-OPTION(rgw_sts_max_session_duration, OPT_U64) // Max duration in seconds for which the session token is valid.
 OPTION(fake_statfs_for_testing, OPT_INT) // Set a value for kb and compute kb_used from total of num_bytes
-OPTION(rgw_sts_token_introspection_url, OPT_STR)  // url for introspecting web tokens
-OPTION(rgw_sts_client_id, OPT_STR) // Client Id
-OPTION(rgw_sts_client_secret, OPT_STR) // Client Secret
 OPTION(debug_allow_any_pool_priority, OPT_BOOL)

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -98,7 +98,7 @@ namespace rgw {
   {
     /* write completion interval */
     RGWLibFS::write_completion_interval_s =
-      cct->_conf->rgw_nfs_write_completion_interval_s;
+      cct->_conf.get_val<int64_t>("rgw_nfs_write_completion_interval_s");
 
     /* start write timer */
     RGWLibFS::write_timer.resume();
@@ -109,7 +109,7 @@ namespace rgw {
 
       /* dirent invalidate timeout--basically, the upper-bound on
        * inconsistency with the S3 namespace */
-      auto expire_s = cct->_conf->rgw_nfs_namespace_expire_secs;
+      auto expire_s = cct->_conf.get_val<int64_t>("rgw_nfs_namespace_expire_secs");
 
       /* delay between gc cycles */
       auto delay_s = std::max(int64_t(1), std::min(int64_t(MIN_EXPIRE_S), expire_s/2));
@@ -465,7 +465,7 @@ namespace rgw {
   int RGWLibFrontend::init()
   {
     pprocess = new RGWLibProcess(g_ceph_context, &env,
-				 g_conf()->rgw_thread_pool_size, conf);
+				 g_conf().get_val<int64_t>("rgw_thread_pool_size"), conf);
     return 0;
   }
 
@@ -495,7 +495,7 @@ namespace rgw {
     SafeTimer init_timer(g_ceph_context, mutex);
     init_timer.init();
     mutex.Lock();
-    init_timer.add_event_after(g_conf()->rgw_init_timeout, new C_InitTimeout);
+    init_timer.add_event_after(g_conf().get_val<int64_t>("rgw_init_timeout"), new C_InitTimeout);
     mutex.Unlock();
 
     common_init_finish(g_ceph_context);
@@ -507,10 +507,10 @@ namespace rgw {
     rgw_http_client_init(g_ceph_context);
 
     store = RGWStoreManager::get_storage(g_ceph_context,
-					 g_conf()->rgw_enable_gc_threads,
-					 g_conf()->rgw_enable_lc_threads,
-					 g_conf()->rgw_enable_quota_threads,
-					 g_conf()->rgw_run_sync_thread,
+					 g_conf().get_val<bool>("rgw_enable_gc_threads"),
+					 g_conf().get_val<bool>("rgw_enable_lc_threads"),
+					 g_conf().get_val<bool>("rgw_enable_quota_threads"),
+					 g_conf().get_val<bool>("rgw_run_sync_thread"),
 					 g_conf().get_val<bool>("rgw_dynamic_resharding"));
 
     if (!store) {
@@ -535,12 +535,12 @@ namespace rgw {
     if (r)
       return -EIO;
 
-    const string& ldap_uri = store->ctx()->_conf->rgw_ldap_uri;
-    const string& ldap_binddn = store->ctx()->_conf->rgw_ldap_binddn;
-    const string& ldap_searchdn = store->ctx()->_conf->rgw_ldap_searchdn;
-    const string& ldap_searchfilter = store->ctx()->_conf->rgw_ldap_searchfilter;
+    const string& ldap_uri = store->ctx()->_conf.get_val<std::string>("rgw_ldap_uri");
+    const string& ldap_binddn = store->ctx()->_conf.get_val<std::string>("rgw_ldap_binddn");
+    const string& ldap_searchdn = store->ctx()->_conf.get_val<std::string>("rgw_ldap_searchdn");
+    const string& ldap_searchfilter = store->ctx()->_conf.get_val<std::string>("rgw_ldap_searchfilter");
     const string& ldap_dnattr =
-      store->ctx()->_conf->rgw_ldap_dnattr;
+      store->ctx()->_conf.get_val<std::string>("rgw_ldap_dnattr");
     std::string ldap_bindpw = parse_rgw_ldap_bindpw(store->ctx());
 
     ldh = new rgw::LDAPHelper(ldap_uri, ldap_binddn, ldap_bindpw.c_str(),
@@ -554,9 +554,9 @@ namespace rgw {
 
     // XXX ex-RGWRESTMgr_lib, mgr->set_logging(true)
 
-    if (!g_conf()->rgw_ops_log_socket_path.empty()) {
-      olog = new OpsLogSocket(g_ceph_context, g_conf()->rgw_ops_log_data_backlog);
-      olog->init(g_conf()->rgw_ops_log_socket_path);
+    if (!g_conf().get_val<std::string>("rgw_ops_log_socket_path").empty()) {
+      olog = new OpsLogSocket(g_ceph_context, g_conf().get_val<size_t>("rgw_ops_log_data_backlog"));
+      olog->init(g_conf().get_val<std::string>("rgw_ops_log_socket_path"));
     }
 
     int port = 80;

--- a/src/rgw/librgw_admin_user.cc
+++ b/src/rgw/librgw_admin_user.cc
@@ -93,7 +93,7 @@ namespace rgw {
     SafeTimer init_timer(g_ceph_context, mutex);
     init_timer.init();
     mutex.Lock();
-    init_timer.add_event_after(g_conf()->rgw_init_timeout, new C_InitTimeout);
+    init_timer.add_event_after(g_conf().get_val<int64_t>("rgw_init_timeout"), new C_InitTimeout);
     mutex.Unlock();
 
     common_init_finish(g_ceph_context);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2734,8 +2734,8 @@ int main(int argc, const char **argv)
                          CODE_ENVIRONMENT_UTILITY, 0);
 
   // for region -> zonegroup conversion (must happen before common_init_finish())
-  if (!g_conf()->rgw_region.empty() && g_conf()->rgw_zonegroup.empty()) {
-    g_conf().set_val_or_die("rgw_zonegroup", g_conf()->rgw_region.c_str());
+  if (!g_conf().get_val<std::string>("rgw_region").empty() && g_conf()->rgw_zonegroup.empty()) {
+    g_conf().set_val_or_die("rgw_zonegroup", g_conf().get_val<std::string>("rgw_region").c_str());
   }
 
   common_init_finish(g_ceph_context);
@@ -3424,7 +3424,7 @@ int main(int argc, const char **argv)
     store = RGWStoreManager::get_raw_storage(g_ceph_context);
   } else {
     store = RGWStoreManager::get_storage(g_ceph_context, false, false, false, false, false,
-      need_cache && g_conf()->rgw_cache_enabled);
+      need_cache && g_conf().get_val<bool>("rgw_cache_enabled"));
   }
   if (!store) {
     cerr << "couldn't init storage provider" << std::endl;
@@ -6879,7 +6879,7 @@ next:
     RGWMetadataLog *meta_log = store->meta_mgr->get_log(period_id);
 
     formatter->open_array_section("entries");
-    for (; i < g_ceph_context->_conf->rgw_md_log_max_shards; i++) {
+    for (; i < g_ceph_context->_conf.get_val<int64_t>("rgw_md_log_max_shards"); i++) {
       void *handle;
       list<cls_log_entry> entries;
 
@@ -6926,7 +6926,7 @@ next:
 
     formatter->open_array_section("entries");
 
-    for (; i < g_ceph_context->_conf->rgw_md_log_max_shards; i++) {
+    for (; i < g_ceph_context->_conf.get_val<int64_t>("rgw_md_log_max_shards"); i++) {
       RGWMetadataLogInfo info;
       meta_log->get_info(i, &info);
 
@@ -6953,7 +6953,7 @@ next:
       return -ret;
     }
 
-    auto num_shards = g_conf()->rgw_md_log_max_shards;
+    auto num_shards = g_conf().get_val<int64_t>("rgw_md_log_max_shards");
     ret = crs.run(create_admin_meta_log_trim_cr(dpp(), store, &http, num_shards));
     if (ret < 0) {
       cerr << "automated mdlog trim failed with " << cpp_strerror(ret) << std::endl;
@@ -7578,7 +7578,7 @@ next:
     int i = (specified_shard_id ? shard_id : 0);
 
     formatter->open_array_section("entries");
-    for (; i < g_ceph_context->_conf->rgw_data_log_num_shards; i++) {
+    for (; i < g_ceph_context->_conf.get_val<int64_t>("rgw_data_log_num_shards"); i++) {
       list<cls_log_entry> entries;
 
       RGWDataChangesLogInfo info;
@@ -7603,7 +7603,7 @@ next:
       return -ret;
     }
 
-    auto num_shards = g_conf()->rgw_data_log_num_shards;
+    auto num_shards = g_conf().get_val<int64_t>("rgw_data_log_num_shards");
     std::vector<std::string> markers(num_shards);
     ret = crs.run(create_admin_data_log_trim_cr(store, &http, num_shards, markers));
     if (ret < 0) {

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -624,7 +624,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
 int AsioFrontend::run()
 {
   auto cct = ctx();
-  const int thread_count = cct->_conf->rgw_thread_pool_size;
+  const int thread_count = cct->_conf.get_val<int64_t>("rgw_thread_pool_size");
   threads.reserve(thread_count);
 
   ldout(cct, 4) << "frontend spawning " << thread_count << " threads" << dendl;

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -466,7 +466,7 @@ void rgw::auth::RemoteApplier::create_account(const DoutPrefixProvider* dpp,
   user_info.user_id = new_acct_user;
   user_info.display_name = info.acct_name;
 
-  user_info.max_buckets = cct->_conf->rgw_user_max_buckets;
+  user_info.max_buckets = cct->_conf.get_val<int64_t>("rgw_user_max_buckets");
   rgw_apply_default_bucket_quota(user_info.bucket_quota, cct->_conf);
   rgw_apply_default_user_quota(user_info.user_quota, cct->_conf);
 

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -95,7 +95,7 @@ class SecretCache {
   SecretCache()
     : cct(g_ceph_context),
       lock(),
-      max(cct->_conf->rgw_keystone_token_cache_size),
+      max(cct->_conf.get_val<int64_t>("rgw_keystone_token_cache_size")),
       s3_token_expiry_length(300, 0) {
   }
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -449,7 +449,7 @@ void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id,
 
   CephContext *cct = store->ctx();
 
-  size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
+  size_t max_entries = cct->_conf.get_val<int64_t>("rgw_list_buckets_max_chunk");
 
   do {
     int ret = rgw_read_user_buckets(store, user_id, user_buckets, marker,
@@ -1491,13 +1491,13 @@ int RGWBucketAdminOp::limit_check(RGWRados *store,
 {
   int ret = 0;
   const size_t max_entries =
-    store->ctx()->_conf->rgw_list_buckets_max_chunk;
+    store->ctx()->_conf.get_val<int64_t>("rgw_list_buckets_max_chunk");
 
   const size_t safe_max_objs_per_shard =
-    store->ctx()->_conf->rgw_safe_max_objects_per_shard;
+    store->ctx()->_conf.get_val<int64_t>("rgw_safe_max_objects_per_shard");
 
   uint16_t shard_warn_pct =
-    store->ctx()->_conf->rgw_shard_warning_threshold;
+    store->ctx()->_conf.get_val<double>("rgw_shard_warning_threshold");
   if (shard_warn_pct > 100)
     shard_warn_pct = 90;
 
@@ -1615,7 +1615,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
 
   CephContext *cct = store->ctx();
 
-  const size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
+  const size_t max_entries = cct->_conf.get_val<int64_t>("rgw_list_buckets_max_chunk");
 
   bool show_stats = op_state.will_fetch_stats();
   rgw_user user_id = op_state.get_user_id();
@@ -2183,7 +2183,7 @@ int RGWDataChangesLog::renew_entries()
     }
 
     real_time expiration = now;
-    expiration += make_timespan(cct->_conf->rgw_data_log_window);
+    expiration += make_timespan(cct->_conf.get_val<int64_t>("rgw_data_log_window"));
 
     list<rgw_bucket_shard>& buckets = miter->second.first;
     list<rgw_bucket_shard>::iterator liter;
@@ -2290,7 +2290,7 @@ int RGWDataChangesLog::add_entry(rgw_bucket& bucket, int shard_id) {
     status->cur_sent = now;
 
     expiration = now;
-    expiration += ceph::make_timespan(cct->_conf->rgw_data_log_window);
+    expiration += ceph::make_timespan(cct->_conf.get_val<int64_t>("rgw_data_log_window"));
 
     status->lock->Unlock();
   
@@ -2316,7 +2316,7 @@ int RGWDataChangesLog::add_entry(rgw_bucket& bucket, int shard_id) {
 
   status->pending = false;
   status->cur_expiration = status->cur_sent; /* time of when operation started, not completed */
-  status->cur_expiration += make_timespan(cct->_conf->rgw_data_log_window);
+  status->cur_expiration += make_timespan(cct->_conf.get_val<int64_t>("rgw_data_log_window"));
   status->cond = NULL;
   status->lock->Unlock();
 
@@ -2469,7 +2469,7 @@ void *RGWDataChangesLog::ChangesRenewThread::entry() {
     if (log->going_down())
       break;
 
-    int interval = cct->_conf->rgw_data_log_window * 3 / 4;
+    int interval = cct->_conf.get_val<int64_t>("rgw_data_log_window") * 3 / 4;
     lock.Lock();
     cond.WaitInterval(lock, utime_t(interval, 0));
     lock.Unlock();

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -508,12 +508,12 @@ public:
 
   RGWDataChangesLog(CephContext *_cct, RGWRados *_store) : cct(_cct), store(_store),
                                                            lock("RGWDataChangesLog::lock"), modified_lock("RGWDataChangesLog::modified_lock"),
-                                                           changes(cct->_conf->rgw_data_log_changes_size) {
-    num_shards = cct->_conf->rgw_data_log_num_shards;
+                                                           changes(cct->_conf.get_val<int64_t>("rgw_data_log_changes_size")) {
+    num_shards = cct->_conf.get_val<int64_t>("rgw_data_log_num_shards");
 
     oids = new string[num_shards];
 
-    string prefix = cct->_conf->rgw_data_log_obj_prefix;
+    string prefix = cct->_conf.get_val<std::string>("rgw_data_log_obj_prefix");
 
     if (prefix.empty()) {
       prefix = "data_log";

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -89,7 +89,7 @@ int RGWCivetWebFrontend::run()
   auto& conf_map = conf->get_config_map();
 
   set_conf_default(conf_map, "num_threads",
-                   std::to_string(g_conf()->rgw_thread_pool_size));
+                   std::to_string(g_conf().get_val<int64_t>("rgw_thread_pool_size")));
   set_conf_default(conf_map, "decode_url", "no");
   set_conf_default(conf_map, "enable_keep_alive", "yes");
   set_conf_default(conf_map, "validate_http_method", "no");

--- a/src/rgw/rgw_client_io_filters.h
+++ b/src/rgw/rgw_client_io_filters.h
@@ -343,7 +343,7 @@ public:
   size_t send_status(const int status,
                      const char* const status_name) override {
     if ((204 == status || 304 == status) &&
-        ! g_conf()->rgw_print_prohibited_content_length) {
+        ! g_conf().get_val<bool>("rgw_print_prohibited_content_length")) {
       action = ContentLengthAction::INHIBIT;
     } else {
       action = ContentLengthAction::FORWARD;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -207,8 +207,8 @@ static string get_abs_path(const string& request_uri) {
 
 req_info::req_info(CephContext *cct, const class RGWEnv *env) : env(env) {
   method = env->get("REQUEST_METHOD", "");
-  script_uri = env->get("SCRIPT_URI", cct->_conf->rgw_script_uri.c_str());
-  request_uri = env->get("REQUEST_URI", cct->_conf->rgw_request_uri.c_str());
+  script_uri = env->get("SCRIPT_URI", cct->_conf.get_val<std::string>("rgw_script_uri").c_str());
+  request_uri = env->get("REQUEST_URI", cct->_conf.get_val<std::string>("rgw_request_uri").c_str());
   if (request_uri[0] != '/') {
     request_uri = get_abs_path(request_uri);
   }
@@ -1050,7 +1050,7 @@ bool rgw_transport_is_secure(CephContext *cct, const RGWEnv& env)
     return true;
   }
   // ignore proxy headers unless explicitly enabled
-  if (!cct->_conf->rgw_trust_forwarded_https) {
+  if (!cct->_conf.get_val<bool>("rgw_trust_forwarded_https")) {
     return false;
   }
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
@@ -1348,7 +1348,7 @@ bool verify_object_permission(const DoutPrefixProvider* dpp, struct req_state * 
     return true;
   }
 
-  if (!s->cct->_conf->rgw_enforce_swift_acls)
+  if (!s->cct->_conf.get_val<bool>("rgw_enforce_swift_acls"))
     return ret;
 
   if ((perm & (int)s->perm_mask) != perm)
@@ -1396,7 +1396,7 @@ bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp,
     return true;
   }
 
-  if (!s->cct->_conf->rgw_enforce_swift_acls)
+  if (!s->cct->_conf.get_val<bool>("rgw_enforce_swift_acls"))
     return ret;
 
   if ((perm & (int)s->perm_mask) != perm)

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -68,8 +68,8 @@ void RGWAsyncRadosProcessor::RGWWQ::_dump_queue() {
 RGWAsyncRadosProcessor::RGWAsyncRadosProcessor(RGWRados *_store, int num_threads)
   : store(_store), m_tp(store->ctx(), "RGWAsyncRadosProcessor::m_tp", "rados_async", num_threads),
     req_throttle(store->ctx(), "rgw_async_rados_ops", num_threads * 2),
-    req_wq(this, g_conf()->rgw_op_thread_timeout,
-    g_conf()->rgw_op_thread_suicide_timeout, &m_tp) {
+    req_wq(this, g_conf().get_val<int64_t>("rgw_op_thread_timeout"),
+    g_conf().get_val<int64_t>("rgw_op_thread_suicide_timeout"), &m_tp) {
 }
 
 void RGWAsyncRadosProcessor::start() {

--- a/src/rgw/rgw_cr_tools.cc
+++ b/src/rgw/rgw_cr_tools.cc
@@ -15,7 +15,7 @@ int RGWUserCreateCR::Request::_send_request()
 {
   CephContext *cct = store->ctx();
 
-  int32_t default_max_buckets = cct->_conf->rgw_user_max_buckets;
+  int32_t default_max_buckets = cct->_conf.get_val<int64_t>("rgw_user_max_buckets");
 
   RGWUserAdminOpState op_state;
 
@@ -51,13 +51,13 @@ int RGWUserCreateCR::Request::_send_request()
     RGWQuotaInfo bucket_quota;
     RGWQuotaInfo user_quota;
 
-    if (cct->_conf->rgw_bucket_default_quota_max_objects >= 0) {
-      bucket_quota.max_objects = cct->_conf->rgw_bucket_default_quota_max_objects;
+    if (cct->_conf.get_val<int64_t>("rgw_bucket_default_quota_max_objects") >= 0) {
+      bucket_quota.max_objects = cct->_conf.get_val<int64_t>("rgw_bucket_default_quota_max_objects");
       bucket_quota.enabled = true;
     }
 
-    if (cct->_conf->rgw_bucket_default_quota_max_size >= 0) {
-      bucket_quota.max_size = cct->_conf->rgw_bucket_default_quota_max_size;
+    if (cct->_conf.get_val<int64_t>("rgw_bucket_default_quota_max_size") >= 0) {
+      bucket_quota.max_size = cct->_conf.get_val<int64_t>("rgw_bucket_default_quota_max_size");
       bucket_quota.enabled = true;
     }
 
@@ -66,8 +66,8 @@ int RGWUserCreateCR::Request::_send_request()
       user_quota.enabled = true;
     }
 
-    if (cct->_conf->rgw_user_default_quota_max_size >= 0) {
-      user_quota.max_size = cct->_conf->rgw_user_default_quota_max_size;
+    if (cct->_conf.get_val<int64_t>("rgw_user_default_quota_max_size") >= 0) {
+      user_quota.max_size = cct->_conf.get_val<int64_t>("rgw_user_default_quota_max_size");
       user_quota.enabled = true;
     }
 

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -581,7 +581,7 @@ std::string create_random_key_selector(CephContext * const cct) {
 static int get_barbican_url(CephContext * const cct,
                      std::string& url)
 {
-  url = cct->_conf->rgw_barbican_url;
+  url = cct->_conf.get_val<std::string>("rgw_barbican_url");
   if (url.empty()) {
     ldout(cct, 0) << "ERROR: conf rgw_barbican_url is not set" << dendl;
     return -EINVAL;
@@ -646,7 +646,7 @@ static int get_actual_key_from_kms(CephContext *cct,
   int res = 0;
   ldout(cct, 20) << "Getting KMS encryption key for key=" << key_id << dendl;
   static map<string,string> str_map = get_str_map(
-      cct->_conf->rgw_crypt_s3_kms_encryption_keys);
+      cct->_conf.get_val<std::string>("rgw_crypt_s3_kms_encryption_keys"));
 
   map<string, string>::iterator it = str_map.find(std::string(key_id));
   if (it != str_map.end() ) {
@@ -782,7 +782,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         s->err.message = "The requested encryption algorithm is not valid, must be AES256.";
         return -ERR_INVALID_ENCRYPTION_ALGORITHM;
       }
-      if (s->cct->_conf->rgw_crypt_require_ssl &&
+      if (s->cct->_conf.get_val<bool>("rgw_crypt_require_ssl") &&
           !rgw_transport_is_secure(s->cct, *s->info.env)) {
         ldout(s->cct, 5) << "ERROR: Insecure request, rgw_crypt_require_ssl is set" << dendl;
         return -ERR_INVALID_REQUEST;
@@ -888,7 +888,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
                          "HTTP header x-amz-server-side-encryption : aws:kms";
         return -EINVAL;
       }
-      if (s->cct->_conf->rgw_crypt_require_ssl &&
+      if (s->cct->_conf.get_val<bool>("rgw_crypt_require_ssl") &&
           !rgw_transport_is_secure(s->cct, *s->info.env)) {
         ldout(s->cct, 5) << "ERROR: insecure request, rgw_crypt_require_ssl is set" << dendl;
         return -ERR_INVALID_REQUEST;
@@ -944,10 +944,10 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
     }
 
     /* no other encryption mode, check if default encryption is selected */
-    if (s->cct->_conf->rgw_crypt_default_encryption_key != "") {
+    if (s->cct->_conf.get_val<std::string>("rgw_crypt_default_encryption_key") != "") {
       std::string master_encryption_key;
       try {
-        master_encryption_key = from_base64(s->cct->_conf->rgw_crypt_default_encryption_key);
+        master_encryption_key = from_base64(s->cct->_conf.get_val<std::string>("rgw_crypt_default_encryption_key"));
       } catch (...) {
         ldout(s->cct, 5) << "ERROR: rgw_s3_prepare_encrypt invalid default encryption key "
                          << "which contains character that is not base64 encoded."
@@ -1004,7 +1004,7 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
   }
 
   if (stored_mode == "SSE-C-AES256") {
-    if (s->cct->_conf->rgw_crypt_require_ssl &&
+    if (s->cct->_conf.get_val<bool>("rgw_crypt_require_ssl") &&
         !rgw_transport_is_secure(s->cct, *s->info.env)) {
       ldout(s->cct, 5) << "ERROR: Insecure request, rgw_crypt_require_ssl is set" << dendl;
       return -ERR_INVALID_REQUEST;
@@ -1086,7 +1086,7 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
   }
 
   if (stored_mode == "SSE-KMS") {
-    if (s->cct->_conf->rgw_crypt_require_ssl &&
+    if (s->cct->_conf.get_val<bool>("rgw_crypt_require_ssl") &&
         !rgw_transport_is_secure(s->cct, *s->info.env)) {
       ldout(s->cct, 5) << "ERROR: Insecure request, rgw_crypt_require_ssl is set" << dendl;
       return -ERR_INVALID_REQUEST;
@@ -1121,7 +1121,7 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
   if (stored_mode == "RGW-AUTO") {
     std::string master_encryption_key;
     try {
-      master_encryption_key = from_base64(std::string(s->cct->_conf->rgw_crypt_default_encryption_key));
+      master_encryption_key = from_base64(std::string(s->cct->_conf.get_val<std::string>("rgw_crypt_default_encryption_key")));
     } catch (...) {
       ldout(s->cct, 5) << "ERROR: rgw_s3_prepare_decrypt invalid default encryption key "
                        << "which contains character that is not base64 encoded."

--- a/src/rgw/rgw_crypt_sanitize.cc
+++ b/src/rgw/rgw_crypt_sanitize.cc
@@ -20,7 +20,7 @@ const char* dollar_x_amz_server_side_encryption_customer_key = "$x-amz-server-si
 const char* suppression_message = "=suppressed due to key presence=";
 
 std::ostream& operator<<(std::ostream& out, const env& e) {
-  if (g_ceph_context->_conf->rgw_crypt_suppress_logs) {
+  if (g_ceph_context->_conf.get_val<bool>("rgw_crypt_suppress_logs")) {
     if (boost::algorithm::iequals(
         e.name,
         HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
@@ -42,7 +42,7 @@ std::ostream& operator<<(std::ostream& out, const env& e) {
 }
 
 std::ostream& operator<<(std::ostream& out, const x_meta_map& x) {
-  if (g_ceph_context->_conf->rgw_crypt_suppress_logs &&
+  if (g_ceph_context->_conf.get_val<bool>("rgw_crypt_suppress_logs") &&
       boost::algorithm::iequals(x.name, x_amz_server_side_encryption_customer_key))
   {
     out << suppression_message;
@@ -53,7 +53,7 @@ std::ostream& operator<<(std::ostream& out, const x_meta_map& x) {
 }
 
 std::ostream& operator<<(std::ostream& out, const s3_policy& x) {
-  if (g_ceph_context->_conf->rgw_crypt_suppress_logs &&
+  if (g_ceph_context->_conf.get_val<bool>("rgw_crypt_suppress_logs") &&
       boost::algorithm::iequals(x.name, dollar_x_amz_server_side_encryption_customer_key))
   {
     out << suppression_message;
@@ -64,7 +64,7 @@ std::ostream& operator<<(std::ostream& out, const s3_policy& x) {
 }
 
 std::ostream& operator<<(std::ostream& out, const auth& x) {
-  if (g_ceph_context->_conf->rgw_crypt_suppress_logs &&
+  if (g_ceph_context->_conf.get_val<bool>("rgw_crypt_suppress_logs") &&
       x.s->info.env->get(HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY, nullptr) != nullptr)
   {
     out << suppression_message;
@@ -75,7 +75,7 @@ std::ostream& operator<<(std::ostream& out, const auth& x) {
 }
 
 std::ostream& operator<<(std::ostream& out, const log_content& x) {
-  if (g_ceph_context->_conf->rgw_crypt_suppress_logs &&
+  if (g_ceph_context->_conf.get_val<bool>("rgw_crypt_suppress_logs") &&
       boost::algorithm::ifind_first(x.buf, x_amz_server_side_encryption_customer_key)) {
     out << suppression_message;
     return out;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1235,7 +1235,7 @@ public:
 
   void init_lease_cr() {
     set_status("acquiring sync lock");
-    uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
+    uint32_t lock_duration = cct->_conf.get_val<int64_t>("rgw_sync_lease_period");
     string lock_name = "sync_lock";
     if (lease_cr) {
       lease_cr->abort();
@@ -2714,7 +2714,7 @@ public:
     tn = sync_env->sync_tracer->add_node(_tn_parent, "entry", SSTR(key));
 
     tn->log(20, SSTR("bucket sync single entry (source_zone=" << sync_env->source_zone << ") b=" << ss.str() << " log_entry=" << entry_marker << " op=" << (int)op << " op_state=" << (int)op_state));
-    error_injection = (sync_env->cct->_conf->rgw_sync_data_inject_err_probability > 0);
+    error_injection = (sync_env->cct->_conf.get_val<double>("rgw_sync_data_inject_err_probability") > 0);
 
     data_sync_module = sync_env->sync_module->get_data_handler();
     
@@ -2739,7 +2739,7 @@ public:
             goto done;
           }
           if (error_injection &&
-              rand() % 10000 < cct->_conf->rgw_sync_data_inject_err_probability * 10000.0) {
+              rand() % 10000 < cct->_conf.get_val<double>("rgw_sync_data_inject_err_probability") * 10000.0) {
             tn->log(0, SSTR(": injecting data sync error on key=" << key.name));
             retcode = -EIO;
           } else if (op == CLS_RGW_OP_ADD ||
@@ -3235,7 +3235,7 @@ int RGWRunBucketSyncCoroutine::operate()
       lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                               rgw_raw_obj(store->svc.zone->get_zone_params().log_pool, status_oid),
                                               "sync_lock",
-                                              cct->_conf->rgw_sync_lease_period,
+                                              cct->_conf.get_val<int64_t>("rgw_sync_lease_period"),
                                               this));
       lease_stack.reset(spawn(lease_cr.get(), false));
     }

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -129,13 +129,13 @@ void RGWEnv::remove(const char *name)
 
 void RGWConf::init(CephContext *cct)
 {
-  enable_ops_log = cct->_conf->rgw_enable_ops_log;
-  enable_usage_log = cct->_conf->rgw_enable_usage_log;
+  enable_ops_log = cct->_conf.get_val<bool>("rgw_enable_ops_log");
+  enable_usage_log = cct->_conf.get_val<bool>("rgw_enable_usage_log");
 
   defer_to_bucket_acls = 0;  // default
-  if (cct->_conf->rgw_defer_to_bucket_acls == "recurse") {
+  if (cct->_conf.get_val<std::string>("rgw_defer_to_bucket_acls") == "recurse") {
     defer_to_bucket_acls = RGW_DEFER_TO_BUCKET_ACLS_RECURSE;
-  } else if (cct->_conf->rgw_defer_to_bucket_acls == "full_control") {
+  } else if (cct->_conf.get_val<std::string>("rgw_defer_to_bucket_acls") == "full_control") {
     defer_to_bucket_acls = RGW_DEFER_TO_BUCKET_ACLS_FULL_CONTROL;
   }
 }

--- a/src/rgw/rgw_fcgi_process.cc
+++ b/src/rgw/rgw_fcgi_process.cc
@@ -26,10 +26,10 @@ void RGWFCGXProcess::run()
   conf->get_val("socket_path", "", &socket_path);
   conf->get_val("socket_port", g_conf()->rgw_port, &socket_port);
   conf->get_val("socket_host", g_conf()->rgw_host, &socket_host);
-  socket_backlog = g_conf()->rgw_fcgi_socket_backlog;
+  socket_backlog = g_conf().get_val<int64_t>("rgw_fcgi_socket_backlog");
 
   if (socket_path.empty() && socket_port.empty() && socket_host.empty()) {
-    socket_path = g_conf()->rgw_socket_path;
+    socket_path = g_conf().get_val<std::string>("rgw_socket_path");
     if (socket_path.empty()) {
       dout(0) << "ERROR: no socket server point defined, cannot "
 	"start fcgi frontend" << dendl;

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1023,10 +1023,10 @@ namespace rgw {
     /* dirent invalidate timeout--basically, the upper-bound on
      * inconsistency with the S3 namespace */
     auto expire_s
-      = get_context()->_conf->rgw_nfs_namespace_expire_secs;
+      = get_context()->_conf.get_val<int64_t>("rgw_nfs_namespace_expire_secs");
 
     /* max events to gc in one cycle */
-    uint32_t max_ev = get_context()->_conf->rgw_nfs_max_gc;
+    uint32_t max_ev = get_context()->_conf.get_val<int64_t>("rgw_nfs_max_gc");
 
     struct timespec now, expire_ts;
     event_vector ve;
@@ -1487,7 +1487,7 @@ namespace rgw {
     auto now = real_clock::now();
     auto cmptime = state.mtime;
     cmptime.tv_sec +=
-      fs->get_context()->_conf->rgw_nfs_namespace_expire_secs;
+      fs->get_context()->_conf.get_val<int64_t>("rgw_nfs_namespace_expire_secs");
     if (cmptime < real_clock::to_timespec(now)) {
       /* sets ctime as well as mtime, to avoid masking updates should
        * ctime inexplicably hold a higher value */
@@ -1536,7 +1536,7 @@ namespace rgw {
     /* skipping user-supplied etag--we might have one in future, but
      * like data it and other attrs would arrive after open */
 
-    aio.emplace(s->cct->_conf->rgw_put_obj_min_window_size);
+    aio.emplace(s->cct->_conf.get_val<size_t>("rgw_put_obj_min_window_size"));
 
     if (s->bucket_info.versioning_enabled()) {
       if (!version_id.empty()) {
@@ -2013,7 +2013,7 @@ int rgw_lookup(struct rgw_fs *rgw_fs,
 	? RGWFileHandle::FLAG_NONE
 	: RGWFileHandle::FLAG_EXACT_MATCH;
 
-      bool fast_attrs= fs->get_context()->_conf->rgw_nfs_s3_fast_attrs;
+      bool fast_attrs= fs->get_context()->_conf.get_val<bool>("rgw_nfs_s3_fast_attrs");
 
       if ((flags & RGW_LOOKUP_FLAG_RCB) && fast_attrs) {
 	/* FAKE STAT--this should mean, interpolate special

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -921,10 +921,10 @@ namespace rgw {
 	    const char* _key, const char *root)
       : cct(_cct), root_fh(this), invalidate_cb(nullptr),
 	invalidate_arg(nullptr), shutdown(false), refcnt(1),
-	fh_cache(cct->_conf->rgw_nfs_fhcache_partitions,
-		 cct->_conf->rgw_nfs_fhcache_size),
-	fh_lru(cct->_conf->rgw_nfs_lru_lanes,
-	       cct->_conf->rgw_nfs_lru_lane_hiwat),
+	fh_cache(cct->_conf.get_val<int64_t>("rgw_nfs_fhcache_partitions"),
+		 cct->_conf.get_val<int64_t>("rgw_nfs_fhcache_size")),
+	fh_lru(cct->_conf.get_val<int64_t>("rgw_nfs_lru_lanes"),
+	       cct->_conf.get_val<int64_t>("rgw_nfs_lru_lane_hiwat")),
 	uid(_uid), key(_user_id, _key) {
 
       if (!root || !strcmp(root, "/")) {

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -200,7 +200,7 @@ public:
 
   int init() override {
     pprocess = new RGWFCGXProcess(g_ceph_context, &env,
-				  g_conf()->rgw_thread_pool_size, conf);
+				  g_conf().get_val<int64_t>("rgw_thread_pool_size"), conf);
     return 0;
   }
 }; /* RGWFCGXFrontend */
@@ -212,7 +212,7 @@ public:
 
   int init() override {
     int num_threads;
-    conf->get_val("num_threads", g_conf()->rgw_thread_pool_size, &num_threads);
+    conf->get_val("num_threads", g_conf().get_val<int64_t>("rgw_thread_pool_size"), &num_threads);
     RGWLoadGenProcess *pp = new RGWLoadGenProcess(g_ceph_context, &env,
 						  num_threads, conf);
 

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -152,7 +152,7 @@ public:
     : has_send_len(false),
       http_status(HTTP_STATUS_NOSTATUS),
       req_data(nullptr),
-      verify_ssl(cct->_conf->rgw_verify_ssl),
+      verify_ssl(cct->_conf.get_val<bool>("rgw_verify_ssl")),
       cct(cct),
       method(_method),
       url(_url) {

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1576,10 +1576,10 @@ void rgw::keystone::BarbicanTokenRequestVer2::dump(Formatter* const f) const
   f->open_object_section("token_request");
     f->open_object_section("auth");
       f->open_object_section("passwordCredentials");
-        encode_json("username", cct->_conf->rgw_keystone_barbican_user, f);
-        encode_json("password", cct->_conf->rgw_keystone_barbican_password, f);
+        encode_json("username", cct->_conf.get_val<std::string>("rgw_keystone_barbican_user"), f);
+        encode_json("password", cct->_conf.get_val<std::string>("rgw_keystone_barbican_password"), f);
       f->close_section();
-      encode_json("tenantName", cct->_conf->rgw_keystone_barbican_tenant, f);
+      encode_json("tenantName", cct->_conf.get_val<std::string>("rgw_keystone_barbican_tenant"), f);
     f->close_section();
   f->close_section();
 }
@@ -1595,22 +1595,22 @@ void rgw::keystone::BarbicanTokenRequestVer3::dump(Formatter* const f) const
         f->open_object_section("password");
           f->open_object_section("user");
             f->open_object_section("domain");
-              encode_json("name", cct->_conf->rgw_keystone_barbican_domain, f);
+              encode_json("name", cct->_conf.get_val<std::string>("rgw_keystone_barbican_domain"), f);
             f->close_section();
-            encode_json("name", cct->_conf->rgw_keystone_barbican_user, f);
-            encode_json("password", cct->_conf->rgw_keystone_barbican_password, f);
+            encode_json("name", cct->_conf.get_val<std::string>("rgw_keystone_barbican_user"), f);
+            encode_json("password", cct->_conf.get_val<std::string>("rgw_keystone_barbican_password"), f);
           f->close_section();
         f->close_section();
       f->close_section();
       f->open_object_section("scope");
         f->open_object_section("project");
-          if (!cct->_conf->rgw_keystone_barbican_project.empty()) {
-            encode_json("name", cct->_conf->rgw_keystone_barbican_project, f);
+          if (!cct->_conf.get_val<std::string>("rgw_keystone_barbican_project").empty()) {
+            encode_json("name", cct->_conf.get_val<std::string>("rgw_keystone_barbican_project"), f);
           } else {
-            encode_json("name", cct->_conf->rgw_keystone_barbican_tenant, f);
+            encode_json("name", cct->_conf.get_val<std::string>("rgw_keystone_barbican_tenant"), f);
           }
           f->open_object_section("domain");
-            encode_json("name", cct->_conf->rgw_keystone_barbican_domain, f);
+            encode_json("name", cct->_conf.get_val<std::string>("rgw_keystone_barbican_domain"), f);
           f->close_section();
         f->close_section();
       f->close_section();

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -52,14 +52,14 @@ namespace keystone {
 
 ApiVersion CephCtxConfig::get_api_version() const noexcept
 {
-  switch (g_ceph_context->_conf->rgw_keystone_api_version) {
+  switch (g_ceph_context->_conf.get_val<int64_t>("rgw_keystone_api_version")) {
   case 3:
     return ApiVersion::VER_3;
   case 2:
     return ApiVersion::VER_2;
   default:
     dout(0) << "ERROR: wrong Keystone API version: "
-            << g_ceph_context->_conf->rgw_keystone_api_version
+            << g_ceph_context->_conf.get_val<int64_t>("rgw_keystone_api_version")
             << "; falling back to v2" <<  dendl;
     return ApiVersion::VER_2;
   }
@@ -67,7 +67,7 @@ ApiVersion CephCtxConfig::get_api_version() const noexcept
 
 std::string CephCtxConfig::get_endpoint_url() const noexcept
 {
-  static const std::string url = g_ceph_context->_conf->rgw_keystone_url;
+  static const std::string url = g_ceph_context->_conf.get_val<std::string>("rgw_keystone_url");
 
   if (url.empty() || boost::algorithm::ends_with(url, "/")) {
     return url;
@@ -107,11 +107,11 @@ static inline std::string read_secret(const std::string& file_path)
 
 std::string CephCtxConfig::get_admin_token() const noexcept
 {
-  auto& atv = g_ceph_context->_conf->rgw_keystone_admin_token_path;
+  auto& atv = g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_token_path");
   if (!atv.empty()) {
     return read_secret(atv);
   } else {
-    auto& atv = g_ceph_context->_conf->rgw_keystone_admin_token;
+    auto& atv = g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_token");
     if (!atv.empty()) {
       return atv;
     }
@@ -120,11 +120,11 @@ std::string CephCtxConfig::get_admin_token() const noexcept
 }
 
 std::string CephCtxConfig::get_admin_password() const noexcept  {
-  auto& apv = g_ceph_context->_conf->rgw_keystone_admin_password_path;
+  auto& apv = g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_password_path");
   if (!apv.empty()) {
     return read_secret(apv);
   } else {
-    auto& apv = g_ceph_context->_conf->rgw_keystone_admin_password;
+    auto& apv = g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_password");
     if (!apv.empty()) {
       return apv;
     }

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -71,21 +71,21 @@ public:
   std::string get_admin_token() const noexcept override;
 
   boost::string_ref get_admin_user() const noexcept override {
-    return g_ceph_context->_conf->rgw_keystone_admin_user;
+    return g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_user");
   }
 
   std::string get_admin_password() const noexcept override;
 
   boost::string_ref get_admin_tenant() const noexcept override {
-    return g_ceph_context->_conf->rgw_keystone_admin_tenant;
+    return g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_tenant");
   }
 
   boost::string_ref get_admin_project() const noexcept override {
-    return g_ceph_context->_conf->rgw_keystone_admin_project;
+    return g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_project");
   }
 
   boost::string_ref get_admin_domain() const noexcept override {
-    return g_ceph_context->_conf->rgw_keystone_admin_domain;
+    return g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_domain");
   }
 };
 
@@ -102,7 +102,7 @@ public:
                                const string& url,
                                bufferlist * const token_body_bl)
       : RGWHTTPTransceiver(cct, method, url, token_body_bl,
-                           cct->_conf->rgw_keystone_verify_ssl,
+                           cct->_conf.get_val<bool>("rgw_keystone_verify_ssl"),
                            { "X-Subject-Token" }) {
     }
 
@@ -224,7 +224,7 @@ class TokenCache {
   explicit TokenCache(const rgw::keystone::Config& config)
     : cct(g_ceph_context),
       lock("rgw::keystone::TokenCache"),
-      max(cct->_conf->rgw_keystone_token_cache_size) {
+      max(cct->_conf.get_val<int64_t>("rgw_keystone_token_cache_size")) {
   }
 
   ~TokenCache() {

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -103,10 +103,10 @@ void RGWLifecycleConfiguration_S3::decode_xml(XMLObj *obj)
     add_rule(rule);
   }
 
-  if (cct->_conf->rgw_lc_max_rules < rule_map.size()) {
+  if (cct->_conf.get_val<uint64_t>("rgw_lc_max_rules") < rule_map.size()) {
     stringstream ss;
     ss << "Warn: The lifecycle config has too many rules, rule number is:" 
-      << rule_map.size() << ", max number is:" << cct->_conf->rgw_lc_max_rules;
+      << rule_map.size() << ", max number is:" << cct->_conf.get_val<uint64_t>("rgw_lc_max_rules");
     throw RGWXMLDecoder::err(ss.str());
   }
 }

--- a/src/rgw/rgw_ldap.cc
+++ b/src/rgw/rgw_ldap.cc
@@ -16,7 +16,7 @@
 std::string parse_rgw_ldap_bindpw(CephContext* ctx)
 {
   string ldap_bindpw;
-  string ldap_secret = ctx->_conf->rgw_ldap_secret;
+  string ldap_secret = ctx->_conf.get_val<std::string>("rgw_ldap_secret");
 
   if (ldap_secret.empty()) {
     ldout(ctx, 10)

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -108,7 +108,7 @@ class UsageLogger {
   };
 
   void set_timer() {
-    timer.add_event_after(cct->_conf->rgw_usage_log_tick_interval, new C_UsageLogTimeout(this));
+    timer.add_event_after(cct->_conf.get_val<int64_t>("rgw_usage_log_tick_interval"), new C_UsageLogTimeout(this));
   }
 public:
 
@@ -143,7 +143,7 @@ public:
     usage_map[ub].insert(rt, entry, &account);
     if (account)
       num_entries++;
-    bool need_flush = (num_entries > cct->_conf->rgw_usage_log_flush_threshold);
+    bool need_flush = (num_entries > cct->_conf.get_val<int64_t>("rgw_usage_log_flush_threshold"));
     lock.Unlock();
     if (need_flush) {
       Mutex::Locker l(timer_lock);
@@ -330,7 +330,7 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
     return -EINVAL;
   }
   if (s->err.ret == -ERR_NO_SUCH_BUCKET) {
-    if (!s->cct->_conf->rgw_log_nonexistent_bucket) {
+    if (!s->cct->_conf.get_val<bool>("rgw_log_nonexistent_bucket")) {
       ldout(s->cct, 5) << "bucket " << s->bucket << " doesn't exist, not logging" << dendl;
       return 0;
     }
@@ -353,8 +353,8 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
 
   entry.obj_size = s->obj_size;
 
-  if (s->cct->_conf->rgw_remote_addr_param.length())
-    set_param_str(s, s->cct->_conf->rgw_remote_addr_param.c_str(),
+  if (s->cct->_conf.get_val<std::string>("rgw_remote_addr_param").length())
+    set_param_str(s, s->cct->_conf.get_val<std::string>("rgw_remote_addr_param").c_str(),
 		  entry.remote_addr);
   else
     set_param_str(s, "REMOTE_ADDR", entry.remote_addr);
@@ -432,15 +432,15 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
 
   struct tm bdt;
   time_t t = req_state::Clock::to_time_t(entry.time);
-  if (s->cct->_conf->rgw_log_object_name_utc)
+  if (s->cct->_conf.get_val<bool>("rgw_log_object_name_utc"))
     gmtime_r(&t, &bdt);
   else
     localtime_r(&t, &bdt);
 
   int ret = 0;
 
-  if (s->cct->_conf->rgw_ops_log_rados) {
-    string oid = render_log_object_name(s->cct->_conf->rgw_log_object_name, &bdt,
+  if (s->cct->_conf.get_val<bool>("rgw_ops_log_rados")) {
+    string oid = render_log_object_name(s->cct->_conf.get_val<std::string>("rgw_log_object_name"), &bdt,
 				        s->bucket.bucket_id, entry.bucket);
 
     rgw_raw_obj obj(store->svc.zone->get_zone_params().log_pool, oid);

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -108,7 +108,7 @@ static void handle_sigterm(int signum)
     signal_shutdown();
 
     // safety net in case we get stuck doing an orderly shutdown.
-    uint64_t secs = g_ceph_context->_conf->rgw_exit_timeout_secs;
+    uint64_t secs = g_ceph_context->_conf.get_val<int64_t>("rgw_exit_timeout_secs");
     if (secs)
       alarm(secs);
     dout(1) << __func__ << " set alarm for " << secs << dendl;
@@ -251,8 +251,8 @@ int main(int argc, const char **argv)
 			 flags, "rgw_data", false);
 
   // maintain existing region root pool for new multisite objects
-  if (!g_conf()->rgw_region_root_pool.empty()) {
-    const char *root_pool = g_conf()->rgw_region_root_pool.c_str();
+  if (!g_conf().get_val<std::string>("rgw_region_root_pool").empty()) {
+    const char *root_pool = g_conf().get_val<std::string>("rgw_region_root_pool").c_str();
     if (g_conf()->rgw_zonegroup_root_pool.empty()) {
       g_conf().set_val_or_die("rgw_zonegroup_root_pool", root_pool);
     }
@@ -265,8 +265,8 @@ int main(int argc, const char **argv)
   }
 
   // for region -> zonegroup conversion (must happen before common_init_finish())
-  if (!g_conf()->rgw_region.empty() && g_conf()->rgw_zonegroup.empty()) {
-    g_conf().set_val_or_die("rgw_zonegroup", g_conf()->rgw_region.c_str());
+  if (!g_conf().get_val<std::string>("rgw_region").empty() && g_conf()->rgw_zonegroup.empty()) {
+    g_conf().set_val_or_die("rgw_zonegroup", g_conf().get_val<std::string>("rgw_region").c_str());
   }
 
   if (g_conf()->daemonize) {
@@ -276,7 +276,7 @@ int main(int argc, const char **argv)
   SafeTimer init_timer(g_ceph_context, mutex);
   init_timer.init();
   mutex.Lock();
-  init_timer.add_event_after(g_conf()->rgw_init_timeout, new C_InitTimeout);
+  init_timer.add_event_after(g_conf().get_val<int64_t>("rgw_init_timeout"), new C_InitTimeout);
   mutex.Unlock();
 
   common_init_finish(g_ceph_context);
@@ -303,12 +303,12 @@ int main(int argc, const char **argv)
 
   RGWRados *store =
     RGWStoreManager::get_storage(g_ceph_context,
-				 g_conf()->rgw_enable_gc_threads,
-				 g_conf()->rgw_enable_lc_threads,
-				 g_conf()->rgw_enable_quota_threads,
-				 g_conf()->rgw_run_sync_thread,
+				 g_conf().get_val<bool>("rgw_enable_gc_threads"),
+				 g_conf().get_val<bool>("rgw_enable_lc_threads"),
+				 g_conf().get_val<bool>("rgw_enable_quota_threads"),
+				 g_conf().get_val<bool>("rgw_run_sync_thread"),
 				 g_conf().get_val<bool>("rgw_dynamic_resharding"),
-				 g_conf()->rgw_cache_enabled);
+				 g_conf().get_val<bool>("rgw_cache_enabled"));
   if (!store) {
     mutex.Lock();
     init_timer.cancel_all_events();
@@ -348,8 +348,8 @@ int main(int argc, const char **argv)
   }
 
   /* warn about insecure keystone secret config options */
-  if (!(g_ceph_context->_conf->rgw_keystone_admin_token.empty() ||
-	g_ceph_context->_conf->rgw_keystone_admin_password.empty())) {
+  if (!(g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_token").empty() ||
+	g_ceph_context->_conf.get_val<std::string>("rgw_keystone_admin_password").empty())) {
     dout(0) << "WARNING: rgw_keystone_admin_token and rgw_keystone_admin_password should be avoided as they can expose secrets.  Prefer the new rgw_keystone_admin_token_path and rgw_keystone_admin_password_path options, which read their secrets from files." << dendl;
   }
 
@@ -358,7 +358,7 @@ int main(int argc, const char **argv)
   const bool sts_enabled = apis_map.count("sts") > 0;
   const bool iam_enabled = apis_map.count("iam") > 0;
   // Swift API entrypoint could placed in the root instead of S3
-  const bool swift_at_root = g_conf()->rgw_swift_url_prefix == "/";
+  const bool swift_at_root = g_conf().get_val<std::string>("rgw_swift_url_prefix") == "/";
   if (apis_map.count("s3") > 0 || s3website_enabled) {
     if (! swift_at_root) {
       rest.register_default_mgr(set_logging(rest_filter(store, RGW_REST_S3,
@@ -373,7 +373,7 @@ int main(int argc, const char **argv)
   if (apis_map.count("swift") > 0) {
     RGWRESTMgr_SWIFT* const swift_resource = new RGWRESTMgr_SWIFT;
 
-    if (! g_conf()->rgw_cross_domain_policy.empty()) {
+    if (! g_conf().get_val<std::string>("rgw_cross_domain_policy").empty()) {
       swift_resource->register_resource("crossdomain.xml",
                           set_logging(new RGWRESTMgr_SWIFT_CrossDomain));
     }
@@ -385,7 +385,7 @@ int main(int argc, const char **argv)
                           set_logging(new RGWRESTMgr_SWIFT_Info));
 
     if (! swift_at_root) {
-      rest.register_resource(g_conf()->rgw_swift_url_prefix,
+      rest.register_resource(g_conf().get_val<std::string>("rgw_swift_url_prefix"),
                           set_logging(rest_filter(store, RGW_REST_SWIFT,
                                                   swift_resource)));
     } else {
@@ -400,7 +400,7 @@ int main(int argc, const char **argv)
   }
 
   if (apis_map.count("swift_auth") > 0) {
-    rest.register_resource(g_conf()->rgw_swift_auth_entry,
+    rest.register_resource(g_conf().get_val<std::string>("rgw_swift_auth_entry"),
                set_logging(new RGWRESTMgr_SWIFT_Auth));
   }
 
@@ -415,7 +415,7 @@ int main(int argc, const char **argv)
     admin_resource->register_resource("log", new RGWRESTMgr_Log);
     admin_resource->register_resource("config", new RGWRESTMgr_Config);
     admin_resource->register_resource("realm", new RGWRESTMgr_Realm);
-    rest.register_resource(g_conf()->rgw_admin_entry, admin_resource);
+    rest.register_resource(g_conf().get_val<std::string>("rgw_admin_entry"), admin_resource);
   }
 
   /* Initialize the registry of auth strategies which will coordinate
@@ -424,7 +424,7 @@ int main(int argc, const char **argv)
     rgw::auth::StrategyRegistry::create(g_ceph_context, store);
 
   /* Header custom behavior */
-  rest.register_x_headers(g_conf()->rgw_log_http_headers);
+  rest.register_x_headers(g_conf().get_val<std::string>("rgw_log_http_headers"));
 
   if (cct->_conf.get_val<std::string>("rgw_scheduler_type") == "dmclock" &&
       !cct->check_experimental_feature_enabled("dmclock")){
@@ -438,9 +438,9 @@ int main(int argc, const char **argv)
 
   OpsLogSocket *olog = NULL;
 
-  if (!g_conf()->rgw_ops_log_socket_path.empty()) {
-    olog = new OpsLogSocket(g_ceph_context, g_conf()->rgw_ops_log_data_backlog);
-    olog->init(g_conf()->rgw_ops_log_socket_path);
+  if (!g_conf().get_val<std::string>("rgw_ops_log_socket_path").empty()) {
+    olog = new OpsLogSocket(g_ceph_context, g_conf().get_val<size_t>("rgw_ops_log_data_backlog"));
+    olog->init(g_conf().get_val<std::string>("rgw_ops_log_socket_path"));
   }
 
   r = signal_fd_init();

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -107,7 +107,7 @@ int RGWMetadataLog::add_entry(RGWMetadataHandler *handler, const string& section
   handler->get_hash_key(section, key, hash_key);
 
   int shard_id;
-  store->shard_name(prefix, cct->_conf->rgw_md_log_max_shards, hash_key, oid, &shard_id);
+  store->shard_name(prefix, cct->_conf.get_val<int64_t>("rgw_md_log_max_shards"), hash_key, oid, &shard_id);
   mark_modified(shard_id);
   real_time now = real_clock::now();
   return store->time_log_add(oid, now, section, key, bl);
@@ -1166,6 +1166,6 @@ int RGWMetadataManager::get_log_shard_id(const string& section,
   }
   string hash_key;
   handler->get_hash_key(section, key, hash_key);
-  *shard_id = store->key_to_shard_id(hash_key, cct->_conf->rgw_md_log_max_shards);
+  *shard_id = store->key_to_shard_id(hash_key, cct->_conf.get_val<int64_t>("rgw_md_log_max_shards"));
   return 0;
 }

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -96,7 +96,7 @@ int main(const int argc, const char **argv)
   RGWObjectExpirer objexp(store);
   objexp.start_processor();
 
-  const utime_t interval(g_ceph_context->_conf->rgw_objexp_gc_interval, 0);
+  const utime_t interval(g_ceph_context->_conf.get_val<uint64_t>("rgw_objexp_gc_interval"), 0);
   while (true) {
     interval.sleep();
   }

--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -158,9 +158,9 @@ bool RGWObjectExpirer::process_single_shard(const string& shard,
   bool done = true;
 
   CephContext *cct = store->ctx();
-  int num_entries = cct->_conf->rgw_objexp_chunk_size;
+  int num_entries = cct->_conf.get_val<uint64_t>("rgw_objexp_chunk_size");
 
-  int max_secs = cct->_conf->rgw_objexp_gc_interval;
+  int max_secs = cct->_conf.get_val<uint64_t>("rgw_objexp_gc_interval");
   utime_t end = ceph_clock_now();
   end += max_secs;
 
@@ -214,7 +214,7 @@ bool RGWObjectExpirer::inspect_all_shards(const utime_t& last_run,
                                           const utime_t& round_start)
 {
   CephContext * const cct = store->ctx();
-  int num_shards = cct->_conf->rgw_objexp_hints_num_shards;
+  int num_shards = cct->_conf.get_val<uint64_t>("rgw_objexp_hints_num_shards");
   bool all_done = true;
 
   for (int i = 0; i < num_shards; i++) {
@@ -271,7 +271,7 @@ void *RGWObjectExpirer::OEWorker::entry() {
 
     utime_t end = ceph_clock_now();
     end -= start;
-    int secs = cct->_conf->rgw_objexp_gc_interval;
+    int secs = cct->_conf.get_val<uint64_t>("rgw_objexp_gc_interval");
 
     if (secs <= end.sec())
       continue; // next round

--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -13,7 +13,7 @@ int rgw_opa_authorize(RGWOp *& op,
   ldpp_dout(op, 2) << "authorizing request using OPA" << dendl;
 
   /* get OPA url */
-  const string& opa_url = s->cct->_conf->rgw_opa_url;
+  const string& opa_url = s->cct->_conf.get_val<std::string>("rgw_opa_url");
   if (opa_url == "") {
     ldpp_dout(op, 2) << "OPA_URL not provided" << dendl;
     return -ERR_INVALID_REQUEST;
@@ -21,7 +21,7 @@ int rgw_opa_authorize(RGWOp *& op,
   ldpp_dout(op, 2) << "OPA URL= " << opa_url.c_str() << dendl;
 
   /* get authentication token for OPA */
-  const string& opa_token = s->cct->_conf->rgw_opa_token;
+  const string& opa_token = s->cct->_conf.get_val<std::string>("rgw_opa_token");
 
   int ret;
   bufferlist bl;
@@ -32,7 +32,7 @@ int rgw_opa_authorize(RGWOp *& op,
   req.append_header("Content-Type", "application/json");
 
   /* check if we want to verify OPA server SSL certificate */
-  req.set_verify_ssl(s->cct->_conf->rgw_opa_verify_ssl);
+  req.set_verify_ssl(s->cct->_conf.get_val<bool>("rgw_opa_verify_ssl"));
 
   /* create json request body */
   JSONFormatter jf;

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -195,7 +195,7 @@ int RGWOrphanSearch::init(const string& job_name, RGWOrphanSearchInfo *info, boo
 
   constexpr int64_t MAX_LIST_OBJS_ENTRIES=100;
 
-  max_list_bucket_entries = std::max(store->ctx()->_conf->rgw_list_bucket_min_readahead,
+  max_list_bucket_entries = std::max(store->ctx()->_conf.get_val<int64_t>("rgw_list_bucket_min_readahead"),
                                      MAX_LIST_OBJS_ENTRIES);
 
   detailed_mode = _detailed_mode;

--- a/src/rgw/rgw_period_pusher.cc
+++ b/src/rgw/rgw_period_pusher.cc
@@ -38,8 +38,8 @@ class PushAndRetryCR : public RGWCoroutine {
                  RGWHTTPManager* http, RGWPeriod& period)
     : RGWCoroutine(cct), zone(zone), conn(conn), http(http), period(period),
       epoch(std::to_string(period.get_epoch())),
-      timeout(cct->_conf->rgw_period_push_interval),
-      timeout_max(cct->_conf->rgw_period_push_interval_max),
+      timeout(cct->_conf.get_val<double>("rgw_period_push_interval")),
+      timeout_max(cct->_conf.get_val<double>("rgw_period_push_interval_max")),
       counter(0)
   {}
 

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -129,7 +129,7 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
   }
 
   /* Check if OPA is used to authorize requests */
-  if (s->cct->_conf->rgw_use_opa_authz) {
+  if (s->cct->_conf.get_val<bool>("rgw_use_opa_authz")) {
     ret = rgw_opa_authorize(op, s);
     if (ret < 0) {
       return ret;

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -101,8 +101,8 @@ public:
       conf(conf),
       sock_fd(-1),
       uri_prefix(pe->uri_prefix),
-      req_wq(this, g_conf()->rgw_op_thread_timeout,
-	     g_conf()->rgw_op_thread_suicide_timeout, &m_tp) {
+      req_wq(this, g_conf().get_val<int64_t>("rgw_op_thread_timeout"),
+	     g_conf().get_val<int64_t>("rgw_op_thread_suicide_timeout"), &m_tp) {
   }
   
   virtual ~RGWProcess() = default;

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -242,7 +242,7 @@ int AtomicObjectProcessor::prepare(optional_yield y)
   }
 
   uint64_t stripe_size;
-  const uint64_t default_stripe_size = store->ctx()->_conf->rgw_obj_stripe_size;
+  const uint64_t default_stripe_size = store->ctx()->_conf.get_val<size_t>("rgw_obj_stripe_size");
 
   store->get_max_aligned_size(default_stripe_size, alignment, &stripe_size);
 
@@ -361,7 +361,7 @@ int MultipartObjectProcessor::process_first_chunk(bufferlist&& data,
 
 int MultipartObjectProcessor::prepare_head()
 {
-  const uint64_t default_stripe_size = store->ctx()->_conf->rgw_obj_stripe_size;
+  const uint64_t default_stripe_size = store->ctx()->_conf.get_val<size_t>("rgw_obj_stripe_size");
   uint64_t chunk_size;
   uint64_t stripe_size;
   uint64_t alignment;
@@ -563,7 +563,7 @@ int AppendObjectProcessor::prepare(optional_yield y)
     cur_manifest = &astate->manifest;
     manifest.set_prefix(cur_manifest->get_prefix());
   }
-  manifest.set_multipart_part_rule(store->ctx()->_conf->rgw_obj_stripe_size, cur_part_num);
+  manifest.set_multipart_part_rule(store->ctx()->_conf.get_val<size_t>("rgw_obj_stripe_size"), cur_part_num);
 
   r = manifest_gen.create_begin(store->ctx(), &manifest, bucket_info.placement_rule, &tail_placement_rule, head_obj.bucket, head_obj);
   if (r < 0) {

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -104,12 +104,12 @@ void RGWRealmReloader::reload()
     // recreate and initialize a new store
     store =
       RGWStoreManager::get_storage(cct,
-				   cct->_conf->rgw_enable_gc_threads,
-				   cct->_conf->rgw_enable_lc_threads,
-				   cct->_conf->rgw_enable_quota_threads,
-				   cct->_conf->rgw_run_sync_thread,
+				   cct->_conf.get_val<bool>("rgw_enable_gc_threads"),
+				   cct->_conf.get_val<bool>("rgw_enable_lc_threads"),
+				   cct->_conf.get_val<bool>("rgw_enable_quota_threads"),
+				   cct->_conf.get_val<bool>("rgw_run_sync_thread"),
 				   cct->_conf.get_val<bool>("rgw_dynamic_resharding"),
-				   cct->_conf->rgw_cache_enabled);
+				   cct->_conf.get_val<bool>("rgw_cache_enabled"));
 
     ldout(cct, 1) << "Creating new store" << dendl;
 

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -187,7 +187,7 @@ void rgw_rest_init(CephContext *cct, RGWRados *store, const RGWZoneGroup& zone_g
   }
 
   list<string> extended_http_attrs;
-  get_str_list(cct->_conf->rgw_extended_http_attrs, extended_http_attrs);
+  get_str_list(cct->_conf.get_val<std::string>("rgw_extended_http_attrs"), extended_http_attrs);
 
   list<string>::iterator iter;
   for (iter = extended_http_attrs.begin(); iter != extended_http_attrs.end(); ++iter) {
@@ -206,7 +206,7 @@ void rgw_rest_init(CephContext *cct, RGWRados *store, const RGWZoneGroup& zone_g
     http_status_names[h->code] = h->name;
   }
 
-  hostnames_set.insert(cct->_conf->rgw_dns_name);
+  hostnames_set.insert(cct->_conf.get_val<std::string>("rgw_dns_name"));
   hostnames_set.insert(zone_group.hostnames.begin(), zone_group.hostnames.end());
   hostnames_set.erase(""); // filter out empty hostnames
   ldout(cct, 20) << "RGW hostnames: " << hostnames_set << dendl;
@@ -220,7 +220,7 @@ void rgw_rest_init(CephContext *cct, RGWRados *store, const RGWZoneGroup& zone_g
    * X.B.A ambigously splits to both {X, B.A} and {X.B, A}
    */
 
-  hostnames_s3website_set.insert(cct->_conf->rgw_dns_s3website_name);
+  hostnames_s3website_set.insert(cct->_conf.get_val<std::string>("rgw_dns_s3website_name"));
   hostnames_s3website_set.insert(zone_group.hostnames_s3website.begin(), zone_group.hostnames_s3website.end());
   hostnames_s3website_set.erase(""); // filter out empty hostnames
   ldout(cct, 20) << "RGW S3website hostnames: " << hostnames_s3website_set << dendl;
@@ -407,7 +407,7 @@ void dump_etag(struct req_state* const s,
 
 void dump_bucket_from_state(struct req_state *s)
 {
-  if (g_conf()->rgw_expose_bucket && ! s->bucket_name.empty()) {
+  if (g_conf().get_val<bool>("rgw_expose_bucket") && ! s->bucket_name.empty()) {
     if (! s->bucket_tenant.empty()) {
       dump_header(s, "Bucket",
                   url_encode(s->bucket_tenant + "/" + s->bucket_name));
@@ -616,7 +616,7 @@ void end_header(struct req_state* s, RGWOp* op, const char *content_type,
   if (content_type) {
     dump_header(s, "Content-Type", content_type);
   }
-  dump_header_if_nonempty(s, "Server", g_conf()->rgw_service_provider_name);
+  dump_header_if_nonempty(s, "Server", g_conf().get_val<std::string>("rgw_service_provider_name"));
 
   try {
     RESTFUL_IO(s)->complete_header();
@@ -1012,7 +1012,7 @@ int RGWPutObj_ObjStore::verify_params()
 int RGWPutObj_ObjStore::get_params()
 {
   /* start gettorrent */
-  if (s->cct->_conf->rgw_torrent_flag)
+  if (s->cct->_conf.get_val<bool>("rgw_torrent_flag"))
   {
     int ret = 0;
     ret = torrent.get_params();
@@ -1434,7 +1434,7 @@ int RGWPostObj_ObjStore::get_params()
 
 int RGWPutACLs_ObjStore::get_params()
 {
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   std::tie(op_ret, data) = rgw_rest_read_all_input(s, max_size, false);
   ldout(s->cct, 0) << "RGWPutACLs_ObjStore::get_params read data is: " << data.c_str() << dendl;
   return op_ret;
@@ -1442,21 +1442,21 @@ int RGWPutACLs_ObjStore::get_params()
 
 int RGWPutLC_ObjStore::get_params()
 {
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   std::tie(op_ret, data) = rgw_rest_read_all_input(s, max_size, false);
   return op_ret;
 }
 
 int RGWPutBucketObjectLock_ObjStore::get_params()
 {
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   std::tie(op_ret, data) = rgw_rest_read_all_input(s, max_size, false);
   return op_ret;
 }
 
 int RGWPutObjLegalHold_ObjStore::get_params()
 {
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   std::tie(op_ret, data) = rgw_rest_read_all_input(s, max_size, false);
   return op_ret;
 }
@@ -1551,7 +1551,7 @@ int RGWCompleteMultipart_ObjStore::get_params()
     return op_ret;
   }
 
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   std::tie(op_ret, data) = rgw_rest_read_all_input(s, max_size);
   if (op_ret < 0)
     return op_ret;
@@ -1617,7 +1617,7 @@ int RGWDeleteMultiObj_ObjStore::get_params()
   // everything is probably fine, set the bucket
   bucket = s->bucket;
 
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   std::tie(op_ret, data) = rgw_rest_read_all_input(s, max_size, false);
   return op_ret;
 }
@@ -2060,7 +2060,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
       << " in_hosted_domain_s3website=" << in_hosted_domain_s3website 
       << dendl;
 
-    if (g_conf()->rgw_resolve_cname
+    if (g_conf().get_val<bool>("rgw_resolve_cname")
 	&& !in_hosted_domain
 	&& !in_hosted_domain_s3website) {
       string cname;
@@ -2153,7 +2153,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
   }
 
   if (s->info.domain.empty()) {
-    s->info.domain = s->cct->_conf->rgw_dns_name;
+    s->info.domain = s->cct->_conf.get_val<std::string>("rgw_dns_name");
   }
 
   s->decoded_uri = url_decode(s->info.request_uri);
@@ -2182,7 +2182,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
   if (!http_content_length != !content_length) {
     /* Easy case: one or the other is missing */
     s->length = (content_length ? content_length : http_content_length);
-  } else if (s->cct->_conf->rgw_content_length_compat &&
+  } else if (s->cct->_conf.get_val<bool>("rgw_content_length_compat") &&
 	     content_length && http_content_length) {
     /* Hard case: Both are set, we have to disambiguate */
     int64_t content_length_i, http_content_length_i;
@@ -2241,7 +2241,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
     }
   }
 
-  if (g_conf()->rgw_print_continue) {
+  if (g_conf().get_val<bool>("rgw_print_continue")) {
     const char *expect = info.env->get("HTTP_EXPECT");
     s->expect_cont = (expect && !strcasecmp(expect, "100-continue"));
   }

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -136,7 +136,7 @@ void RGWOp_MDLog_List::send_response() {
 }
 
 void RGWOp_MDLog_Info::execute() {
-  num_objects = s->cct->_conf->rgw_md_log_max_shards;
+  num_objects = s->cct->_conf.get_val<int64_t>("rgw_md_log_max_shards");
   period = store->meta_mgr->read_oldest_log_period();
   http_ret = period.get_error();
 }
@@ -645,7 +645,7 @@ void RGWOp_DATALog_List::send_response() {
 
 
 void RGWOp_DATALog_Info::execute() {
-  num_objects = s->cct->_conf->rgw_data_log_num_shards;
+  num_objects = s->cct->_conf.get_val<int64_t>("rgw_data_log_num_shards");
   http_ret = 0;
 }
 

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -97,7 +97,7 @@ void RGWOp_Period_Post::execute()
   period.init(cct, store->svc.sysobj, false);
 
   // decode the period from input
-  const auto max_size = cct->_conf->rgw_max_put_param_size;
+  const auto max_size = cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   bool empty;
   http_ret = rgw_rest_get_json_input(cct, s, period, max_size, &empty);
   if (http_ret < 0) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -437,7 +437,7 @@ int RGWPutObjTags_ObjStore_S3::get_params()
     return -EINVAL;
   }
 
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
 
   int r = 0;
   bufferlist data;
@@ -530,7 +530,7 @@ int RGWPutBucketTags_ObjStore_S3::get_params()
     return -EINVAL;
   }
 
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   int r = 0;
   bufferlist data;
 
@@ -741,7 +741,7 @@ void RGWGetUsage_ObjStore_S3::send_response()
        formatter->close_section(); // user
      }
 
-     if (s->cct->_conf->rgw_rest_getusage_op_compat) {
+     if (s->cct->_conf.get_val<bool>("rgw_rest_getusage_op_compat")) {
        formatter->open_object_section("Stats");
      }
 
@@ -749,7 +749,7 @@ void RGWGetUsage_ObjStore_S3::send_response()
      encode_json("TotalBytesRounded", header.stats.total_bytes_rounded, formatter);
      encode_json("TotalEntries", header.stats.total_entries, formatter);
 
-     if (s->cct->_conf->rgw_rest_getusage_op_compat) {
+     if (s->cct->_conf.get_val<bool>("rgw_rest_getusage_op_compat")) {
        formatter->close_section(); //Stats
      }
 
@@ -1283,7 +1283,7 @@ int RGWSetBucketVersioning_ObjStore_S3::get_params()
   int r = 0;
   bufferlist data;
   std::tie(r, data) =
-    rgw_rest_read_all_input(s, s->cct->_conf->rgw_max_put_param_size, false);
+    rgw_rest_read_all_input(s, s->cct->_conf.get_val<size_t>("rgw_max_put_param_size"), false);
   if (r < 0) {
     return r;
   }
@@ -1352,7 +1352,7 @@ void RGWSetBucketVersioning_ObjStore_S3::send_response()
 
 int RGWSetBucketWebsite_ObjStore_S3::get_params()
 {
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
 
   int r = 0;
   bufferlist data;
@@ -1389,7 +1389,7 @@ int RGWSetBucketWebsite_ObjStore_S3::get_params()
   }
 
 #define WEBSITE_ROUTING_RULES_MAX_NUM      50
-  int max_num = s->cct->_conf->rgw_website_routing_rules_max_num;
+  int max_num = s->cct->_conf.get_val<int64_t>("rgw_website_routing_rules_max_num");
   if (max_num < 0) {
     max_num = WEBSITE_ROUTING_RULES_MAX_NUM;
   }
@@ -1539,7 +1539,7 @@ int RGWCreateBucket_ObjStore_S3::get_params()
 
   policy = s3policy;
 
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
 
   int op_ret = 0;
   bufferlist data;
@@ -1857,9 +1857,9 @@ void RGWPutObj_ObjStore_S3::send_response()
     set_req_state_err(s, op_ret);
     dump_errno(s);
   } else {
-    if (s->cct->_conf->rgw_s3_success_create_obj_status) {
+    if (s->cct->_conf.get_val<int64_t>("rgw_s3_success_create_obj_status")) {
       op_ret = get_success_retcode(
-	s->cct->_conf->rgw_s3_success_create_obj_status);
+	s->cct->_conf.get_val<int64_t>("rgw_s3_success_create_obj_status"));
       set_req_state_err(s, op_ret);
     }
     if (copy_source.empty()) {
@@ -2802,7 +2802,7 @@ int RGWPutCORS_ObjStore_S3::get_params()
   RGWCORSXMLParser_S3 parser(s->cct);
   RGWCORSConfiguration_S3 *cors_config;
 
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
 
   int r = 0;
   bufferlist data;
@@ -2832,7 +2832,7 @@ int RGWPutCORS_ObjStore_S3::get_params()
   }
 
 #define CORS_RULES_MAX_NUM      100
-  int max_num = s->cct->_conf->rgw_cors_rules_max_num;
+  int max_num = s->cct->_conf.get_val<int64_t>("rgw_cors_rules_max_num");
   if (max_num < 0) {
     max_num = CORS_RULES_MAX_NUM;
   }
@@ -2956,7 +2956,7 @@ public:
 
 int RGWSetRequestPayment_ObjStore_S3::get_params()
 {
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
 
   int r = 0;
   std::tie(r, in_data) = rgw_rest_read_all_input(s, max_size, false);
@@ -3461,7 +3461,7 @@ int RGWPutObjRetention_ObjStore_S3::get_params()
     bypass_governance_mode = boost::algorithm::iequals(bypass_gov_decoded, "true");
   }
 
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
   std::tie(op_ret, data) = rgw_rest_read_all_input(s, max_size, false);
   return op_ret;
 }
@@ -3533,7 +3533,7 @@ RGWOp *RGWHandler_REST_Service_S3::op_head()
 
 RGWOp *RGWHandler_REST_Service_S3::op_post()
 {
-  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
 
   int ret = 0;
   bufferlist data;
@@ -3588,7 +3588,7 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_get()
     return new RGWGetBucketVersioning_ObjStore_S3;
 
   if (s->info.args.sub_resource_exists("website")) {
-    if (!s->cct->_conf->rgw_enable_static_website) {
+    if (!s->cct->_conf.get_val<bool>("rgw_enable_static_website")) {
       return NULL;
     }
     return new RGWGetBucketWebsite_ObjStore_S3;
@@ -3635,7 +3635,7 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_put()
   if (s->info.args.sub_resource_exists("versioning"))
     return new RGWSetBucketVersioning_ObjStore_S3;
   if (s->info.args.sub_resource_exists("website")) {
-    if (!s->cct->_conf->rgw_enable_static_website) {
+    if (!s->cct->_conf.get_val<bool>("rgw_enable_static_website")) {
       return NULL;
     }
     return new RGWSetBucketWebsite_ObjStore_S3;
@@ -3674,7 +3674,7 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_delete()
   }
 
   if (s->info.args.sub_resource_exists("website")) {
-    if (!s->cct->_conf->rgw_enable_static_website) {
+    if (!s->cct->_conf.get_val<bool>("rgw_enable_static_website")) {
       return NULL;
     }
     return new RGWDeleteBucketWebsite_ObjStore_S3;
@@ -3883,7 +3883,7 @@ static int verify_mfa(RGWRados *store, RGWUserInfo *user, const string& mfa_str,
 int RGWHandler_REST_S3::postauth_init()
 {
   struct req_init_state *t = &s->init_state;
-  bool relaxed_names = s->cct->_conf->rgw_relaxed_s3_bucket_names;
+  bool relaxed_names = s->cct->_conf.get_val<bool>("rgw_relaxed_s3_bucket_names");
 
   rgw_parse_url_bucket(t->url_bucket, s->user->user_id.tenant,
 		      s->bucket_tenant, s->bucket_name);
@@ -3933,7 +3933,7 @@ int RGWHandler_REST_S3::init(RGWRados *store, struct req_state *s,
   ret = rgw_validate_tenant_name(s->bucket_tenant);
   if (ret)
     return ret;
-  bool relaxed_names = s->cct->_conf->rgw_relaxed_s3_bucket_names;
+  bool relaxed_names = s->cct->_conf.get_val<bool>("rgw_relaxed_s3_bucket_names");
   if (!s->bucket_name.empty()) {
     ret = valid_s3_bucket_name(s->bucket_name, relaxed_names);
     if (ret)
@@ -4040,9 +4040,9 @@ int RGW_Auth_S3::authorize(const DoutPrefixProvider *dpp,
 {
 
   /* neither keystone and rados enabled; warn and exit! */
-  if (!store->ctx()->_conf->rgw_s3_auth_use_rados &&
-      !store->ctx()->_conf->rgw_s3_auth_use_keystone &&
-      !store->ctx()->_conf->rgw_s3_auth_use_ldap) {
+  if (!store->ctx()->_conf.get_val<bool>("rgw_s3_auth_use_rados") &&
+      !store->ctx()->_conf.get_val<bool>("rgw_s3_auth_use_keystone") &&
+      !store->ctx()->_conf.get_val<bool>("rgw_s3_auth_use_ldap")) {
     ldpp_dout(dpp, 0) << "WARNING: no authorization backend enabled! Users will never authenticate." << dendl;
     return -EPERM;
   }
@@ -4789,19 +4789,19 @@ std::mutex rgw::auth::s3::LDAPEngine::mtx;
 
 void rgw::auth::s3::LDAPEngine::init(CephContext* const cct)
 {
-  if (! cct->_conf->rgw_s3_auth_use_ldap ||
-      cct->_conf->rgw_ldap_uri.empty()) {
+  if (! cct->_conf.get_val<bool>("rgw_s3_auth_use_ldap") ||
+      cct->_conf.get_val<std::string>("rgw_ldap_uri").empty()) {
     return;
   }
 
   if (! ldh) {
     std::lock_guard<std::mutex> lck(mtx);
     if (! ldh) {
-      const string& ldap_uri = cct->_conf->rgw_ldap_uri;
-      const string& ldap_binddn = cct->_conf->rgw_ldap_binddn;
-      const string& ldap_searchdn = cct->_conf->rgw_ldap_searchdn;
-      const string& ldap_searchfilter = cct->_conf->rgw_ldap_searchfilter;
-      const string& ldap_dnattr = cct->_conf->rgw_ldap_dnattr;
+      const string& ldap_uri = cct->_conf.get_val<std::string>("rgw_ldap_uri");
+      const string& ldap_binddn = cct->_conf.get_val<std::string>("rgw_ldap_binddn");
+      const string& ldap_searchdn = cct->_conf.get_val<std::string>("rgw_ldap_searchdn");
+      const string& ldap_searchfilter = cct->_conf.get_val<std::string>("rgw_ldap_searchfilter");
+      const string& ldap_dnattr = cct->_conf.get_val<std::string>("rgw_ldap_dnattr");
       std::string ldap_bindpw = parse_rgw_ldap_bindpw(cct);
 
       ldh = new rgw::LDAPHelper(ldap_uri, ldap_binddn, ldap_bindpw,
@@ -4975,7 +4975,7 @@ rgw::auth::s3::STSEngine::get_session_token(const DoutPrefixProvider* dpp, const
   if (! cryptohandler) {
     return -EINVAL;
   }
-  string secret_s = cct->_conf->rgw_sts_key;
+  string secret_s = cct->_conf.get_val<std::string>("rgw_sts_key");
   buffer::ptr secret(secret_s.c_str(), secret_s.length());
   int ret = 0;
   if (ret = cryptohandler->validate_secret(secret); ret < 0) {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -1060,7 +1060,7 @@ public:
                             ) const override {
     return aplptr_t(
       new rgw::auth::RemoteApplier(cct, store, std::move(acl_alg), info,
-                                   cct->_conf->rgw_keystone_implicit_tenants));
+                                   cct->_conf.get_val<bool>("rgw_keystone_implicit_tenants")));
   }
 
   aplptr_t create_apl_local(CephContext* const cct,

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -51,12 +51,12 @@ boost::optional<WebTokenEngine::token_t>
 WebTokenEngine::get_from_idp(const DoutPrefixProvider* dpp, const std::string& token) const
 {
   //Access token conforming to OAuth2.0
-  if (! cct->_conf->rgw_sts_token_introspection_url.empty()) {
+  if (! cct->_conf.get_val<std::string>("rgw_sts_token_introspection_url").empty()) {
     bufferlist introspect_resp;
-    RGWHTTPTransceiver introspect_req(cct, "POST", cct->_conf->rgw_sts_token_introspection_url, &introspect_resp);
+    RGWHTTPTransceiver introspect_req(cct, "POST", cct->_conf.get_val<std::string>("rgw_sts_token_introspection_url"), &introspect_resp);
     //Headers
     introspect_req.append_header("Content-Type", "application/x-www-form-urlencoded");
-    string base64_creds = "Basic " + rgw::to_base64(cct->_conf->rgw_sts_client_id + ":" + cct->_conf->rgw_sts_client_secret);
+    string base64_creds = "Basic " + rgw::to_base64(cct->_conf.get_val<std::string>("rgw_sts_client_id") + ":" + cct->_conf.get_val<std::string>("rgw_sts_client_secret"));
     introspect_req.append_header("Authorization", base64_creds);
     // POST data
     string post_data = "token=" + token;
@@ -189,7 +189,7 @@ int RGWSTSGetSessionToken::get_params()
   if (! duration.empty()) {
     uint64_t duration_in_secs = stoull(duration);
     if (duration_in_secs < STS::GetSessionTokenRequest::getMinDuration() ||
-            duration_in_secs > s->cct->_conf->rgw_sts_max_session_duration)
+            duration_in_secs > s->cct->_conf.get_val<uint64_t>("rgw_sts_max_session_duration"))
       return -EINVAL;
   }
 

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -119,7 +119,7 @@ void RGWOp_User_Create::execute()
   bool exclusive;
 
   int32_t max_buckets;
-  int32_t default_max_buckets = s->cct->_conf->rgw_user_max_buckets;
+  int32_t default_max_buckets = s->cct->_conf.get_val<int64_t>("rgw_user_max_buckets");
 
   RGWUserAdminOpState op_state;
 

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -67,7 +67,7 @@ int Credentials::generateCredentials(CephContext* cct,
   if (! cryptohandler) {
     return -EINVAL;
   }
-  string secret_s = cct->_conf->rgw_sts_key;
+  string secret_s = cct->_conf.get_val<std::string>("rgw_sts_key");
   buffer::ptr secret(secret_s.c_str(), secret_s.length());
   int ret = 0;
   if (ret = cryptohandler->validate_secret(secret); ret < 0) {

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -322,7 +322,7 @@ TempURLEngine::authenticate(const DoutPrefixProvider* dpp, const req_state* cons
    * of Swift API entry point removed. */
 
   /* XXX can we search this ONCE? */
-  const size_t pos = g_conf()->rgw_swift_url_prefix.find_last_not_of('/') + 1;
+  const size_t pos = g_conf().get_val<std::string>("rgw_swift_url_prefix").find_last_not_of('/') + 1;
   const boost::string_view ref_uri = s->decoded_uri;
   const std::array<boost::string_view, 2> allowed_paths = {
     ref_uri,
@@ -388,7 +388,7 @@ bool ExternalTokenEngine::is_applicable(const std::string& token) const noexcept
 {
   if (token.empty()) {
     return false;
-  } else if (g_conf()->rgw_swift_auth_url.empty()) {
+  } else if (g_conf().get_val<std::string>("rgw_swift_auth_url").empty()) {
     return false;
   } else {
     return true;
@@ -404,7 +404,7 @@ ExternalTokenEngine::authenticate(const DoutPrefixProvider* dpp,
     return result_t::deny();
   }
 
-  std::string auth_url = g_conf()->rgw_swift_auth_url;
+  std::string auth_url = g_conf().get_val<std::string>("rgw_swift_auth_url");
   if (auth_url.back() != '/') {
     auth_url.append("/");
   }
@@ -494,7 +494,7 @@ static int encode_token(CephContext *cct, string& swift_user, string& key,
   const auto nonce = ceph::util::generate_random_number<uint64_t>();
 
   utime_t expiration = ceph_clock_now();
-  expiration += cct->_conf->rgw_swift_token_expiration;
+  expiration += cct->_conf.get_val<int64_t>("rgw_swift_token_expiration");
 
   return build_token(swift_user, key, nonce, expiration, bl);
 }
@@ -628,8 +628,8 @@ void RGW_SWIFT_Auth_Get::execute()
   RGWAccessKey *swift_key;
   map<string, RGWAccessKey>::iterator siter;
 
-  string swift_url = g_conf()->rgw_swift_url;
-  string swift_prefix = g_conf()->rgw_swift_url_prefix;
+  string swift_url = g_conf().get_val<std::string>("rgw_swift_url");
+  string swift_prefix = g_conf().get_val<std::string>("rgw_swift_url_prefix");
   string tenant_path;
 
   /*
@@ -699,10 +699,10 @@ void RGW_SWIFT_Auth_Get::execute()
     goto done;
   }
 
-  if (!g_conf()->rgw_swift_tenant_name.empty()) {
+  if (!g_conf().get_val<std::string>("rgw_swift_tenant_name").empty()) {
     tenant_path = "/AUTH_";
-    tenant_path.append(g_conf()->rgw_swift_tenant_name);
-  } else if (g_conf()->rgw_swift_account_in_url) {
+    tenant_path.append(g_conf().get_val<std::string>("rgw_swift_tenant_name"));
+  } else if (g_conf().get_val<bool>("rgw_swift_account_in_url")) {
     tenant_path = "/AUTH_";
     tenant_path.append(info.user_id.to_str());
   }

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -197,7 +197,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
       rgw::auth::add_3rdparty(store, s->account_name,
         rgw::auth::add_sysreq(cct, store, s,
           rgw::auth::RemoteApplier(cct, store, std::move(extra_acl_strategy), info,
-                                   cct->_conf->rgw_keystone_implicit_tenants)));
+                                   cct->_conf.get_val<bool>("rgw_keystone_implicit_tenants"))));
     /* TODO(rzarzynski): replace with static_ptr. */
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
@@ -251,7 +251,7 @@ public:
 
     /* The auth strategy is responsible for deciding whether a parcular
      * engine is disabled or not. */
-    if (! cct->_conf->rgw_keystone_url.empty()) {
+    if (! cct->_conf.get_val<std::string>("rgw_keystone_url").empty()) {
       keystone_engine.emplace(cct,
                               static_cast<rgw::auth::TokenExtractor*>(this),
                               static_cast<rgw::auth::RemoteApplier::Factory*>(this),
@@ -260,7 +260,7 @@ public:
 
       add_engine(Control::SUFFICIENT, *keystone_engine);
     }
-    if (! cct->_conf->rgw_swift_auth_url.empty()) {
+    if (! cct->_conf.get_val<std::string>("rgw_swift_auth_url").empty()) {
       add_engine(Control::SUFFICIENT, external_engine);
     }
 

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -649,7 +649,7 @@ public:
     reenter(this) {
       yield {
         set_status("acquiring sync lock");
-	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
+	uint32_t lock_duration = cct->_conf.get_val<int64_t>("rgw_sync_lease_period");
         string lock_name = "sync_lock";
         RGWRados *store = sync_env->store;
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
@@ -884,7 +884,7 @@ public:
     reenter(this) {
       yield {
         set_status(string("acquiring lock (") + sync_env->status_oid() + ")");
-	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
+	uint32_t lock_duration = cct->_conf.get_val<int64_t>("rgw_sync_lease_period");
         string lock_name = "sync_lock";
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados,
                                                 sync_env->store,
@@ -1251,7 +1251,7 @@ RGWMetaSyncSingleEntryCR::RGWMetaSyncSingleEntryCR(RGWMetaSyncEnv *_sync_env,
                                                       op_status(_op_status),
                                                       pos(0), sync_status(0),
                                                       marker_tracker(_marker_tracker), tries(0) {
-  error_injection = (sync_env->cct->_conf->rgw_sync_meta_inject_err_probability > 0);
+  error_injection = (sync_env->cct->_conf.get_val<double>("rgw_sync_meta_inject_err_probability") > 0);
   tn = sync_env->sync_tracer->add_node(_tn_parent, "entry", raw_key);
 }
 
@@ -1260,7 +1260,7 @@ int RGWMetaSyncSingleEntryCR::operate() {
 #define NUM_TRANSIENT_ERROR_RETRIES 10
 
     if (error_injection &&
-        rand() % 10000 < cct->_conf->rgw_sync_meta_inject_err_probability * 10000.0) {
+        rand() % 10000 < cct->_conf.get_val<double>("rgw_sync_meta_inject_err_probability") * 10000.0) {
       ldpp_dout(sync_env->dpp, 0) << __FILE__ << ":" << __LINE__ << ": injecting meta sync error on key=" << raw_key << dendl;
       return set_cr_error(-EIO);
     }
@@ -1550,7 +1550,7 @@ public:
       can_adjust_marker = true;
       /* grab lock */
       yield {
-	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
+	uint32_t lock_duration = cct->_conf.get_val<int64_t>("rgw_sync_lease_period");
         string lock_name = "sync_lock";
         RGWRados *store = sync_env->store;
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
@@ -1696,7 +1696,7 @@ public:
       /* grab lock */
       if (!lease_cr) { /* could have had  a lease_cr lock from previous state */
         yield {
-          uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
+          uint32_t lock_duration = cct->_conf.get_val<int64_t>("rgw_sync_lease_period");
           string lock_name = "sync_lock";
           RGWRados *store = sync_env->store;
           lease_cr.reset( new RGWContinuousLeaseCR(sync_env->async_rados, store,

--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -805,7 +805,7 @@ class RGWPSCreateNotif_ObjStore_S3 : public RGWPSCreateNotifOp {
   rgw_pubsub_s3_notifications configurations;
 
   int get_params_from_body() {
-    const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+    const auto max_size = s->cct->_conf.get_val<size_t>("rgw_max_put_param_size");
     int r;
     bufferlist data;
     std::tie(r, data) = rgw_rest_read_all_input(s, max_size, false);

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -23,7 +23,7 @@ RGWSyncTraceNode::RGWSyncTraceNode(CephContext *_cct, uint64_t _handle,
                                                                              type(_type),
                                                                              id(_id),
                                                                              handle(_handle),
-                                                                             history(cct->_conf->rgw_sync_trace_per_node_log_size)
+                                                                             history(cct->_conf.get_val<int64_t>("rgw_sync_trace_per_node_log_size"))
 {
   if (parent.get()) {
     prefix = parent->get_prefix();
@@ -58,7 +58,7 @@ class RGWSyncTraceServiceMapThread : public RGWRadosThread {
   RGWSyncTraceManager *manager;
 
   uint64_t interval_msec() override {
-    return cct->_conf->rgw_sync_trace_servicemap_update_interval * 1000;
+    return cct->_conf.get_val<int64_t>("rgw_sync_trace_servicemap_update_interval") * 1000;
   }
 public:
   RGWSyncTraceServiceMapThread(RGWRados *_store, RGWSyncTraceManager *_manager)

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -431,7 +431,7 @@ int RGWDataAccess::Object::put(bufferlist& data,
 
   RGWBucketInfo& bucket_info = bucket->bucket_info;
 
-  rgw::BlockingAioThrottle aio(store->ctx()->_conf->rgw_put_obj_min_window_size);
+  rgw::BlockingAioThrottle aio(store->ctx()->_conf.get_val<size_t>("rgw_put_obj_min_window_size"));
 
   RGWObjectCtx obj_ctx(store);
   rgw_obj obj(bucket_info.bucket, key);
@@ -538,7 +538,7 @@ void RGWDataAccess::Object::set_policy(const RGWAccessControlPolicy& policy)
 int rgw_tools_init(CephContext *cct)
 {
   ext_mime_map = new std::map<std::string, std::string>;
-  ext_mime_map_init(cct, cct->_conf->rgw_mime_types_file.c_str());
+  ext_mime_map_init(cct, cct->_conf.get_val<std::string>("rgw_mime_types_file").c_str());
   // ignore errors; missing mime.types is not fatal
   return 0;
 }

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -174,12 +174,12 @@ void seed::sha1(SHA1 *h, bufferlist &bl, off_t bl_len)
 int seed::get_params()
 {
   is_torrent = true;
-  info.piece_length = g_conf()->rgw_torrent_sha_unit;
-  create_by = g_conf()->rgw_torrent_createby;
-  encoding = g_conf()->rgw_torrent_encoding;
-  origin = g_conf()->rgw_torrent_origin;
-  comment = g_conf()->rgw_torrent_comment;
-  announce = g_conf()->rgw_torrent_tracker;
+  info.piece_length = g_conf().get_val<size_t>("rgw_torrent_sha_unit");
+  create_by = g_conf().get_val<std::string>("rgw_torrent_createby");
+  encoding = g_conf().get_val<std::string>("rgw_torrent_encoding");
+  origin = g_conf().get_val<std::string>("rgw_torrent_origin");
+  comment = g_conf().get_val<std::string>("rgw_torrent_comment");
+  announce = g_conf().get_val<std::string>("rgw_torrent_tracker");
 
   /* tracker and tracker list is empty, set announce to origin */
   if (announce.empty() && !origin.empty())

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -84,7 +84,7 @@ int PurgePeriodLogsCR::operate()
       yield {
         const auto mdlog = metadata->get_log(cursor.get_period().get_id());
         const auto& pool = store->svc.zone->get_zone_params().log_pool;
-        auto num_shards = cct->_conf->rgw_md_log_max_shards;
+        auto num_shards = cct->_conf.get_val<int64_t>("rgw_md_log_max_shards");
         call(new PurgeLogShardsCR(store, mdlog, pool, num_shards));
       }
       if (retcode < 0) {
@@ -164,7 +164,7 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
   if (first == last) {
     return -EINVAL;
   }
-  const size_t num_shards = cct->_conf->rgw_md_log_max_shards;
+  const size_t num_shards = cct->_conf.get_val<int64_t>("rgw_md_log_max_shards");
 
   status->sync_info.realm_epoch = std::numeric_limits<epoch_t>::max();
   for (auto p = first; p != last; ++p) {

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -49,7 +49,7 @@ void rgw_get_anon_user(RGWUserInfo& info)
 int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)
 {
   CephContext *cct = store->ctx();
-  size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
+  size_t max_entries = cct->_conf.get_val<int64_t>("rgw_list_buckets_max_chunk");
   bool is_truncated = false;
   string marker;
   int ret;
@@ -103,7 +103,7 @@ int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)
 int rgw_user_get_all_buckets_stats(RGWRados *store, const rgw_user& user_id, map<string, cls_user_bucket_entry>&buckets_usage_map)
 {
   CephContext *cct = store->ctx();
-  size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
+  size_t max_entries = cct->_conf.get_val<int64_t>("rgw_list_buckets_max_chunk");
   bool done;
   bool is_truncated;
   string marker;
@@ -1997,7 +1997,7 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
   if (op_state.max_buckets_specified) {
     user_info.max_buckets = op_state.get_max_buckets();
   } else {
-    user_info.max_buckets = cct->_conf->rgw_user_max_buckets;
+    user_info.max_buckets = cct->_conf.get_val<int64_t>("rgw_user_max_buckets");
   }
 
   user_info.suspended = op_state.get_suspension_status();
@@ -2099,7 +2099,7 @@ int RGWUser::execute_remove(RGWUserAdminOpState& op_state, std::string *err_msg,
   bool is_truncated = false;
   string marker;
   CephContext *cct = store->ctx();
-  size_t max_buckets = cct->_conf->rgw_list_buckets_max_chunk;
+  size_t max_buckets = cct->_conf.get_val<int64_t>("rgw_list_buckets_max_chunk");
   do {
     RGWUserBuckets buckets;
     ret = rgw_read_user_buckets(store, uid, buckets, marker, string(),
@@ -2260,7 +2260,7 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
     bool is_truncated = false;
     string marker;
     CephContext *cct = store->ctx();
-    size_t max_buckets = cct->_conf->rgw_list_buckets_max_chunk;
+    size_t max_buckets = cct->_conf.get_val<int64_t>("rgw_list_buckets_max_chunk");
     do {
       ret = rgw_read_user_buckets(store, user_id, buckets, marker, string(),
 				  max_buckets, false, &is_truncated);

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -60,11 +60,11 @@ void RGWDefaultZoneGroupInfo::decode_json(JSONObj *obj) {
 
 rgw_pool RGWZoneGroup::get_pool(CephContext *cct_) const
 {
-  if (cct_->_conf->rgw_zonegroup_root_pool.empty()) {
+  if (cct_->_conf.get_val<std::string>("rgw_zonegroup_root_pool").empty()) {
     return rgw_pool(RGW_DEFAULT_ZONEGROUP_ROOT_POOL);
   }
 
-  return rgw_pool(cct_->_conf->rgw_zonegroup_root_pool);
+  return rgw_pool(cct_->_conf.get_val<std::string>("rgw_zonegroup_root_pool"));
 }
 
 int RGWZoneGroup::create_default(bool old_format)
@@ -134,15 +134,15 @@ int RGWZoneGroup::create_default(bool old_format)
 const string RGWZoneGroup::get_default_oid(bool old_region_format) const
 {
   if (old_region_format) {
-    if (cct->_conf->rgw_default_region_info_oid.empty()) {
+    if (cct->_conf.get_val<std::string>("rgw_default_region_info_oid").empty()) {
       return default_region_info_oid;
     }
-    return cct->_conf->rgw_default_region_info_oid;
+    return cct->_conf.get_val<std::string>("rgw_default_region_info_oid");
   }
 
-  string default_oid = cct->_conf->rgw_default_zonegroup_info_oid;
+  string default_oid = cct->_conf.get_val<std::string>("rgw_default_zonegroup_info_oid");
 
-  if (cct->_conf->rgw_default_zonegroup_info_oid.empty()) {
+  if (cct->_conf.get_val<std::string>("rgw_default_zonegroup_info_oid").empty()) {
     default_oid = default_zone_group_info_oid;
   }
 
@@ -768,18 +768,18 @@ int RGWRealm::delete_control()
 
 rgw_pool RGWRealm::get_pool(CephContext *cct) const
 {
-  if (cct->_conf->rgw_realm_root_pool.empty()) {
+  if (cct->_conf.get_val<std::string>("rgw_realm_root_pool").empty()) {
     return rgw_pool(RGW_DEFAULT_REALM_ROOT_POOL);
   }
-  return rgw_pool(cct->_conf->rgw_realm_root_pool);
+  return rgw_pool(cct->_conf.get_val<std::string>("rgw_realm_root_pool"));
 }
 
 const string RGWRealm::get_default_oid(bool old_format) const
 {
-  if (cct->_conf->rgw_default_realm_info_oid.empty()) {
+  if (cct->_conf.get_val<std::string>("rgw_default_realm_info_oid").empty()) {
     return default_realm_info_oid;
   }
-  return cct->_conf->rgw_default_realm_info_oid;
+  return cct->_conf.get_val<std::string>("rgw_default_realm_info_oid");
 }
 
 const string& RGWRealm::get_names_oid_prefix() const
@@ -865,7 +865,7 @@ std::string RGWPeriodConfig::get_oid(const std::string& realm_id)
 
 rgw_pool RGWPeriodConfig::get_pool(CephContext *cct)
 {
-  const auto& pool_name = cct->_conf->rgw_period_root_pool;
+  const auto& pool_name = cct->_conf.get_val<std::string>("rgw_period_root_pool");
   if (pool_name.empty()) {
     return {RGW_DEFAULT_PERIOD_ROOT_POOL};
   }
@@ -1223,10 +1223,10 @@ int RGWPeriod::store_info(bool exclusive)
 
 rgw_pool RGWPeriod::get_pool(CephContext *cct) const
 {
-  if (cct->_conf->rgw_period_root_pool.empty()) {
+  if (cct->_conf.get_val<std::string>("rgw_period_root_pool").empty()) {
     return rgw_pool(RGW_DEFAULT_PERIOD_ROOT_POOL);
   }
-  return rgw_pool(cct->_conf->rgw_period_root_pool);
+  return rgw_pool(cct->_conf.get_val<std::string>("rgw_period_root_pool"));
 }
 
 int RGWPeriod::add_zonegroup(const RGWZoneGroup& zonegroup)
@@ -1680,20 +1680,20 @@ int RGWZoneParams::create(bool exclusive)
 
 rgw_pool RGWZoneParams::get_pool(CephContext *cct) const
 {
-  if (cct->_conf->rgw_zone_root_pool.empty()) {
+  if (cct->_conf.get_val<std::string>("rgw_zone_root_pool").empty()) {
     return rgw_pool(RGW_DEFAULT_ZONE_ROOT_POOL);
   }
 
-  return rgw_pool(cct->_conf->rgw_zone_root_pool);
+  return rgw_pool(cct->_conf.get_val<std::string>("rgw_zone_root_pool"));
 }
 
 const string RGWZoneParams::get_default_oid(bool old_format) const
 {
   if (old_format) {
-    return cct->_conf->rgw_default_zone_info_oid;
+    return cct->_conf.get_val<std::string>("rgw_default_zone_info_oid");
   }
 
-  return cct->_conf->rgw_default_zone_info_oid + "." + realm_id;
+  return cct->_conf.get_val<std::string>("rgw_default_zone_info_oid") + "." + realm_id;
 }
 
 const string& RGWZoneParams::get_names_oid_prefix() const

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -160,7 +160,7 @@ RGWSI_RADOS::Obj RGWSI_Notify::pick_control_obj(const string& key)
 
 int RGWSI_Notify::init_watch()
 {
-  num_watchers = cct->_conf->rgw_num_control_oids;
+  num_watchers = cct->_conf.get_val<int64_t>("rgw_num_control_oids");
 
   bool compat_oid = (num_watchers == 0);
 

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -90,10 +90,8 @@ protected:
   void set_enabled(bool status);
 
 public:
-  RGWSI_SysObj_Cache(CephContext *cct) : RGWSI_SysObj_Core(cct) {
-    cache.set_ctx(cct);
-  }
-
+  RGWSI_SysObj_Cache(CephContext *cct) : RGWSI_SysObj_Core(cct), cache(cct) {}
+    
   bool chain_cache_entry(std::initializer_list<rgw_cache_entry_info *> cache_info_entries,
                          RGWChainedCache::Entry *chained_entry);
   void register_chained_cache(RGWChainedCache *cc);

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -300,7 +300,7 @@ int RGWSI_Zone::replace_region_with_zonegroup()
 {
   /* copy default region */
   /* convert default region to default zonegroup */
-  string default_oid = cct->_conf->rgw_default_region_info_oid;
+  string default_oid = cct->_conf.get_val<std::string>("rgw_default_region_info_oid");
   if (default_oid.empty()) {
     default_oid = default_region_info_oid;
   }
@@ -718,7 +718,7 @@ int RGWSI_Zone::convert_regionmap()
 {
   RGWZoneGroupMap zonegroupmap;
 
-  string pool_name = cct->_conf->rgw_zone_root_pool;
+  string pool_name = cct->_conf.get_val<std::string>("rgw_zone_root_pool");
   if (pool_name.empty()) {
     pool_name = RGW_DEFAULT_ZONE_ROOT_POOL;
   }

--- a/src/test/test_rgw_admin_log.cc
+++ b/src/test/test_rgw_admin_log.cc
@@ -712,7 +712,7 @@ TEST(TestRGWAdmin, datalog_list) {
   const char *cname = "datalog",
              *perm = "*";
   string rest_req;
-  unsigned shard_id = get_datalog_shard_id(TEST_BUCKET_NAME, g_ceph_context->_conf->rgw_data_log_num_shards);
+  unsigned shard_id = get_datalog_shard_id(TEST_BUCKET_NAME, g_ceph_context->_conf.get_val<int64_t>("rgw_data_log_num_shards"));
   stringstream ss;
   list<rgw_data_change> entries;
 
@@ -727,7 +727,7 @@ TEST(TestRGWAdmin, datalog_list) {
   int num_objects;
   EXPECT_EQ (parse_json_resp(parser), 0);
   JSONDecoder::decode_json("num_objects", num_objects, (JSONObj *)&parser);
-  ASSERT_EQ(num_objects,g_ceph_context->_conf->rgw_data_log_num_shards);
+  ASSERT_EQ(num_objects,g_ceph_context->_conf.get_val<int64_t>("rgw_data_log_num_shards"));
  
   sleep(1);
   ASSERT_EQ(0, create_bucket());
@@ -945,7 +945,7 @@ TEST(TestRGWAdmin, datalog_trim) {
   const char *cname = "datalog",
              *perm = "*";
   string rest_req;
-  unsigned shard_id = get_datalog_shard_id(TEST_BUCKET_NAME, g_ceph_context->_conf->rgw_data_log_num_shards);
+  unsigned shard_id = get_datalog_shard_id(TEST_BUCKET_NAME, g_ceph_context->_conf.get_val<int64_t>("rgw_data_log_num_shards"));
   stringstream ss;
   list<rgw_data_change> entries;
 
@@ -1040,7 +1040,7 @@ TEST(TestRGWAdmin, mdlog_list) {
   const char *cname = "mdlog",
              *perm = "*";
   string rest_req;
-  unsigned shard_id = get_mdlog_shard_id(uid, g_ceph_context->_conf->rgw_md_log_max_shards);
+  unsigned shard_id = get_mdlog_shard_id(uid, g_ceph_context->_conf.get_val<int64_t>("rgw_md_log_max_shards"));
   stringstream ss;
 
   sleep(2);
@@ -1055,7 +1055,7 @@ TEST(TestRGWAdmin, mdlog_list) {
   int num_objects;
   EXPECT_EQ (parse_json_resp(parser), 0);
   JSONDecoder::decode_json("num_objects", num_objects, (JSONObj *)&parser);
-  ASSERT_EQ(num_objects,g_ceph_context->_conf->rgw_md_log_max_shards);
+  ASSERT_EQ(num_objects,g_ceph_context->_conf.get_val<int64_t>("rgw_md_log_max_shards"));
 
   ss.str("");
   ss << "/admin/log?type=metadata&id=" << shard_id << "&start-time=" << start_time;
@@ -1215,7 +1215,7 @@ TEST(TestRGWAdmin, mdlog_trim) {
              *perm = "*";
   string rest_req;
   list<cls_log_entry_json> entries;
-  unsigned shard_id = get_mdlog_shard_id(uid, g_ceph_context->_conf->rgw_md_log_max_shards);
+  unsigned shard_id = get_mdlog_shard_id(uid, g_ceph_context->_conf.get_val<int64_t>("rgw_md_log_max_shards"));
   ostringstream ss;
 
   sleep(1);


### PR DESCRIPTION
use get_val instead of the deprecated method of getting parameters
and using config observer api to selected variables.

Signed-off-by: Albin Antony <aantony@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

