### PR TITLE
common: add ref header

### DIFF
--- a/src/common/ref.h
+++ b/src/common/ref.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef COMMON_REF_H
+#define COMMON_REF_H
+
+#include <boost/intrusive_ptr.hpp>
+
+namespace ceph {
+template<typename T> using ref_t = boost::intrusive_ptr<T>;
+template<typename T> using cref_t = boost::intrusive_ptr<const T>;
+template<class T, class U>
+boost::intrusive_ptr<T> ref_cast(const boost::intrusive_ptr<U>& r) noexcept {
+  return static_cast<T*>(r.get());
+}
+template<class T, class U>
+boost::intrusive_ptr<T> ref_cast(boost::intrusive_ptr<U>&& r) noexcept {
+  return {static_cast<T*>(r.detach()), false};
+}
+template<class T, class U>
+boost::intrusive_ptr<const T> ref_cast(const boost::intrusive_ptr<const U>& r) noexcept {
+  return static_cast<const T*>(r.get());
+}
+}
+
+#endif

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -25,6 +25,7 @@
 #include "common/RefCountedObj.h"
 #include "common/ThrottleInterface.h"
 #include "common/config.h"
+#include "common/ref.h"
 #include "common/debug.h"
 #include "common/zipkin_trace.h"
 #include "include/ceph_assert.h" // Because intrusive_ptr clobbers our assert...
@@ -519,22 +520,8 @@ private:
 };
 
 namespace ceph {
-template<typename T> using ref_t = boost::intrusive_ptr<T>;
-template<typename T> using cref_t = boost::intrusive_ptr<const T>;
-template<class T, class U>
-boost::intrusive_ptr<T> ref_cast(const boost::intrusive_ptr<U>& r) noexcept {
-  return static_cast<T*>(r.get());
-}
-template<class T, class U>
-boost::intrusive_ptr<T> ref_cast(boost::intrusive_ptr<U>&& r) noexcept {
-  return {static_cast<T*>(r.detach()), false};
-}
-template<class T, class U>
-boost::intrusive_ptr<const T> ref_cast(const boost::intrusive_ptr<const U>& r) noexcept {
-  return static_cast<const T*>(r.get());
-}
 template<class T, typename... Args>
-boost::intrusive_ptr<T> make_message(Args&&... args) {
+ceph::ref_t<T> make_message(Args&&... args) {
   return {new T(std::forward<Args>(args)...), false};
 }
 }


### PR DESCRIPTION
This enables the use of these handy ref templates outside of Message.h.
This is necessary for a future rework of #26348.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

