### PR TITLE
Sharded BlueStore - 3 - resharding tool

### DIFF
--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -15,8 +15,19 @@ Synopsis
 Description
 ===========
 
-:program:`ceph-kvstore-tool` is a kvstore manipulation tool. It allows users to manipulate
-leveldb/rocksdb's data (like OSD's omap) offline.
+:program:`ceph-kvstore-tool` is a tool to interact with key-value database used internally by ceph.
+Key-value databases are part of object store instances.
+Modes *leveldb* and *rocksdb* are for FileStore and *bluestore-kv* is for BlueStore.
+FileStore uses DB only for OMAP, while BlueStore also preserves internal metadata in DB.
+
+OSD must be offline to manipulate on its key-value DB.
+Operations are not logically validated. Modifications of BlueStore's metadata are unadvised.
+
+Column Families
+===============
+In some BlueStore deployments rocksdb key-value database can be internally split into
+multiple separate column families. This division is transparent and *column* part is unnecessary. 
+To select a specific column family for debug purposes *column* part should be provided.
 
 Commands
 ========
@@ -24,37 +35,37 @@ Commands
 :program:`ceph-kvstore-tool` utility uses many commands for debugging purpose
 which are as follows:
 
-:command:`list [prefix]`
+:command:`list [column/][prefix]`
     Print key of all KV pairs stored with the URL encoded prefix.
 
-:command:`list-crc [prefix]`
+:command:`list-crc [column/][prefix]`
     Print CRC of all KV pairs stored with the URL encoded prefix.
 
-:command:`dump [prefix]`
+:command:`dump [column/][prefix]`
     Print key and value of all KV pairs stored with the URL encoded prefix.
 
-:command:`exists <prefix> [key]`
+:command:`exists [column/]<prefix> [key]`
     Check if there is any KV pair stored with the URL encoded prefix. If key
     is also specified, check for the key with the prefix instead.
 
-:command:`get <prefix> <key> [out <file>]`
+:command:`get [column/]<prefix> <key> [out <file>]`
     Get the value of the KV pair stored with the URL encoded prefix and key.
     If file is also specified, write the value to the file.
 
-:command:`crc <prefix> <key>`
+:command:`crc [column/]<prefix> <key>`
     Get the CRC of the KV pair stored with the URL encoded prefix and key. 
 
-:command:`get-size [<prefix> <key>]`
+:command:`get-size [[column/]<prefix> <key>]`
     Get estimated store size or size of value specified by prefix and key.
 
-:command:`set <prefix> <key> [ver <N>|in <file>]`
+:command:`set [column/]<prefix> <key> [ver <N>|in <file>]`
     Set the value of the KV pair stored with the URL encoded prefix and key. 
     The value could be *version_t* or text.
 
-:command:`rm <prefix> <key>`
+:command:`rm [column/]<prefix> <key>`
     Remove the KV pair stored with the URL encoded prefix and key.
 
-:command:`rm-prefix <prefix>`
+:command:`rm-prefix [column/]<prefix>`
     Remove all KV pairs stored with the URL encoded prefix.
 
 :command:`store-copy <path> [num-keys-per-tx]`
@@ -69,10 +80,10 @@ which are as follows:
     the database, and trigger a database's compaction. After compaction, some 
     disk space may be released.
 
-:command:`compact-prefix <prefix>`
+:command:`compact-prefix [column/]<prefix>`
     Compact all entries specified by the URL encoded prefix. 
    
-:command:`compact-range <prefix> <start> <end>`
+:command:`compact-range [column/]<prefix> <start> <end>`
     Compact some entries specified by the URL encoded prefix and range.
 
 :command:`destructive-repair`

--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -68,6 +68,9 @@ which are as follows:
 :command:`rm-prefix [column/]<prefix>`
     Remove all KV pairs stored with the URL encoded prefix.
 
+:command:`list-columns`
+    List column families present in database.
+
 :command:`store-copy <path> [num-keys-per-tx]`
     Copy all KV pairs to another directory specified by ``path``. 
     [num-keys-per-tx] is the number of KV pairs copied for a transaction.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4390,8 +4390,13 @@ std::vector<Option> get_global_options() {
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("M= P= L=")
-    .set_description("List of whitespace-separate key/value pairs where key is CF name and value is CF options"),
+    .set_default("O7= M5= L= P= b= C=")
+    .set_description("Defines sharding of bluestore Key-Value DB into RocksDB column-families")
+    .set_long_description("List of whitespace separated key/value pairs, "
+      "where key is CF name and value is CF options. "
+      "When CF name is followed with a number, eg. M5, then multiple CFs are created M-0, M-1, ... M-4. "
+      "When no number follows CF name then only single CF is created eg. L-0. "
+      "Prefixes not listed remain part of 'default' column family."),
 
     Option("bluestore_fsck_on_mount", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -43,6 +43,7 @@ public:
     bool operator==(void* rhs) const {return rhs == priv;}
     bool operator!=(void* rhs) const {return rhs != priv;}
     operator bool() const {return priv != nullptr;}
+    void clear() { priv = nullptr; }
   };
 
   class TransactionImpl {

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -42,6 +42,7 @@ public:
     bool operator!=(struct ColumnFamilyHandle rhs) const {return rhs.priv != priv;}
     bool operator==(void* rhs) const {return rhs == priv;}
     bool operator!=(void* rhs) const {return rhs != priv;}
+    operator bool() const {return priv != nullptr;}
   };
 
   class TransactionImpl {

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -36,7 +36,8 @@ public:
   };
 
   struct ColumnFamilyHandle {
-    void* priv = nullptr;
+    ColumnFamilyHandle() : priv(nullptr) {}
+    void* priv;
     bool operator==(struct ColumnFamilyHandle rhs) const {return rhs.priv == priv;}
     bool operator!=(struct ColumnFamilyHandle rhs) const {return rhs.priv != priv;}
     bool operator==(void* rhs) const {return rhs == priv;}
@@ -174,7 +175,7 @@ public:
   /// test whether we can successfully initialize; may have side effects (e.g., create)
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(string option_str="") = 0;
-  /*
+  /**
    * Opens existing database
    *
    * Makes transition to state that allows to fetch/store data into database.
@@ -192,7 +193,7 @@ public:
    *   0 - success, <0 error code
    */
   virtual int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) = 0;
-  /*
+  /**
    * Creates new database
    *
    * Enables access to newly created database. This database is empty, with exception that
@@ -213,7 +214,7 @@ public:
 
   virtual void close() { }
 
-  /*
+  /**
    * @defgroup column_family Column Families
    * There are 3 categories of column families.
    *
@@ -234,7 +235,7 @@ public:
    * Merge operator name must not include prefixes handled by mono column families.
    */
 
-  /*
+  /**
    * @ingroup column_family
    * List column families
    *
@@ -253,7 +254,7 @@ public:
   virtual int column_family_list(vector<std::string>& cf_names)
   { cf_names.clear(); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Create new column family
    *
@@ -269,7 +270,7 @@ public:
   virtual int column_family_create(const std::string& cf_name, const std::string& cf_options)
   { ceph_abort_msg("Not implemented"); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Delete column family
    *
@@ -285,7 +286,7 @@ public:
   virtual int column_family_delete(const std::string& cf_name)
   { ceph_abort_msg("Not implemented"); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Get handle to column family
    *
@@ -297,8 +298,8 @@ public:
    * Result:
    *   handle to column family, or nullptr when cf_name does not exist
    */
-  virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name)
-  { ceph_abort_msg("Not implemented"); return {nullptr}; }
+  virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name) const
+  { ceph_abort_msg("Not implemented"); return ColumnFamilyHandle(); }
 
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.
   virtual int repair(std::ostream &out) { return 0; }
@@ -524,7 +525,8 @@ public:
 
   /// estimate space utilization for a prefix (in bytes)
   virtual int64_t estimate_prefix_size(const string& prefix,
-				       const string& key_prefix) {
+				       const string& key_prefix,
+                                       ColumnFamilyHandle cfh = ColumnFamilyHandle()) {
     return 0;
   }
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -208,7 +208,7 @@ public:
    */
   virtual int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) = 0;
 
-  virtual int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) {
+  virtual int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options = {}) {
     return -ENOTSUP;
   }
 
@@ -300,6 +300,18 @@ public:
    */
   virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name) const
   { ceph_abort_msg("Not implemented"); return ColumnFamilyHandle(); }
+
+  virtual int column_family_compact(const std::string& cf_name,
+                            const string& prefix,
+                            const string& start,
+                            const string& end)
+  { ceph_abort_msg("Not implemented"); return 0; }
+
+  virtual int column_family_compact_async(const std::string& cf_name,
+                                  const string& prefix,
+                                  const string& start,
+                                  const string& end)
+  { ceph_abort_msg("Not implemented"); return 0; }
 
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.
   virtual int repair(std::ostream &out) { return 0; }

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -165,7 +165,7 @@ int MemDB::set_merge_operator(
   const string& prefix,
   std::shared_ptr<KeyValueDB::MergeOperator> mop)
 {
-  merge_ops.push_back(std::make_pair(prefix, mop));
+  merge_ops.emplace(prefix, mop);
   return 0;
 }
 
@@ -338,10 +338,9 @@ int MemDB::_rmkey(ms_op_t &op)
 
 std::shared_ptr<KeyValueDB::MergeOperator> MemDB::_find_merge_op(const std::string &prefix)
 {
-  for (const auto& i : merge_ops) {
-    if (i.first == prefix) {
-      return i.second;
-    }
+  auto i = merge_ops.find(prefix);
+  if (i != merge_ops.end()) {
+    return i->second;
   }
 
   dtrace << __func__ << " No merge op for " << prefix << dendl;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1087,7 +1087,7 @@ int RocksDBStore::cf_create(const std::string& cf_name, const std::string& cf_op
 }
 
 
-KeyValueDB::ColumnFamilyHandle RocksDBStore::cf_wrap_handle(rocksdb::ColumnFamilyHandle* rocks_cfh) const
+KeyValueDB::ColumnFamilyHandle RocksDBStore::cf_wrap_handle(rocksdb::ColumnFamilyHandle* rocks_cfh)
 {
   KeyValueDB::ColumnFamilyHandle cfh;
   cfh.priv = static_cast<void*>(rocks_cfh);
@@ -1400,7 +1400,7 @@ void RocksDBStore::RocksDBTransactionImpl::set(
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
   if (db->cf_check_mode(cf, prefix)) {
-    string key(k, keylen);  // fixme?
+    string key(k, keylen); 
     put_bat(bat, cf, key, to_set_bl);
   } else {
     string key;
@@ -1451,7 +1451,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix
   bool is_mono = db->cf_check_mode(cf, prefix);
   uint64_t cnt = db->delete_range_threshold;
   bat.SetSavePoint();
-  auto it = db->get_iterator(prefix);
+  auto it = db->get_iterator_cf(RocksDBStore::cf_wrap_handle(cf), prefix);
   for (it->seek_to_first(); it->valid(); it->next()) {
     if (!cnt) {
       bat.RollbackToSavePoint();
@@ -1484,7 +1484,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
   bool is_mono = db->cf_check_mode(cf, prefix);
   uint64_t cnt = db->delete_range_threshold;
-  auto it = db->get_iterator(prefix);
+  auto it = db->get_iterator_cf(RocksDBStore::cf_wrap_handle(cf), prefix); 
   bat.SetSavePoint();
   it->lower_bound(start);
   while (it->valid()) {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1135,8 +1135,9 @@ RocksDBStore::~RocksDBStore()
 
   // Ensure db is destroyed before dependent db_cache and filterpolicy
   for (auto& p : column_families) {
-    db->DestroyColumnFamilyHandle(
-      static_cast<rocksdb::ColumnFamilyHandle*>(p.second.handle.priv));
+    if (p.second.handle)
+      db->DestroyColumnFamilyHandle(
+        static_cast<rocksdb::ColumnFamilyHandle*>(p.second.handle.priv));
   }
   default_cf = nullptr;
   delete db;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -859,7 +859,7 @@ int RocksDBStore::column_family_delete(const std::string& cf_name)
   RWLock::WLocker l(api_lock);
   rocksdb::ColumnFamilyHandle* handle = cf_get_handle(cf_name);
   rocksdb::Status status = db->DropColumnFamily(handle);
-  if (!status.ok()) {
+  if (status.ok()) {
     column_families.erase(cf_name);
   } else {
       derr << __func__ << " problem deleting column family '" << cf_name << "'" << dendl;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -2095,7 +2095,8 @@ public:
     return dbiter->status().ok() ? 0 : -1;
   }
   int lower_bound(const string &to) override {
-    rocksdb::Slice slice_bound(prefix + "\000" + to);
+    string bound = RocksDBStore::combine_strings(prefix, to);
+    rocksdb::Slice slice_bound(bound);
     dbiter->Seek(slice_bound);
     return dbiter->status().ok() ? 0 : -1;
   }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -610,7 +610,7 @@ int RocksDBStore::_open(ostream &out, bool read_only, const std::vector<ColumnFa
     for (size_t i = 0; i < existing_cfs.size(); ++i) {
       if (existing_cfs[i] == rocksdb::kDefaultColumnFamilyName) {
         default_cf = handles[i];
-        must_close_default_cf = true;
+        column_families[existing_cfs[i]].handle = cf_wrap_handle(default_cf);
       } else {
         // add_column_family(existing_cfs[i], static_cast<void*>(handles[i]));
         // store the new CF handle
@@ -1130,10 +1130,6 @@ RocksDBStore::~RocksDBStore()
   for (auto& p : column_families) {
     db->DestroyColumnFamilyHandle(
       static_cast<rocksdb::ColumnFamilyHandle*>(p.second.handle.priv));
-  }
-  if (must_close_default_cf) {
-    db->DestroyColumnFamilyHandle(default_cf);
-    must_close_default_cf = false;
   }
   default_cf = nullptr;
   delete db;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -93,8 +93,11 @@ public:
       n += p.second;
     }
     // it is wrong if content of merge operator changes after initialization
-    ceph_assert(name.size() == 0 || n == name);
-    name = n;
+    if (name.size() == 0) {
+      name = n;
+    } else {
+      ceph_assert(n == name);
+    }
     return name.c_str();
   }
 
@@ -174,8 +177,11 @@ public:
       n += p.second->name();
     }
     // it is wrong if content of merge operator changes after initialization
-    ceph_assert(name.size() == 0 || n == name);
-    name = n;
+    if (name.size() == 0) {
+      name = n;
+    } else {
+      ceph_assert(n == name);
+    }
     return name.c_str();
   }
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -61,32 +61,31 @@ static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl,
 class RocksDBStore::MergeOperatorRouter
   : public rocksdb::AssociativeMergeOperator
 {
+protected:
   RocksDBStore& store;
+  mutable std::string name;
 public:
   const char *Name() const override {
     // Construct a name that rocksDB will validate against. We want to
     // do this in a way that doesn't constrain the ordering of calls
     // to set_merge_operator, so sort the merge operators and then
     // construct a name from all of those parts.
-    store.assoc_name.clear();
+    name.clear();
     map<std::string,std::string> names;
 
     for (auto& p : store.merge_ops) {
       names[p.first] = p.second->name();
     }
-    //TODO: name of merge operator excludes prefixes for mono tables
-    //TODO: this makes it difficult to merge data back to main table
-    //TODO: regardless of cranky name, this should handle all prefixes?
     for (auto& p : store.cf_mono_handles) {
       names.erase(p.first);
     }
     for (auto& p : names) {
-      store.assoc_name += '.';
-      store.assoc_name += p.first;
-      store.assoc_name += ':';
-      store.assoc_name += p.second;
+      name += '.';
+      name += p.first;
+      name += ':';
+      name += p.second;
     }
-    return store.assoc_name.c_str();
+    return name.c_str();
   }
 
   explicit MergeOperatorRouter(RocksDBStore &_store) : store(_store) {}
@@ -150,6 +149,116 @@ public:
   }
 };
 
+//
+// Merge operator that encompasses all prefixes.
+//
+class RocksDBStore::MergeOperatorAll : public RocksDBStore::MergeOperatorRouter
+{
+public:
+  const char *Name() const override {
+    name.clear();
+    for (auto& p : store.merge_ops) {
+      name += '.';
+      name += p.first;
+      name += ':';
+      name += p.second->name();
+    }
+    return name.c_str();
+  }
+
+  explicit MergeOperatorAll(RocksDBStore &store) : MergeOperatorRouter(store) {}
+};
+
+struct RocksWBHandler: public rocksdb::WriteBatch::Handler {
+  std::string seen ;
+  int num_seen = 0;
+  static string pretty_binary_string(const string& in) {
+    char buf[10];
+    string out;
+    out.reserve(in.length() * 3);
+    enum { NONE, HEX, STRING } mode = NONE;
+    unsigned from = 0, i;
+    for (i=0; i < in.length(); ++i) {
+      if ((in[i] < 32 || (unsigned char)in[i] > 126) ||
+        (mode == HEX && in.length() - i >= 4 &&
+        ((in[i] < 32 || (unsigned char)in[i] > 126) ||
+        (in[i+1] < 32 || (unsigned char)in[i+1] > 126) ||
+        (in[i+2] < 32 || (unsigned char)in[i+2] > 126) ||
+        (in[i+3] < 32 || (unsigned char)in[i+3] > 126)))) {
+
+        if (mode == STRING) {
+          out.append(in.substr(from, i - from));
+          out.push_back('\'');
+        }
+        if (mode != HEX) {
+          out.append("0x");
+          mode = HEX;
+        }
+        if (in.length() - i >= 4) {
+          // print a whole u32 at once
+          snprintf(buf, sizeof(buf), "%08x",
+                (uint32_t)(((unsigned char)in[i] << 24) |
+                          ((unsigned char)in[i+1] << 16) |
+                          ((unsigned char)in[i+2] << 8) |
+                          ((unsigned char)in[i+3] << 0)));
+          i += 3;
+        } else {
+          snprintf(buf, sizeof(buf), "%02x", (int)(unsigned char)in[i]);
+        }
+        out.append(buf);
+      } else {
+        if (mode != STRING) {
+          out.push_back('\'');
+          mode = STRING;
+          from = i;
+        }
+      }
+    }
+    if (mode == STRING) {
+      out.append(in.substr(from, i - from));
+      out.push_back('\'');
+    }
+    return out;
+  }
+  void Put(const rocksdb::Slice& key,
+                  const rocksdb::Slice& value) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    uint64_t size = (value.ToString()).size();
+    seen += "\nPut( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode)
+          + " Value size = " + std::to_string(size) + ")";
+    num_seen++;
+  }
+  void SingleDelete(const rocksdb::Slice& key) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    seen += "\nSingleDelete(Prefix = "+ prefix + " Key = "
+          + pretty_binary_string(key_to_decode) + ")";
+    num_seen++;
+  }
+  void Delete(const rocksdb::Slice& key) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    seen += "\nDelete( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode) + ")";
+
+    num_seen++;
+  }
+  void Merge(const rocksdb::Slice& key,
+                    const rocksdb::Slice& value) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    uint64_t size = (value.ToString()).size();
+    seen += "\nMerge( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode) + " Value size = "
+          + std::to_string(size) + ")";
+
+    num_seen++;
+  }
+  bool Continue() override { return num_seen < 50; }
+};
+
 int RocksDBStore::set_merge_operator(
   const string& prefix,
   std::shared_ptr<KeyValueDB::MergeOperator> mop)
@@ -158,6 +267,72 @@ int RocksDBStore::set_merge_operator(
   ceph_assert(db == nullptr);
   merge_ops.emplace(prefix, mop);
   return 0;
+}
+
+uint64_t RocksDBStore::get_estimated_size(map<string,uint64_t> &extra) {
+  DIR *store_dir = opendir(path.c_str());
+  if (!store_dir) {
+    lderr(cct) << __func__ << " something happened opening the store: "
+        << cpp_strerror(errno) << dendl;
+    return 0;
+  }
+
+  uint64_t total_size = 0;
+  uint64_t sst_size = 0;
+  uint64_t log_size = 0;
+  uint64_t misc_size = 0;
+
+  struct dirent *entry = NULL;
+  while ((entry = readdir(store_dir)) != NULL) {
+    string n(entry->d_name);
+
+    if (n == "." || n == "..")
+      continue;
+
+    string fpath = path + '/' + n;
+    struct stat s;
+    int err = stat(fpath.c_str(), &s);
+    if (err < 0)
+      err = -errno;
+    // we may race against rocksdb while reading files; this should only
+    // happen when those files are being updated, data is being shuffled
+    // and files get removed, in which case there's not much of a problem
+    // as we'll get to them next time around.
+    if (err == -ENOENT) {
+      continue;
+    }
+    if (err < 0) {
+      lderr(cct) << __func__ << " error obtaining stats for " << fpath
+          << ": " << cpp_strerror(err) << dendl;
+      goto err;
+    }
+
+    size_t pos = n.find_last_of('.');
+    if (pos == string::npos) {
+      misc_size += s.st_size;
+      continue;
+    }
+
+    string ext = n.substr(pos+1);
+    if (ext == "sst") {
+      sst_size += s.st_size;
+    } else if (ext == "log") {
+      log_size += s.st_size;
+    } else {
+      misc_size += s.st_size;
+    }
+  }
+
+  total_size = sst_size + log_size + misc_size;
+
+  extra["sst"] = sst_size;
+  extra["log"] = log_size;
+  extra["misc"] = misc_size;
+  extra["total"] = total_size;
+
+  err:
+  closedir(store_dir);
+  return total_size;
 }
 
 class CephRocksdbLogger : public rocksdb::Logger {
@@ -670,7 +845,7 @@ RocksDBStore::cf_get_merge_operator(const std::string& cf_name)
   }
   //Column family name is not exact to any defined merge operators.
   //Use all-prefix merge operator.
-  return std::shared_ptr<rocksdb::MergeOperator>(new MergeOperatorRouter(*this));
+  return std::shared_ptr<rocksdb::MergeOperator>(new RocksDBStore::MergeOperatorAll(*this));
 }
 
 int RocksDBStore::_test_init(const string& dir)
@@ -948,7 +1123,7 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     put_bat(bat, cf, k, to_set_bl);
   } else {
     string key = combine_strings(prefix, k);
@@ -962,7 +1137,7 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     string key(k, keylen);  // fixme?
     put_bat(bat, cf, key, to_set_bl);
   } else {
@@ -976,7 +1151,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const string &k)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.Delete(cf, rocksdb::Slice(k));
   } else {
     bat.Delete(cf, combine_strings(prefix, k));
@@ -988,7 +1163,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 						 size_t keylen)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.Delete(cf, rocksdb::Slice(k, keylen));
   } else {
     string key;
@@ -1001,7 +1176,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 					                 const string &k)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.SingleDelete(cf, k);
   } else {
     bat.SingleDelete(cf, combine_strings(prefix, k));
@@ -1011,7 +1186,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  bool is_mono = db->check_mode(cf, prefix);
+  bool is_mono = db->cf_check_mode(cf, prefix);
   uint64_t cnt = db->delete_range_threshold;
   bat.SetSavePoint();
   auto it = db->get_iterator(prefix);
@@ -1045,7 +1220,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
                                                          const string &end)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  bool is_mono = db->check_mode(cf, prefix);
