### PR TITLE
mgr/progress: clamp pg recovery ratio to 0

### DIFF
--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -149,12 +149,12 @@ class PgRecoveryEvent(Event):
     Always call update() immediately after construction.
     """
 
-    def __init__(self, message, refs, which_pgs, evacuate_osds, start_epoch):
+    def __init__(self, message, refs, which_pgs, which_osds, start_epoch):
         super(PgRecoveryEvent, self).__init__(message, refs)
 
         self._pgs = which_pgs
 
-        self._evacuate_osds = evacuate_osds
+        self._which_osds = which_osds
 
         self._original_pg_count = len(self._pgs)
 
@@ -169,8 +169,8 @@ class PgRecoveryEvent(Event):
         self._refresh()
 
     @property
-    def evacuating_osds(self):
-        return self. _evacuate_osds
+    def which_osds(self):
+        return self. _which_osds
 
     def pg_update(self, pg_dump, log):
         # FIXME: O(pg_num) in python
@@ -392,7 +392,7 @@ class Module(MgrModule):
         # previous recovery event for that osd
         if marked == "in":
             for ev_id, ev in self._events.items():
-                if isinstance(ev, PgRecoveryEvent) and osd_id in ev.evacuating_osds:
+                if isinstance(ev, PgRecoveryEvent) and osd_id in ev.which_osds:
                     self.log.info("osd.{0} came back in, cancelling event".format(
                         osd_id
                     ))
@@ -403,7 +403,7 @@ class Module(MgrModule):
                     "Rebalancing after osd.{0} marked {1}".format(osd_id, marked),
                     refs=[("osd", osd_id)],
                     which_pgs=affected_pgs,
-                    evacuate_osds=[osd_id],
+                    which_osds=[osd_id],
                     start_epoch=self.get_osdmap().get_epoch()
                     )
             ev.pg_update(self.get("pg_dump"), self.log)

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -237,6 +237,7 @@ class PgRecoveryEvent(Event):
                         # exceed the contents of the PG (moment in time), we
                         # must clamp this
                         ratio = min(ratio, 1.0)
+                        ratio = max(ratio, 0.0)
 
                     else:
                         # Dataless PGs (e.g. containing only OMAPs) count


### PR DESCRIPTION
There were times that I could observe the num_bytes_recovered field
of pg_stat_t may decrease, e.g., due to the primary switching (or similar).
Clamp the pg recovery ratio to 0 too since it might go negative.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

