### PR TITLE
Client: bump ll_ref from int32 to uint64_t

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10793,7 +10793,7 @@ void Client::_ll_get(Inode *in)
   ldout(cct, 20) << __func__ << " " << in << " " << in->ino << " -> " << in->ll_ref << dendl;
 }
 
-int Client::_ll_put(Inode *in, int num)
+int Client::_ll_put(Inode *in, uint64_t num)
 {
   in->ll_put(num);
   ldout(cct, 20) << __func__ << " " << in << " " << in->ino << " " << num << " -> " << in->ll_ref << dendl;
@@ -10834,7 +10834,7 @@ void Client::_ll_drop_pins()
   }
 }
 
-bool Client::_ll_forget(Inode *in, int count)
+bool Client::_ll_forget(Inode *in, uint64_t count)
 {
   inodeno_t ino = in->ino;
 
@@ -10863,7 +10863,7 @@ bool Client::_ll_forget(Inode *in, int count)
   return last;
 }
 
-bool Client::ll_forget(Inode *in, int count)
+bool Client::ll_forget(Inode *in, uint64_t count)
 {
   std::lock_guard lock(client_lock);
   return _ll_forget(in, count);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -502,7 +502,7 @@ public:
   int ll_lookupx(Inode *parent, const char *name, Inode **out,
 			struct ceph_statx *stx, unsigned want, unsigned flags,
 			const UserPerm& perms);
-  bool ll_forget(Inode *in, int count);
+  bool ll_forget(Inode *in, uint64_t count);
   bool ll_put(Inode *in);
   int ll_get_snap_ref(snapid_t snap);
 
@@ -1036,7 +1036,7 @@ private:
   void _fragmap_remove_stopped_mds(Inode *in, mds_rank_t mds);
 
   void _ll_get(Inode *in);
-  int _ll_put(Inode *in, int num);
+  int _ll_put(Inode *in, uint64_t num);
   void _ll_drop_pins();
 
   Fh *_create_fh(Inode *in, int flags, int cmode, const UserPerm& perms);
@@ -1187,7 +1187,7 @@ private:
   int _lookup_parent(Inode *in, const UserPerm& perms, Inode **parent=NULL);
   int _lookup_name(Inode *in, Inode *parent, const UserPerm& perms);
   int _lookup_ino(inodeno_t ino, const UserPerm& perms, Inode **inode=NULL);
-  bool _ll_forget(Inode *in, int count);
+  bool _ll_forget(Inode *in, uint64_t count);
 
 
   uint32_t deleg_timeout = 0;

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -221,7 +221,7 @@ struct Inode {
   uint64_t     reported_size, wanted_max_size, requested_max_size;
 
   int       _ref;      // ref count. 1 for each dentry, fh that links to me.
-  int       ll_ref;   // separate ref count for ll client
+  uint64_t  ll_ref;   // separate ref count for ll client
   xlist<Dentry *> dentries; // if i'm linked to a dentry.
   string    symlink;  // symlink content, if it's a symlink
   map<string,bufferptr> xattrs;
@@ -249,7 +249,7 @@ struct Inode {
   void ll_get() {
     ll_ref++;
   }
-  void ll_put(int n=1) {
+  void ll_put(uint64_t n=1) {
     ceph_assert(ll_ref >= n);
     ll_ref -= n;
   }


### PR DESCRIPTION
ll_ref can surge up if application repeatly lookup same dentry
and finally cause overflow.

https://tracker.ceph.com/issues/40775 is an example.

in kernel fuse driver and libfuse, uint64_t is used, update
ceph-fuse side to match.

Fixes: https://tracker.ceph.com/issues/40775

Signed-off-by: Xiaoxi CHEN <xiaoxchen@ebay.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

