### PR TITLE
src/script/unhexdump-C: script to reverse a 'hexdump -C' style hexdump

### DIFF
--- a/src/script/unhexdump-C
+++ b/src/script/unhexdump-C
@@ -1,0 +1,18 @@
+#/bin/bash
+
+cat $1 | \
+    sed -E 's/ /: /' | \
+    cut -c 1-59 | \
+    sed -E 's/ (..) (..)/ \1\2/g' | \
+    sed 's/  / /g' | \
+    grep ': '  | \
+    xxd -r > $2
+
+# real hexdump -C has a trailing file size, but it isn't always
+# present
+hexsize=$(tail -1 $1)
+if [ ${#hexsize} = 8 ]; then
+    decsize=$(printf '%d' $hexsize)
+    echo "truncate up to $decsize"
+    truncate --size $decsize $2
+fi


### PR DESCRIPTION
Notably, this is the format for the bufferlist::hexdump() dump.

All sorts of ugly, but it works.