+  bool is_mono = db->cf_check_mode(cf, prefix);
   uint64_t cnt = db->delete_range_threshold;
   auto it = db->get_iterator(prefix);
   bat.SetSavePoint();
@@ -1065,7 +1240,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
       }
       return;
     }
-    if (cf) {
+    if (is_mono) {
       bat.Delete(cf, rocksdb::Slice(it->key()));
     } else {
       bat.Delete(cf, combine_strings(prefix, it->key()));
@@ -1082,7 +1257,7 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     // special mono column family case
     // bufferlist::c_str() is non-constant, so we can't call c_str()
     if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
@@ -1249,7 +1424,7 @@ int RocksDBStore::get(
     std::map<std::string, bufferlist> *out) {
   utime_t start = ceph_clock_now();
   auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle.priv);
-  if (check_mode(cf, prefix)) {
+  if (cf_check_mode(cf, prefix)) {
     for (auto& key : keys) {
       std::string value;
       auto status = db->Get(rocksdb::ReadOptions(),
@@ -1295,7 +1470,7 @@ int RocksDBStore::get(
   string value;
   rocksdb::Status s;
   auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle.priv);
-  if (check_mode(cf, prefix)) {
+  if (cf_check_mode(cf, prefix)) {
     s = db->Get(rocksdb::ReadOptions(),
                 cf,
                 rocksdb::Slice(key),

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -863,9 +863,6 @@ int RocksDBStore::column_family_delete(const std::string& cf_name)
 KeyValueDB::ColumnFamilyHandle RocksDBStore::column_family_handle(const std::string& cf_name) const
 {
   RWLock::RLocker l(api_lock);
-  if (cf_name == "default") {
-    return cf_wrap_handle(default_cf);
-  }
   auto it = column_families.find(cf_name);
   if (it == column_families.end())
     return KeyValueDB::ColumnFamilyHandle();

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -180,73 +180,11 @@ public:
   }
 
   void close() override;
-  /*
-   * @defgroup column_family Column Families
-   * There are 3 categories of column families.
-   *
-   * 1) mono column family
-   * Tightly bound to single prefix (P) value.
-   * Name of column family is P.
-   * Only keys with prefix P are all allowed.
-   * Merge operator (if exists) must be named P.
-   *
-   * 2) regular column family
-   * Can contain keys with any prefix.
-   * Name of column family may not be exact to any registered merge operators.
-   * Merge operator must encompass all available prefix merge operators, and so must its name.
-   *
-   * 3) default column family
-   * Can contain keys with any prefix except those handled by mono column families.
-   * Merge operator must encompass all prefixes, except those handled by mono column families.
-   * Merge operator name must not include prefixes handled by mono column families.
-   */
 
-  /*
-   * @ingroup column_family
-   * List existing column families
-   *
-   * Queries database for names of all defined column families.
-   * When invoked before \ref open it queries stored database.
-   * When invoked after \ref open or \ref create_and_open it just reports current state.
-   * Invoking on non-existent database must return empty \ref cf_names.
-   *
-   * Params:
-   * - cf_names vector to fill with known column family names
-   * Result:
-   *   0 - success, <0 error code
-   */
   int column_family_list(vector<std::string>& cf_names) override;
-
-  /*
-   * @ingroup column_family
-   * Create new column family
-   *
-   * Create additional column family in running database.
-   * This may be invoked only on opened database.
-   *
-   * Params:
-   * - name name of column family
-   * - options extra options to apply for column family
-   * Result:
-   *   0 - success, <0 error code
-   */
   int column_family_create(const std::string& name, const std::string& options) override;
-
-  /*
-   * @ingroup column_family
-   * Delete column family
-   *
-   * Removes column family from running database.
-   * This may be invoked only on opened database.
-   *
-   * Params:
-   * - name name of column family
-   * - options extra options to apply for column family
-   * Result:
-   *   0 - success, <0 error code
-   */
-  int column_family_delete(const std::string& name) override { return -1; }
-
+  int column_family_delete(const std::string& name) override;
+  KeyValueDB::ColumnFamilyHandle column_family_handle(const std::string& cf_name) override;
   //virtual std::string cf_get_options(const std::string& cf_name);
   /* returns merge operator for column family that contains only `prefix` keys */
   virtual std::shared_ptr<rocksdb::MergeOperator>
@@ -262,7 +200,7 @@ private:
     if (iter == cf_mono_handles.end())
       return nullptr;
     else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
+      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
   }
 
   /// Determines if prefix points to mono column family.
@@ -282,19 +220,17 @@ private:
   rocksdb::Options rocksdb_options;
   int open_existing(rocksdb::Options& rocksdb_options);
 
-  int read_column_families();
-  typedef std::string ColumnFamilyName;
   struct ColumnFamilyData {
-      //string name;      //< name of this individual column family
-      string options;    //< specific configure option string for this CF
-      void* handle;
-      ColumnFamilyData(const string &options, void* handle = nullptr)
+      string options;                   ///< specific configure option string for this CF
+      ColumnFamilyHandle handle;        ///< handle to column family
+      ColumnFamilyData(const string &options, ColumnFamilyHandle handle = {nullptr})
         : options(options), handle(handle) {}
-      ColumnFamilyData() : handle(nullptr) {}
+      ColumnFamilyData() {}
     };
+  typedef std::string ColumnFamilyName;
   std::map<ColumnFamilyName, ColumnFamilyData> column_families;
-//  std::vector<ColumnFamily> column_families;
-  //std::vector<rocksdb::ColumnFamilyDescriptor> column_family_descriptors;
+
+  std::unordered_map<std::string, ColumnFamilyHandle> cf_mono_handles;
 
   void perf_counters_register();
 
@@ -304,17 +240,8 @@ public:
     if (iter == cf_mono_handles.end())
       return nullptr;
     else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
+      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
   }
-
-  rocksdb::ColumnFamilyHandle *get_cf_handle_nonmono(const std::string& cf_name) {
-    auto iter = column_families.find(cf_name);
-    if (iter == column_families.end())
-      return default_cf;
-    else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.handle);
-  }
-
 
   int repair(std::ostream &out) override;
   void split_stats(const std::string &s, char delim, std::vector<std::string> &elems);
@@ -469,7 +396,7 @@ public:
       const string& k,
       const bufferlist &bl) override;
     void select(
-      void* column_family_handle) override;
+        KeyValueDB::ColumnFamilyHandle column_family_handle) override;
   };
 
   KeyValueDB::Transaction get_transaction() override {
@@ -494,12 +421,12 @@ public:
     size_t keylen,
     bufferlist *out) override;
   int get(
-    void* cf_handle,
+    KeyValueDB::ColumnFamilyHandle cf_handle,
     const std::string &prefix,
     const std::set<std::string> &keys,
     std::map<std::string, bufferlist> *out) override;
   int get(
-    void* cf_handle,
+    KeyValueDB::ColumnFamilyHandle cf_handle,
     const string &prefix,
     const string &key,
     bufferlist *out
@@ -535,6 +462,7 @@ public:
   };
 
   Iterator get_iterator(const std::string& prefix) override;
+  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override;
 
   /// Utility
   static string combine_strings(const string &prefix, const string &value) {
@@ -650,6 +578,7 @@ err:
   }
 
   WholeSpaceIterator get_wholespace_iterator() override;
+  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override;
 };
 
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -203,6 +203,7 @@ private:
   void perf_counters_register();
 
   friend class RocksWBHandler;
+  friend class BlueStore_DB_Hash;
 public:
 
   int repair(std::ostream &out) override;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -183,7 +183,7 @@ private:
   bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) const;
   std::pair<std::string, ColumnFamilyHandle> cf_get_by_rocksdb_ID(uint32_t ID) const;
   int cf_create(const std::string& name, const std::string& options);
-  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*);
+  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*) const;
   int cf_compact(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
   int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -85,7 +85,6 @@ private:
   uint64_t cache_size = 0;
   bool set_cache_flag = false;
 
-  bool must_close_default_cf = false;
   rocksdb::ColumnFamilyHandle *default_cf = nullptr;
   RWLock api_lock;
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -171,20 +171,28 @@ public:
   int column_family_create(const std::string& name, const std::string& options) override;
   int column_family_delete(const std::string& name) override;
   KeyValueDB::ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override;
-  int column_family_compact(const std::string& cf_name, const string& prefix, const string& start, const string& end) override;
-  int column_family_compact_async(const std::string& cf_name, const string& prefix, const string& start, const string& end) override;
+  int column_family_compact(
+		  const std::string& cf_name,
+		  const std::string& prefix,
+		  const std::string& start,
+		  const std::string& end) override;
+  int column_family_compact_async(
+		  const std::string& cf_name,
+		  const std::string& prefix,
+		  const std::string& start,
+		  const std::string& end) override;
 
 private:
-  int _open(ostream &out, bool read_only, const std::vector<ColumnFamily>& options);
+  int _open(std::ostream &out, bool read_only, const std::vector<ColumnFamily>& options);
   std::shared_ptr<rocksdb::MergeOperator> cf_get_merge_operator(const std::string& prefix) const;
   rocksdb::ColumnFamilyHandle* cf_get_mono_handle(const std::string& cf_name) const;
   rocksdb::ColumnFamilyHandle* cf_get_handle(const std::string& cf_name) const;
-  bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) const;
+  bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const std::string &prefix) const;
   std::pair<std::string, ColumnFamilyHandle> cf_get_by_rocksdb_ID(uint32_t ID) const;
   int cf_create(const std::string& name, const std::string& options);
   KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*) const;
-  int cf_compact(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
-  int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
+  int cf_compact(rocksdb::ColumnFamilyHandle* cf, const std::string& start, const std::string& end);
+  int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const std::string& start, const std::string& end);
 
   rocksdb::Options rocksdb_options;
   struct ColumnFamilyData;
@@ -210,8 +218,8 @@ public:
     const std::string &property,
     uint64_t *out) final;
 
-  int64_t estimate_prefix_size(const string& prefix,
-			       const string& key_prefix,
+  int64_t estimate_prefix_size(const std::string& prefix,
+			       const std::string& key_prefix,
                                ColumnFamilyHandle cfh = ColumnFamilyHandle{}) override;
 
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
@@ -288,13 +296,12 @@ public:
     KeyValueDB::ColumnFamilyHandle cf_handle,
     const std::string &prefix,
     const std::set<std::string> &keys,
-    std::map<std::string, bufferlist> *out) override;
+    std::map<std::string, ceph::bufferlist> *out) override;
   int get(
     KeyValueDB::ColumnFamilyHandle cf_handle,
-    const string &prefix,
-    const string &key,
-    bufferlist *out
-    ) override;
+    const std::string &prefix,
+    const std::string &key,
+    ceph::bufferlist *out) override;
 
   class RocksDBWholeSpaceIteratorImpl :
     public KeyValueDB::WholeSpaceIteratorImpl {
@@ -360,7 +367,7 @@ public:
   virtual int64_t get_cache_usage() const override {
     return static_cast<int64_t>(bbt_opts.block_cache->GetUsage());
   }
-  uint64_t get_estimated_size(map<string,uint64_t> &extra) override;
+  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override;
   int set_cache_size(uint64_t s) override {
     cache_size = s;
     set_cache_flag = true;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -242,8 +242,10 @@ private:
 
   void perf_counters_register();
 
+  std::pair<std::string, ColumnFamilyHandle> get_cf_by_rocksdb_ID(uint32_t ID) const;
+  friend class RocksWBHandler;
 public:
-  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) {
+  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) const {
     auto iter = cf_mono_handles.find(cf_name);
     if (iter == cf_mono_handles.end())
       return nullptr;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -190,7 +190,7 @@ private:
   bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const std::string &prefix) const;
   std::pair<std::string, ColumnFamilyHandle> cf_get_by_rocksdb_ID(uint32_t ID) const;
   int cf_create(const std::string& name, const std::string& options);
-  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*) const;
+  static KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*);
   int cf_compact(rocksdb::ColumnFamilyHandle* cf, const std::string& start, const std::string& end);
   int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const std::string& start, const std::string& end);
 

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -28,6 +28,7 @@ if(WITH_BLUESTORE)
     bluestore/bluefs_types.cc
     bluestore/BlueRocksEnv.cc
     bluestore/BlueStore.cc
+    bluestore/BlueStore_DB_Hash.cc
     bluestore/bluestore_types.cc
     bluestore/fastbmap_allocator_impl.cc
     bluestore/FreelistManager.cc

--- a/src/os/ObjectMap.h
+++ b/src/os/ObjectMap.h
@@ -157,7 +157,7 @@ public:
 
   virtual void compact() {}
 
-  typedef KeyValueDB::SimplestIteratorImpl ObjectMapIteratorImpl;
+  typedef KeyValueDB::ObjectMapIteratorImpl ObjectMapIteratorImpl;
   typedef std::shared_ptr<ObjectMapIteratorImpl> ObjectMapIterator;
   virtual ObjectMapIterator get_iterator(const ghobject_t &oid) {
     return ObjectMapIterator();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -56,6 +56,8 @@
 #endif
 
 KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB*, const std::map<std::string, size_t>& = {});
+#include "BlueStore_DB_Hash.h"
+#include "common/url_escape.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -55,6 +55,8 @@
 #define tracepoint(...)
 #endif
 
+KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB*, const std::map<std::string, size_t>& = {});
+
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 
@@ -5743,6 +5745,8 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
     env = NULL;
     return -EIO;
   }
+  //wrap DB with sharded features
+  db = make_BlueStore_DB_Hash(db);
 
   FreelistManager::setup_merge_operators(db);
   db->set_merge_operator(PREFIX_STAT, merge_op);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -58,6 +58,7 @@
 KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB*, const std::map<std::string, size_t>& = {});
 #include "BlueStore_DB_Hash.h"
 #include "common/url_escape.h"
+#include "kv/RocksDBStore.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
@@ -5763,8 +5764,8 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
 
     if (r == 0 && sharding_schema.size() > 0) {
       /* enable sharding of rocksdb */
-      std::map<std::string, size_t> shards;
-      r = get_sharding(sharding_schema, cfs, shards);
+      BlueStore_DB_Hash::ShardingSchema shards;
+      r = parse_sharding(sharding_schema, cfs, shards);
       if (r < 0)
         return r;
       RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
@@ -5824,9 +5825,9 @@ void BlueStore::_close_db()
   }
 }
 
