### PR TITLE
doc: Update 'ceph-iscsi' min version

### DIFF
--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -21,7 +21,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
    -  ``tcmu-runner-1.4.0`` or newer package
 
-   -  ``ceph-iscsi-2.7`` or newer package
+   -  ``ceph-iscsi-3.2`` or newer package
 
      .. important::
         If previous versions of these packages exist, then they must


### PR DESCRIPTION
Ceph requires `ceph-iscsi` >= 3.2.

Signed-off-by: Ricardo Marques <rimarques@suse.com>