### PR TITLE
mgr/dashboard: RGW bucket creation when no placement target received

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -144,7 +144,7 @@ class RgwBucket(RgwRESTController):
         result = self.proxy('GET', 'bucket', {'bucket': bucket})
         return self._append_bid(result)
 
-    def create(self, bucket, uid, zonegroup, placement_target):
+    def create(self, bucket, uid, zonegroup=None, placement_target=None):
         try:
             rgw_client = RgwClient.instance(uid)
             return rgw_client.create_bucket(bucket, zonegroup, placement_target)

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -448,14 +448,17 @@ class RgwClient(RestClient):
             raise e
 
     @RestClient.api_put('/{bucket_name}')
-    def create_bucket(self, bucket_name, zonegroup, placement_target, request=None):
+    def create_bucket(self, bucket_name, zonegroup=None, placement_target=None, request=None):
         logger.info("Creating bucket: %s, zonegroup: %s, placement_target: %s",
                     bucket_name, zonegroup, placement_target)
-        create_bucket_configuration = ET.Element('CreateBucketConfiguration')
-        location_constraint = ET.SubElement(create_bucket_configuration, 'LocationConstraint')
-        location_constraint.text = '{}:{}'.format(zonegroup, placement_target)
+        data = None
+        if zonegroup and placement_target:
+            create_bucket_configuration = ET.Element('CreateBucketConfiguration')
+            location_constraint = ET.SubElement(create_bucket_configuration, 'LocationConstraint')
+            location_constraint.text = '{}:{}'.format(zonegroup, placement_target)
+            data = ET.tostring(create_bucket_configuration, encoding='utf-8')
 
-        return request(data=ET.tostring(create_bucket_configuration, encoding='utf-8'))
+        return request(data=data)
 
     def get_placement_targets(self):  # type: () -> Dict[str, Any]
         zone = self._get_daemon_zone_info()


### PR DESCRIPTION
This fixes:
```
ERROR: test_get_export (tasks.mgr.dashboard.test_ganesha.GaneshaTest)

ERROR:tasks.mgr.dashboard.helper:Request response: {"status": 500, "task": {"name": "nfs/create", "metadata": {"path": "mybucket", "cluster_id": "cluster2",         "fsal": "RGW"}}, "component": null, "detail": "create_bucket() takes at least 4 arguments (3 given)"} 
```

Fixes: https://tracker.ceph.com/issues/40567

Signed-off-by: alfonsomthd <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

