### PR TITLE
Sharded BlueStore - 1 - KeyValueDB

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -42,6 +42,7 @@ public:
     bool operator!=(struct ColumnFamilyHandle rhs) const {return rhs.priv != priv;}
     bool operator==(void* rhs) const {return rhs == priv;}
     bool operator!=(void* rhs) const {return rhs != priv;}
+    operator bool() const {return priv != nullptr;}
   };
 
   class TransactionImpl {

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -36,7 +36,8 @@ public:
   };
 
   struct ColumnFamilyHandle {
-    void* priv = nullptr;
+    ColumnFamilyHandle() : priv(nullptr) {}
+    void* priv;
     bool operator==(struct ColumnFamilyHandle rhs) const {return rhs.priv == priv;}
     bool operator!=(struct ColumnFamilyHandle rhs) const {return rhs.priv != priv;}
     bool operator==(void* rhs) const {return rhs == priv;}
@@ -174,7 +175,7 @@ public:
   /// test whether we can successfully initialize; may have side effects (e.g., create)
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(string option_str="") = 0;
-  /*
+  /**
    * Opens existing database
    *
    * Makes transition to state that allows to fetch/store data into database.
@@ -192,7 +193,7 @@ public:
    *   0 - success, <0 error code
    */
   virtual int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) = 0;
-  /*
+  /**
    * Creates new database
    *
    * Enables access to newly created database. This database is empty, with exception that
@@ -213,7 +214,7 @@ public:
 
   virtual void close() { }
 
-  /*
+  /**
    * @defgroup column_family Column Families
    * There are 3 categories of column families.
    *
@@ -234,7 +235,7 @@ public:
    * Merge operator name must not include prefixes handled by mono column families.
    */
 
-  /*
+  /**
    * @ingroup column_family
    * List column families
    *
@@ -253,7 +254,7 @@ public:
   virtual int column_family_list(vector<std::string>& cf_names)
   { cf_names.clear(); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Create new column family
    *
@@ -269,7 +270,7 @@ public:
   virtual int column_family_create(const std::string& cf_name, const std::string& cf_options)
   { ceph_abort_msg("Not implemented"); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Delete column family
    *
@@ -285,7 +286,7 @@ public:
   virtual int column_family_delete(const std::string& cf_name)
   { ceph_abort_msg("Not implemented"); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Get handle to column family
    *
@@ -297,8 +298,8 @@ public:
    * Result:
    *   handle to column family, or nullptr when cf_name does not exist
    */
-  virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name)
-  { ceph_abort_msg("Not implemented"); return {nullptr}; }
+  virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name) const
+  { ceph_abort_msg("Not implemented"); return ColumnFamilyHandle(); }
 
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.
   virtual int repair(std::ostream &out) { return 0; }
@@ -524,7 +525,8 @@ public:
 
   /// estimate space utilization for a prefix (in bytes)
   virtual int64_t estimate_prefix_size(const string& prefix,
-				       const string& key_prefix) {
+				       const string& key_prefix,
+                                       ColumnFamilyHandle cfh = ColumnFamilyHandle()) {
     return 0;
   }
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -208,7 +208,7 @@ public:
    */
   virtual int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) = 0;
 
-  virtual int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) {
+  virtual int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options = {}) {
     return -ENOTSUP;
   }
 
@@ -300,6 +300,18 @@ public:
    */
   virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name) const
   { ceph_abort_msg("Not implemented"); return ColumnFamilyHandle(); }
+
+  virtual int column_family_compact(const std::string& cf_name,
+                            const string& prefix,
+                            const string& start,
+                            const string& end)
+  { ceph_abort_msg("Not implemented"); return 0; }
+
+  virtual int column_family_compact_async(const std::string& cf_name,
+                                  const string& prefix,
+                                  const string& start,
+                                  const string& end)
+  { ceph_abort_msg("Not implemented"); return 0; }
 
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.
   virtual int repair(std::ostream &out) { return 0; }

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -165,7 +165,7 @@ int MemDB::set_merge_operator(
   const string& prefix,
   std::shared_ptr<KeyValueDB::MergeOperator> mop)
 {
-  merge_ops.push_back(std::make_pair(prefix, mop));
+  merge_ops.emplace(prefix, mop);
   return 0;
 }
 
