### PR TITLE
mgr/dashboard: fix tox test failure

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_pool.py
+++ b/src/pybind/mgr/dashboard/tests/test_pool.py
@@ -23,9 +23,10 @@ class PoolControllerTest(ControllerTestCase):
         Pool._cp_config['tools.authenticate.on'] = False
         cls.setup_controllers([Pool, Task])
 
+    @mock.patch('dashboard.services.progress.get_progress_tasks')
     @mock.patch('dashboard.controllers.pool.Pool._get')
     @mock.patch('dashboard.services.ceph_service.CephService.send_command')
-    def test_creation(self, send_command, _get):
+    def test_creation(self, send_command, _get, get_progress_tasks):
         _get.side_effect = [{
             'pool_name': 'test-pool',
             'pg_num': 64,
@@ -46,6 +47,7 @@ class PoolControllerTest(ControllerTestCase):
             time.sleep(3)
 
         send_command.side_effect = _send_cmd
+        get_progress_tasks.return_value = [], []
 
         self._task_post('/api/pool', {
             'pool': 'test-pool',


### PR DESCRIPTION
`api/task` now also returns tasks in progress module.
Mock related function for tests.

Fixes: https://tracker.ceph.com/issues/40827

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

