### PR TITLE
mgr/balancer: create progress event for balancer

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -292,7 +292,7 @@ class Module(MgrModule):
         {
             'name': 'upmap_max_iterations',
             'type': 'uint',
-            'default': 10,
+            'default': 60,
             'desc': 'maximum upmap optimization iterations',
             'runtime': True,
         },
@@ -1264,12 +1264,12 @@ class Module(MgrModule):
             self.log.info('ceph osd pg-upmap-items %s mappings %s', item['pgid'],
                           item['mappings'])
             osdlist = []
-            evacuate_osds = []
+            which_osds = []
             affected_pgs = [] 
             for m in item['mappings']:
                 osdlist += [m['from'], m['to']]
-                if m['from'] not in evacuate_osds:
-                    evacuate_osds += [m['from']]
+                if m['from'] not in which_osds:
+                    which_osds += [m['from']]
                 temp_list = item['pgid'].split('.')
                 pg_obj = self.remote('progress', 'construct_pgid', pool_id=int(temp_list[0]), ps=int(temp_list[1]))
                 affected_pgs.append(pg_obj)
@@ -1291,11 +1291,11 @@ class Module(MgrModule):
                 return r, outs
         plan.mode = self.get_module_option('mode')
         if plan.mode == 'upmap':
-            ev=self.remote('progress', 'construct_pg_recovery_event', 
-                        message= "Balancer upmap %s" % plan.message,
+            ev = self.remote('progress', 'construct_pg_recovery_event', 
+                        message="Balancer upmap %s" % plan.message,
                         refs=[("Balancer", "upmap")],
                         which_pgs=affected_pgs,
-                        evacuate_osds=evacuate_osds,
+                        which_osds=which_osds,
                         start_epoch=self.get_osdmap().get_epoch()
                         )
             ev.pg_update(self.get("pg_dump"), self.log)

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -53,7 +53,6 @@ class Plan:
         self.name = name
         self.initial = ms
         self.pools = pools
-        
         self.osd_weights = {}
         self.compat_ws = {}
         self.inc = ms.osdmap.new_incremental()
@@ -286,7 +285,7 @@ class Module(MgrModule):
         {
             'name': 'sleep_interval',
             'type': 'secs',
-            'default': 10,
+            'default': 60,
             'desc': 'how frequently to wake up and attempt optimization',
             'runtime': True,
         },
@@ -1132,9 +1131,9 @@ class Module(MgrModule):
             fudge = .001
 
         if best_pe.score < pe.score + fudge:
-            msg = 'Success, score %f -> %f' % (pe.score, best_pe.score)
+            msg = 'score %f -> %f' % (pe.score, best_pe.score)
             plan.message = msg
-            self.log.info(msg)
+            self.log.info('Success, %s' % msg)
             plan.compat_ws = best_ws
             for osd, w in six.iteritems(best_ow):
                 if w != orig_osd_weight[osd]:
@@ -1208,7 +1207,6 @@ class Module(MgrModule):
         self.log.info('Executing plan %s' % plan.name)
 
         commands = []
-        flag = False
         # compat weight-set
         if len(plan.compat_ws) and \
            not CRUSHMap.have_default_choose_args(plan.initial.crush_dump):
@@ -1284,7 +1282,6 @@ class Module(MgrModule):
                 'id': osdlist,
             }), 'foo')
             commands.append(result)
-                
         # wait for commands
         self.log.debug('commands %s' % commands)
         for result in commands:

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -370,6 +370,43 @@ class Module(MgrModule):
                     self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