@@ -338,10 +338,9 @@ int MemDB::_rmkey(ms_op_t &op)
 
 std::shared_ptr<KeyValueDB::MergeOperator> MemDB::_find_merge_op(const std::string &prefix)
 {
-  for (const auto& i : merge_ops) {
-    if (i.first == prefix) {
-      return i.second;
-    }
+  auto i = merge_ops.find(prefix);
+  if (i != merge_ops.end()) {
+    return i->second;
   }
 
   dtrace << __func__ << " No merge op for " << prefix << dendl;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1087,7 +1087,7 @@ int RocksDBStore::cf_create(const std::string& cf_name, const std::string& cf_op
 }
 
 
-KeyValueDB::ColumnFamilyHandle RocksDBStore::cf_wrap_handle(rocksdb::ColumnFamilyHandle* rocks_cfh) const
+KeyValueDB::ColumnFamilyHandle RocksDBStore::cf_wrap_handle(rocksdb::ColumnFamilyHandle* rocks_cfh)
 {
   KeyValueDB::ColumnFamilyHandle cfh;
   cfh.priv = static_cast<void*>(rocks_cfh);
@@ -1400,7 +1400,7 @@ void RocksDBStore::RocksDBTransactionImpl::set(
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
   if (db->cf_check_mode(cf, prefix)) {
-    string key(k, keylen);  // fixme?
+    string key(k, keylen); 
     put_bat(bat, cf, key, to_set_bl);
   } else {
     string key;
@@ -1451,7 +1451,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix
   bool is_mono = db->cf_check_mode(cf, prefix);
   uint64_t cnt = db->delete_range_threshold;
   bat.SetSavePoint();
-  auto it = db->get_iterator(prefix);
+  auto it = db->get_iterator_cf(RocksDBStore::cf_wrap_handle(cf), prefix);
   for (it->seek_to_first(); it->valid(); it->next()) {
     if (!cnt) {
       bat.RollbackToSavePoint();
@@ -1484,7 +1484,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
   bool is_mono = db->cf_check_mode(cf, prefix);
   uint64_t cnt = db->delete_range_threshold;
-  auto it = db->get_iterator(prefix);
+  auto it = db->get_iterator_cf(RocksDBStore::cf_wrap_handle(cf), prefix); 
   bat.SetSavePoint();
   it->lower_bound(start);
   while (it->valid()) {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -859,7 +859,7 @@ int RocksDBStore::column_family_delete(const std::string& cf_name)
   RWLock::WLocker l(api_lock);
   rocksdb::ColumnFamilyHandle* handle = cf_get_handle(cf_name);
   rocksdb::Status status = db->DropColumnFamily(handle);
-  if (!status.ok()) {
+  if (status.ok()) {
     column_families.erase(cf_name);
   } else {
       derr << __func__ << " problem deleting column family '" << cf_name << "'" << dendl;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -610,7 +610,7 @@ int RocksDBStore::_open(ostream &out, bool read_only, const std::vector<ColumnFa
     for (size_t i = 0; i < existing_cfs.size(); ++i) {
       if (existing_cfs[i] == rocksdb::kDefaultColumnFamilyName) {
         default_cf = handles[i];
-        must_close_default_cf = true;
+        column_families[existing_cfs[i]].handle = cf_wrap_handle(default_cf);
       } else {
         // add_column_family(existing_cfs[i], static_cast<void*>(handles[i]));
         // store the new CF handle
@@ -1130,10 +1130,6 @@ RocksDBStore::~RocksDBStore()
   for (auto& p : column_families) {
     db->DestroyColumnFamilyHandle(
       static_cast<rocksdb::ColumnFamilyHandle*>(p.second.handle.priv));
-  }
-  if (must_close_default_cf) {
-    db->DestroyColumnFamilyHandle(default_cf);
-    must_close_default_cf = false;
   }
   default_cf = nullptr;
   delete db;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -61,32 +61,31 @@ static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl,
 class RocksDBStore::MergeOperatorRouter
   : public rocksdb::AssociativeMergeOperator
 {
+protected:
   RocksDBStore& store;
+  mutable std::string name;
 public:
   const char *Name() const override {
     // Construct a name that rocksDB will validate against. We want to
     // do this in a way that doesn't constrain the ordering of calls
     // to set_merge_operator, so sort the merge operators and then
     // construct a name from all of those parts.
-    store.assoc_name.clear();
+    name.clear();
     map<std::string,std::string> names;
 
     for (auto& p : store.merge_ops) {
       names[p.first] = p.second->name();
     }
-    //TODO: name of merge operator excludes prefixes for mono tables
-    //TODO: this makes it difficult to merge data back to main table
-    //TODO: regardless of cranky name, this should handle all prefixes?
     for (auto& p : store.cf_mono_handles) {
       names.erase(p.first);
     }
     for (auto& p : names) {
-      store.assoc_name += '.';
-      store.assoc_name += p.first;
-      store.assoc_name += ':';
-      store.assoc_name += p.second;
+      name += '.';
+      name += p.first;
+      name += ':';
+      name += p.second;
     }
-    return store.assoc_name.c_str();
+    return name.c_str();
   }
 
   explicit MergeOperatorRouter(RocksDBStore &_store) : store(_store) {}
@@ -150,6 +149,116 @@ public:
   }
 };
 
+//
+// Merge operator that encompasses all prefixes.
+//
+class RocksDBStore::MergeOperatorAll : public RocksDBStore::MergeOperatorRouter
+{
+public:
+  const char *Name() const override {
+    name.clear();
+    for (auto& p : store.merge_ops) {
+      name += '.';
+      name += p.first;
+      name += ':';
+      name += p.second->name();
+    }
+    return name.c_str();
+  }
+
+  explicit MergeOperatorAll(RocksDBStore &store) : MergeOperatorRouter(store) {}
+};
+
+struct RocksWBHandler: public rocksdb::WriteBatch::Handler {
+  std::string seen ;
+  int num_seen = 0;
+  static string pretty_binary_string(const string& in) {
+    char buf[10];
+    string out;
+    out.reserve(in.length() * 3);
+    enum { NONE, HEX, STRING } mode = NONE;
+    unsigned from = 0, i;
+    for (i=0; i < in.length(); ++i) {
+      if ((in[i] < 32 || (unsigned char)in[i] > 126) ||
+        (mode == HEX && in.length() - i >= 4 &&
+        ((in[i] < 32 || (unsigned char)in[i] > 126) ||
+        (in[i+1] < 32 || (unsigned char)in[i+1] > 126) ||
+        (in[i+2] < 32 || (unsigned char)in[i+2] > 126) ||
+        (in[i+3] < 32 || (unsigned char)in[i+3] > 126)))) {
+
+        if (mode == STRING) {
+          out.append(in.substr(from, i - from));
+          out.push_back('\'');
+        }
+        if (mode != HEX) {
+          out.append("0x");
+          mode = HEX;
+        }
+        if (in.length() - i >= 4) {
+          // print a whole u32 at once
+          snprintf(buf, sizeof(buf), "%08x",
+                (uint32_t)(((unsigned char)in[i] << 24) |
+                          ((unsigned char)in[i+1] << 16) |
+                          ((unsigned char)in[i+2] << 8) |
+                          ((unsigned char)in[i+3] << 0)));
+          i += 3;
+        } else {
+          snprintf(buf, sizeof(buf), "%02x", (int)(unsigned char)in[i]);
+        }
+        out.append(buf);
+      } else {
+        if (mode != STRING) {
+          out.push_back('\'');
+          mode = STRING;
+          from = i;
+        }
+      }
+    }
+    if (mode == STRING) {
+      out.append(in.substr(from, i - from));
+      out.push_back('\'');
+    }
+    return out;
+  }
+  void Put(const rocksdb::Slice& key,
+                  const rocksdb::Slice& value) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    uint64_t size = (value.ToString()).size();
+    seen += "\nPut( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode)
+          + " Value size = " + std::to_string(size) + ")";
+    num_seen++;
+  }
+  void SingleDelete(const rocksdb::Slice& key) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    seen += "\nSingleDelete(Prefix = "+ prefix + " Key = "
+          + pretty_binary_string(key_to_decode) + ")";
+    num_seen++;
+  }
+  void Delete(const rocksdb::Slice& key) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    seen += "\nDelete( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode) + ")";
+
+    num_seen++;
+  }
+  void Merge(const rocksdb::Slice& key,
+                    const rocksdb::Slice& value) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    uint64_t size = (value.ToString()).size();
+    seen += "\nMerge( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode) + " Value size = "
+          + std::to_string(size) + ")";
+
+    num_seen++;
+  }
+  bool Continue() override { return num_seen < 50; }
+};
+
 int RocksDBStore::set_merge_operator(
   const string& prefix,
   std::shared_ptr<KeyValueDB::MergeOperator> mop)
@@ -158,6 +267,72 @@ int RocksDBStore::set_merge_operator(
   ceph_assert(db == nullptr);
   merge_ops.emplace(prefix, mop);
   return 0;
+}
+
+uint64_t RocksDBStore::get_estimated_size(map<string,uint64_t> &extra) {
+  DIR *store_dir = opendir(path.c_str());
+  if (!store_dir) {
+    lderr(cct) << __func__ << " something happened opening the store: "
+        << cpp_strerror(errno) << dendl;
+    return 0;
+  }
+
+  uint64_t total_size = 0;
+  uint64_t sst_size = 0;
+  uint64_t log_size = 0;
+  uint64_t misc_size = 0;
+
+  struct dirent *entry = NULL;
+  while ((entry = readdir(store_dir)) != NULL) {
+    string n(entry->d_name);
+
+    if (n == "." || n == "..")
+      continue;
+
+    string fpath = path + '/' + n;
+    struct stat s;
+    int err = stat(fpath.c_str(), &s);
+    if (err < 0)
+      err = -errno;
+    // we may race against rocksdb while reading files; this should only
+    // happen when those files are being updated, data is being shuffled
+    // and files get removed, in which case there's not much of a problem
+    // as we'll get to them next time around.
+    if (err == -ENOENT) {
+      continue;
+    }
+    if (err < 0) {
+      lderr(cct) << __func__ << " error obtaining stats for " << fpath
+          << ": " << cpp_strerror(err) << dendl;
+      goto err;
+    }
+
+    size_t pos = n.find_last_of('.');
+    if (pos == string::npos) {
+      misc_size += s.st_size;
+      continue;
+    }
+
+    string ext = n.substr(pos+1);
+    if (ext == "sst") {
+      sst_size += s.st_size;
+    } else if (ext == "log") {
+      log_size += s.st_size;
+    } else {
+      misc_size += s.st_size;
+    }
+  }
+
+  total_size = sst_size + log_size + misc_size;
+
+  extra["sst"] = sst_size;
+  extra["log"] = log_size;
+  extra["misc"] = misc_size;
+  extra["total"] = total_size;
+
+  err:
+  closedir(store_dir);
+  return total_size;
 }
 
 class CephRocksdbLogger : public rocksdb::Logger {
@@ -670,7 +845,7 @@ RocksDBStore::cf_get_merge_operator(const std::string& cf_name)
   }
   //Column family name is not exact to any defined merge operators.
   //Use all-prefix merge operator.
-  return std::shared_ptr<rocksdb::MergeOperator>(new MergeOperatorRouter(*this));
+  return std::shared_ptr<rocksdb::MergeOperator>(new RocksDBStore::MergeOperatorAll(*this));
 }
 
 int RocksDBStore::_test_init(const string& dir)
@@ -948,7 +1123,7 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     put_bat(bat, cf, k, to_set_bl);
   } else {
     string key = combine_strings(prefix, k);
@@ -962,7 +1137,7 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     string key(k, keylen);  // fixme?
     put_bat(bat, cf, key, to_set_bl);
   } else {
@@ -976,7 +1151,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const string &k)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.Delete(cf, rocksdb::Slice(k));
   } else {
     bat.Delete(cf, combine_strings(prefix, k));
@@ -988,7 +1163,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 						 size_t keylen)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.Delete(cf, rocksdb::Slice(k, keylen));
   } else {
     string key;
@@ -1001,7 +1176,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 					                 const string &k)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.SingleDelete(cf, k);
   } else {
     bat.SingleDelete(cf, combine_strings(prefix, k));
@@ -1011,7 +1186,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  bool is_mono = db->check_mode(cf, prefix);
+  bool is_mono = db->cf_check_mode(cf, prefix);
   uint64_t cnt = db->delete_range_threshold;
   bat.SetSavePoint();
   auto it = db->get_iterator(prefix);
@@ -1045,7 +1220,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
                                                          const string &end)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  bool is_mono = db->check_mode(cf, prefix);
+  bool is_mono = db->cf_check_mode(cf, prefix);
   uint64_t cnt = db->delete_range_threshold;
   auto it = db->get_iterator(prefix);
   bat.SetSavePoint();
@@ -1065,7 +1240,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
       }
       return;
     }
