### PR TITLE
rgw multisite: bucket full sync skips objects we've already seen

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -941,6 +941,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
       rgw_bucket_dir_entry_meta& meta = op.meta;
       rgw_bucket_category_stats& stats = header.stats[meta.category];
       entry.meta = meta;
+      entry.meta.zones_trace = op.zones_trace;
       entry.key = op.key;
       entry.exists = true;
       entry.tag = op.tag;
@@ -1117,6 +1118,10 @@ public:
     instance_entry.tag = "delete-marker";
 
     initialized = true;
+  }
+
+  void add_zones(const rgw_zone_set& zones) {
+    instance_entry.meta.zones_trace.insert(zones.begin(), zones.end());
   }
 
   void set_epoch(uint64_t epoch) {
@@ -1484,6 +1489,8 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
     /* a deletion marker, need to initialize entry as such */
     obj.init_as_delete_marker(op.meta);
   }
+  // record any extra zones in the instance entry
+  obj.add_zones(op.zones_trace);
 
   /* read olh */
   bool olh_found;

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -65,6 +65,7 @@ void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
   encode_json("accounted_size", accounted_size, f);
   encode_json("user_data", user_data, f);
   encode_json("appendable", appendable, f);
+  encode_json("zones_trace", zones_trace, f);
 }
 
 void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
@@ -83,6 +84,7 @@ void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("accounted_size", accounted_size, obj);
   JSONDecoder::decode_json("user_data", user_data, obj);
   JSONDecoder::decode_json("appendable", appendable, obj);
+  JSONDecoder::decode_json("zones_trace", zones_trace, obj);
 }
 
 void rgw_bucket_dir_entry::generate_test_instances(list<rgw_bucket_dir_entry*>& o)

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -121,12 +121,13 @@ struct rgw_bucket_dir_entry_meta {
   string user_data;
   string storage_class;
   bool appendable;
+  rgw_zone_set zones_trace; // zones known to have applied this object version
 
   rgw_bucket_dir_entry_meta() :
     category(RGWObjCategory::None), size(0), accounted_size(0), appendable(false) { }
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(7, 3, bl);
+    ENCODE_START(8, 3, bl);
     encode(category, bl);
     encode(size, bl);
     encode(mtime, bl);
@@ -138,11 +139,12 @@ struct rgw_bucket_dir_entry_meta {
     encode(user_data, bl);
     encode(storage_class, bl);
     encode(appendable, bl);
+    encode(zones_trace, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(6, 3, 3, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(8, 3, 3, bl);
     decode(category, bl);
     decode(size, bl);
     decode(mtime, bl);
@@ -161,6 +163,8 @@ struct rgw_bucket_dir_entry_meta {
       decode(storage_class, bl);
     if (struct_v >= 7)
       decode(appendable, bl);
+    if (struct_v >= 8)
+      decode(zones_trace, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5466,11 +5466,6 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
 
       meta.owner = params.obj_owner.get_id().to_str();
       meta.owner_display_name = params.obj_owner.get_display_name();
-      if (params.zones_trace) {
-        // store the zone trace with the delete marker so it's available for
-        // full sync in DeleteMarkerZonesTrace
-        meta.dm_zones_trace = *params.zones_trace;
-      }
 
       if (real_clock::is_zero(params.mtime)) {
         meta.mtime = real_clock::now();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5466,6 +5466,11 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
 
       meta.owner = params.obj_owner.get_id().to_str();
       meta.owner_display_name = params.obj_owner.get_display_name();
+      if (params.zones_trace) {
+        // store the zone trace with the delete marker so it's available for
+        // full sync in DeleteMarkerZonesTrace
+        meta.dm_zones_trace = *params.zones_trace;
+      }
 
       if (real_clock::is_zero(params.mtime)) {
         meta.mtime = real_clock::now();

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -909,6 +909,7 @@ void RGWListBucket_ObjStore_S3::send_versioned_response()
       s->formatter->open_object_section(section_name);
       if (objs_container) {
         s->formatter->dump_bool("IsDeleteMarker", iter->is_delete_marker());
+        encode_json("ZonesTrace", iter->meta.zones_trace, s->formatter);
       }
       rgw_obj_key key(iter->key);
       if (encode_key) {


### PR DESCRIPTION
the bucket index log contains a trace of all zones that have applied the given change, and bucket incremental sync uses this trace to avoid cycles where we re-apply a change that we've applied before (and so generate a new bilog entry that we'll see again later). bucket full sync has no such mechanism and - while it doesn't produce sync feedback loops - can race to recreate an object that was previously created and deleted. this race reproduces most easily with delete markers, because full sync writes them directly instead of fetching them from a remote zone, and can cause bucket deletion to fail even when all creates/deletes occur on the master zone

Fixes: http://tracker.ceph.com/issues/40818