### PR TITLE
mgr/dashboard: run e2e tests against prod build (jenkins job)

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -12,7 +12,7 @@
     "test:ci": "npm run test:config && JEST_SILENT_REPORTER_DOTS=true jest --coverage --reporters jest-silent-reporter",
     "test:config": "if [ ! -e 'src/unit-test-configuration.ts' ]; then cp 'src/unit-test-configuration.ts.sample' 'src/unit-test-configuration.ts'; fi",
     "e2e": "npm run env_build && ng e2e",
-    "e2e:dev": "npm run env_build && ng e2e --dev-server-target",
+    "e2e:ci": "npm run env_build && ng e2e --dev-server-target",
     "lint:tslint": "ng lint",
     "lint:prettier": "prettier --list-different \"{src,e2e}/**/*.{ts,scss}\"",
     "lint:html": "html-linter --config html-linter.config.json",

--- a/src/pybind/mgr/dashboard/frontend/protractor.conf.js
+++ b/src/pybind/mgr/dashboard/frontend/protractor.conf.js
@@ -15,7 +15,7 @@ exports.config = {
     }
   },
   directConnect: true,
-  baseUrl: 'http://localhost:4200/',
+  baseUrl: process.env.BASE_URL || 'http://localhost:4200/',
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,


### PR DESCRIPTION
It's preferable to run e2e tests directly against production build in jenkins job and taking into account that ng e2e "--baseUrl" is deprecated,
```run-frontend-e2e-tests.sh``` exports BASE_URL (that is read in ```protractor.conf.js```)
and runs ```e2e:ci```.

Signed-off-by: alfonsomthd <almartin@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

