### PR TITLE
mgr/dashboard: Fix dashboard health test failure

### DIFF
--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -58,7 +58,10 @@ class HealthTest(DashboardTestCase):
                 'status': str,
             }),
             'hosts': int,
-            'iscsi_daemons': int,
+            'iscsi_daemons': JObj({
+                'up': int,
+                'down': int
+            }),
             'mgr_map': JObj({
                 'active_name': str,
                 'standbys': JList(JLeaf(dict))
@@ -183,7 +186,10 @@ class HealthTest(DashboardTestCase):
                 'status': str,
             }),
             'hosts': int,
-            'iscsi_daemons': int,
+            'iscsi_daemons': JObj({
+                'up': int,
+                'down': int
+            }),
             'mgr_map': JObj({
                 'active_addr': str,
                 'active_addrs': JObj({


### PR DESCRIPTION
Fixes a test failure introduced by PR https://github.com/ceph/ceph/pull/29112.

Fixes: https://tracker.ceph.com/issues/40869

Signed-off-by: Ricardo Marques <rimarques@suse.com>

