### PR TITLE
mgr/dashboard: Prevent deletion of iSCSI IQNs with open sessions

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -207,6 +207,11 @@ class IscsiTarget(RESTController):
             raise DashboardException(msg='Target does not exist',
                                      code='target_does_not_exist',
                                      component='iscsi')
+        target_info = IscsiClient.instance().get_targetinfo(target_iqn)
+        if target_info['num_sessions'] > 0:
+            raise DashboardException(msg='Target has active sessions',
+                                     code='target_has_active_sessions',
+                                     component='iscsi')
         IscsiTarget._delete(target_iqn, config, 0, 100)
 
     @iscsi_target_task('create', {'target_iqn': '{target_iqn}'})

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
+import * as _ from 'lodash';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { Subscription } from 'rxjs';
 
@@ -83,7 +84,9 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
         permission: 'delete',
         icon: Icons.destroy,
         click: () => this.deleteIscsiTargetModal(),
-        name: this.actionLabels.DELETE
+        name: this.actionLabels.DELETE,
+        disable: () => !this.selection.first() || !_.isUndefined(this.getDeleteDisableDesc()),
+        disableDesc: () => this.getDeleteDisableDesc()
       }
     ];
   }
@@ -142,6 +145,12 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     if (this.summaryDataSubscription) {
       this.summaryDataSubscription.unsubscribe();
+    }
+  }
+
+  getDeleteDisableDesc(): string | undefined {
+    if (this.selection.first() && this.selection.first()['info']['num_sessions']) {
+      return this.i18n('Target has active sessions');
     }
   }
 


### PR DESCRIPTION
![Screenshot from 2019-07-19 15-04-38](https://user-images.githubusercontent.com/14297426/61541659-fad99f00-aa37-11e9-95e0-56915741ba44.png)

Fixes: https://tracker.ceph.com/issues/38332

Signed-off-by: Ricardo Marques <rimarques@suse.com>
