### PR TITLE
mds: fix non empty error when delete a director

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2133,9 +2133,13 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
 	if (in->is_dir()) {
 	  pf->fragstat.nsubdirs += linkunlink;
 	  //pf->rstat.rsubdirs += linkunlink;
+	  if (pf->fragstat.nsubdirs < 0)
+	    pf->fragstat.nsubdirs = 0;
 	} else {
  	  pf->fragstat.nfiles += linkunlink;
  	  //pf->rstat.rfiles += linkunlink;
+	  if (pf->fragstat.nfiles < 0)
+	    pf->fragstat.nfiles = 0;
 	}
       }
     }


### PR DESCRIPTION
Sometimes for unknown reasons, a directory's nsubdirs & nfiles is incorrect, when delete the directory mds return "non empty" error, so we limit the two numbers can't be negative, make sure delete the directory successfully.

Fixes: https://tracker.ceph.com/issues/40932
Signed-off-by: XiaoGuoDong2019 <xiaogd@inspur.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