-    if (cf) {
+    if (is_mono) {
       bat.Delete(cf, rocksdb::Slice(it->key()));
     } else {
       bat.Delete(cf, combine_strings(prefix, it->key()));
@@ -1082,7 +1257,7 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     // special mono column family case
     // bufferlist::c_str() is non-constant, so we can't call c_str()
     if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
@@ -1249,7 +1424,7 @@ int RocksDBStore::get(
     std::map<std::string, bufferlist> *out) {
   utime_t start = ceph_clock_now();
   auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle.priv);
-  if (check_mode(cf, prefix)) {
+  if (cf_check_mode(cf, prefix)) {
     for (auto& key : keys) {
       std::string value;
       auto status = db->Get(rocksdb::ReadOptions(),
@@ -1295,7 +1470,7 @@ int RocksDBStore::get(
   string value;
   rocksdb::Status s;
   auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle.priv);
-  if (check_mode(cf, prefix)) {
+  if (cf_check_mode(cf, prefix)) {
     s = db->Get(rocksdb::ReadOptions(),
                 cf,
                 rocksdb::Slice(key),

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -863,9 +863,6 @@ int RocksDBStore::column_family_delete(const std::string& cf_name)
 KeyValueDB::ColumnFamilyHandle RocksDBStore::column_family_handle(const std::string& cf_name) const
 {
   RWLock::RLocker l(api_lock);
-  if (cf_name == "default") {
-    return cf_wrap_handle(default_cf);
-  }
   auto it = column_families.find(cf_name);
   if (it == column_families.end())
     return KeyValueDB::ColumnFamilyHandle();

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -180,73 +180,11 @@ public:
   }
 
   void close() override;
-  /*
-   * @defgroup column_family Column Families
-   * There are 3 categories of column families.
-   *
-   * 1) mono column family
-   * Tightly bound to single prefix (P) value.
-   * Name of column family is P.
-   * Only keys with prefix P are all allowed.
-   * Merge operator (if exists) must be named P.
-   *
-   * 2) regular column family
-   * Can contain keys with any prefix.
-   * Name of column family may not be exact to any registered merge operators.
-   * Merge operator must encompass all available prefix merge operators, and so must its name.
-   *
-   * 3) default column family
-   * Can contain keys with any prefix except those handled by mono column families.
-   * Merge operator must encompass all prefixes, except those handled by mono column families.
-   * Merge operator name must not include prefixes handled by mono column families.
-   */
 
-  /*
-   * @ingroup column_family
-   * List existing column families
-   *
-   * Queries database for names of all defined column families.
-   * When invoked before \ref open it queries stored database.
-   * When invoked after \ref open or \ref create_and_open it just reports current state.
-   * Invoking on non-existent database must return empty \ref cf_names.
-   *
-   * Params:
-   * - cf_names vector to fill with known column family names
-   * Result:
-   *   0 - success, <0 error code
-   */
   int column_family_list(vector<std::string>& cf_names) override;
-
-  /*
-   * @ingroup column_family
-   * Create new column family
-   *
-   * Create additional column family in running database.
-   * This may be invoked only on opened database.
-   *
-   * Params:
-   * - name name of column family
-   * - options extra options to apply for column family
-   * Result:
-   *   0 - success, <0 error code
-   */
   int column_family_create(const std::string& name, const std::string& options) override;
-
-  /*
-   * @ingroup column_family
-   * Delete column family
-   *
-   * Removes column family from running database.
-   * This may be invoked only on opened database.
-   *
-   * Params:
-   * - name name of column family
-   * - options extra options to apply for column family
-   * Result:
-   *   0 - success, <0 error code
-   */
-  int column_family_delete(const std::string& name) override { return -1; }
-
+  int column_family_delete(const std::string& name) override;
+  KeyValueDB::ColumnFamilyHandle column_family_handle(const std::string& cf_name) override;
   //virtual std::string cf_get_options(const std::string& cf_name);
   /* returns merge operator for column family that contains only `prefix` keys */
   virtual std::shared_ptr<rocksdb::MergeOperator>
@@ -262,7 +200,7 @@ private:
     if (iter == cf_mono_handles.end())
       return nullptr;
     else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
+      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
   }
 
   /// Determines if prefix points to mono column family.
@@ -282,19 +220,17 @@ private:
   rocksdb::Options rocksdb_options;
   int open_existing(rocksdb::Options& rocksdb_options);
 
-  int read_column_families();
-  typedef std::string ColumnFamilyName;
   struct ColumnFamilyData {
-      //string name;      //< name of this individual column family
-      string options;    //< specific configure option string for this CF
-      void* handle;
-      ColumnFamilyData(const string &options, void* handle = nullptr)
+      string options;                   ///< specific configure option string for this CF
+      ColumnFamilyHandle handle;        ///< handle to column family
+      ColumnFamilyData(const string &options, ColumnFamilyHandle handle = {nullptr})
         : options(options), handle(handle) {}
-      ColumnFamilyData() : handle(nullptr) {}
+      ColumnFamilyData() {}
     };
+  typedef std::string ColumnFamilyName;
   std::map<ColumnFamilyName, ColumnFamilyData> column_families;
-//  std::vector<ColumnFamily> column_families;
-  //std::vector<rocksdb::ColumnFamilyDescriptor> column_family_descriptors;
+
+  std::unordered_map<std::string, ColumnFamilyHandle> cf_mono_handles;
 
   void perf_counters_register();
 
@@ -304,17 +240,8 @@ public:
     if (iter == cf_mono_handles.end())
       return nullptr;
     else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
+      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
   }
-
-  rocksdb::ColumnFamilyHandle *get_cf_handle_nonmono(const std::string& cf_name) {
-    auto iter = column_families.find(cf_name);
-    if (iter == column_families.end())
-      return default_cf;
-    else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.handle);
-  }
-
 
   int repair(std::ostream &out) override;
   void split_stats(const std::string &s, char delim, std::vector<std::string> &elems);
@@ -469,7 +396,7 @@ public:
       const string& k,
       const bufferlist &bl) override;
     void select(
-      void* column_family_handle) override;
+        KeyValueDB::ColumnFamilyHandle column_family_handle) override;
   };
 
   KeyValueDB::Transaction get_transaction() override {
@@ -494,12 +421,12 @@ public:
     size_t keylen,
     bufferlist *out) override;
   int get(
-    void* cf_handle,
+    KeyValueDB::ColumnFamilyHandle cf_handle,
     const std::string &prefix,
     const std::set<std::string> &keys,
     std::map<std::string, bufferlist> *out) override;
   int get(
-    void* cf_handle,
+    KeyValueDB::ColumnFamilyHandle cf_handle,
     const string &prefix,
     const string &key,
     bufferlist *out
@@ -535,6 +462,7 @@ public:
   };
 
   Iterator get_iterator(const std::string& prefix) override;
+  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override;
 
   /// Utility
   static string combine_strings(const string &prefix, const string &value) {
@@ -650,6 +578,7 @@ err:
   }
 
   WholeSpaceIterator get_wholespace_iterator() override;
+  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override;
 };
 
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -183,7 +183,7 @@ private:
   bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) const;
   std::pair<std::string, ColumnFamilyHandle> cf_get_by_rocksdb_ID(uint32_t ID) const;
   int cf_create(const std::string& name, const std::string& options);
-  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*);
+  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*) const;
   int cf_compact(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
   int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -85,7 +85,6 @@ private:
   uint64_t cache_size = 0;
   bool set_cache_flag = false;
 
-  bool must_close_default_cf = false;
   rocksdb::ColumnFamilyHandle *default_cf = nullptr;
   RWLock api_lock;
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -171,20 +171,28 @@ public:
   int column_family_create(const std::string& name, const std::string& options) override;
   int column_family_delete(const std::string& name) override;
   KeyValueDB::ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override;
-  int column_family_compact(const std::string& cf_name, const string& prefix, const string& start, const string& end) override;
-  int column_family_compact_async(const std::string& cf_name, const string& prefix, const string& start, const string& end) override;
+  int column_family_compact(
+		  const std::string& cf_name,
+		  const std::string& prefix,
+		  const std::string& start,
+		  const std::string& end) override;
+  int column_family_compact_async(
+		  const std::string& cf_name,
+		  const std::string& prefix,
+		  const std::string& start,
+		  const std::string& end) override;
 
 private:
-  int _open(ostream &out, bool read_only, const std::vector<ColumnFamily>& options);
+  int _open(std::ostream &out, bool read_only, const std::vector<ColumnFamily>& options);
   std::shared_ptr<rocksdb::MergeOperator> cf_get_merge_operator(const std::string& prefix) const;
   rocksdb::ColumnFamilyHandle* cf_get_mono_handle(const std::string& cf_name) const;
   rocksdb::ColumnFamilyHandle* cf_get_handle(const std::string& cf_name) const;
-  bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) const;
+  bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const std::string &prefix) const;
   std::pair<std::string, ColumnFamilyHandle> cf_get_by_rocksdb_ID(uint32_t ID) const;
   int cf_create(const std::string& name, const std::string& options);
   KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*) const;
