### PR TITLE
mgr/volumes: add `ceph fs subvolumegroup getpath` command

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -47,6 +47,12 @@ class TestVolumes(CephFSTestCase):
         else:
             self.volname = result[0]['name']
 
+    def  _get_subvolume_group_path(self, vol_name, group_name):
+        args = ("subvolumegroup", "getpath", vol_name, group_name)
+        path = self._fs_cmd(*args)
+        # remove the leading '/', and trailing whitespaces
+        return path[1:].rstrip()
+
     def  _get_subvolume_path(self, vol_name, subvol_name, group_name=None):
         args = ["subvolume", "getpath", vol_name, subvol_name]
         if group_name:
@@ -178,7 +184,7 @@ class TestVolumes(CephFSTestCase):
 
         # create group
         self._fs_cmd("subvolumegroup", "create", self.volname, group1)
-        group1_path = os.path.join('volumes', group1)
+        group1_path = self._get_subvolume_group_path(self.volname, group1)
 
         default_pool = self.mount_a.getfattr(group1_path, "ceph.dir.layout.pool")
         new_pool = "new_pool"
@@ -190,7 +196,7 @@ class TestVolumes(CephFSTestCase):
         # create group specifying the new data pool as its pool layout
         self._fs_cmd("subvolumegroup", "create", self.volname, group2,
                      "--pool_layout", new_pool)
-        group2_path = os.path.join('volumes', group2)
+        group2_path = self._get_subvolume_group_path(self.volname, group2)
 
         desired_pool = self.mount_a.getfattr(group2_path, "ceph.dir.layout.pool")
         self.assertEqual(desired_pool, new_pool)
@@ -242,8 +248,8 @@ class TestVolumes(CephFSTestCase):
         self._fs_cmd("subvolumegroup", "create", self.volname, group1)
         self._fs_cmd("subvolumegroup", "create", self.volname, group2, "--mode", "777")
 
-        group1_path = os.path.join('volumes', group1)
-        group2_path = os.path.join('volumes', group2)
+        group1_path = self._get_subvolume_group_path(self.volname, group1)
+        group2_path = self._get_subvolume_group_path(self.volname, group2)
 
         # check group's mode
         actual_mode1 = self.mount_a.run_shell(['stat', '-c' '%a', group1_path]).stdout.getvalue().strip()

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -507,6 +507,20 @@ class VolumeClient(object):
             ret = self.volume_exception_to_retval(ve)
         return ret
 
+    @connection_pool_wrap
+    def getpath_subvolume_group(self, fs_handle, **kwargs):
+        groupname  = kwargs['group_name']
+        try:
+            with SubVolume(self.mgr, fs_handle) as sv:
+                spec = SubvolumeSpec("", groupname)
+                path = sv.get_group_path(spec)
+                if path is None:
+                    raise VolumeException(
+                        -errno.ENOENT, "Subvolume group '{0}' not found".format(groupname))
+                return 0, path, ""
+        except VolumeException as ve:
+            return self.volume_exception_to_retval(ve)
+
     ### group snapshot
 
     @connection_pool_wrap

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -84,6 +84,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'rw'
         },
         {
+            'cmd': 'fs subvolumegroup getpath '
+                   'name=vol_name,type=CephString '
+                   'name=group_name,type=CephString ',
+            'desc': "Get the mountpath of a CephFS subvolume group in a volume",
+            'perm': 'r'
+        },
+        {
             'cmd': 'fs subvolume getpath '
                    'name=vol_name,type=CephString '
                    'name=sub_name,type=CephString '
@@ -230,6 +237,10 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                         sub_name=cmd['sub_name'],
                                         group_name=cmd.get('group_name', None),
                                         force=cmd.get('force', False))
+
+    def _cmd_fs_subvolumegroup_getpath(self, inbuf, cmd):
+        return self.vc.getpath_subvolume_group(
+                None, vol_name=cmd['vol_name'], group_name=cmd['group_name'])
 
     def _cmd_fs_subvolume_getpath(self, inbuf, cmd):
         return self.vc.subvolume_getpath(None, vol_name=cmd['vol_name'],


### PR DESCRIPTION
... to return the path of a FS subvolume group.

Fixes: http://tracker.ceph.com/issues/40617

Signed-off-by: Ramana Raja <rraja@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

