### PR TITLE
mgr/rook: Add caching for the Dashboard

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -123,7 +123,11 @@ def raise_if_exception(c):
         return my_obj
 
     if c.exception is not None:
-        raise copy_to_this_subinterpreter(c.exception)
+        try:
+            e = copy_to_this_subinterpreter(c.exception)
+        except (KeyError, AttributeError):
+            raise Exception(str(c.exception))
+        raise e
 
 
 class ReadCompletion(_Completion):

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -346,6 +346,15 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             sd.nodename = p['nodename']
             sd.container_id = p['name']
             sd.service_type = p['labels']['app'].replace('rook-ceph-', '')
+            status = {
+                'Pending': -1,
+                'Running': 1,
+                'Succeeded': 0,
+                'Failed': -1,
+                'Unknown': -1,
+            }[p['phase']]
+            sd.status = status
+            sd.status_desc = p['phase']
 
             if sd.service_type == "osd":
                 sd.service_instance = "%s" % p['labels']["ceph-osd-id"]

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -14,6 +14,13 @@ try:
     from kubernetes.client.rest import ApiException
 
     kubernetes_imported = True
+
+    # https://github.com/kubernetes-client/python/issues/895
+    from kubernetes.client.models.v1_container_image import V1ContainerImage
+    def names(self, names):
+        self._names = names
+    V1ContainerImage.names = V1ContainerImage.names.setter(names)
+
 except ImportError:
     kubernetes_imported = False
     client = None

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -9,7 +9,7 @@ except ImportError:
     pass  # just for type checking
 
 try:
-    from kubernetes import client, config
+    from kubernetes import client, config, watch
     from kubernetes.client.rest import ApiException
 
     kubernetes_imported = True
@@ -138,6 +138,161 @@ def deferred_read(f):
     return wrapper
 
 
+def threaded(f):
+    def wrapper(*args, **kwargs):
+        t = threading.Thread(target=f, args=args, kwargs=kwargs)
+        t.daemon = True
+        t.start()
+        return t
+    return wrapper
+
+
+class KubernetesResource(object):
+    """ Generic kubernetes Resource parent class
+
+    The api fetch and watch methods should be common across resource types,
+    so this class implements the basics, and child classes should implement 
+    anything specific to the resource type
+    """
+
+    def __init__(self, api_name, method_name, log):
+        self.api_name = api_name
+        self.api = None
+        self.method_name = method_name
+        self.health = 'OK'                  # OK or error reason
+        self.raw_data = None
+        self.log = log
+
+    @property
+    def valid(self):
+        """ Check that the api, and method are viable """
+
+        if not hasattr(client, self.api_name):
+            self.health = "[ERR] : API is invalid"
+            return False
+        try:
+            _api = getattr(client, self.api_name)()
+        except ApiException:
+            self.health = "[ERR] : API is inaccessible"
+            return False
+        else:
+            self.api = _api
+            if not hasattr(_api, self.method_name):
+                self.health = "[ERR] : {} is an anvalid method of {}".format(self.method_name, self.api_name)
+                return False
+        return True
+
+    def fetch(self):
+        """ Execute the requested api method as a one-off fetch"""
+        if self.valid:
+            try:
+                response = getattr(self.api, self.method_name)()
+            except ApiException:
+                self.raw_data = None
+                self.health = "[ERR] : k8s API call failed against {}.{}".format(self.api_name,
+                                                                                 self.method_name)
+                self.log.error(self.health) 
+            else:
+                self.last = time.time()
+                self.raw_data = response
+                if hasattr(response, 'items'):
+                    self.items.clear()
+                    for item in response.items:
+                        name = item.metadata.name
+                        self.items[name] = item
+            self.health = "[ERR] : API {}.{} is invalid/inaccessible".format(self.api_name,
+                                                                             self.method_name)
+            self.log.error(self.health)
+
+
+    @property
+    def data(self):
+        """ Process raw_data into a consumable dict - Override in the child """
+        return self.raw_data
+
+    @property
+    def resource_version(self):
+        # metadata is a V1ListMeta object type
+        if hasattr(self.raw_data, 'metadata'):
+            return self.raw_data.metadata.resource_version
+        else:
+            return None
+
+    @threaded
+    def watch(self):
+        """ Start a thread which will use the kubernetes watch client against a resource """
+        self.fetch()
+        if self.api_ok:
+            self.log.info("[INF] : Attaching resource watcher for k8s "
+                          "{}.{}".format(self.api_name, self.method_name))
+            self.watcher = self._watch()
+
+    @threaded
+    def _watch(self):
+        """ worker thread that runs the kubernetes watch """
+
+        res_ver = self.resource_version
+            self.log.info("[INF] Attaching resource watcher for k8s "
+                          "{}/{}".format(self.api_name, self.method_name))
+        w = watch.Watch()
+        func = getattr(self.api, self.method_name)
+
+        try:
+            # execute generator to continually watch resource for changes
+            for item in w.stream(func, resource_version=res_ver, watch=True):
+                    obj = item['object']
+                    try:
+                        name = obj.metadata.name
+                    except AttributeError:
+                        name = None
+                        self.log.warning("[WRN] {}.{} doesn't contain a metadata.name. "
+                                         "Unable to track changes".format(self.api_name,
+                                                                          self.method_name))
+
+                if item['type'] == 'ADDED':
+                        if self.filter(obj):
+                            if self.items and name:
+                                self.items[name] = obj
+
+                elif item['type'] == 'DELETED':
+                        if self.filter(obj):
+                            if self.items and name:
+                                del self.items[name]
+
+        except AttributeError as e:
+            self.health = "[ERR] : Unable to attach watcher - incompatible urllib3? ({})".format(e)
+            self.log.error(self.health)
+
+       
+
+class StorageClass(KubernetesResource):
+
+    def __init__(self, api_name='StorageV1Api', method_name='list_storage_class', log=None):
+        KubernetesResource.__init__(self, api_name, method_name, log)
+    
+    @property
+    def data(self):
+        """ provide a more readable/consumable version of the list_storage_class raw data """
+
+        pool_lookup = dict()
+
+        # raw_data contains an items list of V1StorageClass objects. Each object contains metadata
+        # attribute which is a V1ObjectMeta object
+        for item in self.raw_data.items:
+            if not item.provisioner.startswith(('ceph.rook', 'cephfs.csi.ceph', "rbd.csi.ceph")):
+                continue
+            
+            sc_name = item.metadata.name
+            # pool used by ceph csi, blockPool by legacy storageclass definition
+            pool_name = item.parameters.get('pool', item.parameters.get('blockPool'))
+            if pool_name in pool_lookup:
+                    pool_lookup[pool_name].append(sc_name)
+            else:
+                pool_lookup[pool_name] = list([sc_name])
+
+        return pool_lookup
+
+
 class RookEnv(object):
     def __init__(self):
         # POD_NAMESPACE already exist for Rook 0.9
