### PR TITLE
rgw: add a small efficiency

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7134,8 +7134,8 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   // new_bucket_id and returns 0, otherwise it returns a negative
   // error code
   auto fetch_new_bucket_id =
-    [this, bucket_info](const std::string& log_tag,
-			std::string* new_bucket_id) -> int {
+    [this, &bucket_info](const std::string& log_tag,
+			 std::string* new_bucket_id) -> int {
       RGWBucketInfo fresh_bucket_info = bucket_info;
       int ret = try_refresh_bucket_info(fresh_bucket_info, nullptr);
       if (ret < 0) {


### PR DESCRIPTION
In a specific lambda, capture a data structure by reference rather than by copy.

This addresses a comment by @cbodley in another PR that was missed (https://github.com/ceph/ceph/pull/27223).