### PR TITLE
cephfs: Resolve a memory leak in cephfs/Resetter.cc

### DIFF
--- a/src/tools/cephfs/Resetter.cc
+++ b/src/tools/cephfs/Resetter.cc
@@ -11,7 +11,7 @@
  * Foundation.  See file COPYING.
  * 
  */
-
+#include <memory>
 #include "common/errno.h"
 #include "osdc/Journaler.h"
 #include "mds/JournalPointer.h"
@@ -196,7 +196,7 @@ int Resetter::_write_reset_event(Journaler *journaler)
 {
   ceph_assert(journaler != NULL);
 
-  LogEvent *le = new EResetJournal;
+  auto le = std::make_unique<EResetJournal>();
 
   bufferlist bl;
   le->encode_with_header(bl, CEPH_FEATURES_SUPPORTED_DEFAULT);


### PR DESCRIPTION
use a smart pointer instead of using 'new' to resolve a memory leak .

Fixes: https://tracker.ceph.com/issues/40936
Signed-off-by: XiaoGuoDong2019 <xiaogd@inspur.com>