-int BlueStore::get_sharding(const std::string& sharding_schema,
+int BlueStore::parse_sharding(const std::string& sharding_schema,
                             std::vector<KeyValueDB::ColumnFamily>& cfs,
-                            std::map<std::string, size_t>& shards)
+                            BlueStore_DB_Hash::ShardingSchema& shards)
 {
   cfs.clear();
   map<string,string> cf_map;
@@ -5835,17 +5836,18 @@ int BlueStore::get_sharding(const std::string& sharding_schema,
               &cf_map,
               " \t");
 
-  shards = std::map<std::string, size_t> {
-    {PREFIX_SUPER, 0},
-    {PREFIX_STAT, 0},
-    {PREFIX_COLL, 0},
-    {PREFIX_OBJ, 0},
-    {PREFIX_OMAP, 0},
-    {PREFIX_PGMETA_OMAP, 0},
-    {PREFIX_DEFERRED, 0},
-    {PREFIX_ALLOC, 0},
-    {PREFIX_ALLOC_BITMAP, 0},
-    {PREFIX_SHARED_BLOB, 0}
+  shards = BlueStore_DB_Hash::ShardingSchema {
+    {PREFIX_SUPER, {0, 0}},
+    {PREFIX_STAT, {0, 0}},
+    {PREFIX_COLL, {0, 0}},
+    {PREFIX_OBJ, {0, 0}},
+    {PREFIX_OMAP, {0, sizeof(BlueStore::Onode::onode.nid)}},
+    {PREFIX_PGMETA_OMAP, {0, sizeof(BlueStore::Onode::onode.nid)}},
+    {PREFIX_PERPOOL_OMAP, {0, 0}},
+    {PREFIX_DEFERRED, {0, 0}},
+    {PREFIX_ALLOC, {0, 0}},
+    {PREFIX_ALLOC_BITMAP, {0, 0}},
+    {PREFIX_SHARED_BLOB, {0, 0}}
   };
 
   for (auto& i : cf_map) {
@@ -5860,7 +5862,7 @@ int BlueStore::get_sharding(const std::string& sharding_schema,
       derr << __func__ << " db prefix '" << prefix << "' illegal " << dendl;
       return -EINVAL;
     }
-    sh->second = prefix_count;
+    sh->second.shards = prefix_count;
     dout(10) << "prefix '" << prefix << "' split into " << prefix_count << "column families" << dendl;
 
     for(int k = 0; k < prefix_count; k++) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8915,17 +8915,9 @@ int BlueStore::reshard(const std::string& new_sharding)
 int BlueStore::_reshard(const std::string& new_sharding)
 {
   KeyValueDB* source_db = nullptr;
-  int r = _mount(true, false);
+  int r = _mount(true, true);
   if (r < 0)
     return r;
-
-  stringstream err;
-  r = db->open(err);
-  if (r < 0) {
-    derr << __func__ << " erroring opening db: " << err.str() << dendl;
-    _close_db();
-    return -EIO;
-  }
 
   BlueStore_DB_Hash* hdb = dynamic_cast<BlueStore_DB_Hash*>(db);
   //column families to iterate over
@@ -9001,7 +8993,7 @@ int BlueStore::_reshard(const std::string& new_sharding)
 
     while (data_source->valid()) {
       std::pair<std::string, std::string> raw_key = data_source->raw_key();
-      if (ops_in_transaction == 10000 || data_in_transaction > 10000000) {
+      if (keys_in_iterator == 10000 || data_in_iterator > 10000000) {
         data_source = create_iterator(raw_key.first, raw_key.second);
       }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5746,7 +5746,20 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
     return -EIO;
   }
   //wrap DB with sharded features
-  db = make_BlueStore_DB_Hash(db);
+  std::map<std::string, size_t> shards{
+    {PREFIX_SUPER, 1},
+    {PREFIX_STAT, 1},
+    {PREFIX_COLL, 1},
+    {PREFIX_OBJ, 7},
+    {PREFIX_OMAP, 11},
+    {PREFIX_PGMETA_OMAP, 1},
+    {PREFIX_DEFERRED, 1},
+    {PREFIX_ALLOC, 1},
+    {PREFIX_ALLOC_BITMAP, 9},
+    {PREFIX_SHARED_BLOB, 5}
+  };
+
+  db = make_BlueStore_DB_Hash(db, shards);
 
   FreelistManager::setup_merge_operators(db);
   db->set_merge_operator(PREFIX_STAT, merge_op);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8866,6 +8866,236 @@ out_scan:
   return errors - (int)repaired;
 }
 
+int BlueStore::reshard(const std::string& new_sharding)
+{
+  KeyValueDB* source_db = nullptr;
+  int r = _mount(true, false);
+  if (r < 0)
+    return r;
+
+  stringstream err;
+  r = db->open(err);
+  if (r < 0) {
+    derr << __func__ << " erroring opening db: " << err.str() << dendl;
+    _close_db();
+    return -EIO;
+  }
+
+  BlueStore_DB_Hash* hdb = dynamic_cast<BlueStore_DB_Hash*>(db);
+  //column families to iterate over
+  std::vector<std::string> columns_to_iterate;
+  if (hdb == nullptr) {
+    /* not sharded DB, yet */
+    source_db = db;
+    columns_to_iterate.push_back("default");
+  } else {
+    //list columns that have to be iterated over
+    hdb->column_family_list(columns_to_iterate);
+    source_db = hdb->db;
+  }
+  dout(10) << "Columns to iterate over: " << columns_to_iterate << dendl;
+
+  std::vector<KeyValueDB::ColumnFamily> new_cfs;
+  BlueStore_DB_Hash::ShardingSchema new_shards;
+  r = parse_sharding(new_sharding, new_cfs, new_shards);
+
+  if (r != 0) {
+    derr << "Sharding schema '" << new_sharding << "' invalid" << dendl;
+    return r;
+  }
+  RocksDBStore* r_source_db = dynamic_cast<RocksDBStore*>(source_db);
+  ceph_assert(r_source_db && "BlueStore not based on RocksDB");
+
+  //target_db is a somewhat clone of source_db, but it is lacking knowledge of MergeOperators
+  //new columns needed for target_db must be created by source_db handle before we open
+  for (auto new_column: new_cfs) {
+    bool has_column = false;
+    for (auto c: columns_to_iterate) {
+      if (new_column.name == c) {
+        has_column = true;
+        break;
+      }
+    }
+    if (!has_column) {
+      dout(5) << "Create required column family '" << new_column.name <<
+          "' with options '" << new_column.option << "'" << dendl;
+      r = source_db->column_family_create(new_column.name, new_column.option);
+      assert(r == 0);
+    }
+  }
+
+  //list column families that can contain ALLOC_BITMAP entries
+  std::vector<std::string> target_alloc_bitmap_cfs;
+  auto it = new_shards.find(PREFIX_ALLOC_BITMAP);
+  ceph_assert(it != new_shards.end());
+  if (it->second.shards > 0) {
+    for(size_t i = 0; i < it->second.shards; i++) {
+      target_alloc_bitmap_cfs.push_back(it->first + "-" + to_string(i));
+    }
+  } else {
+    target_alloc_bitmap_cfs.push_back("default");
+  }
+
+  //all columns created, now opening of targer_hash_db should succeed
+  BlueStore_DB_Hash target_hash_db(r_source_db, new_shards);
+
+
+
+  auto do_move = [&](
+      KeyValueDB::IteratorBase data_source,
+      std::string source_cf_name,
+      bool skip_bitmap_entries) {
+    KeyValueDB::ColumnFamilyHandle source_cf_handle = source_db->column_family_handle(source_cf_name);
+    ceph_assert(source_cf_handle);
+
+    KeyValueDB::Transaction transaction = source_db->get_transaction();
+    size_t data_in_transaction = 0;
+    size_t ops_in_transaction = 0;
+
+    while (data_source->valid()) {
+      std::pair<std::string, std::string> raw_key = data_source->raw_key();
+      ceph::bufferlist data = data_source->value();
+      dout(20) << "Processing key '" << url_escape(raw_key.first) << " " << url_escape(raw_key.second) << "'" << dendl;
+
+      std::string target_cf_name;
+      target_hash_db.locate_column_name(raw_key, target_cf_name);
+      dout(20) << "prev name=" << source_cf_name << " new name=" << target_cf_name << dendl;
+      if (target_cf_name == source_cf_name) {
+        dout(20) << "Skipped" << dendl;
+      } else {
+        KeyValueDB::ColumnFamilyHandle target_cf_handle = source_db->column_family_handle(target_cf_name);
+        ceph_assert(target_cf_handle);
+        if (raw_key.first != PREFIX_ALLOC_BITMAP) {
+          transaction->select(source_cf_handle);
+          transaction->rm_single_key(raw_key.first, raw_key.second);
+          transaction->select(target_cf_handle);
+          transaction->set(raw_key.first, raw_key.second, data);
+          ops_in_transaction++;
+          data_in_transaction += data.length();
+        } else {
+          //there is special handling of prefix PREFIX_ALLOC_BITMAP as it is used internally by bluefs
+          //do not delete those entries, only move them
+          ceph::bufferlist tmp;
+          if (source_db->get(target_cf_handle, raw_key.first, raw_key.second, &tmp) != 0) {
+            if (!(tmp == data)) {
+              transaction->select(target_cf_handle);
+              transaction->set(raw_key.first, raw_key.second, data);
+              ops_in_transaction++;
+              data_in_transaction += data.length();
+            }
+          }
+        }
+      }
+      if (ops_in_transaction == 1000 || data_in_transaction > 100000 || !data_source->valid()) {
+        dout(10) << "Submitting #" << ops_in_transaction << " ops" << dendl;
+        r = source_db->submit_transaction_sync(transaction);
+        ceph_assert(r == 0);
+        ops_in_transaction = 0;
+        data_in_transaction = 0;
+        transaction = source_db->get_transaction();
+      }
+      data_source->next();
+    }
+
+    if (ops_in_transaction > 0) {
+      dout(10) << "Submitting #" << ops_in_transaction << " ops" << dendl;
+      r = source_db->submit_transaction_sync(transaction);
+      ceph_assert(r == 0);
+    }
+  };
+
+  //walk columns and move data, except PREFIX_ALLOC_BITMAP
+  for (std::string source_cf_name: columns_to_iterate) {
+    dout(10) << "Starting processing column family '" << source_cf_name << "'" << dendl;
+    KeyValueDB::ColumnFamilyHandle source_cf_handle = source_db->column_family_handle(source_cf_name);
+    ceph_assert(source_cf_handle);
+    KeyValueDB::WholeSpaceIterator data_source = source_db->get_wholespace_iterator_cf(source_cf_handle);
+    data_source->seek_to_first();
+    do_move(data_source, source_cf_name, true);
+    dout(10) << "Finished processing column family '" << source_cf_name << "'" << dendl;
+  }
+
+  //processing ALLOC_BITMAP
+  //column families where ALLOC_BITMAP are expected to be located
+  //will scan those locations to check if these values didn't change
+
+  bool moved_allocation = false;
+  do {
+    for (std::string source_cf_name: columns_to_iterate) {
+      dout(10) << "Starting processing column family '" << source_cf_name <<
+          "' for ALLOC_BITMAP" << dendl;
+      KeyValueDB::ColumnFamilyHandle source_cf_handle = source_db->column_family_handle(source_cf_name);
+      ceph_assert(source_cf_handle);
+      KeyValueDB::Iterator data_source = source_db->get_iterator_cf(source_cf_handle, PREFIX_ALLOC_BITMAP);
+      data_source->seek_to_first();
+      do_move(data_source, source_cf_name, true);
+      dout(10) << "Finished processing column family '" << source_cf_name << "'" << dendl;
+    }
+
+    //deleting stale values
+    KeyValueDB::Transaction transaction = source_db->get_transaction();
+    size_t ops_in_transaction = 0;
+    for (auto& target_cf : target_alloc_bitmap_cfs) {
+      KeyValueDB::ColumnFamilyHandle cfh = source_db->column_family_handle(target_cf);
+      ceph_assert(cfh);
+      KeyValueDB::Iterator data_source = source_db->get_iterator_cf(cfh, PREFIX_ALLOC_BITMAP);
+
+      data_source->seek_to_first();
+      while (data_source->valid()) {
+        std::pair<std::string, std::string> raw_key = data_source->raw_key();
+        ceph::bufferlist data = data_source->value();
+        ceph::bufferlist tmp;
+        if (source_db->get(raw_key.first, raw_key.second, &tmp) != 0) {
+          moved_allocation = true;
+          transaction->select(cfh);
+          transaction->rm_single_key(raw_key.first, raw_key.second);
+        }
+        ops_in_transaction++;
+        if (ops_in_transaction == 1000) {
+          dout(10) << "Submitting #" << ops_in_transaction << " ops" << dendl;
+          r = source_db->submit_transaction_sync(transaction);
+          ceph_assert(r == 0);
+          ops_in_transaction = 0;
+          transaction = source_db->get_transaction();
+        }
+        data_source->next();
+      }
+      if (ops_in_transaction > 0) {
+        dout(10) << "Submitting #" << ops_in_transaction << " ops" << dendl;
+        r = source_db->submit_transaction_sync(transaction);
+        ceph_assert(r == 0);
+        ops_in_transaction = 0;
+      }
+    }
+  } while (moved_allocation);
+  dout(10) << "Finished moving BITMAP_ALLOC data" << dendl;
+
+  //some columns may now not be necessary, delete
+  for (auto c: columns_to_iterate) {
+    if (c == "default") continue;
+    bool needed = false;
+    for (auto n: new_cfs) {
+      if (c == n.name) {
+        needed = true;
+        break;
+      }
+    }
+    if (!needed) {
+      dout(5) << "Delete column family '" << c << dendl;
+      r = source_db->column_family_delete(c);
+      ceph_assert(r == 0);
+    }
+  }
+
+  umount();
+  write_meta("sharding", new_sharding);
+  dout(5) << "Resharding finished." << dendl;
+  target_hash_db.unlink_db();
+  return 0;
+}
+
+
+
 /// methods to inject various errors fsck can repair
 void BlueStore::inject_broken_shared_blob_key(const string& key,
 				  const bufferlist& bl)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2527,6 +2527,7 @@ public:
     return _fsck(FSCK_SHALLOW, true);
   }
   int reshard(const std::string& new_sharding);
+  int _reshard(const std::string& new_sharding);
   void set_cache_shards(unsigned num) override;
   void dump_cache_stats(Formatter *f) override {
     int onode_count = 0, buffers_bytes = 0;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -51,6 +51,7 @@
 #include "BlockDevice.h"
 #include "BlueFS.h"
 #include "common/EventTrace.h"
+#include "BlueStore_DB_Hash.h"
 
 class Allocator;
 class FreelistManager;
@@ -2274,12 +2275,13 @@ private:
   int _open_db(bool create,
 	       bool to_repair_db=false,
 	       bool read_only = false);
+
   /*
    * splits string of sharding definition into ColumnFamily definition
    */
-  int get_sharding(const std::string& sharding_schema,
-                   std::vector<KeyValueDB::ColumnFamily>& cfs,
-                   std::map<std::string, size_t>& shards);
+  int parse_sharding(const std::string& sharding_schema,
+                     std::vector<KeyValueDB::ColumnFamily>& cfs,
+                     BlueStore_DB_Hash::ShardingSchema& shards);
   void _close_db();
   int _open_fm(KeyValueDB::Transaction t);
   void _close_fm();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2274,6 +2274,12 @@ private:
   int _open_db(bool create,
 	       bool to_repair_db=false,
 	       bool read_only = false);
+  /*
+   * splits string of sharding definition into ColumnFamily definition
+   */
+  int get_sharding(const std::string& sharding_schema,
+                   std::vector<KeyValueDB::ColumnFamily>& cfs,
+                   std::map<std::string, size_t>& shards);
   void _close_db();
   int _open_fm(KeyValueDB::Transaction t);
   void _close_fm();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2526,7 +2526,7 @@ public:
   int quick_fix() override {
     return _fsck(FSCK_SHALLOW, true);
   }
-
+  int reshard(const std::string& new_sharding);
   void set_cache_shards(unsigned num) override;
   void dump_cache_stats(Formatter *f) override {
     int onode_count = 0, buffers_bytes = 0;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2075,6 +2075,12 @@ private:
 
   bool per_pool_stat_collection = true;
 
+  friend class HashSharded_TransactionImpl;
+  KeyValueDB::Transaction get_transaction();
+  KeyValueDB::ColumnFamilyHandle get_db_shard(const std::string &prefix, const char *k, size_t keylen);
+  std::vector<KeyValueDB::ColumnFamilyHandle>& get_shards(const std::string &prefix);
+
+
   struct MempoolThread : public Thread {
   public:
     BlueStore *store;

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -1,798 +1,800 @@
-#include "BlueStore.h"
-#include "kv/RocksDBStore.h"
+#include "BlueStore_DB_Hash.h"
+
+#include "common/debug.h"
 #include "include/ceph_hash.h"
+
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "shard-db "
 
 
-class BlueStore_DB_Hash : public KeyValueDB {
-public:
-  typedef std::map<std::string, size_t> ShardingSchema;
 
-private:
-  RocksDBStore* db;
-  CephContext* cct;
+
+static int compare(const rocksdb::Comparator* comparator,
+                   const std::string& a,
+                   const std::string& b) {
+  rocksdb::Slice _a(a.data(), a.size());
+  rocksdb::Slice _b(b.data(), b.size());
+  return comparator->Compare(_a, _b);
+}
+
+struct KeyLess {
   const rocksdb::Comparator* comparator;
-  ShardingSchema sharding_schema;
-  typedef std::map<std::string, std::vector<KeyValueDB::ColumnFamilyHandle> > ActiveShards;
-  ActiveShards shards;
-
-public:
-  BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sharding_schema)
-  : db(db), cct(db->cct), sharding_schema(sharding_schema) {
-    comparator = db->rocksdb_options.comparator;
-    ceph_assert(db);
-  }
-  virtual ~BlueStore_DB_Hash() {
-    delete db;
-  }
-private:
-  int open_shards() {
-    for (auto& s_it: sharding_schema) {
-      if (s_it.second == 0) {
-        auto cf_handle = db->column_family_handle("default");
-        shards[s_it.first].push_back(cf_handle);
-        dout(5) << "Column family '" << s_it.first << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+  KeyLess(const rocksdb::Comparator* comparator) : comparator(comparator) { };
+  bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
+  {
+    if (a->valid()) {
+      if (b->valid()) {
+        return compare(comparator, a->key(), b->key()) < 0;
       } else {
-        for (size_t i = 0; i < s_it.second; i++) {
-          std::string name = s_it.first + "-" + to_string(i);
-          auto cf_handle = db->column_family_handle(name);
-          dout(5) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
-          shards[s_it.first].push_back(cf_handle);
-        }
+        return true;
+      }
+    } else {
+      if (b->valid()) {
+        return false;
+      } else {
+        return (void*)a.get() < (void*)b.get();
       }
     }
-    return 0;
   }
-  KeyValueDB::ColumnFamilyHandle get_db_shard(const std::string &prefix, const char *k, size_t keylen) {
-    auto it = shards.find(prefix);
-    ceph_assert(it != shards.end());
-    unsigned hash = ceph_str_hash_linux(k, keylen);
-    return it->second[hash % it->second.size()];
+};
+
+class BlueStore_DB_Hash::HashSharded_TransactionImpl : public RocksDBStore::RocksDBTransactionImpl //KeyValueDB::TransactionImpl
+{
+private:
+  typedef RocksDBStore::RocksDBTransactionImpl base;
+  BlueStore_DB_Hash &db_hash;
+public:
+  HashSharded_TransactionImpl(BlueStore_DB_Hash &db_hash)
+: RocksDBStore::RocksDBTransactionImpl(db_hash.db)
+  , db_hash(db_hash) {
   }
-  std::vector<KeyValueDB::ColumnFamilyHandle>& get_shards(const std::string &prefix) {
-    auto it = shards.find(prefix);
-    ceph_assert(it != shards.end());
-    return it->second;
+  virtual ~HashSharded_TransactionImpl() {
   }
 
-#undef dout_context
-#define dout_context db_hash.cct
-
-  class HashSharded_TransactionImpl : public RocksDBStore::RocksDBTransactionImpl //KeyValueDB::TransactionImpl
-  {
-  private:
-    typedef RocksDBStore::RocksDBTransactionImpl base;
-    BlueStore_DB_Hash &db_hash;
-  public:
-    HashSharded_TransactionImpl(BlueStore_DB_Hash &db_hash)
-    : RocksDBStore::RocksDBTransactionImpl(db_hash.db)
-    , db_hash(db_hash) {
-    }
-    virtual ~HashSharded_TransactionImpl() {
-    }
-
-    void set(
+  void set(
       const string &prefix,
       const string &k,
       const bufferlist &bl) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
-      base::select(cf);
-      base::set(prefix, k, bl);
-    }
-    void set(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    base::select(cf);
+    base::set(prefix, k, bl);
+  }
+  void set(
       const string &prefix,
       const char *k,
       size_t keylen,
       const bufferlist &bl) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
-      base::select(cf);
-      base::set(prefix, k, keylen, bl);
-    }
-    void rmkey(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+    base::select(cf);
+    base::set(prefix, k, keylen, bl);
+  }
+  void rmkey(
       const string &prefix,
       const string &k) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
-      base::select(cf);
-      base::rmkey(prefix, k);
-    }
-    void rmkey(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    base::select(cf);
+    base::rmkey(prefix, k);
+  }
+  void rmkey(
       const string &prefix,
       const char *k,
       size_t keylen) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
-      base::select(cf);
-      base::rmkey(prefix, k, keylen);
-    }
-    void rm_single_key(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+    base::select(cf);
+    base::rmkey(prefix, k, keylen);
+  }
+  void rm_single_key(
       const string &prefix,
       const string &k) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
-      base::select(cf);
-      base::rm_single_key(prefix, k);
-    }
-    void rmkeys_by_prefix(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    base::select(cf);
+    base::rm_single_key(prefix, k);
+  }
+  void rmkeys_by_prefix(
       const string &prefix
-      ) override {
-      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
-      for (auto &s : shards) {
-        base::select(s);
-        base::rmkeys_by_prefix(prefix);
-      }
+  ) override {
+    std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+    for (auto &s : shards) {
+      base::select(s);
+      base::rmkeys_by_prefix(prefix);
     }
-    void rm_range_keys(
+  }
+  void rm_range_keys(
       const string &prefix,
       const string &start,
       const string &end) override {
-      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
-      for (auto &s : shards) {
-        base::select(s);
-        base::rm_range_keys(prefix, start, end);
-      }
+    std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+    for (auto &s : shards) {
+      base::select(s);
+      base::rm_range_keys(prefix, start, end);
     }
-    void merge(
+  }
+  void merge(
       const string& prefix,
       const string& k,
       const bufferlist &bl) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
-      base::select(cf);
-      base::merge(prefix, k, bl);
-    }
-    void select(
-        KeyValueDB::ColumnFamilyHandle column_family_handle) override {
-      ceph_abort("Not expected");
-    }
-  };
-
-#undef dout_context
-#define dout_context cct
-
-  int init(string option_str="") override {
-    int r = db->init(option_str);
-    return r;
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    base::select(cf);
+    base::merge(prefix, k, bl);
   }
-  int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override {
-    return _do_open(out, false, options);
+  void select(
+      KeyValueDB::ColumnFamilyHandle column_family_handle) override {
+    ceph_abort("Not expected");
   }
-  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override {
-    int r = db->create_and_open(out, new_cfs);
-    if (r != 0)
-      return r;
-    for (auto& s_it: sharding_schema) {
-      for (size_t i = 0; i < s_it.second; i++) {
-        std::string name = s_it.first + "-" + to_string(i);
-        if (db->column_family_handle(name) == ColumnFamilyHandle()) {
-          r = db->column_family_create(name, "");
-          if (r != 0) {
-            derr << "Unable to create column family: '" << name << "' " << dendl;
-            ceph_abort();
-          }
+};
+
+
+
+
+class ShardedIteratorBase {
+  ssize_t position = 0;
+  std::vector<KeyValueDB::Iterator> shards;
+  const rocksdb::Comparator* comparator;
+public:
+  ShardedIteratorBase(std::vector<KeyValueDB::Iterator>&& shards, const rocksdb::Comparator* comparator)
+: shards(std::move(shards))
+, comparator(comparator) { }
+
+  ~ShardedIteratorBase() { }
+
+  int open(const std::vector<KeyValueDB::Iterator>& new_shards) {
+    shards = new_shards;
+    return 0;
+  }
+  KeyValueDB::Iterator& item() {
+    return shards[position];
+  }
+  int seek_to_last() {
+    ceph_assert(false && "expected seek_to_last() not called");
+    return 0;
+  }
+  int seek_to_first() {
+    for (auto& it: shards) {
+      it->seek_to_first();
+    }
+    position = 0;
+    std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+    return 0;
+  }
+  int upper_bound(const string &after) {
+    for(auto& it: shards) {
+      it->upper_bound(after);
+    }
+    position = 0;
+    std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+    return 0;
+  }
+  int lower_bound(const string &to) {
+    for(auto& it: shards) {
+      it->lower_bound(to);
+    }
+    position = 0;
+    std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+    return 0;
+  }
+  bool valid() {
+    if (position >= (ssize_t)shards.size() )
+      return false;
+    return shards[position]->valid();
+  }
+  /*
+   * simulation of next/prev work
+   * v_______________________v   ---
+   * it0 it1 it2 it3 it4 it5 it6 it7
+   * next
+   * it1 it2 it0 it3 it4 it5 it6 it7
+   * next
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   * next
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   * next, it2 expired
+   * --- v___________________v   ---
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   * next, it0 expired
+   * --- --- v_______________v   ---
+   * prev, requires checking before, revived it0
+   * --- v___________________v   ---
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   * prev, checks before, but not revives
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   */
+  int next() {
+    shards[position]->next();
+    if (shards[position]->valid()) {
+      /* sort, as other shards may point to key that is less then
+       * key that we just moved to */
+      std::string key0 = shards[position]->key();
+      for (size_t p = position + 1; p < shards.size(); p++) {
+        std::string key1 = shards[p]->key();
+        if (compare(comparator, key0, key1) < 0) {
+          /* all in order, no need to sort more */
+          break;
         }
+        std::swap(shards[p - 1], shards[p]);
       }
+    } else {
+      position++;
     }
-    r = open_shards();
-    return r;
-  }
-  int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override {
-    return _do_open(out, true, options);
-  }
-  int _do_open(std::ostream &out, bool read_only, const std::vector<ColumnFamily>& options = {}) {
-    int r = read_only ?
-      db->open_read_only(out, options) :
-      db->open(out, options);
-    if (r != 0)
-      return r;
-    vector<std::string> cf_names;
-    db->column_family_list(cf_names);
-    for (auto& s_it: sharding_schema) {
-      for (size_t i = 0; i < s_it.second; i++) {
-        std::string name = s_it.first + "-" + to_string(i);
-        auto n_it = std::find(std::begin(cf_names), std::end(cf_names), name);
-        if (n_it == cf_names.end()) {
-          derr << "Missing column family: '" << name << "' " << dendl;
-          ceph_abort();
-        }
-      }
-    }
-    r = open_shards();
-    return r;
-  }
-  void close() override {
-    db->close();
-  }
-  int column_family_list(vector<std::string>& cf_names) override {
-    return db->column_family_list(cf_names);
-  }
-  int column_family_create(const std::string& cf_name, const std::string& cf_options) override {
-    return db->column_family_create(cf_name, cf_options);
-  }
-  int column_family_delete(const std::string& cf_name) override {
-    return db->column_family_delete(cf_name);
-  }
-  ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override {
-    return db->column_family_handle(cf_name);
-  }
-  int repair(std::ostream &out) override {
-    return db->repair(out);
-  }
-  Transaction get_transaction() override {
-    KeyValueDB::Transaction t = std::make_shared<HashSharded_TransactionImpl>(*this);
-    return t;
-  }
-  int submit_transaction(Transaction t) override {
-    return db->submit_transaction(t);
-  }
-  int submit_transaction_sync(Transaction t) override {
-    return db->submit_transaction_sync(t);
-  }
-
-  int get(const std::string &prefix,
-          const std::set<std::string> &keys,
-          std::map<std::string, bufferlist> *out) override {
-    std::map<void*, std::set<std::string> > sharded_keys;
-    for (auto& key : keys) {
-      std::string value;
-      KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
-      sharded_keys[cf.priv].emplace(key);
-    }
-    int r = 0;
-    for (auto sh = sharded_keys.begin(); r == 0 && sh != sharded_keys.end(); sh++) {
-      ColumnFamilyHandle cf;
-      cf.priv = sh->first;
-      db->get(cf, prefix, sh->second, out);
-    }
-    return r;
-  }
-
-  int get(const std::string &prefix,
-          const std::string &key,
-          bufferlist *value) override {
-    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
-    return db->get(cf, prefix, key, value);
-  }
-  int get(const string &prefix,
-          const char *key, size_t keylen,
-          bufferlist *value) override {
-    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key, keylen);
-    std::string s_key(key, keylen);
-    return db->get(cf, prefix, s_key, value);
-  }
-
-  int get(ColumnFamilyHandle cf_handle,
-                  const std::string &prefix,
-                  const std::set<std::string> &keys,
-                  std::map<std::string, bufferlist> *out) override {
-    ceph_assert(false && "invalid call");
+    /* signal if we iterated out of range */
+    if (position >= (ssize_t)shards.size())
+      return -1;
     return 0;
   }
 
-  int get(ColumnFamilyHandle cf_handle,///< [in] Column family handle
-                  const std::string &prefix,    ///< [in] prefix or CF name
-                  const std::string &key,       ///< [in] key
-                  bufferlist *value) override {          ///< [out] value
-    ceph_assert(false && "invalid call");
+  int prev() {
+    return -1;
+  }
+};
+
+
+
+
+class BlueStore_DB_Hash::WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
+private:
+  BlueStore_DB_Hash &db_hash;
+  ActiveShards::iterator shards_it;
+  ShardedIteratorBase iter;
+
+  void open_shards(std::vector<KeyValueDB::Iterator>& shards) {
+    for (auto& it: shards_it->second) {
+      Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
+      wsi->seek_to_first();
+      if (wsi->valid())
+        shards.emplace_back(wsi);
+    }
+  }
+  void open_shards(std::vector<KeyValueDB::Iterator>& shards, const std::string& prefix) {
+    shards.emplace_back(db_hash.db->get_iterator(prefix));
+  }
+
+public:
+  WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash)
+: db_hash(db_hash)
+, iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {}
+
+  virtual ~WholeSpaceIteratorMerged_Impl() {}
+
+  int seek_to_first_existing() {
+    while (shards_it != db_hash.shards.end()) {
+      std::vector<KeyValueDB::Iterator> shards;
+      if (shards_it->second.size() == 0) {
+        /* no separate shard, is part of default column family */
+        open_shards(shards, shards_it->first);
+      } else {
+        open_shards(shards);
+      }
+      iter.open(shards);
+      iter.seek_to_first();
+      if (iter.valid()) {
+        return 0;
+      }
+      //this shard is empty, go next
+      ++shards_it;
+    };
+    return -1;
+  }
+
+  int seek_to_first() override {
+    shards_it = db_hash.shards.begin();
+    return seek_to_first_existing();
+  }
+  int seek_to_first(const string &prefix) override {
+    shards_it = db_hash.shards.find(prefix);
+    return seek_to_first_existing();
+  }
+  int seek_to_last() override {
+    ceph_assert(false && "expected seek_to_last() not called");
     return 0;
   }
-
-  static int compare(const rocksdb::Comparator* comparator,
-                     const std::string& a,
-                     const std::string& b) {
-    rocksdb::Slice _a(a.data(), a.size());
-    rocksdb::Slice _b(b.data(), b.size());
-    return comparator->Compare(_a, _b);
+  int seek_to_last(const string &prefix) override {
+    ceph_assert(false && "expected seek_to_last() not called");
+    return 0;
   }
-
-  struct KeyLess {
-    const rocksdb::Comparator* comparator;
-    KeyLess(const rocksdb::Comparator* comparator) : comparator(comparator) { };
-    bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
-    {
-      if (a->valid()) {
-        if (b->valid()) {
-          return compare(comparator, a->key(), b->key()) < 0;
-        } else {
-          return true;
-        }
-      } else {
-        if (b->valid()) {
-          return false;
-        } else {
-          return (void*)a.get() < (void*)b.get();
-        }
-      }
-    }
-  };
-
-
-  class ShardedIteratorBase {
-    ssize_t position = 0;
-    std::vector<KeyValueDB::Iterator> shards;
-    const rocksdb::Comparator* comparator;
-  public:
-    ShardedIteratorBase(std::vector<KeyValueDB::Iterator>&& shards, const rocksdb::Comparator* comparator)
-    : shards(std::move(shards))
-    , comparator(comparator) { }
-
-    ~ShardedIteratorBase() { }
-
-    int open(const std::vector<KeyValueDB::Iterator>& new_shards) {
-      shards = new_shards;
-      return 0;
-    }
-    KeyValueDB::Iterator& item() {
-      return shards[position];
-    }
-    int seek_to_last() {
-      ceph_assert(false && "expected seek_to_last() not called");
-      return 0;
-    }
-    int seek_to_first() {
-      for (auto& it: shards) {
-        it->seek_to_first();
-      }
-      position = 0;
-      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
-      return 0;
-    }
-    int upper_bound(const string &after) {
-      for(auto& it: shards) {
-        it->upper_bound(after);
-      }
-      position = 0;
-      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
-      return 0;
-    }
-    int lower_bound(const string &to) {
-      for(auto& it: shards) {
-        it->lower_bound(to);
-      }
-      position = 0;
-      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
-      return 0;
-    }
-    bool valid() {
-      if (position >= (ssize_t)shards.size() )
-        return false;
-      return shards[position]->valid();
-    }
-    /*
-     * simulation of next/prev work
-     * v_______________________v   ---
-     * it0 it1 it2 it3 it4 it5 it6 it7
-     * next
-     * it1 it2 it0 it3 it4 it5 it6 it7
-     * next
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next, it2 expired
-     * --- v___________________v   ---
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next, it0 expired
-     * --- --- v_______________v   ---
-     * prev, requires checking before, revived it0
-     * --- v___________________v   ---
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * prev, checks before, but not revives
-     * it2 it0 it3 it4 it1 it5 it6 it7
-    */
-    int next() {
-      shards[position]->next();
-      if (shards[position]->valid()) {
-        /* sort, as other shards may point to key that is less then
-         * key that we just moved to */
-        std::string key0 = shards[position]->key();
-        for (size_t p = position + 1; p < shards.size(); p++) {
-          std::string key1 = shards[p]->key();
-          if (compare(comparator, key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(shards[p - 1], shards[p]);
-        }
-      } else {
-        position++;
-      }
-      /* signal if we iterated out of range */
-      if (position >= (ssize_t)shards.size())
-        return -1;
-      return 0;
-    }
-
-    int prev() {
+  int upper_bound(const string &prefix, const string &after) override {
+    shards_it = db_hash.shards.lower_bound(prefix);
+    if (shards_it == db_hash.shards.end()) {
       return -1;
     }
-  };
+    seek_to_first_existing();
+    if (shards_it == db_hash.shards.end()) {
+      return -1;
+    }
+    if (shards_it->first == prefix) {
+      /* we are in intended prefix, we need more detailed upper_bound */
+      iter.upper_bound(after);
+      if (!iter.valid()) {
+        /* nothing after target of upper_bound*/
+        ++shards_it;
+        return seek_to_first();
+      }
+    }
+    return 0;
+  }
+  int lower_bound(const string &prefix, const string &to) override {
+    shards_it = db_hash.shards.lower_bound(prefix);
+    if (shards_it == db_hash.shards.end()) {
+      return -1;
+    }
+    seek_to_first_existing();
+    if (shards_it == db_hash.shards.end()) {
+      return -1;
+    }
+    if (shards_it->first == prefix) {
+      /* we are in intended prefix, we need more detailed upper_bound */
+      iter.lower_bound(to);
+      if (!iter.valid()) {
+        /* nothing after target of upper_bound*/
+        ++shards_it;
+        return seek_to_first_existing();
+      }
+    }
+    return 0;
+  }
+  bool valid() override {
+    return iter.valid();
+  }
+  int next() override {
+    int r = iter.next();
+    if (r < 0) {
+      /* if we iterated out of current shard, go on */
+      ++shards_it;
+      return seek_to_first_existing();
+    }
+    return r;
+  }
+  int prev() override {
+    ceph_assert(false && "expected prev() not called");
+    return 0;
+  }
+  string key() override {
+    return iter.item()->key();
+  }
+  pair<string,string> raw_key() override {
+    return iter.item()->raw_key();
+  }
+  bool raw_key_is_prefixed(const string &prefix) override {
+    return prefix == shards_it->first;
+  }
+  bufferlist value() override {
+    return iter.item()->value();
+  }
+  bufferptr value_as_ptr() override {
+    return iter.item()->value_as_ptr();
+  }
+  int status() override {
+    return iter.item()->status();
+  }
+};
 
-  class WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
-  private:
-    BlueStore_DB_Hash &db_hash;
-    ActiveShards::iterator shards_it;
-    ShardedIteratorBase iter;
+class BlueStore_DB_Hash::SinglePrefixIteratorMerged_Impl: public IteratorImpl {
+private:
+  ShardedIteratorBase iter;
 
-    void open_shards(std::vector<KeyValueDB::Iterator>& shards) {
+  static void prefix_to_iterators(
+      std::vector<KeyValueDB::Iterator>& shards,
+      const BlueStore_DB_Hash &db_hash,
+      const string& prefix) {
+    auto shards_it = db_hash.shards.find(prefix);
+    if (shards_it != db_hash.shards.end()) {
       for (auto& it: shards_it->second) {
         Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
         wsi->seek_to_first();
         if (wsi->valid())
           shards.emplace_back(wsi);
       }
+      std::sort(shards.begin(), shards.end(), KeyLess(db_hash.comparator));
     }
-    void open_shards(std::vector<KeyValueDB::Iterator>& shards, const std::string& prefix) {
-      shards.emplace_back(db_hash.db->get_iterator(prefix));
-    }
-
-  public:
-    WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash)
-      : db_hash(db_hash)
-      , iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {}
-
-    virtual ~WholeSpaceIteratorMerged_Impl() {}
-
-    int seek_to_first_existing() {
-      while (shards_it != db_hash.shards.end()) {
-        std::vector<KeyValueDB::Iterator> shards;
-        if (shards_it->second.size() == 0) {
-          /* no separate shard, is part of default column family */
-          open_shards(shards, shards_it->first);
-        } else {
-          open_shards(shards);
-        }
-        iter.open(shards);
-        iter.seek_to_first();
-        if (iter.valid()) {
-          return 0;
-        }
-        //this shard is empty, go next
-        ++shards_it;
-      };
-      return -1;
-    }
-
-    int seek_to_first() override {
-      shards_it = db_hash.shards.begin();
-      return seek_to_first_existing();
-    }
-    int seek_to_first(const string &prefix) override {
-      shards_it = db_hash.shards.find(prefix);
-      return seek_to_first_existing();
-    }
-    int seek_to_last() override {
-      ceph_assert(false && "expected seek_to_last() not called");
-      return 0;
-    }
-    int seek_to_last(const string &prefix) override {
-      ceph_assert(false && "expected seek_to_last() not called");
-      return 0;
-    }
-    int upper_bound(const string &prefix, const string &after) override {
-      shards_it = db_hash.shards.lower_bound(prefix);
-      if (shards_it == db_hash.shards.end()) {
-        return -1;
-      }
-      seek_to_first_existing();
-      if (shards_it == db_hash.shards.end()) {
-        return -1;
-      }
-      if (shards_it->first == prefix) {
-        /* we are in intended prefix, we need more detailed upper_bound */
-        iter.upper_bound(after);
-        if (!iter.valid()) {
-          /* nothing after target of upper_bound*/
-          ++shards_it;
-          return seek_to_first();
-        }
-      }
-      return 0;
-    }
-    int lower_bound(const string &prefix, const string &to) override {
-      shards_it = db_hash.shards.lower_bound(prefix);
-      if (shards_it == db_hash.shards.end()) {
-        return -1;
-      }
-      seek_to_first_existing();
-      if (shards_it == db_hash.shards.end()) {
-        return -1;
-      }
-      if (shards_it->first == prefix) {
-        /* we are in intended prefix, we need more detailed upper_bound */
-        iter.lower_bound(to);
-        if (!iter.valid()) {
-          /* nothing after target of upper_bound*/
-          ++shards_it;
-          return seek_to_first_existing();
-        }
-      }
-      return 0;
-    }
-    bool valid() override {
-      return iter.valid();
-    }
-    int next() override {
-      int r = iter.next();
-      if (r < 0) {
-        /* if we iterated out of current shard, go on */
-        ++shards_it;
-        return seek_to_first_existing();
-      }
-      return r;
-    }
-    int prev() override {
-      ceph_assert(false && "expected prev() not called");
-      return 0;
-    }
-    string key() override {
-      return iter.item()->key();
-    }
-    pair<string,string> raw_key() override {
-      return iter.item()->raw_key();
-    }
-    bool raw_key_is_prefixed(const string &prefix) override {
-      return prefix == shards_it->first;
-    }
-    bufferlist value() override {
-      return iter.item()->value();
-    }
-    bufferptr value_as_ptr() override {
-      return iter.item()->value_as_ptr();
-    }
-    int status() override {
-      return iter.item()->status();
-    }
-  };
-
-#undef dout_context
-#define dout_context db_hash.cct
-
-  class SinglePrefixIteratorMerged_Impl: public IteratorImpl {
-  private:
-    ShardedIteratorBase iter;
-
-    static void prefix_to_iterators(
-        std::vector<KeyValueDB::Iterator>& shards,
-        const BlueStore_DB_Hash &db_hash,
-        const string& prefix) {
-      auto shards_it = db_hash.shards.find(prefix);
-      if (shards_it != db_hash.shards.end()) {
-        for (auto& it: shards_it->second) {
-          Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
-          wsi->seek_to_first();
-          if (wsi->valid())
-            shards.emplace_back(wsi);
-        }
-        std::sort(shards.begin(), shards.end(), KeyLess(db_hash.comparator));
-      }
-    }
-
-  public:
-    SinglePrefixIteratorMerged_Impl(BlueStore_DB_Hash &db_hash, const string& prefix)
-    : iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {
-      std::vector<KeyValueDB::Iterator> shards;
-      prefix_to_iterators(shards, db_hash, prefix);
-      iter.open(shards);
-    }
-
-    virtual ~SinglePrefixIteratorMerged_Impl() {
-    }
-
-    int seek_to_first() override {
-      return iter.seek_to_first();
-    }
-
-    int seek_to_last() override {
-      ceph_assert(false && "expected seek_to_last() not called");
-      return 0;
-    }
-
-    int upper_bound(const string &after) override {
-      return iter.upper_bound(after);
-    }
-
-    int lower_bound(const string &to) override {
-      return iter.lower_bound(to);
-    }
-
-    bool valid() override {
-      return iter.valid();
-    }
-
-    int next() override {
-      return iter.next();
-    }
-
-    int prev() override {
-      ceph_assert(false && "expected prev() not called");
-      return 0;
-    }
-
-    string key() override {
-      return iter.item()->key();
-    }
-
-    pair<string,string> raw_key() override {
-      return iter.item()->raw_key();
-    }
-
-    bufferlist value() override {
-      return iter.item()->value();
-    }
-
-    bufferptr value_as_ptr() override {
-      return iter.item()->value_as_ptr();
-    }
-
-    int status() override {
-      return iter.item()->status();
-    }
-  };
-
-#undef dout_context
-#define dout_context cct
-
-  // This class filters a WholeSpaceIterator by a prefix.
-  class PrefixIteratorImpl : public IteratorImpl {
-    const std::string prefix;
-    WholeSpaceIterator generic_iter;
-  public:
-    PrefixIteratorImpl(const std::string &prefix, WholeSpaceIterator iter) :
-      prefix(prefix), generic_iter(iter) { }
-    ~PrefixIteratorImpl() override { }
-
-    int seek_to_first() override {
-      return generic_iter->seek_to_first(prefix);
-    }
-    int seek_to_last() override {
-      return generic_iter->seek_to_last(prefix);
-    }
-    int upper_bound(const std::string &after) override {
-      return generic_iter->upper_bound(prefix, after);
-    }
-    int lower_bound(const std::string &to) override {
-      return generic_iter->lower_bound(prefix, to);
-    }
-    bool valid() override {
-      if (!generic_iter->valid())
-        return false;
-      return generic_iter->raw_key_is_prefixed(prefix);
-    }
-    int next() override {
-      return generic_iter->next();
-    }
-    int prev() override {
-      return generic_iter->prev();
-    }
-    std::string key() override {
-      return generic_iter->key();
-    }
-    std::pair<std::string, std::string> raw_key() override {
-      return generic_iter->raw_key();
-    }
-    bufferlist value() override {
-      return generic_iter->value();
-    }
-    bufferptr value_as_ptr() override {
-      return generic_iter->value_as_ptr();
-    }
-    int status() override {
-      return generic_iter->status();
-    }
-  };
+  }
 
 public:
-
-  WholeSpaceIterator get_wholespace_iterator() override {
-    return std::make_shared<WholeSpaceIteratorMerged_Impl>(*this);
-  }
-  Iterator get_iterator(const std::string &prefix) override {
-    auto shards_it = shards.find(prefix);
-    if (shards_it != shards.end()) {
-      return std::make_shared<SinglePrefixIteratorMerged_Impl>(*this, prefix);
-    }
-    return db->get_iterator(prefix);
-  }
-  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override {
-    ceph_abort_msg("Not implemented"); return {};
-  }
-  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override {
-    ceph_abort_msg("Not implemented"); return {};
+  SinglePrefixIteratorMerged_Impl(BlueStore_DB_Hash &db_hash, const string& prefix)
+: iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {
+    std::vector<KeyValueDB::Iterator> shards;
+    prefix_to_iterators(shards, db_hash, prefix);
+    iter.open(shards);
   }
 
-  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override {
-    return db->get_estimated_size(extra);
-  }
-  int get_statfs(struct store_statfs_t *buf) override {
-    return -EOPNOTSUPP;
+  virtual ~SinglePrefixIteratorMerged_Impl() {
   }
 
-  int set_cache_size(uint64_t) override {
-    return -EOPNOTSUPP;
+  int seek_to_first() override {
+    return iter.seek_to_first();
   }
 
-  int set_cache_high_pri_pool_ratio(double ratio) override {
-    return db->set_cache_high_pri_pool_ratio(ratio);
-  }
-
-  int64_t get_cache_usage() const override {
-    return db->get_cache_usage();
-  }
-
-  /// estimate space utilization for a prefix (in bytes)
-  int64_t estimate_prefix_size(const string& prefix,
-                               ColumnFamilyHandle cfh = ColumnFamilyHandle()) override {
+  int seek_to_last() override {
+    ceph_assert(false && "expected seek_to_last() not called");
     return 0;
   }
 
-  void compact() override {
-    db->compact();
-  }
-  void compact_async() override {
-    db->compact_async();
-  }
-  void compact_prefix(const std::string& prefix) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      for (size_t i = 0; i < it->second; i++) {
-        std::string cf_name = prefix + "-" + to_string(i);
-        db->column_family_compact(cf_name, prefix, "", "");
-      }
-    }
-  }
-  void compact_prefix_async(const std::string& prefix) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      for (size_t i = 0; i < it->second; i++) {
-        std::string cf_name = prefix + "-" + to_string(i);
-        db->column_family_compact_async(cf_name, prefix, "", "");
-      }
-    }
-  }
-  void compact_range(const std::string& prefix,
-                     const std::string& start, const std::string& end) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      for (size_t i = 0; i < it->second; i++) {
-        std::string cf_name = prefix + "-" + to_string(i);
-        db->column_family_compact(cf_name, prefix, start, end);
-      }
-    }
-  }
-  void compact_range_async(const std::string& prefix,
-                           const std::string& start, const std::string& end) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      for (size_t i = 0; i < it->second; i++) {
-        std::string cf_name = prefix + "-" + to_string(i);
-        db->column_family_compact_async(cf_name, prefix, start, end);
-      }
-    }
+  int upper_bound(const string &after) override {
+    return iter.upper_bound(after);
   }
 
-  int set_merge_operator(const std::string& prefix,
-                         std::shared_ptr<MergeOperator> mop) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      if (it->second == 0) {
-        db->set_merge_operator(prefix, mop);
-      } else {
-        for (size_t i = 0; i < it->second; i++) {
-          std::string cf_name = prefix + "-" + to_string(i);
-          db->set_merge_operator(cf_name, mop);
-        }
-      }
-      return 0;
-    }
-    return -EINVAL;
+  int lower_bound(const string &to) override {
+    return iter.lower_bound(to);
   }
 
-  void get_statistics(Formatter *f) override {
-    db->get_statistics(f);
+  bool valid() override {
+    return iter.valid();
+  }
+
+  int next() override {
+    return iter.next();
+  }
+
+  int prev() override {
+    ceph_assert(false && "expected prev() not called");
+    return 0;
+  }
+
+  string key() override {
+    return iter.item()->key();
+  }
+
+  pair<string,string> raw_key() override {
+    return iter.item()->raw_key();
+  }
+
+  bufferlist value() override {
+    return iter.item()->value();
+  }
+
+  bufferptr value_as_ptr() override {
+    return iter.item()->value_as_ptr();
+  }
+
+  int status() override {
+    return iter.item()->status();
   }
 };
 
+
+
+
+// This class filters a WholeSpaceIterator by a prefix.
+class BlueStore_DB_Hash::PrefixIteratorImpl : public IteratorImpl {
+  const std::string prefix;
+  WholeSpaceIterator generic_iter;
+public:
+  PrefixIteratorImpl(const std::string &prefix, WholeSpaceIterator iter) :
+    prefix(prefix), generic_iter(iter) { }
+  ~PrefixIteratorImpl() override { }
+
+  int seek_to_first() override {
+    return generic_iter->seek_to_first(prefix);
+  }
+  int seek_to_last() override {
+    return generic_iter->seek_to_last(prefix);
+  }
+  int upper_bound(const std::string &after) override {
+    return generic_iter->upper_bound(prefix, after);
+  }
+  int lower_bound(const std::string &to) override {
+    return generic_iter->lower_bound(prefix, to);
+  }
+  bool valid() override {
+    if (!generic_iter->valid())
+      return false;
+    return generic_iter->raw_key_is_prefixed(prefix);
+  }
+  int next() override {
+    return generic_iter->next();
+  }
+  int prev() override {
+    return generic_iter->prev();
+  }
+  std::string key() override {
+    return generic_iter->key();
+  }
+  std::pair<std::string, std::string> raw_key() override {
+    return generic_iter->raw_key();
+  }
+  bufferlist value() override {
+    return generic_iter->value();
+  }
+  bufferptr value_as_ptr() override {
+    return generic_iter->value_as_ptr();
+  }
+  int status() override {
+    return generic_iter->status();
+  }
+};
+
+BlueStore_DB_Hash::BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sharding_schema)
+: db(db), cct(db->cct), sharding_schema(sharding_schema) {
+  comparator = db->rocksdb_options.comparator;
+  ceph_assert(db);
+}
+BlueStore_DB_Hash::~BlueStore_DB_Hash() {
+  delete db;
+}
+
+void BlueStore_DB_Hash::unlink_db() {
+  db = nullptr;
+}
+
+int BlueStore_DB_Hash::open_shards() {
+  for (auto& s_it: sharding_schema) {
+    if (s_it.second == 0) {
+      auto cf_handle = db->column_family_handle("default");
+      shards[s_it.first].push_back(cf_handle);
+      dout(5) << "Column family '" << s_it.first << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+    } else {
+      for (size_t i = 0; i < s_it.second; i++) {
+        std::string name = s_it.first + "-" + to_string(i);
+        auto cf_handle = db->column_family_handle(name);
+        dout(5) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+        shards[s_it.first].push_back(cf_handle);
+      }
+    }
+  }
+  return 0;
+}
+KeyValueDB::ColumnFamilyHandle BlueStore_DB_Hash::get_db_shard(const std::string &prefix, const char *k, size_t keylen) {
+  auto it = shards.find(prefix);
+  ceph_assert(it != shards.end());
+  unsigned hash = ceph_str_hash_linux(k, keylen);
+  return it->second[hash % it->second.size()];
+}
+std::vector<KeyValueDB::ColumnFamilyHandle>& BlueStore_DB_Hash::get_shards(const std::string &prefix) {
+  auto it = shards.find(prefix);
+  ceph_assert(it != shards.end());
+  return it->second;
+}
+
+int BlueStore_DB_Hash::init(string option_str) {
+  int r = db->init(option_str);
+  return r;
+}
+int BlueStore_DB_Hash::open(std::ostream &out, const std::vector<ColumnFamily>& options) {
+  return _do_open(out, false, options);
+}
+int BlueStore_DB_Hash::create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs) {
+  int r = db->create_and_open(out, new_cfs);
+  if (r != 0)
+    return r;
+  for (auto& s_it: sharding_schema) {
+    for (size_t i = 0; i < s_it.second; i++) {
+      std::string name = s_it.first + "-" + to_string(i);
+      if (db->column_family_handle(name) == ColumnFamilyHandle()) {
+        r = db->column_family_create(name, "");
+        if (r != 0) {
+          derr << "Unable to create column family: '" << name << "' " << dendl;
+          ceph_abort();
+        }
+      }
+    }
+  }
+  r = open_shards();
+  return r;
+}
+int BlueStore_DB_Hash::open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options) {
+  return _do_open(out, true, options);
+}
+int BlueStore_DB_Hash::_do_open(std::ostream &out, bool read_only, const std::vector<ColumnFamily>& options) {
+  int r = read_only ?
+      db->open_read_only(out, options) :
+      db->open(out, options);
+  if (r != 0)
+    return r;
+  vector<std::string> cf_names;
+  db->column_family_list(cf_names);
+  for (auto& s_it: sharding_schema) {
+    for (size_t i = 0; i < s_it.second; i++) {
+      std::string name = s_it.first + "-" + to_string(i);
+      auto n_it = std::find(std::begin(cf_names), std::end(cf_names), name);
+      if (n_it == cf_names.end()) {
+        derr << "Missing column family: '" << name << "' " << dendl;
+        ceph_abort();
+      }
+    }
+  }
+  r = open_shards();
+  return r;
+}
+void BlueStore_DB_Hash::close() {
+  db->close();
+}
+int BlueStore_DB_Hash::column_family_list(vector<std::string>& cf_names) {
+  return db->column_family_list(cf_names);
+}
+int BlueStore_DB_Hash::column_family_create(const std::string& cf_name, const std::string& cf_options) {
+  return db->column_family_create(cf_name, cf_options);
+}
+int BlueStore_DB_Hash::column_family_delete(const std::string& cf_name) {
+  return db->column_family_delete(cf_name);
+}
+KeyValueDB::ColumnFamilyHandle BlueStore_DB_Hash::column_family_handle(const std::string& cf_name) const {
+  return db->column_family_handle(cf_name);
+}
+int BlueStore_DB_Hash::repair(std::ostream &out) {
+  return db->repair(out);
+}
+KeyValueDB::Transaction BlueStore_DB_Hash::get_transaction() {
+  KeyValueDB::Transaction t = std::make_shared<HashSharded_TransactionImpl>(*this);
+  return t;
+}
+int BlueStore_DB_Hash::submit_transaction(Transaction t) {
+  return db->submit_transaction(t);
+}
+int BlueStore_DB_Hash::submit_transaction_sync(Transaction t) {
+  return db->submit_transaction_sync(t);
+}
+
+int BlueStore_DB_Hash::get(const std::string &prefix,
+                           const std::set<std::string> &keys,
+                           std::map<std::string, bufferlist> *out) {
+  std::map<void*, std::set<std::string> > sharded_keys;
+  for (auto& key : keys) {
+    std::string value;
+    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
+    sharded_keys[cf.priv].emplace(key);
+  }
+  int r = 0;
+  for (auto sh = sharded_keys.begin(); r == 0 && sh != sharded_keys.end(); sh++) {
+    ColumnFamilyHandle cf;
+    cf.priv = sh->first;
+    db->get(cf, prefix, sh->second, out);
+  }
+  return r;
+}
+
+int BlueStore_DB_Hash::get(const std::string &prefix,
+                           const std::string &key,
+                           bufferlist *value) {
+  KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
+  return db->get(cf, prefix, key, value);
+}
+int BlueStore_DB_Hash::get(const string &prefix,
+                           const char *key, size_t keylen,
+                           bufferlist *value) {
+  KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key, keylen);
+  std::string s_key(key, keylen);
+  return db->get(cf, prefix, s_key, value);
+}
+
+int BlueStore_DB_Hash::get(ColumnFamilyHandle cf_handle,
+                           const std::string &prefix,
+                           const std::set<std::string> &keys,
+                           std::map<std::string, bufferlist> *out) {
+  ceph_assert(false && "invalid call");
+  return 0;
+}
+
+int BlueStore_DB_Hash::get(ColumnFamilyHandle cf_handle,///< [in] Column family handle
+                           const std::string &prefix,    ///< [in] prefix or CF name
+                           const std::string &key,       ///< [in] key
+                           bufferlist *value) {          ///< [out] value
+  ceph_assert(false && "invalid call");
+  return 0;
+}
+
+KeyValueDB::WholeSpaceIterator BlueStore_DB_Hash::get_wholespace_iterator() {
+  return std::make_shared<WholeSpaceIteratorMerged_Impl>(*this);
+}
+KeyValueDB::Iterator BlueStore_DB_Hash::get_iterator(const std::string &prefix) {
+  auto shards_it = shards.find(prefix);
+  if (shards_it != shards.end()) {
+    return std::make_shared<SinglePrefixIteratorMerged_Impl>(*this, prefix);
+  }
+  return db->get_iterator(prefix);
+}
+KeyValueDB::WholeSpaceIterator BlueStore_DB_Hash::get_wholespace_iterator_cf(ColumnFamilyHandle cfh) {
+  ceph_abort_msg("Not implemented"); return {};
+}
+KeyValueDB::Iterator BlueStore_DB_Hash::get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) {
+  ceph_abort_msg("Not implemented"); return {};
+}
+
+uint64_t BlueStore_DB_Hash::get_estimated_size(std::map<std::string,uint64_t> &extra) {
+  return db->get_estimated_size(extra);
+}
+int BlueStore_DB_Hash::get_statfs(struct store_statfs_t *buf) {
+  return -EOPNOTSUPP;
+}
+
+int BlueStore_DB_Hash::set_cache_size(uint64_t) {
+  return -EOPNOTSUPP;
+}
+
+int BlueStore_DB_Hash::set_cache_high_pri_pool_ratio(double ratio) {
+  return db->set_cache_high_pri_pool_ratio(ratio);
+}
+
+int64_t BlueStore_DB_Hash::get_cache_usage() const {
+  return db->get_cache_usage();
+}
+
+/// estimate space utilization for a prefix (in bytes)
+int64_t BlueStore_DB_Hash::estimate_prefix_size(const string& prefix,
+                                                ColumnFamilyHandle cfh) {
+  return 0;
+}
+
+void BlueStore_DB_Hash::compact() {
+  db->compact();
+}
+void BlueStore_DB_Hash::compact_async() {
+  db->compact_async();
+}
+void BlueStore_DB_Hash::compact_prefix(const std::string& prefix) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    for (size_t i = 0; i < it->second; i++) {
+      std::string cf_name = prefix + "-" + to_string(i);
+      db->column_family_compact(cf_name, prefix, "", "");
+    }
+  }
+}
+void BlueStore_DB_Hash::compact_prefix_async(const std::string& prefix) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    for (size_t i = 0; i < it->second; i++) {
+      std::string cf_name = prefix + "-" + to_string(i);
+      db->column_family_compact_async(cf_name, prefix, "", "");
+    }
+  }
+}
+void BlueStore_DB_Hash::compact_range(const std::string& prefix,
+                                      const std::string& start, const std::string& end) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    for (size_t i = 0; i < it->second; i++) {
+      std::string cf_name = prefix + "-" + to_string(i);
+      db->column_family_compact(cf_name, prefix, start, end);
+    }
+  }
+}
+void BlueStore_DB_Hash::compact_range_async(const std::string& prefix,
+                                            const std::string& start, const std::string& end) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    for (size_t i = 0; i < it->second; i++) {
+      std::string cf_name = prefix + "-" + to_string(i);
+      db->column_family_compact_async(cf_name, prefix, start, end);
+    }
+  }
+}
+
+int BlueStore_DB_Hash::set_merge_operator(const std::string& prefix,
+                                          std::shared_ptr<MergeOperator> mop) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    if (it->second == 0) {
+      db->set_merge_operator(prefix, mop);
+    } else {
+      for (size_t i = 0; i < it->second; i++) {
+        std::string cf_name = prefix + "-" + to_string(i);
+        db->set_merge_operator(cf_name, mop);
+      }
+    }
+    return 0;
+  }
+  return -EINVAL;
+}
+
+void BlueStore_DB_Hash::get_statistics(Formatter *f) {
+  db->get_statistics(f);
+}
+
+int BlueStore_DB_Hash::locate_column_name(const std::pair<std::string, std::string>& raw_key,
+                                          std::string& column_name) {
+
+  auto it = sharding_schema.find(raw_key.first);
+  if (it != sharding_schema.end() && it->second != 0) {
+    unsigned hash = ceph_str_hash_linux(raw_key.second.c_str(), raw_key.second.size());
+    hash = hash % it->second;
+    column_name = it->first + "-" + to_string(hash);
+  } else {
+    column_name = "default";
+  }
+  return 0;
+}
+
 KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB* db, const BlueStore_DB_Hash::ShardingSchema& schema) {
   RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
-  ceph_assert(db != nullptr);
+  ceph_assert(rdb != nullptr);
   return new BlueStore_DB_Hash(rdb, schema);
 }

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -1,3 +1,4 @@
+#include "BlueStore.h"
 #include "BlueStore_DB_Hash.h"
 
 #include "common/debug.h"

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -163,10 +163,12 @@ private:
     for (auto& s_it: sharding_schema) {
       for (size_t i = 0; i < s_it.second; i++) {
         std::string name = s_it.first + "-" + to_string(i);
-        r = db->column_family_create(name, "");
-        if (r != 0) {
-          derr << "Unable to create column family: '" << name << "' " << dendl;
-          ceph_abort();
+        if (db->column_family_handle(name) == ColumnFamilyHandle()) {
+          r = db->column_family_create(name, "");
+          if (r != 0) {
+            derr << "Unable to create column family: '" << name << "' " << dendl;
+            ceph_abort();
+          }
         }
       }
     }

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -713,7 +713,15 @@ int64_t BlueStore_DB_Hash::get_cache_usage() const {
 
 /// estimate space utilization for a prefix (in bytes)
 int64_t BlueStore_DB_Hash::estimate_prefix_size(const string& prefix,
+                                                const std::string& key_prefix,
                                                 ColumnFamilyHandle cfh) {
+  int64_t sum;
+  auto it = shards.find(prefix);
+  if (it != shards.end()) {
+    for (auto& cf : it->second.shards_cf_handle) {
+      sum += db->estimate_prefix_size(prefix, key_prefix, cf);
+    }
+  }
   return 0;
 }
 

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -1,0 +1,678 @@
+#include "BlueStore.h"
+#include "kv/RocksDBStore.h"
+#include "include/ceph_hash.h"
+#define dout_context cct
+#define dout_subsys ceph_subsys_bluestore
+#undef dout_prefix
+#define dout_prefix *_dout << "shard-db "
+
+
+
+
+
+
+
+class BlueStore_DB_Hash : public KeyValueDB {
+public:
+  typedef std::map<std::string, size_t> ShardingSchema;
+private:
+  RocksDBStore* db;
+  CephContext* cct;
+  const rocksdb::Comparator* comparator;
+  ShardingSchema sharding_schema;
+  typedef std::map<std::string, std::vector<KeyValueDB::ColumnFamilyHandle> > ActiveShards;
+  ActiveShards shards;
+
+public:
+  BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sharding_schema)
+  : db(db), cct(db->cct), sharding_schema(sharding_schema) {
+    comparator = db->rocksdb_options.comparator;
+    ceph_assert(db);
+  }
+  virtual ~BlueStore_DB_Hash() {
+    delete db;
+  }
+private:
+  int open_shards() {
+    for (auto& s_it: sharding_schema) {
+      for (size_t i = 0; i < s_it.second; i++) {
+        std::string name = s_it.first + "-" + to_string(i);
+        auto cf_handle = db->column_family_handle(name);
+        dout(0) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+        shards[s_it.first].push_back(cf_handle);
+      }
+    }
+    return 0;
+  }
+  KeyValueDB::ColumnFamilyHandle get_db_shard(const std::string &prefix, const char *k, size_t keylen) {
+    auto it = shards.find(prefix);
+    ceph_assert(it != shards.end());
+    unsigned hash = ceph_str_hash_linux(k, keylen);
+    return it->second[hash % it->second.size()];
+  }
+  std::vector<KeyValueDB::ColumnFamilyHandle>& get_shards(const std::string &prefix) {
+    auto it = shards.find(prefix);
+    ceph_assert(it != shards.end());
+    return it->second;
+  }
+
+#undef dout_context
+#define dout_context db_hash.cct
+
+  class HashSharded_TransactionImpl : public RocksDBStore::RocksDBTransactionImpl //KeyValueDB::TransactionImpl
+  {
+  private:
+    typedef RocksDBStore::RocksDBTransactionImpl base;
+    BlueStore_DB_Hash &db_hash;
+  public:
+    HashSharded_TransactionImpl(BlueStore_DB_Hash &db_hash)
+    : RocksDBStore::RocksDBTransactionImpl(db_hash.db)
+    , db_hash(db_hash) {
+    }
+    virtual ~HashSharded_TransactionImpl() {
+    }
+
+    void set(
+      const string &prefix,
+      const string &k,
+      const bufferlist &bl) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+      base::select(cf);
+      base::set(prefix, k, bl);
+    }
+    void set(
+      const string &prefix,
+      const char *k,
+      size_t keylen,
+      const bufferlist &bl) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+      base::select(cf);
+      base::set(prefix, k, keylen, bl);
+    }
+    void rmkey(
+      const string &prefix,
+      const string &k) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+      base::select(cf);
+      base::rmkey(prefix, k);
+    }
+    void rmkey(
+      const string &prefix,
+      const char *k,
+      size_t keylen) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+      base::select(cf);
+      base::rmkey(prefix, k, keylen);
+    }
+    void rm_single_key(
+      const string &prefix,
+      const string &k) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+      base::select(cf);
+      base::rm_single_key(prefix, k);
+    }
+    void rmkeys_by_prefix(
+      const string &prefix
+      ) override {
+      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+      for (auto &s : shards) {
+        base::select(s);
+        base::rmkeys_by_prefix(prefix);
+      }
+    }
+    void rm_range_keys(
+      const string &prefix,
+      const string &start,
+      const string &end) override {
+      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+      for (auto &s : shards) {
+        base::select(s);
+        base::rm_range_keys(prefix, start, end);
+      }
+    }
+    void merge(
+      const string& prefix,
+      const string& k,
+      const bufferlist &bl) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+      base::select(cf);
+      base::merge(prefix, k, bl);
+    }
+    void select(
+        KeyValueDB::ColumnFamilyHandle column_family_handle) override {
+      ceph_abort("Not expected");
+    }
+  };
+
+#undef dout_context
+#define dout_context cct
+
+public:
+  int init(string option_str="") override {
+    int r = db->init(option_str);
+    return r;
+  }
+  int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override {
+    int r = db->open(out, options);
+    if (r != 0)
+      return r;
+    vector<std::string> cf_names;
+    db->column_family_list(cf_names);
+    for (auto& s_it: sharding_schema) {
+      for (size_t i = 0; i < s_it.second; i++) {
+        std::string name = s_it.first + "-" + to_string(i);
+        auto n_it = std::find(std::begin(cf_names), std::end(cf_names), name);
+        if (n_it != cf_names.end()) {
+          derr << "Missing column family: '" << name << "' " << dendl;
+          ceph_abort();
+        }
+      }
+    }
+    r = open_shards();
+    return r;
+  }
+  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override {
+    int r = db->create_and_open(out, new_cfs);
+    if (r != 0)
+      return r;
+    for (auto& s_it: sharding_schema) {
+      for (size_t i = 0; i < s_it.second; i++) {
+        std::string name = s_it.first + "-" + to_string(i);
+        r = db->column_family_create(name, "");
+        if (r != 0) {
+          derr << "Unable to create column family: '" << name << "' " << dendl;
+          ceph_abort();
+        }
+      }
+    }
+    r = open_shards();
+    return r;
+  }
+  void close() override {
+    db->close();
+  }
+  int column_family_list(vector<std::string>& cf_names) override {
+    return db->column_family_list(cf_names);
+  }
+  int column_family_create(const std::string& cf_name, const std::string& cf_options) override {
+    return db->column_family_create(cf_name, cf_options);
+  }
+  int column_family_delete(const std::string& cf_name) override {
+    return db->column_family_delete(cf_name);
+  }
+  ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override {
+    return db->column_family_handle(cf_name);
+  }
+  int repair(std::ostream &out) override {
+    return db->repair(out);
+  }
+  Transaction get_transaction() override {
+    KeyValueDB::Transaction t = std::make_shared<HashSharded_TransactionImpl>(*this);
+    return t;
+  }
+  int submit_transaction(Transaction t) override {
+    return db->submit_transaction(t);
+  }
+  int submit_transaction_sync(Transaction t) override {
+    return db->submit_transaction_sync(t);
+  }
+
+  int get(const std::string &prefix,
+          const std::set<std::string> &keys,
+          std::map<std::string, bufferlist> *out) override {
+    std::map<void*, std::set<std::string> > sharded_keys;
+    for (auto& key : keys) {
+      std::string value;
+      KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
+      sharded_keys[cf.priv].emplace(key);
+    }
+    int r = 0;
+    for (auto sh = sharded_keys.begin(); r == 0 && sh != sharded_keys.end(); sh++) {
+      ColumnFamilyHandle cf;
+      cf.priv = sh->first;
+      db->get(cf, prefix, sh->second, out);
+    }
+    return r;
+  }
+
+  int get(const std::string &prefix,
+          const std::string &key,
+          bufferlist *value) override {
+    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
+    return db->get(cf, prefix, key, value);
+  }
+  int get(const string &prefix,
+          const char *key, size_t keylen,
+          bufferlist *value) override {
+    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key, keylen);
+    std::string s_key(key, keylen);
+    return db->get(cf, prefix, s_key, value);
+  }
+
+  int get(ColumnFamilyHandle cf_handle,
+                  const std::string &prefix,
+                  const std::set<std::string> &keys,
+                  std::map<std::string, bufferlist> *out) override {
+    ceph_assert(false && "invalid call");
+    return 0;
+  }
+
+  int get(ColumnFamilyHandle cf_handle,///< [in] Column family handle
+                  const std::string &prefix,    ///< [in] prefix or CF name
+                  const std::string &key,       ///< [in] key
+                  bufferlist *value) override {          ///< [out] value
+    ceph_assert(false && "invalid call");
+    return 0;
+  }
+
+  class WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
+  private:
+    BlueStore_DB_Hash &db_hash;
+    ActiveShards::iterator shards_it;
+    /** for currently processed prefix, contains iterators to shards */
+    std::vector<KeyValueDB::Iterator> current_shards_iterators;
+    /** for currently processed prefix, marks first iterator that is not exhaused */
+    ssize_t position;
+    /*
+     * simulation of next/prev work
+     * v_______________________v   ---
+     * it0 it1 it2 it3 it4 it5 it6 it7
+     * next
+     * it1 it2 it0 it3 it4 it5 it6 it7
+     * next
+     * it2 it0 it3 it4 it1 it5 it6 it7
+     * next
+     * it2 it0 it3 it4 it1 it5 it6 it7
+     * next, it2 expired
+     * --- v___________________v   ---
+     * it2 it0 it3 it4 it1 it5 it6 it7
+     * next, it0 expired
+     * --- --- v_______________v   ---
+     * prev, requires checking before, revived it0
+     * --- v___________________v   ---
+     * it2 it0 it3 it4 it1 it5 it6 it7
+     * prev, checks before, but not revives
+     * it2 it0 it3 it4 it1 it5 it6 it7
+    */
+    bool open_shards() {
+      current_shards_iterators.clear();
+      for (auto& it: shards_it->second) {
+        Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
+        wsi->seek_to_first();
+        if (wsi->valid())
+          current_shards_iterators.emplace_back(wsi);
+      }
+      position = 0;
+      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
+      return true;
+    }
+    int compare(const std::string& a, const std::string& b) {
+      rocksdb::Slice _a(a.data(), a.size());
+      rocksdb::Slice _b(b.data(), b.size());
+      return db_hash.comparator->Compare(_a, _b);
+    }
+    struct KeyLess {
+      WholeSpaceIteratorMerged_Impl& iter;
+      KeyLess(WholeSpaceIteratorMerged_Impl& iter) : iter(iter) {};
+      bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
+      {
+        if (!a->valid())
+          return false;
+        return iter.compare(a->key(), b->key()) < 0;
+      }
+    };
+
+  public:
+    WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash) : db_hash(db_hash), position(-1) {
+    }
+
+    virtual ~WholeSpaceIteratorMerged_Impl() {
+    }
+
+    int seek_to_first() override {
+      shards_it = db_hash.shards.begin();
+      if (shards_it == db_hash.shards.end())
+        return -1;
+      if (open_shards())
+        return 0;
+      else
+        return -1;
+    }
+
+    int seek_to_first(const string &prefix) override {
+      shards_it = db_hash.shards.find(prefix);
+      if (shards_it == db_hash.shards.end())
+        return -1;
+      if (open_shards())
+        return 0;
+      else
+        return -1;
+    }
+
+    int seek_to_last() override {
+      ceph_assert(false && "expected seek_to_last() not called");
+      return 0;
+    }
+
+    int seek_to_last(const string &prefix) override {
+      ceph_assert(false && "expected seek_to_last() not called");
+      return 0;
+    }
+
+    int upper_bound(const string &prefix, const string &after) override {
+      int r = seek_to_first(prefix);
+      if (r < 0)
+        return r;
+      for(auto& it: current_shards_iterators) {
+        it->upper_bound(after);
+      }
+      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
+      return 0;
+    }
+
+    int lower_bound(const string &prefix, const string &to) override {
+      int r = seek_to_first(prefix);
+      if (r < 0)
+        return r;
+      for(auto& it: current_shards_iterators) {
+        it->lower_bound(to);
+      }
+      struct KeyLess {
+        WholeSpaceIteratorMerged_Impl& iter;
+        KeyLess(WholeSpaceIteratorMerged_Impl& iter) : iter(iter) {};
+        bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
+        {
+          if (!a->valid())
+            return false;
+          return iter.compare(a->key(), b->key()) < 0;
+        }
+      };
+      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
+      return 0;
+    }
+
+    bool valid() override {
+      if ((position < 0) || (position >= (ssize_t)current_shards_iterators.size()) )
+        return false;
+      return current_shards_iterators[position]->valid();
+    }
+
+    int next() override {
+      current_shards_iterators[position]->next();
+      if (current_shards_iterators[position]->valid()) {
+        /* this means that next element on this iterator is ok,
+         * but it is likely that it will NOT be next in order */
+        if (position == (ssize_t)current_shards_iterators.size() - 1) {
+          /* this is last one, so it must be correct one */
+          return 0;
+        }
+        std::string key0 = current_shards_iterators[position]->key();
+        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
+          std::string key1 = current_shards_iterators[p]->key();
+          if (compare(key0, key1) < 0) {
+            /* all in order, no need to sort more */
+            break;
+          }
+          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
+        }
+        return 0;
+      }
+      ceph_assert(!current_shards_iterators[position]->valid());
+
+      /* this shard is used up */
+      position++;
+      if (position == (ssize_t)current_shards_iterators.size()) {
+        /* end of current prefix, try next */
+        shards_it++;
+        if (shards_it == db_hash.shards.end())
+          return -1;
+        open_shards();
+      }
+      return 0;
+    }
+
+    int prev() override {
+      ceph_assert(false && "expected prev() not called");
+      if (position > 0) {
+        if (!current_shards_iterators[position - 1]->valid()) {
+          current_shards_iterators[position - 1]->seek_to_last();
+        }
+      }
+
+      current_shards_iterators[position]->prev();
+      if (!current_shards_iterators[position]->valid()) {
+        current_shards_iterators[position]->seek_to_first();
+      }
+
+      current_shards_iterators[position]->prev();
+      if (current_shards_iterators[position]->valid()) {
+        /* this means that prev element on this iterator is ok,
+         * but it is likely that it will NOT be prev in order */
+        if (position == (ssize_t)current_shards_iterators.size() - 1) {
+          /* this is last one, so it must be correct one */
+          return 0;
+        }
+        std::string key0 = current_shards_iterators[position]->key();
+        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
+          std::string key1 = current_shards_iterators[p]->key();
+          if (compare(key0, key1) < 0) {
+            /* all in order, no need to sort more */
+            break;
+          }
+          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
+          std::swap(key0, key1);
+        }
+        return 0;
+      }
+      ceph_assert(!current_shards_iterators[position]->valid());
+
+      /* this shard is used up */
+      if (position)
+      position--;
+      if (position == (ssize_t)current_shards_iterators.size()) {
+        /* end! */
+        return -1;
+      }
+      return 0;
+    }
+
+    string key() override {
+      return current_shards_iterators[position]->key();
+    }
+    pair<string,string> raw_key() override {
+      return current_shards_iterators[position]->raw_key();
+    }
+    bool raw_key_is_prefixed(const string &prefix) override {
+      return prefix == shards_it->first;
+      //return current_shards_iterators[position]->raw_key_is_prefixed(prefix);
+    }
+    bufferlist value() override {
+      return current_shards_iterators[position]->value();
+    }
+    bufferptr value_as_ptr() override {
+      return current_shards_iterators[position]->value_as_ptr();
+    }
+    int status() override {
+      return current_shards_iterators[position]->status();
+    }
+  };
+private:
+
+#if 1
+  // This class filters a WholeSpaceIterator by a prefix.
+  class PrefixIteratorImpl : public IteratorImpl {
+    const std::string prefix;
+    WholeSpaceIterator generic_iter;
+  public:
+    PrefixIteratorImpl(const std::string &prefix, WholeSpaceIterator iter) :
+      prefix(prefix), generic_iter(iter) { }
+    ~PrefixIteratorImpl() override { }
+
+    int seek_to_first() override {
+      return generic_iter->seek_to_first(prefix);
+    }
+    int seek_to_last() override {
+      return generic_iter->seek_to_last(prefix);
+    }
+    int upper_bound(const std::string &after) override {
+      return generic_iter->upper_bound(prefix, after);
+    }
+    int lower_bound(const std::string &to) override {
+      return generic_iter->lower_bound(prefix, to);
+    }
+    bool valid() override {
+      if (!generic_iter->valid())
+        return false;
+      return generic_iter->raw_key_is_prefixed(prefix);
+    }
+    int next() override {
+      return generic_iter->next();
+    }
+    int prev() override {
+      return generic_iter->prev();
+    }
+    std::string key() override {
+      return generic_iter->key();
+    }
+    std::pair<std::string, std::string> raw_key() override {
+      return generic_iter->raw_key();
+    }
+    bufferlist value() override {
+      return generic_iter->value();
+    }
+    bufferptr value_as_ptr() override {
+      return generic_iter->value_as_ptr();
+    }
+    int status() override {
+      return generic_iter->status();
+    }
+  };
+#endif
+
+public:
+
+  WholeSpaceIterator get_wholespace_iterator() override {
+    return std::make_shared<WholeSpaceIteratorMerged_Impl>(*this);
+  }
+  Iterator get_iterator(const std::string &prefix) override {
+    return std::make_shared<PrefixIteratorImpl>(
+      prefix,
+      get_wholespace_iterator());
+  }
+  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override {
+    ceph_abort_msg("Not implemented"); return {};
+  }
+  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override {
+    ceph_abort_msg("Not implemented"); return {};
+  }
+
+  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override {
+    return db->get_estimated_size(extra);
+  }
+  int get_statfs(struct store_statfs_t *buf) override {
+    return -EOPNOTSUPP;
+  }
+
+  int set_cache_size(uint64_t) override {
+    return -EOPNOTSUPP;
+  }
+
+  // PriCache
+  int64_t request_cache_bytes(PriorityCache::Priority pri, uint64_t chunk_bytes) const override {
+    return db->request_cache_bytes(pri, chunk_bytes);
+  }
+
+  int64_t get_cache_bytes(PriorityCache::Priority pri) const override {
+    return db->get_cache_bytes(pri);
+  }
+
+  int64_t get_cache_bytes() const override {
+    return db->get_cache_bytes();
+  }
+
+  void set_cache_bytes(PriorityCache::Priority pri, int64_t bytes) override {
+    db->set_cache_bytes(pri, bytes);
+  }
+
+  void add_cache_bytes(PriorityCache::Priority pri, int64_t bytes) override {
+    db->add_cache_bytes(pri, bytes);
+  }
+
+  int64_t commit_cache_size() override {
+    return db->commit_cache_size();
+  }
+
+  double get_cache_ratio() const override {
+    return db->get_cache_ratio();
+  }
+
+  void set_cache_ratio(double ratio) override {
+    db->set_cache_ratio(ratio);
+  }
+
+  string get_cache_name() const override {
+    return db->get_cache_name();
+  }
+
+  // End PriCache
+
+  int set_cache_high_pri_pool_ratio(double ratio) override {
+    return db->set_cache_high_pri_pool_ratio(ratio);
+  }
+
+  int64_t get_cache_usage() const override {
+    return db->get_cache_usage();
+  }
+
+  /// estimate space utilization for a prefix (in bytes)
+  int64_t estimate_prefix_size(const string& prefix,
+                               ColumnFamilyHandle cfh = ColumnFamilyHandle()) override {
+    return 0;
+  }
+
+  void compact() override {
+    db->compact();
+  }
+  void compact_async() override {
+    db->compact_async();
+  }
+  void compact_prefix(const std::string& prefix) override {
+    //TODO
+    db->compact_prefix(prefix);
+  }
+  void compact_prefix_async(const std::string& prefix) override {
+    //TODO
+    db->compact_prefix_async(prefix);
+  }
+  void compact_range(const std::string& prefix,
+                     const std::string& start, const std::string& end) override {
+    //TODO
+    db->compact_range(prefix, start, end);
+  }
+  void compact_range_async(const std::string& prefix,
+                           const std::string& start, const std::string& end) override {
+    //TODO
+    db->compact_range_async(prefix, start, end);
+  }
+
+  int set_merge_operator(const std::string& prefix,
+                         std::shared_ptr<MergeOperator> mop) override {
+    //TODO!!
+    return db->set_merge_operator(prefix, mop);
+    return -EOPNOTSUPP;
+  }
+
+  void get_statistics(Formatter *f) override {
+    db->get_statistics(f);
+  }
+
+};
+
+
+
+KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB* db, const BlueStore_DB_Hash::ShardingSchema& schema) {
+  RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
+  ceph_assert(db != nullptr);
+  return new BlueStore_DB_Hash(rdb, schema);
+}
+

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -7,14 +7,10 @@
 #define dout_prefix *_dout << "shard-db "
 
 
