### PR TITLE
luminous: rgw: LC: handle resharded buckets

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -347,16 +347,17 @@ int RGWLC::bucket_lc_process(string& shard_id)
   boost::split(result, shard_id, boost::is_any_of(":"));
   string bucket_tenant = result[0];
   string bucket_name = result[1];
-  string bucket_id = result[2];
+  string bucket_marker = result[2];
   int ret = store->get_bucket_info(obj_ctx, bucket_tenant, bucket_name, bucket_info, NULL, &bucket_attrs);
   if (ret < 0) {
     ldout(cct, 0) << "LC:get_bucket_info failed" << bucket_name <<dendl;
     return ret;
   }
 
-  ret = bucket_info.bucket.bucket_id.compare(bucket_id) ;
-  if (ret !=0) {
-    ldout(cct, 0) << "LC:old bucket id find, should be delete" << bucket_name <<dendl;
+  if (bucket_info.bucket.marker != bucket_marker) {
+    ldout(cct, 0) << "LC: deleting stale entry found for bucket=" << bucket_tenant
+                       << ":" << bucket_name << " cur_marker=" << bucket_info.bucket.marker
+                       << " orig_marker=" << bucket_marker << dendl;
     return -ENOENT;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4957,7 +4957,7 @@ void RGWPutLC::execute()
   op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs, &s->bucket_info.objv_tracker);
   if (op_ret < 0)
     return;
-  string shard_id = s->bucket.tenant + ':' + s->bucket.name + ':' + s->bucket.bucket_id;  
+  string shard_id = s->bucket.tenant + ':' + s->bucket.name + ':' + s->bucket.marker;  
   string oid; 
   get_lc_oid(s, oid);
   pair<string, int> entry(shard_id, lc_uninitial);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/38884

---

partial backport of #26564
parent tracker https://tracker.ceph.com/issues/36512

Backport rationale:

Since it's almost not possible to backport the entire PR #26564. The dependencies make it difficult and not proper to back port all of them. 
I only backported the 2 commits that fixes the lifecycle not taking effect after resharding.
I think this is the main pain for ceph user, as you can't expect lifecycle to work with dynamic resharding enabled. 

The other part of  PR #26564, is about adding a command to radosgw-admin "radosgw-admin lc reshard fix" which can re-add the lifecycle to the old bucket. 
This part is not proper for backport. 
And user can always reset their lifecycle to the old bucket via commands like "s3cmd setlifecycle" as a workaround.  I think we can leave this part for now.  
