### PR TITLE
os/bluestore:fix two calculation bugs

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1423,7 +1423,7 @@ int BlueStore::BufferSpace::_discard(BufferCacheShard* cache, uint32_t offset, u
 		      0, b);
 	}
 	if (!b->is_writing()) {
-	  cache->_adjust_size(b, front - (int64_t)b->length);
+	  cache->_adjust_size(b, tail + front - (int64_t)b->length);
 	}
 	b->truncate(front);
 	b->maybe_rebuild();

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -421,6 +421,7 @@ bool bluestore_blob_use_tracker_t::put(
 	if (release_units) {
           if (release_units->empty() || next_offs != pos * au_size) {
   	    release_units->emplace_back(pos * au_size, au_size);
+            next_offs = pos * au_size;
           } else {
             release_units->back().length += au_size;
           }


### PR DESCRIPTION
First:
When discard buffer is in middle, we should reserve both the tail and head size.

Second:
Record next_offs when  offset is not sequential.

Signed-off-by: Xiangyang Yu `<penglaiyxy@gmail.com>`