-
-
-
-
-
 class BlueStore_DB_Hash : public KeyValueDB {
 public:
   typedef std::map<std::string, size_t> ShardingSchema;
+
 private:
   RocksDBStore* db;
   CephContext* cct;
@@ -38,12 +34,12 @@ private:
       if (s_it.second == 0) {
         auto cf_handle = db->column_family_handle("default");
         shards[s_it.first].push_back(cf_handle);
-        dout(0) << "Column family '" << s_it.first << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+        dout(5) << "Column family '" << s_it.first << "' handle: " << (void*)cf_handle.priv << " " << dendl;
       } else {
         for (size_t i = 0; i < s_it.second; i++) {
           std::string name = s_it.first + "-" + to_string(i);
           auto cf_handle = db->column_family_handle(name);
-          dout(0) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+          dout(5) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
           shards[s_it.first].push_back(cf_handle);
         }
       }
@@ -153,7 +149,6 @@ private:
 #undef dout_context
 #define dout_context cct
 
-public:
   int init(string option_str="") override {
     int r = db->init(option_str);
     return r;
@@ -271,14 +266,87 @@ public:
     return 0;
   }
 
-  class WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
-  private:
-    BlueStore_DB_Hash &db_hash;
-    ActiveShards::iterator shards_it;
-    /** for currently processed prefix, contains iterators to shards */
-    std::vector<KeyValueDB::Iterator> current_shards_iterators;
-    /** for currently processed prefix, marks first iterator that is not exhaused */
-    ssize_t position;
+  static int compare(const rocksdb::Comparator* comparator,
+                     const std::string& a,
+                     const std::string& b) {
+    rocksdb::Slice _a(a.data(), a.size());
+    rocksdb::Slice _b(b.data(), b.size());
+    return comparator->Compare(_a, _b);
+  }
+
+  struct KeyLess {
+    const rocksdb::Comparator* comparator;
+    KeyLess(const rocksdb::Comparator* comparator) : comparator(comparator) { };
+    bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
+    {
+      if (a->valid()) {
+        if (b->valid()) {
+          return compare(comparator, a->key(), b->key()) < 0;
+        } else {
+          return true;
+        }
+      } else {
+        if (b->valid()) {
+          return false;
+        } else {
+          return (void*)a.get() < (void*)b.get();
+        }
+      }
+    }
+  };
+
+
+  class ShardedIteratorBase {
+    ssize_t position = 0;
+    std::vector<KeyValueDB::Iterator> shards;
+    const rocksdb::Comparator* comparator;
+  public:
+    ShardedIteratorBase(std::vector<KeyValueDB::Iterator>&& shards, const rocksdb::Comparator* comparator)
+    : shards(std::move(shards))
+    , comparator(comparator) { }
+
+    ~ShardedIteratorBase() { }
+
+    int open(const std::vector<KeyValueDB::Iterator>& new_shards) {
+      shards = new_shards;
+      return 0;
+    }
+    KeyValueDB::Iterator& item() {
+      return shards[position];
+    }
+    int seek_to_last() {
+      ceph_assert(false && "expected seek_to_last() not called");
+      return 0;
+    }
+    int seek_to_first() {
+      for (auto& it: shards) {
+        it->seek_to_first();
+      }
+      position = 0;
+      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+      return 0;
+    }
+    int upper_bound(const string &after) {
+      for(auto& it: shards) {
+        it->upper_bound(after);
+      }
+      position = 0;
+      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+      return 0;
+    }
+    int lower_bound(const string &to) {
+      for(auto& it: shards) {
+        it->lower_bound(to);
+      }
+      position = 0;
+      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+      return 0;
+    }
+    bool valid() {
+      if (position >= (ssize_t)shards.size() )
+        return false;
+      return shards[position]->valid();
+    }
     /*
      * simulation of next/prev work
      * v_______________________v   ---
@@ -300,289 +368,207 @@ public:
      * prev, checks before, but not revives
      * it2 it0 it3 it4 it1 it5 it6 it7
     */
-    bool open_shards() {
-      current_shards_iterators.clear();
+    int next() {
+      shards[position]->next();
+      if (shards[position]->valid()) {
+        /* sort, as other shards may point to key that is less then
+         * key that we just moved to */
+        std::string key0 = shards[position]->key();
+        for (size_t p = position + 1; p < shards.size(); p++) {
+          std::string key1 = shards[p]->key();
+          if (compare(comparator, key0, key1) < 0) {
+            /* all in order, no need to sort more */
+            break;
+          }
+          std::swap(shards[p - 1], shards[p]);
+        }
+      } else {
+        position++;
+      }
+      /* signal if we iterated out of range */
+      if (position >= (ssize_t)shards.size())
+        return -1;
+      return 0;
+    }
+
+    int prev() {
+      return -1;
+    }
+  };
+
+  class WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
+  private:
+    BlueStore_DB_Hash &db_hash;
+    ActiveShards::iterator shards_it;
+    ShardedIteratorBase iter;
+
+    void open_shards(std::vector<KeyValueDB::Iterator>& shards) {
       for (auto& it: shards_it->second) {
         Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
         wsi->seek_to_first();
         if (wsi->valid())
-          current_shards_iterators.emplace_back(wsi);
+          shards.emplace_back(wsi);
       }
-      position = 0;
-      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      return true;
     }
-    int compare(const std::string& a, const std::string& b) {
-      rocksdb::Slice _a(a.data(), a.size());
-      rocksdb::Slice _b(b.data(), b.size());
-      return db_hash.comparator->Compare(_a, _b);
+    void open_shards(std::vector<KeyValueDB::Iterator>& shards, const std::string& prefix) {
+      shards.emplace_back(db_hash.db->get_iterator(prefix));
     }
-    struct KeyLess {
-      WholeSpaceIteratorMerged_Impl& iter;
-      KeyLess(WholeSpaceIteratorMerged_Impl& iter) : iter(iter) {};
-      bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
-      {
-        if (!a->valid())
-          return false;
-        return iter.compare(a->key(), b->key()) < 0;
-      }
-    };
 
   public:
-    WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash) : db_hash(db_hash), position(-1) {
-    }
+    WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash)
+      : db_hash(db_hash)
+      , iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {}
 
-    virtual ~WholeSpaceIteratorMerged_Impl() {
+    virtual ~WholeSpaceIteratorMerged_Impl() {}
+
+    int seek_to_first_existing() {
+      while (shards_it != db_hash.shards.end()) {
+        std::vector<KeyValueDB::Iterator> shards;
+        if (shards_it->second.size() == 0) {
+          /* no separate shard, is part of default column family */
+          open_shards(shards, shards_it->first);
+        } else {
+          open_shards(shards);
+        }
+        iter.open(shards);
+        iter.seek_to_first();
+        if (iter.valid()) {
+          return 0;
+        }
+        //this shard is empty, go next
+        ++shards_it;
+      };
+      return -1;
     }
 
     int seek_to_first() override {
       shards_it = db_hash.shards.begin();
-      if (shards_it == db_hash.shards.end())
-        return -1;
-      if (open_shards())
-        return 0;
-      else
-        return -1;
+      return seek_to_first_existing();
     }
-
     int seek_to_first(const string &prefix) override {
       shards_it = db_hash.shards.find(prefix);
-      if (shards_it == db_hash.shards.end())
-        return -1;
-      if (open_shards())
-        return 0;
-      else
-        return -1;
+      return seek_to_first_existing();
     }
-
     int seek_to_last() override {
       ceph_assert(false && "expected seek_to_last() not called");
       return 0;
     }
-
     int seek_to_last(const string &prefix) override {
       ceph_assert(false && "expected seek_to_last() not called");
       return 0;
     }
-
     int upper_bound(const string &prefix, const string &after) override {
-      int r = seek_to_first(prefix);
-      if (r < 0)
-        return r;
-      for(auto& it: current_shards_iterators) {
-        it->upper_bound(after);
-      }
-      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      return 0;
-    }
-
-    int lower_bound(const string &prefix, const string &to) override {
-      int r = seek_to_first(prefix);
-      if (r < 0)
-        return r;
-      for(auto& it: current_shards_iterators) {
-        it->lower_bound(to);
-      }
-      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      return 0;
-    }
-
-    bool valid() override {
-      if ((position < 0) || (position >= (ssize_t)current_shards_iterators.size()) )
-        return false;
-      return current_shards_iterators[position]->valid();
-    }
-
-    int next() override {
-      current_shards_iterators[position]->next();
-      if (current_shards_iterators[position]->valid()) {
-        /* this means that next element on this iterator is ok,
-         * but it is likely that it will NOT be next in order */
-        if (position == (ssize_t)current_shards_iterators.size() - 1) {
-          /* this is last one, so it must be correct one */
-          return 0;
-        }
-        std::string key0 = current_shards_iterators[position]->key();
-        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
-          std::string key1 = current_shards_iterators[p]->key();
-          if (compare(key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
-        }
-        return 0;
-      }
-      ceph_assert(!current_shards_iterators[position]->valid());
-
-      /* this shard is used up */
-      position++;
-      if (position == (ssize_t)current_shards_iterators.size()) {
-        /* end of current prefix, try next */
-        shards_it++;
-        if (shards_it == db_hash.shards.end())
-          return -1;
-        open_shards();
-      }
-      return 0;
-    }
-
-    int prev() override {
-      ceph_assert(false && "expected prev() not called");
-      if (position > 0) {
-        if (!current_shards_iterators[position - 1]->valid()) {
-          current_shards_iterators[position - 1]->seek_to_last();
-        }
-      }
-
-      current_shards_iterators[position]->prev();
-      if (!current_shards_iterators[position]->valid()) {
-        current_shards_iterators[position]->seek_to_first();
-      }
-
-      current_shards_iterators[position]->prev();
-      if (current_shards_iterators[position]->valid()) {
-        /* this means that prev element on this iterator is ok,
-         * but it is likely that it will NOT be prev in order */
-        if (position == (ssize_t)current_shards_iterators.size() - 1) {
-          /* this is last one, so it must be correct one */
-          return 0;
-        }
-        std::string key0 = current_shards_iterators[position]->key();
-        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
-          std::string key1 = current_shards_iterators[p]->key();
-          if (compare(key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
-          std::swap(key0, key1);
-        }
-        return 0;
-      }
-      ceph_assert(!current_shards_iterators[position]->valid());
-
-      /* this shard is used up */
-      if (position)
-      position--;
-      if (position == (ssize_t)current_shards_iterators.size()) {
-        /* end! */
+      shards_it = db_hash.shards.lower_bound(prefix);
+      if (shards_it == db_hash.shards.end()) {
         return -1;
       }
+      seek_to_first_existing();
+      if (shards_it == db_hash.shards.end()) {
+        return -1;
+      }
+      if (shards_it->first == prefix) {
+        /* we are in intended prefix, we need more detailed upper_bound */
+        iter.upper_bound(after);
+        if (!iter.valid()) {
+          /* nothing after target of upper_bound*/
+          ++shards_it;
+          return seek_to_first();
+        }
+      }
       return 0;
     }
-
+    int lower_bound(const string &prefix, const string &to) override {
+      shards_it = db_hash.shards.lower_bound(prefix);
+      if (shards_it == db_hash.shards.end()) {
+        return -1;
+      }
+      seek_to_first_existing();
+      if (shards_it == db_hash.shards.end()) {
+        return -1;
+      }
+      if (shards_it->first == prefix) {
+        /* we are in intended prefix, we need more detailed upper_bound */
+        iter.lower_bound(to);
+        if (!iter.valid()) {
+          /* nothing after target of upper_bound*/
+          ++shards_it;
+          return seek_to_first_existing();
+        }
+      }
+      return 0;
+    }
+    bool valid() override {
+      return iter.valid();
+    }
+    int next() override {
+      int r = iter.next();
+      if (r < 0) {
+        /* if we iterated out of current shard, go on */
+        ++shards_it;
+        return seek_to_first_existing();
+      }
+      return r;
+    }
+    int prev() override {
+      ceph_assert(false && "expected prev() not called");
+      return 0;
+    }
     string key() override {
-      return current_shards_iterators[position]->key();
+      return iter.item()->key();
     }
     pair<string,string> raw_key() override {
-      return current_shards_iterators[position]->raw_key();
+      return iter.item()->raw_key();
     }
     bool raw_key_is_prefixed(const string &prefix) override {
       return prefix == shards_it->first;
-      //return current_shards_iterators[position]->raw_key_is_prefixed(prefix);
     }
     bufferlist value() override {
-      return current_shards_iterators[position]->value();
+      return iter.item()->value();
     }
     bufferptr value_as_ptr() override {
-      return current_shards_iterators[position]->value_as_ptr();
+      return iter.item()->value_as_ptr();
     }
     int status() override {
-      return current_shards_iterators[position]->status();
+      return iter.item()->status();
     }
   };
 
 #undef dout_context
 #define dout_context db_hash.cct
 
-
   class SinglePrefixIteratorMerged_Impl: public IteratorImpl {
   private:
-    BlueStore_DB_Hash &db_hash;
-    ActiveShards::iterator shards_it;
-    /** for currently processed prefix, contains iterators to shards */
-    std::vector<KeyValueDB::Iterator> current_shards_iterators;
-    /** for currently processed prefix, marks first iterator that is not exhaused */
-    ssize_t position;
-    /*
-     * simulation of next/prev work
-     * v_______________________v   ---
-     * it0 it1 it2 it3 it4 it5 it6 it7
-     * next
-     * it1 it2 it0 it3 it4 it5 it6 it7
-     * next
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next, it2 expired
-     * --- v___________________v   ---
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next, it0 expired
-     * --- --- v_______________v   ---
-     * prev, requires checking before, revived it0
-     * --- v___________________v   ---
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * prev, checks before, but not revives
-     * it2 it0 it3 it4 it1 it5 it6 it7
-    */
-    bool open_shards() {
-      current_shards_iterators.clear();
-      for (auto& it: shards_it->second) {
-        Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
-        wsi->seek_to_first();
-        if (wsi->valid())
-          current_shards_iterators.emplace_back(wsi);
-      }
-      position = 0;
-      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      return true;
-    }
-    int compare(const std::string& a, const std::string& b) {
-      rocksdb::Slice _a(a.data(), a.size());
-      rocksdb::Slice _b(b.data(), b.size());
-      return db_hash.comparator->Compare(_a, _b);
-    }
-    struct KeyLess {
-      SinglePrefixIteratorMerged_Impl& iter;
-      KeyLess(SinglePrefixIteratorMerged_Impl& iter) : iter(iter) {};
-      bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
-      {
-        if (!a->valid())
-          return false;
-        return iter.compare(a->key(), b->key()) < 0;
-      }
-    };
+    ShardedIteratorBase iter;
 
-  public:
-    SinglePrefixIteratorMerged_Impl(BlueStore_DB_Hash &db_hash, const string& prefix) : db_hash(db_hash), position(-1) {
-      shards_it = db_hash.shards.find(prefix);
+    static void prefix_to_iterators(
+        std::vector<KeyValueDB::Iterator>& shards,
+        const BlueStore_DB_Hash &db_hash,
+        const string& prefix) {
+      auto shards_it = db_hash.shards.find(prefix);
       if (shards_it != db_hash.shards.end()) {
         for (auto& it: shards_it->second) {
           Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
           wsi->seek_to_first();
           if (wsi->valid())
-            current_shards_iterators.emplace_back(wsi);
+            shards.emplace_back(wsi);
         }
-        if (!current_shards_iterators.empty()) {
-          position = 0;
-          std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-        }
+        std::sort(shards.begin(), shards.end(), KeyLess(db_hash.comparator));
       }
+    }
+
+  public:
+    SinglePrefixIteratorMerged_Impl(BlueStore_DB_Hash &db_hash, const string& prefix)
+    : iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {
+      std::vector<KeyValueDB::Iterator> shards;
+      prefix_to_iterators(shards, db_hash, prefix);
+      iter.open(shards);
     }
 
     virtual ~SinglePrefixIteratorMerged_Impl() {
     }
 
     int seek_to_first() override {
-      for (auto& it: current_shards_iterators) {
-        it->seek_to_first();
-      }
-      if (!current_shards_iterators.empty()) {
-        position = 0;
-        std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      }
-      return 0;
+      return iter.seek_to_first();
     }
 
     int seek_to_last() override {
@@ -591,125 +577,50 @@ public:
     }
 
     int upper_bound(const string &after) override {
-      for(auto& it: current_shards_iterators) {
-        it->upper_bound(after);
-      }
-      if (!current_shards_iterators.empty()) {
-        position = 0;
-        std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      }
-      return 0;
+      return iter.upper_bound(after);
     }
 
     int lower_bound(const string &to) override {
-      for(auto& it: current_shards_iterators) {
-        it->lower_bound(to);
-      }
-      if (!current_shards_iterators.empty()) {
-        position = 0;
-        std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      }
-      return 0;
+      return iter.lower_bound(to);
     }
 
     bool valid() override {
-      if ((position < 0) || (position >= (ssize_t)current_shards_iterators.size()) )
-        return false;
-      return current_shards_iterators[position]->valid();
+      return iter.valid();
     }
 
     int next() override {
-      current_shards_iterators[position]->next();
-      if (current_shards_iterators[position]->valid()) {
-        /* this means that next element on this iterator is ok,
-         * but it is likely that it will NOT be next in order */
-        if (position == (ssize_t)current_shards_iterators.size() - 1) {
-          /* this is last one, so it must be correct one */
-          return 0;
-        }
-        std::string key0 = current_shards_iterators[position]->key();
-        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
-          std::string key1 = current_shards_iterators[p]->key();
-          if (compare(key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
-        }
-        return 0;
-      }
-      ceph_assert(!current_shards_iterators[position]->valid());
-      return -1;
+      return iter.next();
     }
 
     int prev() override {
       ceph_assert(false && "expected prev() not called");
-      if (position > 0) {
-        if (!current_shards_iterators[position - 1]->valid()) {
-          current_shards_iterators[position - 1]->seek_to_last();
-        }
-      }
-
-      current_shards_iterators[position]->prev();
-      if (!current_shards_iterators[position]->valid()) {
-        current_shards_iterators[position]->seek_to_first();
-      }
-
-      current_shards_iterators[position]->prev();
-      if (current_shards_iterators[position]->valid()) {
-        /* this means that prev element on this iterator is ok,
-         * but it is likely that it will NOT be prev in order */
-        if (position == (ssize_t)current_shards_iterators.size() - 1) {
-          /* this is last one, so it must be correct one */
-          return 0;
-        }
-        std::string key0 = current_shards_iterators[position]->key();
-        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
-          std::string key1 = current_shards_iterators[p]->key();
-          if (compare(key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
-          std::swap(key0, key1);
-        }
-        return 0;
-      }
-      ceph_assert(!current_shards_iterators[position]->valid());
-
-      /* this shard is used up */
-      if (position)
-      position--;
-      if (position == (ssize_t)current_shards_iterators.size()) {
-        /* end! */
-        return -1;
-      }
       return 0;
     }
 
     string key() override {
-      return current_shards_iterators[position]->key();
+      return iter.item()->key();
     }
+
     pair<string,string> raw_key() override {
-      return current_shards_iterators[position]->raw_key();
+      return iter.item()->raw_key();
     }
+
     bufferlist value() override {
-      return current_shards_iterators[position]->value();
+      return iter.item()->value();
     }
+
     bufferptr value_as_ptr() override {
-      return current_shards_iterators[position]->value_as_ptr();
+      return iter.item()->value_as_ptr();
     }
+
     int status() override {
-      return current_shards_iterators[position]->status();
+      return iter.item()->status();
     }
   };
+
 #undef dout_context
 #define dout_context cct
 
-
-private:
-
-#if 1
   // This class filters a WholeSpaceIterator by a prefix.
   class PrefixIteratorImpl : public IteratorImpl {
     const std::string prefix;
@@ -758,7 +669,6 @@ private:
       return generic_iter->status();
     }
   };
-#endif
 
 public:
 
@@ -908,14 +818,10 @@ public:
   void get_statistics(Formatter *f) override {
     db->get_statistics(f);
   }
-
 };
-
-
 
 KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB* db, const BlueStore_DB_Hash::ShardingSchema& schema) {
   RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
   ceph_assert(db != nullptr);
   return new BlueStore_DB_Hash(rdb, schema);
 }
-

--- a/src/os/bluestore/BlueStore_DB_Hash.h
+++ b/src/os/bluestore/BlueStore_DB_Hash.h
@@ -88,6 +88,7 @@ public:
   int64_t get_cache_usage() const override;
   /// estimate space utilization for a prefix (in bytes)
   int64_t estimate_prefix_size(const string& prefix,
+                               const std::string& key_prefix,
                                ColumnFamilyHandle cfh = ColumnFamilyHandle()) override;
   void compact() override;
   void compact_async() override;

--- a/src/os/bluestore/BlueStore_DB_Hash.h
+++ b/src/os/bluestore/BlueStore_DB_Hash.h
@@ -1,0 +1,96 @@
+#ifndef BLUESTORE_DB_HASH_H
+#define BLUESTORE_DB_HASH_H
+
+
+#include "kv/RocksDBStore.h"
+
+class BlueStore_DB_Hash : public KeyValueDB {
+  friend class BlueStore;
+public:
+  typedef std::map<std::string, size_t> ShardingSchema;
+  class HashSharded_TransactionImpl;
+  class WholeSpaceIteratorMerged_Impl;
+  class SinglePrefixIteratorMerged_Impl;
+  class PrefixIteratorImpl;
+private:
+  RocksDBStore* db;
+  CephContext* cct;
+  const rocksdb::Comparator* comparator;
+  ShardingSchema sharding_schema;
+  typedef std::map<std::string, std::vector<KeyValueDB::ColumnFamilyHandle> > ActiveShards;
+  ActiveShards shards;
+
+public:
+  BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sharding_schema);
+  virtual ~BlueStore_DB_Hash();
+  void unlink_db();
+
+private:
+  int open_shards();
+  KeyValueDB::ColumnFamilyHandle get_db_shard(const std::string &prefix, const char *k, size_t keylen);
+  std::vector<KeyValueDB::ColumnFamilyHandle>& get_shards(const std::string &prefix);
+
+public:
+  int init(string option_str="") override;
+  int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override;
+  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override;
+  int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override;
+  int _do_open(std::ostream &out, bool read_only, const std::vector<ColumnFamily>& options = {});
+  void close() override;
+  int column_family_list(vector<std::string>& cf_names) override;
+  int column_family_create(const std::string& cf_name, const std::string& cf_options) override;
+  int column_family_delete(const std::string& cf_name) override;
+  ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override;
+  int repair(std::ostream &out) override;
+  Transaction get_transaction() override;
+  int submit_transaction(Transaction t) override;
+  int submit_transaction_sync(Transaction t) override;
+
+  int get(const std::string &prefix,
+          const std::set<std::string> &keys,
+          std::map<std::string, bufferlist> *out) override;
+  int get(const std::string &prefix,
+          const std::string &key,
+          bufferlist *value) override;
+  int get(const string &prefix,
+          const char *key, size_t keylen,
+          bufferlist *value) override;
+  int get(ColumnFamilyHandle cf_handle,
+                  const std::string &prefix,
+                  const std::set<std::string> &keys,
+                  std::map<std::string, bufferlist> *out) override;
+  int get(ColumnFamilyHandle cf_handle,           ///< [in] Column family handle
+                  const std::string &prefix,      ///< [in] prefix or CF name
+                  const std::string &key,         ///< [in] key
+                  bufferlist *value) override;    ///< [out] value
+
+  WholeSpaceIterator get_wholespace_iterator() override;
+  Iterator get_iterator(const std::string &prefix) override;
+  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override;
+  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override;
+  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override;
+  int get_statfs(struct store_statfs_t *buf) override;
+  int set_cache_size(uint64_t) override;
+  int set_cache_high_pri_pool_ratio(double ratio) override;
+  int64_t get_cache_usage() const override;
+  /// estimate space utilization for a prefix (in bytes)
+  int64_t estimate_prefix_size(const string& prefix,
+                               ColumnFamilyHandle cfh = ColumnFamilyHandle()) override;
+  void compact() override;
+  void compact_async() override;
+  void compact_prefix(const std::string& prefix) override;
+  void compact_prefix_async(const std::string& prefix) override;
+  void compact_range(const std::string& prefix,
+                     const std::string& start, const std::string& end) override;
+  void compact_range_async(const std::string& prefix,
+                           const std::string& start, const std::string& end) override;
+  int set_merge_operator(const std::string& prefix,
+                         std::shared_ptr<MergeOperator> mop) override;
+  void get_statistics(Formatter *f) override;
+  int locate_column_name(const std::pair<std::string, std::string>& raw_key,
+                           std::string& column_name);
+};
+
+KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB* db, const BlueStore_DB_Hash::ShardingSchema& schema);
+
+#endif

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -12,6 +12,7 @@
     set [column/]<prefix> <key> [ver <N>|in <file>]
     rm [column/]<prefix> <key>
     rm-prefix [column/]<prefix>
+    list-columns
     store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...]
     store-crc <path>
     compact

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -2,21 +2,22 @@
   Usage: ceph-kvstore-tool <leveldb|rocksdb|bluestore-kv> <store path> command [args...]
   
   Commands:
-    list [prefix]
-    list-crc [prefix]
-    dump [prefix]
-    exists <prefix> [key]
-    get <prefix> <key> [out <file>]
-    crc <prefix> <key>
-    get-size [<prefix> <key>]
-    set <prefix> <key> [ver <N>|in <file>]
-    rm <prefix> <key>
-    rm-prefix <prefix>
-    store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...] 
+    list [column/][prefix]
+    list-crc [column/][prefix]
+    dump [column/][prefix]
+    exists [column/]<prefix> [key]
+    get [column/]<prefix> <key> [out <file>]
+    crc [column/]<prefix> <key>
+    get-size [[column/]<prefix> <key>]
+    set [column/]<prefix> <key> [ver <N>|in <file>]
+    rm [column/]<prefix> <key>
+    rm-prefix [column/]<prefix>
+    store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...]
     store-crc <path>
     compact
