### PR TITLE
mgr/dashboard: Show iSCSI gateways status in the health page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -113,7 +113,10 @@
                   class="cd-status-card"
                   contentClass="content-highlight"
                   *ngIf="enabledFeature.iscsi && healthData.iscsi_daemons != null">
-      {{ healthData.iscsi_daemons }} total
+      {{ healthData.iscsi_daemons.up + healthData.iscsi_daemons.down }} total
+      <span class="card-text-line-break"></span>
+      {{ healthData.iscsi_daemons.up }} up,
+      <span [ngClass]="{'card-text-error': healthData.iscsi_daemons.down > 0}">{{ healthData.iscsi_daemons.down }} down</span>
     </cd-info-card>
   </cd-info-group>
 


### PR DESCRIPTION
This PR will show the number of iSCSI gateways that are **UP** and **DOWN**, in the health page.

![Screenshot from 2019-07-18 15-35-26](https://user-images.githubusercontent.com/14297426/61466618-22feca80-a972-11e9-8ff6-9cbdca66c0bb.png)


Fixes: https://tracker.ceph.com/issues/39028

Signed-off-by: Ricardo Marques <rimarques@suse.com>

