### PR TITLE
nautilus: core: librados: move buffer free functions to inline namespace

### DIFF
--- a/src/common/buffer_seastar.cc
+++ b/src/common/buffer_seastar.cc
@@ -31,10 +31,6 @@ class raw_seastar_foreign_ptr : public raw {
   }
 };
 
-raw* create_foreign(temporary_buffer&& buf) {
-  return new raw_seastar_foreign_ptr(std::move(buf));
-}
-
 class raw_seastar_local_ptr : public raw {
   temporary_buffer buf;
  public:
@@ -45,9 +41,17 @@ class raw_seastar_local_ptr : public raw {
   }
 };
 
+inline namespace v14_2_0 {
+
+raw* create_foreign(temporary_buffer&& buf) {
+  return new raw_seastar_foreign_ptr(std::move(buf));
+}
+
 raw* create(temporary_buffer&& buf) {
   return new raw_seastar_local_ptr(std::move(buf));
 }
+
+} // inline namespace v14_2_0
 
 // buffer::ptr conversions
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -104,6 +104,8 @@ struct unique_leakable_ptr : public std::unique_ptr<T, ceph::nop_delete<T>> {
 };
 
 namespace buffer CEPH_BUFFER_API {
+inline namespace v14_2_0 {
+
   /*
    * exceptions
    */
@@ -188,8 +190,6 @@ namespace buffer CEPH_BUFFER_API {
 #if defined(HAVE_XIO)
   raw* create_msg(unsigned len, char *buf, XioDispatchHook *m_hook);
 #endif
-
-inline namespace v14_2_0 {
 
   /*
    * a buffer pointer.  references (a subsequence of) a raw buffer.
@@ -1308,7 +1308,7 @@ inline bool operator<=(bufferlist& l, bufferlist& r) {
 
 std::ostream& operator<<(std::ostream& out, const buffer::ptr& bp);
 
-std::ostream& operator<<(std::ostream& out, const raw &r);
+std::ostream& operator<<(std::ostream& out, const buffer::raw &r);
 
 std::ostream& operator<<(std::ostream& out, const buffer::list& bl);
 

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -24,6 +24,8 @@
 #include "include/spinlock.h"
 
 namespace ceph::buffer {
+inline namespace v14_2_0 {
+
   class raw {
   public:
     // In the future we might want to have a slab allocator here with few
@@ -118,6 +120,8 @@ public:
       last_crc_offset.second = std::numeric_limits<size_t>::max();
     }
   };
+
+} // inline namespace v14_2_0
 } // namespace ceph::buffer
 
 #endif // CEPH_BUFFER_RAW_H


### PR DESCRIPTION
http://tracker.ceph.com/issues/40274