### PR TITLE
mgr/dashboard: rgw_client: add default values for zonegroup and placement_target

### DIFF
--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -448,7 +448,8 @@ class RgwClient(RestClient):
             raise e
 
     @RestClient.api_put('/{bucket_name}')
-    def create_bucket(self, bucket_name, zonegroup, placement_target, request=None):
+    def create_bucket(self, bucket_name, zonegroup="default", placement_target="default-placement",
+                      request=None):
         logger.info("Creating bucket: %s, zonegroup: %s, placement_target: %s",
                     bucket_name, zonegroup, placement_target)
         create_bucket_configuration = ET.Element('CreateBucketConfiguration')


### PR DESCRIPTION
NFS-Ganesha still does not work with RGW multi-site so we need to
provide the default values for zonegroup and placement.

Currently dashboard NFS ganesha QA test is failing due to:

```
ERROR: test_get_export (tasks.mgr.dashboard.test_ganesha.GaneshaTest)

ERROR:tasks.mgr.dashboard.helper:Request response: {"status": 500, "task": {"name": "nfs/create", "metadata": {"path": "mybucket", "cluster_id": "cluster2",         "fsal": "RGW"}}, "component": null, "detail": "create_bucket() takes at least 4 arguments (3 given)"} 
```

This patch should fix the issue.

Signed-off-by: Ricardo Dias <rdias@suse.com>


