### PR TITLE
cephfs-shell: Fix flake8 blank line and indentation error

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -100,6 +100,7 @@ def get_chunks(file_size):
 def to_bytes(string):
     return bytes(string, encoding='utf-8')
 
+
 def ls(path, opts=''):
     # opts tries to be like /bin/ls opts
     almost_all = 'A' in opts
@@ -114,6 +115,7 @@ def ls(path, opts=''):
                 yield dent
     except cephfs.ObjectNotFound:
         return []
+
 
 def glob(path, pattern):
     if isinstance(path, bytes):

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -16,7 +16,7 @@ import re
 import shlex
 
 if sys.version_info.major < 3:
-   raise RuntimeError("cephfs-shell is only compatible with python3")
+    raise RuntimeError("cephfs-shell is only compatible with python3")
 
 try:
     from cmd2 import with_argparser
@@ -123,7 +123,7 @@ def glob(path, pattern):
     if parent_dir == '':
         parent_dir = '/'
     if path == '/' or is_dir_exists(os.path.basename(path),
-                                        parent_dir):
+                                    parent_dir):
         for i in ls(path, opts='A'):
             if fnmatch.fnmatch(i.d_name, pattern):
                 paths.append(os.path.join(path, i.d_name))


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
This patch series fixes the following flake8 errors:
```
cephfs-shell:19:4: E111 indentation is not a multiple of four
cephfs-shell:103:1: E302 expected 2 blank lines, found 1
cephfs-shell:118:1: E302 expected 2 blank lines, found 1
cephfs-shell:126:41: E127 continuation line over-indented for visual indent
```
Fixes: https://tracker.ceph.com/issues/40836
Signed-off-by: Varsha Rao <varao@redhat.com>