@@ -224,6 +379,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._k8s = None
         self._rook_cluster = None
         self._rook_env = RookEnv()
+        self.k8s_resource = dict()
 
         self._shutdown = threading.Event()
 
@@ -240,6 +396,18 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         # type: () -> RookCluster
         self._initialized.wait()
         return self._rook_cluster
+
+    def get_k8s_resource(self, resource_type=None, mode='readable'):
+        """ Return specific k8s resource data """
+
+        if resource_type in self.k8s_resource:
+            if mode == 'readable':
+                return self.k8s_resource[resource_type].data
+            else:
+                return self.k8s_resource[resource_type].raw_data
+        else:
+            self.log.warning("[WRN] request ignored for non-existent k8s resource - {}".format(resource_type))
+            return None
 
     def serve(self):
         # For deployed clusters, we should always be running inside
@@ -260,6 +428,15 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             configuration.verify_ssl = False
 
         self._k8s = client.CoreV1Api()
+
+        self.k8s_object['storageclass'] = StorageClass(log=self.log)
+        if self.k8s_object['storageclass'].valid:
+            self.log.info("Fetching available storageclass definitions")
+            self.k8s_object['storageclass'].watch()
+        else:
+            self.log.warning("[WRN] Unable to use k8s API - "
+                           "{}/{}".format(self.k8s_object['storageclass'].api_name, 
+                                          self.k8s_object['storageclass'].method_name))
 
         try:
             # XXX mystery hack -- I need to do an API call from

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -309,7 +309,8 @@ class RookCluster(object):
             pods_summary.append({
                 "name": d['metadata']['name'],
                 "nodename": d['spec']['node_name'],
-                "labels": d['metadata']['labels']
+                "labels": d['metadata']['labels'],
+                'phase': d['status']['phase']
             })
 
         return pods_summary


### PR DESCRIPTION
Use `KubernetesResource` as cache for pods, inventory maps and nodes.

This is required for the dashboard and is based on an implementation by @pcuzner .

It uses the watcher API pattern provided by the Kubernetes API to prevent full fetches every time the user clicks on the dashboard.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] **Remove Python 3 code, which was a great help while doing the development**
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

