### PR TITLE
nautilus: core: osd beacon sometimes has empty pg list

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6298,7 +6298,7 @@ void OSD::send_beacon(const ceph::coarse_mono_clock::time_point& now)
     {
       std::lock_guard l{min_last_epoch_clean_lock};
       beacon = new MOSDBeacon(osdmap->get_epoch(), min_last_epoch_clean);
-      std::swap(beacon->pgs, min_last_epoch_clean_pgs);
+      beacon->pgs = min_last_epoch_clean_pgs;
       last_sent_beacon = now;
     }
     monc->send_mon_message(beacon);


### PR DESCRIPTION
http://tracker.ceph.com/issues/40465