-    compact-prefix <prefix>
-    compact-range <prefix> <start> <end>
+    compact-prefix [column/]<prefix>
+    compact-range [column/]<prefix> <start> <end>
     destructive-repair  (use only as last resort! may corrupt healthy data)
     stats
   
+

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -623,16 +623,16 @@ TEST_P(KVTest, RocksDB_estimate_size) {
     bufferlist v1;
     v1.append(string(1000, '1'));
     for (int i = 0; i < 100; i++)
-      t->set("A", to_string(rand()%100000), v1);
+      t->set("A", to_string(i%10)+to_string(1000 * test + i), v1);
     db->submit_transaction_sync(t);
     db->compact();
 
     int64_t size_a = db->estimate_prefix_size("A","");
-    ASSERT_GT(size_a, (test + 1) * 1000 * 100 * 0.5);
-    ASSERT_LT(size_a, (test + 1) * 1000 * 100 * 1.5);
+    ASSERT_GT(size_a, (test + 1) * 1000 * 100 * 0.8);
+    ASSERT_LT(size_a, (test + 1) * 1000 * 100 * 1.2);
     int64_t size_a1 = db->estimate_prefix_size("A","1");
-    ASSERT_GT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 0.5);
-    ASSERT_LT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 1.5);
+    ASSERT_GT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 0.8);
+    ASSERT_LT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 1.2);
     int64_t size_b = db->estimate_prefix_size("B","");
     ASSERT_EQ(size_b, 0);
   }