-  int cf_compact(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
-  int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
+  int cf_compact(rocksdb::ColumnFamilyHandle* cf, const std::string& start, const std::string& end);
+  int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const std::string& start, const std::string& end);
 
   rocksdb::Options rocksdb_options;
   struct ColumnFamilyData;
@@ -210,8 +218,8 @@ public:
     const std::string &property,
     uint64_t *out) final;
 
-  int64_t estimate_prefix_size(const string& prefix,
-			       const string& key_prefix,
+  int64_t estimate_prefix_size(const std::string& prefix,
+			       const std::string& key_prefix,
                                ColumnFamilyHandle cfh = ColumnFamilyHandle{}) override;
 
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
@@ -288,13 +296,12 @@ public:
     KeyValueDB::ColumnFamilyHandle cf_handle,
     const std::string &prefix,
     const std::set<std::string> &keys,
-    std::map<std::string, bufferlist> *out) override;
+    std::map<std::string, ceph::bufferlist> *out) override;
   int get(
     KeyValueDB::ColumnFamilyHandle cf_handle,
-    const string &prefix,
-    const string &key,
-    bufferlist *out
-    ) override;
+    const std::string &prefix,
+    const std::string &key,
+    ceph::bufferlist *out) override;
 
   class RocksDBWholeSpaceIteratorImpl :
     public KeyValueDB::WholeSpaceIteratorImpl {
@@ -360,7 +367,7 @@ public:
   virtual int64_t get_cache_usage() const override {
     return static_cast<int64_t>(bbt_opts.block_cache->GetUsage());
   }
-  uint64_t get_estimated_size(map<string,uint64_t> &extra) override;
+  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override;
   int set_cache_size(uint64_t s) override {
     cache_size = s;
     set_cache_flag = true;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -242,8 +242,10 @@ private:
 
   void perf_counters_register();
 
+  std::pair<std::string, ColumnFamilyHandle> get_cf_by_rocksdb_ID(uint32_t ID) const;
+  friend class RocksWBHandler;
 public:
-  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) {
+  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) const {
     auto iter = cf_mono_handles.find(cf_name);
     if (iter == cf_mono_handles.end())
       return nullptr;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -190,7 +190,7 @@ private:
   bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const std::string &prefix) const;
   std::pair<std::string, ColumnFamilyHandle> cf_get_by_rocksdb_ID(uint32_t ID) const;
   int cf_create(const std::string& name, const std::string& options);
-  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*) const;
+  static KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*);
   int cf_compact(rocksdb::ColumnFamilyHandle* cf, const std::string& start, const std::string& end);
   int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const std::string& start, const std::string& end);
 

