### PR TITLE
osd: refcounting chunks for snapshotted manifest object

### DIFF
--- a/src/cls/cas/cls_cas.cc
+++ b/src/cls/cas/cls_cas.cc
@@ -107,15 +107,7 @@ static int chunk_create_or_get_ref(cls_method_context_t hctx,
     CLS_LOG(10, "inc ref oid=%s\n",
 	    op.source.oid.name.c_str());
 
-    if (!objr.get(op.source)) {
-      // we could perhaps return -EEXIST here, but instead we will
-      // behave in an idempotent fashion, since we know that it is possible
-      // for references to be leaked.  If A has a ref, tries to drop it and
-      // fails (leaks), and then later tries to take it again, we should
-      // simply succeed if we know we already have it.  This will serve to
-      // silently correct the mistake.
-      return 0;
-    }
+    objr.get(op.source);
 
     ret = chunk_set_refcount(hctx, objr);
     if (ret < 0) {
@@ -148,15 +140,7 @@ static int chunk_get_ref(cls_method_context_t hctx,
   // existing chunk; inc ref
   CLS_LOG(10, "oid=%s\n", op.source.oid.name.c_str());
   
-  if (!objr.get(op.source)) {
-    // we could perhaps return -EEXIST here, but instead we will
-    // behave in an idempotent fashion, since we know that it is possible
-    // for references to be leaked.  If A has a ref, tries to drop it and
-    // fails (leaks), and then later tries to take it again, we should
-    // simply succeed if we know we already have it.  This will serve to
-    // silently correct the mistake.
-    return 0;
-  }
+  objr.get(op.source);
 
   ret = chunk_set_refcount(hctx, objr);
   if (ret < 0) {

--- a/src/cls/cas/cls_cas_internal.h
+++ b/src/cls/cas/cls_cas_internal.h
@@ -104,7 +104,7 @@ WRITE_CLASS_ENCODER(chunk_refs_t)
 // these are internal and should generally not be used directly
 
 struct chunk_refs_by_object_t : public chunk_refs_t::refs_t {
-  std::set<hobject_t> by_object;
+  std::multiset<hobject_t> by_object;
 
   uint8_t get_type() const {
     return chunk_refs_t::TYPE_BY_OBJECT;
@@ -116,9 +116,6 @@ struct chunk_refs_by_object_t : public chunk_refs_t::refs_t {
     return by_object.size();
   }
   bool get(const hobject_t& o) override {
-    if (by_object.count(o)) {
-      return false;
-    }
     by_object.insert(o);
     return true;
   }

--- a/src/cls/cas/cls_cas_internal.h
+++ b/src/cls/cas/cls_cas_internal.h
@@ -39,7 +39,7 @@ struct chunk_refs_t {
     virtual uint8_t get_type() const = 0;
     virtual bool empty() const = 0;
     virtual uint64_t count() const = 0;
-    virtual bool get(const hobject_t& o) = 0;
+    virtual void get(const hobject_t& o) = 0;
     virtual bool put(const hobject_t& o) = 0;
     virtual void dump(Formatter *f) const = 0;
     virtual std::string describe_encoding() const {
@@ -72,8 +72,8 @@ struct chunk_refs_t {
     return r->count();
   }
 
-  bool get(const hobject_t& o) {
-    return r->get(o);
+  void get(const hobject_t& o) {
+    r->get(o);
   }
   bool put(const hobject_t& o) {
     bool ret = r->put(o);
@@ -115,9 +115,8 @@ struct chunk_refs_by_object_t : public chunk_refs_t::refs_t {
   uint64_t count() const override {
     return by_object.size();
   }
-  bool get(const hobject_t& o) override {
+  void get(const hobject_t& o) override {
     by_object.insert(o);
-    return true;
   }
   bool put(const hobject_t& o) override {
     auto p = by_object.find(o);
@@ -196,10 +195,9 @@ struct chunk_refs_by_hash_t : public chunk_refs_t::refs_t {
   uint64_t count() const override {
     return total;
   }
-  bool get(const hobject_t& o) override {
+  void get(const hobject_t& o) override {
     by_hash[make_pair(o.pool, o.get_hash() & mask())]++;
     ++total;
-    return true;
   }
   bool put(const hobject_t& o) override {
     auto p = by_hash.find(make_pair(o.pool, o.get_hash() & mask()));
@@ -286,10 +284,9 @@ struct chunk_refs_by_pool_t : public chunk_refs_t::refs_t {
   uint64_t count() const override {
     return total;
   }
-  bool get(const hobject_t& o) override {
+  void get(const hobject_t& o) override {
     ++by_pool[o.pool];
     ++total;
-    return true;
   }
   bool put(const hobject_t& o) override {
     auto p = by_pool.find(o.pool);
@@ -364,9 +361,8 @@ struct chunk_refs_count_t : public chunk_refs_t::refs_t {
   uint64_t count() const override {
     return total;
   }
-  bool get(const hobject_t& o) override {
+  void get(const hobject_t& o) override {
     ++total;
-    return true;
   }
   bool put(const hobject_t& o) override {
     if (!total) {

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -326,7 +326,7 @@ extern const char *ceph_osd_state_name(int s);
 	f(SET_CHUNK,	__CEPH_OSD_OP(WR, DATA, 40),	"set-chunk")	    \
 	f(TIER_PROMOTE,	__CEPH_OSD_OP(WR, DATA, 41),	"tier-promote")	    \
 	f(UNSET_MANIFEST, __CEPH_OSD_OP(WR, DATA, 42),	"unset-manifest")   \
-	f(TIER_FLUSH, __CEPH_OSD_OP(WR, DATA, 43),	"tier-flush")	    \
+	f(TIER_FLUSH, __CEPH_OSD_OP(CACHE, DATA, 43),	"tier-flush")	    \
 									    \
 	/** attrs **/							    \
 	/* read */							    \

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -518,7 +518,6 @@ inline namespace v14_2_0 {
                    std::string tgt_oid, uint64_t tgt_offset, int flag = 0);
     void tier_promote();
     void unset_manifest();
-    void tier_flush();
 
 
     friend class IoCtx;
@@ -733,6 +732,12 @@ inline namespace v14_2_0 {
      * triggering a promote on the OSD (that is then evicted).
      */
     void cache_evict();
+
+    /**
+     * flush a manifest tier object to backing tier; will block racing
+     * updates.
+     */
+    void tier_flush();
   };
 
   /* IoCtx : This is a context in which we can perform I/O.

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -631,6 +631,13 @@ void librados::ObjectReadOperation::cache_evict()
   o->cache_evict();
 }
 
+void librados::ObjectReadOperation::tier_flush()
+{
+  ceph_assert(impl);
+  ::ObjectOperation *o = &impl->o;
+  o->tier_flush();
+}
+
 void librados::ObjectWriteOperation::set_redirect(const std::string& tgt_obj, 
 						  const IoCtx& tgt_ioctx,
 						  uint64_t tgt_version,
@@ -667,13 +674,6 @@ void librados::ObjectWriteOperation::unset_manifest()
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
   o->unset_manifest();
-}
-
-void librados::ObjectWriteOperation::tier_flush()
-{
-  ceph_assert(impl);
-  ::ObjectOperation *o = &impl->o;
-  o->tier_flush();
 }
 
 void librados::ObjectWriteOperation::tmap_update(const bufferlist& cmdbl)

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2587,7 +2587,7 @@ int PrimaryLogPG::do_manifest_flush(OpRequestRef op, ObjectContextRef obc, Flush
 	}
       }();
       bufferlist in;
-      if (fp_oid != tgt_soid.oid && (!obc->ssc && !obc->ssc->snapset.clones.size())) {
+      if (fp_oid != tgt_soid.oid && !obc->ssc->snapset.clones.size()) {
 	// TODO: don't retain reference to dirty extents
 	// decrement old chunk's reference count
 	ObjectOperation dec_op;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3515,9 +3515,12 @@ void PrimaryLogPG::dec_all_refcount_manifest(const object_info_t& oi, OpContext*
       refs);
 
     if (!refs.is_empty()) {
+      hobject_t soid = ctx->obc->obs.oi.soid;
       ctx->register_on_commit(
-	[ctx, this, refs](){
-	  dec_refcount(ctx->obc, refs);
+	[soid, this, refs](){
+	  ObjectContextRef obc = get_object_context(soid, false, NULL);
+	  ceph_assert(obc);
+	  dec_refcount(obc, refs);
 	});
     }
   } else if (oi.manifest.is_redirect()) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6994,7 +6994,8 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  result = -EOPNOTSUPP;
 	  break;
 	}
-	if (soid.has_snapset()) {
+	if (ctx->snapc.snaps.size() || 
+	    (ctx->obc->ssc && ctx->obc->ssc->snapset.clones.size()) ) {
 	  result = -EOPNOTSUPP;
 	  break;
 	}

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1501,7 +1501,7 @@ protected:
   void cancel_manifest_ops(bool requeue, vector<ceph_tid_t> *tids);
   void refcount_manifest(hobject_t src_soid, hobject_t tgt_soid, refcount_t type,
 			 RefCountCallback* cb);
-  void dec_all_refcount_manifest(object_info_t& oi, OpContext* ctx);
+  void dec_all_refcount_manifest(const object_info_t& oi, OpContext* ctx);
   void dec_refcount(ObjectContextRef obc, const object_ref_delta_t& refs);
 
   friend struct C_ProxyChunkRead;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1499,11 +1499,10 @@ protected:
   void handle_manifest_flush(hobject_t oid, ceph_tid_t tid, int r,
 			     uint64_t offset, uint64_t last_offset, epoch_t lpr);
   void cancel_manifest_ops(bool requeue, vector<ceph_tid_t> *tids);
-  void refcount_manifest(ObjectContextRef obc, hobject_t src_soid, object_locator_t oloc,
-			 hobject_t tgt_soid, SnapContext snapc, refcount_t type, RefCountCallback* cb);
-  void dec_all_refcount_head_manifest(object_info_t& oi, OpContext* ctx, const hobject_t &coid);
-  void dec_refcount(ObjectContextRef obc, const object_info_t& oi, 
-		    const object_ref_delta_t& refs);
+  void refcount_manifest(hobject_t src_soid, hobject_t tgt_soid, refcount_t type,
+			 RefCountCallback* cb);
+  void dec_all_refcount_manifest(object_info_t& oi, OpContext* ctx);
+  void dec_refcount(ObjectContextRef obc, const object_ref_delta_t& refs);
 
   friend struct C_ProxyChunkRead;
   friend class PromoteManifestCallback;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1503,7 +1503,7 @@ protected:
 			 hobject_t tgt_soid, SnapContext snapc, refcount_t type, RefCountCallback* cb);
   void dec_all_refcount_head_manifest(object_info_t& oi, OpContext* ctx);
   void dec_refcount_non_intersection(ObjectContextRef obc, const object_info_t& oi, 
-				     set<uint64_t> intersection_set);
+				     const set<uint64_t>& intersection_set);
 
   friend struct C_ProxyChunkRead;
   friend class PromoteManifestCallback;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1501,9 +1501,9 @@ protected:
   void cancel_manifest_ops(bool requeue, vector<ceph_tid_t> *tids);
   void refcount_manifest(ObjectContextRef obc, hobject_t src_soid, object_locator_t oloc,
 			 hobject_t tgt_soid, SnapContext snapc, refcount_t type, RefCountCallback* cb);
-  void dec_all_refcount_head_manifest(object_info_t& oi, OpContext* ctx);
-  void dec_refcount_non_intersection(ObjectContextRef obc, const object_info_t& oi, 
-				     const set<uint64_t>& intersection_set);
+  void dec_all_refcount_head_manifest(object_info_t& oi, OpContext* ctx, const hobject_t &coid);
+  void dec_refcount(ObjectContextRef obc, const object_info_t& oi, 
+		    const object_ref_delta_t& refs);
 
   friend struct C_ProxyChunkRead;
   friend class PromoteManifestCallback;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1476,6 +1476,10 @@ protected:
   friend struct C_ProxyWrite_Commit;
 
   // -- chunkop --
+  enum class refcount_t {
+    INCREMENT_REF,
+    DECREMENT_REF,
+  };
   void do_proxy_chunked_op(OpRequestRef op, const hobject_t& missing_oid, 
 			   ObjectContextRef obc, bool write_ordered);
   void do_proxy_chunked_read(OpRequestRef op, ObjectContextRef obc, int op_index,
@@ -1494,9 +1498,12 @@ protected:
 			     uint64_t last_offset);
   void handle_manifest_flush(hobject_t oid, ceph_tid_t tid, int r,
 			     uint64_t offset, uint64_t last_offset, epoch_t lpr);
-  void cancel_manifest_ops(bool requeue, std::vector<ceph_tid_t> *tids);
-  void refcount_manifest(ObjectContextRef obc, object_locator_t oloc, hobject_t soid,
-                         SnapContext snapc, bool get, RefCountCallback *cb, uint64_t offset);
+  void cancel_manifest_ops(bool requeue, vector<ceph_tid_t> *tids);
+  void refcount_manifest(ObjectContextRef obc, hobject_t src_soid, object_locator_t oloc,
+			 hobject_t tgt_soid, SnapContext snapc, refcount_t type, RefCountCallback* cb);
+  void dec_all_refcount_head_manifest(object_info_t& oi, OpContext* ctx);
+  void dec_refcount_non_intersection(ObjectContextRef obc, const object_info_t& oi, 
+				     set<uint64_t> intersection_set);
 
   friend struct C_ProxyChunkRead;
   friend class PromoteManifestCallback;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5827,6 +5827,13 @@ bool chunk_info_t::operator==(const chunk_info_t& cit) const
   return false;
 }
 
+bool operator==(const std::pair<const long unsigned int, chunk_info_t> & l,
+		const std::pair<const long unsigned int, chunk_info_t> & r) 
+{
+  return l.first == r.first &&
+	 l.second == r.second;
+}
+
 ostream& operator<<(ostream& out, const chunk_info_t& ci)
 {
   return out << "(len: " << ci.length << " oid: " << ci.oid
@@ -5836,19 +5843,24 @@ ostream& operator<<(ostream& out, const chunk_info_t& ci)
 
 // -- object_manifest_t --
 
-void object_manifest_t::build_intersection_set(std::map<uint64_t, chunk_info_t>& map, 
-	      set<uint64_t>& intersection, interval_set<uint64_t>* check_intersection)
-{
-  for (auto p : chunk_map) {
-    if (check_intersection) {
-      if (check_intersection->intersects(p.first, p.second.length)) {
-	intersection.insert(p.first);	
-	continue;
-      }
-    }
+/**
+ * build_intersection_set
+ *
+ * Returns the set offsets to references common (offset, length, and target match) to
+ * both map and this->chunk_map.
+ *
+ * @param map [in] map of object against which to compare
+ * @param map [in,out] set of target ids common to both maps
+ * @return void
+ */
 
-    for (auto c : map) {
-      if (p.second == c.second) {
+void object_manifest_t::build_intersection_set(const std::map<uint64_t, chunk_info_t>& map,
+					       std::set<uint64_t>& intersection)
+{
+  for (const auto &p : chunk_map) {
+    auto c = map.find(p.first);
+    if (c != map.cend()) {
+      if (p == *c) {
 	intersection.insert(p.first);
       }
     }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5883,15 +5883,20 @@ void object_manifest_t::calc_refs_to_drop_on_removal(
       std::numeric_limits<uint64_t>::max() : i->first;
   };
 
-  // Translate current, iter, map to a chunk_info_t, nullopt_t if iter
-  // is ahead of current or is at end()
+  /* If current matches the offset at iter, returns the chunk at *iter
+   * and increments iter.  Otherwise, returns nullptr.
+   *
+   * current will always be derived from the min of *giter, *iter, and
+   * *liter on each cycle, so the result will be that each loop iteration
+   * will pick up all chunks at the offest being considered, each offset
+   * will be considered once, and all offsets will be considered.
+   */
   auto get_chunk = [](
     uint64_t current, decltype(iter) &i, const object_manifest_t &manifest)
     -> const chunk_info_t * {
     if (i == manifest.chunk_map.end() || current != i->first) {
       return nullptr;
     } else {
-      // We advance the iterator iff we consider the chunk_map on this iteration
       return &(i++)->second;
     }
   };

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5530,8 +5530,8 @@ struct object_manifest_t {
     redirect_target = hobject_t();
     chunk_map.clear();
   }
-  void build_intersection_set(std::map<uint64_t, chunk_info_t>& map, 
-		set<uint64_t>& intersection, interval_set<uint64_t>* check_intersection);
+  void build_intersection_set(const std::map<uint64_t, chunk_info_t>& map,
+                              std::set<uint64_t>& intersection);
   static void generate_test_instances(std::list<object_manifest_t*>& o);
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5460,6 +5460,9 @@ public:
   bool operator!=(const object_ref_delta_t &rhs) const {
     return !(*this == rhs);
   }
+  bool is_empty() {
+    return ref_delta.empty();
+  }
   friend std::ostream& operator<<(std::ostream& out, const object_ref_delta_t & ci);
 };
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5485,6 +5485,7 @@ struct chunk_info_t {
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
   friend std::ostream& operator<<(std::ostream& out, const chunk_info_t& ci);
+  bool operator==(const chunk_info_t& cit) const;
 };
 WRITE_CLASS_ENCODER(chunk_info_t)
 std::ostream& operator<<(std::ostream& out, const chunk_info_t& ci);
@@ -5529,6 +5530,8 @@ struct object_manifest_t {
     redirect_target = hobject_t();
     chunk_map.clear();
   }
+  void build_intersection_set(std::map<uint64_t, chunk_info_t>& map, 
+		set<uint64_t>& intersection, interval_set<uint64_t>* check_intersection);
   static void generate_test_instances(std::list<object_manifest_t*>& o);
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);

--- a/src/test/cls_cas/test_cls_cas.cc
+++ b/src/test/cls_cas/test_cls_cas.cc
@@ -310,8 +310,7 @@ TEST(chunk_refs_t, size)
   for (size_t i = 1; i <= max; ++i) {
     hobject_t h(sobject_t(object_t("foo"s + stringify(i)), i));
     h.pool = i > pool_cutoff ? i : (i & pool_mask);
-    bool ret = r.get(h);
-    ASSERT_TRUE(ret);
+    r.get(h);
     if (count_bits(i) <= 2) {
       bufferlist bl;
       r.dynamic_encode(bl, 512);

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -3576,10 +3576,12 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushRead) {
   }
   // flush
   {
-    ObjectWriteOperation op;
+    ObjectReadOperation op;
     op.tier_flush();
     librados::AioCompletion *completion = cluster.aio_create_completion();
-    ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo-chunk", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
     completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
@@ -3598,6 +3600,432 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushRead) {
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
+}
+
+TEST_F(LibRadosTwoPoolsPP, ManifestSnapRefcount) {
+  // skip test if not yet octopus
+  if (_get_required_osd_release(cluster) < "octopus") {
+    cout << "cluster is not yet octopus, skipping test" << std::endl;
+    return;
+  }
+
+  bufferlist inbl;
+  ASSERT_EQ(0, cluster.mon_command(
+	set_pool_str(pool_name, "fingerprint_algorithm", "sha1"),
+	inbl, NULL, NULL));
+  cluster.wait_for_latest_osdmap();
+
+  // create object
+  {
+    bufferlist bl;
+    bl.append("there hi");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, ioctx.operate("foo", &op));
+  }
+  {
+    bufferlist bl;
+    bl.append("there hi");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, cache_ioctx.operate("bar", &op));
+  }
+
+  // wait for maps to settle
+  cluster.wait_for_latest_osdmap();
+
+  // set-chunk (dedup)
+  {
+    ObjectWriteOperation op;
+    op.set_chunk(2, 2, cache_ioctx, "bar", 0,
+	CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+  // set-chunk (dedup)
+  {
+    ObjectWriteOperation op;
+    op.set_chunk(6, 2, cache_ioctx, "bar", 0,
+	CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+
+
+  // make all chunks dirty --> flush
+  // foo: [er] [hi]
+
+  // make a dirty chunks
+  {
+    bufferlist bl;
+    bl.append("There hi");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, ioctx.operate("foo", &op));
+  }
+  // flush
+  {
+    ObjectReadOperation op;
+    op.tier_flush();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+
+  // create a snapshot, clone
+  vector<uint64_t> my_snaps(1);
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps[0]));
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_set_write_ctx(my_snaps[0],
+	my_snaps));
+
+  // foo: [bb] [hi]
+  // make a dirty chunks
+  {
+    bufferlist bl;
+    bl.append("Thbbe");
+    ASSERT_EQ(0, ioctx.write("foo", bl, bl.length(), 0));
+  }
+  // flush
+  {
+    ObjectReadOperation op;
+    op.tier_flush();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+
+  // and another
+  my_snaps.resize(2);
+  my_snaps[1] = my_snaps[0];
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps[0]));
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_set_write_ctx(my_snaps[0],
+	my_snaps));
+
+  // foo: [cc] [hi]
+  // make a dirty chunks
+  {
+    bufferlist bl;
+    bl.append("Thcce");
+    ASSERT_EQ(0, ioctx.write("foo", bl, bl.length(), 0));
+  }
+  // flush
+  {
+    ObjectReadOperation op;
+    op.tier_flush();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+
+  // check chunk's refcount
+  {
+    bufferlist in, out;
+    SHA1 sha1_gen;
+    int size = strlen("hi");
+    unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
+    char p_str[CEPH_CRYPTO_SHA1_DIGESTSIZE*2+1] = {0};
+    sha1_gen.Update((const unsigned char *)"hi", size);
+    sha1_gen.Final(fingerprint);
+    buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
+    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
+    cls_chunk_refcount_read_ret read_ret;
+    try {
+      auto iter = out.cbegin();
+      decode(read_ret, iter);
+    } catch (buffer::error& err) {
+      ASSERT_TRUE(0);
+    }
+    ASSERT_EQ(1u, read_ret.refs.size());
+  }
+
+  // remove snap
+  ioctx.selfmanaged_snap_remove(my_snaps[1]);
+
+  sleep(10);
+
+  // check chunk's refcount
+  {
+    bufferlist in, out;
+    SHA1 sha1_gen;
+    int size = strlen("hi");
+    unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
+    char p_str[CEPH_CRYPTO_SHA1_DIGESTSIZE*2+1] = {0};
+    sha1_gen.Update((const unsigned char *)"hi", size);
+    sha1_gen.Final(fingerprint);
+    buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
+    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
+    cls_chunk_refcount_read_ret read_ret;
+    try {
+      auto iter = out.cbegin();
+      decode(read_ret, iter);
+    } catch (buffer::error& err) {
+      ASSERT_TRUE(0);
+    }
+    ASSERT_EQ(1u, read_ret.refs.size());
+  }
+}
+
+TEST_F(LibRadosTwoPoolsPP, ManifestFlushSnap) {
+  // skip test if not yet octopus
+  if (_get_required_osd_release(cluster) < "octopus") {
+    cout << "cluster is not yet octopus, skipping test" << std::endl;
+    return;
+  }
+
+  bufferlist inbl;
+  ASSERT_EQ(0, cluster.mon_command(
+	set_pool_str(pool_name, "fingerprint_algorithm", "sha1"),
+	inbl, NULL, NULL));
+  cluster.wait_for_latest_osdmap();
+
+  // create object
+  {
+    bufferlist bl;
+    bl.append("there hi");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, ioctx.operate("foo", &op));
+  }
+  {
+    bufferlist bl;
+    bl.append("there hi");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, cache_ioctx.operate("bar", &op));
+  }
+
+  // wait for maps to settle
+  cluster.wait_for_latest_osdmap();
+
+  // set-chunk (dedup)
+  {
+    ObjectWriteOperation op;
+    op.set_chunk(2, 2, cache_ioctx, "bar", 0,
+	CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+  // set-chunk (dedup)
+  {
+    ObjectWriteOperation op;
+    op.set_chunk(6, 2, cache_ioctx, "bar", 0,
+	CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+
+
+  // foo head: [er] [hi]
+  // make a dirty chunks
+  {
+    bufferlist bl;
+    bl.append("There");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, ioctx.operate("foo", &op));
+  }
+
+  // create a snapshot, clone
+  vector<uint64_t> my_snaps(1);
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps[0]));
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_set_write_ctx(my_snaps[0],
+	my_snaps));
+
+  // make a dirty chunks
+  // foo head: [bb] [hi]
+  {
+    bufferlist bl;
+    bl.append("Thbbe");
+    ASSERT_EQ(0, ioctx.write("foo", bl, bl.length(), 0));
+  }
+
+  // and another
+  my_snaps.resize(2);
+  my_snaps[1] = my_snaps[0];
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps[0]));
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_set_write_ctx(my_snaps[0],
+	my_snaps));
+
+  // make a dirty chunks
+  // foo head: [cc] [hi]
+  {
+    bufferlist bl;
+    bl.append("Thcce");
+    ASSERT_EQ(0, ioctx.write("foo", bl, bl.length(), 0));
+  }
+
+  // flush on head (should fail)
+  ioctx.snap_set_read(librados::SNAP_HEAD);
+  // flush
+  {
+    ObjectReadOperation op;
+    op.tier_flush();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    //ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(-EBUSY, completion->get_return_value());
+    completion->release();
+  }
+
+  // flush on recent snap (should fail)
+  ioctx.snap_set_read(my_snaps[0]);
+  {
+    ObjectReadOperation op;
+    op.tier_flush();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(-EBUSY, completion->get_return_value());
+    completion->release();
+  }
+
+  // flush on oldest snap
+  ioctx.snap_set_read(my_snaps[1]);
+  {
+    ObjectReadOperation op;
+    op.tier_flush();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+
+  // flush on oldest snap
+  ioctx.snap_set_read(my_snaps[0]);
+  {
+    ObjectReadOperation op;
+    op.tier_flush();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+
+  ioctx.snap_set_read(librados::SNAP_HEAD);
+  {
+    ObjectReadOperation op;
+    op.tier_flush();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate(
+      "foo", completion, &op,
+      librados::OPERATION_IGNORE_CACHE, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+
+
+  // check chunk's refcount
+  {
+    bufferlist in, out;
+    SHA1 sha1_gen;
+    int size = strlen("er");
+    unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
+    char p_str[CEPH_CRYPTO_SHA1_DIGESTSIZE*2+1] = {0};
+    sha1_gen.Update((const unsigned char *)"er", size);
+    sha1_gen.Final(fingerprint);
+    buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
+    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
+    cls_chunk_refcount_read_ret read_ret;
+    try {
+      auto iter = out.cbegin();
+      decode(read_ret, iter);
+    } catch (buffer::error& err) {
+      ASSERT_TRUE(0);
+    }
+    ASSERT_EQ(1u, read_ret.refs.size());
+  }
+
+  // check chunk's refcount
+  {
+    bufferlist in, out;
+    SHA1 sha1_gen;
+    int size = strlen("bb");
+    unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
+    char p_str[CEPH_CRYPTO_SHA1_DIGESTSIZE*2+1] = {0};
+    sha1_gen.Update((const unsigned char *)"bb", size);
+    sha1_gen.Final(fingerprint);
+    buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
+    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
+    cls_chunk_refcount_read_ret read_ret;
+    try {
+      auto iter = out.cbegin();
+      decode(read_ret, iter);
+    } catch (buffer::error& err) {
+      ASSERT_TRUE(0);
+    }
+    ASSERT_EQ(1u, read_ret.refs.size());
+  }
+
+  // check chunk's refcount
+  {
+    bufferlist in, out;
+    SHA1 sha1_gen;
+    int size = strlen("cc");
+    unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
+    char p_str[CEPH_CRYPTO_SHA1_DIGESTSIZE*2+1] = {0};
+    sha1_gen.Update((const unsigned char *)"cc", size);
+    sha1_gen.Final(fingerprint);
+    buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
+    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
+    cls_chunk_refcount_read_ret read_ret;
+    try {
+      auto iter = out.cbegin();
+      decode(read_ret, iter);
+    } catch (buffer::error& err) {
+      ASSERT_TRUE(0);
+    }
+    ASSERT_EQ(1u, read_ret.refs.size());
+  }
+
+  ioctx.snap_set_read(librados::SNAP_HEAD);
+  {
+    bufferlist bl;
+    ASSERT_EQ(4, ioctx.read("foo", bl, 4, 0));
+    ASSERT_EQ('c', bl[2]);
+  }
+
+  ioctx.snap_set_read(my_snaps[0]);
+  {
+    bufferlist bl;
+    ASSERT_EQ(4, ioctx.read("foo", bl, 4, 0));
+    ASSERT_EQ('b', bl[2]);
+  }
 }
 
 class LibRadosTwoPoolsECPP : public RadosTestECPP

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -3737,7 +3737,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapRefcount) {
 
   // check chunk's refcount
   {
-    bufferlist in, out;
+    bufferlist t;
     SHA1 sha1_gen;
     int size = strlen("hi");
     unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
@@ -3745,15 +3745,15 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapRefcount) {
     sha1_gen.Update((const unsigned char *)"hi", size);
     sha1_gen.Final(fingerprint);
     buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
-    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
-    cls_chunk_refcount_read_ret read_ret;
+    cache_ioctx.getxattr(p_str, CHUNK_REFCOUNT_ATTR, t);
+    chunk_refs_t refs;
     try {
-      auto iter = out.cbegin();
-      decode(read_ret, iter);
+      auto iter = t.cbegin();
+      decode(refs, iter);
     } catch (buffer::error& err) {
       ASSERT_TRUE(0);
     }
-    ASSERT_EQ(1u, read_ret.refs.size());
+    ASSERT_EQ(1u, refs.count());
   }
 
   // remove snap
@@ -3763,7 +3763,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapRefcount) {
 
   // check chunk's refcount
   {
-    bufferlist in, out;
+    bufferlist t;
     SHA1 sha1_gen;
     int size = strlen("hi");
     unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
@@ -3771,15 +3771,15 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapRefcount) {
     sha1_gen.Update((const unsigned char *)"hi", size);
     sha1_gen.Final(fingerprint);
     buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
-    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
-    cls_chunk_refcount_read_ret read_ret;
+    cache_ioctx.getxattr(p_str, CHUNK_REFCOUNT_ATTR, t);
+    chunk_refs_t refs;
     try {
-      auto iter = out.cbegin();
-      decode(read_ret, iter);
+      auto iter = t.cbegin();
+      decode(refs, iter);
     } catch (buffer::error& err) {
       ASSERT_TRUE(0);
     }
-    ASSERT_EQ(1u, read_ret.refs.size());
+    ASSERT_EQ(1u, refs.count());
   }
 }
 
@@ -3952,7 +3952,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushSnap) {
 
   // check chunk's refcount
   {
-    bufferlist in, out;
+    bufferlist t;
     SHA1 sha1_gen;
     int size = strlen("er");
     unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
@@ -3960,20 +3960,20 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushSnap) {
     sha1_gen.Update((const unsigned char *)"er", size);
     sha1_gen.Final(fingerprint);
     buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
-    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
-    cls_chunk_refcount_read_ret read_ret;
+    cache_ioctx.getxattr(p_str, CHUNK_REFCOUNT_ATTR, t);
+    chunk_refs_t refs;
     try {
-      auto iter = out.cbegin();
-      decode(read_ret, iter);
+      auto iter = t.cbegin();
+      decode(refs, iter);
     } catch (buffer::error& err) {
       ASSERT_TRUE(0);
     }
-    ASSERT_EQ(1u, read_ret.refs.size());
+    ASSERT_EQ(1u, refs.count());
   }
 
   // check chunk's refcount
   {
-    bufferlist in, out;
+    bufferlist t;
     SHA1 sha1_gen;
     int size = strlen("bb");
     unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
@@ -3981,20 +3981,20 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushSnap) {
     sha1_gen.Update((const unsigned char *)"bb", size);
     sha1_gen.Final(fingerprint);
     buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
-    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
-    cls_chunk_refcount_read_ret read_ret;
+    cache_ioctx.getxattr(p_str, CHUNK_REFCOUNT_ATTR, t);
+    chunk_refs_t refs;
     try {
-      auto iter = out.cbegin();
-      decode(read_ret, iter);
+      auto iter = t.cbegin();
+      decode(refs, iter);
     } catch (buffer::error& err) {
       ASSERT_TRUE(0);
     }
-    ASSERT_EQ(1u, read_ret.refs.size());
+    ASSERT_EQ(1u, refs.count());
   }
 
   // check chunk's refcount
   {
-    bufferlist in, out;
+    bufferlist t;
     SHA1 sha1_gen;
     int size = strlen("cc");
     unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];
@@ -4002,15 +4002,15 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushSnap) {
     sha1_gen.Update((const unsigned char *)"cc", size);
     sha1_gen.Final(fingerprint);
     buf_to_hex(fingerprint, CEPH_CRYPTO_SHA1_DIGESTSIZE, p_str);
-    cache_ioctx.exec(p_str, "cas", "chunk_read", in, out);
-    cls_chunk_refcount_read_ret read_ret;
+    cache_ioctx.getxattr(p_str, CHUNK_REFCOUNT_ATTR, t);
+    chunk_refs_t refs;
     try {
-      auto iter = out.cbegin();
-      decode(read_ret, iter);
+      auto iter = t.cbegin();
+      decode(refs, iter);
     } catch (buffer::error& err) {
       ASSERT_TRUE(0);
     }
-    ASSERT_EQ(1u, read_ret.refs.size());
+    ASSERT_EQ(1u, refs.count());
   }
 
   ioctx.snap_set_read(librados::SNAP_HEAD);

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2700,7 +2700,7 @@ public:
 class TierFlushOp : public TestOp {
 public:
   librados::AioCompletion *completion;
-  librados::ObjectWriteOperation op;
+  librados::ObjectReadOperation op;
   string oid;
   std::shared_ptr<int> in_use;
 
@@ -2728,8 +2728,9 @@ public:
     context->state_lock.unlock();
 
     op.tier_flush();
+    unsigned flags = librados::OPERATION_IGNORE_CACHE;
     int r = context->io_ctx.aio_operate(context->prefix+oid, completion,
-					&op);
+					&op, flags, NULL);
     ceph_assert(!r);
   }
 


### PR DESCRIPTION
https://lists.ceph.io/hyperkitty/list/dev@ceph.io/thread/7G222W5F7MD7X5MJS3BF6YDJ76RKJGN5/

To prevent removing a manifest object in use,
chunk maps in clone object are introduced.

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

