### PR TITLE
[DNM][RFC] os/BlueStore: avoid double caching bluestore onodes in rocksdb block_cache

### DIFF
--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -15,8 +15,19 @@ Synopsis
 Description
 ===========
 
-:program:`ceph-kvstore-tool` is a kvstore manipulation tool. It allows users to manipulate
-leveldb/rocksdb's data (like OSD's omap) offline.
+:program:`ceph-kvstore-tool` is a tool to interact with key-value database used internally by ceph.
+Key-value databases are part of object store instances.
+Modes *leveldb* and *rocksdb* are for FileStore and *bluestore-kv* is for BlueStore.
+FileStore uses DB only for OMAP, while BlueStore also preserves internal metadata in DB.
+
+OSD must be offline to manipulate on its key-value DB.
+Operations are not logically validated. Modifications of BlueStore's metadata are unadvised.
+
+Column Families
+===============
+In some BlueStore deployments rocksdb key-value database can be internally split into
+multiple separate column families. This division is transparent and *column* part is unnecessary. 
+To select a specific column family for debug purposes *column* part should be provided.
 
 Commands
 ========
@@ -24,37 +35,37 @@ Commands
 :program:`ceph-kvstore-tool` utility uses many commands for debugging purpose
 which are as follows:
 
-:command:`list [prefix]`
+:command:`list [column/][prefix]`
     Print key of all KV pairs stored with the URL encoded prefix.
 
-:command:`list-crc [prefix]`
+:command:`list-crc [column/][prefix]`
     Print CRC of all KV pairs stored with the URL encoded prefix.
 
-:command:`dump [prefix]`
+:command:`dump [column/][prefix]`
     Print key and value of all KV pairs stored with the URL encoded prefix.
 
-:command:`exists <prefix> [key]`
+:command:`exists [column/]<prefix> [key]`
     Check if there is any KV pair stored with the URL encoded prefix. If key
     is also specified, check for the key with the prefix instead.
 
-:command:`get <prefix> <key> [out <file>]`
+:command:`get [column/]<prefix> <key> [out <file>]`
     Get the value of the KV pair stored with the URL encoded prefix and key.
     If file is also specified, write the value to the file.
 
-:command:`crc <prefix> <key>`
+:command:`crc [column/]<prefix> <key>`
     Get the CRC of the KV pair stored with the URL encoded prefix and key. 
 
-:command:`get-size [<prefix> <key>]`
+:command:`get-size [[column/]<prefix> <key>]`
     Get estimated store size or size of value specified by prefix and key.
 
-:command:`set <prefix> <key> [ver <N>|in <file>]`
+:command:`set [column/]<prefix> <key> [ver <N>|in <file>]`
     Set the value of the KV pair stored with the URL encoded prefix and key. 
     The value could be *version_t* or text.
 
-:command:`rm <prefix> <key>`
+:command:`rm [column/]<prefix> <key>`
     Remove the KV pair stored with the URL encoded prefix and key.
 
-:command:`rm-prefix <prefix>`
+:command:`rm-prefix [column/]<prefix>`
     Remove all KV pairs stored with the URL encoded prefix.
 
 :command:`store-copy <path> [num-keys-per-tx]`
@@ -69,10 +80,10 @@ which are as follows:
     the database, and trigger a database's compaction. After compaction, some 
     disk space may be released.
 
-:command:`compact-prefix <prefix>`
+:command:`compact-prefix [column/]<prefix>`
     Compact all entries specified by the URL encoded prefix. 
    
-:command:`compact-range <prefix> <start> <end>`
+:command:`compact-range [column/]<prefix> <start> <end>`
     Compact some entries specified by the URL encoded prefix and range.
 
 :command:`destructive-repair`

--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -38,11 +38,12 @@ namespace PriorityCache
     // shrink it to 1/256 of the rounded up cache size
     chunk /= 256;
 
-    // bound the chunk size to be between 4MB and 32MB
+    // bound the chunk size to be between 4MB and 64MB
     chunk = (chunk > 4ul*1024*1024) ? chunk : 4ul*1024*1024;
-    chunk = (chunk < 16ul*1024*1024) ? chunk : 16ul*1024*1024;
+    chunk = (chunk < 64ul*1024*1024) ? chunk : 64ul*1024*1024;
 
-    /* Add 16 chunks of headroom and round up to the near chunk.  Note that
+    /* FIXME: Hardcoded to force get_chunk to never drop below 64MB.
+     * Note that
      * if RocksDB is used, it's a good idea to have N MB of headroom where
      * N is the target_file_size_base value.  RocksDB will read SST files
      * into the block cache during compaction which potentially can force out
@@ -51,7 +52,7 @@ namespace PriorityCache
      * compaction reads allows the kv cache grow even during extremely heavy
      * compaction workloads.
      */
-    uint64_t val = usage + (16 * chunk);
+    uint64_t val = usage + 64*1024*1024;
     uint64_t r = (val) % chunk;
     if (r > 0)
       val = val + chunk - r;

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4588,14 +4588,19 @@ std::vector<Option> get_global_options() {
     .add_see_also("bluestore_cache_size"),
 
     Option("bluestore_cache_meta_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
-    .set_default(.4)
+    .set_default(.45)
     .add_see_also("bluestore_cache_size")
     .set_description("Ratio of bluestore cache to devote to metadata"),
 
     Option("bluestore_cache_kv_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
-    .set_default(.4)
+    .set_default(.45)
     .add_see_also("bluestore_cache_size")
     .set_description("Ratio of bluestore cache to devote to kv database (rocksdb)"),
+
+    Option("bluestore_cache_kv_onode_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(.04)
+    .add_see_also("bluestore_cache_size")
+    .set_description("Ratio of bluestore cache to devote to kv onode column family (rocksdb)"),
 
     Option("bluestore_cache_autotune", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
@@ -4640,7 +4645,7 @@ std::vector<Option> get_global_options() {
     .set_description("Rocksdb options"),
 
     Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4644,8 +4644,8 @@ std::vector<Option> get_global_options() {
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("M= P= L=")
-    .set_description("List of whitespace-separate key/value pairs where key is CF name and value is CF options"),
+    .set_default("O7= M5= L= P= b= C=")
+    .set_description("List of whitespace-separate key/value pairs where key is CF name and value is CF options. When CF name is followed with a number, eg. M5, then multiple CFs are created M-0, M-1, ... M-4. No number after CF name means only single CF is created eg. L-0. Prefixes not listed remain part of 'default' column family."),
 
     Option("bluestore_fsck_on_mount", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -43,6 +43,7 @@ public:
     bool operator==(void* rhs) const {return rhs == priv;}
     bool operator!=(void* rhs) const {return rhs != priv;}
     operator bool() const {return priv != nullptr;}
+    void clear() { priv = nullptr; }
   };
 
   class TransactionImpl {

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -42,6 +42,7 @@ public:
     bool operator!=(struct ColumnFamilyHandle rhs) const {return rhs.priv != priv;}
     bool operator==(void* rhs) const {return rhs == priv;}
     bool operator!=(void* rhs) const {return rhs != priv;}
+    operator bool() const {return priv != nullptr;}
   };
 
   class TransactionImpl {

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -208,7 +208,7 @@ public:
    */
   virtual int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) = 0;
 
-  virtual int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) {
+  virtual int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options = {}) {
     return -ENOTSUP;
   }
 
@@ -300,6 +300,18 @@ public:
    */
   virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name) const
   { ceph_abort_msg("Not implemented"); return ColumnFamilyHandle(); }
+
+  virtual int column_family_compact(const std::string& cf_name,
+                            const string& prefix,
+                            const string& start,
+                            const string& end)
+  { ceph_abort_msg("Not implemented"); return 0; }
+
+  virtual int column_family_compact_async(const std::string& cf_name,
+                                  const string& prefix,
+                                  const string& start,
+                                  const string& end)
+  { ceph_abort_msg("Not implemented"); return 0; }
 
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.
   virtual int repair(std::ostream &out) { return 0; }

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -144,6 +144,15 @@ public:
       const ceph::buffer::list  &value     ///< [in] value to be merged into key
     ) { ceph_abort_msg("Not implemented"); }
 
+    /// Select column family space to execute operations on.
+    /// Selection persists for all subsequent calls.
+    /// Initially default column family is selected.
+    /// Handlers must be obtained by \ref column_family_handle.
+    /// It is legal to construct transaction that spans multiple column families.
+    virtual void select(
+      void* column_family_handle ///< [in] column family handler, or nullptr for default column family
+    ) { ceph_abort_msg("Not implemented"); }
+
     virtual ~TransactionImpl() {}
   };
   typedef std::shared_ptr< TransactionImpl > Transaction;
@@ -157,10 +166,38 @@ public:
   /// test whether we can successfully initialize; may have side effects (e.g., create)
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(string option_str="") = 0;
-  virtual int open(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) = 0;
-  // std::vector cfs contains column families to be created when db is created.
-  virtual int create_and_open(std::ostream &out,
-			      const std::vector<ColumnFamily>& cfs = {}) = 0;
+  /*
+   * Opens existing database
+   *
+   * Makes transition to state that allows to fetch/store data into database.
+   * It enables operation on main DB and all column family defined within the database.
+   * If opening a column family requires additional options, they can be specified via _options_ parameter.
+   * Before calling this all merge operators for DB must be registered see \ref set_merge_operator.
+   *
+   * Note 1: Not mentioning column family in _options_ means that column is handled with default options.
+   * Note 2: Set of merge operators \ref set_merge_operator must be exact as when DB was created \ref create_and_open.
+   *
+   * Params:
+   *   out - textual representation of error
+   *   options - column families specific options
+   * Result:
+   *   0 - success, <0 error code
+   */
+  virtual int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) = 0;
+  /*
+   * Creates new database
+   *
+   * Enables access to newly created database. This database is empty, with exception that
+   * additional column families may be created, according to _new_cfs_ parameter.
+   * The _new_cfs_ is optional, and column families can be created later, using \ref create_column_family.
+   *
+   * Params:
+   *   out - textual representation of error
+   *   new_cfs - column families to be created
+   * Result:
+   *   0 - success, <0 error code
+   */
+  virtual int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) = 0;
 
   virtual int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) {
     return -ENOTSUP;
@@ -168,6 +205,22 @@ public:
 
   virtual void close() { }
 
+  /*
+   * Lists column families
+   *
+   * Lists column families present in database.
+   * This can be invoked before open() to query existing column families.
+   * Also it allows to query ability of database to support multiple column families.
+   *
+    Params:
+   *   [out] cf_names - names of all existing column families
+   * Result:
+   *   0 - success, <0 - db does not support column families
+   */
+  virtual int column_family_list(vector<std::string>& cf_names) { cf_names.clear(); return -1; }
+  virtual int column_family_create(const std::string& cf_name, const std::string& cf_options) { ceph_abort_msg("Not implemented"); return -1; }
+  virtual int column_family_delete(const std::string& cf_name) { ceph_abort_msg("Not implemented"); return -1; }
+  virtual void* column_family_handle(const std::string& cf_name) { ceph_abort_msg("Not implemented"); return nullptr; }
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.
   virtual int repair(std::ostream &out) { return 0; }
 
@@ -202,6 +255,30 @@ public:
 		  const char *key, size_t keylen,
 		  ceph::buffer::list *value) {
     return get(prefix, string(key, keylen), value);
+  }
+
+  virtual int get(void* cf_handle,                         ///< [in] Column family handle
+                  const std::string &prefix,               ///< [in] Prefix/CF for key
+                  const std::set<std::string> &keys,       ///< [in] Keys to retrieve
+                  std::map<std::string, bufferlist> *out) {///< [out] Key values retrieved
+    ceph_abort_msg("Not implemented"); return -1;
+  };
+
+  virtual int get(void* cf_handle,           ///< [in] Column family handle
+                  const std::string &prefix, ///< [in] prefix or CF name
+                  const std::string &key,    ///< [in] key
+                  bufferlist *value) {       ///< [out] value
+    std::set<std::string> ks;
+    ks.insert(key);
+    std::map<std::string,bufferlist> om;
+    int r = get(cf_handle, prefix, ks, &om);
+    if (om.find(key) != om.end()) {
+      *value = std::move(om[key]);
+    } else {
+      *value = bufferlist();
+      r = -ENOENT;
+    }
+    return r;
   }
 
   class IteratorBase {
@@ -335,11 +412,11 @@ public:
   }
 
   void add_column_family(const std::string& cf_name, void *handle) {
-    cf_handles.insert(std::make_pair(cf_name, handle));
+    cf_mono_handles.insert(std::make_pair(cf_name, handle));
   }
 
   bool is_column_family(const std::string& prefix) {
-    return cf_handles.count(prefix);
+    return cf_mono_handles.count(prefix);
   }
 
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;
@@ -404,7 +481,20 @@ public:
     virtual ~MergeOperator() {}
   };
 
-  /// Setup one or more operators, this needs to be done BEFORE the DB is opened.
+  /*
+   * Register merge operator
+   *
+   * Registers merge operator to invoke on values with specific \ref prefix.
+   * Value \ref prefix must be equal to whole prefix; substrings will not match.
+   * Merge operators may be registered only before DB is opened, i.e.
+   * before \ref open or \ref create_and_open calls.
+   *
+   * Params:
+   * - prefix for which merge is registered
+   * - mop actual merge operation handler
+   * Return:
+   *   0 - success, <0 DB in incorrect state
+   */
   virtual int set_merge_operator(const std::string& prefix,
 				 std::shared_ptr<MergeOperator> mop) {
     return -EOPNOTSUPP;
@@ -424,11 +514,10 @@ public:
   }
 protected:
   /// List of matching prefixes/ColumnFamilies and merge operators
-  std::vector<std::pair<std::string,
-			std::shared_ptr<MergeOperator> > > merge_ops;
+  std::map<std::string, std::shared_ptr<MergeOperator> > merge_ops;
 
   /// column families in use, name->handle
-  std::unordered_map<std::string, void *> cf_handles;
+  std::unordered_map<std::string, void *> cf_mono_handles;
 };
 
 #endif

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -36,7 +36,8 @@ public:
   };
 
   struct ColumnFamilyHandle {
-    void* priv = nullptr;
+    ColumnFamilyHandle() : priv(nullptr) {}
+    void* priv;
     bool operator==(struct ColumnFamilyHandle rhs) const {return rhs.priv == priv;}
     bool operator!=(struct ColumnFamilyHandle rhs) const {return rhs.priv != priv;}
     bool operator==(void* rhs) const {return rhs == priv;}
@@ -174,7 +175,7 @@ public:
   /// test whether we can successfully initialize; may have side effects (e.g., create)
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(string option_str="") = 0;
-  /*
+  /**
    * Opens existing database
    *
    * Makes transition to state that allows to fetch/store data into database.
@@ -192,7 +193,7 @@ public:
    *   0 - success, <0 error code
    */
   virtual int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) = 0;
-  /*
+  /**
    * Creates new database
    *
    * Enables access to newly created database. This database is empty, with exception that
@@ -213,7 +214,7 @@ public:
 
   virtual void close() { }
 
-  /*
+  /**
    * @defgroup column_family Column Families
    * There are 3 categories of column families.
    *
@@ -234,7 +235,7 @@ public:
    * Merge operator name must not include prefixes handled by mono column families.
    */
 
-  /*
+  /**
    * @ingroup column_family
    * List column families
    *
@@ -253,7 +254,7 @@ public:
   virtual int column_family_list(vector<std::string>& cf_names)
   { cf_names.clear(); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Create new column family
    *
@@ -269,7 +270,7 @@ public:
   virtual int column_family_create(const std::string& cf_name, const std::string& cf_options)
   { ceph_abort_msg("Not implemented"); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Delete column family
    *
@@ -285,7 +286,7 @@ public:
   virtual int column_family_delete(const std::string& cf_name)
   { ceph_abort_msg("Not implemented"); return -1; }
 
-  /*
+  /**
    * @ingroup column_family
    * Get handle to column family
    *
@@ -297,8 +298,8 @@ public:
    * Result:
    *   handle to column family, or nullptr when cf_name does not exist
    */
-  virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name)
-  { ceph_abort_msg("Not implemented"); return {nullptr}; }
+  virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name) const
+  { ceph_abort_msg("Not implemented"); return ColumnFamilyHandle(); }
 
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.
   virtual int repair(std::ostream &out) { return 0; }
@@ -520,7 +521,8 @@ public:
   virtual ~KeyValueDB() {}
 
   /// estimate space utilization for a prefix (in bytes)
-  virtual int64_t estimate_prefix_size(const string& prefix) {
+  virtual int64_t estimate_prefix_size(const string& prefix,
+                                       ColumnFamilyHandle cfh = ColumnFamilyHandle()) {
     return 0;
   }
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -31,11 +31,8 @@ public:
   struct ColumnFamily {
     string name;      //< name of this individual column family
     string option;    //< configure option string for this CF
-    bool share_cache = true; //< should this column family share the default block_cache?
     ColumnFamily(const string &name, const string &option)
       : name(name), option(option) {}
-    ColumnFamily(const string &name, const string &option, bool share_cache)
-      : name(name), option(option), share_cache(share_cache) {}
   };
 
   struct ColumnFamilyHandle {

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -204,7 +204,7 @@ public:
     return get(prefix, string(key, keylen), value);
   }
 
-  class ForwardIterator {
+  class IteratorBase {
   public:
     virtual int seek_to_first() = 0;
     virtual bool valid() = 0;
@@ -221,45 +221,46 @@ public:
         ceph_abort();
       }
     }
+    virtual std::pair<std::string, std::string> raw_key() {
+      return std::make_pair(key(), value().c_str());
+    }
     virtual int status() = 0;
-    virtual ~ForwardIterator() {}
+    virtual int seek_to_last() { ceph_abort(); return 0; }
+    virtual int prev() { ceph_abort(); return 0; }
+    virtual ~IteratorBase() {}
   };
 
   // This superclass is used both by kv iterators *and* by the ObjectMap
   // omap iterator.  The class hierarchies are unfortunately tied together
   // by the legacy DBOjectMap implementation :(.
