### PR TITLE
os/bluestore: add slow op detection for collection_listing

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1066,6 +1066,7 @@ OPTION(bluestore_warn_on_bluefs_spillover, OPT_BOOL)
 OPTION(bluestore_warn_on_legacy_statfs, OPT_BOOL)
 OPTION(bluestore_log_op_age, OPT_DOUBLE)
 OPTION(bluestore_log_omap_iterator_age, OPT_DOUBLE)
+OPTION(bluestore_log_collection_list_age, OPT_DOUBLE)
 OPTION(bluestore_debug_enforce_settings, OPT_STR)
 
 OPTION(kstore_max_ops, OPT_U64)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4826,7 +4826,7 @@ std::vector<Option> get_global_options() {
     .set_description("log operation if it's slower than this age (seconds)"),
 
     Option("bluestore_log_omap_iterator_age", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(1)
+    .set_default(5)
     .set_description("log omap iteration operation if it's slower than this age (seconds)"),
 
     Option("bluestore_debug_enforce_settings", Option::TYPE_STR, Option::LEVEL_DEV)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4829,6 +4829,10 @@ std::vector<Option> get_global_options() {
     .set_default(5)
     .set_description("log omap iteration operation if it's slower than this age (seconds)"),
 
+    Option("bluestore_log_collection_list_age", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(60)
+    .set_description("log collection list operation if it's slower than this age (seconds)"),
+
     Option("bluestore_debug_enforce_settings", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("default")
     .set_enum_allowed({"default", "hdd", "ssd"})

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -132,35 +132,6 @@ const string BLUESTORE_GLOBAL_STATFS_KEY = "bluestore_statfs";
  */
 #define EXTENT_SHARD_KEY_SUFFIX 'x'
 
-// FIXME minor: make a BlueStore method once we have effecient way to
-// map idx to counter nickname
-#define LOG_LATENCY_I(logger, cct, name, idx, v, info) { \
-  ceph::timespan lat = v; \
-  logger->tinc(idx, lat); \
-  if (cct->_conf->bluestore_log_op_age > 0.0 && \
-      lat >= make_timespan(cct->_conf->bluestore_log_op_age)) { \
-    dout(0) << __func__ << " slow operation observed for " << name \
-      << ", latency = " << lat \
-      << info \
-      << dendl; \
-  } \
-}
-
-#define LOG_LATENCY_FN(logger, cct, name, idx, v, fn) { \
-  ceph::timespan lat = v; \
-  logger->tinc(idx, lat); \
-  if (cct->_conf->bluestore_log_op_age > 0.0 && \
-      lat >= make_timespan(cct->_conf->bluestore_log_op_age)) { \
-    dout(0) << __func__ << " slow operation observed for " << name \
-      << ", latency = " << lat \
-      << fn(lat) \
-      << dendl; \
-  } \
-}
-
-#define LOG_LATENCY(logger, cct, name, idx, v) \
-  LOG_LATENCY_I(logger, cct, name, idx, v, "")
-
 /*
  * string encoding in the key
  *
@@ -3821,14 +3792,10 @@ int BlueStore::OmapIteratorImpl::seek_to_first()
   } else {
     it = KeyValueDB::Iterator();
   }
-  c->store->log_latency_fn(
+  c->store->log_latency(
     __func__,
     l_bluestore_omap_seek_to_first_lat,
-    mono_clock::now() - start1,
-    [&] (const ceph::timespan& lat) {
-      return ", lat = " + timespan_str(lat) + _stringify();
-    }
-  );
+    mono_clock::now() - start1);
 
   return 0;
 }
@@ -3851,7 +3818,7 @@ int BlueStore::OmapIteratorImpl::upper_bound(const string& after)
     l_bluestore_omap_upper_bound_lat,
     mono_clock::now() - start1,
     [&] (const ceph::timespan& lat) {
-      return ", after = " + after + ", lat = " + timespan_str(lat) +
+      return ", after = " + after +
 	_stringify();
     }
   );
@@ -3876,7 +3843,7 @@ int BlueStore::OmapIteratorImpl::lower_bound(const string& to)
     l_bluestore_omap_lower_bound_lat,
     mono_clock::now() - start1,
     [&] (const ceph::timespan& lat) {
-      return ", to = " + to + ", lat = " + timespan_str(lat) +
+      return ", to = " + to +
 	_stringify();
     }
   );
@@ -3905,14 +3872,10 @@ int BlueStore::OmapIteratorImpl::next()
     it->next();
     r = 0;
   }
-  c->store->log_latency_fn(
+  c->store->log_latency(
     __func__,
     l_bluestore_omap_next_lat,
-    mono_clock::now() - start1,
-    [&] (const ceph::timespan& lat) {
-      return ", lat = " + timespan_str(lat) + _stringify();
-    }
-  );
+    mono_clock::now() - start1);
 
   return r;
 }
@@ -8431,7 +8394,7 @@ int BlueStore::read(
     RWLock::RLocker l(c->lock);
     auto start1 = mono_clock::now();
     OnodeRef o = c->get_onode(oid, false);
-    LOG_LATENCY(logger, cct, "get_onode@read",
+    log_latency("get_onode@read",
       l_bluestore_read_onode_meta_lat, mono_clock::now() - start1);
     if (!o || !o->exists) {
       r = -ENOENT;
@@ -8461,7 +8424,7 @@ int BlueStore::read(
   dout(10) << __func__ << " " << cid << " " << oid
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
 	   << " = " << r << dendl;
-  LOG_LATENCY(logger, cct, __func__,
+  log_latency(__func__,
     l_bluestore_read_lat, mono_clock::now() - start);
   return r;
 }
@@ -8554,7 +8517,7 @@ int BlueStore::_do_read(
 
   auto start = mono_clock::now();
   o->extent_map.fault_range(db, offset, length);
-  LOG_LATENCY(logger, cct, __func__,
+  log_latency(__func__,
     l_bluestore_read_onode_meta_lat, mono_clock::now() - start);
   _dump_onode<30>(cct, *o);
 
@@ -8750,7 +8713,7 @@ int BlueStore::_do_read(
       return -EIO;
     }
   }
-  LOG_LATENCY_FN(logger, cct, __func__,
+  log_latency_fn(__func__,
     l_bluestore_read_wait_aio_lat,
     mono_clock::now() - start,
     [&](auto lat) { return ", num_ios = " + stringify(num_ios); }
@@ -8900,7 +8863,7 @@ int BlueStore::_verify_csum(OnodeRef& o,
       derr << __func__ << " failed with exit code: " << cpp_strerror(r) << dendl;
     }
   }
-  LOG_LATENCY(logger, cct, __func__,
+  log_latency(__func__,
     l_bluestore_csum_lat, mono_clock::now() - start);
   if (cct->_conf->bluestore_ignore_data_csum) {
     return 0;
@@ -8936,7 +8899,7 @@ int BlueStore::_decompress(bufferlist& source, bufferlist* result)
       r = -EIO;
     }
   }
-  LOG_LATENCY(logger, cct, __func__,
+  log_latency(__func__,
     l_bluestore_decompress_lat, mono_clock::now() - start);
   return r;
 }
@@ -10128,8 +10091,7 @@ void BlueStore::_txc_committed_kv(TransContext *txc)
     }
   }
   txc->log_state_latency(logger, l_bluestore_state_kv_committing_lat);
-  LOG_LATENCY_FN(logger,
-    cct,
+  log_latency_fn(
     __func__,
     l_bluestore_commit_lat,
     ceph::make_timespan(ceph_clock_now() - txc->start),
@@ -10641,11 +10603,11 @@ void BlueStore::_kv_sync_thread()
 	  << " in " << dur
 	  << " (" << dur_flush << " flush + " << dur_kv << " kv commit)"
 	  << dendl;
-	LOG_LATENCY(logger, cct, "kv_flush",
+	log_latency("kv_flush",
 	  l_bluestore_kv_flush_lat, dur_flush);
-	LOG_LATENCY(logger, cct, "kv_commit",
+	log_latency("kv_commit",
 	  l_bluestore_kv_commit_lat, dur_kv);
-	LOG_LATENCY(logger, cct, "kv_sync",
+	log_latency("kv_sync",
 	  l_bluestore_kv_sync_lat, dur);
       }
 
@@ -10740,7 +10702,7 @@ void BlueStore::_kv_finalize_thread()
       logger->set(l_bluestore_fragmentation,
 	  (uint64_t)(alloc->get_fragmentation(min_alloc_size) * 1000));
 
-      LOG_LATENCY(logger, cct, "kv_final",
+      log_latency("kv_final",
 	l_bluestore_kv_final_lat, mono_clock::now() - start);
 
       l.lock();
@@ -11069,9 +11031,9 @@ int BlueStore::queue_transactions(
     }
   }
 
-  LOG_LATENCY(logger, cct, "submit_transact",
+  log_latency("submit_transact",
     l_bluestore_submit_lat, mono_clock::now() - start);
-  LOG_LATENCY(logger, cct, "throttle_transact",
+  log_latency("throttle_transact",
     l_bluestore_throttle_lat, tend - tstart);
   return 0;
 }
@@ -12116,7 +12078,7 @@ int BlueStore::_do_alloc_write(
 	logger->inc(l_bluestore_compress_rejected_count);
 	need += wi.blob_length;
       }
-      LOG_LATENCY(logger, cct, "compress@_do_alloc_write",
+      log_latency("compress@_do_alloc_write",
 	l_bluestore_compress_lat,
         mono_clock::now() - start);
     } else {
@@ -13614,13 +13576,36 @@ int BlueStore::_merge_collection(
   return r;
 }
 
+void BlueStore::log_latency(
+  const char* name,
+  int idx,
+  const ceph::timespan& l,
+  const char* info) const
+{
+  logger->tinc(idx, l);
+  if (cct->_conf->bluestore_log_op_age > 0.0 &&
+      l >= make_timespan(cct->_conf->bluestore_log_op_age)) {
+    dout(0) << __func__ << " slow operation observed for " << name
+      << ", latency = " << l
+      << info
+      << dendl;
+  }
+}
+
 void BlueStore::log_latency_fn(
   const char* name,
   int idx,
   const ceph::timespan& l,
-  std::function<string (const ceph::timespan& lat)> fn)
+  std::function<string (const ceph::timespan& lat)> fn) const
 {
-  LOG_LATENCY_FN(logger, cct, name, idx, l, fn);
+  logger->tinc(idx, l);
+  if (cct->_conf->bluestore_log_op_age > 0.0 &&
+      l >= make_timespan(cct->_conf->bluestore_log_op_age)) {
+    dout(0) << __func__ << " slow operation observed for " << name
+      << ", latency = " << l
+      << fn(l)
+      << dendl;
+  }
 }
 
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -127,6 +127,7 @@ enum {
   l_bluestore_omap_upper_bound_lat,
   l_bluestore_omap_lower_bound_lat,
   l_bluestore_omap_next_lat,
+  l_bluestore_clist_lat,
   l_bluestore_last
 };
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2686,11 +2686,13 @@ public:
   inline void log_latency(const char* name,
     int idx,
     const ceph::timespan& lat,
+    double lat_threshold,
     const char* info = "") const;
 
   inline void log_latency_fn(const char* name,
     int idx,
     const ceph::timespan& lat,
+    double lat_threshold,
     std::function<string (const ceph::timespan& lat)> fn) const;
 
 private:

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2683,10 +2683,15 @@ public:
     uint64_t size,
     PExtentVector* extents);
 
-  void log_latency_fn(const char* name,
-		      int idx,
-		      const ceph::timespan& lat,
-		      std::function<string (const ceph::timespan& lat)> fn);
+  inline void log_latency(const char* name,
+    int idx,
+    const ceph::timespan& lat,
+    const char* info = "") const;
+
+  inline void log_latency_fn(const char* name,
+    int idx,
+    const ceph::timespan& lat,
+    std::function<string (const ceph::timespan& lat)> fn) const;
 
 private:
   bool _debug_data_eio(const ghobject_t& o) {


### PR DESCRIPTION
During troubleshooting of http://tracker.ceph.com/issues/40741
it has been discovered that collection listing (triggered during pool removal) might cause significant delays resulting in suicides.

Hence adding some instrumentation to detect such an issue in future.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