+    def balancer_crush_compat(self, old_map, old_dump, new_map, msg):
+        # For the crush compat to use in creating a PgRecovery event
+        
+        osd_list = []
+        affected_pgs = []
+        for pool in old_dump['pools']:
+            pool_id = pool['pool']
+            for ps in range(0, pool['pg_num']):
+
+                # Was this OSD affected by the OSD coming in/out?
+                # Compare old and new osds using
+                # data from the json dump
+                old_up_acting = old_map.pg_to_up_acting_osds(pool['pool'], ps)
+                old_osds = set(old_up_acting['acting'])
+
+                new_up_acting = new_map.pg_to_up_acting_osds(pool['pool'], ps)
+                new_osds = set(new_up_acting['acting'])
+                osds_dif = old_osds - new_osds
+                osd_list = osd_list + list(osds_dif)
+                is_relocated = len(osds_dif) > 0
+                self.log.debug("new_up_acting: {0}".format(json.dumps(new_up_acting,indent=2)))
+                if is_relocated:
+                    affected_pgs.append(PgId(pool_id, ps))
+
+        if len(affected_pgs) > 0:
+            ev = PgRecoveryEvent(
+                        "Balancer crush-compat %s" % msg,
+                        refs=[("Balancer", "crush-compat")],
+                        which_pgs=affected_pgs,
+                        evacuate_osds=osd_list,
+                        start_epoch=self.get_osdmap().get_epoch()
+                        )
+            ev.pg_update(self.get("pg_dump"), self.log)
+            self._events[ev.id] = ev
+
+
+
     def _osd_in_out(self, old_map, old_dump, new_map, osd_id, marked):
         # A function that will create or complete an event when an
         # OSD is marked in or out according to the affected PGs
@@ -391,6 +428,7 @@ class Module(MgrModule):
                 # Check the osd_id being in the acting set for both old
                 # and new maps to cover both out and in cases
                 was_on_out_or_in_osd = osd_id in old_osds or osd_id in new_osds
+
                 if not was_on_out_or_in_osd:
                     continue
 
@@ -420,6 +458,7 @@ class Module(MgrModule):
                     # This PG didn't get a new location, we'll log it
                     unmoved_pgs.append(PgId(pool_id, ps))
 
+ 
         # In the case that we ignored some PGs, log the reason why (we may
         # not end up creating a progress event)
         if len(unmoved_pgs):
@@ -683,7 +722,8 @@ class Module(MgrModule):
             return 0, json.dumps(self._json(), indent=2), ""
         else:
             raise NotImplementedError(cmd['prefix'])
-
+    
+    # For other module to use.
     def construct_pgid(self, pool_id, ps):
         return PgId(pool_id, ps)
 

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -589,6 +589,10 @@ class Module(MgrModule):
         ev.set_progress(ev_progress)
         ev._refresh()
 
+    def add_event(self, ev):
+            self._events[ev.id] = ev
+            return None
+
     def _complete(self, ev):
         duration = (time.time() - ev.started_at)
         self.log.info("Completed event {0} ({1}) in {2} seconds".format(
@@ -679,3 +683,11 @@ class Module(MgrModule):
             return 0, json.dumps(self._json(), indent=2), ""
         else:
             raise NotImplementedError(cmd['prefix'])
+
+    def construct_pgid(self, pool_id, ps):
+        return PgId(pool_id, ps)
+
+    def construct_pg_recovery_event(self, message, refs, which_pgs, evacuate_osds, start_epoch):
+        return PgRecoveryEvent(message, refs, which_pgs,
+                evacuate_osds, start_epoch)
+

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -719,8 +719,11 @@ class Module(MgrModule):
             raise NotImplementedError(cmd['prefix'])
 
     # For other module to use.
-    def construct_pgid(self, pool_id, ps):
+
+    @staticmethod
+    def create_pgid(pool_id, ps):
         return PgId(pool_id, ps)
 
-    def construct_pg_recovery_event(self, message, refs, which_pgs, which_osds, start_epoch):
-        return PgRecoveryEvent(message, refs, which_pgs, which_osds, start_epoch)
+    @staticmethod
+    def create_pg_recovery_event(message, refs, pgs, osds, start_epoch):
+        return PgRecoveryEvent(message, refs, pgs, osds, start_epoch)


### PR DESCRIPTION
Enable balancer to create progress event for
upmap, will create one for crush compact later as
well. Made some changes to the progress module
to support function calls from other module.
Basically an event will triggered when the
balancer executes the actual plan, the update
happens in the progress module pg_update
function.

Fixes: http://pulpito.ceph.com/kchai-2019-08-06_05:23:57-rados-wip-kefu-testing-2019-08-06-1102-distro-basic-mira/4187832/


Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