--- a/src/os/ObjectMap.h
+++ b/src/os/ObjectMap.h
@@ -157,7 +157,7 @@ public:
 
   virtual void compact() {}
 
-  typedef KeyValueDB::SimplestIteratorImpl ObjectMapIteratorImpl;
+  typedef KeyValueDB::ObjectMapIteratorImpl ObjectMapIteratorImpl;
   typedef std::shared_ptr<ObjectMapIteratorImpl> ObjectMapIterator;
   virtual ObjectMapIterator get_iterator(const ghobject_t &oid) {
     return ObjectMapIterator();

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -623,16 +623,16 @@ TEST_P(KVTest, RocksDB_estimate_size) {
     bufferlist v1;
     v1.append(string(1000, '1'));
     for (int i = 0; i < 100; i++)
-      t->set("A", to_string(rand()%100000), v1);
+      t->set("A", to_string(i%10)+to_string(1000 * test + i), v1);
     db->submit_transaction_sync(t);
     db->compact();
 
     int64_t size_a = db->estimate_prefix_size("A","");
-    ASSERT_GT(size_a, (test + 1) * 1000 * 100 * 0.5);
-    ASSERT_LT(size_a, (test + 1) * 1000 * 100 * 1.5);
+    ASSERT_GT(size_a, (test + 1) * 1000 * 100 * 0.8);
+    ASSERT_LT(size_a, (test + 1) * 1000 * 100 * 1.2);
     int64_t size_a1 = db->estimate_prefix_size("A","1");
-    ASSERT_GT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 0.5);
-    ASSERT_LT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 1.5);
+    ASSERT_GT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 0.8);
+    ASSERT_LT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 1.2);
     int64_t size_b = db->estimate_prefix_size("B","");
     ASSERT_EQ(size_b, 0);
   }
