### PR TITLE
mon: set recovery_priority, pg_num_min, pg_autoscale_bias via 'fs new' command

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -258,6 +258,9 @@ class FsNewHandler : public FileSystemCommandHandler
 				   pool_opts_t::RECOVERY_PRIORITY,
 				   static_cast<int64_t>(5));
     mon->osdmon()->do_set_pool_opt(metadata,
+				   pool_opts_t::PG_NUM_MIN,
+				   static_cast<int64_t>(16));
+    mon->osdmon()->do_set_pool_opt(metadata,
 				   pool_opts_t::PG_AUTOSCALE_BIAS,
 				   static_cast<double>(4.0));
     mon->osdmon()->propose_pending();

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -254,6 +254,9 @@ class FsNewHandler : public FileSystemCommandHandler
     mon->osdmon()->do_application_enable(metadata,
 					 pg_pool_t::APPLICATION_NAME_CEPHFS,
 					 "metadata", fs_name);
+    mon->osdmon()->do_set_pool_opt(metadata,
+				   pool_opts_t::RECOVERY_PRIORITY,
+				   static_cast<int64_t>(5));
     mon->osdmon()->propose_pending();
 
     // All checks passed, go ahead and create.

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -257,6 +257,9 @@ class FsNewHandler : public FileSystemCommandHandler
     mon->osdmon()->do_set_pool_opt(metadata,
 				   pool_opts_t::RECOVERY_PRIORITY,
 				   static_cast<int64_t>(5));
+    mon->osdmon()->do_set_pool_opt(metadata,
+				   pool_opts_t::PG_AUTOSCALE_BIAS,
+				   static_cast<double>(4.0));
     mon->osdmon()->propose_pending();
 
     // All checks passed, go ahead and create.

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4355,6 +4355,15 @@ void OSDMonitor::do_application_enable(int64_t pool_id,
   pending_inc.new_pools[pool_id] = p;
 }
 
+void OSDMonitor::do_set_pool_opt(int64_t pool_id,
+				 pool_opts_t::key_t opt,
+				 pool_opts_t::value_t val)
+{
+  auto p = pending_inc.new_pools.try_emplace(
+    pool_id, *osdmap.get_pg_pool(pool_id));
+  p.first->second.opts.set(opt, val);
+}
+
 unsigned OSDMonitor::scan_for_creating_pgs(
   const mempool::osdmap::map<int64_t,pg_pool_t>& pools,
   const mempool::osdmap::set<int64_t>& removed_pools,

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -748,6 +748,8 @@ public:
   void do_application_enable(int64_t pool_id, const std::string &app_name,
 			     const std::string &app_key="",
 			     const std::string &app_value="");
+  void do_set_pool_opt(int64_t pool_id, pool_opts_t::key_t opt,
+		       pool_opts_t::value_t);
 
   void add_flag(int flag) {
     if (!(osdmap.flags & flag)) {

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -200,7 +200,7 @@ class VolumeClient(object):
         """
         return ve.to_tuple()
 
-    def create_pool(self, pool_name, pg_num, pg_num_min=None, pg_autoscale_factor=None):
+    def create_pool(self, pool_name, pg_num, pg_num_min=None):
         # create the given pool
         command = {'prefix': 'osd pool create', 'pool': pool_name, 'pg_num': pg_num}
         if pg_num_min:
@@ -209,11 +209,6 @@ class VolumeClient(object):
         if r != 0:
             return r, outb, outs
 
-        # set pg autoscale if needed
-        if pg_autoscale_factor:
-            command = {'prefix': 'osd pool set', 'pool': pool_name, 'var': 'pg_autoscale_bias',
-                       'val': str(pg_autoscale_factor)}
-            r, outb, outs = self.mgr.mon_command(command)
         return r, outb, outs
 
     def remove_pool(self, pool_name):
@@ -258,7 +253,7 @@ class VolumeClient(object):
         """
         metadata_pool, data_pool = self.gen_pool_names(volname)
         # create pools
-        r, outs, outb = self.create_pool(metadata_pool, 16, pg_num_min=16, pg_autoscale_factor=4.0)
+        r, outs, outb = self.create_pool(metadata_pool, 16, pg_num_min=16)
         if r != 0:
             return r, outb, outs
         r, outb, outs = self.create_pool(data_pool, 8)

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -200,11 +200,9 @@ class VolumeClient(object):
         """
         return ve.to_tuple()
 
-    def create_pool(self, pool_name, pg_num, pg_num_min=None):
+    def create_pool(self, pool_name, pg_num):
         # create the given pool
         command = {'prefix': 'osd pool create', 'pool': pool_name, 'pg_num': pg_num}
-        if pg_num_min:
-            command['pg_num_min'] = pg_num_min
         r, outb, outs = self.mgr.mon_command(command)
         if r != 0:
             return r, outb, outs
@@ -253,7 +251,7 @@ class VolumeClient(object):
         """
         metadata_pool, data_pool = self.gen_pool_names(volname)
         # create pools
-        r, outs, outb = self.create_pool(metadata_pool, 16, pg_num_min=16)
+        r, outs, outb = self.create_pool(metadata_pool, 16)
         if r != 0:
             return r, outb, outs
         r, outb, outs = self.create_pool(data_pool, 8)


### PR DESCRIPTION
This removes the code in mgr/volumes that does pg_num_min and the bias.  This way we capture any 'fs new' user.