### PR TITLE
osd: set collection pool opts on collection create, pg load

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4143,6 +4143,8 @@ PGRef OSD::handle_pg_create_info(const OSDMapRef& osdmap,
     false,
     rctx.transaction);
 
+  pg->init_collection_pool_opts();
+
   if (pg->is_primary()) {
     Mutex::Locker locker(m_perf_queries_lock);
     pg->set_dynamic_perf_stats_queries(m_perf_queries);
@@ -8784,6 +8786,8 @@ void OSD::split_pgs(
       i->pgid,
       child,
       split_bits);
+
+    child->init_collection_pool_opts();
 
     child->finish_split_stats(*stat_iter, rctx.transaction);
     child->unlock();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1142,6 +1142,9 @@ void PG::read_state(ObjectStore *store)
       recovery_state.set_role(-1);
   }
 
+  // init pool options
+  store->set_collection_opts(ch, pool.info.opts);
+
   PeeringCtx rctx;
   handle_initialize(rctx);
   // note: we don't activate here because we know the OSD will advance maps
@@ -3684,12 +3687,17 @@ void PG::handle_query_state(Formatter *f)
   }
 }
 
-void PG::on_pool_change()
+void PG::init_collection_pool_opts()
 {
   auto r = osd->store->set_collection_opts(ch, pool.info.opts);
-  if(r < 0 && r != -EOPNOTSUPP) {
+  if (r < 0 && r != -EOPNOTSUPP) {
     derr << __func__ << " set_collection_opts returns error:" << r << dendl;
   }
+}
+
+void PG::on_pool_change()
+{
+  init_collection_pool_opts();
   plpg_on_pool_change();
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -395,6 +395,7 @@ public:
   void on_role_change() override;
   virtual void plpg_on_role_change() = 0;
 
+  void init_collection_pool_opts();
   void on_pool_change() override;
   virtual void plpg_on_pool_change() = 0;
 


### PR DESCRIPTION
We need to tell the ObjectStore's Collections what the pool options are
for things like the bluestore compression mode and so on to take effect.

Apply these

- when we create new collections, due to a new pg or a split
- when we start up and open an existing collection

We already apply these changes when there is a pool change.

Fixes: https://tracker.ceph.com/issues/40483
Signed-off-by: Sage Weil <sage@redhat.com>