### PR TITLE
qa/suites/rados/multimon: whitelist SLOW_OPS while thrashing mons

### DIFF
--- a/qa/suites/rados/multimon/tasks/mon_recovery.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_recovery.yaml
@@ -5,4 +5,5 @@ tasks:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(PG_AVAILABILITY\)
+      - \(SLOW_OPS\)
 - mon_recovery:


### PR DESCRIPTION
The mons may have slow ops.

Signed-off-by: Sage Weil <sage@redhat.com>