### PR TITLE
mimic: rgw/OutputDataSocket: append_output(buffer::list&) says it will (but does not) discard output at data_max_backlog 

### DIFF
--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -92,6 +92,7 @@ OutputDataSocket::OutputDataSocket(CephContext *cct, uint64_t _backlog)
     m_shutdown_wr_fd(-1),
     going_down(false),
     data_size(0),
+    skipped(0),
     m_lock("OutputDataSocket::m_lock")
 {
 }
@@ -290,12 +291,12 @@ void OutputDataSocket::handle_connection(int fd)
 int OutputDataSocket::dump_data(int fd)
 {
   m_lock.Lock(); 
-  list<bufferlist> l = std::move(data);
+  vector<buffer::list> l = std::move(data);
   data.clear();
   data_size = 0;
   m_lock.Unlock();
 
-  for (list<bufferlist>::iterator iter = l.begin(); iter != l.end(); ++iter) {
+  for (auto iter = l.begin(); iter != l.end(); ++iter) {
     bufferlist& bl = *iter;
     int ret = safe_write(fd, bl.c_str(), bl.length());
     if (ret >= 0) {
@@ -384,11 +385,17 @@ void OutputDataSocket::append_output(bufferlist& bl)
   Mutex::Locker l(m_lock);
 
   if (data_size + bl.length() > data_max_backlog) {
-    ldout(m_cct, 20) << "dropping data output, max backlog reached" << dendl;
+    if (skipped % 100 == 0) {
+      ldout(m_cct, 0) << "dropping data output, max backlog reached (skipped=="
+		      << skipped << ")"
+		      << dendl;
+      skipped = 1;
+    } else
+      ++skipped;
+    return;
   }
+
   data.push_back(bl);
-
   data_size += bl.length();
-
   cond.Signal();
 }

--- a/src/common/OutputDataSocket.h
+++ b/src/common/OutputDataSocket.h
@@ -53,13 +53,13 @@ protected:
   bool going_down;
 
   uint64_t data_size;
+  uint32_t skipped;
 
-  std::list<bufferlist> data;
+  std::vector<buffer::list> data;
 
   Mutex m_lock;
   Cond cond;
-
-  bufferlist delim;
+  buffer::list delim;
 };
 
 #endif


### PR DESCRIPTION
http://tracker.ceph.com/issues/40351