### PR TITLE
mimic: kcephfs TestClientLimits.test_client_pin fails with client caps fell below min

### DIFF
--- a/qa/tasks/cephfs/test_client_limits.py
+++ b/qa/tasks/cephfs/test_client_limits.py
@@ -87,9 +87,7 @@ class TestClientLimits(CephFSTestCase):
         recall_expected_value = int((1.0-mds_max_ratio_caps_per_client)*(open_files+2))
         def expected_caps():
             num_caps = self.get_session(mount_a_client_id)['num_caps']
-            if num_caps < mds_min_caps_per_client:
-                raise RuntimeError("client caps fell below min!")
-            elif num_caps == mds_min_caps_per_client:
+            if num_caps <= mds_min_caps_per_client:
                 return True
             elif recall_expected_value*.95 <= num_caps <= recall_expected_value*1.05:
                 return True


### PR DESCRIPTION
http://tracker.ceph.com/issues/38687