### PR TITLE
mgr: check for unicode passed to "set_health_checks()"

### DIFF
--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -284,24 +284,23 @@ ceph_set_health_checks(BaseMgrModule *self, PyObject *args)
       }
       string ks(k);
       if (ks == "severity") {
-	if (!PyString_Check(v)) {
+	if (auto [vs, valid] = PyString_ToString(v); !valid) {
 	  derr << __func__ << " check " << check_name
 	       << " severity value not string" << dendl;
 	  continue;
-	}
-	string vs(PyString_AsString(v));
-	if (vs == "warning") {
+	} else if (vs == "warning") {
 	  severity = HEALTH_WARN;
 	} else if (vs == "error") {
 	  severity = HEALTH_ERR;
 	}
       } else if (ks == "summary") {
-	if (!PyString_Check(v) && !PyUnicode_Check(v)) {
+	if (auto [vs, valid] = PyString_ToString(v); !valid) {
 	  derr << __func__ << " check " << check_name
 	       << " summary value not [unicode] string" << dendl;
 	  continue;
+	} else {
+	  summary = std::move(vs);
 	}
-	summary = PyString_AsString(v);
       } else if (ks == "detail") {
 	if (!PyList_Check(v)) {
 	  derr << __func__ << " check " << check_name
@@ -310,12 +309,13 @@ ceph_set_health_checks(BaseMgrModule *self, PyObject *args)
 	}
 	for (int k = 0; k < PyList_Size(v); ++k) {
 	  PyObject *di = PyList_GET_ITEM(v, k);
-	  if (!PyString_Check(di) && !PyUnicode_Check(di)) {
+	  if (auto [vs, valid] = PyString_ToString(di); !valid) {
 	    derr << __func__ << " check " << check_name
 		 << " detail item " << k << " not a [unicode] string" << dendl;
 	    continue;
+	  } else {
+	    detail.push_back(std::move(vs));
 	  }
-	  detail.push_back(PyString_AsString(di));
 	}
       } else {
 	derr << __func__ << " check " << check_name

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -21,6 +21,9 @@
 #include "PythonCompat.h"
 
 #include <stack>
+#include <string>
+#include <string_view>
+#include <sstream>
 #include <memory>
 #include <list>
 

--- a/src/mgr/PythonCompat.h
+++ b/src/mgr/PythonCompat.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <Python.h>
+#include <string>
 
 // Python's pyconfig-64.h conflicts with ceph's acconfig.h
 #undef HAVE_SYS_WAIT_H
@@ -36,3 +37,19 @@ inline PyObject* PyInt_FromString(const char *str, char **pend, int base) {
 }
 #define PyString_Type PyUnicode_Type
 #endif
+
+inline std::pair<std::string, bool> PyString_ToString(PyObject *o) {
+#if PY_MAJOR_VERSION >= 3
+  if (PyUnicode_Check(o)) {
+    return {PyUnicode_AsUTF8(o), true};
+  } else {
+    return {{}, false};
+  }
+#else
+  if (PyString_Check(o) || PyUnicode_Check(o)) {
+    return {PyString_AsString(o), true};
+  } else {
+    return {{}, false};
+  }
+#endif
+}


### PR DESCRIPTION
in python2, in addition to `str`, a string could also be unicode
string. there is chance that user passes a unicode string to
`set_health_checks()`, so let's check for unicode string also.

in python3, all strings are `unicode` string, and `PyString_Check()` is
defined as an alias of `PyUnicode_Check()`, so we are fine with python3.

the wrapper method of `PyString_ToString()` returns a pair of converted
string and a bool. if it fails to detect a string, an empty string and
false are returned.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

