### PR TITLE
mon,osd: add dead_epoch, --dead flag to 'osd down'

### DIFF
--- a/src/messages/MOSDMarkMeDead.h
+++ b/src/messages/MOSDMarkMeDead.h
@@ -1,0 +1,62 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "messages/PaxosServiceMessage.h"
+
+class MOSDMarkMeDead : public PaxosServiceMessage {
+private:
+  static constexpr int HEAD_VERSION = 1;
+  static constexpr int COMPAT_VERSION = 1;
+
+ public:
+  uuid_d fsid;
+  int32_t target_osd;
+  epoch_t epoch = 0;
+
+  MOSDMarkMeDead()
+    : PaxosServiceMessage{MSG_OSD_MARK_ME_DEAD, 0,
+			  HEAD_VERSION, COMPAT_VERSION} { }
+  MOSDMarkMeDead(const uuid_d &fs, int osd,
+		 epoch_t e)
+    : PaxosServiceMessage{MSG_OSD_MARK_ME_DEAD, e,
+			  HEAD_VERSION, COMPAT_VERSION},
+      fsid(fs), target_osd(osd),
+      epoch(e) {}
+ private:
+  ~MOSDMarkMeDead() override {}
+
+public:
+  epoch_t get_epoch() const { return epoch; }
+
+  void decode_payload() override {
+    auto p = payload.cbegin();
+    paxos_decode(p);
+    decode(fsid, p);
+    decode(target_osd, p);
+    decode(epoch, p);
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    paxos_encode();
+    header.version = HEAD_VERSION;
+    header.compat_version = COMPAT_VERSION;
+    encode(fsid, payload);
+    encode(target_osd, payload, features);
+    encode(epoch, payload);
+  }
+
+  std::string_view get_type_name() const override { return "MOSDMarkMeDead"; }
+  void print(ostream& out) const override {
+    out << "MOSDMarkMeDead("
+	<< "osd." << target_osd
+	<< ", epoch " << epoch
+	<< ", fsid=" << fsid
+	<< ")";
+  }
+private:
+  template<class T, typename... Args>
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+};

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -813,7 +813,8 @@ COMMAND("osd require-osd-release "\
 	"set the minimum allowed OSD release to participate in the cluster",
 	"osd", "rw")
 COMMAND("osd down " \
-	"type=CephString,name=ids,n=N", \
+	"name=ids,type=CephString,n=N "
+	"name=definitely_dead,type=CephBool,req=false",	\
 	"set osd(s) <id> [<id>...] down, " \
         "or use <any|all> to set all osds down", \
         "osd", "rw")

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4481,6 +4481,7 @@ void Monitor::dispatch_op(MonOpRequestRef op)
     case CEPH_MSG_POOLOP:
     case MSG_OSD_BEACON:
     case MSG_OSD_MARK_ME_DOWN:
+    case MSG_OSD_MARK_ME_DEAD:
     case MSG_OSD_FULL:
     case MSG_OSD_FAILURE:
     case MSG_OSD_BOOT:

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2799,6 +2799,10 @@ void OSDMonitor::force_failure(int target_osd, int by)
 
   dout(1) << " we're forcing failure of osd." << target_osd << dendl;
   pending_inc.new_state[target_osd] = CEPH_OSD_UP;
+  if (!pending_inc.new_xinfo.count(target_osd)) {
+    pending_inc.new_xinfo[target_osd] = osdmap.osd_xinfo[target_osd];
+  }
+  pending_inc.new_xinfo[target_osd].dead_epoch = pending_inc.epoch;
 
   mon->clog->info() << "osd." << target_osd << " failed ("
 		    << osdmap.crush->get_full_location_ordered_string(target_osd)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3202,7 +3202,9 @@ bool OSDMonitor::prepare_boot(MonOpRequestRef op)
 	pair<epoch_t,epoch_t>(begin, end);
     }
 
