### PR TITLE
qa/suites/rados/mgr/tasks/module_selftest: whitelist mgr client getting backlisted

### DIFF
--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -18,6 +18,7 @@ tasks:
         - influxdb python module not found
         - \(MGR_ZABBIX_
         - foo bar
+        - evicting unresponsive client
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest


### PR DESCRIPTION
The mgr's libcephfs client gets evicted after the mgr fails over.
Whitelist the message.

Signed-off-by: Sage Weil <sage@redhat.com>