### PR TITLE
nautilus: msg/async, v2: make the reset_recv_state() unconditional

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -612,7 +612,6 @@
    fun:_ZN10ProtocolV231handle_read_frame_epilogue_mainEOSt10unique_ptrIN4ceph6buffer7v14_2_08ptr_nodeENS4_8disposerEEi
    fun:_ZN10ProtocolV216run_continuationER2CtIS_E
    ...
-   fun:_ZN15AsyncConnection7processEv
    fun:_ZN11EventCenter14process_eventsEjPNSt6chrono8durationImSt5ratioILl1ELl1000000000EEEE
    fun:operator()
    fun:_ZNSt17_Function_handlerIFvvEZN12NetworkStack10add_threadEjEUlvE_E9_M_invokeERKSt9_Any_data

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -220,14 +220,11 @@ uint64_t ProtocolV2::discard_requeued_up_to(uint64_t out_seq, uint64_t seq) {
 }
 
 void ProtocolV2::reset_recv_state() {
-  if ((state >= AUTH_CONNECTING && state <= SESSION_RECONNECTING) ||
-      state == READY) {
-    auth_meta.reset(new AuthConnectionMeta);
-    session_stream_handlers.tx.reset(nullptr);
-    session_stream_handlers.rx.reset(nullptr);
-    pre_auth.txbuf.clear();
-    pre_auth.rxbuf.clear();
-  }
+  auth_meta.reset(new AuthConnectionMeta);
+  session_stream_handlers.tx.reset(nullptr);
+  session_stream_handlers.rx.reset(nullptr);
+  pre_auth.txbuf.clear();
+  pre_auth.rxbuf.clear();
 
   // clean read and write callbacks
   connection->pendingReadLen.reset();
@@ -2663,6 +2660,10 @@ CtPtr ProtocolV2::reuse_connection(AsyncConnectionRef existing,
 
   ldout(messenger->cct, 5) << __func__ << " stop myself to swap existing"
                            << dendl;
+
+  std::swap(exproto->session_stream_handlers, session_stream_handlers);
+  exproto->auth_meta = auth_meta;
+
   // avoid _stop shutdown replacing socket
   // queue a reset on the new connection, which we're dumping for the old
   stop();
@@ -2672,8 +2673,6 @@ CtPtr ProtocolV2::reuse_connection(AsyncConnectionRef existing,
   exproto->can_write = false;
   exproto->reconnecting = reconnecting;
   exproto->replacing = true;
-  std::swap(exproto->session_stream_handlers, session_stream_handlers);
-  exproto->auth_meta = auth_meta;
   existing->state_offset = 0;
   // avoid previous thread modify event
   exproto->state = NONE;


### PR DESCRIPTION
http://tracker.ceph.com/issues/40441