### PR TITLE
rgw: add rgw_rados_pool_recovery_priority (default 5)

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6076,6 +6076,11 @@ std::vector<Option> get_rgw_options() {
     .set_min_max(1, 1024)
     .set_description("pg_num_min value for RGW metadata (omap-heavy) pools"),
 
+    Option("rgw_rados_pool_recovery_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(5)
+    .set_min_max(-10, 10)
+    .set_description("recovery_priority value for RGW metadata (omap-heavy) pools"),
+
     Option("rgw_zone", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description("Zone name")

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -81,9 +81,20 @@ int rgw_init_ioctx(librados::Rados *rados, const rgw_pool& pool,
 	pool.name + "\", \"var\": \"pg_num_min\", \"val\": \"" +
 	stringify(min) + "\"}",
 	inbl, NULL, NULL);
-     if (r < 0) {
-       dout(10) << __func__ << " warning: failed to set pg_num_min on "
-		<< pool.name << dendl;
+      if (r < 0) {
+	dout(10) << __func__ << " warning: failed to set pg_num_min on "
+		 << pool.name << dendl;
+      }
+      // set recovery_priority
+      int p = g_conf().get_val<uint64_t>("rgw_rados_pool_recovery_priority");
+      r = rados->mon_command(
+	"{\"prefix\": \"osd pool set\", \"pool\": \"" +
+	pool.name + "\", \"var\": \"recovery_priority\": \"" +
+	stringify(p) + "\"}",
+	inbl, NULL, NULL);
+      if (r < 0) {
+	dout(10) << __func__ << " warning: failed to set recovery_priority on "
+		 << pool.name << dendl;
       }
     }
   } else if (r < 0) {


### PR DESCRIPTION
By default, set a higher priority for recovery of rgw metadata pools.

Signed-off-by: Sage Weil <sage@redhat.com>