-    osd_xinfo_t xi = osdmap.get_xinfo(from);
+    if (pending_inc.new_xinfo.count(from) == 0)
+      pending_inc.new_xinfo[from] = osdmap.osd_xinfo[from];
+    osd_xinfo_t& xi = pending_inc.new_xinfo[from];
     if (m->boot_epoch == 0) {
       xi.laggy_probability *= (1.0 - g_conf()->mon_osd_laggy_weight);
       xi.laggy_interval *= (1.0 - g_conf()->mon_osd_laggy_weight);
@@ -3237,8 +3239,8 @@ bool OSDMonitor::prepare_boot(MonOpRequestRef op)
 	(g_conf()->mon_osd_auto_mark_new_in && (oldstate & CEPH_OSD_NEW)) ||
 	(g_conf()->mon_osd_auto_mark_in)) {
       if (can_mark_in(from)) {
-	if (osdmap.osd_xinfo[from].old_weight > 0) {
-	  pending_inc.new_weight[from] = osdmap.osd_xinfo[from].old_weight;
+	if (xi.old_weight > 0) {
+	  pending_inc.new_weight[from] = xi.old_weight;
 	  xi.old_weight = 0;
 	} else {
 	  pending_inc.new_weight[from] = CEPH_OSD_IN;
@@ -3248,8 +3250,6 @@ bool OSDMonitor::prepare_boot(MonOpRequestRef op)
 		<< m->get_orig_source_addr() << dendl;
       }
     }
-
-    pending_inc.new_xinfo[from] = xi;
 
     // wait
     wait_for_finished_proposal(op, new C_Booted(this, op));

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -403,6 +403,9 @@ private:
   void process_failures();
   void take_all_failures(list<MonOpRequestRef>& ls);
 
+  bool preprocess_mark_me_dead(MonOpRequestRef op);
+  bool prepare_mark_me_dead(MonOpRequestRef op);
+
   bool preprocess_full(MonOpRequestRef op);
   bool prepare_full(MonOpRequestRef op);
 

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -62,6 +62,7 @@
 #include "messages/MOSDPGTemp.h"
 #include "messages/MOSDFailure.h"
 #include "messages/MOSDMarkMeDown.h"
+#include "messages/MOSDMarkMeDead.h"
 #include "messages/MOSDFull.h"
 #include "messages/MOSDPing.h"
 #include "messages/MOSDOp.h"
@@ -474,6 +475,9 @@ Message *decode_message(CephContext *cct, int crcflags,
     break;
   case MSG_OSD_MARK_ME_DOWN:
     m = make_message<MOSDMarkMeDown>();
+    break;
+  case MSG_OSD_MARK_ME_DEAD:
+    m = make_message<MOSDMarkMeDead>();
     break;
   case MSG_OSD_FULL:
     m = make_message<MOSDFull>();

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -71,6 +71,7 @@
 #define MSG_OSD_ALIVE        73
 #define MSG_OSD_MARK_ME_DOWN 74
 #define MSG_OSD_FULL         75
+#define MSG_OSD_MARK_ME_DEAD 123
 
 // removed right after luminous
 //#define MSG_OSD_SUBOP        76

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -71,6 +71,7 @@
 #include "messages/MOSDPing.h"
 #include "messages/MOSDFailure.h"
 #include "messages/MOSDMarkMeDown.h"
+#include "messages/MOSDMarkMeDead.h"
 #include "messages/MOSDFull.h"
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
@@ -8023,6 +8024,14 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
           clog->debug() << "map e" << osdmap->get_epoch()
                         << " wrongly marked me down at e"
                         << osdmap->get_down_at(whoami);
+	}
+	if (monc->monmap.min_mon_release >= ceph_release_t::octopus) {
+	  // note that this is best-effort...
+	  monc->send_mon_message(
+	    new MOSDMarkMeDead(
+	      monc->get_fsid(),
+	      whoami,
+	      osdmap->get_epoch()));
 	}
       } else if (!osdmap->get_addrs(whoami).legacy_equals(
 		   client_messenger->get_myaddrs())) {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -133,6 +133,7 @@ void osd_xinfo_t::dump(Formatter *f) const
   f->dump_int("features", features);
   f->dump_unsigned("old_weight", old_weight);
   f->dump_stream("last_purged_snaps_scrub") << last_purged_snaps_scrub;
+  f->dump_int("dead_epoch", dead_epoch);
 }
 
 void osd_xinfo_t::encode(ceph::buffer::list& bl, uint64_t enc_features) const
@@ -150,6 +151,7 @@ void osd_xinfo_t::encode(ceph::buffer::list& bl, uint64_t enc_features) const
   encode(old_weight, bl);
   if (v >= 4) {
     encode(last_purged_snaps_scrub, bl);
+    encode(dead_epoch, bl);
   }
   ENCODE_FINISH(bl);
 }
@@ -172,6 +174,9 @@ void osd_xinfo_t::decode(ceph::buffer::list::const_iterator& bl)
     old_weight = 0;
   if (struct_v >= 4) {
     decode(last_purged_snaps_scrub, bl);
+    decode(dead_epoch, bl);
+  } else {
+    dead_epoch = 0;
   }
   DECODE_FINISH(bl);
 }
@@ -192,7 +197,8 @@ ostream& operator<<(ostream& out, const osd_xinfo_t& xi)
 	     << " laggy_probability " << xi.laggy_probability
 	     << " laggy_interval " << xi.laggy_interval
 	     << " old_weight " << xi.old_weight
-	     << " last_purged_snaps_scrub " << xi.last_purged_snaps_scrub;
+	     << " last_purged_snaps_scrub " << xi.last_purged_snaps_scrub
+	     << " dead_epoch " << xi.dead_epoch;
 }
 
 // ----------------------------------

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -846,6 +846,13 @@ public:
     return !is_out(osd);
   }
 
+  bool is_dead(int osd) const {
+    if (!exists(osd)) {
+      return false; // unclear if they know they are removed from map
+    }
+    return get_xinfo(osd).dead_epoch > get_info(osd).up_from;
+  }
+
   unsigned get_osd_crush_node_flags(int osd) const;
   unsigned get_crush_node_flags(int id) const;
   unsigned get_device_class_flags(int id) const;

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -93,6 +93,7 @@ struct osd_xinfo_t {
   uint64_t features;       ///< features supported by this osd we should know about
   __u32 old_weight;        ///< weight prior to being auto marked out
   utime_t last_purged_snaps_scrub; ///< last scrub of purged_snaps
+  epoch_t dead_epoch = 0;  ///< last epoch we were confirmed dead (not just down)
 
   osd_xinfo_t() : laggy_probability(0), laggy_interval(0),
                   features(0), old_weight(0) {}


### PR DESCRIPTION
This tells us when an OSD is known to be dead, or be self-aware and know it is marked down.  It will be used for the read hole machinery.