-  class SimplestIteratorImpl : public ForwardIterator {
+  class ObjectMapIteratorImpl : public IteratorBase {
   public:
     virtual int upper_bound(const std::string &after) = 0;
     virtual int lower_bound(const std::string &to) = 0;
-    virtual ~SimplestIteratorImpl() {}
+    virtual ~ObjectMapIteratorImpl() {}
   };
 
-  class BackwardIterator {
+
+  class IteratorImpl : public ObjectMapIteratorImpl {
   public:
-    virtual int seek_to_last() = 0;
-    virtual int prev() = 0;
-    virtual std::pair<std::string, std::string> raw_key() = 0;
-    virtual ~BackwardIterator() {}
-  };
-  class IteratorImpl : public SimplestIteratorImpl, public BackwardIterator {
-  public:
+    int seek_to_last() override = 0;
+    int prev() override = 0;
     virtual ~IteratorImpl() {}
   };
   typedef std::shared_ptr< IteratorImpl > Iterator;
 
   // This is the low-level iterator implemented by the underlying KV store.
-  class WholeSpaceIteratorImpl : public ForwardIterator, public BackwardIterator {
+  class WholeSpaceIteratorImpl : public IteratorBase {
   public:
-    using ForwardIterator::seek_to_first;
-    using BackwardIterator::seek_to_last;
-    using ForwardIterator::valid;
-    using ForwardIterator::next;
-    using BackwardIterator::prev;
-    using ForwardIterator::key;
-    using ForwardIterator::value;
-    using ForwardIterator::value_as_ptr;
-    using ForwardIterator::status;
+    using IteratorBase::seek_to_first;
+    int seek_to_last() override = 0;
+    using IteratorBase::valid;
+    using IteratorBase::next;
+    int prev() override = 0;
+    using IteratorBase::key;
+    using IteratorBase::value;
+    using IteratorBase::value_as_ptr;
+    using IteratorBase::status;
     virtual int seek_to_first(const std::string &prefix) = 0;
     virtual int seek_to_last(const std::string &prefix) = 0;
     virtual int upper_bound(const std::string &prefix, const std::string &after) = 0;

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -31,8 +31,11 @@ public:
   struct ColumnFamily {
     string name;      //< name of this individual column family
     string option;    //< configure option string for this CF
+    bool share_cache = true; //< should this column family share the default block_cache?
     ColumnFamily(const string &name, const string &option)
       : name(name), option(option) {}
+    ColumnFamily(const string &name, const string &option, bool share_cache)
+      : name(name), option(option), share_cache(share_cache) {}
   };
 
   struct ColumnFamilyHandle {
@@ -528,7 +531,15 @@ public:
     return -EOPNOTSUPP;
   }
 
+  virtual int64_t get_cache_usage(std::string prefix) const {
+    return -EOPNOTSUPP;
+  }
+
   virtual std::shared_ptr<PriorityCache::PriCache> get_priority_cache() const {
+    return nullptr;
+  }
+
+  virtual std::shared_ptr<PriorityCache::PriCache> get_priority_cache(std::string prefix) const {
     return nullptr;
   }
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -204,71 +204,72 @@ public:
     return get(prefix, string(key, keylen), value);
   }
 
-  // This superclass is used both by kv iterators *and* by the ObjectMap
-  // omap iterator.  The class hierarchies are unfortunately tied together
-  // by the legacy DBOjectMap implementation :(.
-  class SimplestIteratorImpl {
+  class ForwardIterator {
   public:
     virtual int seek_to_first() = 0;
-    virtual int upper_bound(const std::string &after) = 0;
-    virtual int lower_bound(const std::string &to) = 0;
     virtual bool valid() = 0;
     virtual int next() = 0;
     virtual std::string key() = 0;
     virtual ceph::buffer::list value() = 0;
-    virtual int status() = 0;
-    virtual ~SimplestIteratorImpl() {}
-  };
-
-  class IteratorImpl : public SimplestIteratorImpl {
-  public:
-    virtual ~IteratorImpl() {}
-    virtual int seek_to_last() = 0;
-    virtual int prev() = 0;
-    virtual std::pair<std::string, std::string> raw_key() = 0;
-    virtual ceph::buffer::ptr value_as_ptr() {
-      ceph::buffer::list bl = value();
+    virtual bufferptr value_as_ptr() {
+      bufferlist bl = value();
       if (bl.length() == 1) {
         return *bl.buffers().begin();
       } else if (bl.length() == 0) {
         return ceph::buffer::ptr();
       } else {
-	ceph_abort();
+        ceph_abort();
       }
     }
+    virtual int status() = 0;
+    virtual ~ForwardIterator() {}
+  };
+
+  // This superclass is used both by kv iterators *and* by the ObjectMap
+  // omap iterator.  The class hierarchies are unfortunately tied together
+  // by the legacy DBOjectMap implementation :(.
+  class SimplestIteratorImpl : public ForwardIterator {
+  public:
+    virtual int upper_bound(const std::string &after) = 0;
+    virtual int lower_bound(const std::string &to) = 0;
+    virtual ~SimplestIteratorImpl() {}
+  };
+
+  class BackwardIterator {
+  public:
+    virtual int seek_to_last() = 0;
+    virtual int prev() = 0;
+    virtual std::pair<std::string, std::string> raw_key() = 0;
+    virtual ~BackwardIterator() {}
+  };
+  class IteratorImpl : public SimplestIteratorImpl, public BackwardIterator {
+  public:
+    virtual ~IteratorImpl() {}
   };
   typedef std::shared_ptr< IteratorImpl > Iterator;
 
   // This is the low-level iterator implemented by the underlying KV store.
-  class WholeSpaceIteratorImpl {
+  class WholeSpaceIteratorImpl : public ForwardIterator, public BackwardIterator {
   public:
-    virtual int seek_to_first() = 0;
+    using ForwardIterator::seek_to_first;
+    using BackwardIterator::seek_to_last;
+    using ForwardIterator::valid;
+    using ForwardIterator::next;
+    using BackwardIterator::prev;
+    using ForwardIterator::key;
+    using ForwardIterator::value;
+    using ForwardIterator::value_as_ptr;
+    using ForwardIterator::status;
     virtual int seek_to_first(const std::string &prefix) = 0;
-    virtual int seek_to_last() = 0;
     virtual int seek_to_last(const std::string &prefix) = 0;
     virtual int upper_bound(const std::string &prefix, const std::string &after) = 0;
     virtual int lower_bound(const std::string &prefix, const std::string &to) = 0;
-    virtual bool valid() = 0;
-    virtual int next() = 0;
-    virtual int prev() = 0;
-    virtual std::string key() = 0;
-    virtual std::pair<std::string,std::string> raw_key() = 0;
     virtual bool raw_key_is_prefixed(const std::string &prefix) = 0;
-    virtual ceph::buffer::list value() = 0;
-    virtual ceph::buffer::ptr value_as_ptr() {
-      ceph::buffer::list bl = value();
-      if (bl.length()) {
-        return *bl.buffers().begin();
-      } else {
-        return ceph::buffer::ptr();
-      }
-    }
-    virtual int status() = 0;
     virtual size_t key_size() {
-      return 0;
+      return key().size();
     }
     virtual size_t value_size() {
-      return 0;
+      return value().length();
     }
     virtual ~WholeSpaceIteratorImpl() { }
   };

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -35,6 +35,14 @@ public:
       : name(name), option(option) {}
   };
 
+  struct ColumnFamilyHandle {
+    void* priv = nullptr;
+    bool operator==(struct ColumnFamilyHandle rhs) const {return rhs.priv == priv;}
+    bool operator!=(struct ColumnFamilyHandle rhs) const {return rhs.priv != priv;}
+    bool operator==(void* rhs) const {return rhs == priv;}
+    bool operator!=(void* rhs) const {return rhs != priv;}
+  };
+
   class TransactionImpl {
   public:
     /// Set Keys
@@ -150,7 +158,7 @@ public:
     /// Handlers must be obtained by \ref column_family_handle.
     /// It is legal to construct transaction that spans multiple column families.
     virtual void select(
-      void* column_family_handle ///< [in] column family handler, or nullptr for default column family
+        KeyValueDB::ColumnFamilyHandle column_family_handle ///< [in] column family handler, or nullptr for default column family
     ) { ceph_abort_msg("Not implemented"); }
 
     virtual ~TransactionImpl() {}
@@ -206,9 +214,34 @@ public:
   virtual void close() { }
 
   /*
-   * Lists column families
+   * @defgroup column_family Column Families
+   * There are 3 categories of column families.
    *
-   * Lists column families present in database.
+   * 1) mono column family
+   * Tightly bound to single prefix (P) value.
+   * Name of column family is P.
+   * Only keys with prefix P are all allowed.
+   * Merge operator (if exists) must be named P.
+   *
+   * 2) regular column family
+   * Can contain keys with any prefix.
+   * Name of column family may not be exact to any registered merge operators.
+   * Merge operator must encompass all available prefix merge operators, and so must its name.
+   *
+   * 3) default column family
+   * Can contain keys with any prefix except those handled by mono column families.
+   * Merge operator must encompass all prefixes, except those handled by mono column families.
+   * Merge operator name must not include prefixes handled by mono column families.
+   */
+
+  /*
+   * @ingroup column_family
+   * List column families
+   *
+   * Queries database for names of all defined column families.
+   * When invoked before \ref open it queries stored database.
+   * When invoked after \ref open or \ref create_and_open it just reports current state.
+   * Invoking on non-existent database must return empty \ref cf_names.
    * This can be invoked before open() to query existing column families.
    * Also it allows to query ability of database to support multiple column families.
    *
@@ -217,10 +250,56 @@ public:
    * Result:
    *   0 - success, <0 - db does not support column families
    */
-  virtual int column_family_list(vector<std::string>& cf_names) { cf_names.clear(); return -1; }
-  virtual int column_family_create(const std::string& cf_name, const std::string& cf_options) { ceph_abort_msg("Not implemented"); return -1; }
-  virtual int column_family_delete(const std::string& cf_name) { ceph_abort_msg("Not implemented"); return -1; }
-  virtual void* column_family_handle(const std::string& cf_name) { ceph_abort_msg("Not implemented"); return nullptr; }
+  virtual int column_family_list(vector<std::string>& cf_names)
+  { cf_names.clear(); return -1; }
+
+  /*
+   * @ingroup column_family
+   * Create new column family
+   *
+   * Create additional column family in running database.
+   * This may be invoked only on opened database.
+   *
+   * Params:
+   * - name name of column family
+   * - options extra options to apply for column family
+   * Result:
+   *   0 - success, <0 error code
+   */
+  virtual int column_family_create(const std::string& cf_name, const std::string& cf_options)
+  { ceph_abort_msg("Not implemented"); return -1; }
+
+  /*
+   * @ingroup column_family
+   * Delete column family
+   *
+   * Removes column family from running database.
+   * This may be invoked only on opened database.
+   *
+   * Params:
+   * - name name of column family
+   * - options extra options to apply for column family
+   * Result:
+   *   0 - success, <0 error code
+   */
+  virtual int column_family_delete(const std::string& cf_name)
+  { ceph_abort_msg("Not implemented"); return -1; }
+
+  /*
+   * @ingroup column_family
+   * Get handle to column family
+   *
+   * This works properly only if column family names cf_name exists.
+   * Note: If requested for handle to
+   *
+   * Params:
+   * - cf_name name of column family
+   * Result:
+   *   handle to column family, or nullptr when cf_name does not exist
+   */
+  virtual ColumnFamilyHandle column_family_handle(const std::string& cf_name)
+  { ceph_abort_msg("Not implemented"); return {nullptr}; }
+
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.
   virtual int repair(std::ostream &out) { return 0; }
 
@@ -257,17 +336,17 @@ public:
     return get(prefix, string(key, keylen), value);
   }
 
-  virtual int get(void* cf_handle,                         ///< [in] Column family handle
+  virtual int get(ColumnFamilyHandle cf_handle,           ///< [in] Column family handle
                   const std::string &prefix,               ///< [in] Prefix/CF for key
                   const std::set<std::string> &keys,       ///< [in] Keys to retrieve
                   std::map<std::string, bufferlist> *out) {///< [out] Key values retrieved
     ceph_abort_msg("Not implemented"); return -1;
   };
 
-  virtual int get(void* cf_handle,           ///< [in] Column family handle
-                  const std::string &prefix, ///< [in] prefix or CF name
-                  const std::string &key,    ///< [in] key
-                  bufferlist *value) {       ///< [out] value
+  virtual int get(ColumnFamilyHandle cf_handle,///< [in] Column family handle
+                  const std::string &prefix,    ///< [in] prefix or CF name
+                  const std::string &key,       ///< [in] key
+                  bufferlist *value) {          ///< [out] value
     std::set<std::string> ks;
     ks.insert(key);
     std::map<std::string,bufferlist> om;
@@ -281,7 +360,7 @@ public:
     return r;
   }
 
-  class IteratorBase {
+  class IteratorBaseImpl {
   public:
     virtual int seek_to_first() = 0;
     virtual bool valid() = 0;
@@ -304,19 +383,19 @@ public:
     virtual int status() = 0;
     virtual int seek_to_last() { ceph_abort(); return 0; }
     virtual int prev() { ceph_abort(); return 0; }
-    virtual ~IteratorBase() {}
+    virtual ~IteratorBaseImpl() {}
   };
+  typedef std::shared_ptr< IteratorBaseImpl > IteratorBase;
 
   // This superclass is used both by kv iterators *and* by the ObjectMap
   // omap iterator.  The class hierarchies are unfortunately tied together
   // by the legacy DBOjectMap implementation :(.
-  class ObjectMapIteratorImpl : public IteratorBase {
+  class ObjectMapIteratorImpl : public IteratorBaseImpl {
   public:
     virtual int upper_bound(const std::string &after) = 0;
     virtual int lower_bound(const std::string &to) = 0;
     virtual ~ObjectMapIteratorImpl() {}
   };
-
 
   class IteratorImpl : public ObjectMapIteratorImpl {
   public:
@@ -327,17 +406,17 @@ public:
   typedef std::shared_ptr< IteratorImpl > Iterator;
 
   // This is the low-level iterator implemented by the underlying KV store.
-  class WholeSpaceIteratorImpl : public IteratorBase {
+  class WholeSpaceIteratorImpl : public IteratorBaseImpl {
   public:
-    using IteratorBase::seek_to_first;
+    using IteratorBaseImpl::seek_to_first;
     int seek_to_last() override = 0;
-    using IteratorBase::valid;
-    using IteratorBase::next;
+    using IteratorBaseImpl::valid;
+    using IteratorBaseImpl::next;
     int prev() override = 0;
-    using IteratorBase::key;
-    using IteratorBase::value;
-    using IteratorBase::value_as_ptr;
-    using IteratorBase::status;
+    using IteratorBaseImpl::key;
+    using IteratorBaseImpl::value;
+    using IteratorBaseImpl::value_as_ptr;
+    using IteratorBaseImpl::status;
     virtual int seek_to_first(const std::string &prefix) = 0;
     virtual int seek_to_last(const std::string &prefix) = 0;
     virtual int upper_bound(const std::string &prefix, const std::string &after) = 0;
@@ -410,13 +489,11 @@ public:
       prefix,
       get_wholespace_iterator());
   }
-
-  void add_column_family(const std::string& cf_name, void *handle) {
-    cf_mono_handles.insert(std::make_pair(cf_name, handle));
+  virtual WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) {
+    ceph_abort_msg("Not implemented"); return {};
   }
-
-  bool is_column_family(const std::string& prefix) {
-    return cf_mono_handles.count(prefix);
+  virtual Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) {
+    ceph_abort_msg("Not implemented"); return {};
   }
 
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;
@@ -515,9 +592,6 @@ public:
 protected:
   /// List of matching prefixes/ColumnFamilies and merge operators
   std::map<std::string, std::shared_ptr<MergeOperator> > merge_ops;
-
-  /// column families in use, name->handle
-  std::unordered_map<std::string, void *> cf_mono_handles;
 };
 
 #endif

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -165,7 +165,7 @@ int MemDB::set_merge_operator(
   const string& prefix,
   std::shared_ptr<KeyValueDB::MergeOperator> mop)
 {
-  merge_ops.push_back(std::make_pair(prefix, mop));
+  merge_ops.emplace(prefix, mop);
   return 0;
 }
 
@@ -338,10 +338,9 @@ int MemDB::_rmkey(ms_op_t &op)
 
 std::shared_ptr<KeyValueDB::MergeOperator> MemDB::_find_merge_op(const std::string &prefix)
 {
-  for (const auto& i : merge_ops) {
-    if (i.first == prefix) {
-      return i.second;
-    }
+  auto i = merge_ops.find(prefix);
+  if (i != merge_ops.end()) {
+    return i->second;
   }
 
   dtrace << __func__ << " No merge op for " << prefix << dendl;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -848,9 +848,6 @@ int RocksDBStore::column_family_delete(const std::string& cf_name)
 KeyValueDB::ColumnFamilyHandle RocksDBStore::column_family_handle(const std::string& cf_name) const
 {
   RWLock::RLocker l(api_lock);
-  if (cf_name == "default") {
-    return cf_wrap_handle(default_cf);
-  }
   auto it = column_families.find(cf_name);
   if (it == column_families.end())
     return KeyValueDB::ColumnFamilyHandle();

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -835,12 +835,22 @@ int RocksDBStore::column_family_create(const std::string& cf_name, const std::st
 
 int RocksDBStore::column_family_delete(const std::string& cf_name)
 {
-  return -1;
+  RWLock::WLocker l(api_lock);
+  rocksdb::ColumnFamilyHandle* handle = cf_get_handle(cf_name);
+  rocksdb::Status status = db->DropColumnFamily(handle);
+  if (!status.ok()) {
+      derr << __func__ << " problem deleting column family '" << cf_name << "'" << dendl;
+      return -EINVAL;
+  }
+  return 0;
 }
 
 KeyValueDB::ColumnFamilyHandle RocksDBStore::column_family_handle(const std::string& cf_name) const
 {
   RWLock::RLocker l(api_lock);
+  if (cf_name == "default") {
+    return cf_wrap_handle(default_cf);
+  }
   auto it = column_families.find(cf_name);
   if (it == column_families.end())
     return KeyValueDB::ColumnFamilyHandle();
@@ -1060,7 +1070,7 @@ int RocksDBStore::cf_create(const std::string& cf_name, const std::string& cf_op
 }
 
 
-KeyValueDB::ColumnFamilyHandle RocksDBStore::cf_wrap_handle(rocksdb::ColumnFamilyHandle* rocks_cfh)
+KeyValueDB::ColumnFamilyHandle RocksDBStore::cf_wrap_handle(rocksdb::ColumnFamilyHandle* rocks_cfh) const
 {
   KeyValueDB::ColumnFamilyHandle cfh;
   cfh.priv = static_cast<void*>(rocks_cfh);

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -61,32 +61,31 @@ static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl,
 class RocksDBStore::MergeOperatorRouter
   : public rocksdb::AssociativeMergeOperator
 {
+protected:
   RocksDBStore& store;
+  mutable std::string name;
 public:
   const char *Name() const override {
     // Construct a name that rocksDB will validate against. We want to
     // do this in a way that doesn't constrain the ordering of calls
     // to set_merge_operator, so sort the merge operators and then
     // construct a name from all of those parts.
-    store.assoc_name.clear();
+    name.clear();
     map<std::string,std::string> names;
 
     for (auto& p : store.merge_ops) {
       names[p.first] = p.second->name();
     }
-    //TODO: name of merge operator excludes prefixes for mono tables
-    //TODO: this makes it difficult to merge data back to main table
-    //TODO: regardless of cranky name, this should handle all prefixes?
     for (auto& p : store.cf_mono_handles) {
       names.erase(p.first);
     }
     for (auto& p : names) {
-      store.assoc_name += '.';
-      store.assoc_name += p.first;
-      store.assoc_name += ':';
-      store.assoc_name += p.second;
+      name += '.';
+      name += p.first;
+      name += ':';
+      name += p.second;
     }
-    return store.assoc_name.c_str();
+    return name.c_str();
   }
 
   explicit MergeOperatorRouter(RocksDBStore &_store) : store(_store) {}
@@ -150,6 +149,116 @@ public:
   }
 };
 
+//
+// Merge operator that encompasses all prefixes.
+//
+class RocksDBStore::MergeOperatorAll : public RocksDBStore::MergeOperatorRouter
+{
+public:
+  const char *Name() const override {
+    name.clear();
+    for (auto& p : store.merge_ops) {
+      name += '.';
+      name += p.first;
+      name += ':';
+      name += p.second->name();
+    }
+    return name.c_str();
+  }
+
+  explicit MergeOperatorAll(RocksDBStore &store) : MergeOperatorRouter(store) {}
+};
+
+struct RocksWBHandler: public rocksdb::WriteBatch::Handler {
+  std::string seen ;
+  int num_seen = 0;
+  static string pretty_binary_string(const string& in) {
+    char buf[10];
+    string out;
+    out.reserve(in.length() * 3);
+    enum { NONE, HEX, STRING } mode = NONE;
+    unsigned from = 0, i;
+    for (i=0; i < in.length(); ++i) {
+      if ((in[i] < 32 || (unsigned char)in[i] > 126) ||
+        (mode == HEX && in.length() - i >= 4 &&
+        ((in[i] < 32 || (unsigned char)in[i] > 126) ||
+        (in[i+1] < 32 || (unsigned char)in[i+1] > 126) ||
+        (in[i+2] < 32 || (unsigned char)in[i+2] > 126) ||
+        (in[i+3] < 32 || (unsigned char)in[i+3] > 126)))) {
+
+        if (mode == STRING) {
+          out.append(in.substr(from, i - from));
+          out.push_back('\'');
+        }
+        if (mode != HEX) {
+          out.append("0x");
+          mode = HEX;
+        }
+        if (in.length() - i >= 4) {
+          // print a whole u32 at once
+          snprintf(buf, sizeof(buf), "%08x",
+                (uint32_t)(((unsigned char)in[i] << 24) |
+                          ((unsigned char)in[i+1] << 16) |
+                          ((unsigned char)in[i+2] << 8) |
+                          ((unsigned char)in[i+3] << 0)));
+          i += 3;
+        } else {
+          snprintf(buf, sizeof(buf), "%02x", (int)(unsigned char)in[i]);
+        }
+        out.append(buf);
+      } else {
+        if (mode != STRING) {
+          out.push_back('\'');
+          mode = STRING;
+          from = i;
+        }
+      }
+    }
+    if (mode == STRING) {
+      out.append(in.substr(from, i - from));
+      out.push_back('\'');
+    }
+    return out;
+  }
+  void Put(const rocksdb::Slice& key,
+                  const rocksdb::Slice& value) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    uint64_t size = (value.ToString()).size();
+    seen += "\nPut( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode)
+          + " Value size = " + std::to_string(size) + ")";
+    num_seen++;
+  }
+  void SingleDelete(const rocksdb::Slice& key) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    seen += "\nSingleDelete(Prefix = "+ prefix + " Key = "
+          + pretty_binary_string(key_to_decode) + ")";
+    num_seen++;
+  }
+  void Delete(const rocksdb::Slice& key) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    seen += "\nDelete( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode) + ")";
+
+    num_seen++;
+  }
+  void Merge(const rocksdb::Slice& key,
+                    const rocksdb::Slice& value) override {
+    string prefix ((key.ToString()).substr(0,1));
+    string key_to_decode ((key.ToString()).substr(2,string::npos));
+    uint64_t size = (value.ToString()).size();
+    seen += "\nMerge( Prefix = " + prefix + " key = "
+          + pretty_binary_string(key_to_decode) + " Value size = "
+          + std::to_string(size) + ")";
+
+    num_seen++;
+  }
+  bool Continue() override { return num_seen < 50; }
+};
+
 int RocksDBStore::set_merge_operator(
   const string& prefix,
   std::shared_ptr<KeyValueDB::MergeOperator> mop)
@@ -158,6 +267,72 @@ int RocksDBStore::set_merge_operator(
   ceph_assert(db == nullptr);
   merge_ops.emplace(prefix, mop);
   return 0;
+}
+
+uint64_t RocksDBStore::get_estimated_size(map<string,uint64_t> &extra) {
+  DIR *store_dir = opendir(path.c_str());
+  if (!store_dir) {
+    lderr(cct) << __func__ << " something happened opening the store: "
+        << cpp_strerror(errno) << dendl;
+    return 0;
+  }
+
+  uint64_t total_size = 0;
+  uint64_t sst_size = 0;
+  uint64_t log_size = 0;
+  uint64_t misc_size = 0;
+
+  struct dirent *entry = NULL;
+  while ((entry = readdir(store_dir)) != NULL) {
+    string n(entry->d_name);
+
+    if (n == "." || n == "..")
+      continue;
+
+    string fpath = path + '/' + n;
+    struct stat s;
+    int err = stat(fpath.c_str(), &s);
+    if (err < 0)
+      err = -errno;
+    // we may race against rocksdb while reading files; this should only
+    // happen when those files are being updated, data is being shuffled
+    // and files get removed, in which case there's not much of a problem
+    // as we'll get to them next time around.
+    if (err == -ENOENT) {
+      continue;
+    }
+    if (err < 0) {
+      lderr(cct) << __func__ << " error obtaining stats for " << fpath
+          << ": " << cpp_strerror(err) << dendl;
+      goto err;
+    }
+
+    size_t pos = n.find_last_of('.');
+    if (pos == string::npos) {
+      misc_size += s.st_size;
+      continue;
+    }
+
+    string ext = n.substr(pos+1);
+    if (ext == "sst") {
+      sst_size += s.st_size;
+    } else if (ext == "log") {
+      log_size += s.st_size;
+    } else {
+      misc_size += s.st_size;
+    }
+  }
+
+  total_size = sst_size + log_size + misc_size;
+
+  extra["sst"] = sst_size;
+  extra["log"] = log_size;
+  extra["misc"] = misc_size;
+  extra["total"] = total_size;
+
+  err:
+  closedir(store_dir);
+  return total_size;
 }
 
 class CephRocksdbLogger : public rocksdb::Logger {
@@ -655,7 +830,7 @@ RocksDBStore::cf_get_merge_operator(const std::string& cf_name)
   }
   //Column family name is not exact to any defined merge operators.
   //Use all-prefix merge operator.
-  return std::shared_ptr<rocksdb::MergeOperator>(new MergeOperatorRouter(*this));
+  return std::shared_ptr<rocksdb::MergeOperator>(new RocksDBStore::MergeOperatorAll(*this));
 }
 
 int RocksDBStore::_test_init(const string& dir)
@@ -923,7 +1098,7 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     put_bat(bat, cf, k, to_set_bl);
   } else {
     string key = combine_strings(prefix, k);
@@ -937,7 +1112,7 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     string key(k, keylen);  // fixme?
     put_bat(bat, cf, key, to_set_bl);
   } else {
@@ -951,7 +1126,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const string &k)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.Delete(cf, rocksdb::Slice(k));
   } else {
     bat.Delete(cf, combine_strings(prefix, k));
@@ -963,7 +1138,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 						 size_t keylen)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.Delete(cf, rocksdb::Slice(k, keylen));
   } else {
     string key;
@@ -976,7 +1151,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 					                 const string &k)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     bat.SingleDelete(cf, k);
   } else {
     bat.SingleDelete(cf, combine_strings(prefix, k));
@@ -986,7 +1161,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     if (db->enable_rmrange) {
       string endprefix("\xff\xff\xff\xff");  // FIXME: this is cheating...
       if (db->max_items_rmrange) {
@@ -1059,7 +1234,7 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
                                                          const string &end)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     if (db->enable_rmrange) {
       if (db->max_items_rmrange) {
         uint64_t cnt = db->max_items_rmrange;
@@ -1146,7 +1321,7 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
   const bufferlist &to_set_bl)
 {
   rocksdb::ColumnFamilyHandle* cf = cf_handle;
-  if (db->check_mode(cf, prefix)) {
+  if (db->cf_check_mode(cf, prefix)) {
     // special mono column family case
     // bufferlist::c_str() is non-constant, so we can't call c_str()
     if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
@@ -1313,7 +1488,7 @@ int RocksDBStore::get(
     std::map<std::string, bufferlist> *out) {
   utime_t start = ceph_clock_now();
   auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle.priv);
-  if (check_mode(cf, prefix)) {
+  if (cf_check_mode(cf, prefix)) {
     for (auto& key : keys) {
       std::string value;
       auto status = db->Get(rocksdb::ReadOptions(),
@@ -1359,7 +1534,7 @@ int RocksDBStore::get(
   string value;
   rocksdb::Status s;
   auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle.priv);
-  if (check_mode(cf, prefix)) {
+  if (cf_check_mode(cf, prefix)) {
     s = db->Get(rocksdb::ReadOptions(),
                 cf,
                 rocksdb::Slice(key),

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -339,7 +339,7 @@ int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
         }
       }
       //mark existence of new column_family
-      column_families.emplace(cf_name, ColumnFamilyData(cf_specific_options, nullptr));
+      column_families.emplace(cf_name, ColumnFamilyData(cf_specific_options, {nullptr}));
       status = rocksdb::GetColumnFamilyOptionsFromString(
           cf_opt, cf_specific_options, &cf_opt);
       if (!status.ok()) {
@@ -372,12 +372,13 @@ int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
         auto it = merge_ops.find(existing_cfs[i]);
         if (it != merge_ops.end()) {
           //this is creation of mono column family
-          cf_mono_handles.emplace(existing_cfs[i], static_cast<void*>(handles[i]));
+          cf_mono_handles.emplace(existing_cfs[i], KeyValueDB::ColumnFamilyHandle{static_cast<void*>(handles[i]) } );
         }
         //column_families.emplace(cf_name, ColumnFamilyData(cf_options, static_cast<void*>(cf_handle)));
 
         //todo fix add_column_family
-        column_families[existing_cfs[i]].handle = static_cast<void*>(handles[i]);
+        column_families[existing_cfs[i]].handle =
+            KeyValueDB::ColumnFamilyHandle{static_cast<void*>(handles[i])};
       }
     }
   }
@@ -625,10 +626,24 @@ int RocksDBStore::column_family_create(const std::string& cf_name, const std::st
   auto i = merge_ops.find(cf_name);
   if (i != merge_ops.end()) {
     //this is creation of mono column family
-    cf_mono_handles.emplace(cf_name, static_cast<void*>(cf_handle));
+    cf_mono_handles.emplace(cf_name, KeyValueDB::ColumnFamilyHandle{static_cast<void*>(cf_handle)} );
   }
-  column_families.emplace(cf_name, ColumnFamilyData(cf_options, static_cast<void*>(cf_handle)));
+  column_families.emplace(cf_name, ColumnFamilyData(cf_options,
+    KeyValueDB::ColumnFamilyHandle{ static_cast<void*>(cf_handle) } ));
   return 0;
+}
+
+int RocksDBStore::column_family_delete(const std::string& cf_name)
+{
+  return -1;
+}
+
+KeyValueDB::ColumnFamilyHandle RocksDBStore::column_family_handle(const std::string& cf_name)
+{
+  auto it = column_families.find(cf_name);
+  if (it == column_families.end())
+    return {nullptr};
+ return it->second.handle;
 }
 
 std::shared_ptr<rocksdb::MergeOperator>
@@ -662,7 +677,7 @@ RocksDBStore::~RocksDBStore()
   // Ensure db is destroyed before dependent db_cache and filterpolicy
   for (auto& p : column_families) {
     db->DestroyColumnFamilyHandle(
-      static_cast<rocksdb::ColumnFamilyHandle*>(p.second.handle));
+      static_cast<rocksdb::ColumnFamilyHandle*>(p.second.handle.priv));
   }
   if (must_close_default_cf) {
     db->DestroyColumnFamilyHandle(default_cf);
@@ -1168,10 +1183,10 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
 }
 
 void RocksDBStore::RocksDBTransactionImpl::select(
-      void* column_family_handle)
+    KeyValueDB::ColumnFamilyHandle column_family_handle)
 {
-  if (column_family_handle != nullptr)
-    cf_handle = static_cast<rocksdb::ColumnFamilyHandle *>(column_family_handle);
+  if (column_family_handle.priv != nullptr)
+    cf_handle = static_cast<rocksdb::ColumnFamilyHandle *>(column_family_handle.priv);
   else
     cf_handle = nullptr;
 }
@@ -1292,12 +1307,12 @@ int RocksDBStore::get(
 }
 
 int RocksDBStore::get(
-    void* cf_handle,
+    KeyValueDB::ColumnFamilyHandle cf_handle,
     const std::string &prefix,
     const std::set<std::string> &keys,
     std::map<std::string, bufferlist> *out) {
   utime_t start = ceph_clock_now();
-  auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle);
+  auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle.priv);
   if (check_mode(cf, prefix)) {
     for (auto& key : keys) {
       std::string value;
@@ -1333,7 +1348,7 @@ int RocksDBStore::get(
 }
 
 int RocksDBStore::get(
-    void* cf_handle,
+    KeyValueDB::ColumnFamilyHandle cf_handle,
     const string &prefix,
     const string &key,
     bufferlist *out)
@@ -1343,7 +1358,7 @@ int RocksDBStore::get(
   int r = 0;
   string value;
   rocksdb::Status s;
-  auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle);
+  auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle.priv);
   if (check_mode(cf, prefix)) {
     s = db->Get(rocksdb::ReadOptions(),
                 cf,
@@ -1394,10 +1409,10 @@ void RocksDBStore::compact()
   logger->inc(l_rocksdb_compact);
   rocksdb::CompactRangeOptions options;
   db->CompactRange(options, default_cf, nullptr, nullptr);
-  for (auto cf : cf_mono_handles) {
+  for (auto cf : column_families) {
     db->CompactRange(
       options,
-      static_cast<rocksdb::ColumnFamilyHandle*>(cf.second),
+      static_cast<rocksdb::ColumnFamilyHandle*>(cf.second.handle.priv),
       nullptr, nullptr);
   }
 }
@@ -1621,6 +1636,16 @@ RocksDBStore::WholeSpaceIterator RocksDBStore::get_wholespace_iterator()
     db->NewIterator(rocksdb::ReadOptions(), default_cf));
 }
 
+RocksDBStore::WholeSpaceIterator RocksDBStore::get_wholespace_iterator_cf(ColumnFamilyHandle cfh)
+{
+  rocksdb::ColumnFamilyHandle *cf_handle =
+      static_cast<rocksdb::ColumnFamilyHandle*>(cfh.priv);
+  if (cfh.priv == nullptr)
+      cf_handle = default_cf;
+  return std::make_shared<RocksDBWholeSpaceIteratorImpl>(
+    db->NewIterator(rocksdb::ReadOptions(), cf_handle));
+}
+
 class CFIteratorImpl : public KeyValueDB::IteratorImpl {
 protected:
   string prefix;
@@ -1697,4 +1722,15 @@ KeyValueDB::Iterator RocksDBStore::get_iterator(const std::string& prefix)
   } else {
     return KeyValueDB::get_iterator(prefix);
   }
+}
+
+KeyValueDB::Iterator RocksDBStore::get_iterator_cf(ColumnFamilyHandle cfh, const std::string& prefix)
+{
+  rocksdb::ColumnFamilyHandle *cf_handle =
+    static_cast<rocksdb::ColumnFamilyHandle*>(cfh.priv);
+  if (cfh.priv == nullptr)
+    cf_handle = default_cf;
+  return std::make_shared<CFIteratorImpl>(
+    prefix,
+    db->NewIterator(rocksdb::ReadOptions(), cf_handle));
 }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -2042,6 +2042,82 @@ public:
   }
 };
 
+class CFUnboundIteratorImpl : public KeyValueDB::IteratorImpl {
+protected:
+  string prefix;
+  rocksdb::Iterator *dbiter;
+public:
+  explicit CFUnboundIteratorImpl(const std::string& p,
+                                 rocksdb::Iterator *iter)
+    : prefix(p), dbiter(iter) { }
+  ~CFUnboundIteratorImpl() {
+    delete dbiter;
+  }
+
+  int seek_to_first() override {
+    dbiter->Seek(rocksdb::Slice(prefix));
+    //dbiter->SeekToFirst();
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int seek_to_last() override {
+    dbiter->SeekForPrev(rocksdb::Slice(prefix+"\001"));
+    if (dbiter->Valid()) dbiter->Prev();
+    //dbiter->SeekToLast();
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int upper_bound(const string &after) override {
+    lower_bound(after);
+    if (valid() && (key() == after)) {
+      next();
+    }
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int lower_bound(const string &to) override {
+    rocksdb::Slice slice_bound(prefix + "\000" + to);
+    dbiter->Seek(slice_bound);
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int next() override {
+    if (valid()) {
+      dbiter->Next();
+    }
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int prev() override {
+    if (valid()) {
+      dbiter->Prev();
+    }
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  bool valid() override {
+    if (!dbiter->Valid())
+      return false;
+    std::string p;
+    RocksDBStore::split_key(dbiter->key(), &p, nullptr);
+    return prefix == p;
+  }
+  string key() override {
+    std::string k;
+    RocksDBStore::split_key(dbiter->key(), nullptr, &k);
+    return k;
+  }
+  std::pair<std::string, std::string> raw_key() override {
+    std::string p, k;
+    RocksDBStore::split_key(dbiter->key(), &p, &k);
+    return make_pair(p, k);
+  }
+  bufferlist value() override {
+    return to_bufferlist(dbiter->value());
+  }
+  bufferptr value_as_ptr() override {
+    rocksdb::Slice val = dbiter->value();
+    return bufferptr(val.data(), val.size());
+  }
+  int status() override {
+    return dbiter->status().ok() ? 0 : -1;
+  }
+};
+
 KeyValueDB::Iterator RocksDBStore::get_iterator(const std::string& prefix)
 {
   rocksdb::ColumnFamilyHandle *cf_handle = cf_get_mono_handle(prefix);
@@ -2050,17 +2126,33 @@ KeyValueDB::Iterator RocksDBStore::get_iterator(const std::string& prefix)
       prefix,
       db->NewIterator(rocksdb::ReadOptions(), cf_handle));
   } else {
-    return KeyValueDB::get_iterator(prefix);
+    cf_handle = cf_get_handle(prefix);
+    if (cf_handle) {
+      return std::make_shared<CFUnboundIteratorImpl>(
+          prefix,
+          db->NewIterator(rocksdb::ReadOptions(), cf_handle));
+    } else {
+      return KeyValueDB::get_iterator(prefix);
+    }
   }
 }
 
 KeyValueDB::Iterator RocksDBStore::get_iterator_cf(ColumnFamilyHandle cfh, const std::string& prefix)
 {
   rocksdb::ColumnFamilyHandle *cf_handle =
-    static_cast<rocksdb::ColumnFamilyHandle*>(cfh.priv);
-  if (cfh.priv == nullptr)
-    cf_handle = default_cf;
-  return std::make_shared<CFIteratorImpl>(
-    prefix,
-    db->NewIterator(rocksdb::ReadOptions(), cf_handle));
+      static_cast<rocksdb::ColumnFamilyHandle*>(cfh.priv);
+  if (cf_handle == nullptr) {
+    cf_handle = cf_get_mono_handle(prefix);
+    if (cf_handle != nullptr) {
+      return std::make_shared<CFIteratorImpl>(
+          prefix,
+          db->NewIterator(rocksdb::ReadOptions(), cf_handle));
+    } else {
+      return KeyValueDB::get_iterator(prefix);
+    }
+  } else {
+      return std::make_shared<CFUnboundIteratorImpl>(
+          prefix,
+          db->NewIterator(rocksdb::ReadOptions(), cf_handle));
+  }
 }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -170,7 +170,9 @@ public:
 };
 
 struct RocksWBHandler: public rocksdb::WriteBatch::Handler {
-  std::string seen ;
+  RocksWBHandler(const RocksDBStore& db) : db(db) {}
+  const RocksDBStore& db;
+  std::stringstream seen ;
   int num_seen = 0;
   static string pretty_binary_string(const string& in) {
     char buf[10];
@@ -220,42 +222,69 @@ struct RocksWBHandler: public rocksdb::WriteBatch::Handler {
     }
     return out;
   }
+  void dump(const char* op_name,
+            uint32_t column_family_id,
+            const rocksdb::Slice& key,
+            const rocksdb::Slice* value = nullptr) {
+    string prefix;
+    string key_to_decode;
+    ssize_t size = value ? value->size() : -1;
+    seen << std::endl << op_name << "(";
+
+    bool mono = false;
+    if (column_family_id != 0) {
+      auto cf = db.get_cf_by_rocksdb_ID(column_family_id);
+      seen << " column family = " << cf.first;
+      if (db.get_cf_handle(cf.first) != nullptr) {
+        prefix = cf.first;
+        key_to_decode = key.ToString();
+        mono = true;
+      }
+    }
+    if (!mono) {
+      db.split_key(key, &prefix, &key_to_decode);
+    }
+    seen << " prefix = " << prefix;
+    seen << " key = " << pretty_binary_string(key_to_decode);
+    if (size != -1)
+      seen << " value size = " << std::to_string(size);
+    seen << ")";
+    num_seen++;
+  }
   void Put(const rocksdb::Slice& key,
                   const rocksdb::Slice& value) override {
-    string prefix ((key.ToString()).substr(0,1));
-    string key_to_decode ((key.ToString()).substr(2,string::npos));
-    uint64_t size = (value.ToString()).size();
-    seen += "\nPut( Prefix = " + prefix + " key = "
-          + pretty_binary_string(key_to_decode)
-          + " Value size = " + std::to_string(size) + ")";
-    num_seen++;
+    dump("Put", 0, key, &value);
+  }
+  rocksdb::Status PutCF(uint32_t column_family_id, const rocksdb::Slice& key,
+                           const rocksdb::Slice& value) override {
+    dump("PutCF", column_family_id, key, &value);
+    return rocksdb::Status::OK();
   }
   void SingleDelete(const rocksdb::Slice& key) override {
-    string prefix ((key.ToString()).substr(0,1));
-    string key_to_decode ((key.ToString()).substr(2,string::npos));
-    seen += "\nSingleDelete(Prefix = "+ prefix + " Key = "
-          + pretty_binary_string(key_to_decode) + ")";
-    num_seen++;
+    dump("SingleDelete", 0, key);
+  }
+  rocksdb::Status SingleDeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) override {
+    dump("SingleDeleteCF", column_family_id, key);
+    return rocksdb::Status::OK();
   }
   void Delete(const rocksdb::Slice& key) override {
-    string prefix ((key.ToString()).substr(0,1));
-    string key_to_decode ((key.ToString()).substr(2,string::npos));
-    seen += "\nDelete( Prefix = " + prefix + " key = "
-          + pretty_binary_string(key_to_decode) + ")";
-
-    num_seen++;
+    dump("Delete", 0, key);
   }
+  rocksdb::Status DeleteCF(uint32_t column_family_id, const rocksdb::Slice& key) override {
+    dump("DeleteCF", column_family_id, key);
+    return rocksdb::Status::OK();
+  }
+
   void Merge(const rocksdb::Slice& key,
                     const rocksdb::Slice& value) override {
-    string prefix ((key.ToString()).substr(0,1));
-    string key_to_decode ((key.ToString()).substr(2,string::npos));
-    uint64_t size = (value.ToString()).size();
-    seen += "\nMerge( Prefix = " + prefix + " key = "
-          + pretty_binary_string(key_to_decode) + " Value size = "
-          + std::to_string(size) + ")";
-
-    num_seen++;
+    dump("Merge", 0, key, &value);
   }
+  rocksdb::Status MergeCF(uint32_t column_family_id, const rocksdb::Slice& key,
+                         const rocksdb::Slice& value) override {
+    dump("MergeCF", column_family_id, key, &value);
+    return rocksdb::Status::OK();
+  }
+
   bool Continue() override { return num_seen < 50; }
 };
 
@@ -833,6 +862,17 @@ RocksDBStore::cf_get_merge_operator(const std::string& cf_name)
   return std::shared_ptr<rocksdb::MergeOperator>(new RocksDBStore::MergeOperatorAll(*this));
 }
 
+std::pair<std::string, RocksDBStore::ColumnFamilyHandle>
+RocksDBStore::get_cf_by_rocksdb_ID(uint32_t ID) const {
+  for (auto& i : column_families) {
+    rocksdb::ColumnFamilyHandle* cfh =
+      static_cast<rocksdb::ColumnFamilyHandle*>(i.second.handle.priv);
+    if (cfh->GetID() == ID)
+      return std::make_pair(cfh->GetName(), i.second.handle);
+  }
+  return std::make_pair(std::string(), ColumnFamilyHandle{nullptr});
+}
+
 int RocksDBStore::_test_init(const string& dir)
 {
   rocksdb::Options options;
@@ -1003,16 +1043,16 @@ int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Tra
     static_cast<RocksDBTransactionImpl *>(t.get());
   woptions.disableWAL = disableWAL;
   lgeneric_subdout(cct, rocksdb, 30) << __func__;
-  RocksWBHandler bat_txc;
+  RocksWBHandler bat_txc(*this);
   _t->bat.Iterate(&bat_txc);
-  *_dout << " Rocksdb transaction: " << bat_txc.seen << dendl;
+  *_dout << " Rocksdb transaction: " << bat_txc.seen.str() << dendl;
   
   rocksdb::Status s = db->Write(woptions, &_t->bat);
   if (!s.ok()) {
-    RocksWBHandler rocks_txc;
+    RocksWBHandler rocks_txc(*this);
     _t->bat.Iterate(&rocks_txc);
     derr << __func__ << " error: " << s.ToString() << " code = " << s.code()
-         << " Rocksdb transaction: " << rocks_txc.seen << dendl;
+         << " Rocksdb transaction: " << rocks_txc.seen.str() << dendl;
   }
 
   if (g_conf()->rocksdb_perf) {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -847,6 +847,107 @@ KeyValueDB::ColumnFamilyHandle RocksDBStore::column_family_handle(const std::str
  return it->second.handle;
 }
 
+int RocksDBStore::column_family_compact(const std::string& cf_name,
+                                        const string& prefix,
+                                        const string& start,
+                                        const string& end) {
+  RWLock::RLocker l(api_lock);
+  auto it = column_families.find(cf_name);
+  if (it == column_families.end())
+    return -EINVAL;
+  auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(it->second.handle.priv);
+  if (prefix.empty()) {
+    if (start.empty() && end.empty()) {
+      cf_compact(cf, string(), string());
+    } else {
+      return -EINVAL;
+    }
+  } else {
+    cf_compact(cf, combine_strings(prefix, start), combine_strings(prefix, end));
+  }
+  return 0;
+}
+
+int RocksDBStore::column_family_compact_async(const std::string& cf_name,
+                                              const string& prefix,
+                                              const string& _start,
+                                              const string& _end) {
+  RWLock::RLocker l(api_lock);
+  auto it = column_families.find(cf_name);
+  if (it == column_families.end())
+    return -EINVAL;
+  rocksdb::ColumnFamilyHandle* h = static_cast<rocksdb::ColumnFamilyHandle*>(it->second.handle.priv);
+  string start;
+  string end;
+  if (prefix.empty()) {
+    if (!_start.empty() || !_end.empty()) {
+      return -EINVAL;
+    }
+  } else {
+    start = combine_strings(prefix, _start);
+    end = combine_strings(prefix, _end);
+  }
+
+  return cf_compact_async(h, start, end);
+}
+
+int RocksDBStore::cf_compact(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end)
+{
+  rocksdb::CompactRangeOptions options;
+  rocksdb::Slice cstart;
+  rocksdb::Slice cend;
+  if (!start.empty()) {
+    cstart = rocksdb::Slice(start);
+  }
+  if (!end.empty()) {
+    cend = rocksdb::Slice(end);
+  }
+  db->CompactRange(options, cf, &cstart, &cend);
+  return 0;
+}
+
+int RocksDBStore::cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end)
+{
+  std::lock_guard ll(compact_queue_lock);
+
+  // try to merge adjacent ranges.  this is O(n), but the queue should
+  // be short.  note that we do not cover all overlap cases and merge
+  // opportunities here, but we capture the ones we currently need.
+  auto p = compact_queue.begin();
+  while (p != compact_queue.end()) {
+    if (p->cf_handle != cf) {
+      //only can merge same column families
+      p++;
+      continue;
+    }
+    if (end < p->start || p->end < start) {
+      /* no common range*/
+      p++;
+      continue;
+    }
+    compact_queue.emplace(p, cf,
+                          std::min(p->start, start),
+                          std::max(p->end, end));
+    compact_queue.erase(p);
+    logger->inc(l_rocksdb_compact_queue_merge);
+    break;
+  }
+
+  if (p == compact_queue.end()) {
+    // no merge, new entry.
+    compact_queue.emplace_back(cf, start, end);
+    logger->set(l_rocksdb_compact_queue_len, compact_queue.size());
+  }
+  compact_queue_cond.Signal();
+  if (!compact_thread.is_started()) {
+    compact_thread.create("rstore_compact");
+  }
+  return 0;
+}
+
+
+
+
 /**
  * Get merge operator for column family.
  */
@@ -1748,21 +1849,24 @@ void RocksDBStore::compact()
   }
 }
 
-
 void RocksDBStore::compact_thread_entry()
 {
   compact_queue_lock.Lock();
   while (!compact_queue_stop) {
     while (!compact_queue.empty()) {
-      pair<string,string> range = compact_queue.front();
+      compact_command range = compact_queue.front();
       compact_queue.pop_front();
       logger->set(l_rocksdb_compact_queue_len, compact_queue.size());
       compact_queue_lock.Unlock();
       logger->inc(l_rocksdb_compact_range);
-      if (range.first.empty() && range.second.empty()) {
-        compact();
+      if (range.cf_handle == nullptr) {
+        if (range.start.empty() && range.end.empty()) {
+          compact();
+        } else {
+          compact_range(range.start, range.end);
+        }
       } else {
-        compact_range(range.first, range.second);
+        /*TODO*/
       }
       compact_queue_lock.Lock();
       continue;
@@ -1774,46 +1878,9 @@ void RocksDBStore::compact_thread_entry()
 
 void RocksDBStore::compact_range_async(const string& start, const string& end)
 {
-  std::lock_guard l(compact_queue_lock);
-
-  // try to merge adjacent ranges.  this is O(n), but the queue should
-  // be short.  note that we do not cover all overlap cases and merge
-  // opportunities here, but we capture the ones we currently need.
-  list< pair<string,string> >::iterator p = compact_queue.begin();
-  while (p != compact_queue.end()) {
-    if (p->first == start && p->second == end) {
-      // dup; no-op
-      return;
-    }
-    if (start <= p->first && p->first <= end) {
-      // new region crosses start of existing range
-      // select right bound that is bigger
-      compact_queue.push_back(make_pair(start, end > p->second ? end : p->second));
-      compact_queue.erase(p);
-      logger->inc(l_rocksdb_compact_queue_merge);
-      break;
-    }
-    if (start <= p->second && p->second <= end) {
-      // new region crosses end of existing range
-      //p->first < p->second and p->second <= end, so p->first <= end.
-      //But we break if previous condition, so start > p->first.
-      compact_queue.push_back(make_pair(p->first, end));
-      compact_queue.erase(p);
-      logger->inc(l_rocksdb_compact_queue_merge);
-      break;
-    }
-    ++p;
-  }
-  if (p == compact_queue.end()) {
-    // no merge, new entry.
-    compact_queue.push_back(make_pair(start, end));
-    logger->set(l_rocksdb_compact_queue_len, compact_queue.size());
-  }
-  compact_queue_cond.Signal();
-  if (!compact_thread.is_started()) {
-    compact_thread.create("rstore_compact");
-  }
+  cf_compact_async(default_cf, start, end);
 }
+
 bool RocksDBStore::check_omap_dir(string &omap_dir)
 {
   rocksdb::Options options;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -53,6 +53,13 @@ static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl,
   return rocksdb::SliceParts(slices->data(), slices->size());
 }
 
+struct RocksDBStore::ColumnFamilyData {
+    string options;                   ///< specific configure option string for this CF
+    ColumnFamilyHandle handle;        ///< handle to column family
+    ColumnFamilyData(const string &options, ColumnFamilyHandle handle = ColumnFamilyHandle())
+      : options(options), handle(handle) {}
+    ColumnFamilyData() {}
+  };
 
 //
 // One of these for the default rocksdb column family, routing each prefix
@@ -62,7 +69,7 @@ class RocksDBStore::MergeOperatorRouter
   : public rocksdb::AssociativeMergeOperator
 {
 protected:
-  RocksDBStore& store;
+  const RocksDBStore& store;
   mutable std::string name;
 public:
   const char *Name() const override {
@@ -88,7 +95,7 @@ public:
     return name.c_str();
   }
 
-  explicit MergeOperatorRouter(RocksDBStore &_store) : store(_store) {}
+  explicit MergeOperatorRouter(const RocksDBStore &store) : store(store) {}
 
   bool Merge(const rocksdb::Slice& key,
 	     const rocksdb::Slice* existing_value,
@@ -166,7 +173,7 @@ public:
     return name.c_str();
   }
 
-  explicit MergeOperatorAll(RocksDBStore &store) : MergeOperatorRouter(store) {}
+  explicit MergeOperatorAll(const RocksDBStore &store) : MergeOperatorRouter(store) {}
 };
 
 struct RocksWBHandler: public rocksdb::WriteBatch::Handler {
@@ -233,9 +240,9 @@ struct RocksWBHandler: public rocksdb::WriteBatch::Handler {
 
     bool mono = false;
     if (column_family_id != 0) {
-      auto cf = db.get_cf_by_rocksdb_ID(column_family_id);
+      auto cf = db.cf_get_by_rocksdb_ID(column_family_id);
       seen << " column family = " << cf.first;
-      if (db.get_cf_handle(cf.first) != nullptr) {
+      if (db.cf_get_mono_handle(cf.first) != nullptr) {
         prefix = cf.first;
         key_to_decode = key.ToString();
         mono = true;
@@ -505,6 +512,17 @@ int RocksDBStore::create_db_dir()
 
 int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
 {
+  return _open(out, false, options);
+}
+
+int RocksDBStore::open_read_only(ostream &out, const std::vector<ColumnFamily>& options)
+{
+  return _open(out, true, options);
+}
+
+int RocksDBStore::_open(ostream &out, bool read_only, const std::vector<ColumnFamily>& options)
+{
+  RWLock::WLocker l(api_lock);
   int r = create_db_dir();
   if (r < 0)
     return r;
@@ -521,7 +539,11 @@ int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
   dout(1) << __func__ << " existing column families: " << existing_cfs << dendl;
   if (existing_cfs.empty()) {
     // no column families
-    status = rocksdb::DB::Open(rocksdb_options, path, &db);
+    if (read_only) {
+      status = rocksdb::DB::OpenForReadOnly(rocksdb_options, path, &db);
+    } else {
+      status = rocksdb::DB::Open(rocksdb_options, path, &db);
+    }
     if (!status.ok()) {
       derr << status.ToString() << dendl;
       return -EINVAL;
@@ -543,7 +565,7 @@ int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
         }
       }
       //mark existence of new column_family
-      column_families.emplace(cf_name, ColumnFamilyData(cf_specific_options, {nullptr}));
+      column_families.emplace(cf_name, ColumnFamilyData(cf_specific_options, ColumnFamilyHandle()));
       status = rocksdb::GetColumnFamilyOptionsFromString(
           cf_opt, cf_specific_options, &cf_opt);
       if (!status.ok()) {
@@ -558,9 +580,15 @@ int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
           rocksdb::ColumnFamilyDescriptor(cf_name, cf_opt));
     }
     std::vector<rocksdb::ColumnFamilyHandle*> handles;
-    status = rocksdb::DB::Open(rocksdb::DBOptions(rocksdb_options),
+    if (read_only) {
+      status = rocksdb::DB::OpenForReadOnly(rocksdb::DBOptions(rocksdb_options),
                                path, column_family_descriptors, &handles, &db);
 
+    } else {
+      status = rocksdb::DB::Open(rocksdb::DBOptions(rocksdb_options),
+                               path, column_family_descriptors, &handles, &db);
+    }
+    
     if (!status.ok()) {
       derr << status.ToString() << dendl;
       return -EINVAL;
@@ -576,13 +604,9 @@ int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
         auto it = merge_ops.find(existing_cfs[i]);
         if (it != merge_ops.end()) {
           //this is creation of mono column family
-          cf_mono_handles.emplace(existing_cfs[i], KeyValueDB::ColumnFamilyHandle{static_cast<void*>(handles[i]) } );
+          cf_mono_handles.emplace(existing_cfs[i], cf_wrap_handle(handles[i]));
         }
-        //column_families.emplace(cf_name, ColumnFamilyData(cf_options, static_cast<void*>(cf_handle)));
-
-        //todo fix add_column_family
-        column_families[existing_cfs[i]].handle =
-            KeyValueDB::ColumnFamilyHandle{static_cast<void*>(handles[i])};
+        column_families[existing_cfs[i]].handle = cf_wrap_handle(handles[i]);
       }
     }
   }
@@ -599,6 +623,7 @@ int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
 int RocksDBStore::create_and_open(ostream &out,
 				  const vector<ColumnFamily>& to_create)
 {
+  RWLock::WLocker l(api_lock);
   int r = create_db_dir();
   if (r < 0)
     return r;
@@ -615,7 +640,7 @@ int RocksDBStore::create_and_open(ostream &out,
   ceph_assert(default_cf != nullptr);
   r=0;
   for (size_t i=0; r==0 && i < to_create.size(); i++) {
-    r = column_family_create(to_create[i].name, to_create[i].option);
+    r = cf_create(to_create[i].name, to_create[i].option);
     if (r < 0)
       return r;
   }
@@ -788,6 +813,7 @@ void RocksDBStore::perf_counters_register()
 
 int RocksDBStore::column_family_list(vector<std::string>& cf_names)
 {
+  RWLock::RLocker l(api_lock);
   cf_names.clear();
   rocksdb::Status status;
   std::vector<string> existing_cfs;
@@ -802,6 +828,102 @@ int RocksDBStore::column_family_list(vector<std::string>& cf_names)
 }
 
 int RocksDBStore::column_family_create(const std::string& cf_name, const std::string& cf_options)
+{
+  RWLock::WLocker l(api_lock);
+  return cf_create(cf_name, cf_options);
+}
+
+int RocksDBStore::column_family_delete(const std::string& cf_name)
+{
+  return -1;
+}
+
+KeyValueDB::ColumnFamilyHandle RocksDBStore::column_family_handle(const std::string& cf_name) const
+{
+  RWLock::RLocker l(api_lock);
+  auto it = column_families.find(cf_name);
+  if (it == column_families.end())
+    return KeyValueDB::ColumnFamilyHandle();
+ return it->second.handle;
+}
+
+/**
+ * Get merge operator for column family.
+ */
+std::shared_ptr<rocksdb::MergeOperator>
+RocksDBStore::cf_get_merge_operator(const std::string& cf_name) const
+{
+  auto i = merge_ops.find(cf_name);
+  if (i != merge_ops.end()) {
+    return std::shared_ptr<rocksdb::MergeOperator>(new MergeOperatorLinker(i->second));
+  }
+  //Column family name is not exact to any defined merge operators.
+  //Use all-prefix merge operator.
+  return std::shared_ptr<rocksdb::MergeOperator>(new RocksDBStore::MergeOperatorAll(*this));
+}
+
+/**
+ * Returns handle to mono column family.
+ * Does not return handles for regular column family, even if name matches
+ */
+rocksdb::ColumnFamilyHandle* RocksDBStore::cf_get_mono_handle(const std::string& cf_name) const
+{
+  auto iter = cf_mono_handles.find(cf_name);
+  if (iter == cf_mono_handles.end())
+    return nullptr;
+  else
+    return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
+}
+
+/**
+ * Returns handle to column family.
+ * This works for both mono column families and regular column families.
+ */
+rocksdb::ColumnFamilyHandle* RocksDBStore::cf_get_handle(const std::string& cf_name) const
+{
+  auto it = column_families.find(cf_name);
+   if (it == column_families.end())
+     return nullptr;
+  return static_cast<rocksdb::ColumnFamilyHandle*>(it->second.handle.priv);
+}
+
+/**
+ * Determines how 'prefix' should be handled.
+ * It is a convenience function that allow to better structuralize conditions
+ * in functions that operate on both mono column families and regular column families.
+ *
+ * Param:
+ *  - cf [in] column family handle as requested by client
+ *       [out] fixed column family handle after redirection
+ *  - prefix [in] as requested by client
+ * Result:
+ *  true - we operate on mono column family, false - we operate on normal column family
+ */
+bool RocksDBStore::cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) const
+{
+  if (cf != nullptr) {
+    return false;
+  }
+  cf = cf_get_mono_handle(prefix);
+  if (cf != nullptr)
+    return true;
+  cf = default_cf;
+  return false;
+}
+
+std::pair<std::string, RocksDBStore::ColumnFamilyHandle>
+RocksDBStore::cf_get_by_rocksdb_ID(uint32_t ID) const
+{
+  for (auto& i : column_families) {
+    rocksdb::ColumnFamilyHandle* cfh =
+      static_cast<rocksdb::ColumnFamilyHandle*>(i.second.handle.priv);
+    if (cfh->GetID() == ID)
+      return std::make_pair(cfh->GetName(), i.second.handle);
+  }
+  return std::make_pair(std::string(), ColumnFamilyHandle());
+}
+
+int RocksDBStore::cf_create(const std::string& cf_name, const std::string& cf_options)
 {
   rocksdb::Status status;
   // copy default CF settings, block cache, merge operators as
@@ -830,48 +952,20 @@ int RocksDBStore::column_family_create(const std::string& cf_name, const std::st
   auto i = merge_ops.find(cf_name);
   if (i != merge_ops.end()) {
     //this is creation of mono column family
-    cf_mono_handles.emplace(cf_name, KeyValueDB::ColumnFamilyHandle{static_cast<void*>(cf_handle)} );
+    cf_mono_handles.emplace(cf_name, cf_wrap_handle(cf_handle));
   }
-  column_families.emplace(cf_name, ColumnFamilyData(cf_options,
-    KeyValueDB::ColumnFamilyHandle{ static_cast<void*>(cf_handle) } ));
+  column_families.emplace(cf_name, ColumnFamilyData(cf_options, cf_wrap_handle(cf_handle)));
   return 0;
 }
 
-int RocksDBStore::column_family_delete(const std::string& cf_name)
+
+KeyValueDB::ColumnFamilyHandle RocksDBStore::cf_wrap_handle(rocksdb::ColumnFamilyHandle* rocks_cfh)
 {
-  return -1;
+  KeyValueDB::ColumnFamilyHandle cfh;
+  cfh.priv = static_cast<void*>(rocks_cfh);
+  return cfh;
 }
 
-KeyValueDB::ColumnFamilyHandle RocksDBStore::column_family_handle(const std::string& cf_name)
-{
-  auto it = column_families.find(cf_name);
-  if (it == column_families.end())
-    return {nullptr};
- return it->second.handle;
-}
-
-std::shared_ptr<rocksdb::MergeOperator>
-RocksDBStore::cf_get_merge_operator(const std::string& cf_name)
-{
-  auto i = merge_ops.find(cf_name);
-  if (i != merge_ops.end()) {
-    return std::shared_ptr<rocksdb::MergeOperator>(new MergeOperatorLinker(i->second));
-  }
-  //Column family name is not exact to any defined merge operators.
-  //Use all-prefix merge operator.
-  return std::shared_ptr<rocksdb::MergeOperator>(new RocksDBStore::MergeOperatorAll(*this));
-}
-
-std::pair<std::string, RocksDBStore::ColumnFamilyHandle>
-RocksDBStore::get_cf_by_rocksdb_ID(uint32_t ID) const {
-  for (auto& i : column_families) {
-    rocksdb::ColumnFamilyHandle* cfh =
-      static_cast<rocksdb::ColumnFamilyHandle*>(i.second.handle.priv);
-    if (cfh->GetID() == ID)
-      return std::make_pair(cfh->GetName(), i.second.handle);
-  }
-  return std::make_pair(std::string(), ColumnFamilyHandle{nullptr});
-}
 
 int RocksDBStore::_test_init(const string& dir)
 {
@@ -883,6 +977,25 @@ int RocksDBStore::_test_init(const string& dir)
   db = nullptr;
   return status.ok() ? 0 : -EIO;
 }
+
+RocksDBStore::RocksDBStore(CephContext *c, const string &path, map<string,string> opt, void *p) :
+  cct(c),
+  logger(NULL),
+  path(path),
+  kv_options(opt),
+  priv(p),
+  db(NULL),
+  env(static_cast<rocksdb::Env*>(p)),
+  dbstats(NULL),
+  api_lock("RocksDBStore::api_lock"),
+  compact_queue_lock("RocksDBStore::compact_thread_lock"),
+  compact_queue_stop(false),
+  compact_thread(this),
+  compact_on_mount(false),
+  disableWAL(false),
+  enable_rmrange(cct->_conf->rocksdb_enable_rmrange),
+  max_items_rmrange(cct->_conf.get_val<uint64_t>("rocksdb_max_items_rmrange"))
+{}
 
 RocksDBStore::~RocksDBStore()
 {
@@ -951,14 +1064,17 @@ void RocksDBStore::split_stats(const std::string &s, char delim, std::vector<std
     }
 }
 
-int64_t RocksDBStore::estimate_prefix_size(const string& prefix)
+int64_t RocksDBStore::estimate_prefix_size(const string& prefix,
+                                           KeyValueDB::ColumnFamilyHandle cfh)
 {
-  auto cf = get_cf_handle(prefix);
+  rocksdb::ColumnFamilyHandle* cf =
+    static_cast<rocksdb::ColumnFamilyHandle *>(cfh.priv);
+  bool is_mono = cf_check_mode(cf, prefix);
   uint64_t size = 0;
   uint8_t flags =
     //rocksdb::DB::INCLUDE_MEMTABLES |  // do not include memtables...
     rocksdb::DB::INCLUDE_FILES;
-  if (cf) {
+  if (is_mono) {
     string start(1, '\x00');
     string limit("\xff\xff\xff\xff");
     rocksdb::Range r(start, limit);
@@ -966,7 +1082,7 @@ int64_t RocksDBStore::estimate_prefix_size(const string& prefix)
   } else {
     string limit = prefix + "\xff\xff\xff\xff";
     rocksdb::Range r(prefix, limit);
-    db->GetApproximateSizes(default_cf,
+    db->GetApproximateSizes(cf,
 			    &r, 1, &size, flags);
   }
   return size;
@@ -1412,7 +1528,7 @@ int RocksDBStore::get(
     std::map<string, bufferlist> *out)
 {
   utime_t start = ceph_clock_now();
-  auto cf = get_cf_handle(prefix);
+  auto cf = cf_get_mono_handle(prefix);
   if (cf) {
     for (auto& key : keys) {
       std::string value;
@@ -1457,7 +1573,7 @@ int RocksDBStore::get(
   int r = 0;
   string value;
   rocksdb::Status s;
-  auto cf = get_cf_handle(prefix);
+  auto cf = cf_get_mono_handle(prefix);
   if (cf) {
     s = db->Get(rocksdb::ReadOptions(),
 		cf,
@@ -1494,7 +1610,7 @@ int RocksDBStore::get(
   int r = 0;
   string value;
   rocksdb::Status s;
-  auto cf = get_cf_handle(prefix);
+  auto cf = cf_get_mono_handle(prefix);
   if (cf) {
     s = db->Get(rocksdb::ReadOptions(),
 		cf,
@@ -1928,8 +2044,7 @@ public:
 
 KeyValueDB::Iterator RocksDBStore::get_iterator(const std::string& prefix)
 {
-  rocksdb::ColumnFamilyHandle *cf_handle =
-    static_cast<rocksdb::ColumnFamilyHandle*>(get_cf_handle(prefix));
+  rocksdb::ColumnFamilyHandle *cf_handle = cf_get_mono_handle(prefix);
   if (cf_handle) {
     return std::make_shared<CFIteratorImpl>(
       prefix,

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -2143,7 +2143,8 @@ public:
     return dbiter->status().ok() ? 0 : -1;
   }
   int lower_bound(const string &to) override {
-    rocksdb::Slice slice_bound(prefix + "\000" + to);
+    string bound = RocksDBStore::combine_strings(prefix, to);
+    rocksdb::Slice slice_bound(bound);
     dbiter->Seek(slice_bound);
     return dbiter->status().ok() ? 0 : -1;
   }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -597,7 +597,7 @@ int RocksDBStore::_open(ostream &out, bool read_only, const std::vector<ColumnFa
     for (size_t i = 0; i < existing_cfs.size(); ++i) {
       if (existing_cfs[i] == rocksdb::kDefaultColumnFamilyName) {
         default_cf = handles[i];
-        must_close_default_cf = true;
+        column_families[existing_cfs[i]].handle = cf_wrap_handle(default_cf);
       } else {
         // add_column_family(existing_cfs[i], static_cast<void*>(handles[i]));
         // store the new CF handle
@@ -1117,10 +1117,6 @@ RocksDBStore::~RocksDBStore()
   for (auto& p : column_families) {
     db->DestroyColumnFamilyHandle(
       static_cast<rocksdb::ColumnFamilyHandle*>(p.second.handle.priv));
-  }
-  if (must_close_default_cf) {
-    db->DestroyColumnFamilyHandle(default_cf);
-    must_close_default_cf = false;
   }
   default_cf = nullptr;
   delete db;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -74,7 +74,10 @@ public:
     for (auto& p : store.merge_ops) {
       names[p.first] = p.second->name();
     }
-    for (auto& p : store.cf_handles) {
+    //TODO: name of merge operator excludes prefixes for mono tables
+    //TODO: this makes it difficult to merge data back to main table
+    //TODO: regardless of cranky name, this should handle all prefixes?
+    for (auto& p : store.cf_mono_handles) {
       names.erase(p.first);
     }
     for (auto& p : names) {
@@ -153,7 +156,7 @@ int RocksDBStore::set_merge_operator(
 {
   // If you fail here, it's because you can't do this on an open database
   ceph_assert(db == nullptr);
-  merge_ops.push_back(std::make_pair(prefix,mop));
+  merge_ops.emplace(prefix, mop);
   return 0;
 }
 
@@ -296,31 +299,124 @@ int RocksDBStore::create_db_dir()
   return 0;
 }
 
-int RocksDBStore::install_cf_mergeop(
-  const string &cf_name,
-  rocksdb::ColumnFamilyOptions *cf_opt)
+int RocksDBStore::open(ostream &out, const std::vector<ColumnFamily>& options)
 {
-  ceph_assert(cf_opt != nullptr);
-  cf_opt->merge_operator.reset();
-  for (auto& i : merge_ops) {
-    if (i.first == cf_name) {
-      cf_opt->merge_operator.reset(new MergeOperatorLinker(i.second));
+  int r = create_db_dir();
+  if (r < 0)
+    return r;
+  r = load_rocksdb_options(false, rocksdb_options);
+  if (r) {
+    dout(1) << __func__ << " load rocksdb options failed" << dendl;
+    return r;
+  }
+
+  rocksdb::Status status;
+  std::vector<string> existing_cfs;
+  status = rocksdb::DB::ListColumnFamilies(
+    rocksdb::DBOptions(rocksdb_options), path, &existing_cfs);
+  dout(1) << __func__ << " existing column families: " << existing_cfs << dendl;
+  if (existing_cfs.empty()) {
+    // no column families
+    status = rocksdb::DB::Open(rocksdb_options, path, &db);
+    if (!status.ok()) {
+      derr << status.ToString() << dendl;
+      return -EINVAL;
     }
+    default_cf = db->DefaultColumnFamily();
+  } else {
+    // we cannot change column families for a created database.  so, map
+    // what options we are given to whatever cf's already exist.
+    std::vector<rocksdb::ColumnFamilyDescriptor> column_family_descriptors;
+    for (auto& cf_name : existing_cfs) {
+      // copy default CF settings, block cache, merge operators as
+      // the base for new CF
+      rocksdb::ColumnFamilyOptions cf_opt(rocksdb_options);
+      std::string cf_specific_options;
+      for (auto& i : options) {
+        if (i.name == cf_name) {
+          cf_specific_options = i.option;
+          break;
+        }
+      }
+      //mark existence of new column_family
+      column_families.emplace(cf_name, ColumnFamilyData(cf_specific_options, nullptr));
+      status = rocksdb::GetColumnFamilyOptionsFromString(
+          cf_opt, cf_specific_options, &cf_opt);
+      if (!status.ok()) {
+        derr << __func__ << " invalid db column family options for CF '"
+            << cf_name << "': " << cf_specific_options << dendl;
+        return -EINVAL;
+      }
+      //find proper merge operator for column family
+      std::shared_ptr<rocksdb::MergeOperator> mo = cf_get_merge_operator(cf_name);
+      cf_opt.merge_operator = mo;
+      column_family_descriptors.push_back(
+          rocksdb::ColumnFamilyDescriptor(cf_name, cf_opt));
+    }
+    std::vector<rocksdb::ColumnFamilyHandle*> handles;
+    status = rocksdb::DB::Open(rocksdb::DBOptions(rocksdb_options),
+                               path, column_family_descriptors, &handles, &db);
+
+    if (!status.ok()) {
+      derr << status.ToString() << dendl;
+      return -EINVAL;
+    }
+
+    for (size_t i = 0; i < existing_cfs.size(); ++i) {
+      if (existing_cfs[i] == rocksdb::kDefaultColumnFamilyName) {
+        default_cf = handles[i];
+        must_close_default_cf = true;
+      } else {
+        // add_column_family(existing_cfs[i], static_cast<void*>(handles[i]));
+        // store the new CF handle
+        auto it = merge_ops.find(existing_cfs[i]);
+        if (it != merge_ops.end()) {
+          //this is creation of mono column family
+          cf_mono_handles.emplace(existing_cfs[i], static_cast<void*>(handles[i]));
+        }
+        //column_families.emplace(cf_name, ColumnFamilyData(cf_options, static_cast<void*>(cf_handle)));
+
+        //todo fix add_column_family
+        column_families[existing_cfs[i]].handle = static_cast<void*>(handles[i]);
+      }
+    }
+  }
+  ceph_assert(default_cf != nullptr);
+  perf_counters_register();
+  if (compact_on_mount) {
+    derr << "Compacting rocksdb store..." << dendl;
+    compact();
+    derr << "Finished compacting rocksdb store" << dendl;
   }
   return 0;
 }
 
 int RocksDBStore::create_and_open(ostream &out,
-				  const vector<ColumnFamily>& cfs)
+				  const vector<ColumnFamily>& to_create)
 {
   int r = create_db_dir();
   if (r < 0)
     return r;
-  if (cfs.empty()) {
-    return do_open(out, true, false, nullptr);
-  } else {
-    return do_open(out, true, false, &cfs);
+  r = load_rocksdb_options(true, rocksdb_options);
+  if (r < 0)
+    return r;
+  rocksdb::Status status;
+  status = rocksdb::DB::Open(rocksdb_options, path, &db);
+  if (!status.ok()) {
+    derr << status.ToString() << dendl;
+    return -EINVAL;
   }
+  default_cf = db->DefaultColumnFamily();
+  ceph_assert(default_cf != nullptr);
+  r=0;
+  for (size_t i=0; r==0 && i < to_create.size(); i++) {
+    r = column_family_create(to_create[i].name, to_create[i].option);
+    if (r < 0)
+      return r;
+  }
+  perf_counters_register();
+
+  return r;
 }
 
 int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options& opt)
@@ -463,128 +559,8 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
   return 0;
 }
 
-int RocksDBStore::do_open(ostream &out,
-			  bool create_if_missing,
-			  bool open_readonly,
-			  const vector<ColumnFamily>* cfs)
+void RocksDBStore::perf_counters_register()
 {
-  ceph_assert(!(create_if_missing && open_readonly));
-  rocksdb::Options opt;
-  int r = load_rocksdb_options(create_if_missing, opt);
-  if (r) {
-    dout(1) << __func__ << " load rocksdb options failed" << dendl;
-    return r;
-  }
-  rocksdb::Status status;
-  if (create_if_missing) {
-    status = rocksdb::DB::Open(opt, path, &db);
-    if (!status.ok()) {
-      derr << status.ToString() << dendl;
-      return -EINVAL;
-    }
-    // create and open column families
-    if (cfs) {
-      for (auto& p : *cfs) {
-	// copy default CF settings, block cache, merge operators as
-	// the base for new CF
-	rocksdb::ColumnFamilyOptions cf_opt(opt);
-	// user input options will override the base options
-	status = rocksdb::GetColumnFamilyOptionsFromString(
-	  cf_opt, p.option, &cf_opt);
-	if (!status.ok()) {
-	  derr << __func__ << " invalid db column family option string for CF: "
-	       << p.name << dendl;
-	  return -EINVAL;
-	}
-	install_cf_mergeop(p.name, &cf_opt);
-	rocksdb::ColumnFamilyHandle *cf;
-	status = db->CreateColumnFamily(cf_opt, p.name, &cf);
-	if (!status.ok()) {
-	  derr << __func__ << " Failed to create rocksdb column family: "
-	       << p.name << dendl;
-	  return -EINVAL;
-	}
-	// store the new CF handle
-	add_column_family(p.name, static_cast<void*>(cf));
-      }
-    }
-    default_cf = db->DefaultColumnFamily();
-  } else {
-    std::vector<string> existing_cfs;
-    status = rocksdb::DB::ListColumnFamilies(
-      rocksdb::DBOptions(opt),
-      path,
-      &existing_cfs);
-    dout(1) << __func__ << " column families: " << existing_cfs << dendl;
-    if (existing_cfs.empty()) {
-      // no column families
-      if (open_readonly) {
-	status = rocksdb::DB::Open(opt, path, &db);
-      } else {
-	status = rocksdb::DB::OpenForReadOnly(opt, path, &db);
-      }
-      if (!status.ok()) {
-	derr << status.ToString() << dendl;
-	return -EINVAL;
-      }
-      default_cf = db->DefaultColumnFamily();
-    } else {
-      // we cannot change column families for a created database.  so, map
-      // what options we are given to whatever cf's already exist.
-      std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
-      for (auto& n : existing_cfs) {
-	// copy default CF settings, block cache, merge operators as
-	// the base for new CF
-	rocksdb::ColumnFamilyOptions cf_opt(opt);
-	bool found = false;
-	if (cfs) {
-	  for (auto& i : *cfs) {
-	    if (i.name == n) {
-	      found = true;
-	      status = rocksdb::GetColumnFamilyOptionsFromString(
-		cf_opt, i.option, &cf_opt);
-	      if (!status.ok()) {
-		derr << __func__ << " invalid db column family options for CF '"
-		     << i.name << "': " << i.option << dendl;
-		return -EINVAL;
-	      }
-	    }
-	  }
-	}
-	if (n != rocksdb::kDefaultColumnFamilyName) {
-	  install_cf_mergeop(n, &cf_opt);
-	}
-	column_families.push_back(rocksdb::ColumnFamilyDescriptor(n, cf_opt));
-	if (!found && n != rocksdb::kDefaultColumnFamilyName) {
-	  dout(1) << __func__ << " column family '" << n
-		  << "' exists but not expected" << dendl;
-	}
-      }
-      std::vector<rocksdb::ColumnFamilyHandle*> handles;
-      if (open_readonly) {
-        status = rocksdb::DB::OpenForReadOnly(rocksdb::DBOptions(opt),
-				              path, column_families,
-					      &handles, &db);
-      } else {
-        status = rocksdb::DB::Open(rocksdb::DBOptions(opt),
-				   path, column_families, &handles, &db);
-      }
-      if (!status.ok()) {
-	derr << status.ToString() << dendl;
-	return -EINVAL;
-      }
-      for (unsigned i = 0; i < existing_cfs.size(); ++i) {
-	if (existing_cfs[i] == rocksdb::kDefaultColumnFamilyName) {
-	  default_cf = handles[i];
-	  must_close_default_cf = true;
-	} else {
-	  add_column_family(existing_cfs[i], static_cast<void*>(handles[i]));
-	}
-      }
-    }
-  }
-  ceph_assert(default_cf != nullptr);
-  
   PerfCountersBuilder plb(g_ceph_context, "rocksdb", l_rocksdb_first, l_rocksdb_last);
   plb.add_u64_counter(l_rocksdb_gets, "get", "Gets");
   plb.add_u64_counter(l_rocksdb_txns, "submit_transaction", "Submit transactions");
@@ -599,17 +575,72 @@ int RocksDBStore::do_open(ostream &out,
   plb.add_time_avg(l_rocksdb_write_wal_time, "rocksdb_write_wal_time", "Rocksdb write wal time");
   plb.add_time_avg(l_rocksdb_write_memtable_time, "rocksdb_write_memtable_time", "Rocksdb write memtable time");
   plb.add_time_avg(l_rocksdb_write_delay_time, "rocksdb_write_delay_time", "Rocksdb write delay time");
-  plb.add_time_avg(l_rocksdb_write_pre_and_post_process_time, 
+  plb.add_time_avg(l_rocksdb_write_pre_and_post_process_time,
       "rocksdb_write_pre_and_post_time", "total time spent on writing a record, excluding write process");
   logger = plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
+}
 
-  if (compact_on_mount) {
-    derr << "Compacting rocksdb store..." << dendl;
-    compact();
-    derr << "Finished compacting rocksdb store" << dendl;
+int RocksDBStore::column_family_list(vector<std::string>& cf_names)
+{
+  cf_names.clear();
+  rocksdb::Status status;
+  std::vector<string> existing_cfs;
+  status = rocksdb::DB::ListColumnFamilies(
+    rocksdb::DBOptions(rocksdb_options), path, &existing_cfs);
+  if (!status.ok()) {
+    derr << status.ToString() << dendl;
+    return -EINVAL;
   }
+  cf_names = existing_cfs;
   return 0;
+}
+
+int RocksDBStore::column_family_create(const std::string& cf_name, const std::string& cf_options)
+{
+  rocksdb::Status status;
+  // copy default CF settings, block cache, merge operators as
+  // the base for new CF
+  rocksdb::ColumnFamilyOptions cf_opt(rocksdb_options);
+  // user input options will override the base options
+  status = rocksdb::GetColumnFamilyOptionsFromString(
+      cf_opt, cf_options, &cf_opt);
+  if (!status.ok()) {
+    derr << __func__ << " invalid db column family option string for CF: "
+        << cf_name << dendl;
+    return -EINVAL;
+  }
+  // find proper merge operator for column family
+  std::shared_ptr<rocksdb::MergeOperator> mo = cf_get_merge_operator(cf_name);
+  cf_opt.merge_operator = mo;
+
+  rocksdb::ColumnFamilyHandle *cf_handle;
+  status = db->CreateColumnFamily(cf_opt, cf_name, &cf_handle);
+  if (!status.ok()) {
+    derr << __func__ << " Failed to create rocksdb column family: "
+        << cf_name << dendl;
+    return -EINVAL;
+  }
+  // store the new CF handle
+  auto i = merge_ops.find(cf_name);
+  if (i != merge_ops.end()) {
+    //this is creation of mono column family
+    cf_mono_handles.emplace(cf_name, static_cast<void*>(cf_handle));
+  }
+  column_families.emplace(cf_name, ColumnFamilyData(cf_options, static_cast<void*>(cf_handle)));
+  return 0;
+}
+
+std::shared_ptr<rocksdb::MergeOperator>
+RocksDBStore::cf_get_merge_operator(const std::string& cf_name)
+{
+  auto i = merge_ops.find(cf_name);
+  if (i != merge_ops.end()) {
+    return std::shared_ptr<rocksdb::MergeOperator>(new MergeOperatorLinker(i->second));
+  }
+  //Column family name is not exact to any defined merge operators.
+  //Use all-prefix merge operator.
+  return std::shared_ptr<rocksdb::MergeOperator>(new MergeOperatorRouter(*this));
 }
 
 int RocksDBStore::_test_init(const string& dir)
@@ -629,10 +660,9 @@ RocksDBStore::~RocksDBStore()
   delete logger;
 
   // Ensure db is destroyed before dependent db_cache and filterpolicy
-  for (auto& p : cf_handles) {
+  for (auto& p : column_families) {
     db->DestroyColumnFamilyHandle(
-      static_cast<rocksdb::ColumnFamilyHandle*>(p.second));
-    p.second = nullptr;
+      static_cast<rocksdb::ColumnFamilyHandle*>(p.second.handle));
   }
   if (must_close_default_cf) {
     db->DestroyColumnFamilyHandle(default_cf);
@@ -849,9 +879,7 @@ int RocksDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
 }
 
 RocksDBStore::RocksDBTransactionImpl::RocksDBTransactionImpl(RocksDBStore *_db)
-{
-  db = _db;
-}
+: db(_db), cf_handle(nullptr) {}
 
 void RocksDBStore::RocksDBTransactionImpl::put_bat(
   rocksdb::WriteBatch& bat,
@@ -879,12 +907,12 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const string &k,
   const bufferlist &to_set_bl)
 {
-  auto cf = db->get_cf_handle(prefix);
-  if (cf) {
+  rocksdb::ColumnFamilyHandle* cf = cf_handle;
+  if (db->check_mode(cf, prefix)) {
     put_bat(bat, cf, k, to_set_bl);
   } else {
     string key = combine_strings(prefix, k);
-    put_bat(bat, db->default_cf, key, to_set_bl);
+    put_bat(bat, cf, key, to_set_bl);
   }
 }
 
@@ -893,8 +921,8 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const char *k, size_t keylen,
   const bufferlist &to_set_bl)
 {
-  auto cf = db->get_cf_handle(prefix);
-  if (cf) {
+  rocksdb::ColumnFamilyHandle* cf = cf_handle;
+  if (db->check_mode(cf, prefix)) {
     string key(k, keylen);  // fixme?
     put_bat(bat, cf, key, to_set_bl);
   } else {
@@ -907,11 +935,11 @@ void RocksDBStore::RocksDBTransactionImpl::set(
 void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const string &k)
 {
-  auto cf = db->get_cf_handle(prefix);
-  if (cf) {
+  rocksdb::ColumnFamilyHandle* cf = cf_handle;
+  if (db->check_mode(cf, prefix)) {
     bat.Delete(cf, rocksdb::Slice(k));
   } else {
-    bat.Delete(db->default_cf, combine_strings(prefix, k));
+    bat.Delete(cf, combine_strings(prefix, k));
   }
 }
 
@@ -919,31 +947,31 @@ void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const char *k,
 						 size_t keylen)
 {
-  auto cf = db->get_cf_handle(prefix);
-  if (cf) {
+  rocksdb::ColumnFamilyHandle* cf = cf_handle;
+  if (db->check_mode(cf, prefix)) {
     bat.Delete(cf, rocksdb::Slice(k, keylen));
   } else {
     string key;
     combine_strings(prefix, k, keylen, &key);
-    bat.Delete(db->default_cf, rocksdb::Slice(key));
+    bat.Delete(cf, rocksdb::Slice(key));
   }
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 					                 const string &k)
 {
-  auto cf = db->get_cf_handle(prefix);
-  if (cf) {
+  rocksdb::ColumnFamilyHandle* cf = cf_handle;
+  if (db->check_mode(cf, prefix)) {
     bat.SingleDelete(cf, k);
   } else {
-    bat.SingleDelete(db->default_cf, combine_strings(prefix, k));
+    bat.SingleDelete(cf, combine_strings(prefix, k));
   }
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
 {
-  auto cf = db->get_cf_handle(prefix);
-  if (cf) {
+  rocksdb::ColumnFamilyHandle* cf = cf_handle;
+  if (db->check_mode(cf, prefix)) {
     if (db->enable_rmrange) {
       string endprefix("\xff\xff\xff\xff");  // FIXME: this is cheating...
       if (db->max_items_rmrange) {
@@ -986,17 +1014,17 @@ void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix
              it->next()) {
           if (!cnt) {
             bat.RollbackToSavePoint();
-            bat.DeleteRange(db->default_cf,
+            bat.DeleteRange(cf,
                 combine_strings(prefix, string()),
                 combine_strings(endprefix, string()));
             return;
           }
-          bat.Delete(db->default_cf, combine_strings(prefix, it->key()));
+          bat.Delete(cf, combine_strings(prefix, it->key()));
           --cnt;
         }
         bat.PopSavePoint();
       } else {
-        bat.DeleteRange(db->default_cf,
+        bat.DeleteRange(cf,
             combine_strings(prefix, string()),
             combine_strings(endprefix, string()));
       }
@@ -1005,7 +1033,7 @@ void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix
       for (it->seek_to_first();
 	   it->valid();
 	   it->next()) {
-	bat.Delete(db->default_cf, combine_strings(prefix, it->key()));
+	bat.Delete(cf, combine_strings(prefix, it->key()));
       }
     }
   }
@@ -1015,8 +1043,8 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
                                                          const string &start,
                                                          const string &end)
 {
-  auto cf = db->get_cf_handle(prefix);
-  if (cf) {
+  rocksdb::ColumnFamilyHandle* cf = cf_handle;
+  if (db->check_mode(cf, prefix)) {
     if (db->enable_rmrange) {
       if (db->max_items_rmrange) {
         uint64_t cnt = db->max_items_rmrange;
@@ -1065,12 +1093,12 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
           if (!cnt) {
             bat.RollbackToSavePoint();
             bat.DeleteRange(
-                db->default_cf,
+                cf,
                 rocksdb::Slice(combine_strings(prefix, start)),
                 rocksdb::Slice(combine_strings(prefix, end)));
             return;
           }
-          bat.Delete(db->default_cf,
+          bat.Delete(cf,
           combine_strings(prefix, it->key()));
           it->next();
           --cnt;
@@ -1078,18 +1106,18 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
         bat.PopSavePoint();
       } else {
         bat.DeleteRange(
-            db->default_cf,
+            cf,
             rocksdb::Slice(combine_strings(prefix, start)),
             rocksdb::Slice(combine_strings(prefix, end)));
       }
     } else {
-      auto it = db->get_iterator(prefix);
+      auto it = db->get_iterator(prefix); //FIXME iterator over proper column family
       it->lower_bound(start);
       while (it->valid()) {
 	if (it->key() >= end) {
 	  break;
 	}
-	bat.Delete(db->default_cf,
+	bat.Delete(cf,
 		   combine_strings(prefix, it->key()));
 	it->next();
       }
@@ -1102,39 +1130,50 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
   const string &k,
   const bufferlist &to_set_bl)
 {
-  auto cf = db->get_cf_handle(prefix);
-  if (cf) {
+  rocksdb::ColumnFamilyHandle* cf = cf_handle;
+  if (db->check_mode(cf, prefix)) {
+    // special mono column family case
     // bufferlist::c_str() is non-constant, so we can't call c_str()
     if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
       bat.Merge(
-	cf,
-	rocksdb::Slice(k),
-	rocksdb::Slice(to_set_bl.buffers().front().c_str(), to_set_bl.length()));
+       cf,
+       rocksdb::Slice(k),
+       rocksdb::Slice(to_set_bl.buffers().front().c_str(), to_set_bl.length()));
     } else {
       // make a copy
       rocksdb::Slice key_slice(k);
       vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
       bat.Merge(cf, rocksdb::SliceParts(&key_slice, 1),
-		prepare_sliceparts(to_set_bl, &value_slices));
+                prepare_sliceparts(to_set_bl, &value_slices));
     }
+    return;
   } else {
     string key = combine_strings(prefix, k);
     // bufferlist::c_str() is non-constant, so we can't call c_str()
     if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
       bat.Merge(
-	db->default_cf,
-	rocksdb::Slice(key),
-	rocksdb::Slice(to_set_bl.buffers().front().c_str(), to_set_bl.length()));
+       cf,
+       rocksdb::Slice(key),
+       rocksdb::Slice(to_set_bl.buffers().front().c_str(), to_set_bl.length()));
     } else {
       // make a copy
       rocksdb::Slice key_slice(key);
       vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
       bat.Merge(
-	db->default_cf,
-	rocksdb::SliceParts(&key_slice, 1),
-	prepare_sliceparts(to_set_bl, &value_slices));
+       cf,
+       rocksdb::SliceParts(&key_slice, 1),
+       prepare_sliceparts(to_set_bl, &value_slices));
     }
   }
+}
+
+void RocksDBStore::RocksDBTransactionImpl::select(
+      void* column_family_handle)
+{
+  if (column_family_handle != nullptr)
+    cf_handle = static_cast<rocksdb::ColumnFamilyHandle *>(column_family_handle);
+  else
+    cf_handle = nullptr;
 }
 
 int RocksDBStore::get(
@@ -1252,6 +1291,84 @@ int RocksDBStore::get(
   return r;
 }
 
+int RocksDBStore::get(
+    void* cf_handle,
+    const std::string &prefix,
+    const std::set<std::string> &keys,
+    std::map<std::string, bufferlist> *out) {
+  utime_t start = ceph_clock_now();
+  auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle);
+  if (check_mode(cf, prefix)) {
+    for (auto& key : keys) {
+      std::string value;
+      auto status = db->Get(rocksdb::ReadOptions(),
+                            cf,
+                            rocksdb::Slice(key),
+                            &value);
+      if (status.ok()) {
+        (*out)[key].append(value);
+      } else if (status.IsIOError()) {
+        ceph_abort_msg(status.getState());
+      }
+    }
+  } else {
+    for (auto& key : keys) {
+      std::string value;
+      string k = combine_strings(prefix, key);
+      auto status = db->Get(rocksdb::ReadOptions(),
+                            cf,
+                            rocksdb::Slice(k),
+                            &value);
+      if (status.ok()) {
+        (*out)[key].append(value);
+      } else if (status.IsIOError()) {
+        ceph_abort_msg(status.getState());
+      }
+    }
+  }
+  utime_t lat = ceph_clock_now() - start;
+  logger->inc(l_rocksdb_gets);
+  logger->tinc(l_rocksdb_get_latency, lat);
+  return 0;
+}
+
+int RocksDBStore::get(
+    void* cf_handle,
+    const string &prefix,
+    const string &key,
+    bufferlist *out)
+{
+  ceph_assert(out && (out->length() == 0));
+  utime_t start = ceph_clock_now();
+  int r = 0;
+  string value;
+  rocksdb::Status s;
+  auto cf = static_cast<rocksdb::ColumnFamilyHandle*>(cf_handle);
+  if (check_mode(cf, prefix)) {
+    s = db->Get(rocksdb::ReadOptions(),
+                cf,
+                rocksdb::Slice(key),
+                &value);
+  } else {
+    string k = combine_strings(prefix, key);
+    s = db->Get(rocksdb::ReadOptions(),
+                cf,
+                rocksdb::Slice(k),
+                &value);
+  }
+  if (s.ok()) {
+    out->append(value);
+  } else if (s.IsNotFound()) {
+    r = -ENOENT;
+  } else {
+    ceph_abort_msg(s.getState());
+  }
+  utime_t lat = ceph_clock_now() - start;
+  logger->inc(l_rocksdb_gets);
+  logger->tinc(l_rocksdb_get_latency, lat);
+  return r;
+}
+
 int RocksDBStore::split_key(rocksdb::Slice in, string *prefix, string *key)
 {
   size_t prefix_len = 0;
@@ -1277,7 +1394,7 @@ void RocksDBStore::compact()
   logger->inc(l_rocksdb_compact);
   rocksdb::CompactRangeOptions options;
   db->CompactRange(options, default_cf, nullptr, nullptr);
-  for (auto cf : cf_handles) {
+  for (auto cf : cf_mono_handles) {
     db->CompactRange(
       options,
       static_cast<rocksdb::ColumnFamilyHandle*>(cf.second),

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -85,7 +85,6 @@ private:
   uint64_t cache_size = 0;
   bool set_cache_flag = false;
 
-  bool must_close_default_cf = false;
   rocksdb::ColumnFamilyHandle *default_cf = nullptr;
   RWLock api_lock;
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -25,6 +25,7 @@
 #include "common/Cond.h"
 #include "common/ceph_context.h"
 #include "common/PriorityCache.h"
+#include "common/RWLock.h"
 
 class PerfCounters;
 
@@ -65,11 +66,11 @@ namespace rocksdb{
 }
 
 extern rocksdb::Logger *create_rocksdb_ceph_logger();
-
 /**
  * Uses RocksDB to implement the KeyValueDB interface
  */
 class RocksDBStore : public KeyValueDB {
+private:
   CephContext *cct;
   PerfCounters *logger;
   string path;
@@ -86,7 +87,7 @@ class RocksDBStore : public KeyValueDB {
 
   bool must_close_default_cf = false;
   rocksdb::ColumnFamilyHandle *default_cf = nullptr;
-
+  RWLock api_lock;
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);
 
   int create_db_dir();
@@ -97,6 +98,7 @@ class RocksDBStore : public KeyValueDB {
   Cond compact_queue_cond;
   list< pair<string,string> > compact_queue;
   bool compact_queue_stop;
+
   class CompactThread : public Thread {
     RocksDBStore *db;
   public:
@@ -144,111 +146,42 @@ public:
     compact_range_async(combine_strings(prefix, start), combine_strings(prefix, end));
   }
 
-  RocksDBStore(CephContext *c, const string &path, map<string,string> opt, void *p) :
-    cct(c),
-    logger(NULL),
-    path(path),
-    kv_options(opt),
-    priv(p),
-    db(NULL),
-    env(static_cast<rocksdb::Env*>(p)),
-    dbstats(NULL),
-    compact_queue_lock("RocksDBStore::compact_thread_lock"),
-    compact_queue_stop(false),
-    compact_thread(this),
-    compact_on_mount(false),
-    disableWAL(false),
-    enable_rmrange(cct->_conf->rocksdb_enable_rmrange),
-    max_items_rmrange(cct->_conf.get_val<uint64_t>("rocksdb_max_items_rmrange"))
-  {}
-
+  RocksDBStore(CephContext *c, const string &path, map<string,string> opt, void *p);
   ~RocksDBStore() override;
 
   static bool check_omap_dir(string &omap_dir);
   int open(ostream &out, const std::vector<ColumnFamily>& options = {}) override;
   /// Creates underlying db if missing and opens it
   int create_and_open(ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override;
-
-  int open_read_only(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
-    return do_open(out, false, true, &cfs);
-  }
-
+  int open_read_only(ostream &out, const vector<ColumnFamily>& cfs = {}) override;
+  
   void close() override;
 
   int column_family_list(vector<std::string>& cf_names) override;
   int column_family_create(const std::string& name, const std::string& options) override;
   int column_family_delete(const std::string& name) override;
-  KeyValueDB::ColumnFamilyHandle column_family_handle(const std::string& cf_name) override;
+  KeyValueDB::ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override;
 
 private:
-  /*
-   * Get merge operator for column family.
-   */
-  std::shared_ptr<rocksdb::MergeOperator> cf_get_merge_operator(const std::string& prefix);
+  int _open(ostream &out, bool read_only, const std::vector<ColumnFamily>& options);
+  std::shared_ptr<rocksdb::MergeOperator> cf_get_merge_operator(const std::string& prefix) const;
+  rocksdb::ColumnFamilyHandle* cf_get_mono_handle(const std::string& cf_name) const;
+  rocksdb::ColumnFamilyHandle* cf_get_handle(const std::string& cf_name) const;
+  bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) const;
+  std::pair<std::string, ColumnFamilyHandle> cf_get_by_rocksdb_ID(uint32_t ID) const;
+  int cf_create(const std::string& name, const std::string& options);
+  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*);
 
-  /*
-   * Returns handle to mono column family.
-   * Does not return handles for regular column family, even if name matches
-   */
-  rocksdb::ColumnFamilyHandle *cf_mono_get_handle(const std::string& cf_name) {
-    auto iter = cf_mono_handles.find(cf_name);
-    if (iter == cf_mono_handles.end())
-      return nullptr;
-    else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
-  }
-
-  /*
-   * Determines how 'prefix' should be handled.
-   * It is a convenience function that allow to better structuralize conditions
-   * in functions that operate on both mono column families and regular column families.
-   *
-   * Param:
-   *  - cf [in] column family handle as requested by client
-   *       [out] fixed column family handle after redirection
-   *  - prefix [in] as requested by client
-   * Result:
-   *  true - we operate on mono column family, false - we operate on normal column family
-   */
-  bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) {
-    if (cf != nullptr) {
-      return false;
-    }
-    cf = get_cf_handle(prefix);
-    if (cf != nullptr)
-      return true;
-    cf = default_cf;
-    return false;
-  }
-
-private:
   rocksdb::Options rocksdb_options;
-  int open_existing(rocksdb::Options& rocksdb_options);
-
-  struct ColumnFamilyData {
-      string options;                   ///< specific configure option string for this CF
-      ColumnFamilyHandle handle;        ///< handle to column family
-      ColumnFamilyData(const string &options, ColumnFamilyHandle handle = {nullptr})
-        : options(options), handle(handle) {}
-      ColumnFamilyData() {}
-    };
+  struct ColumnFamilyData;
   typedef std::string ColumnFamilyName;
   std::map<ColumnFamilyName, ColumnFamilyData> column_families;
-
   std::unordered_map<std::string, ColumnFamilyHandle> cf_mono_handles;
 
   void perf_counters_register();
 
-  std::pair<std::string, ColumnFamilyHandle> get_cf_by_rocksdb_ID(uint32_t ID) const;
   friend class RocksWBHandler;
 public:
-  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) const {
-    auto iter = cf_mono_handles.find(cf_name);
-    if (iter == cf_mono_handles.end())
-      return nullptr;
-    else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
-  }
 
   int repair(std::ostream &out) override;
   void split_stats(const std::string &s, char delim, std::vector<std::string> &elems);
@@ -259,7 +192,8 @@ public:
     return logger;
   }
 
-  int64_t estimate_prefix_size(const string& prefix) override;
+  int64_t estimate_prefix_size(const string& prefix,
+                               ColumnFamilyHandle cfh = ColumnFamilyHandle{}) override;
 
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -89,9 +89,9 @@ class RocksDBStore : public KeyValueDB {
 
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);
   int install_cf_mergeop(const string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
+
   int create_db_dir();
-  int do_open(ostream &out, bool create_if_missing, bool open_readonly,
-	      const vector<ColumnFamily>* cfs = nullptr);
+  int do_open(ostream &out, bool create_if_missing, const vector<ColumnFamily>* cfs = nullptr);
   int load_rocksdb_options(bool create_if_missing, rocksdb::Options& opt);
 
   // manage async compactions
@@ -168,26 +168,151 @@ public:
 
   static bool check_omap_dir(string &omap_dir);
   /// Opens underlying db
-  int open(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
-    return do_open(out, false, false, &cfs);
-  }
+  int open(ostream &out, const std::vector<ColumnFamily>& options = {}) override;
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out,
-		      const vector<ColumnFamily>& cfs = {}) override;
+  int create_and_open(ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override;
 
   int open_read_only(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
     return do_open(out, false, true, &cfs);
   }
 
   void close() override;
+  /*
+   * @defgroup column_family Column Families
+   * There are 3 categories of column families.
+   *
+   * 1) mono column family
+   * Tightly bound to single prefix (P) value.
+   * Name of column family is P.
+   * Only keys with prefix P are all allowed.
+   * Merge operator (if exists) must be named P.
+   *
+   * 2) regular column family
+   * Can contain keys with any prefix.
+   * Name of column family may not be exact to any registered merge operators.
+   * Merge operator must encompass all available prefix merge operators, and so must its name.
+   *
+   * 3) default column family
+   * Can contain keys with any prefix except those handled by mono column families.
+   * Merge operator must encompass all prefixes, except those handled by mono column families.
+   * Merge operator name must not include prefixes handled by mono column families.
+   */
 
-  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) {
-    auto iter = cf_handles.find(cf_name);
-    if (iter == cf_handles.end())
+  /*
+   * @ingroup column_family
+   * List existing column families
+   *
+   * Queries database for names of all defined column families.
+   * When invoked before \ref open it queries stored database.
+   * When invoked after \ref open or \ref create_and_open it just reports current state.
+   * Invoking on non-existent database must return empty \ref cf_names.
+   *
+   * Params:
+   * - cf_names vector to fill with known column family names
+   * Result:
+   *   0 - success, <0 error code
+   */
+  int column_family_list(vector<std::string>& cf_names) override;
+
+  /*
+   * @ingroup column_family
+   * Create new column family
+   *
+   * Create additional column family in running database.
+   * This may be invoked only on opened database.
+   *
+   * Params:
+   * - name name of column family
+   * - options extra options to apply for column family
+   * Result:
+   *   0 - success, <0 error code
+   */
+  int column_family_create(const std::string& name, const std::string& options) override;
+
+  /*
+   * @ingroup column_family
+   * Delete column family
+   *
+   * Removes column family from running database.
+   * This may be invoked only on opened database.
+   *
+   * Params:
+   * - name name of column family
+   * - options extra options to apply for column family
+   * Result:
+   *   0 - success, <0 error code
+   */
+  int column_family_delete(const std::string& name) override { return -1; }
+
+  //virtual std::string cf_get_options(const std::string& cf_name);
+  /* returns merge operator for column family that contains only `prefix` keys */
+  virtual std::shared_ptr<rocksdb::MergeOperator>
+    cf_get_merge_operator(const std::string& prefix);
+
+private:
+  /*
+   * Returns handle to mono column family.
+   * Does not return handles for regular column family, even if name matches
+   */
+  rocksdb::ColumnFamilyHandle *cf_mono_get_handle(const std::string& cf_name) {
+    auto iter = cf_mono_handles.find(cf_name);
+    if (iter == cf_mono_handles.end())
       return nullptr;
     else
       return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
   }
+
+  /// Determines if prefix points to mono column family.
+  /// Sets handle to proper column family.
+  bool check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) {
+    if (cf != nullptr) {
+      return false;
+    }
+    cf = get_cf_handle(prefix);
+    if (cf != nullptr)
+      return true;
+    cf = default_cf;
+    return false;
+  }
+
+private:
+  rocksdb::Options rocksdb_options;
+  int open_existing(rocksdb::Options& rocksdb_options);
+
+  int read_column_families();
+  typedef std::string ColumnFamilyName;
+  struct ColumnFamilyData {
+      //string name;      //< name of this individual column family
+      string options;    //< specific configure option string for this CF
+      void* handle;
+      ColumnFamilyData(const string &options, void* handle = nullptr)
+        : options(options), handle(handle) {}
+      ColumnFamilyData() : handle(nullptr) {}
+    };
+  std::map<ColumnFamilyName, ColumnFamilyData> column_families;
+//  std::vector<ColumnFamily> column_families;
+  //std::vector<rocksdb::ColumnFamilyDescriptor> column_family_descriptors;
+
+  void perf_counters_register();
+
+public:
+  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) {
+    auto iter = cf_mono_handles.find(cf_name);
+    if (iter == cf_mono_handles.end())
+      return nullptr;
+    else
+      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
+  }
+
+  rocksdb::ColumnFamilyHandle *get_cf_handle_nonmono(const std::string& cf_name) {
+    auto iter = column_families.find(cf_name);
+    if (iter == column_families.end())
+      return default_cf;
+    else
+      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.handle);
+  }
+
+
   int repair(std::ostream &out) override;
   void split_stats(const std::string &s, char delim, std::vector<std::string> &elems);
   void get_statistics(Formatter *f) override;
@@ -297,6 +422,8 @@ public:
 
     explicit RocksDBTransactionImpl(RocksDBStore *_db);
   private:
+    rocksdb::ColumnFamilyHandle *cf_handle;
+
     void put_bat(
       rocksdb::WriteBatch& bat,
       rocksdb::ColumnFamilyHandle *cf,
@@ -333,6 +460,8 @@ public:
       const string& prefix,
       const string& k,
       const bufferlist &bl) override;
+    void select(
+      void* column_family_handle) override;
   };
 
   KeyValueDB::Transaction get_transaction() override {
@@ -356,7 +485,17 @@ public:
     const char *key,
     size_t keylen,
     bufferlist *out) override;
-
+  int get(
+    void* cf_handle,
+    const std::string &prefix,
+    const std::set<std::string> &keys,
+    std::map<std::string, bufferlist> *out) override;
+  int get(
+    void* cf_handle,
+    const string &prefix,
+    const string &key,
+    bufferlist *out
+    ) override;
 
   class RocksDBWholeSpaceIteratorImpl :
     public KeyValueDB::WholeSpaceIteratorImpl {

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -239,8 +239,10 @@ private:
 
   void perf_counters_register();
 
+  std::pair<std::string, ColumnFamilyHandle> get_cf_by_rocksdb_ID(uint32_t ID) const;
+  friend class RocksWBHandler;
 public:
-  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) {
+  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) const {
     auto iter = cf_mono_handles.find(cf_name);
     if (iter == cf_mono_handles.end())
       return nullptr;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -88,10 +88,8 @@ class RocksDBStore : public KeyValueDB {
   rocksdb::ColumnFamilyHandle *default_cf = nullptr;
 
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);
-  int install_cf_mergeop(const string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
 
   int create_db_dir();
-  int do_open(ostream &out, bool create_if_missing, const vector<ColumnFamily>* cfs = nullptr);
   int load_rocksdb_options(bool create_if_missing, rocksdb::Options& opt);
 
   // manage async compactions
@@ -167,7 +165,6 @@ public:
   ~RocksDBStore() override;
 
   static bool check_omap_dir(string &omap_dir);
-  /// Opens underlying db
   int open(ostream &out, const std::vector<ColumnFamily>& options = {}) override;
   /// Creates underlying db if missing and opens it
   int create_and_open(ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override;
@@ -182,12 +179,13 @@ public:
   int column_family_create(const std::string& name, const std::string& options) override;
   int column_family_delete(const std::string& name) override;
   KeyValueDB::ColumnFamilyHandle column_family_handle(const std::string& cf_name) override;
-  //virtual std::string cf_get_options(const std::string& cf_name);
-  /* returns merge operator for column family that contains only `prefix` keys */
-  virtual std::shared_ptr<rocksdb::MergeOperator>
-    cf_get_merge_operator(const std::string& prefix);
 
 private:
+  /*
+   * Get merge operator for column family.
+   */
+  std::shared_ptr<rocksdb::MergeOperator> cf_get_merge_operator(const std::string& prefix);
+
   /*
    * Returns handle to mono column family.
    * Does not return handles for regular column family, even if name matches
@@ -200,9 +198,19 @@ private:
       return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
   }
 
-  /// Determines if prefix points to mono column family.
-  /// Sets handle to proper column family.
-  bool check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) {
+  /*
+   * Determines how 'prefix' should be handled.
+   * It is a convenience function that allow to better structuralize conditions
+   * in functions that operate on both mono column families and regular column families.
+   *
+   * Param:
+   *  - cf [in] column family handle as requested by client
+   *       [out] fixed column family handle after redirection
+   *  - prefix [in] as requested by client
+   * Result:
+   *  true - we operate on mono column family, false - we operate on normal column family
+   */
+  bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) {
     if (cf != nullptr) {
       return false;
     }
@@ -250,97 +258,6 @@ public:
   }
 
   int64_t estimate_prefix_size(const string& prefix) override;
-
-  struct  RocksWBHandler: public rocksdb::WriteBatch::Handler {
-    std::string seen ;
-    int num_seen = 0;
-    static string pretty_binary_string(const string& in) {
-      char buf[10];
-      string out;
-      out.reserve(in.length() * 3);
-      enum { NONE, HEX, STRING } mode = NONE;
-      unsigned from = 0, i;
-      for (i=0; i < in.length(); ++i) {
-        if ((in[i] < 32 || (unsigned char)in[i] > 126) ||
-          (mode == HEX && in.length() - i >= 4 &&
-          ((in[i] < 32 || (unsigned char)in[i] > 126) ||
-          (in[i+1] < 32 || (unsigned char)in[i+1] > 126) ||
-          (in[i+2] < 32 || (unsigned char)in[i+2] > 126) ||
-          (in[i+3] < 32 || (unsigned char)in[i+3] > 126)))) {
-
-          if (mode == STRING) {
-            out.append(in.substr(from, i - from));
-            out.push_back('\'');
-          }
-          if (mode != HEX) {
-            out.append("0x");
-            mode = HEX;
-          }
-          if (in.length() - i >= 4) {
-            // print a whole u32 at once
-            snprintf(buf, sizeof(buf), "%08x",
-                  (uint32_t)(((unsigned char)in[i] << 24) |
-                            ((unsigned char)in[i+1] << 16) |
-                            ((unsigned char)in[i+2] << 8) |
-                            ((unsigned char)in[i+3] << 0)));
-            i += 3;
-          } else {
-            snprintf(buf, sizeof(buf), "%02x", (int)(unsigned char)in[i]);
-          }
-          out.append(buf);
-        } else {
-          if (mode != STRING) {
-            out.push_back('\'');
-            mode = STRING;
-            from = i;
-          }
-        }
-      }
-      if (mode == STRING) {
-        out.append(in.substr(from, i - from));
-        out.push_back('\'');
-      }
-      return out;
-    }
-    void Put(const rocksdb::Slice& key,
-                    const rocksdb::Slice& value) override {
-      string prefix ((key.ToString()).substr(0,1));
-      string key_to_decode ((key.ToString()).substr(2,string::npos));
-      uint64_t size = (value.ToString()).size();
-      seen += "\nPut( Prefix = " + prefix + " key = " 
-            + pretty_binary_string(key_to_decode) 
-            + " Value size = " + std::to_string(size) + ")";
-      num_seen++;
-    }
-    void SingleDelete(const rocksdb::Slice& key) override {
-      string prefix ((key.ToString()).substr(0,1));
-      string key_to_decode ((key.ToString()).substr(2,string::npos));
-      seen += "\nSingleDelete(Prefix = "+ prefix + " Key = " 
-            + pretty_binary_string(key_to_decode) + ")";
-      num_seen++;
-    }
-    void Delete(const rocksdb::Slice& key) override {
-      string prefix ((key.ToString()).substr(0,1));
-      string key_to_decode ((key.ToString()).substr(2,string::npos));
-      seen += "\nDelete( Prefix = " + prefix + " key = " 
-            + pretty_binary_string(key_to_decode) + ")";
-
-      num_seen++;
-    }
-    void Merge(const rocksdb::Slice& key,
-                      const rocksdb::Slice& value) override {
-      string prefix ((key.ToString()).substr(0,1));
-      string key_to_decode ((key.ToString()).substr(2,string::npos));
-      uint64_t size = (value.ToString()).size();
-      seen += "\nMerge( Prefix = " + prefix + " key = " 
-            + pretty_binary_string(key_to_decode) + " Value size = " 
-            + std::to_string(size) + ")";
-
-      num_seen++;
-    }
-    bool Continue() override { return num_seen < 50; }
-
-  };
 
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:
@@ -478,88 +395,28 @@ public:
 
   class MergeOperatorRouter;
   class MergeOperatorLinker;
+  class MergeOperatorAll;
+
   friend class MergeOperatorRouter;
   int set_merge_operator(
     const std::string& prefix,
     std::shared_ptr<KeyValueDB::MergeOperator> mop) override;
-  string assoc_name; ///< Name of associative operator
-
-  uint64_t get_estimated_size(map<string,uint64_t> &extra) override {
-    DIR *store_dir = opendir(path.c_str());
-    if (!store_dir) {
-      lderr(cct) << __func__ << " something happened opening the store: "
-                 << cpp_strerror(errno) << dendl;
-      return 0;
-    }
-
-    uint64_t total_size = 0;
-    uint64_t sst_size = 0;
-    uint64_t log_size = 0;
-    uint64_t misc_size = 0;
-
-    struct dirent *entry = NULL;
-    while ((entry = readdir(store_dir)) != NULL) {
-      string n(entry->d_name);
-
-      if (n == "." || n == "..")
-        continue;
-
-      string fpath = path + '/' + n;
-      struct stat s;
-      int err = stat(fpath.c_str(), &s);
-      if (err < 0)
-	err = -errno;
-      // we may race against rocksdb while reading files; this should only
-      // happen when those files are being updated, data is being shuffled
-      // and files get removed, in which case there's not much of a problem
-      // as we'll get to them next time around.
-      if (err == -ENOENT) {
-	continue;
-      }
-      if (err < 0) {
-        lderr(cct) << __func__ << " error obtaining stats for " << fpath
-                   << ": " << cpp_strerror(err) << dendl;
-        goto err;
-      }
-
-      size_t pos = n.find_last_of('.');
-      if (pos == string::npos) {
-        misc_size += s.st_size;
-        continue;
-      }
-
-      string ext = n.substr(pos+1);
-      if (ext == "sst") {
-        sst_size += s.st_size;
-      } else if (ext == "log") {
-        log_size += s.st_size;
-      } else {
-        misc_size += s.st_size;
-      }
-    }
-
-    total_size = sst_size + log_size + misc_size;
-
-    extra["sst"] = sst_size;
-    extra["log"] = log_size;
-    extra["misc"] = misc_size;
-    extra["total"] = total_size;
-
-err:
-    closedir(store_dir);
-    return total_size;
-  }
 
   virtual int64_t get_cache_usage() const override {
     return static_cast<int64_t>(bbt_opts.block_cache->GetUsage());
   }
-
+  uint64_t get_estimated_size(map<string,uint64_t> &extra) override;
+  virtual int64_t request_cache_bytes(
+      PriorityCache::Priority pri, uint64_t cache_bytes) const override;
+  virtual int64_t commit_cache_size() override;
+  virtual std::string get_cache_name() const override {
+    return "RocksDB Block Cache";
+  }
   int set_cache_size(uint64_t s) override {
     cache_size = s;
     set_cache_flag = true;
     return 0;
   }
-
   int set_cache_capacity(int64_t capacity);
   int64_t get_cache_capacity();
 
@@ -572,7 +429,5 @@ err:
   WholeSpaceIterator get_wholespace_iterator() override;
   WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override;
 };
-
-
 
 #endif

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -179,7 +179,7 @@ private:
   bool cf_check_mode(rocksdb::ColumnFamilyHandle* &cf, const string &prefix) const;
   std::pair<std::string, ColumnFamilyHandle> cf_get_by_rocksdb_ID(uint32_t ID) const;
   int cf_create(const std::string& name, const std::string& options);
-  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*);
+  KeyValueDB::ColumnFamilyHandle cf_wrap_handle(rocksdb::ColumnFamilyHandle*) const;
   int cf_compact(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
   int cf_compact_async(rocksdb::ColumnFamilyHandle* cf, const string& start, const string& end);
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -191,7 +191,9 @@ private:
   std::unordered_map<std::string, ColumnFamilyHandle> cf_mono_handles;
 
   void perf_counters_register();
-
+  bool apply_cache_group(rocksdb::ColumnFamilyOptions& cf_opt,
+			 const std::string& cf_options,
+			 std::unordered_map<std::string, std::string>& cf_options_map);
   friend class RocksWBHandler;
   friend class BlueStore_DB_Hash;
 public:

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -191,6 +191,7 @@ private:
   void perf_counters_register();
 
   friend class RocksWBHandler;
+  friend class BlueStore_DB_Hash;
 public:
 
   int repair(std::ostream &out) override;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -177,73 +177,11 @@ public:
   }
 
   void close() override;
-  /*
-   * @defgroup column_family Column Families
-   * There are 3 categories of column families.
-   *
-   * 1) mono column family
-   * Tightly bound to single prefix (P) value.
-   * Name of column family is P.
-   * Only keys with prefix P are all allowed.
-   * Merge operator (if exists) must be named P.
-   *
-   * 2) regular column family
-   * Can contain keys with any prefix.
-   * Name of column family may not be exact to any registered merge operators.
-   * Merge operator must encompass all available prefix merge operators, and so must its name.
-   *
-   * 3) default column family
-   * Can contain keys with any prefix except those handled by mono column families.
-   * Merge operator must encompass all prefixes, except those handled by mono column families.
-   * Merge operator name must not include prefixes handled by mono column families.
-   */
 
-  /*
-   * @ingroup column_family
-   * List existing column families
-   *
-   * Queries database for names of all defined column families.
-   * When invoked before \ref open it queries stored database.
-   * When invoked after \ref open or \ref create_and_open it just reports current state.
-   * Invoking on non-existent database must return empty \ref cf_names.
-   *
-   * Params:
-   * - cf_names vector to fill with known column family names
-   * Result:
-   *   0 - success, <0 error code
-   */
   int column_family_list(vector<std::string>& cf_names) override;
-
-  /*
-   * @ingroup column_family
-   * Create new column family
-   *
-   * Create additional column family in running database.
-   * This may be invoked only on opened database.
-   *
-   * Params:
-   * - name name of column family
-   * - options extra options to apply for column family
-   * Result:
-   *   0 - success, <0 error code
-   */
   int column_family_create(const std::string& name, const std::string& options) override;
-
-  /*
-   * @ingroup column_family
-   * Delete column family
-   *
-   * Removes column family from running database.
-   * This may be invoked only on opened database.
-   *
-   * Params:
-   * - name name of column family
-   * - options extra options to apply for column family
-   * Result:
-   *   0 - success, <0 error code
-   */
-  int column_family_delete(const std::string& name) override { return -1; }
-
+  int column_family_delete(const std::string& name) override;
+  KeyValueDB::ColumnFamilyHandle column_family_handle(const std::string& cf_name) override;
   //virtual std::string cf_get_options(const std::string& cf_name);
   /* returns merge operator for column family that contains only `prefix` keys */
   virtual std::shared_ptr<rocksdb::MergeOperator>
@@ -259,7 +197,7 @@ private:
     if (iter == cf_mono_handles.end())
       return nullptr;
     else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
+      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
   }
 
   /// Determines if prefix points to mono column family.
@@ -279,19 +217,17 @@ private:
   rocksdb::Options rocksdb_options;
   int open_existing(rocksdb::Options& rocksdb_options);
 
-  int read_column_families();
-  typedef std::string ColumnFamilyName;
   struct ColumnFamilyData {
-      //string name;      //< name of this individual column family
-      string options;    //< specific configure option string for this CF
-      void* handle;
-      ColumnFamilyData(const string &options, void* handle = nullptr)
+      string options;                   ///< specific configure option string for this CF
+      ColumnFamilyHandle handle;        ///< handle to column family
+      ColumnFamilyData(const string &options, ColumnFamilyHandle handle = {nullptr})
         : options(options), handle(handle) {}
-      ColumnFamilyData() : handle(nullptr) {}
+      ColumnFamilyData() {}
     };
+  typedef std::string ColumnFamilyName;
   std::map<ColumnFamilyName, ColumnFamilyData> column_families;
-//  std::vector<ColumnFamily> column_families;
-  //std::vector<rocksdb::ColumnFamilyDescriptor> column_family_descriptors;
+
+  std::unordered_map<std::string, ColumnFamilyHandle> cf_mono_handles;
 
   void perf_counters_register();
 
@@ -301,17 +237,8 @@ public:
     if (iter == cf_mono_handles.end())
       return nullptr;
     else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
+      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.priv);
   }
-
-  rocksdb::ColumnFamilyHandle *get_cf_handle_nonmono(const std::string& cf_name) {
-    auto iter = column_families.find(cf_name);
-    if (iter == column_families.end())
-      return default_cf;
-    else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second.handle);
-  }
-
 
   int repair(std::ostream &out) override;
   void split_stats(const std::string &s, char delim, std::vector<std::string> &elems);
@@ -461,7 +388,7 @@ public:
       const string& k,
       const bufferlist &bl) override;
     void select(
-      void* column_family_handle) override;
+        KeyValueDB::ColumnFamilyHandle column_family_handle) override;
   };
 
   KeyValueDB::Transaction get_transaction() override {
@@ -486,12 +413,12 @@ public:
     size_t keylen,
     bufferlist *out) override;
   int get(
-    void* cf_handle,
+    KeyValueDB::ColumnFamilyHandle cf_handle,
     const std::string &prefix,
     const std::set<std::string> &keys,
     std::map<std::string, bufferlist> *out) override;
   int get(
-    void* cf_handle,
+    KeyValueDB::ColumnFamilyHandle cf_handle,
     const string &prefix,
     const string &key,
     bufferlist *out
@@ -527,6 +454,7 @@ public:
   };
 
   Iterator get_iterator(const std::string& prefix) override;
+  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override;
 
   /// Utility
   static string combine_strings(const string &prefix, const string &value) {
@@ -642,6 +570,7 @@ err:
   }
 
   WholeSpaceIterator get_wholespace_iterator() override;
+  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override;
 };
 
 

--- a/src/kv/rocksdb_cache/BinnedLRUCache.cc
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.cc
@@ -101,9 +101,10 @@ void BinnedLRUHandleTable::Resize() {
   length_ = new_length;
 }
 
-BinnedLRUCacheShard::BinnedLRUCacheShard(size_t capacity, bool strict_capacity_limit,
+BinnedLRUCacheShard::BinnedLRUCacheShard(CephContext *c, size_t capacity, bool strict_capacity_limit,
                              double high_pri_pool_ratio)
-    : capacity_(0),
+    : cct(c),
+      capacity_(0),
       high_pri_pool_usage_(0),
       strict_capacity_limit_(strict_capacity_limit),
       high_pri_pool_ratio_(high_pri_pool_ratio),
@@ -480,7 +481,7 @@ BinnedLRUCache::BinnedLRUCache(CephContext *c,
   size_t per_shard = (capacity + (num_shards_ - 1)) / num_shards_;
   for (int i = 0; i < num_shards_; i++) {
     new (&shards_[i])
-        BinnedLRUCacheShard(per_shard, strict_capacity_limit, high_pri_pool_ratio);
+      BinnedLRUCacheShard(c, per_shard, strict_capacity_limit, high_pri_pool_ratio);
   }
 }
 

--- a/src/kv/rocksdb_cache/BinnedLRUCache.h
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.h
@@ -171,7 +171,7 @@ class BinnedLRUHandleTable {
 // A single shard of sharded cache.
 class alignas(CACHE_LINE_SIZE) BinnedLRUCacheShard : public CacheShard {
  public:
-  BinnedLRUCacheShard(size_t capacity, bool strict_capacity_limit,
+  BinnedLRUCacheShard(CephContext *c, size_t capacity, bool strict_capacity_limit,
                 double high_pri_pool_ratio);
   virtual ~BinnedLRUCacheShard();
 
@@ -225,6 +225,7 @@ class alignas(CACHE_LINE_SIZE) BinnedLRUCacheShard : public CacheShard {
   size_t GetHighPriPoolUsage() const;
 
  private:
+  CephContext *cct;
   void LRU_Remove(BinnedLRUHandle* e);
   void LRU_Insert(BinnedLRUHandle* e);
 

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -27,6 +27,7 @@ if(WITH_BLUESTORE)
     bluestore/bluefs_types.cc
     bluestore/BlueRocksEnv.cc
     bluestore/BlueStore.cc
+    bluestore/BlueStore_DB_Hash.cc
     bluestore/bluestore_types.cc
     bluestore/fastbmap_allocator_impl.cc
     bluestore/FreelistManager.cc

--- a/src/os/ObjectMap.h
+++ b/src/os/ObjectMap.h
@@ -157,7 +157,7 @@ public:
 
   virtual void compact() {}
 
-  typedef KeyValueDB::SimplestIteratorImpl ObjectMapIteratorImpl;
+  typedef KeyValueDB::ObjectMapIteratorImpl ObjectMapIteratorImpl;
   typedef std::shared_ptr<ObjectMapIteratorImpl> ObjectMapIterator;
   virtual ObjectMapIterator get_iterator(const ghobject_t &oid) {
     return ObjectMapIterator();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7974,6 +7974,51 @@ int BlueStore::_fsck(bool deep, bool repair)
 
 int BlueStore::reshard(const std::string& new_sharding)
 {
+  //special case if sharding goes
+  std::string curr_sharding;
+  std::vector<KeyValueDB::ColumnFamily> curr_cfs, new_cfs;
+  std::map<std::string, size_t> curr_shards, new_shards;
+
+  int r = read_meta("sharding", &curr_sharding);
+  if (!curr_sharding.empty()) {
+    r = get_sharding(curr_sharding, curr_cfs, curr_shards);
+    ceph_assert(r == 0);
+    r = get_sharding(new_sharding, new_cfs, new_shards);
+    if (r != 0) {
+      derr << "Sharding schema '" << new_sharding << "' invalid" << dendl;
+      return r;
+    }
+    if (curr_shards[PREFIX_ALLOC_BITMAP] != 0 &&
+        new_shards[PREFIX_ALLOC_BITMAP] != 0 &&
+        curr_shards[PREFIX_ALLOC_BITMAP] != new_shards[PREFIX_ALLOC_BITMAP]) {
+      //we change 'b' prefix sharding, we have to reduce 'b' to 0 first
+      map<string,string> cf_map;
+      get_str_map(new_sharding,
+                  &cf_map,
+                  " \t");
+      std::string new_sharding_without_b;
+      for (auto& i : cf_map) {
+        std::string prefix = i.first.substr(0, 1);
+        if (prefix == PREFIX_ALLOC_BITMAP) {
+          continue;
+        }
+        if (!new_sharding_without_b.empty())
+          new_sharding_without_b += " ";
+        new_sharding_without_b += i.first + "=" + i.second;
+      }
+      dout(5) << "Trimming 'b' prefix. Temporary sharding is: '" << new_sharding_without_b << "'" << dendl;
+      r = _reshard(new_sharding_without_b);
+      if (r != 0)
+        return r;
+    }
+  }
+  dout(5) << "Sharding to: '" << new_sharding << "'" << dendl;
+  r = _reshard(new_sharding);
+  return r;
+}
+
+int BlueStore::_reshard(const std::string& new_sharding)
+{
   KeyValueDB* source_db = nullptr;
   int r = _mount(true, false);
   if (r < 0)
@@ -8026,7 +8071,7 @@ int BlueStore::reshard(const std::string& new_sharding)
       dout(5) << "Create required column family '" << new_column.name <<
           "' with options '" << new_column.option << "'" << dendl;
       r = source_db->column_family_create(new_column.name, new_column.option);
-      assert(r == 0);
+      ceph_assert(r == 0);
     }
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -43,6 +43,7 @@
 #include "common/numa.h"
 #include "BlueStore_DB_Hash.h"
 #include "common/url_escape.h"
+#include "functional"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
@@ -8034,7 +8035,7 @@ int BlueStore::reshard(const std::string& new_sharding)
   auto it = new_shards.find(PREFIX_ALLOC_BITMAP);
   ceph_assert(it != new_shards.end());
   if (it->second > 0) {
-    for(int i = 0; i < it->second; i++) {
+    for(size_t i = 0; i < it->second; i++) {
       target_alloc_bitmap_cfs.push_back(it->first + "-" + to_string(i));
     }
   } else {
@@ -8044,21 +8045,26 @@ int BlueStore::reshard(const std::string& new_sharding)
   //all columns created, now opening of targer_hash_db should succeed
   BlueStore_DB_Hash target_hash_db(r_source_db, new_shards);
 
-
-
-  auto do_move = [&](
-      KeyValueDB::IteratorBase data_source,
+  auto reshard_move = [&](
+      std::function<KeyValueDB::IteratorBase(const std::string&, const std::string&)> create_iterator,
       std::string source_cf_name,
       bool skip_bitmap_entries) {
     KeyValueDB::ColumnFamilyHandle source_cf_handle = source_db->column_family_handle(source_cf_name);
     ceph_assert(source_cf_handle);
+    KeyValueDB::IteratorBase data_source = create_iterator("","");
 
     KeyValueDB::Transaction transaction = source_db->get_transaction();
     size_t data_in_transaction = 0;
     size_t ops_in_transaction = 0;
+    size_t keys_in_iterator = 0;
+    size_t data_in_iterator = 0;
 
     while (data_source->valid()) {
       std::pair<std::string, std::string> raw_key = data_source->raw_key();
+      if (ops_in_transaction == 10000 || data_in_transaction > 10000000) {
+        data_source = create_iterator(raw_key.first, raw_key.second);
+      }
+
       ceph::bufferlist data = data_source->value();
       dout(20) << "Processing key '" << url_escape(raw_key.first) << " " << url_escape(raw_key.second) << "'" << dendl;
 
@@ -8077,6 +8083,8 @@ int BlueStore::reshard(const std::string& new_sharding)
           transaction->set(raw_key.first, raw_key.second, data);
           ops_in_transaction++;
           data_in_transaction += data.length();
+          keys_in_iterator ++;
+          data_in_iterator += data.length();
         } else {
           //there is special handling of prefix PREFIX_ALLOC_BITMAP as it is used internally by bluefs
           //do not delete those entries, only move them
@@ -8087,6 +8095,8 @@ int BlueStore::reshard(const std::string& new_sharding)
               transaction->set(raw_key.first, raw_key.second, data);
               ops_in_transaction++;
               data_in_transaction += data.length();
+              keys_in_iterator ++;
+              data_in_iterator += data.length();
             }
           }
         }
@@ -8114,9 +8124,15 @@ int BlueStore::reshard(const std::string& new_sharding)
     dout(10) << "Starting processing column family '" << source_cf_name << "'" << dendl;
     KeyValueDB::ColumnFamilyHandle source_cf_handle = source_db->column_family_handle(source_cf_name);
     ceph_assert(source_cf_handle);
-    KeyValueDB::WholeSpaceIterator data_source = source_db->get_wholespace_iterator_cf(source_cf_handle);
-    data_source->seek_to_first();
-    do_move(data_source, source_cf_name, true);
+    reshard_move(
+        [&](const std::string& prefix, const std::string& key) -> KeyValueDB::IteratorBase {
+              KeyValueDB::WholeSpaceIterator data_source = source_db->get_wholespace_iterator_cf(source_cf_handle);
+              data_source->lower_bound(prefix, key);
+              return data_source;
+            },
+        source_cf_name,
+        true
+    );
     dout(10) << "Finished processing column family '" << source_cf_name << "'" << dendl;
   }
 
@@ -8131,9 +8147,16 @@ int BlueStore::reshard(const std::string& new_sharding)
           "' for ALLOC_BITMAP" << dendl;
       KeyValueDB::ColumnFamilyHandle source_cf_handle = source_db->column_family_handle(source_cf_name);
       ceph_assert(source_cf_handle);
-      KeyValueDB::Iterator data_source = source_db->get_iterator_cf(source_cf_handle, PREFIX_ALLOC_BITMAP);
-      data_source->seek_to_first();
-      do_move(data_source, source_cf_name, true);
+      reshard_move(
+          [&](const std::string& prefix, const std::string& key) -> KeyValueDB::IteratorBase {
+              KeyValueDB::Iterator data_source = source_db->get_iterator_cf(source_cf_handle, PREFIX_ALLOC_BITMAP);
+              //KeyValueDB::WholeSpaceIterator data_source = source_db->get_wholespace_iterator_cf(source_cf_handle);
+              data_source->lower_bound(key);
+              return data_source;
+          },
+          source_cf_name,
+          false
+      );
       dout(10) << "Finished processing column family '" << source_cf_name << "'" << dendl;
     }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -42,6 +42,8 @@
 #include "common/blkdev.h"
 #include "common/numa.h"
 
+KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB*, const std::map<std::string, size_t>& = {});
+
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 
@@ -5521,6 +5523,8 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
     env = NULL;
     return -EIO;
   }
+  //wrap DB with sharded features
+  db = make_BlueStore_DB_Hash(db);
 
   FreelistManager::setup_merge_operators(db);
   db->set_merge_operator(PREFIX_STAT, merge_op);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5666,15 +5666,10 @@ int BlueStore::get_sharding(const std::string& sharding_schema,
     sh->second = prefix_count;
     dout(10) << "prefix '" << prefix << "' split into " << prefix_count << "column families" << dendl;
 
-    bool share_cache = true;
-    // Don't share cache for the onode CF
-    if (prefix == PREFIX_OBJ) {
-      share_cache = false;
-    }
     for(int k = 0; k < prefix_count; k++) {
       std::string cf_name = prefix + "-" + to_string(k);
       dout(10) << "column family name=" << cf_name << ", options=" << i.second << dendl;
-      cfs.push_back(KeyValueDB::ColumnFamily(cf_name, i.second, share_cache));
+      cfs.push_back(KeyValueDB::ColumnFamily(cf_name, i.second));
     }
   }
   return 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5523,49 +5523,64 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
     env = NULL;
     return -EIO;
   }
-  //wrap DB with sharded features
-  std::map<std::string, size_t> shards{
-    {PREFIX_SUPER, 1},
-    {PREFIX_STAT, 1},
-    {PREFIX_COLL, 1},
-    {PREFIX_OBJ, 7},
-    {PREFIX_OMAP, 11},
-    {PREFIX_PGMETA_OMAP, 1},
-    {PREFIX_DEFERRED, 1},
-    {PREFIX_ALLOC, 1},
-    {PREFIX_ALLOC_BITMAP, 9},
-    {PREFIX_SHARED_BLOB, 5}
-  };
-
-  db = make_BlueStore_DB_Hash(db, shards);
-
-  FreelistManager::setup_merge_operators(db);
-  db->set_merge_operator(PREFIX_STAT, merge_op);
-  db->set_cache_size(cache_kv_ratio * cache_size);
 
   if (kv_backend == "rocksdb") {
     options = cct->_conf->bluestore_rocksdb_options;
 
-    map<string,string> cf_map;
-    cct->_conf.with_val<string>("bluestore_rocksdb_cfs",
-                                 get_str_map,
-                                 &cf_map,
-                                 " \t");
-    for (auto& i : cf_map) {
-      dout(10) << "column family " << i.first << ": " << i.second << dendl;
-      cfs.push_back(KeyValueDB::ColumnFamily(i.first, i.second));
+    if (cct->_conf.get_val<bool>("bluestore_rocksdb_cf")) {
+      /* enable sharding of rocksdb */
+      map<string,string> cf_map;
+      cct->_conf.with_val<string>("bluestore_rocksdb_cfs",
+                                  get_str_map,
+                                  &cf_map,
+                                  " \t");
+      std::map<std::string, size_t> shards {
+        {PREFIX_SUPER, 0},
+        {PREFIX_STAT, 0},
+        {PREFIX_COLL, 0},
+        {PREFIX_OBJ, 0},
+        {PREFIX_OMAP, 0},
+        {PREFIX_PGMETA_OMAP, 0},
+        {PREFIX_DEFERRED, 0},
+        {PREFIX_ALLOC, 0},
+        {PREFIX_ALLOC_BITMAP, 0},
+        {PREFIX_SHARED_BLOB, 0}
+      };
+
+      for (auto& i : cf_map) {
+        std::string prefix = i.first.substr(0, 1);
+        std::string prefix_count_str = i.first.substr(1);
+        int prefix_count = 1;
+        if (prefix_count_str.size() > 0) {
+          prefix_count = std::stoi(prefix_count_str);
+        }
+        auto sh = shards.find(prefix);
+        if (sh == shards.end()) {
+          derr << __func__ << " db prefix '" << prefix << "' illegal " << dendl;
+          return -EINVAL;
+        }
+        sh->second = prefix_count;
+        dout(10) << "prefix '" << prefix << "' split into " << prefix_count << "column families" << dendl;
+
+        for(int k = 0; k < prefix_count; k++) {
+          std::string cf_name = prefix + "-" + to_string(k);
+          dout(10) << "column family name=" << cf_name << ", options=" << i.second << dendl;
+          cfs.push_back(KeyValueDB::ColumnFamily(cf_name, i.second));
+        }
+      }
+
+      db = make_BlueStore_DB_Hash(db, shards);
     }
   }
+  FreelistManager::setup_merge_operators(db);
+  db->set_merge_operator(PREFIX_STAT, merge_op);
+  db->set_cache_size(cache_kv_ratio * cache_size);
 
   db->init(options);
   if (to_repair_db)
     return 0;
   if (create) {
-    if (cct->_conf.get_val<bool>("bluestore_rocksdb_cf")) {
-      r = db->create_and_open(err, cfs);
-    } else {
-      r = db->create_and_open(err);
-    }
+    r = db->create_and_open(err, cfs);
   } else {
     // we pass in cf list here, but it is only used if the db already has
     // column families created.

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5524,7 +5524,20 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
     return -EIO;
   }
   //wrap DB with sharded features
-  db = make_BlueStore_DB_Hash(db);
+  std::map<std::string, size_t> shards{
+    {PREFIX_SUPER, 1},
+    {PREFIX_STAT, 1},
+    {PREFIX_COLL, 1},
+    {PREFIX_OBJ, 7},
+    {PREFIX_OMAP, 11},
+    {PREFIX_PGMETA_OMAP, 1},
+    {PREFIX_DEFERRED, 1},
+    {PREFIX_ALLOC, 1},
+    {PREFIX_ALLOC_BITMAP, 9},
+    {PREFIX_SHARED_BLOB, 5}
+  };
+
+  db = make_BlueStore_DB_Hash(db, shards);
 
   FreelistManager::setup_merge_operators(db);
   db->set_merge_operator(PREFIX_STAT, merge_op);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2226,6 +2226,12 @@ private:
   int _open_db(bool create,
 	       bool to_repair_db=false,
 	       bool read_only = false);
+  /*
+   * splits string of sharding definition into ColumnFamily definition
+   */
+  int get_sharding(const std::string& sharding_schema,
+                   std::vector<KeyValueDB::ColumnFamily>& cfs,
+                   std::map<std::string, size_t>& shards);
   void _close_db();
   int _open_fm(KeyValueDB::Transaction t);
   void _close_fm();
@@ -2449,6 +2455,8 @@ public:
   int repair(bool deep) override {
     return _fsck(deep, true);
   }
+  int reshard(const std::string& new_sharding);
+
   int _fsck(bool deep, bool repair);
 
   void set_cache_shards(unsigned num) override;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2005,6 +2005,7 @@ private:
   uint64_t cache_size = 0;       ///< total cache size
   double cache_meta_ratio = 0;   ///< cache ratio dedicated to metadata
   double cache_kv_ratio = 0;     ///< cache ratio dedicated to kv (e.g., rocksdb)
+  double cache_kv_onode_ratio = 0; ///< cache ratio dedicated to kv onodes (e.g., rocksdb onode CF)
   double cache_data_ratio = 0;   ///< cache ratio dedicated to object data
   bool cache_autotune = false;   ///< cache autotune setting
   double cache_autotune_interval = 0; ///< time to wait between cache rebalancing
@@ -2036,6 +2037,7 @@ private:
     ceph::mutex lock = ceph::make_mutex("BlueStore::MempoolThread::lock");
     bool stop = false;
     std::shared_ptr<PriorityCache::PriCache> binned_kv_cache = nullptr;
+    std::shared_ptr<PriorityCache::PriCache> binned_kv_onode_cache = nullptr;
     std::shared_ptr<PriorityCache::Manager> pcm = nullptr;
 
     struct MempoolCache : public PriorityCache::PriCache {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2456,7 +2456,7 @@ public:
     return _fsck(deep, true);
   }
   int reshard(const std::string& new_sharding);
-
+  int _reshard(const std::string& new_sharding);
   int _fsck(bool deep, bool repair);
 
   void set_cache_shards(unsigned num) override;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2022,6 +2022,12 @@ private:
 
   bool per_pool_stat_collection = true;
 
+  friend class HashSharded_TransactionImpl;
+  KeyValueDB::Transaction get_transaction();
+  KeyValueDB::ColumnFamilyHandle get_db_shard(const std::string &prefix, const char *k, size_t keylen);
+  std::vector<KeyValueDB::ColumnFamilyHandle>& get_shards(const std::string &prefix);
+
+
   struct MempoolThread : public Thread {
   public:
     BlueStore *store;

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -163,10 +163,12 @@ private:
     for (auto& s_it: sharding_schema) {
       for (size_t i = 0; i < s_it.second; i++) {
         std::string name = s_it.first + "-" + to_string(i);
-        r = db->column_family_create(name, "");
-        if (r != 0) {
-          derr << "Unable to create column family: '" << name << "' " << dendl;
-          ceph_abort();
+        if (db->column_family_handle(name) == ColumnFamilyHandle()) {
+          r = db->column_family_create(name, "");
+          if (r != 0) {
+            derr << "Unable to create column family: '" << name << "' " << dendl;
+            ceph_abort();
+          }
         }
       }
     }

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -1,0 +1,678 @@
+#include "BlueStore.h"
+#include "kv/RocksDBStore.h"
+#include "include/ceph_hash.h"
+#define dout_context cct
+#define dout_subsys ceph_subsys_bluestore
+#undef dout_prefix
+#define dout_prefix *_dout << "shard-db "
+
+
+
+
+
+
+
+class BlueStore_DB_Hash : public KeyValueDB {
+public:
+  typedef std::map<std::string, size_t> ShardingSchema;
+private:
+  RocksDBStore* db;
+  CephContext* cct;
+  const rocksdb::Comparator* comparator;
+  ShardingSchema sharding_schema;
+  typedef std::map<std::string, std::vector<KeyValueDB::ColumnFamilyHandle> > ActiveShards;
+  ActiveShards shards;
+
+public:
+  BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sharding_schema)
+  : db(db), cct(db->cct), sharding_schema(sharding_schema) {
+    comparator = db->rocksdb_options.comparator;
+    ceph_assert(db);
+  }
+  virtual ~BlueStore_DB_Hash() {
+    delete db;
+  }
+private:
+  int open_shards() {
+    for (auto& s_it: sharding_schema) {
+      for (size_t i = 0; i < s_it.second; i++) {
+        std::string name = s_it.first + "-" + to_string(i);
+        auto cf_handle = db->column_family_handle(name);
+        dout(0) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+        shards[s_it.first].push_back(cf_handle);
+      }
+    }
+    return 0;
+  }
+  KeyValueDB::ColumnFamilyHandle get_db_shard(const std::string &prefix, const char *k, size_t keylen) {
+    auto it = shards.find(prefix);
+    ceph_assert(it != shards.end());
+    unsigned hash = ceph_str_hash_linux(k, keylen);
+    return it->second[hash % it->second.size()];
+  }
+  std::vector<KeyValueDB::ColumnFamilyHandle>& get_shards(const std::string &prefix) {
+    auto it = shards.find(prefix);
+    ceph_assert(it != shards.end());
+    return it->second;
+  }
+
+#undef dout_context
+#define dout_context db_hash.cct
+
+  class HashSharded_TransactionImpl : public RocksDBStore::RocksDBTransactionImpl //KeyValueDB::TransactionImpl
+  {
+  private:
+    typedef RocksDBStore::RocksDBTransactionImpl base;
+    BlueStore_DB_Hash &db_hash;
+  public:
+    HashSharded_TransactionImpl(BlueStore_DB_Hash &db_hash)
+    : RocksDBStore::RocksDBTransactionImpl(db_hash.db)
+    , db_hash(db_hash) {
+    }
+    virtual ~HashSharded_TransactionImpl() {
+    }
+
+    void set(
+      const string &prefix,
+      const string &k,
+      const bufferlist &bl) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+      base::select(cf);
+      base::set(prefix, k, bl);
+    }
+    void set(
+      const string &prefix,
+      const char *k,
+      size_t keylen,
+      const bufferlist &bl) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+      base::select(cf);
+      base::set(prefix, k, keylen, bl);
+    }
+    void rmkey(
+      const string &prefix,
+      const string &k) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+      base::select(cf);
+      base::rmkey(prefix, k);
+    }
+    void rmkey(
+      const string &prefix,
+      const char *k,
+      size_t keylen) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+      base::select(cf);
+      base::rmkey(prefix, k, keylen);
+    }
+    void rm_single_key(
+      const string &prefix,
+      const string &k) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+      base::select(cf);
+      base::rm_single_key(prefix, k);
+    }
+    void rmkeys_by_prefix(
+      const string &prefix
+      ) override {
+      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+      for (auto &s : shards) {
+        base::select(s);
+        base::rmkeys_by_prefix(prefix);
+      }
+    }
+    void rm_range_keys(
+      const string &prefix,
+      const string &start,
+      const string &end) override {
+      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+      for (auto &s : shards) {
+        base::select(s);
+        base::rm_range_keys(prefix, start, end);
+      }
+    }
+    void merge(
+      const string& prefix,
+      const string& k,
+      const bufferlist &bl) override {
+      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+      base::select(cf);
+      base::merge(prefix, k, bl);
+    }
+    void select(
+        KeyValueDB::ColumnFamilyHandle column_family_handle) override {
+      ceph_abort("Not expected");
+    }
+  };
+
+#undef dout_context
+#define dout_context cct
+
+public:
+  int init(string option_str="") override {
+    int r = db->init(option_str);
+    return r;
+  }
+  int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override {
+    int r = db->open(out, options);
+    if (r != 0)
+      return r;
+    vector<std::string> cf_names;
+    db->column_family_list(cf_names);
+    for (auto& s_it: sharding_schema) {
+      for (size_t i = 0; i < s_it.second; i++) {
+        std::string name = s_it.first + "-" + to_string(i);
+        auto n_it = std::find(std::begin(cf_names), std::end(cf_names), name);
+        if (n_it != cf_names.end()) {
+          derr << "Missing column family: '" << name << "' " << dendl;
+          ceph_abort();
+        }
+      }
+    }
+    r = open_shards();
+    return r;
+  }
+  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override {
+    int r = db->create_and_open(out, new_cfs);
+    if (r != 0)
+      return r;
+    for (auto& s_it: sharding_schema) {
+      for (size_t i = 0; i < s_it.second; i++) {
+        std::string name = s_it.first + "-" + to_string(i);
+        r = db->column_family_create(name, "");
+        if (r != 0) {
+          derr << "Unable to create column family: '" << name << "' " << dendl;
+          ceph_abort();
+        }
+      }
+    }
+    r = open_shards();
+    return r;
+  }
+  void close() override {
+    db->close();
+  }
+  int column_family_list(vector<std::string>& cf_names) override {
+    return db->column_family_list(cf_names);
+  }
+  int column_family_create(const std::string& cf_name, const std::string& cf_options) override {
+    return db->column_family_create(cf_name, cf_options);
+  }
+  int column_family_delete(const std::string& cf_name) override {
+    return db->column_family_delete(cf_name);
+  }
+  ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override {
+    return db->column_family_handle(cf_name);
+  }
+  int repair(std::ostream &out) override {
+    return db->repair(out);
+  }
+  Transaction get_transaction() override {
+    KeyValueDB::Transaction t = std::make_shared<HashSharded_TransactionImpl>(*this);
+    return t;
+  }
+  int submit_transaction(Transaction t) override {
+    return db->submit_transaction(t);
+  }
+  int submit_transaction_sync(Transaction t) override {
+    return db->submit_transaction_sync(t);
+  }
+
+  int get(const std::string &prefix,
+          const std::set<std::string> &keys,
+          std::map<std::string, bufferlist> *out) override {
+    std::map<void*, std::set<std::string> > sharded_keys;
+    for (auto& key : keys) {
+      std::string value;
+      KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
+      sharded_keys[cf.priv].emplace(key);
+    }
+    int r = 0;
+    for (auto sh = sharded_keys.begin(); r == 0 && sh != sharded_keys.end(); sh++) {
+      ColumnFamilyHandle cf;
+      cf.priv = sh->first;
+      db->get(cf, prefix, sh->second, out);
+    }
+    return r;
+  }
+
+  int get(const std::string &prefix,
+          const std::string &key,
+          bufferlist *value) override {
+    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
+    return db->get(cf, prefix, key, value);
+  }
+  int get(const string &prefix,
+          const char *key, size_t keylen,
+          bufferlist *value) override {
+    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key, keylen);
+    std::string s_key(key, keylen);
+    return db->get(cf, prefix, s_key, value);
+  }
+
+  int get(ColumnFamilyHandle cf_handle,
+                  const std::string &prefix,
+                  const std::set<std::string> &keys,
+                  std::map<std::string, bufferlist> *out) override {
+    ceph_assert(false && "invalid call");
+    return 0;
+  }
+
+  int get(ColumnFamilyHandle cf_handle,///< [in] Column family handle
+                  const std::string &prefix,    ///< [in] prefix or CF name
+                  const std::string &key,       ///< [in] key
+                  bufferlist *value) override {          ///< [out] value
+    ceph_assert(false && "invalid call");
+    return 0;
+  }
+
+  class WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
+  private:
+    BlueStore_DB_Hash &db_hash;
+    ActiveShards::iterator shards_it;
+    /** for currently processed prefix, contains iterators to shards */
+    std::vector<KeyValueDB::Iterator> current_shards_iterators;
+    /** for currently processed prefix, marks first iterator that is not exhaused */
+    ssize_t position;
+    /*
+     * simulation of next/prev work
+     * v_______________________v   ---
+     * it0 it1 it2 it3 it4 it5 it6 it7
+     * next
+     * it1 it2 it0 it3 it4 it5 it6 it7
+     * next
+     * it2 it0 it3 it4 it1 it5 it6 it7
+     * next
+     * it2 it0 it3 it4 it1 it5 it6 it7
+     * next, it2 expired
+     * --- v___________________v   ---
+     * it2 it0 it3 it4 it1 it5 it6 it7
+     * next, it0 expired
+     * --- --- v_______________v   ---
+     * prev, requires checking before, revived it0
+     * --- v___________________v   ---
+     * it2 it0 it3 it4 it1 it5 it6 it7
+     * prev, checks before, but not revives
+     * it2 it0 it3 it4 it1 it5 it6 it7
+    */
+    bool open_shards() {
+      current_shards_iterators.clear();
+      for (auto& it: shards_it->second) {
+        Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
+        wsi->seek_to_first();
+        if (wsi->valid())
+          current_shards_iterators.emplace_back(wsi);
+      }
+      position = 0;
+      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
+      return true;
+    }
+    int compare(const std::string& a, const std::string& b) {
+      rocksdb::Slice _a(a.data(), a.size());
+      rocksdb::Slice _b(b.data(), b.size());
+      return db_hash.comparator->Compare(_a, _b);
+    }
+    struct KeyLess {
+      WholeSpaceIteratorMerged_Impl& iter;
+      KeyLess(WholeSpaceIteratorMerged_Impl& iter) : iter(iter) {};
+      bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
+      {
+        if (!a->valid())
+          return false;
+        return iter.compare(a->key(), b->key()) < 0;
+      }
+    };
+
+  public:
+    WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash) : db_hash(db_hash), position(-1) {
+    }
+
+    virtual ~WholeSpaceIteratorMerged_Impl() {
+    }
+
+    int seek_to_first() override {
+      shards_it = db_hash.shards.begin();
+      if (shards_it == db_hash.shards.end())
+        return -1;
+      if (open_shards())
+        return 0;
+      else
+        return -1;
+    }
+
+    int seek_to_first(const string &prefix) override {
+      shards_it = db_hash.shards.find(prefix);
+      if (shards_it == db_hash.shards.end())
+        return -1;
+      if (open_shards())
+        return 0;
+      else
+        return -1;
+    }
+
+    int seek_to_last() override {
+      ceph_assert(false && "expected seek_to_last() not called");
+      return 0;
+    }
+
+    int seek_to_last(const string &prefix) override {
+      ceph_assert(false && "expected seek_to_last() not called");
+      return 0;
+    }
+
+    int upper_bound(const string &prefix, const string &after) override {
+      int r = seek_to_first(prefix);
+      if (r < 0)
+        return r;
+      for(auto& it: current_shards_iterators) {
+        it->upper_bound(after);
+      }
+      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
+      return 0;
+    }
+
+    int lower_bound(const string &prefix, const string &to) override {
+      int r = seek_to_first(prefix);
+      if (r < 0)
+        return r;
+      for(auto& it: current_shards_iterators) {
+        it->lower_bound(to);
+      }
+      struct KeyLess {
+        WholeSpaceIteratorMerged_Impl& iter;
+        KeyLess(WholeSpaceIteratorMerged_Impl& iter) : iter(iter) {};
+        bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
+        {
+          if (!a->valid())
+            return false;
+          return iter.compare(a->key(), b->key()) < 0;
+        }
+      };
+      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
+      return 0;
+    }
+
+    bool valid() override {
+      if ((position < 0) || (position >= (ssize_t)current_shards_iterators.size()) )
+        return false;
+      return current_shards_iterators[position]->valid();
+    }
+
+    int next() override {
+      current_shards_iterators[position]->next();
+      if (current_shards_iterators[position]->valid()) {
+        /* this means that next element on this iterator is ok,
+         * but it is likely that it will NOT be next in order */
+        if (position == (ssize_t)current_shards_iterators.size() - 1) {
+          /* this is last one, so it must be correct one */
+          return 0;
+        }
+        std::string key0 = current_shards_iterators[position]->key();
+        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
+          std::string key1 = current_shards_iterators[p]->key();
+          if (compare(key0, key1) < 0) {
+            /* all in order, no need to sort more */
+            break;
+          }
+          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
+        }
+        return 0;
+      }
+      ceph_assert(!current_shards_iterators[position]->valid());
+
+      /* this shard is used up */
+      position++;
+      if (position == (ssize_t)current_shards_iterators.size()) {
+        /* end of current prefix, try next */
+        shards_it++;
+        if (shards_it == db_hash.shards.end())
+          return -1;
+        open_shards();
+      }
+      return 0;
+    }
+
+    int prev() override {
+      ceph_assert(false && "expected prev() not called");
+      if (position > 0) {
+        if (!current_shards_iterators[position - 1]->valid()) {
+          current_shards_iterators[position - 1]->seek_to_last();
+        }
+      }
+
+      current_shards_iterators[position]->prev();
+      if (!current_shards_iterators[position]->valid()) {
+        current_shards_iterators[position]->seek_to_first();
+      }
+
+      current_shards_iterators[position]->prev();
+      if (current_shards_iterators[position]->valid()) {
+        /* this means that prev element on this iterator is ok,
+         * but it is likely that it will NOT be prev in order */
+        if (position == (ssize_t)current_shards_iterators.size() - 1) {
+          /* this is last one, so it must be correct one */
+          return 0;
+        }
+        std::string key0 = current_shards_iterators[position]->key();
+        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
+          std::string key1 = current_shards_iterators[p]->key();
+          if (compare(key0, key1) < 0) {
+            /* all in order, no need to sort more */
+            break;
+          }
+          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
+          std::swap(key0, key1);
+        }
+        return 0;
+      }
+      ceph_assert(!current_shards_iterators[position]->valid());
+
+      /* this shard is used up */
+      if (position)
+      position--;
+      if (position == (ssize_t)current_shards_iterators.size()) {
+        /* end! */
+        return -1;
+      }
+      return 0;
+    }
+
+    string key() override {
+      return current_shards_iterators[position]->key();
+    }
+    pair<string,string> raw_key() override {
+      return current_shards_iterators[position]->raw_key();
+    }
+    bool raw_key_is_prefixed(const string &prefix) override {
+      return prefix == shards_it->first;
+      //return current_shards_iterators[position]->raw_key_is_prefixed(prefix);
+    }
+    bufferlist value() override {
+      return current_shards_iterators[position]->value();
+    }
+    bufferptr value_as_ptr() override {
+      return current_shards_iterators[position]->value_as_ptr();
+    }
+    int status() override {
+      return current_shards_iterators[position]->status();
+    }
+  };
+private:
+
+#if 1
+  // This class filters a WholeSpaceIterator by a prefix.
+  class PrefixIteratorImpl : public IteratorImpl {
+    const std::string prefix;
+    WholeSpaceIterator generic_iter;
+  public:
+    PrefixIteratorImpl(const std::string &prefix, WholeSpaceIterator iter) :
+      prefix(prefix), generic_iter(iter) { }
+    ~PrefixIteratorImpl() override { }
+
+    int seek_to_first() override {
+      return generic_iter->seek_to_first(prefix);
+    }
+    int seek_to_last() override {
+      return generic_iter->seek_to_last(prefix);
+    }
+    int upper_bound(const std::string &after) override {
+      return generic_iter->upper_bound(prefix, after);
+    }
+    int lower_bound(const std::string &to) override {
+      return generic_iter->lower_bound(prefix, to);
+    }
+    bool valid() override {
+      if (!generic_iter->valid())
+        return false;
+      return generic_iter->raw_key_is_prefixed(prefix);
+    }
+    int next() override {
+      return generic_iter->next();
+    }
+    int prev() override {
+      return generic_iter->prev();
+    }
+    std::string key() override {
+      return generic_iter->key();
+    }
+    std::pair<std::string, std::string> raw_key() override {
+      return generic_iter->raw_key();
+    }
+    bufferlist value() override {
+      return generic_iter->value();
+    }
+    bufferptr value_as_ptr() override {
+      return generic_iter->value_as_ptr();
+    }
+    int status() override {
+      return generic_iter->status();
+    }
+  };
+#endif
+
+public:
+
+  WholeSpaceIterator get_wholespace_iterator() override {
+    return std::make_shared<WholeSpaceIteratorMerged_Impl>(*this);
+  }
+  Iterator get_iterator(const std::string &prefix) override {
+    return std::make_shared<PrefixIteratorImpl>(
+      prefix,
+      get_wholespace_iterator());
+  }
+  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override {
+    ceph_abort_msg("Not implemented"); return {};
+  }
+  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override {
+    ceph_abort_msg("Not implemented"); return {};
+  }
+
+  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override {
+    return db->get_estimated_size(extra);
+  }
+  int get_statfs(struct store_statfs_t *buf) override {
+    return -EOPNOTSUPP;
+  }
+
+  int set_cache_size(uint64_t) override {
+    return -EOPNOTSUPP;
+  }
+
+  // PriCache
+  int64_t request_cache_bytes(PriorityCache::Priority pri, uint64_t chunk_bytes) const override {
+    return db->request_cache_bytes(pri, chunk_bytes);
+  }
+
+  int64_t get_cache_bytes(PriorityCache::Priority pri) const override {
+    return db->get_cache_bytes(pri);
+  }
+
+  int64_t get_cache_bytes() const override {
+    return db->get_cache_bytes();
+  }
+
+  void set_cache_bytes(PriorityCache::Priority pri, int64_t bytes) override {
+    db->set_cache_bytes(pri, bytes);
+  }
+
+  void add_cache_bytes(PriorityCache::Priority pri, int64_t bytes) override {
+    db->add_cache_bytes(pri, bytes);
+  }
+
+  int64_t commit_cache_size() override {
+    return db->commit_cache_size();
+  }
+
+  double get_cache_ratio() const override {
+    return db->get_cache_ratio();
+  }
+
+  void set_cache_ratio(double ratio) override {
+    db->set_cache_ratio(ratio);
+  }
+
+  string get_cache_name() const override {
+    return db->get_cache_name();
+  }
+
+  // End PriCache
+
+  int set_cache_high_pri_pool_ratio(double ratio) override {
+    return db->set_cache_high_pri_pool_ratio(ratio);
+  }
+
+  int64_t get_cache_usage() const override {
+    return db->get_cache_usage();
+  }
+
+  /// estimate space utilization for a prefix (in bytes)
+  int64_t estimate_prefix_size(const string& prefix,
+                               ColumnFamilyHandle cfh = ColumnFamilyHandle()) override {
+    return 0;
+  }
+
+  void compact() override {
+    db->compact();
+  }
+  void compact_async() override {
+    db->compact_async();
+  }
+  void compact_prefix(const std::string& prefix) override {
+    //TODO
+    db->compact_prefix(prefix);
+  }
+  void compact_prefix_async(const std::string& prefix) override {
+    //TODO
+    db->compact_prefix_async(prefix);
+  }
+  void compact_range(const std::string& prefix,
+                     const std::string& start, const std::string& end) override {
+    //TODO
+    db->compact_range(prefix, start, end);
+  }
+  void compact_range_async(const std::string& prefix,
+                           const std::string& start, const std::string& end) override {
+    //TODO
+    db->compact_range_async(prefix, start, end);
+  }
+
+  int set_merge_operator(const std::string& prefix,
+                         std::shared_ptr<MergeOperator> mop) override {
+    //TODO!!
+    return db->set_merge_operator(prefix, mop);
+    return -EOPNOTSUPP;
+  }
+
+  void get_statistics(Formatter *f) override {
+    db->get_statistics(f);
+  }
+
+};
+
+
+
+KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB* db, const BlueStore_DB_Hash::ShardingSchema& schema) {
+  RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
+  ceph_assert(db != nullptr);
+  return new BlueStore_DB_Hash(rdb, schema);
+}
+

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -7,14 +7,10 @@
 #define dout_prefix *_dout << "shard-db "
 
 
-
-
-
-
-
 class BlueStore_DB_Hash : public KeyValueDB {
 public:
   typedef std::map<std::string, size_t> ShardingSchema;
+
 private:
   RocksDBStore* db;
   CephContext* cct;
@@ -38,12 +34,12 @@ private:
       if (s_it.second == 0) {
         auto cf_handle = db->column_family_handle("default");
         shards[s_it.first].push_back(cf_handle);
-        dout(0) << "Column family '" << s_it.first << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+        dout(5) << "Column family '" << s_it.first << "' handle: " << (void*)cf_handle.priv << " " << dendl;
       } else {
         for (size_t i = 0; i < s_it.second; i++) {
           std::string name = s_it.first + "-" + to_string(i);
           auto cf_handle = db->column_family_handle(name);
-          dout(0) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+          dout(5) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
           shards[s_it.first].push_back(cf_handle);
         }
       }
@@ -153,7 +149,6 @@ private:
 #undef dout_context
 #define dout_context cct
 
-public:
   int init(string option_str="") override {
     int r = db->init(option_str);
     return r;
@@ -271,14 +266,87 @@ public:
     return 0;
   }
 
-  class WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
-  private:
-    BlueStore_DB_Hash &db_hash;
-    ActiveShards::iterator shards_it;
-    /** for currently processed prefix, contains iterators to shards */
-    std::vector<KeyValueDB::Iterator> current_shards_iterators;
-    /** for currently processed prefix, marks first iterator that is not exhaused */
-    ssize_t position;
+  static int compare(const rocksdb::Comparator* comparator,
+                     const std::string& a,
+                     const std::string& b) {
+    rocksdb::Slice _a(a.data(), a.size());
+    rocksdb::Slice _b(b.data(), b.size());
+    return comparator->Compare(_a, _b);
+  }
+
+  struct KeyLess {
+    const rocksdb::Comparator* comparator;
+    KeyLess(const rocksdb::Comparator* comparator) : comparator(comparator) { };
+    bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
+    {
+      if (a->valid()) {
+        if (b->valid()) {
+          return compare(comparator, a->key(), b->key()) < 0;
+        } else {
+          return true;
+        }
+      } else {
+        if (b->valid()) {
+          return false;
+        } else {
+          return (void*)a.get() < (void*)b.get();
+        }
+      }
+    }
+  };
+
+
+  class ShardedIteratorBase {
+    ssize_t position = 0;
+    std::vector<KeyValueDB::Iterator> shards;
+    const rocksdb::Comparator* comparator;
+  public:
+    ShardedIteratorBase(std::vector<KeyValueDB::Iterator>&& shards, const rocksdb::Comparator* comparator)
+    : shards(std::move(shards))
+    , comparator(comparator) { }
+
+    ~ShardedIteratorBase() { }
+
+    int open(const std::vector<KeyValueDB::Iterator>& new_shards) {
+      shards = new_shards;
+      return 0;
+    }
+    KeyValueDB::Iterator& item() {
+      return shards[position];
+    }
+    int seek_to_last() {
+      ceph_assert(false && "expected seek_to_last() not called");
+      return 0;
+    }
+    int seek_to_first() {
+      for (auto& it: shards) {
+        it->seek_to_first();
+      }
+      position = 0;
+      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+      return 0;
+    }
+    int upper_bound(const string &after) {
+      for(auto& it: shards) {
+        it->upper_bound(after);
+      }
+      position = 0;
+      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+      return 0;
+    }
+    int lower_bound(const string &to) {
+      for(auto& it: shards) {
+        it->lower_bound(to);
+      }
+      position = 0;
+      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+      return 0;
+    }
+    bool valid() {
+      if (position >= (ssize_t)shards.size() )
+        return false;
+      return shards[position]->valid();
+    }
     /*
      * simulation of next/prev work
      * v_______________________v   ---
@@ -300,289 +368,207 @@ public:
      * prev, checks before, but not revives
      * it2 it0 it3 it4 it1 it5 it6 it7
     */
-    bool open_shards() {
-      current_shards_iterators.clear();
+    int next() {
+      shards[position]->next();
+      if (shards[position]->valid()) {
+        /* sort, as other shards may point to key that is less then
+         * key that we just moved to */
+        std::string key0 = shards[position]->key();
+        for (size_t p = position + 1; p < shards.size(); p++) {
+          std::string key1 = shards[p]->key();
+          if (compare(comparator, key0, key1) < 0) {
+            /* all in order, no need to sort more */
+            break;
+          }
+          std::swap(shards[p - 1], shards[p]);
+        }
+      } else {
+        position++;
+      }
+      /* signal if we iterated out of range */
+      if (position >= (ssize_t)shards.size())
+        return -1;
+      return 0;
+    }
+
+    int prev() {
+      return -1;
+    }
+  };
+
+  class WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
+  private:
+    BlueStore_DB_Hash &db_hash;
+    ActiveShards::iterator shards_it;
+    ShardedIteratorBase iter;
+
+    void open_shards(std::vector<KeyValueDB::Iterator>& shards) {
       for (auto& it: shards_it->second) {
         Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
         wsi->seek_to_first();
         if (wsi->valid())
-          current_shards_iterators.emplace_back(wsi);
+          shards.emplace_back(wsi);
       }
-      position = 0;
-      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      return true;
     }
-    int compare(const std::string& a, const std::string& b) {
-      rocksdb::Slice _a(a.data(), a.size());
-      rocksdb::Slice _b(b.data(), b.size());
-      return db_hash.comparator->Compare(_a, _b);
+    void open_shards(std::vector<KeyValueDB::Iterator>& shards, const std::string& prefix) {
+      shards.emplace_back(db_hash.db->get_iterator(prefix));
     }
-    struct KeyLess {
-      WholeSpaceIteratorMerged_Impl& iter;
-      KeyLess(WholeSpaceIteratorMerged_Impl& iter) : iter(iter) {};
-      bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
-      {
-        if (!a->valid())
-          return false;
-        return iter.compare(a->key(), b->key()) < 0;
-      }
-    };
 
   public:
-    WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash) : db_hash(db_hash), position(-1) {
-    }
+    WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash)
+      : db_hash(db_hash)
+      , iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {}
 
-    virtual ~WholeSpaceIteratorMerged_Impl() {
+    virtual ~WholeSpaceIteratorMerged_Impl() {}
+
+    int seek_to_first_existing() {
+      while (shards_it != db_hash.shards.end()) {
+        std::vector<KeyValueDB::Iterator> shards;
+        if (shards_it->second.size() == 0) {
+          /* no separate shard, is part of default column family */
+          open_shards(shards, shards_it->first);
+        } else {
+          open_shards(shards);
+        }
+        iter.open(shards);
+        iter.seek_to_first();
+        if (iter.valid()) {
+          return 0;
+        }
+        //this shard is empty, go next
+        ++shards_it;
+      };
+      return -1;
     }
 
     int seek_to_first() override {
       shards_it = db_hash.shards.begin();
-      if (shards_it == db_hash.shards.end())
-        return -1;
-      if (open_shards())
-        return 0;
-      else
-        return -1;
+      return seek_to_first_existing();
     }
-
     int seek_to_first(const string &prefix) override {
       shards_it = db_hash.shards.find(prefix);
-      if (shards_it == db_hash.shards.end())
-        return -1;
-      if (open_shards())
-        return 0;
-      else
-        return -1;
+      return seek_to_first_existing();
     }
-
     int seek_to_last() override {
       ceph_assert(false && "expected seek_to_last() not called");
       return 0;
     }
-
     int seek_to_last(const string &prefix) override {
       ceph_assert(false && "expected seek_to_last() not called");
       return 0;
     }
-
     int upper_bound(const string &prefix, const string &after) override {
-      int r = seek_to_first(prefix);
-      if (r < 0)
-        return r;
-      for(auto& it: current_shards_iterators) {
-        it->upper_bound(after);
-      }
-      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      return 0;
-    }
-
-    int lower_bound(const string &prefix, const string &to) override {
-      int r = seek_to_first(prefix);
-      if (r < 0)
-        return r;
-      for(auto& it: current_shards_iterators) {
-        it->lower_bound(to);
-      }
-      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      return 0;
-    }
-
-    bool valid() override {
-      if ((position < 0) || (position >= (ssize_t)current_shards_iterators.size()) )
-        return false;
-      return current_shards_iterators[position]->valid();
-    }
-
-    int next() override {
-      current_shards_iterators[position]->next();
-      if (current_shards_iterators[position]->valid()) {
-        /* this means that next element on this iterator is ok,
-         * but it is likely that it will NOT be next in order */
-        if (position == (ssize_t)current_shards_iterators.size() - 1) {
-          /* this is last one, so it must be correct one */
-          return 0;
-        }
-        std::string key0 = current_shards_iterators[position]->key();
-        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
-          std::string key1 = current_shards_iterators[p]->key();
-          if (compare(key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
-        }
-        return 0;
-      }
-      ceph_assert(!current_shards_iterators[position]->valid());
-
-      /* this shard is used up */
-      position++;
-      if (position == (ssize_t)current_shards_iterators.size()) {
-        /* end of current prefix, try next */
-        shards_it++;
-        if (shards_it == db_hash.shards.end())
-          return -1;
-        open_shards();
-      }
-      return 0;
-    }
-
-    int prev() override {
-      ceph_assert(false && "expected prev() not called");
-      if (position > 0) {
-        if (!current_shards_iterators[position - 1]->valid()) {
-          current_shards_iterators[position - 1]->seek_to_last();
-        }
-      }
-
-      current_shards_iterators[position]->prev();
-      if (!current_shards_iterators[position]->valid()) {
-        current_shards_iterators[position]->seek_to_first();
-      }
-
-      current_shards_iterators[position]->prev();
-      if (current_shards_iterators[position]->valid()) {
-        /* this means that prev element on this iterator is ok,
-         * but it is likely that it will NOT be prev in order */
-        if (position == (ssize_t)current_shards_iterators.size() - 1) {
-          /* this is last one, so it must be correct one */
-          return 0;
-        }
-        std::string key0 = current_shards_iterators[position]->key();
-        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
-          std::string key1 = current_shards_iterators[p]->key();
-          if (compare(key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
-          std::swap(key0, key1);
-        }
-        return 0;
-      }
-      ceph_assert(!current_shards_iterators[position]->valid());
-
-      /* this shard is used up */
-      if (position)
-      position--;
-      if (position == (ssize_t)current_shards_iterators.size()) {
-        /* end! */
+      shards_it = db_hash.shards.lower_bound(prefix);
+      if (shards_it == db_hash.shards.end()) {
         return -1;
       }
+      seek_to_first_existing();
+      if (shards_it == db_hash.shards.end()) {
+        return -1;
+      }
+      if (shards_it->first == prefix) {
+        /* we are in intended prefix, we need more detailed upper_bound */
+        iter.upper_bound(after);
+        if (!iter.valid()) {
+          /* nothing after target of upper_bound*/
+          ++shards_it;
+          return seek_to_first();
+        }
+      }
       return 0;
     }
-
+    int lower_bound(const string &prefix, const string &to) override {
+      shards_it = db_hash.shards.lower_bound(prefix);
+      if (shards_it == db_hash.shards.end()) {
+        return -1;
+      }
+      seek_to_first_existing();
+      if (shards_it == db_hash.shards.end()) {
+        return -1;
+      }
+      if (shards_it->first == prefix) {
+        /* we are in intended prefix, we need more detailed upper_bound */
+        iter.lower_bound(to);
+        if (!iter.valid()) {
+          /* nothing after target of upper_bound*/
+          ++shards_it;
+          return seek_to_first_existing();
+        }
+      }
+      return 0;
+    }
+    bool valid() override {
+      return iter.valid();
+    }
+    int next() override {
+      int r = iter.next();
+      if (r < 0) {
+        /* if we iterated out of current shard, go on */
+        ++shards_it;
+        return seek_to_first_existing();
+      }
+      return r;
+    }
+    int prev() override {
+      ceph_assert(false && "expected prev() not called");
+      return 0;
+    }
     string key() override {
-      return current_shards_iterators[position]->key();
+      return iter.item()->key();
     }
     pair<string,string> raw_key() override {
-      return current_shards_iterators[position]->raw_key();
+      return iter.item()->raw_key();
     }
     bool raw_key_is_prefixed(const string &prefix) override {
       return prefix == shards_it->first;
-      //return current_shards_iterators[position]->raw_key_is_prefixed(prefix);
     }
     bufferlist value() override {
-      return current_shards_iterators[position]->value();
+      return iter.item()->value();
     }
     bufferptr value_as_ptr() override {
-      return current_shards_iterators[position]->value_as_ptr();
+      return iter.item()->value_as_ptr();
     }
     int status() override {
-      return current_shards_iterators[position]->status();
+      return iter.item()->status();
     }
   };
 
 #undef dout_context
 #define dout_context db_hash.cct
 
-
   class SinglePrefixIteratorMerged_Impl: public IteratorImpl {
   private:
-    BlueStore_DB_Hash &db_hash;
-    ActiveShards::iterator shards_it;
-    /** for currently processed prefix, contains iterators to shards */
-    std::vector<KeyValueDB::Iterator> current_shards_iterators;
-    /** for currently processed prefix, marks first iterator that is not exhaused */
-    ssize_t position;
-    /*
-     * simulation of next/prev work
-     * v_______________________v   ---
-     * it0 it1 it2 it3 it4 it5 it6 it7
-     * next
-     * it1 it2 it0 it3 it4 it5 it6 it7
-     * next
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next, it2 expired
-     * --- v___________________v   ---
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next, it0 expired
-     * --- --- v_______________v   ---
-     * prev, requires checking before, revived it0
-     * --- v___________________v   ---
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * prev, checks before, but not revives
-     * it2 it0 it3 it4 it1 it5 it6 it7
-    */
-    bool open_shards() {
-      current_shards_iterators.clear();
-      for (auto& it: shards_it->second) {
-        Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
-        wsi->seek_to_first();
-        if (wsi->valid())
-          current_shards_iterators.emplace_back(wsi);
-      }
-      position = 0;
-      std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      return true;
-    }
-    int compare(const std::string& a, const std::string& b) {
-      rocksdb::Slice _a(a.data(), a.size());
-      rocksdb::Slice _b(b.data(), b.size());
-      return db_hash.comparator->Compare(_a, _b);
-    }
-    struct KeyLess {
-      SinglePrefixIteratorMerged_Impl& iter;
-      KeyLess(SinglePrefixIteratorMerged_Impl& iter) : iter(iter) {};
-      bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
-      {
-        if (!a->valid())
-          return false;
-        return iter.compare(a->key(), b->key()) < 0;
-      }
-    };
+    ShardedIteratorBase iter;
 
-  public:
-    SinglePrefixIteratorMerged_Impl(BlueStore_DB_Hash &db_hash, const string& prefix) : db_hash(db_hash), position(-1) {
-      shards_it = db_hash.shards.find(prefix);
+    static void prefix_to_iterators(
+        std::vector<KeyValueDB::Iterator>& shards,
+        const BlueStore_DB_Hash &db_hash,
+        const string& prefix) {
+      auto shards_it = db_hash.shards.find(prefix);
       if (shards_it != db_hash.shards.end()) {
         for (auto& it: shards_it->second) {
           Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
           wsi->seek_to_first();
           if (wsi->valid())
-            current_shards_iterators.emplace_back(wsi);
+            shards.emplace_back(wsi);
         }
-        if (!current_shards_iterators.empty()) {
-          position = 0;
-          std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-        }
+        std::sort(shards.begin(), shards.end(), KeyLess(db_hash.comparator));
       }
+    }
+
+  public:
+    SinglePrefixIteratorMerged_Impl(BlueStore_DB_Hash &db_hash, const string& prefix)
+    : iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {
+      std::vector<KeyValueDB::Iterator> shards;
+      prefix_to_iterators(shards, db_hash, prefix);
+      iter.open(shards);
     }
 
     virtual ~SinglePrefixIteratorMerged_Impl() {
     }
 
     int seek_to_first() override {
-      for (auto& it: current_shards_iterators) {
-        it->seek_to_first();
-      }
-      if (!current_shards_iterators.empty()) {
-        position = 0;
-        std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      }
-      return 0;
+      return iter.seek_to_first();
     }
 
     int seek_to_last() override {
@@ -591,125 +577,50 @@ public:
     }
 
     int upper_bound(const string &after) override {
-      for(auto& it: current_shards_iterators) {
-        it->upper_bound(after);
-      }
-      if (!current_shards_iterators.empty()) {
-        position = 0;
-        std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      }
-      return 0;
+      return iter.upper_bound(after);
     }
 
     int lower_bound(const string &to) override {
-      for(auto& it: current_shards_iterators) {
-        it->lower_bound(to);
-      }
-      if (!current_shards_iterators.empty()) {
-        position = 0;
-        std::sort(current_shards_iterators.begin(), current_shards_iterators.end(), KeyLess(*this));
-      }
-      return 0;
+      return iter.lower_bound(to);
     }
 
     bool valid() override {
-      if ((position < 0) || (position >= (ssize_t)current_shards_iterators.size()) )
-        return false;
-      return current_shards_iterators[position]->valid();
+      return iter.valid();
     }
 
     int next() override {
-      current_shards_iterators[position]->next();
-      if (current_shards_iterators[position]->valid()) {
-        /* this means that next element on this iterator is ok,
-         * but it is likely that it will NOT be next in order */
-        if (position == (ssize_t)current_shards_iterators.size() - 1) {
-          /* this is last one, so it must be correct one */
-          return 0;
-        }
-        std::string key0 = current_shards_iterators[position]->key();
-        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
-          std::string key1 = current_shards_iterators[p]->key();
-          if (compare(key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
-        }
-        return 0;
-      }
-      ceph_assert(!current_shards_iterators[position]->valid());
-      return -1;
+      return iter.next();
     }
 
     int prev() override {
       ceph_assert(false && "expected prev() not called");
-      if (position > 0) {
-        if (!current_shards_iterators[position - 1]->valid()) {
-          current_shards_iterators[position - 1]->seek_to_last();
-        }
-      }
-
-      current_shards_iterators[position]->prev();
-      if (!current_shards_iterators[position]->valid()) {
-        current_shards_iterators[position]->seek_to_first();
-      }
-
-      current_shards_iterators[position]->prev();
-      if (current_shards_iterators[position]->valid()) {
-        /* this means that prev element on this iterator is ok,
-         * but it is likely that it will NOT be prev in order */
-        if (position == (ssize_t)current_shards_iterators.size() - 1) {
-          /* this is last one, so it must be correct one */
-          return 0;
-        }
-        std::string key0 = current_shards_iterators[position]->key();
-        for (size_t p = position + 1; p < current_shards_iterators.size(); p++) {
-          std::string key1 = current_shards_iterators[p]->key();
-          if (compare(key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(current_shards_iterators[p - 1], current_shards_iterators[p]);
-          std::swap(key0, key1);
-        }
-        return 0;
-      }
-      ceph_assert(!current_shards_iterators[position]->valid());
-
-      /* this shard is used up */
-      if (position)
-      position--;
-      if (position == (ssize_t)current_shards_iterators.size()) {
-        /* end! */
-        return -1;
-      }
       return 0;
     }
 
     string key() override {
-      return current_shards_iterators[position]->key();
+      return iter.item()->key();
     }
+
     pair<string,string> raw_key() override {
-      return current_shards_iterators[position]->raw_key();
+      return iter.item()->raw_key();
     }
+
     bufferlist value() override {
-      return current_shards_iterators[position]->value();
+      return iter.item()->value();
     }
+
     bufferptr value_as_ptr() override {
-      return current_shards_iterators[position]->value_as_ptr();
+      return iter.item()->value_as_ptr();
     }
+
     int status() override {
-      return current_shards_iterators[position]->status();
+      return iter.item()->status();
     }
   };
+
 #undef dout_context
 #define dout_context cct
 
-
-private:
-
-#if 1
   // This class filters a WholeSpaceIterator by a prefix.
   class PrefixIteratorImpl : public IteratorImpl {
     const std::string prefix;
@@ -758,7 +669,6 @@ private:
       return generic_iter->status();
     }
   };
-#endif
 
 public:
 
@@ -908,14 +818,10 @@ public:
   void get_statistics(Formatter *f) override {
     db->get_statistics(f);
   }
-
 };
-
-
 
 KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB* db, const BlueStore_DB_Hash::ShardingSchema& schema) {
   RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
   ceph_assert(db != nullptr);
   return new BlueStore_DB_Hash(rdb, schema);
 }
-

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -45,6 +45,7 @@ class BlueStore_DB_Hash::HashSharded_TransactionImpl : public RocksDBStore::Rock
 private:
   typedef RocksDBStore::RocksDBTransactionImpl base;
   BlueStore_DB_Hash &db_hash;
+  KeyValueDB::ColumnFamilyHandle cf;
 public:
   HashSharded_TransactionImpl(BlueStore_DB_Hash &db_hash)
 : RocksDBStore::RocksDBTransactionImpl(db_hash.db)
@@ -57,71 +58,95 @@ public:
       const string &prefix,
       const string &k,
       const bufferlist &bl) override {
-    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    if (!cf)
+      cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
     base::select(cf);
     base::set(prefix, k, bl);
+    cf.clear();
   }
   void set(
       const string &prefix,
       const char *k,
       size_t keylen,
       const bufferlist &bl) override {
-    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+    if (!cf)
+      cf = db_hash.get_db_shard(prefix, k, keylen);
     base::select(cf);
     base::set(prefix, k, keylen, bl);
+    cf.clear();
   }
   void rmkey(
       const string &prefix,
       const string &k) override {
-    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    if (!cf)
+      cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
     base::select(cf);
     base::rmkey(prefix, k);
+    cf.clear();
   }
   void rmkey(
       const string &prefix,
       const char *k,
       size_t keylen) override {
-    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+    if (!cf)
+      cf = db_hash.get_db_shard(prefix, k, keylen);
     base::select(cf);
     base::rmkey(prefix, k, keylen);
+    cf.clear();
   }
   void rm_single_key(
       const string &prefix,
       const string &k) override {
-    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    if (!cf)
+      cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
     base::select(cf);
     base::rm_single_key(prefix, k);
+    cf.clear();
   }
   void rmkeys_by_prefix(
       const string &prefix
   ) override {
-    std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
-    for (auto &s : shards) {
-      base::select(s);
+    if (!cf) {
+      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+      for (auto &s : shards) {
+	base::select(s);
+	base::rmkeys_by_prefix(prefix);
+      }
+    } else {
+      base::select(cf);
       base::rmkeys_by_prefix(prefix);
+      cf.clear();
     }
   }
   void rm_range_keys(
       const string &prefix,
       const string &start,
       const string &end) override {
-    std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
-    for (auto &s : shards) {
-      base::select(s);
+    if (!cf) {
+      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+      for (auto &s : shards) {
+	base::select(s);
+	base::rm_range_keys(prefix, start, end);
+      }
+    } else {
+      base::select(cf);
       base::rm_range_keys(prefix, start, end);
+      cf.clear();
     }
   }
   void merge(
       const string& prefix,
       const string& k,
       const bufferlist &bl) override {
-    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    if (!cf)
+      cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
     base::select(cf);
     base::merge(prefix, k, bl);
+    cf.clear();
   }
   void select(
       KeyValueDB::ColumnFamilyHandle column_family_handle) override {
-    ceph_abort("Not expected");
+    cf = column_family_handle;
   }
 };
 
@@ -665,16 +690,14 @@ int BlueStore_DB_Hash::get(ColumnFamilyHandle cf_handle,
                            const std::string &prefix,
                            const std::set<std::string> &keys,
                            std::map<std::string, bufferlist> *out) {
-  ceph_assert(false && "invalid call");
-  return 0;
+  return db->get(cf_handle, prefix, keys, out);
 }
 
 int BlueStore_DB_Hash::get(ColumnFamilyHandle cf_handle,///< [in] Column family handle
                            const std::string &prefix,    ///< [in] prefix or CF name
                            const std::string &key,       ///< [in] key
                            bufferlist *value) {          ///< [out] value
-  ceph_assert(false && "invalid call");
-  return 0;
+  return db->get(cf_handle, prefix, key, value);
 }
 
 KeyValueDB::WholeSpaceIterator BlueStore_DB_Hash::get_wholespace_iterator() {
@@ -688,10 +711,10 @@ KeyValueDB::Iterator BlueStore_DB_Hash::get_iterator(const std::string &prefix) 
   return db->get_iterator(prefix);
 }
 KeyValueDB::WholeSpaceIterator BlueStore_DB_Hash::get_wholespace_iterator_cf(ColumnFamilyHandle cfh) {
-  ceph_abort_msg("Not implemented"); return {};
+  return db->get_wholespace_iterator_cf(cfh);
 }
 KeyValueDB::Iterator BlueStore_DB_Hash::get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) {
-  ceph_abort_msg("Not implemented"); return {};
+  return db->get_iterator_cf(cfh, prefix);
 }
 
 uint64_t BlueStore_DB_Hash::get_estimated_size(std::map<std::string,uint64_t> &extra) {

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -1,798 +1,801 @@
-#include "BlueStore.h"
-#include "kv/RocksDBStore.h"
-#include "include/ceph_hash.h"
+#include "BlueStore_DB_Hash.h"
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "shard-db "
 
 
-class BlueStore_DB_Hash : public KeyValueDB {
-public:
-  typedef std::map<std::string, size_t> ShardingSchema;
 
-private:
-  RocksDBStore* db;
-  CephContext* cct;
+
+static int compare(const rocksdb::Comparator* comparator,
+                   const std::string& a,
+                   const std::string& b) {
+  rocksdb::Slice _a(a.data(), a.size());
+  rocksdb::Slice _b(b.data(), b.size());
+  return comparator->Compare(_a, _b);
+}
+
+struct KeyLess {
   const rocksdb::Comparator* comparator;
-  ShardingSchema sharding_schema;
-  typedef std::map<std::string, std::vector<KeyValueDB::ColumnFamilyHandle> > ActiveShards;
-  ActiveShards shards;
-
-public:
-  BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sharding_schema)
-  : db(db), cct(db->cct), sharding_schema(sharding_schema) {
-    comparator = db->rocksdb_options.comparator;
-    ceph_assert(db);
-  }
-  virtual ~BlueStore_DB_Hash() {
-    delete db;
-  }
-private:
-  int open_shards() {
-    for (auto& s_it: sharding_schema) {
-      if (s_it.second == 0) {
-        auto cf_handle = db->column_family_handle("default");
-        shards[s_it.first].push_back(cf_handle);
-        dout(5) << "Column family '" << s_it.first << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+  KeyLess(const rocksdb::Comparator* comparator) : comparator(comparator) { };
+  bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
+  {
+    if (a->valid()) {
+      if (b->valid()) {
+        return compare(comparator, a->key(), b->key()) < 0;
       } else {
-        for (size_t i = 0; i < s_it.second; i++) {
-          std::string name = s_it.first + "-" + to_string(i);
-          auto cf_handle = db->column_family_handle(name);
-          dout(5) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
-          shards[s_it.first].push_back(cf_handle);
-        }
+        return true;
+      }
+    } else {
+      if (b->valid()) {
+        return false;
+      } else {
+        return (void*)a.get() < (void*)b.get();
       }
     }
-    return 0;
   }
-  KeyValueDB::ColumnFamilyHandle get_db_shard(const std::string &prefix, const char *k, size_t keylen) {
-    auto it = shards.find(prefix);
-    ceph_assert(it != shards.end());
-    unsigned hash = ceph_str_hash_linux(k, keylen);
-    return it->second[hash % it->second.size()];
+};
+
+
+
+
+class BlueStore_DB_Hash::HashSharded_TransactionImpl : public RocksDBStore::RocksDBTransactionImpl //KeyValueDB::TransactionImpl
+{
+private:
+  typedef RocksDBStore::RocksDBTransactionImpl base;
+  BlueStore_DB_Hash &db_hash;
+public:
+  HashSharded_TransactionImpl(BlueStore_DB_Hash &db_hash)
+: RocksDBStore::RocksDBTransactionImpl(db_hash.db)
+  , db_hash(db_hash) {
   }
-  std::vector<KeyValueDB::ColumnFamilyHandle>& get_shards(const std::string &prefix) {
-    auto it = shards.find(prefix);
-    ceph_assert(it != shards.end());
-    return it->second;
+  virtual ~HashSharded_TransactionImpl() {
   }
 
-#undef dout_context
-#define dout_context db_hash.cct
-
-  class HashSharded_TransactionImpl : public RocksDBStore::RocksDBTransactionImpl //KeyValueDB::TransactionImpl
-  {
-  private:
-    typedef RocksDBStore::RocksDBTransactionImpl base;
-    BlueStore_DB_Hash &db_hash;
-  public:
-    HashSharded_TransactionImpl(BlueStore_DB_Hash &db_hash)
-    : RocksDBStore::RocksDBTransactionImpl(db_hash.db)
-    , db_hash(db_hash) {
-    }
-    virtual ~HashSharded_TransactionImpl() {
-    }
-
-    void set(
+  void set(
       const string &prefix,
       const string &k,
       const bufferlist &bl) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
-      base::select(cf);
-      base::set(prefix, k, bl);
-    }
-    void set(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    base::select(cf);
+    base::set(prefix, k, bl);
+  }
+  void set(
       const string &prefix,
       const char *k,
       size_t keylen,
       const bufferlist &bl) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
-      base::select(cf);
-      base::set(prefix, k, keylen, bl);
-    }
-    void rmkey(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+    base::select(cf);
+    base::set(prefix, k, keylen, bl);
+  }
+  void rmkey(
       const string &prefix,
       const string &k) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
-      base::select(cf);
-      base::rmkey(prefix, k);
-    }
-    void rmkey(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    base::select(cf);
+    base::rmkey(prefix, k);
+  }
+  void rmkey(
       const string &prefix,
       const char *k,
       size_t keylen) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
-      base::select(cf);
-      base::rmkey(prefix, k, keylen);
-    }
-    void rm_single_key(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k, keylen);
+    base::select(cf);
+    base::rmkey(prefix, k, keylen);
+  }
+  void rm_single_key(
       const string &prefix,
       const string &k) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
-      base::select(cf);
-      base::rm_single_key(prefix, k);
-    }
-    void rmkeys_by_prefix(
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    base::select(cf);
+    base::rm_single_key(prefix, k);
+  }
+  void rmkeys_by_prefix(
       const string &prefix
-      ) override {
-      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
-      for (auto &s : shards) {
-        base::select(s);
-        base::rmkeys_by_prefix(prefix);
-      }
+  ) override {
+    std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+    for (auto &s : shards) {
+      base::select(s);
+      base::rmkeys_by_prefix(prefix);
     }
-    void rm_range_keys(
+  }
+  void rm_range_keys(
       const string &prefix,
       const string &start,
       const string &end) override {
-      std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
-      for (auto &s : shards) {
-        base::select(s);
-        base::rm_range_keys(prefix, start, end);
-      }
+    std::vector<KeyValueDB::ColumnFamilyHandle> &shards = db_hash.get_shards(prefix);
+    for (auto &s : shards) {
+      base::select(s);
+      base::rm_range_keys(prefix, start, end);
     }
-    void merge(
+  }
+  void merge(
       const string& prefix,
       const string& k,
       const bufferlist &bl) override {
-      KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
-      base::select(cf);
-      base::merge(prefix, k, bl);
-    }
-    void select(
-        KeyValueDB::ColumnFamilyHandle column_family_handle) override {
-      ceph_abort("Not expected");
-    }
-  };
-
-#undef dout_context
-#define dout_context cct
-
-  int init(string option_str="") override {
-    int r = db->init(option_str);
-    return r;
+    KeyValueDB::ColumnFamilyHandle cf = db_hash.get_db_shard(prefix, k.c_str(), k.size());
+    base::select(cf);
+    base::merge(prefix, k, bl);
   }
-  int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override {
-    return _do_open(out, false, options);
+  void select(
+      KeyValueDB::ColumnFamilyHandle column_family_handle) override {
+    ceph_abort("Not expected");
   }
-  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override {
-    int r = db->create_and_open(out, new_cfs);
-    if (r != 0)
-      return r;
-    for (auto& s_it: sharding_schema) {
-      for (size_t i = 0; i < s_it.second; i++) {
-        std::string name = s_it.first + "-" + to_string(i);
-        if (db->column_family_handle(name) == ColumnFamilyHandle()) {
-          r = db->column_family_create(name, "");
-          if (r != 0) {
-            derr << "Unable to create column family: '" << name << "' " << dendl;
-            ceph_abort();
-          }
+};
+
+
+
+
+class ShardedIteratorBase {
+  ssize_t position = 0;
+  std::vector<KeyValueDB::Iterator> shards;
+  const rocksdb::Comparator* comparator;
+public:
+  ShardedIteratorBase(std::vector<KeyValueDB::Iterator>&& shards, const rocksdb::Comparator* comparator)
+: shards(std::move(shards))
+, comparator(comparator) { }
+
+  ~ShardedIteratorBase() { }
+
+  int open(const std::vector<KeyValueDB::Iterator>& new_shards) {
+    shards = new_shards;
+    return 0;
+  }
+  KeyValueDB::Iterator& item() {
+    return shards[position];
+  }
+  int seek_to_last() {
+    ceph_assert(false && "expected seek_to_last() not called");
+    return 0;
+  }
+  int seek_to_first() {
+    for (auto& it: shards) {
+      it->seek_to_first();
+    }
+    position = 0;
+    std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+    return 0;
+  }
+  int upper_bound(const string &after) {
+    for(auto& it: shards) {
+      it->upper_bound(after);
+    }
+    position = 0;
+    std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+    return 0;
+  }
+  int lower_bound(const string &to) {
+    for(auto& it: shards) {
+      it->lower_bound(to);
+    }
+    position = 0;
+    std::sort(shards.begin(), shards.end(), KeyLess(comparator));
+    return 0;
+  }
+  bool valid() {
+    if (position >= (ssize_t)shards.size() )
+      return false;
+    return shards[position]->valid();
+  }
+  /*
+   * simulation of next/prev work
+   * v_______________________v   ---
+   * it0 it1 it2 it3 it4 it5 it6 it7
+   * next
+   * it1 it2 it0 it3 it4 it5 it6 it7
+   * next
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   * next
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   * next, it2 expired
+   * --- v___________________v   ---
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   * next, it0 expired
+   * --- --- v_______________v   ---
+   * prev, requires checking before, revived it0
+   * --- v___________________v   ---
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   * prev, checks before, but not revives
+   * it2 it0 it3 it4 it1 it5 it6 it7
+   */
+  int next() {
+    shards[position]->next();
+    if (shards[position]->valid()) {
+      /* sort, as other shards may point to key that is less then
+       * key that we just moved to */
+      std::string key0 = shards[position]->key();
+      for (size_t p = position + 1; p < shards.size(); p++) {
+        std::string key1 = shards[p]->key();
+        if (compare(comparator, key0, key1) < 0) {
+          /* all in order, no need to sort more */
+          break;
         }
+        std::swap(shards[p - 1], shards[p]);
       }
+    } else {
+      position++;
     }
-    r = open_shards();
-    return r;
-  }
-  int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override {
-    return _do_open(out, true, options);
-  }
-  int _do_open(std::ostream &out, bool read_only, const std::vector<ColumnFamily>& options = {}) {
-    int r = read_only ?
-      db->open_read_only(out, options) :
-      db->open(out, options);
-    if (r != 0)
-      return r;
-    vector<std::string> cf_names;
-    db->column_family_list(cf_names);
-    for (auto& s_it: sharding_schema) {
-      for (size_t i = 0; i < s_it.second; i++) {
-        std::string name = s_it.first + "-" + to_string(i);
-        auto n_it = std::find(std::begin(cf_names), std::end(cf_names), name);
-        if (n_it == cf_names.end()) {
-          derr << "Missing column family: '" << name << "' " << dendl;
-          ceph_abort();
-        }
-      }
-    }
-    r = open_shards();
-    return r;
-  }
-  void close() override {
-    db->close();
-  }
-  int column_family_list(vector<std::string>& cf_names) override {
-    return db->column_family_list(cf_names);
-  }
-  int column_family_create(const std::string& cf_name, const std::string& cf_options) override {
-    return db->column_family_create(cf_name, cf_options);
-  }
-  int column_family_delete(const std::string& cf_name) override {
-    return db->column_family_delete(cf_name);
-  }
-  ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override {
-    return db->column_family_handle(cf_name);
-  }
-  int repair(std::ostream &out) override {
-    return db->repair(out);
-  }
-  Transaction get_transaction() override {
-    KeyValueDB::Transaction t = std::make_shared<HashSharded_TransactionImpl>(*this);
-    return t;
-  }
-  int submit_transaction(Transaction t) override {
-    return db->submit_transaction(t);
-  }
-  int submit_transaction_sync(Transaction t) override {
-    return db->submit_transaction_sync(t);
-  }
-
-  int get(const std::string &prefix,
-          const std::set<std::string> &keys,
-          std::map<std::string, bufferlist> *out) override {
-    std::map<void*, std::set<std::string> > sharded_keys;
-    for (auto& key : keys) {
-      std::string value;
-      KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
-      sharded_keys[cf.priv].emplace(key);
-    }
-    int r = 0;
-    for (auto sh = sharded_keys.begin(); r == 0 && sh != sharded_keys.end(); sh++) {
-      ColumnFamilyHandle cf;
-      cf.priv = sh->first;
-      db->get(cf, prefix, sh->second, out);
-    }
-    return r;
-  }
-
-  int get(const std::string &prefix,
-          const std::string &key,
-          bufferlist *value) override {
-    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
-    return db->get(cf, prefix, key, value);
-  }
-  int get(const string &prefix,
-          const char *key, size_t keylen,
-          bufferlist *value) override {
-    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key, keylen);
-    std::string s_key(key, keylen);
-    return db->get(cf, prefix, s_key, value);
-  }
-
-  int get(ColumnFamilyHandle cf_handle,
-                  const std::string &prefix,
-                  const std::set<std::string> &keys,
-                  std::map<std::string, bufferlist> *out) override {
-    ceph_assert(false && "invalid call");
+    /* signal if we iterated out of range */
+    if (position >= (ssize_t)shards.size())
+      return -1;
     return 0;
   }
 
-  int get(ColumnFamilyHandle cf_handle,///< [in] Column family handle
-                  const std::string &prefix,    ///< [in] prefix or CF name
-                  const std::string &key,       ///< [in] key
-                  bufferlist *value) override {          ///< [out] value
-    ceph_assert(false && "invalid call");
+  int prev() {
+    return -1;
+  }
+};
+
+
+
+
+class BlueStore_DB_Hash::WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
+private:
+  BlueStore_DB_Hash &db_hash;
+  ActiveShards::iterator shards_it;
+  ShardedIteratorBase iter;
+
+  void open_shards(std::vector<KeyValueDB::Iterator>& shards) {
+    for (auto& it: shards_it->second) {
+      Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
+      wsi->seek_to_first();
+      if (wsi->valid())
+        shards.emplace_back(wsi);
+    }
+  }
+  void open_shards(std::vector<KeyValueDB::Iterator>& shards, const std::string& prefix) {
+    shards.emplace_back(db_hash.db->get_iterator(prefix));
+  }
+
+public:
+  WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash)
+: db_hash(db_hash)
+, iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {}
+
+  virtual ~WholeSpaceIteratorMerged_Impl() {}
+
+  int seek_to_first_existing() {
+    while (shards_it != db_hash.shards.end()) {
+      std::vector<KeyValueDB::Iterator> shards;
+      if (shards_it->second.size() == 0) {
+        /* no separate shard, is part of default column family */
+        open_shards(shards, shards_it->first);
+      } else {
+        open_shards(shards);
+      }
+      iter.open(shards);
+      iter.seek_to_first();
+      if (iter.valid()) {
+        return 0;
+      }
+      //this shard is empty, go next
+      ++shards_it;
+    };
+    return -1;
+  }
+
+  int seek_to_first() override {
+    shards_it = db_hash.shards.begin();
+    return seek_to_first_existing();
+  }
+  int seek_to_first(const string &prefix) override {
+    shards_it = db_hash.shards.find(prefix);
+    return seek_to_first_existing();
+  }
+  int seek_to_last() override {
+    ceph_assert(false && "expected seek_to_last() not called");
     return 0;
   }
-
-  static int compare(const rocksdb::Comparator* comparator,
-                     const std::string& a,
-                     const std::string& b) {
-    rocksdb::Slice _a(a.data(), a.size());
-    rocksdb::Slice _b(b.data(), b.size());
-    return comparator->Compare(_a, _b);
+  int seek_to_last(const string &prefix) override {
+    ceph_assert(false && "expected seek_to_last() not called");
+    return 0;
   }
-
-  struct KeyLess {
-    const rocksdb::Comparator* comparator;
-    KeyLess(const rocksdb::Comparator* comparator) : comparator(comparator) { };
-    bool operator()(KeyValueDB::Iterator a, KeyValueDB::Iterator b) const
-    {
-      if (a->valid()) {
-        if (b->valid()) {
-          return compare(comparator, a->key(), b->key()) < 0;
-        } else {
-          return true;
-        }
-      } else {
-        if (b->valid()) {
-          return false;
-        } else {
-          return (void*)a.get() < (void*)b.get();
-        }
-      }
-    }
-  };
-
-
-  class ShardedIteratorBase {
-    ssize_t position = 0;
-    std::vector<KeyValueDB::Iterator> shards;
-    const rocksdb::Comparator* comparator;
-  public:
-    ShardedIteratorBase(std::vector<KeyValueDB::Iterator>&& shards, const rocksdb::Comparator* comparator)
-    : shards(std::move(shards))
-    , comparator(comparator) { }
-
-    ~ShardedIteratorBase() { }
-
-    int open(const std::vector<KeyValueDB::Iterator>& new_shards) {
-      shards = new_shards;
-      return 0;
-    }
-    KeyValueDB::Iterator& item() {
-      return shards[position];
-    }
-    int seek_to_last() {
-      ceph_assert(false && "expected seek_to_last() not called");
-      return 0;
-    }
-    int seek_to_first() {
-      for (auto& it: shards) {
-        it->seek_to_first();
-      }
-      position = 0;
-      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
-      return 0;
-    }
-    int upper_bound(const string &after) {
-      for(auto& it: shards) {
-        it->upper_bound(after);
-      }
-      position = 0;
-      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
-      return 0;
-    }
-    int lower_bound(const string &to) {
-      for(auto& it: shards) {
-        it->lower_bound(to);
-      }
-      position = 0;
-      std::sort(shards.begin(), shards.end(), KeyLess(comparator));
-      return 0;
-    }
-    bool valid() {
-      if (position >= (ssize_t)shards.size() )
-        return false;
-      return shards[position]->valid();
-    }
-    /*
-     * simulation of next/prev work
-     * v_______________________v   ---
-     * it0 it1 it2 it3 it4 it5 it6 it7
-     * next
-     * it1 it2 it0 it3 it4 it5 it6 it7
-     * next
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next, it2 expired
-     * --- v___________________v   ---
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * next, it0 expired
-     * --- --- v_______________v   ---
-     * prev, requires checking before, revived it0
-     * --- v___________________v   ---
-     * it2 it0 it3 it4 it1 it5 it6 it7
-     * prev, checks before, but not revives
-     * it2 it0 it3 it4 it1 it5 it6 it7
-    */
-    int next() {
-      shards[position]->next();
-      if (shards[position]->valid()) {
-        /* sort, as other shards may point to key that is less then
-         * key that we just moved to */
-        std::string key0 = shards[position]->key();
-        for (size_t p = position + 1; p < shards.size(); p++) {
-          std::string key1 = shards[p]->key();
-          if (compare(comparator, key0, key1) < 0) {
-            /* all in order, no need to sort more */
-            break;
-          }
-          std::swap(shards[p - 1], shards[p]);
-        }
-      } else {
-        position++;
-      }
-      /* signal if we iterated out of range */
-      if (position >= (ssize_t)shards.size())
-        return -1;
-      return 0;
-    }
-
-    int prev() {
+  int upper_bound(const string &prefix, const string &after) override {
+    shards_it = db_hash.shards.lower_bound(prefix);
+    if (shards_it == db_hash.shards.end()) {
       return -1;
     }
-  };
+    seek_to_first_existing();
+    if (shards_it == db_hash.shards.end()) {
+      return -1;
+    }
+    if (shards_it->first == prefix) {
+      /* we are in intended prefix, we need more detailed upper_bound */
+      iter.upper_bound(after);
+      if (!iter.valid()) {
+        /* nothing after target of upper_bound*/
+        ++shards_it;
+        return seek_to_first();
+      }
+    }
+    return 0;
+  }
+  int lower_bound(const string &prefix, const string &to) override {
+    shards_it = db_hash.shards.lower_bound(prefix);
+    if (shards_it == db_hash.shards.end()) {
+      return -1;
+    }
+    seek_to_first_existing();
+    if (shards_it == db_hash.shards.end()) {
+      return -1;
+    }
+    if (shards_it->first == prefix) {
+      /* we are in intended prefix, we need more detailed upper_bound */
+      iter.lower_bound(to);
+      if (!iter.valid()) {
+        /* nothing after target of upper_bound*/
+        ++shards_it;
+        return seek_to_first_existing();
+      }
+    }
+    return 0;
+  }
+  bool valid() override {
+    return iter.valid();
+  }
+  int next() override {
+    int r = iter.next();
+    if (r < 0) {
+      /* if we iterated out of current shard, go on */
+      ++shards_it;
+      return seek_to_first_existing();
+    }
+    return r;
+  }
+  int prev() override {
+    ceph_assert(false && "expected prev() not called");
+    return 0;
+  }
+  string key() override {
+    return iter.item()->key();
+  }
+  pair<string,string> raw_key() override {
+    return iter.item()->raw_key();
+  }
+  bool raw_key_is_prefixed(const string &prefix) override {
+    return prefix == shards_it->first;
+  }
+  bufferlist value() override {
+    return iter.item()->value();
+  }
+  bufferptr value_as_ptr() override {
+    return iter.item()->value_as_ptr();
+  }
+  int status() override {
+    return iter.item()->status();
+  }
+};
 
-  class WholeSpaceIteratorMerged_Impl: public WholeSpaceIteratorImpl {
-  private:
-    BlueStore_DB_Hash &db_hash;
-    ActiveShards::iterator shards_it;
-    ShardedIteratorBase iter;
 
-    void open_shards(std::vector<KeyValueDB::Iterator>& shards) {
+
+
+class BlueStore_DB_Hash::SinglePrefixIteratorMerged_Impl: public IteratorImpl {
+private:
+  ShardedIteratorBase iter;
+
+  static void prefix_to_iterators(
+      std::vector<KeyValueDB::Iterator>& shards,
+      const BlueStore_DB_Hash &db_hash,
+      const string& prefix) {
+    auto shards_it = db_hash.shards.find(prefix);
+    if (shards_it != db_hash.shards.end()) {
       for (auto& it: shards_it->second) {
         Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
         wsi->seek_to_first();
         if (wsi->valid())
           shards.emplace_back(wsi);
       }
+      std::sort(shards.begin(), shards.end(), KeyLess(db_hash.comparator));
     }
-    void open_shards(std::vector<KeyValueDB::Iterator>& shards, const std::string& prefix) {
-      shards.emplace_back(db_hash.db->get_iterator(prefix));
-    }
-
-  public:
-    WholeSpaceIteratorMerged_Impl(BlueStore_DB_Hash &db_hash)
-      : db_hash(db_hash)
-      , iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {}
-
-    virtual ~WholeSpaceIteratorMerged_Impl() {}
-
-    int seek_to_first_existing() {
-      while (shards_it != db_hash.shards.end()) {
-        std::vector<KeyValueDB::Iterator> shards;
-        if (shards_it->second.size() == 0) {
-          /* no separate shard, is part of default column family */
-          open_shards(shards, shards_it->first);
-        } else {
-          open_shards(shards);
-        }
-        iter.open(shards);
-        iter.seek_to_first();
-        if (iter.valid()) {
-          return 0;
-        }
-        //this shard is empty, go next
-        ++shards_it;
-      };
-      return -1;
-    }
-
-    int seek_to_first() override {
-      shards_it = db_hash.shards.begin();
-      return seek_to_first_existing();
-    }
-    int seek_to_first(const string &prefix) override {
-      shards_it = db_hash.shards.find(prefix);
-      return seek_to_first_existing();
-    }
-    int seek_to_last() override {
-      ceph_assert(false && "expected seek_to_last() not called");
-      return 0;
-    }
-    int seek_to_last(const string &prefix) override {
-      ceph_assert(false && "expected seek_to_last() not called");
-      return 0;
-    }
-    int upper_bound(const string &prefix, const string &after) override {
-      shards_it = db_hash.shards.lower_bound(prefix);
-      if (shards_it == db_hash.shards.end()) {
-        return -1;
-      }
-      seek_to_first_existing();
-      if (shards_it == db_hash.shards.end()) {
-        return -1;
-      }
-      if (shards_it->first == prefix) {
-        /* we are in intended prefix, we need more detailed upper_bound */
-        iter.upper_bound(after);
-        if (!iter.valid()) {
-          /* nothing after target of upper_bound*/
-          ++shards_it;
-          return seek_to_first();
-        }
-      }
-      return 0;
-    }
-    int lower_bound(const string &prefix, const string &to) override {
-      shards_it = db_hash.shards.lower_bound(prefix);
-      if (shards_it == db_hash.shards.end()) {
-        return -1;
-      }
-      seek_to_first_existing();
-      if (shards_it == db_hash.shards.end()) {
-        return -1;
-      }
-      if (shards_it->first == prefix) {
-        /* we are in intended prefix, we need more detailed upper_bound */
-        iter.lower_bound(to);
-        if (!iter.valid()) {
-          /* nothing after target of upper_bound*/
-          ++shards_it;
-          return seek_to_first_existing();
-        }
-      }
-      return 0;
-    }
-    bool valid() override {
-      return iter.valid();
-    }
-    int next() override {
-      int r = iter.next();
-      if (r < 0) {
-        /* if we iterated out of current shard, go on */
-        ++shards_it;
-        return seek_to_first_existing();
-      }
-      return r;
-    }
-    int prev() override {
-      ceph_assert(false && "expected prev() not called");
-      return 0;
-    }
-    string key() override {
-      return iter.item()->key();
-    }
-    pair<string,string> raw_key() override {
-      return iter.item()->raw_key();
-    }
-    bool raw_key_is_prefixed(const string &prefix) override {
-      return prefix == shards_it->first;
-    }
-    bufferlist value() override {
-      return iter.item()->value();
-    }
-    bufferptr value_as_ptr() override {
-      return iter.item()->value_as_ptr();
-    }
-    int status() override {
-      return iter.item()->status();
-    }
-  };
-
-#undef dout_context
-#define dout_context db_hash.cct
-
-  class SinglePrefixIteratorMerged_Impl: public IteratorImpl {
-  private:
-    ShardedIteratorBase iter;
-
-    static void prefix_to_iterators(
-        std::vector<KeyValueDB::Iterator>& shards,
-        const BlueStore_DB_Hash &db_hash,
-        const string& prefix) {
-      auto shards_it = db_hash.shards.find(prefix);
-      if (shards_it != db_hash.shards.end()) {
-        for (auto& it: shards_it->second) {
-          Iterator wsi = db_hash.db->get_iterator_cf(it, shards_it->first);
-          wsi->seek_to_first();
-          if (wsi->valid())
-            shards.emplace_back(wsi);
-        }
-        std::sort(shards.begin(), shards.end(), KeyLess(db_hash.comparator));
-      }
-    }
-
-  public:
-    SinglePrefixIteratorMerged_Impl(BlueStore_DB_Hash &db_hash, const string& prefix)
-    : iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {
-      std::vector<KeyValueDB::Iterator> shards;
-      prefix_to_iterators(shards, db_hash, prefix);
-      iter.open(shards);
-    }
-
-    virtual ~SinglePrefixIteratorMerged_Impl() {
-    }
-
-    int seek_to_first() override {
-      return iter.seek_to_first();
-    }
-
-    int seek_to_last() override {
-      ceph_assert(false && "expected seek_to_last() not called");
-      return 0;
-    }
-
-    int upper_bound(const string &after) override {
-      return iter.upper_bound(after);
-    }
-
-    int lower_bound(const string &to) override {
-      return iter.lower_bound(to);
-    }
-
-    bool valid() override {
-      return iter.valid();
-    }
-
-    int next() override {
-      return iter.next();
-    }
-
-    int prev() override {
-      ceph_assert(false && "expected prev() not called");
-      return 0;
-    }
-
-    string key() override {
-      return iter.item()->key();
-    }
-
-    pair<string,string> raw_key() override {
-      return iter.item()->raw_key();
-    }
-
-    bufferlist value() override {
-      return iter.item()->value();
-    }
-
-    bufferptr value_as_ptr() override {
-      return iter.item()->value_as_ptr();
-    }
-
-    int status() override {
-      return iter.item()->status();
-    }
-  };
-
-#undef dout_context
-#define dout_context cct
-
-  // This class filters a WholeSpaceIterator by a prefix.
-  class PrefixIteratorImpl : public IteratorImpl {
-    const std::string prefix;
-    WholeSpaceIterator generic_iter;
-  public:
-    PrefixIteratorImpl(const std::string &prefix, WholeSpaceIterator iter) :
-      prefix(prefix), generic_iter(iter) { }
-    ~PrefixIteratorImpl() override { }
-
-    int seek_to_first() override {
-      return generic_iter->seek_to_first(prefix);
-    }
-    int seek_to_last() override {
-      return generic_iter->seek_to_last(prefix);
-    }
-    int upper_bound(const std::string &after) override {
-      return generic_iter->upper_bound(prefix, after);
-    }
-    int lower_bound(const std::string &to) override {
-      return generic_iter->lower_bound(prefix, to);
-    }
-    bool valid() override {
-      if (!generic_iter->valid())
-        return false;
-      return generic_iter->raw_key_is_prefixed(prefix);
-    }
-    int next() override {
-      return generic_iter->next();
-    }
-    int prev() override {
-      return generic_iter->prev();
-    }
-    std::string key() override {
-      return generic_iter->key();
-    }
-    std::pair<std::string, std::string> raw_key() override {
-      return generic_iter->raw_key();
-    }
-    bufferlist value() override {
-      return generic_iter->value();
-    }
-    bufferptr value_as_ptr() override {
-      return generic_iter->value_as_ptr();
-    }
-    int status() override {
-      return generic_iter->status();
-    }
-  };
+  }
 
 public:
-
-  WholeSpaceIterator get_wholespace_iterator() override {
-    return std::make_shared<WholeSpaceIteratorMerged_Impl>(*this);
-  }
-  Iterator get_iterator(const std::string &prefix) override {
-    auto shards_it = shards.find(prefix);
-    if (shards_it != shards.end()) {
-      return std::make_shared<SinglePrefixIteratorMerged_Impl>(*this, prefix);
-    }
-    return db->get_iterator(prefix);
-  }
-  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override {
-    ceph_abort_msg("Not implemented"); return {};
-  }
-  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override {
-    ceph_abort_msg("Not implemented"); return {};
+  SinglePrefixIteratorMerged_Impl(BlueStore_DB_Hash &db_hash, const string& prefix)
+: iter(std::vector<KeyValueDB::Iterator>(), db_hash.comparator) {
+    std::vector<KeyValueDB::Iterator> shards;
+    prefix_to_iterators(shards, db_hash, prefix);
+    iter.open(shards);
   }
 
-  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override {
-    return db->get_estimated_size(extra);
-  }
-  int get_statfs(struct store_statfs_t *buf) override {
-    return -EOPNOTSUPP;
+  virtual ~SinglePrefixIteratorMerged_Impl() {
   }
 
-  int set_cache_size(uint64_t) override {
-    return -EOPNOTSUPP;
+  int seek_to_first() override {
+    return iter.seek_to_first();
   }
 
-  int set_cache_high_pri_pool_ratio(double ratio) override {
-    return db->set_cache_high_pri_pool_ratio(ratio);
-  }
-
-  int64_t get_cache_usage() const override {
-    return db->get_cache_usage();
-  }
-
-  /// estimate space utilization for a prefix (in bytes)
-  int64_t estimate_prefix_size(const string& prefix,
-                               ColumnFamilyHandle cfh = ColumnFamilyHandle()) override {
+  int seek_to_last() override {
+    ceph_assert(false && "expected seek_to_last() not called");
     return 0;
   }
 
-  void compact() override {
-    db->compact();
-  }
-  void compact_async() override {
-    db->compact_async();
-  }
-  void compact_prefix(const std::string& prefix) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      for (size_t i = 0; i < it->second; i++) {
-        std::string cf_name = prefix + "-" + to_string(i);
-        db->column_family_compact(cf_name, prefix, "", "");
-      }
-    }
-  }
-  void compact_prefix_async(const std::string& prefix) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      for (size_t i = 0; i < it->second; i++) {
-        std::string cf_name = prefix + "-" + to_string(i);
-        db->column_family_compact_async(cf_name, prefix, "", "");
-      }
-    }
-  }
-  void compact_range(const std::string& prefix,
-                     const std::string& start, const std::string& end) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      for (size_t i = 0; i < it->second; i++) {
-        std::string cf_name = prefix + "-" + to_string(i);
-        db->column_family_compact(cf_name, prefix, start, end);
-      }
-    }
-  }
-  void compact_range_async(const std::string& prefix,
-                           const std::string& start, const std::string& end) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      for (size_t i = 0; i < it->second; i++) {
-        std::string cf_name = prefix + "-" + to_string(i);
-        db->column_family_compact_async(cf_name, prefix, start, end);
-      }
-    }
+  int upper_bound(const string &after) override {
+    return iter.upper_bound(after);
   }
 
-  int set_merge_operator(const std::string& prefix,
-                         std::shared_ptr<MergeOperator> mop) override {
-    auto it = sharding_schema.find(prefix);
-    if (it != sharding_schema.end()) {
-      if (it->second == 0) {
-        db->set_merge_operator(prefix, mop);
-      } else {
-        for (size_t i = 0; i < it->second; i++) {
-          std::string cf_name = prefix + "-" + to_string(i);
-          db->set_merge_operator(cf_name, mop);
-        }
-      }
-      return 0;
-    }
-    return -EINVAL;
+  int lower_bound(const string &to) override {
+    return iter.lower_bound(to);
   }
 
-  void get_statistics(Formatter *f) override {
-    db->get_statistics(f);
+  bool valid() override {
+    return iter.valid();
+  }
+
+  int next() override {
+    return iter.next();
+  }
+
+  int prev() override {
+    ceph_assert(false && "expected prev() not called");
+    return 0;
+  }
+
+  string key() override {
+    return iter.item()->key();
+  }
+
+  pair<string,string> raw_key() override {
+    return iter.item()->raw_key();
+  }
+
+  bufferlist value() override {
+    return iter.item()->value();
+  }
+
+  bufferptr value_as_ptr() override {
+    return iter.item()->value_as_ptr();
+  }
+
+  int status() override {
+    return iter.item()->status();
   }
 };
 
+
+
+
+// This class filters a WholeSpaceIterator by a prefix.
+class BlueStore_DB_Hash::PrefixIteratorImpl : public IteratorImpl {
+  const std::string prefix;
+  WholeSpaceIterator generic_iter;
+public:
+  PrefixIteratorImpl(const std::string &prefix, WholeSpaceIterator iter) :
+    prefix(prefix), generic_iter(iter) { }
+  ~PrefixIteratorImpl() override { }
+
+  int seek_to_first() override {
+    return generic_iter->seek_to_first(prefix);
+  }
+  int seek_to_last() override {
+    return generic_iter->seek_to_last(prefix);
+  }
+  int upper_bound(const std::string &after) override {
+    return generic_iter->upper_bound(prefix, after);
+  }
+  int lower_bound(const std::string &to) override {
+    return generic_iter->lower_bound(prefix, to);
+  }
+  bool valid() override {
+    if (!generic_iter->valid())
+      return false;
+    return generic_iter->raw_key_is_prefixed(prefix);
+  }
+  int next() override {
+    return generic_iter->next();
+  }
+  int prev() override {
+    return generic_iter->prev();
+  }
+  std::string key() override {
+    return generic_iter->key();
+  }
+  std::pair<std::string, std::string> raw_key() override {
+    return generic_iter->raw_key();
+  }
+  bufferlist value() override {
+    return generic_iter->value();
+  }
+  bufferptr value_as_ptr() override {
+    return generic_iter->value_as_ptr();
+  }
+  int status() override {
+    return generic_iter->status();
+  }
+};
+
+
+
+
+BlueStore_DB_Hash::BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sharding_schema)
+: db(db), cct(db->cct), sharding_schema(sharding_schema) {
+  comparator = db->rocksdb_options.comparator;
+  ceph_assert(db);
+}
+BlueStore_DB_Hash::~BlueStore_DB_Hash() {
+  delete db;
+}
+
+int BlueStore_DB_Hash::open_shards() {
+  for (auto& s_it: sharding_schema) {
+    if (s_it.second == 0) {
+      auto cf_handle = db->column_family_handle("default");
+      shards[s_it.first].push_back(cf_handle);
+      dout(5) << "Column family '" << s_it.first << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+    } else {
+      for (size_t i = 0; i < s_it.second; i++) {
+        std::string name = s_it.first + "-" + to_string(i);
+        auto cf_handle = db->column_family_handle(name);
+        dout(5) << "Column family '" << name << "' handle: " << (void*)cf_handle.priv << " " << dendl;
+        shards[s_it.first].push_back(cf_handle);
+      }
+    }
+  }
+  return 0;
+}
+KeyValueDB::ColumnFamilyHandle BlueStore_DB_Hash::get_db_shard(const std::string &prefix, const char *k, size_t keylen) {
+  auto it = shards.find(prefix);
+  ceph_assert(it != shards.end());
+  unsigned hash = ceph_str_hash_linux(k, keylen);
+  return it->second[hash % it->second.size()];
+}
+std::vector<KeyValueDB::ColumnFamilyHandle>& BlueStore_DB_Hash::get_shards(const std::string &prefix) {
+  auto it = shards.find(prefix);
+  ceph_assert(it != shards.end());
+  return it->second;
+}
+
+int BlueStore_DB_Hash::init(string option_str) {
+  int r = db->init(option_str);
+  return r;
+}
+int BlueStore_DB_Hash::open(std::ostream &out, const std::vector<ColumnFamily>& options) {
+  return _do_open(out, false, options);
+}
+int BlueStore_DB_Hash::create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs) {
+  int r = db->create_and_open(out, new_cfs);
+  if (r != 0)
+    return r;
+  for (auto& s_it: sharding_schema) {
+    for (size_t i = 0; i < s_it.second; i++) {
+      std::string name = s_it.first + "-" + to_string(i);
+      if (db->column_family_handle(name) == ColumnFamilyHandle()) {
+        r = db->column_family_create(name, "");
+        if (r != 0) {
+          derr << "Unable to create column family: '" << name << "' " << dendl;
+          ceph_abort();
+        }
+      }
+    }
+  }
+  r = open_shards();
+  return r;
+}
+int BlueStore_DB_Hash::open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options) {
+  return _do_open(out, true, options);
+}
+int BlueStore_DB_Hash::_do_open(std::ostream &out, bool read_only, const std::vector<ColumnFamily>& options) {
+  int r = read_only ?
+      db->open_read_only(out, options) :
+      db->open(out, options);
+  if (r != 0)
+    return r;
+  vector<std::string> cf_names;
+  db->column_family_list(cf_names);
+  for (auto& s_it: sharding_schema) {
+    for (size_t i = 0; i < s_it.second; i++) {
+      std::string name = s_it.first + "-" + to_string(i);
+      auto n_it = std::find(std::begin(cf_names), std::end(cf_names), name);
+      if (n_it == cf_names.end()) {
+        derr << "Missing column family: '" << name << "' " << dendl;
+        ceph_abort();
+      }
+    }
+  }
+  r = open_shards();
+  return r;
+}
+void BlueStore_DB_Hash::close() {
+  db->close();
+}
+int BlueStore_DB_Hash::column_family_list(vector<std::string>& cf_names) {
+  return db->column_family_list(cf_names);
+}
+int BlueStore_DB_Hash::column_family_create(const std::string& cf_name, const std::string& cf_options) {
+  return db->column_family_create(cf_name, cf_options);
+}
+int BlueStore_DB_Hash::column_family_delete(const std::string& cf_name) {
+  return db->column_family_delete(cf_name);
+}
+KeyValueDB::ColumnFamilyHandle BlueStore_DB_Hash::column_family_handle(const std::string& cf_name) const {
+  return db->column_family_handle(cf_name);
+}
+int BlueStore_DB_Hash::repair(std::ostream &out) {
+  return db->repair(out);
+}
+KeyValueDB::Transaction BlueStore_DB_Hash::get_transaction() {
+  KeyValueDB::Transaction t = std::make_shared<HashSharded_TransactionImpl>(*this);
+  return t;
+}
+int BlueStore_DB_Hash::submit_transaction(Transaction t) {
+  return db->submit_transaction(t);
+}
+int BlueStore_DB_Hash::submit_transaction_sync(Transaction t) {
+  return db->submit_transaction_sync(t);
+}
+
+int BlueStore_DB_Hash::get(const std::string &prefix,
+                           const std::set<std::string> &keys,
+                           std::map<std::string, bufferlist> *out) {
+  std::map<void*, std::set<std::string> > sharded_keys;
+  for (auto& key : keys) {
+    std::string value;
+    KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
+    sharded_keys[cf.priv].emplace(key);
+  }
+  int r = 0;
+  for (auto sh = sharded_keys.begin(); r == 0 && sh != sharded_keys.end(); sh++) {
+    ColumnFamilyHandle cf;
+    cf.priv = sh->first;
+    db->get(cf, prefix, sh->second, out);
+  }
+  return r;
+}
+
+int BlueStore_DB_Hash::get(const std::string &prefix,
+                           const std::string &key,
+                           bufferlist *value) {
+  KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key.c_str(), key.size());
+  return db->get(cf, prefix, key, value);
+}
+int BlueStore_DB_Hash::get(const string &prefix,
+                           const char *key, size_t keylen,
+                           bufferlist *value) {
+  KeyValueDB::ColumnFamilyHandle cf = get_db_shard(prefix, key, keylen);
+  std::string s_key(key, keylen);
+  return db->get(cf, prefix, s_key, value);
+}
+
+int BlueStore_DB_Hash::get(ColumnFamilyHandle cf_handle,
+                           const std::string &prefix,
+                           const std::set<std::string> &keys,
+                           std::map<std::string, bufferlist> *out) {
+  ceph_assert(false && "invalid call");
+  return 0;
+}
+
+int BlueStore_DB_Hash::get(ColumnFamilyHandle cf_handle,///< [in] Column family handle
+                           const std::string &prefix,    ///< [in] prefix or CF name
+                           const std::string &key,       ///< [in] key
+                           bufferlist *value) {          ///< [out] value
+  ceph_assert(false && "invalid call");
+  return 0;
+}
+
+KeyValueDB::WholeSpaceIterator BlueStore_DB_Hash::get_wholespace_iterator() {
+  return std::make_shared<WholeSpaceIteratorMerged_Impl>(*this);
+}
+KeyValueDB::Iterator BlueStore_DB_Hash::get_iterator(const std::string &prefix) {
+  auto shards_it = shards.find(prefix);
+  if (shards_it != shards.end()) {
+    return std::make_shared<SinglePrefixIteratorMerged_Impl>(*this, prefix);
+  }
+  return db->get_iterator(prefix);
+}
+KeyValueDB::WholeSpaceIterator BlueStore_DB_Hash::get_wholespace_iterator_cf(ColumnFamilyHandle cfh) {
+  ceph_abort_msg("Not implemented"); return {};
+}
+KeyValueDB::Iterator BlueStore_DB_Hash::get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) {
+  ceph_abort_msg("Not implemented"); return {};
+}
+
+uint64_t BlueStore_DB_Hash::get_estimated_size(std::map<std::string,uint64_t> &extra) {
+  return db->get_estimated_size(extra);
+}
+int BlueStore_DB_Hash::get_statfs(struct store_statfs_t *buf) {
+  return -EOPNOTSUPP;
+}
+
+int BlueStore_DB_Hash::set_cache_size(uint64_t) {
+  return -EOPNOTSUPP;
+}
+
+int BlueStore_DB_Hash::set_cache_high_pri_pool_ratio(double ratio) {
+  return db->set_cache_high_pri_pool_ratio(ratio);
+}
+
+int64_t BlueStore_DB_Hash::get_cache_usage() const {
+  return db->get_cache_usage();
+}
+
+/// estimate space utilization for a prefix (in bytes)
+int64_t BlueStore_DB_Hash::estimate_prefix_size(const string& prefix,
+                                                ColumnFamilyHandle cfh) {
+  return 0;
+}
+
+void BlueStore_DB_Hash::compact() {
+  db->compact();
+}
+void BlueStore_DB_Hash::compact_async() {
+  db->compact_async();
+}
+void BlueStore_DB_Hash::compact_prefix(const std::string& prefix) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    for (size_t i = 0; i < it->second; i++) {
+      std::string cf_name = prefix + "-" + to_string(i);
+      db->column_family_compact(cf_name, prefix, "", "");
+    }
+  }
+}
+void BlueStore_DB_Hash::compact_prefix_async(const std::string& prefix) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    for (size_t i = 0; i < it->second; i++) {
+      std::string cf_name = prefix + "-" + to_string(i);
+      db->column_family_compact_async(cf_name, prefix, "", "");
+    }
+  }
+}
+void BlueStore_DB_Hash::compact_range(const std::string& prefix,
+                                      const std::string& start, const std::string& end) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    for (size_t i = 0; i < it->second; i++) {
+      std::string cf_name = prefix + "-" + to_string(i);
+      db->column_family_compact(cf_name, prefix, start, end);
+    }
+  }
+}
+void BlueStore_DB_Hash::compact_range_async(const std::string& prefix,
+                                            const std::string& start, const std::string& end) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    for (size_t i = 0; i < it->second; i++) {
+      std::string cf_name = prefix + "-" + to_string(i);
+      db->column_family_compact_async(cf_name, prefix, start, end);
+    }
+  }
+}
+
+int BlueStore_DB_Hash::set_merge_operator(const std::string& prefix,
+                                          std::shared_ptr<MergeOperator> mop) {
+  auto it = sharding_schema.find(prefix);
+  if (it != sharding_schema.end()) {
+    if (it->second == 0) {
+      db->set_merge_operator(prefix, mop);
+    } else {
+      for (size_t i = 0; i < it->second; i++) {
+        std::string cf_name = prefix + "-" + to_string(i);
+        db->set_merge_operator(cf_name, mop);
+      }
+    }
+    return 0;
+  }
+  return -EINVAL;
+}
+
+void BlueStore_DB_Hash::get_statistics(Formatter *f) {
+  db->get_statistics(f);
+}
+
+int BlueStore_DB_Hash::locate_column_name(const std::pair<std::string, std::string>& raw_key,
+                                          std::string& column_name) {
+
+  auto it = sharding_schema.find(raw_key.first);
+  if (it != sharding_schema.end() && it->second != 0) {
+    unsigned hash = ceph_str_hash_linux(raw_key.second.c_str(), raw_key.second.size());
+    hash = hash % it->second;
+    column_name = it->first + "-" + to_string(hash);
+  } else {
+    column_name = "default";
+  }
+  return 0;
+}
+
 KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB* db, const BlueStore_DB_Hash::ShardingSchema& schema) {
   RocksDBStore* rdb = dynamic_cast<RocksDBStore*>(db);
-  ceph_assert(db != nullptr);
+  ceph_assert(rdb != nullptr);
   return new BlueStore_DB_Hash(rdb, schema);
 }

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -515,6 +515,10 @@ BlueStore_DB_Hash::BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sha
 BlueStore_DB_Hash::~BlueStore_DB_Hash() {
   delete db;
 }
+void BlueStore_DB_Hash::unlink_db() {
+  db = nullptr;
+}
+
 
 int BlueStore_DB_Hash::open_shards() {
   for (auto& s_it: sharding_schema) {

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -736,6 +736,9 @@ int64_t BlueStore_DB_Hash::get_cache_usage() const {
   return db->get_cache_usage();
 }
 
+int64_t BlueStore_DB_Hash::get_cache_usage(std::string prefix) const {
+  return db->get_cache_usage(prefix);
+}
 /// estimate space utilization for a prefix (in bytes)
 int64_t BlueStore_DB_Hash::estimate_prefix_size(const string& prefix,
                                                 ColumnFamilyHandle cfh) {

--- a/src/os/bluestore/BlueStore_DB_Hash.cc
+++ b/src/os/bluestore/BlueStore_DB_Hash.cc
@@ -1,3 +1,4 @@
+#include "BlueStore.h"
 #include "BlueStore_DB_Hash.h"
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore

--- a/src/os/bluestore/BlueStore_DB_Hash.h
+++ b/src/os/bluestore/BlueStore_DB_Hash.h
@@ -1,0 +1,98 @@
+#ifndef BLUESTORE_DB_HASH_H
+#define BLUESTORE_DB_HASH_H
+
+
+#include "BlueStore.h"
+#include "kv/RocksDBStore.h"
+#include "include/ceph_hash.h"
+
+class BlueStore_DB_Hash : public KeyValueDB {
+  friend class BlueStore;
+public:
+  typedef std::map<std::string, size_t> ShardingSchema;
+  class HashSharded_TransactionImpl;
+  class WholeSpaceIteratorMerged_Impl;
+  class SinglePrefixIteratorMerged_Impl;
+  class PrefixIteratorImpl;
+private:
+  RocksDBStore* db;
+  CephContext* cct;
+  const rocksdb::Comparator* comparator;
+  ShardingSchema sharding_schema;
+  typedef std::map<std::string, std::vector<KeyValueDB::ColumnFamilyHandle> > ActiveShards;
+  ActiveShards shards;
+
+public:
+  BlueStore_DB_Hash(RocksDBStore* db, const ShardingSchema& sharding_schema);
+  virtual ~BlueStore_DB_Hash();
+  void unlink_db();
+
+private:
+  int open_shards();
+  KeyValueDB::ColumnFamilyHandle get_db_shard(const std::string &prefix, const char *k, size_t keylen);
+  std::vector<KeyValueDB::ColumnFamilyHandle>& get_shards(const std::string &prefix);
+
+public:
+  int init(string option_str="") override;
+  int open(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override;
+  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& new_cfs = {}) override;
+  int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& options = {}) override;
+  int _do_open(std::ostream &out, bool read_only, const std::vector<ColumnFamily>& options = {});
+  void close() override;
+  int column_family_list(vector<std::string>& cf_names) override;
+  int column_family_create(const std::string& cf_name, const std::string& cf_options) override;
+  int column_family_delete(const std::string& cf_name) override;
+  ColumnFamilyHandle column_family_handle(const std::string& cf_name) const override;
+  int repair(std::ostream &out) override;
+  Transaction get_transaction() override;
+  int submit_transaction(Transaction t) override;
+  int submit_transaction_sync(Transaction t) override;
+
+  int get(const std::string &prefix,
+          const std::set<std::string> &keys,
+          std::map<std::string, bufferlist> *out) override;
+  int get(const std::string &prefix,
+          const std::string &key,
+          bufferlist *value) override;
+  int get(const string &prefix,
+          const char *key, size_t keylen,
+          bufferlist *value) override;
+  int get(ColumnFamilyHandle cf_handle,
+                  const std::string &prefix,
+                  const std::set<std::string> &keys,
+                  std::map<std::string, bufferlist> *out) override;
+  int get(ColumnFamilyHandle cf_handle,           ///< [in] Column family handle
+                  const std::string &prefix,      ///< [in] prefix or CF name
+                  const std::string &key,         ///< [in] key
+                  bufferlist *value) override;    ///< [out] value
+
+  WholeSpaceIterator get_wholespace_iterator() override;
+  Iterator get_iterator(const std::string &prefix) override;
+  WholeSpaceIterator get_wholespace_iterator_cf(ColumnFamilyHandle cfh) override;
+  Iterator get_iterator_cf(ColumnFamilyHandle cfh, const std::string &prefix) override;
+  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override;
+  int get_statfs(struct store_statfs_t *buf) override;
+  int set_cache_size(uint64_t) override;
+  int set_cache_high_pri_pool_ratio(double ratio) override;
+  int64_t get_cache_usage() const override;
+  /// estimate space utilization for a prefix (in bytes)
+  int64_t estimate_prefix_size(const string& prefix,
+                               ColumnFamilyHandle cfh = ColumnFamilyHandle()) override;
+  void compact() override;
+  void compact_async() override;
+  void compact_prefix(const std::string& prefix) override;
+  void compact_prefix_async(const std::string& prefix) override;
+  void compact_range(const std::string& prefix,
+                     const std::string& start, const std::string& end) override;
+  void compact_range_async(const std::string& prefix,
+                           const std::string& start, const std::string& end) override;
+  int set_merge_operator(const std::string& prefix,
+                         std::shared_ptr<MergeOperator> mop) override;
+  void get_statistics(Formatter *f) override;
+  int locate_column_name(const std::pair<std::string, std::string>& raw_key,
+                           std::string& column_name);
+};
+
+KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB* db, const BlueStore_DB_Hash::ShardingSchema& schema);
+
+#endif

--- a/src/os/bluestore/BlueStore_DB_Hash.h
+++ b/src/os/bluestore/BlueStore_DB_Hash.h
@@ -74,6 +74,7 @@ public:
   int set_cache_size(uint64_t) override;
   int set_cache_high_pri_pool_ratio(double ratio) override;
   int64_t get_cache_usage() const override;
+  int64_t get_cache_usage(std::string prefix) const override;
   /// estimate space utilization for a prefix (in bytes)
   int64_t estimate_prefix_size(const string& prefix,
                                ColumnFamilyHandle cfh = ColumnFamilyHandle()) override;

--- a/src/os/bluestore/BlueStore_DB_Hash.h
+++ b/src/os/bluestore/BlueStore_DB_Hash.h
@@ -2,7 +2,6 @@
 #define BLUESTORE_DB_HASH_H
 
 
-#include "BlueStore.h"
 #include "kv/RocksDBStore.h"
 #include "include/ceph_hash.h"
 

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -221,6 +221,7 @@ int main(int argc, char **argv)
   vector<string> devs_source;
   string dev_target;
   string path;
+  string new_sharding;
   string action;
   string log_file;
   string key, value;
@@ -230,6 +231,7 @@ int main(int argc, char **argv)
   po_options.add_options()
     ("help,h", "produce help message")
     ("path", po::value<string>(&path), "bluestore path")
+    ("new-sharding", po::value<string>(&new_sharding), "new split for sharding, same logic as bluestore_rocksdb_cf option")
     ("out-dir", po::value<string>(&out_dir), "output directory")
     ("log-file,l", po::value<string>(&log_file), "log file")
     ("log-level", po::value<int>(&log_level), "log level (30=most, 20=lots, 10=some, 1=little)")
@@ -242,7 +244,9 @@ int main(int argc, char **argv)
     ;
   po::options_description po_positional("Positional options");
   po_positional.add_options()
-    ("command", po::value<string>(&action), "fsck, repair, bluefs-export, bluefs-bdev-sizes, bluefs-bdev-expand, bluefs-bdev-new-db, bluefs-bdev-new-wal, bluefs-bdev-migrate, show-label, set-label-key, rm-label-key, prime-osd-dir, bluefs-log-dump")
+    ("command", po::value<string>(&action),
+        "fsck, repair, bluefs-export, bluefs-bdev-sizes, bluefs-bdev-expand, bluefs-bdev-new-db, bluefs-bdev-new-wal, "
+        "bluefs-bdev-migrate, show-label, set-label-key, rm-label-key, prime-osd-dir, bluefs-log-dump, reshard")
     ;
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
@@ -275,7 +279,7 @@ int main(int argc, char **argv)
     exit(EXIT_FAILURE);
   }
 
-  if (action == "fsck" || action == "repair") {
+  if (action == "fsck" || action == "repair" || action == "reshard") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
@@ -354,6 +358,12 @@ int main(int argc, char **argv)
     }
     if (dev_target.empty()) {
       cerr << "must specify target device with --dev-target" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+  if (action == "reshard") {
+    if (new_sharding.size() == 0) {
+      cerr << "must specify new split for prefixes in bluestore with --new-sharding" << std::endl;
       exit(EXIT_FAILURE);
     }
   }
@@ -792,6 +802,18 @@ int main(int argc, char **argv)
       }
       return r;
     }
+  } else if (action == "reshard") {
+    validate_path(cct.get(), path, false);
+    BlueStore bluestore(cct.get(), path);
+    int r;
+    r = bluestore.reshard(new_sharding);
+    if (r < 0) {
+      cerr << "error from reshard: " << cpp_strerror(r) << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      cout << action << " success" << std::endl;
+    }
+    return r;
   } else {
     cerr << "unrecognized action " << action << std::endl;
     return 1;

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -2,21 +2,22 @@
   Usage: ceph-kvstore-tool <leveldb|rocksdb|bluestore-kv> <store path> command [args...]
   
   Commands:
-    list [prefix]
-    list-crc [prefix]
-    dump [prefix]
-    exists <prefix> [key]
-    get <prefix> <key> [out <file>]
-    crc <prefix> <key>
-    get-size [<prefix> <key>]
-    set <prefix> <key> [ver <N>|in <file>]
-    rm <prefix> <key>
-    rm-prefix <prefix>
-    store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...] 
+    list [column/][prefix]
+    list-crc [column/][prefix]
+    dump [column/][prefix]
+    exists [column/]<prefix> [key]
+    get [column/]<prefix> <key> [out <file>]
+    crc [column/]<prefix> <key>
+    get-size [[column/]<prefix> <key>]
+    set [column/]<prefix> <key> [ver <N>|in <file>]
+    rm [column/]<prefix> <key>
+    rm-prefix [column/]<prefix>
+    store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...]
     store-crc <path>
     compact
-    compact-prefix <prefix>
-    compact-range <prefix> <start> <end>
+    compact-prefix [column/]<prefix>
+    compact-range [column/]<prefix> <start> <end>
     destructive-repair  (use only as last resort! may corrupt healthy data)
     stats
   
+

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -415,6 +415,127 @@ TEST_P(KVTest, RocksDBIteratorTest) {
   fini();
 }
 
+TEST_P(KVTest, RocksDBColumnFamilyHandle) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  cfs.push_back(KeyValueDB::ColumnFamily("cf2", ""));
+  ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  cout << "creating two column families and opening them" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+
+  KeyValueDB::ColumnFamilyHandle cf1h, cf2h, cf3h;
+  ASSERT_NE(cf1h = db->column_family_handle("cf1"), nullptr);
+  ASSERT_NE(cf2h = db->column_family_handle("cf2"), nullptr);
+  ASSERT_EQ(cf3h = db->column_family_handle("cf3"), nullptr);
+
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist value;
+    value.append("value");
+    cout << "write a transaction includes three keys in different CFs" << std::endl;
+    t->set("prefix", "key", value);
+    t->select(cf1h);
+    t->set("cf1", "key", value);
+    t->select(cf2h);
+    t->set("cf2", "key2", value);
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  fini();
+
+  init();
+  ASSERT_EQ(0, db->open(cout, cfs));
+  {
+    ASSERT_NE(cf1h = db->column_family_handle("cf1"), nullptr);
+    ASSERT_NE(cf2h = db->column_family_handle("cf2"), nullptr);
+    bufferlist v1, v2, v3;
+    cout << "reopen db and read those keys" << std::endl;
+    ASSERT_EQ(0, db->get("prefix", "key", &v1));
+    ASSERT_EQ(0, _bl_to_str(v1) != "value");
+    ASSERT_EQ(0, db->get(cf1h, "cf1", "key", &v2));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+    ASSERT_EQ(0, db->get(cf2h, "cf2", "key2", &v3));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+  }
+  {
+    cout << "delete two keys in CFs" << std::endl;
+    KeyValueDB::Transaction t = db->get_transaction();
+    t->rmkey("prefix", "key");
+    t->select(cf2h);
+    t->rmkey("cf2", "key2");
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  fini();
+
+  init();
+  ASSERT_EQ(0, db->open(cout, cfs));
+  {
+    ASSERT_NE(cf1h = db->column_family_handle("cf1"), nullptr);
+    ASSERT_NE(cf2h = db->column_family_handle("cf2"), nullptr);
+    cout << "reopen db and read keys again." << std::endl;
+    bufferlist v1, v2, v3;
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key", &v1));
+    ASSERT_EQ(0, db->get(cf1h, "cf1", "key", &v2));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+    ASSERT_EQ(-ENOENT, db->get(cf2h, "cf2", "key2", &v3));
+  }
+  fini();
+}
+
+TEST_P(KVTest, RocksDBIteratorColumnFamiliesTest) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  cout << "creating one column family and opening it" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+  KeyValueDB::ColumnFamilyHandle cf1h;
+  ASSERT_NE(cf1h = db->column_family_handle("cf1"), nullptr);
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist bl1;
+    bl1.append("hello");
+    bufferlist bl2;
+    bl2.append("world");
+    cout << "write some kv pairs into default and new CFs" << std::endl;
+    t->set("prefix", "key1", bl1);
+    t->set("prefix", "key2", bl2);
+    t->select(cf1h);
+    t->set("cf1", "key1", bl1);
+    t->set("cf1", "key2", bl2);
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  {
+    cout << "iterating the default CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator("prefix");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  {
+    cout << "iterating the new CF" << std::endl;
+    KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator_cf(cf1h);
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  fini();
+}
+
 TEST_P(KVTest, RocksDBCFMerge) {
   if(string(GetParam()) != "rocksdb")
     return;

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -384,6 +384,10 @@ TEST_P(KVTest, RocksDBIteratorTest) {
     cout << "write some kv pairs into default and new CFs" << std::endl;
     t->set("prefix", "key1", bl1);
     t->set("prefix", "key2", bl2);
+    KeyValueDB::ColumnFamilyHandle cf1h;
+    ASSERT_NE(cf1h = db->column_family_handle("cf1"), nullptr);
+
+    t->select(cf1h);
     t->set("cf1", "key1", bl1);
     t->set("cf1", "key2", bl2);
     ASSERT_EQ(0, db->submit_transaction_sync(t));
@@ -520,6 +524,24 @@ TEST_P(KVTest, RocksDBIteratorColumnFamiliesTest) {
     ASSERT_EQ(1, iter->valid());
     ASSERT_EQ("key2", iter->key());
     ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  {
+    cout << "iterating the specialized CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator_cf(cf1h, "cf1");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    auto a = iter->raw_key();
+    ASSERT_EQ("cf1", a.first);
+    ASSERT_EQ("key1", a.second);
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+    a = iter->raw_key();
+    ASSERT_EQ("cf1", a.first);
+    ASSERT_EQ("key2", a.second);
   }
   {
     cout << "iterating the new CF" << std::endl;

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -758,6 +758,79 @@ TEST_F(KVSharded, iterator_basic) {
   ASSERT_EQ(k_v.size(), 0);
 }
 
+TEST_F(KVSharded, iterator_basic_gaps) {
+  std::map<std::string, std::string> k_v;
+  k_v.emplace("0","00000000");
+  k_v.emplace("zzzzzzzz","z");
+  while (k_v.size() < 1000) {
+    std::string k, v;
+    do {
+      k.append(1, '0' + (rand() % ('z' - '0' + 1) ));
+    } while (rand() % 9);
+    do {
+      v.append(1, '0' + (rand() % ('z' - '0' + 1) ));
+    } while (rand() % 15);
+    k_v.emplace(k,v);
+  }
+
+  std::map<std::string, size_t> shards{{"A", 0}, {"C", 7}, {"D", 1}, {"E", 0}, {"F", 7}};
+  db = make_BlueStore_DB_Hash(db, shards);
+  ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  ASSERT_EQ(0, db->create_and_open(cout));
+
+  KeyValueDB::Transaction t = db->get_transaction();
+  for (auto& it: k_v) {
+    bufferlist value;
+    value.append(it.second);
+    t->set("C", it.first, value);
+    t->set("E", it.first, value);
+  }
+  bufferlist a_value;
+  a_value.append("a value");
+  t->set("A","aaa", a_value);
+  t->set("D","ddd", a_value);
+
+  ASSERT_EQ(0, db->submit_transaction_sync(t));
+
+  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+  iter->upper_bound("A","");
+  ASSERT_EQ(1, iter->valid());
+  ASSERT_EQ("aaa", iter->key());
+
+  iter->next();
+  ASSERT_EQ(1, iter->valid());
+  auto k = iter->raw_key();
+  ASSERT_EQ("C", k.first);
+  ASSERT_EQ("0", k.second);
+  
+  iter->upper_bound("D","");
+  ASSERT_EQ(1, iter->valid());
+  ASSERT_EQ("ddd", iter->key());
+  iter->next();
+  ASSERT_EQ(1, iter->valid());
+  k = iter->raw_key();
+  ASSERT_EQ("F", k.first);
+  ASSERT_EQ("0", k.second);
+  
+  iter->upper_bound("B","");
+  ASSERT_EQ(1, iter->valid());
+  k = iter->raw_key();
+  ASSERT_EQ("C", k.first);
+  ASSERT_EQ("0", k.second);
+  
+  ASSERT_EQ(0,iter->lower_bound("F","0"));
+  ASSERT_EQ(1, iter->valid());
+  k = iter->raw_key();
+  ASSERT_EQ("F", k.first);
+  ASSERT_EQ("0", k.second);
+  
+  iter->upper_bound("C","0");
+  ASSERT_EQ(1, iter->valid());
+  k = iter->raw_key();
+  ASSERT_EQ("C", k.first);
+  ASSERT_NE("0", k.second);
+}
+
 TEST_F(KVSharded, iterator_multitable) {
   std::map<char, std::map<std::string, std::string>> prefix_k_v;
   char prefix;

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -73,6 +73,55 @@ public:
   }
 };
 
+class KVSharded : public ::testing::Test {
+public:
+  KeyValueDB* db;
+//  KeyValueDB* sharded_db;
+  KVSharded()
+  : db(nullptr)/*, sharded_db(nullptr)*/ {}
+
+  string _bl_to_str(bufferlist val) {
+    string str(val.c_str(), val.length());
+    return str;
+  }
+
+  void rm_r(string path) {
+    string cmd = string("rm -r ") + path;
+    cout << "==> " << cmd << std::endl;
+    int r = ::system(cmd.c_str());
+    if (r) {
+      cerr << "failed with exit code " << r
+           << ", continuing anyway" << std::endl;
+    }
+  }
+
+  void init() {
+    cout << "Creating rocksdb\n";
+    db = KeyValueDB::create(g_ceph_context,
+                            "rocksdb",
+                            "kv_test_temp_dir");
+  }
+  void fini() {
+    delete(db);
+  }
+
+  void SetUp() override {
+    int r = ::mkdir("kv_test_temp_dir", 0777);
+    if (r < 0 && errno != EEXIST) {
+      r = -errno;
+      cerr << __func__ << ": unable to create kv_test_temp_dir: "
+           << cpp_strerror(r) << std::endl;
+      return;
+    }
+    init();
+  }
+  void TearDown() override {
+    fini();
+    rm_r("kv_test_temp_dir");
+  }
+};
+
+
 TEST_P(KVTest, OpenClose) {
   ASSERT_EQ(0, db->create_and_open(cout));
   fini();
@@ -612,6 +661,155 @@ INSTANTIATE_TEST_SUITE_P(
   KeyValueDB,
   KVTest,
   ::testing::Values("leveldb", "rocksdb", "memdb"));
+
+KeyValueDB* make_BlueStore_DB_Hash(KeyValueDB*, const std::map<std::string, size_t>& = {});
+
+TEST_F(KVSharded, basic_creation) {
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  std::map<std::string, size_t> shards{{"A", 1}, {"C", 4}};
+  db = make_BlueStore_DB_Hash(db, shards);
+  ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+
+  KeyValueDB::Transaction t = db->get_transaction();
+  bufferlist value;
+  value.append("value");
+  t->set("A", "key", value);
+  t->set("C", "key", value);
+  t->set("C", "key2", value);
+  ASSERT_EQ(0, db->submit_transaction_sync(t));
+  bufferlist b1, b2, b3;
+  ASSERT_EQ(0, db->get("A", "key", &b1));
+  ASSERT_EQ(tostr(b1), "value");
+  ASSERT_EQ(0, db->get("C", "key", &b2));
+  ASSERT_EQ(tostr(b2), "value");
+  ASSERT_EQ(0, db->get("C", "key", &b3));
+  ASSERT_EQ(tostr(b3), "value");
+}
+
+TEST_F(KVSharded, massive_creation) {
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  std::map<std::string, size_t> shards{{"A", 1}, {"B", 2}, {"C", 3}, {"D", 4}};
+  db = make_BlueStore_DB_Hash(db, shards);
+  ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+
+  const std::string prefixes[]={"A", "B", "C", "D"};
+  for (int i = 0; i < 50; i++) {
+    KeyValueDB::Transaction t = db->get_transaction();
+    for (int j = 0; j < 10; j++) {
+      int v = i * 10 + j;
+      bufferlist value;
+      value.append(to_string(v));
+      t->set(prefixes[v % 4], to_string(v), value);
+    }
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+
+  for (int i = 0; i < 50; i++) {
+    for (int j = 0; j < 10; j++) {
+      int v = i * 10 + j;
+      bufferlist value;
+      ASSERT_EQ(0, db->get(prefixes[v % 4], to_string(v), &value));
+      ASSERT_EQ(tostr(value), to_string(v));
+    }
+  }
+}
+
+TEST_F(KVSharded, iterator_basic) {
+  std::map<std::string, std::string> k_v;
+  while (k_v.size() < 1000) {
+    std::string k, v;
+    do {
+      k.append(1, '0' + (rand() % ('z' - '0' + 1) ));
+    } while (rand() % 9);
+    do {
+      v.append(1, '0' + (rand() % ('z' - '0' + 1) ));
+    } while (rand() % 15);
+    k_v.emplace(k,v);
+  }
+
+  //std::vector<KeyValueDB::ColumnFamily> cfs;
+  std::map<std::string, size_t> shards{{"A", 7}};
+  db = make_BlueStore_DB_Hash(db, shards);
+  ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  ASSERT_EQ(0, db->create_and_open(cout/*, cfs*/));
+
+  KeyValueDB::Transaction t = db->get_transaction();
+  for (auto& it: k_v) {
+    bufferlist value;
+    value.append(it.second);
+    t->set("A", it.first, value);
+  }
+
+  ASSERT_EQ(0, db->submit_transaction_sync(t));
+
+  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+  iter->seek_to_first();
+
+  ASSERT_EQ(1, iter->valid());
+  while (iter->valid()) {
+    std::pair<std::string, std::string> k = iter->raw_key();
+    std::string v = _bl_to_str(iter->value());
+    ASSERT_EQ(k_v[k.second], v);
+    k_v.erase(k.second);
+    iter->next();
+  }
+  ASSERT_EQ(k_v.size(), 0);
+}
+
+TEST_F(KVSharded, iterator_multitable) {
+  std::map<char, std::map<std::string, std::string>> prefix_k_v;
+  char prefix;
+  do {
+    std::string k, v;
+    prefix = "AIOPBb"[rand() % 6];
+    do {
+      k.append(1, '0' + (rand() % ('z' - '0' + 1) ));
+    } while (rand() % 9);
+    do {
+      v.append(1, '0' + (rand() % ('z' - '0' + 1) ));
+    } while (rand() % 15);
+    prefix_k_v[prefix].emplace(k,v);
+    //std::cout << ":" << std::string(1,prefix) << " " << k << " " << v << std::endl;
+  } while (prefix_k_v[prefix].size() < 1000);
+
+  //std::vector<KeyValueDB::ColumnFamily> cfs;
+  std::map<std::string, size_t> shards{
+    {"A", 7}, {"I", 5}, {"O", 2}, {"P", 1}, {"B", 3}, {"b", 1} };
+  db = make_BlueStore_DB_Hash(db, shards);
+  ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  ASSERT_EQ(0, db->create_and_open(cout/*, cfs*/));
+
+  KeyValueDB::Transaction t = db->get_transaction();
+  for (auto& pit: prefix_k_v) {
+    for (auto& it: pit.second) {
+      bufferlist value;
+      value.append(it.second);
+      t->set(std::string(1,pit.first), it.first, value);
+    }
+  }
+
+  ASSERT_EQ(0, db->submit_transaction_sync(t));
+
+  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+  iter->seek_to_first();
+
+  ASSERT_EQ(1, iter->valid());
+  while (iter->valid()) {
+    std::pair<std::string, std::string> k = iter->raw_key();
+    std::string v = _bl_to_str(iter->value());
+    //std::cout << k.first << " " << k.second << " " << v << std::endl;
+    ASSERT_EQ(prefix_k_v[k.first[0]][k.second], v);
+    prefix_k_v[k.first[0]].erase(k.second);
+    iter->next();
+  }
+  for (auto& it: prefix_k_v) {
+    ASSERT_EQ(it.second.size(), 0);
+  }
+}
+
+
 
 int main(int argc, char **argv) {
   vector<const char*> args;

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -42,7 +42,7 @@ void usage(const char *pname)
     << "  set [column/]<prefix> <key> [ver <N>|in <file>]\n"
     << "  rm [column/]<prefix> <key>\n"
     << "  rm-prefix [column/]<prefix>\n"
-    << "  store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...] \n"
+    << "  store-copy <path> [num-keys-per-tx] [leveldb|rocksdb|...]\n"
     << "  store-crc <path>\n"
     << "  compact\n"
     << "  compact-prefix [column/]<prefix>\n"

--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -55,12 +55,20 @@ int StoreTool::load_bluestore(const string& path, bool need_open_db)
     return 0;
 }
 
-uint32_t StoreTool::traverse(const string& prefix,
+uint32_t StoreTool::traverse(const string& column_family,
+			     const string& prefix,
                              const bool do_crc,
                              const bool do_value_dump,
                              ostream *out)
 {
-  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+  KeyValueDB::WholeSpaceIterator iter;
+  if (column_family.empty()) {
+    iter = db->get_wholespace_iterator();
+  } else {
+    KeyValueDB::ColumnFamilyHandle cfh;
+    cfh = db->column_family_handle(column_family);
+    iter = db->get_wholespace_iterator_cf(cfh);
+  }
 
   if (prefix.empty())
     iter->seek_to_first();
@@ -103,42 +111,60 @@ uint32_t StoreTool::traverse(const string& prefix,
   return crc;
 }
 
-void StoreTool::list(const string& prefix, const bool do_crc,
+void StoreTool::list(const string& column_family, const string& prefix, const bool do_crc,
                      const bool do_value_dump)
 {
-  traverse(prefix, do_crc, do_value_dump,& std::cout);
+  traverse(column_family, prefix, do_crc, do_value_dump,& std::cout);
 }
 
-bool StoreTool::exists(const string& prefix)
+bool StoreTool::exists(const string& column_family, const string& prefix)
 {
+  KeyValueDB::WholeSpaceIterator iter;
   ceph_assert(!prefix.empty());
-  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+  if (column_family.empty()) {
+    iter = db->get_wholespace_iterator();
+  } else {
+    KeyValueDB::ColumnFamilyHandle cfh;
+    cfh = db->column_family_handle(column_family);
+    iter = db->get_wholespace_iterator_cf(cfh);
+  }
+  
   iter->seek_to_first(prefix);
   return (iter->valid() && (iter->raw_key().first == prefix));
 }
 
-bool StoreTool::exists(const string& prefix, const string& key)
+bool StoreTool::exists(const string& column_family, const string& prefix, const string& key)
 {
   ceph_assert(!prefix.empty());
 
   if (key.empty()) {
-    return exists(prefix);
+    return exists(column_family, prefix);
   }
   bool exists = false;
-  get(prefix, key, exists);
+  get(column_family, prefix, key, exists);
   return exists;
 }
 
-bufferlist StoreTool::get(const string& prefix,
+bufferlist StoreTool::get(const string& column_family,
+			  const string& prefix,
 			  const string& key,
 			  bool& exists)
 {
   ceph_assert(!prefix.empty() && !key.empty());
-
+  KeyValueDB::ColumnFamilyHandle cfh = db->column_family_handle(column_family);
+  if (!column_family.empty() && !cfh) {
+    exists = false;
+    return bufferlist();
+  }
   map<string,bufferlist> result;
   std::set<std::string> keys;
   keys.insert(key);
-  db->get(prefix, keys, &result);
+  if (!column_family.empty()) {
+    db->get(cfh, prefix, keys, &result);
+  }
+  else {
+    db->get(prefix, keys, &result);
+  }
 
   if (result.count(key) > 0) {
     exists = true;
@@ -160,36 +186,57 @@ uint64_t StoreTool::get_size()
   return s;
 }
 
-bool StoreTool::set(const string &prefix, const string &key, bufferlist &val)
+bool StoreTool::set(const string& column_family,
+		    const string &prefix,
+		    const string &key,
+		    bufferlist &val)
 {
   ceph_assert(!prefix.empty());
   ceph_assert(!key.empty());
   ceph_assert(val.length() > 0);
-
+  KeyValueDB::ColumnFamilyHandle cfh;
+  if (!column_family.empty()) {
+    cfh = db->column_family_handle(column_family);
+    if (!cfh) 
+      return false;
+  }
   KeyValueDB::Transaction tx = db->get_transaction();
+  if (cfh)
+    tx->select(cfh);
   tx->set(prefix, key, val);
   int ret = db->submit_transaction_sync(tx);
 
   return (ret == 0);
 }
 
-bool StoreTool::rm(const string& prefix, const string& key)
+bool StoreTool::rm(const std::string& column_family,
+		   const string& prefix,
+		   const string& key)
 {
   ceph_assert(!prefix.empty());
   ceph_assert(!key.empty());
+  KeyValueDB::ColumnFamilyHandle cfh = db->column_family_handle(column_family);
+  if (!cfh)
+    return false;
 
   KeyValueDB::Transaction tx = db->get_transaction();
+  tx->select(cfh);
   tx->rmkey(prefix, key);
   int ret = db->submit_transaction_sync(tx);
 
   return (ret == 0);
 }
 
-bool StoreTool::rm_prefix(const string& prefix)
+bool StoreTool::rm_prefix(const std::string& column_family,
+			  const string& prefix)
 {
   ceph_assert(!prefix.empty());
+  KeyValueDB::ColumnFamilyHandle cfh = db->column_family_handle(column_family);
+  if (!cfh)
+    return false;
 
   KeyValueDB::Transaction tx = db->get_transaction();
+  tx->select(cfh);
   tx->rmkeys_by_prefix(prefix);
   int ret = db->submit_transaction_sync(tx);
 
@@ -298,12 +345,14 @@ void StoreTool::compact()
   db->compact();
 }
 
-void StoreTool::compact_prefix(const string& prefix)
+void StoreTool::compact_prefix(const std::string& column_family,
+			       const string& prefix)
 {
   db->compact_prefix(prefix);
 }
 
-void StoreTool::compact_range(const string& prefix,
+void StoreTool::compact_range(const std::string& column_family,
+			      const string& prefix,
                               const string& start,
                               const string& end)
 {

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -39,42 +39,54 @@ class StoreTool
 #endif
 
   const std::string store_path;
-
 public:
   StoreTool(const std::string& type,
 	    const std::string& path,
 	    bool need_open_db = true,
 	    bool need_stats = false);
   int load_bluestore(const std::string& path, bool need_open_db);
-  uint32_t traverse(const std::string& prefix,
+  uint32_t traverse(const std::string& column_family,
+		    const std::string& prefix,
                     const bool do_crc,
                     const bool do_value_dump,
                     ostream *out);
-  void list(const std::string& prefix,
+  void list(const std::string& column_family,
+	    const std::string& prefix,
 	    const bool do_crc,
 	    const bool do_value_dump);
-  bool exists(const std::string& prefix);
-  bool exists(const std::string& prefix, const std::string& key);
-  ceph::bufferlist get(const std::string& prefix,
+  bool exists(const std::string& column_family,
+	      const std::string& prefix);
+  bool exists(const std::string& column_family,
+	      const std::string& prefix,
+	      const std::string& key);
+  ceph::bufferlist get(const std::string& column_family,
+		       const std::string& prefix,
 		       const std::string& key,
 		       bool& exists);
   uint64_t get_size();
-  bool set(const std::string& prefix,
+  bool set(const std::string& column_family,
+	   const std::string& prefix,
 	   const std::string& key,
 	   ceph::bufferlist& val);
-  bool rm(const std::string& prefix, const std::string& key);
-  bool rm_prefix(const std::string& prefix);
+  bool rm(const std::string& column_family,
+	  const std::string& prefix,
+	  const std::string& key);
+  bool rm_prefix(const std::string& column_family,
+		 const std::string& prefix);
   void print_summary(const uint64_t total_keys, const uint64_t total_size,
                      const uint64_t total_txs, const std::string& store_path,
                      const std::string& other_path, const int duration) const;
   int copy_store_to(const std::string& type, const std::string& other_path,
                     const int num_keys_per_tx, const std::string& other_type);
   void compact();
-  void compact_prefix(const std::string& prefix);
-  void compact_range(const std::string& prefix,
+  void compact_prefix(const std::string& column_family,
+		      const std::string& prefix);
+  void compact_range(const std::string& column_family,
+		     const std::string& prefix,
 		     const std::string& start,
 		     const std::string& end);
   int destructive_repair();
 
   int print_stats() const;
+
 };


### PR DESCRIPTION
This is adaptation of #27705 on sharded BlueStore case.
Additional difference is introduction of "block_cache_group" parameter for column family that allows for grouping different column families to have common block cache.