### PR TITLE
radosgw-admin: bucket sync status not 'caught up' during full sync

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2465,11 +2465,11 @@ static int bucket_source_sync_status(RGWRados *store, const RGWZone& zone,
       shards_behind.insert(shard_id);
     }
   }
-  if (shards_behind.empty()) {
-    out << indented{width} << "bucket is caught up with source\n";
-  } else {
+  if (!shards_behind.empty()) {
     out << indented{width} << "bucket is behind on " << shards_behind.size() << " shards\n";
     out << indented{width} << "behind shards: [" << shards_behind << "]\n" ;
+  } else if (!num_full) {
+    out << indented{width} << "bucket is caught up with source\n";
   }
   return 0;
 }


### PR DESCRIPTION
the 'radosgw-admin bucket sync status' command will incorrectly report that the "bucket is caught up with source" if some shards are still on full sync

Fixes: http://tracker.ceph.com/issues/40806