@@ -656,16 +656,16 @@ TEST_P(KVTest, RocksDB_estimate_size_column_family) {
     bufferlist v1;
     v1.append(string(1000, '1'));
     for (int i = 0; i < 100; i++)
-      t->set("cf1", to_string(rand()%100000), v1);
+      t->set("cf1", to_string(i%10) + to_string(1000 * test + i), v1);
     db->submit_transaction_sync(t);
     db->compact();
 
     int64_t size_a = db->estimate_prefix_size("cf1","");
-    ASSERT_GT(size_a, (test + 1) * 1000 * 100 * 0.5);
-    ASSERT_LT(size_a, (test + 1) * 1000 * 100 * 1.5);
+    ASSERT_GT(size_a, (test + 1) * 1000 * 100 * 0.8);
+    ASSERT_LT(size_a, (test + 1) * 1000 * 100 * 1.2);
     int64_t size_a1 = db->estimate_prefix_size("cf1","1");
-    ASSERT_GT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 0.5);
-    ASSERT_LT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 1.5);
+    ASSERT_GT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 0.8);
+    ASSERT_LT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 1.2);
     int64_t size_b = db->estimate_prefix_size("B","");
     ASSERT_EQ(size_b, 0);
   }

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -383,6 +383,10 @@ TEST_P(KVTest, RocksDBIteratorTest) {
     cout << "write some kv pairs into default and new CFs" << std::endl;
     t->set("prefix", "key1", bl1);
     t->set("prefix", "key2", bl2);
+    KeyValueDB::ColumnFamilyHandle cf1h;
+    ASSERT_NE(cf1h = db->column_family_handle("cf1"), nullptr);
+
+    t->select(cf1h);
     t->set("cf1", "key1", bl1);
     t->set("cf1", "key2", bl2);
     ASSERT_EQ(0, db->submit_transaction_sync(t));
@@ -519,6 +523,24 @@ TEST_P(KVTest, RocksDBIteratorColumnFamiliesTest) {
     ASSERT_EQ(1, iter->valid());
     ASSERT_EQ("key2", iter->key());
     ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  {
+    cout << "iterating the specialized CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator_cf(cf1h, "cf1");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    auto a = iter->raw_key();
+    ASSERT_EQ("cf1", a.first);
+    ASSERT_EQ("key1", a.second);
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+    a = iter->raw_key();
+    ASSERT_EQ("cf1", a.first);
+    ASSERT_EQ("key2", a.second);
   }
   {
     cout << "iterating the new CF" << std::endl;


### PR DESCRIPTION
This is 1/3 of code that allows BlueStore to use RocksDB in sharded mode.
First part does:
- redefines hierarchy of Iterators in KeyValueDB to unify WholeSpaceIterators and Iterators
- changes concept of column families in our RocksDBStore
- allow easy access to values in column families