### PR TITLE
cephfs: avoid map client_caps  been inserted by mistake

### DIFF
--- a/src/mds/SnapRealm.h
+++ b/src/mds/SnapRealm.h
@@ -147,9 +147,10 @@ public:
   }
   void remove_cap(client_t client, Capability *cap) {
     cap->item_snaprealm_caps.remove_myself();
-    if (client_caps[client]->empty()) {
-      delete client_caps[client];
-      client_caps.erase(client);
+    auto found = client_caps.find(client);
+    if (found != client_caps.end() && found->second->empty()) {
+      delete found->second;
+      client_caps.erase(found);
     }
   }
 };


### PR DESCRIPTION
if map client_caps has not key client, client_caps[client] will insert key client with null value into the map.

Fixes: https://tracker.ceph.com/issues/40939
Signed-off-by: XiaoGuoDong2019 <xiaogd@inspur.com>


- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

