### PR TITLE
mgr/dashboard: qa: whitelist client eviction warning

### DIFF
--- a/qa/suites/rados/mgr/tasks/dashboard.yaml
+++ b/qa/suites/rados/mgr/tasks/dashboard.yaml
@@ -23,6 +23,7 @@ tasks:
         - \(POOL_APP_NOT_ENABLED\)
         - pauserd,pausewr flag\(s\) set
         - Monitor daemon marked osd\.[[:digit:]]+ down, but it is still running
+        - evicting unresponsive client .+
   - rgw: [client.0]
   - cephfs_test_runner:
       fail_on_skip: false


### PR DESCRIPTION
This warning is caused by the recent changes to the volumes
module that cache the CephFS handles.
Commit 5c41e949af9acabd612b0644de0603e374b4b42a

Signed-off-by: Ricardo Dias <rdias@suse.com>



