### PR TITLE
mimic: mds: mds_cap_revoke_eviction_timeout is not used to initialize Server::cap_revoke_eviction_timeout

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -200,6 +200,7 @@ Server::Server(MDSRank *m) :
   reconnect_evicting(false),
   terminating_sessions(false)
 {
+  cap_revoke_eviction_timeout = g_conf->get_val<double>("mds_cap_revoke_eviction_timeout");
   supported_features = feature_bitset_t(CEPHFS_FEATURES_MDS_SUPPORTED);
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/39210