### PR TITLE
nautilus: mgr: use ipv4 default when ipv6 was disabled

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -15,6 +15,7 @@ import time
 from uuid import uuid4
 from OpenSSL import crypto, SSL
 from mgr_module import MgrModule, MgrStandbyModule, Option
+from mgr_util import get_default_addr
 
 try:
     import cherrypy
@@ -126,7 +127,8 @@ class CherryPyConfig(object):
 
         :returns our URI
         """
-        server_addr = self.get_localized_module_option('server_addr', '::')
+        server_addr = self.get_localized_module_option(
+            'server_addr', get_default_addr())
         ssl = self.get_localized_module_option('ssl', True)
         if not ssl:
             server_port = self.get_localized_module_option('server_port', 8080)
@@ -301,7 +303,7 @@ class Module(MgrModule, CherryPyConfig):
     PLUGIN_MANAGER.hook.register_commands()
 
     MODULE_OPTIONS = [
-        Option(name='server_addr', type='str', default='::'),
+        Option(name='server_addr', type='str', default=get_default_addr()),
         Option(name='server_port', type='int', default=8080),
         Option(name='ssl_server_port', type='int', default=8443),
         Option(name='jwt_token_ttl', type='int', default=28800),

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -1,3 +1,5 @@
+import contextlib
+import socket
 
 (
     BLACK,
@@ -85,3 +87,22 @@ def merge_dicts(*args):
     for arg in args:
         ret.update(arg)
     return ret
+
+
+def get_default_addr():
+    def is_ipv6_enabled():
+        try:
+            sock = socket.socket(socket.AF_INET6)
+            with contextlib.closing(sock):
+                sock.bind(("::1", 0))
+                return True
+        except (AttributeError, socket.error) as e:
+           return False
+
+    try:
+        return get_default_addr.result
+    except AttributeError:
+        result = '::' if is_ipv6_enabled() else '0.0.0.0'
+        get_default_addr.result = result
+        return result
+

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -9,13 +9,13 @@ import socket
 import threading
 import time
 from mgr_module import MgrModule, MgrStandbyModule, CommandResult, PG_STATES
+from mgr_util import get_default_addr
 from rbd import RBD
 
 # Defaults for the Prometheus HTTP server.  Can also set in config-key
 # see https://github.com/prometheus/prometheus/wiki/Default-port-allocations
 # for Prometheus exporter port registry
 
-DEFAULT_ADDR = '::'
 DEFAULT_PORT = 9283
 
 # When the CherryPy server in 3.2.2 (and later) starts it attempts to verify
@@ -999,7 +999,7 @@ class Module(MgrModule):
             'scrape_interval', 5.0)
 
         server_addr = self.get_localized_module_option(
-            'server_addr', DEFAULT_ADDR)
+            'server_addr', get_default_addr())
         server_port = self.get_localized_module_option(
             'server_port', DEFAULT_PORT)
         self.log.info(
@@ -1041,7 +1041,8 @@ class StandbyModule(MgrStandbyModule):
         self.shutdown_event = threading.Event()
 
     def serve(self):
-        server_addr = self.get_localized_module_option('server_addr', '::')
+        server_addr = self.get_localized_module_option(
+            'server_addr', get_default_addr())
         server_port = self.get_localized_module_option(
             'server_port', DEFAULT_PORT)
         self.log.info("server_addr: %s server_port: %s" %


### PR DESCRIPTION
http://tracker.ceph.com/issues/40273