### PR TITLE
nautilus: rbd-mirror: link against the specified alloc library

### DIFF
--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -64,5 +64,6 @@ target_link_libraries(rbd-mirror
   cls_rbd_client
   cls_lock_client
   cls_journal_client
-  global)
+  global
+  ${ALLOC_LIBS})
 install(TARGETS rbd-mirror DESTINATION bin)


### PR DESCRIPTION
http://tracker.ceph.com/issues/40272