### PR TITLE
mgr: Reduce logging noise when handling commands

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -711,7 +711,7 @@ public:
     }
 
     if (r == 0) {
-      dout(4) << __func__ << " success" << dendl;
+      dout(20) << "success" << dendl;
     } else {
       derr << __func__ << " " << cpp_strerror(r) << " " << rs << dendl;
     }
@@ -787,8 +787,7 @@ bool DaemonServer::_handle_command(
   string prefix;
   cmd_getval(cct, cmdctx->cmdmap, "prefix", prefix);
 
-  dout(4) << "decoded " << cmdctx->cmdmap.size() << dendl;
-  dout(4) << "prefix=" << prefix << dendl;
+  dout(10) << "decoded-size=" << cmdctx->cmdmap.size() << " prefix=" << prefix  << dendl;
 
   if (prefix == "get_command_descriptions") {
     dout(10) << "reading commands from python modules" << dendl;
@@ -2180,7 +2179,7 @@ bool DaemonServer::_handle_command(
     return true;
   }
 
-  dout(4) << "passing through " << cmdctx->cmdmap.size() << dendl;
+  dout(10) << "passing through " << cmdctx->cmdmap.size() << dendl;
   finisher.queue(new FunctionContext([this, cmdctx, handler_name, prefix](int r_) {
     std::stringstream ss;
 


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Before:

```
2019-07-25T11:12:18.389+0200 7f43f8536700  4 mgr.server _handle_command decoded 2
2019-07-25T11:12:18.389+0200 7f43f8536700  4 mgr.server _handle_command prefix=orchestrator service ls
2019-07-25T11:12:18.389+0200 7f43f8536700  0 log_channel(audit) log [DBG] : from='client.114324 -' entity='client.admin' cmd=[{"prefix": "orchestrator service ls", "target": ["mgr", ""]}]: dispatch
2019-07-25T11:12:18.389+0200 7f43f8536700  4 mgr.server _handle_command passing through 2
2019-07-25T11:12:18.393+0200 7f43f8d37700  4 mgr[rook] wait: completions=[<rook.module.RookReadCompletion object at 0x7f43e5f9df98>]
2019-07-25T11:12:18.429+0200 7f43f8d37700  0 mgr[rook] Full fetch of <bound method CoreV1Api.list_namespaced_pod of <kubernetes.client.apis.core_v1_api.CoreV1Api object at 0x7f43f8d4de80>>. result: 3
2019-07-25T11:12:18.433+0200 7f43f8d37700  4 mgr.server reply reply success
```

After:
```
2019-07-25T11:12:18.389+0200 7f43f8536700  0 log_channel(audit) log [DBG] : from='client.114324 -' entity='client.admin' cmd=[{"prefix": "orchestrator service ls", "target": ["mgr", ""]}]: dispatch
2019-07-25T11:12:18.393+0200 7f43f8d37700  4 mgr[rook] wait: completions=[<rook.module.RookReadCompletion object at 0x7f43e5f9df98>]
2019-07-25T11:12:18.429+0200 7f43f8d37700  0 mgr[rook] Full fetch of <bound method CoreV1Api.list_namespaced_pod of <kubernetes.client.apis.core_v1_api.CoreV1Api object at 0x7f43f8d4de80>>. result: 3
```


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