@@ -656,16 +656,16 @@ TEST_P(KVTest, RocksDB_estimate_size_column_family) {
     bufferlist v1;
     v1.append(string(1000, '1'));
     for (int i = 0; i < 100; i++)
-      t->set("cf1", to_string(rand()%100000), v1);
+      t->set("cf1", to_string(i%10) + to_string(1000 * test + i), v1);
     db->submit_transaction_sync(t);
     db->compact();
 
     int64_t size_a = db->estimate_prefix_size("cf1","");
-    ASSERT_GT(size_a, (test + 1) * 1000 * 100 * 0.5);
-    ASSERT_LT(size_a, (test + 1) * 1000 * 100 * 1.5);
+    ASSERT_GT(size_a, (test + 1) * 1000 * 100 * 0.8);
+    ASSERT_LT(size_a, (test + 1) * 1000 * 100 * 1.2);
     int64_t size_a1 = db->estimate_prefix_size("cf1","1");
-    ASSERT_GT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 0.5);
-    ASSERT_LT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 1.5);
+    ASSERT_GT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 0.8);
+    ASSERT_LT(size_a1, (test + 1) * 1000 * 100 * 0.1 * 1.2);
     int64_t size_b = db->estimate_prefix_size("B","");
     ASSERT_EQ(size_b, 0);
   }

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -383,6 +383,10 @@ TEST_P(KVTest, RocksDBIteratorTest) {
     cout << "write some kv pairs into default and new CFs" << std::endl;
     t->set("prefix", "key1", bl1);
     t->set("prefix", "key2", bl2);
+    KeyValueDB::ColumnFamilyHandle cf1h;
+    ASSERT_NE(cf1h = db->column_family_handle("cf1"), nullptr);
+
+    t->select(cf1h);
     t->set("cf1", "key1", bl1);
     t->set("cf1", "key2", bl2);
     ASSERT_EQ(0, db->submit_transaction_sync(t));
@@ -519,6 +523,24 @@ TEST_P(KVTest, RocksDBIteratorColumnFamiliesTest) {
     ASSERT_EQ(1, iter->valid());
     ASSERT_EQ("key2", iter->key());
     ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  {
+    cout << "iterating the specialized CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator_cf(cf1h, "cf1");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    auto a = iter->raw_key();
+    ASSERT_EQ("cf1", a.first);
+    ASSERT_EQ("key1", a.second);
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+    a = iter->raw_key();
+    ASSERT_EQ("cf1", a.first);
+    ASSERT_EQ("key2", a.second);
   }
   {
     cout << "iterating the new CF" << std::endl;

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -42,7 +42,7 @@ void usage(const char *pname)
     << "  set [column/]<prefix> <key> [ver <N>|in <file>]\n"
     << "  rm [column/]<prefix> <key>\n"
     << "  rm-prefix [column/]<prefix>\n"
-    << "  store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...] \n"
+    << "  store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...]\n"
     << "  store-crc <path>\n"
     << "  compact\n"
     << "  compact-prefix [column/]<prefix>\n"

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -42,6 +42,7 @@ void usage(const char *pname)
     << "  set [column/]<prefix> <key> [ver <N>|in <file>]\n"
     << "  rm [column/]<prefix> <key>\n"
     << "  rm-prefix [column/]<prefix>\n"
+    << "  list-columns\n"
     << "  store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...]\n"
     << "  store-crc <path>\n"
     << "  compact\n"
@@ -314,6 +315,21 @@ int main(int argc, const char *argv[])
                 << url_escape(prefix) << ")"
 		<< std::endl;
       return 1;
+    }
+  } else if (cmd == "list-columns") {
+    if (argc < 4) {
+      usage(argv[0]);
+      return 1;
+    }
+    std::vector<std::string> columns;
+    bool ret = st.list_columns(columns);
+    if (!ret) {
+      std::cerr << "error listing columns"
+		<< std::endl;
+      return 1;
+    }
+    for (auto& s: columns) {
+      std::cout << s << std::endl;
     }
   } else if (cmd == "store-copy") {
     int num_keys_per_tx = 128; // magic number that just feels right.

--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -239,6 +239,12 @@ bool StoreTool::rm_prefix(const std::string& column_family,
   return (ret == 0);
 }
 
+bool StoreTool::list_columns(std::vector<std::string>& columns)
+{
+  int ret = db->column_family_list(columns);
+  return (ret == 0);
+}
+
 void StoreTool::print_summary(const uint64_t total_keys, const uint64_t total_size,
                               const uint64_t total_txs, const string& store_path,
                               const string& other_path, const int duration) const

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -39,42 +39,54 @@ class StoreTool
 #endif
 
   const std::string store_path;
-
 public:
   StoreTool(const std::string& type,
 	    const std::string& path,
 	    bool need_open_db = true,
 	    bool need_stats = false);
   int load_bluestore(const std::string& path, bool need_open_db);
-  uint32_t traverse(const std::string& prefix,
+  uint32_t traverse(const std::string& column_family,
+		    const std::string& prefix,
                     const bool do_crc,
                     const bool do_value_dump,
                     ostream *out);
-  void list(const std::string& prefix,
+  void list(const std::string& column_family,
+	    const std::string& prefix,
 	    const bool do_crc,
 	    const bool do_value_dump);
-  bool exists(const std::string& prefix);
-  bool exists(const std::string& prefix, const std::string& key);
-  ceph::bufferlist get(const std::string& prefix,
+  bool exists(const std::string& column_family,
+	      const std::string& prefix);
+  bool exists(const std::string& column_family,
+	      const std::string& prefix,
+	      const std::string& key);
+  ceph::bufferlist get(const std::string& column_family,
+		       const std::string& prefix,
 		       const std::string& key,
 		       bool& exists);
   uint64_t get_size();
-  bool set(const std::string& prefix,
+  bool set(const std::string& column_family,
+	   const std::string& prefix,
 	   const std::string& key,
 	   ceph::bufferlist& val);
-  bool rm(const std::string& prefix, const std::string& key);
-  bool rm_prefix(const std::string& prefix);
+  bool rm(const std::string& column_family,
+	  const std::string& prefix,
+	  const std::string& key);
+  bool rm_prefix(const std::string& column_family,
+		 const std::string& prefix);
   void print_summary(const uint64_t total_keys, const uint64_t total_size,
                      const uint64_t total_txs, const std::string& store_path,
                      const std::string& other_path, const int duration) const;
   int copy_store_to(const std::string& type, const std::string& other_path,
                     const int num_keys_per_tx, const std::string& other_type);
   void compact();
-  void compact_prefix(const std::string& prefix);
-  void compact_range(const std::string& prefix,
+  void compact_prefix(const std::string& column_family,
+		      const std::string& prefix);
+  void compact_range(const std::string& column_family,
+		     const std::string& prefix,
 		     const std::string& start,
 		     const std::string& end);
   int destructive_repair();
 
   int print_stats() const;
+
 };

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -73,6 +73,7 @@ public:
 	  const std::string& key);
   bool rm_prefix(const std::string& column_family,
 		 const std::string& prefix);
+  bool list_columns(std::vector<std::string>& columns);
   void print_summary(const uint64_t total_keys, const uint64_t total_size,
                      const uint64_t total_txs, const std::string& store_path,
                      const std::string& other_path, const int duration) const;


### PR DESCRIPTION
This is 3/3 of code that allows BlueStore to use RocksDB in sharded mode.
Third part does:
- add 'reshard' command to ceph_bluestore_tool that modifies column families count per prefix