### PR TITLE
mgr/dashboard: Silences Page e2e Test

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/silences.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/silences.e2e-spec.ts
@@ -1,0 +1,38 @@
+import { SilencesPageHelper } from './silences.po';
+
+describe('Silences page', () => {
+  let silences: SilencesPageHelper;
+  const creator = 'silence-create-expire';
+
+  beforeAll(() => {
+    silences = new SilencesPageHelper();
+  });
+
+  afterEach(async () => {
+    await SilencesPageHelper.checkConsole();
+  });
+
+  describe('breadcrumb test', () => {
+    beforeAll(async () => {
+      await silences.navigateTo();
+    });
+
+    it('should open and show breadcrumb', async () => {
+      await silences.waitTextToBePresent(silences.getBreadcrumb(), 'Silences');
+    });
+  });
+
+  describe('create and expire silence test', () => {
+    beforeAll(async () => {
+      await silences.navigateTo();
+    });
+
+    it('should create silence', async () => {
+      await silences.create(creator, 'very interesting silence comment', 'alertname', 'load_0');
+    });
+
+    it('should expire silence', async () => {
+      await silences.expire(creator);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/silences.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/silences.po.ts
@@ -1,0 +1,107 @@
+import { $, by, element } from 'protractor';
+import { PageHelper } from '../page-helper.po';
+
+/** Class holding silences page functions **/
+export class SilencesPageHelper extends PageHelper {
+  pages = {
+    index: '/#/silence',
+    create: '/#/silence/create'
+  };
+
+  /**
+   * Create a silence with given creator, comment, matcher name and matcher value
+   */
+  async create(creator, comment, matcher_name, matcher_value) {
+    await this.navigateTo('create');
+
+    await this.waitTextToBePresent(this.getBreadcrumb(), 'Create');
+
+    // enter silence creator
+    await element(by.id('created-by')).clear();
+    await element(by.id('created-by')).sendKeys(creator);
+
+    // enter silence comment
+    await element(by.id('comment')).clear();
+    await element(by.id('comment')).sendKeys(comment);
+
+    const addMatcherButton = element(by.cssContainingText('button', 'Add matcher'));
+    await addMatcherButton.click();
+    // select matcher name
+    const nameField = element(by.id('name'));
+    await nameField.click();
+    await expect(nameField.all(by.css('option')).getText()).toMatch(
+      matcher_name,
+      'Invalid matcher name'
+    );
+    await nameField.element(by.cssContainingText('option', matcher_name)).click();
+
+    // enter matcher value
+    const valueField = element(by.id('value'));
+    await valueField.click();
+    await valueField.sendKeys(matcher_value);
+
+    const addButton = element.all(by.cssContainingText('button', 'Add')).last();
+    await addButton.click();
+    const createButton = element(by.cssContainingText('button', 'Create Silence'));
+    // wait for modal container where you select Matcher to dissapear
+    await this.waitStaleness(element(by.cssContainingText('.modal-dialog', 'Matcher')));
+    await createButton.click();
+    // wait for browser to return to silences page and table to be visible
+    await this.waitPresence(this.getDataTables().first(), 'Timed out waiting for silence creation');
+    // Order silences so most recently updated one is on top. Requires clicking 'Updated' twice
+    await element(
+      by.cssContainingText('.datatable-header-cell-label.draggable', 'Updated')
+    ).click();
+    await element(
+      by.cssContainingText('.datatable-header-cell-label.draggable', 'Updated')
+    ).click();
+    // Opens new silence's details table by clicking on silence then check "comment"
+    // row of details table for silence for the correct comment to verify its existence
+    await this.getFirstTableCellWithText(creator).click();
+    await expect(element(by.cssContainingText('.datatable-body-row', 'comment')).getText()).toMatch(
+      comment
+    );
+  }
+
+  /**
+   * Function to expire a silence.
+   * Expire is currently limited to expiring the most recently updated silence with the given creator name
+   */
+  async expire(creator) {
+    await this.navigateTo();
+
+    // filter silence table so only silences with given creator are present
+    const filterTableField = $('input.form-control.ng-valid');
+    await filterTableField.clear();
+    await filterTableField.sendKeys(creator);
+
+    // Order silences so most recently updated one is on top, requires clicking "Updated" twice
+    await element(
+      by.cssContainingText('.datatable-header-cell-label.draggable', 'Updated')
+    ).click();
+    await element(
+      by.cssContainingText('.datatable-header-cell-label.draggable', 'Updated')
+    ).click();
+
+    // Opens new silence's details table by clicking on silence then check "comment"
+    // row of details table for silence for the correct comment to verify its existence
+    await this.getFirstTableCellWithText(creator).click();
+
+    await expect(element(by.cssContainingText('.datatable-body-row', 'state')).getText()).toMatch(
+      'active',
+      'Error: Silence was already expired'
+    );
+
+    await $('.table-actions button.dropdown-toggle').click(); // click toggle menu
+    await $('li.expire a').click(); // click expire
+    await this.waitVisibility($('.custom-control-label'));
+    await $('.custom-control-label').click();
+    await element(by.cssContainingText('button', 'Expire Silence')).click();
+    await this.waitStaleness(element(by.cssContainingText('.modal-dialog', 'Expire Silence')));
+    await this.getFirstTableCellWithText(creator).click();
+    await expect(element(by.cssContainingText('.datatable-body-row', 'state')).getText()).toMatch(
+      'expired',
+      'Error: Silence not expired'
+    );
+  }
+}

--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -45,7 +45,7 @@ cd ../../../../${BUILD_DIR}
 FULL_PATH_BUILD_DIR=`pwd`
 
 if [ "$BASE_URL" == "" ]; then
-    MGR=2 RGW=1 ../src/vstart.sh -n -d
+    MGR=1 RGW=1 ../src/vstart.sh -n -d
     sleep 10
 
     # Create an Object Gateway User
@@ -57,6 +57,13 @@ if [ "$BASE_URL" == "" ]; then
     ./bin/ceph dashboard set-rgw-api-secret-key $(./bin/radosgw-admin user info --uid=dev | jq -r .keys[0].secret_key)
     # Set SSL verify to False
     ./bin/ceph dashboard set-rgw-api-ssl-verify False
+    # Enable Prometheus module
+    ./bin/ceph mgr module enable prometheus
+    sleep 10
+    # Set Alertmanager API Host
+    ./bin/ceph dashboard set-alertmanager-api-host 'http://localhost:9093'
+    # Set Prometheus server
+    ./bin/ceph dashboard set-prometheus-api-host 'http://localhost:9090'
 
     # Disable PG autoscaling for new pools. This is a temporary workaround.
     # e2e tests for pools should be adapted to remove this workaround after


### PR DESCRIPTION
Tests for correct breadcrumb on Silences pages
Tests the ability to create and expire a silence

Fixes: https://tracker.ceph.com/issues/40788
Fixes: https://tracker.ceph.com/issues/40930

Signed-off-by: Adam King <adking@redhat.com>
Signed-off-by: Rafael Quintero <rquinter@redhat.com>