### PR TITLE
cmake: require CMake v3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,18 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10.2)
 # remove cmake/modules/FindPython* once 3.12 is required
 
-project(ceph CXX C ASM)
-set(VERSION 15.0.0)
+project(ceph
+  VERSION 15.0.0
+  LANGUAGES CXX C ASM)
 
 if(POLICY CMP0028)
   cmake_policy(SET CMP0028 NEW)
 endif()
 if(POLICY CMP0046)
   cmake_policy(SET CMP0046 NEW)
+endif()
+if(POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
 endif()
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)

--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -1,7 +1,7 @@
 # Contributor: John Coyle <dx9err@gmail.com>
 # Maintainer: John Coyle <dx9err@gmail.com>
 pkgname=ceph
-pkgver=@VERSION@
+pkgver=@PROJECT_VERSION@
 pkgrel=@RPM_RELEASE@
 pkgdesc="Ceph is a distributed object store and file system"
 pkgusers="ceph"

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -103,7 +103,7 @@
 # main package definition
 #################################################################################
 Name:		ceph
-Version:	@VERSION@
+Version:	@PROJECT_VERSION@
 Release:	@RPM_RELEASE@%{?dist}
 %if 0%{?fedora} || 0%{?rhel}
 Epoch:		2

--- a/cmake/modules/FindStdFilesystem.cmake
+++ b/cmake/modules/FindStdFilesystem.cmake
@@ -2,16 +2,8 @@ set(_std_filesystem_test_src
   ${CMAKE_CURRENT_LIST_DIR}/FindStdFilesystem_test.cc)
 
 macro(try_std_filesystem_library _library _result)
-  if(CMAKE_VERSION VERSION_LESS "3.8")
-    # abuse the definition flags, because they are quite
-    # the same as CMAKE_C_FLAGS: they are passed to the
-    # compiler.
-    set(_std_filesystem_try_compile_arg
-      COMPILE_DEFINITIONS "-std=c++17")
-  else()
-    set(_std_filesystem_try_compile_arg
-      CXX_STANDARD 17)
-  endif()
+  set(_std_filesystem_try_compile_arg
+    CXX_STANDARD 17)
   try_compile(_std_filesystem_compiles
     ${CMAKE_CURRENT_BINARY_DIR}
     SOURCES ${_std_filesystem_test_src}

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -124,6 +124,22 @@ ENDOFKEY
     $SUDO ln -nsf /usr/bin/g++ /usr/bin/$(uname -m)-linux-gnu-g++
 }
 
+function ensure_decent_cmake_on_ubuntu {
+    local new=$1
+    if command -v cmake > /dev/null; then
+        local old=$(cmake --version | grep -Po 'version \K[0-9].*')
+        if dpkg --compare-versions $old ge $new; then
+          return
+        fi
+    fi
+    $SUDO curl --silent https://apt.kitware.com/keys/kitware-archive-latest.asc | $SUDO apt-key add -
+    $SUDO tee /etc/apt/sources.list.d/kitware.list <<EOF
+deb https://apt.kitware.com/ubuntu/ xenial main
+EOF
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get update -y || true
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y cmake
+}
+
 function install_pkg_on_ubuntu {
     local project=$1
     shift
@@ -284,6 +300,7 @@ else
                 ensure_decent_gcc_on_ubuntu 8 trusty
                 ;;
             *Xenial*)
+                ensure_decent_cmake_on_ubuntu 3.10.1
                 ensure_decent_gcc_on_ubuntu 8 xenial
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu xenial
                 ;;

--- a/make-dist
+++ b/make-dist
@@ -116,7 +116,7 @@ echo "including src/.git_version, ceph.spec"
 
 for spec in ceph.spec.in alpine/APKBUILD.in; do
     cat $spec |
-        sed "s/@VERSION@/$rpm_version/g" |
+        sed "s/@PROJECT_VERSION@/$rpm_version/g" |
         sed "s/@RPM_RELEASE@/$rpm_release/g" |
         sed "s/@TARBALL_BASENAME@/ceph-$version/g" > `echo $spec | sed 's/.in$//'`
 done

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,37 +114,13 @@ endif()
 
 
 # require c++17
-if(CMAKE_VERSION VERSION_LESS "3.8")
-  CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
-  if(NOT COMPILER_SUPPORTS_CXX17)
-    message(FATAL_ERROR
-      "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support.")
-  endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-
-  # for compiletest_cxx11_client
-  CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-  if(NOT COMPILER_SUPPORTS_CXX11)
-    message(FATAL_ERROR
-      "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
-  endif()
-
-  include(CheckCCompilerFlag)
-  CHECK_C_COMPILER_FLAG("-std=gnu99" COMPILER_SUPPORTS_GNU99)
-  if(NOT COMPILER_SUPPORTS_GNU99)
-    message(FATAL_ERROR
-      "The compiler ${CMAKE_C_COMPILER} has no GNU C99 support.")
-  endif()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
-else()
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_C_STANDARD 99)
-  # we use `asm()` to inline assembly, so enable the GNU extension
-  set(CMAKE_C_EXTENSIONS ON)
-  set(C_STANDARD_REQUIRED ON)
-endif()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 99)
+# we use `asm()` to inline assembly, so enable the GNU extension
+set(CMAKE_C_EXTENSIONS ON)
+set(C_STANDARD_REQUIRED ON)
 
 include(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -290,7 +290,7 @@
 #cmakedefine HAVE_STATIC_CAST
 
 /* Version number of package */
-#cmakedefine VERSION "@VERSION@"
+#cmakedefine PROJECT_VERSION "@PROJECT_VERSION@"
 
 /* Defined if pthread_setname_np() is available */
 #cmakedefine HAVE_PTHREAD_SETNAME_NP 1

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -362,7 +362,7 @@ extern "C" const char *ceph_version(int *pmajor, int *pminor, int *ppatch)
     *pminor = (n >= 2) ? minor : 0;
   if (ppatch)
     *ppatch = (n >= 3) ? patch : 0;
-  return VERSION;
+  return PROJECT_VERSION;
 }
 
 extern "C" int ceph_create_with_context(struct ceph_mount_info **cmount, CephContext *cct)


### PR DESCRIPTION
since we dropped the support of xenial, we now have the luxury of using
newer CMake!

- for bionic: https://packages.ubuntu.com/bionic/cmake : 3.10.2
- for CentOS7:
https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ : 3.13.5

so in this change,

* bump up the required version to v3.10.2
* cleanups

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

