### PR TITLE
test/rgw: add multisite test_versioned_bucket_delete_on_master

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -863,6 +863,41 @@ def test_bucket_delete_notempty():
     for _, bucket_name in zone_bucket:
         assert c1.get_bucket(bucket_name)
 
+def test_versioned_bucket_delete_on_master():
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    zone_conn = zonegroup_conns.master_zone
+
+    # create a versioned bucket on the master zone
+    bucket_name = gen_bucket_name()
+    log.info('create bucket zone=%s name=%s', zone_conn.name, bucket_name)
+    bucket = zone_conn.conn.create_bucket(bucket_name)
+    bucket.configure_versioning(True)
+    zonegroup_meta_checkpoint(zonegroup)
+
+    # create an object version and delete marker for each object name
+    names = ('testobj{}'.format(i) for i in range(10))
+    keys = []
+    for name in names:
+        k = bucket.new_key(name)
+        k.set_contents_from_string('asdf')
+        keys.append(k)
+
+        dm = bucket.delete_key(name)
+        assert(dm.delete_marker)
+        keys.append(dm)
+
+    # delete all versions and delete markers
+    for k in keys:
+        k.delete()
+
+    # delete the bucket without a bucket checkpoint, so that full sync can race
+    try:
+        bucket.delete()
+    except boto.exception.S3ResponseError as e:
+        log.info('contents: {}'.format(list(bucket.list_versions())))
+        raise e
+
 def test_multi_period_incremental_sync():
     zonegroup = realm.master_zonegroup()
     if len(zonegroup.zones) < 3:


### PR DESCRIPTION
exercises a race between bucket deletion and full sync of delete markers and can occasionally reproduce http://tracker.ceph.com/issues/40818