### PR TITLE
mgr/dashboard: qa: fix RBD test when matching error strings

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -353,7 +353,7 @@ class RbdTest(DashboardTestCase):
         res = self.create_image('rbd', 'test_rbd_twice', 10240)
         self.assertStatus(400)
         self.assertEqual(res, {"code": '17', 'status': 400, "component": "rbd",
-                               "detail": "[errno 17] error creating image",
+                               "detail": "[errno 17] RBD image already exists (error creating image)",
                                'task': {'name': 'rbd/create',
                                         'metadata': {'pool_name': 'rbd',
                                                      'image_name': 'test_rbd_twice'}}})
@@ -412,7 +412,7 @@ class RbdTest(DashboardTestCase):
         res = self.remove_image('rbd', 'i_dont_exist')
         self.assertStatus(400)
         self.assertEqual(res, {u'code': u'2', "status": 400, "component": "rbd",
-                               "detail": "[errno 2] error removing image",
+                               "detail": "[errno 2] RBD image not found (error removing image)",
                                'task': {'name': 'rbd/delete',
                                         'metadata': {'pool_name': 'rbd',
                                                      'image_name': 'i_dont_exist'}}})


### PR DESCRIPTION
This commit fixes a problem caused by changes to the error descriptions in the RBD python bindings introduced in:
a66b06cc764ba66cdabfe2856e9f1bcd738f0772  PR #28054

Signed-off-by: Ricardo Dias <rdias@suse.com>


