### PR TITLE
mgr/dashboard: Support minimum password complexity rules

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -34,7 +34,10 @@
         <div class="form-group row">
           <label i18n
                  class="col-form-label col-sm-3"
-                 for="password">Password</label>
+                 for="password">Password
+            <i class="fa fa-fw fa-question-circle-o" i18n-title
+               title="{{ requiredPasswordRulesMessage }}"></i>
+          </label>
           <div class="col-sm-9">
             <div class="input-group">
               <input class="form-control"
@@ -43,7 +46,8 @@
                      id="password"
                      name="password"
                      autocomplete="new-password"
-                     formControlName="password">
+                     formControlName="password"
+                     (keyup)=checkPassword()>
               <span class="input-group-append">
                 <button type="button"
                         class="btn btn-light"
@@ -51,6 +55,8 @@
                 </button>
               </span>
             </div>
+            <div id="passwordStrengthLevel" class="{{ passwordStrengthLevel }}"></div>
+            {{ passwordStrengthDescription }}
             <span class="invalid-feedback"
                   *ngIf="userForm.showError('password', formDir, 'required')"
                   i18n>This field is required.</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.scss
@@ -1,0 +1,24 @@
+#passwordStrengthLevel {
+  height: 13px;
+  display: block;
+}
+.passwordStrengthLevel0 {
+  width: 250px;
+  background: #ffffff;
+}
+.passwordStrengthLevel1 {
+  width: 40px;
+  background: #b80a0a;
+}
+.passwordStrengthLevel2 {
+  width: 75px;
+  background: #e6cc08;
+}
+.passwordStrengthLevel3 {
+  width: 150px;
+  background: #46a30d;
+}
+.passwordStrengthLevel4 {
+  width: 250px;
+  background: #245e03;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -17,6 +17,7 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
+import { UserChangePasswordService } from '../../../shared/services/user-change-password.service';
 import { UserFormMode } from './user-form-mode.enum';
 import { UserFormRoleModel } from './user-form-role.model';
 import { UserFormModel } from './user-form.model';
@@ -41,6 +42,9 @@ export class UserFormComponent implements OnInit {
   messages = new SelectMessages({ empty: 'There are no roles.' }, this.i18n);
   action: string;
   resource: string;
+  requiredPasswordRulesMessage: string;
+  passwordStrengthLevel: string;
+  passwordStrengthDescription: string;
 
   constructor(
     private authService: AuthService,
@@ -52,7 +56,8 @@ export class UserFormComponent implements OnInit {
     private userService: UserService,
     private notificationService: NotificationService,
     private i18n: I18n,
-    public actionLabels: ActionLabelsI18n
+    public actionLabels: ActionLabelsI18n,
+    private userChangePasswordService: UserChangePasswordService
   ) {
     this.resource = this.i18n('user');
     this.createForm();
@@ -60,6 +65,7 @@ export class UserFormComponent implements OnInit {
   }
 
   createForm() {
+    this.requiredPasswordRulesMessage = this.userChangePasswordService.getPasswordRulesMessage();
     this.userForm = new CdFormGroup(
       {
         username: new FormControl('', {
@@ -169,7 +175,14 @@ export class UserFormComponent implements OnInit {
     }
   }
 
-  private isCurrentUser(): boolean {
+  checkPassword() {
+    const password = this.userForm.get('password').value;
+    const passwordStrength = this.userChangePasswordService.checkPasswordComplexity(password);
+    this.passwordStrengthLevel = passwordStrength[0];
+    this.passwordStrengthDescription = passwordStrength[1];
+  }
+
+  public isCurrentUser(): boolean {
     return this.authStorageService.getUsername() === this.userForm.getValue('username');
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.html
@@ -40,6 +40,10 @@
           <label class="col-form-label col-sm-3"
                  for="newpassword">
             <ng-container i18n>New password</ng-container>
+            <span>
+              <i class="fa fa-fw fa-question-circle-o" i18n-title
+                 title="{{ requiredPasswordRulesMessage }}"></i>
+            </span>
             <span class="required"></span>
           </label>
           <div class="col-sm-9">
@@ -49,13 +53,16 @@
                      placeholder="Password..."
                      id="newpassword"
                      autocomplete="new-password"
-                     formControlName="newpassword">
+                     formControlName="newpassword"
+                     (keyup)="checkPassword()">       
               <span class="input-group-append">
                 <button class="btn btn-light"
                         cdPasswordButton="newpassword">
                 </button>
               </span>
             </div>
+            <div id="passwordStrengthLevel" class="{{ passwordStrengthLevel }}"></div>
+            {{ passwordStrengthDescription }}
             <span class="invalid-feedback"
                   *ngIf="userForm.showError('newpassword', frm, 'required')"
                   i18n>This field is required.</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.scss
@@ -1,0 +1,24 @@
+#passwordStrengthLevel {
+  height: 13px;
+  display: block;
+}
+.passwordStrengthLevel0 {
+  width: 250px;
+  background: #ffffff;
+}
+.passwordStrengthLevel1 {
+  width: 40px;
+  background: #b80a0a;
+}
+.passwordStrengthLevel2 {
+  width: 75px;
+  background: #e6cc08;
+}
+.passwordStrengthLevel3 {
+  width: 150px;
+  background: #46a30d;
+}
+.passwordStrengthLevel4 {
+  width: 250px;
+  background: #245e03;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.ts
@@ -12,6 +12,7 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
+import { UserChangePasswordService } from '../../../shared/services/user-change-password.service';
 
 @Component({
   selector: 'cd-user-password-form',
@@ -22,6 +23,9 @@ export class UserPasswordFormComponent {
   userForm: CdFormGroup;
   action: string;
   resource: string;
+  requiredPasswordRulesMessage: string;
+  passwordStrengthLevel: string;
+  passwordStrengthDescription: string;
 
   constructor(
     private i18n: I18n,
@@ -30,7 +34,8 @@ export class UserPasswordFormComponent {
     private userService: UserService,
     private authStorageService: AuthStorageService,
     private formBuilder: CdFormBuilder,
-    private router: Router
+    private router: Router,
+    private userChangePasswordService: UserChangePasswordService
   ) {
     this.action = this.actionLabels.CHANGE;
     this.resource = this.i18n('password');
@@ -38,6 +43,7 @@ export class UserPasswordFormComponent {
   }
 
   createForm() {
+    this.requiredPasswordRulesMessage = this.userChangePasswordService.getPasswordRulesMessage();
     this.userForm = this.formBuilder.group(
       {
         oldpassword: [null, [Validators.required]],
@@ -59,6 +65,13 @@ export class UserPasswordFormComponent {
         validators: [CdValidators.match('newpassword', 'confirmnewpassword')]
       }
     );
+  }
+
+  checkPassword() {
+    const password = this.userForm.get('newpassword').value;
+    const passwordStrength = this.userChangePasswordService.checkPasswordComplexity(password);
+    this.passwordStrengthLevel = passwordStrength[0];
+    this.passwordStrengthDescription = passwordStrength[1];
   }
 
   onSubmit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/user-change-password.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/user-change-password.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserChangePasswordService {
+  requiredPasswordRulesMessage: string;
+  passwordStrengthLevel: string;
+  passwordStrengthDescription: string;
+
+  constructor() {}
+  getPasswordRulesMessage() {
+    return `Required  rules for password complexity:
+        - cannot contain username
+        - cannot contain any keyword used in Ceph
+        - must  consist of characters from the following groups:
+            * alphabetic a-z, A-Z
+            * numbers 0-9
+            * special chars: "!"#$%&\'()*+,-./:;<=>?@[\\]^_\`{|}~"
+            * any other characters (signs)`;
+  }
+
+  checkPasswordComplexity(password) {
+    this.passwordStrengthLevel = 'passwordStrengthLevel0';
+    this.passwordStrengthDescription = '';
+    const credits = this.checkPasswordComplexityLetters(password);
+    if (credits) {
+      if (credits < 10) {
+        this.passwordStrengthLevel = 'passwordStrengthLevel0';
+        this.passwordStrengthDescription = 'Too weak';
+      } else {
+        if (credits < 15) {
+          this.passwordStrengthLevel = 'passwordStrengthLevel1';
+          this.passwordStrengthDescription = 'Weak';
+        } else {
+          if (credits < 20) {
+            this.passwordStrengthLevel = 'passwordStrengthLevel2';
+            this.passwordStrengthDescription = 'OK';
+          } else {
+            if (credits < 25) {
+              this.passwordStrengthLevel = 'passwordStrengthLevel3';
+              this.passwordStrengthDescription = 'Strong';
+            } else {
+              this.passwordStrengthLevel = 'passwordStrengthLevel4';
+              this.passwordStrengthDescription = 'Very strong';
+            }
+          }
+        }
+      }
+    }
+    return [this.passwordStrengthLevel, this.passwordStrengthDescription];
+  }
+
+  private checkPasswordComplexityLetters(password): number {
+    const digitsNumber = password.replace(/[^0-9]/g, '').length;
+    const smallLettersNumber = password.replace(/[^a-z]/g, '').length;
+    const bigLettersNumber = password.replace(/[^A-Z]/g, '').length;
+    const punctuationNumber = password.replace(/[^!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]/g, '').length;
+    const othersCharactersNumber =
+      password.length - (digitsNumber + smallLettersNumber + bigLettersNumber + punctuationNumber);
+    return (
+      digitsNumber +
+      smallLettersNumber +
+      bigLettersNumber * 2 +
+      punctuationNumber * 3 +
+      othersCharactersNumber * 5
+    );
+  }
+}


### PR DESCRIPTION
Support minimum password complexity rules:
checks if the password is different than user name.
Checks whether the password fulfill required basic rules.

Complexity is checked during creating user and editing user.

Fixes: https://tracker.ceph.com/issues/25232
Signed-off-by: Dziomdziora, Elżbieta elzbieta.dziomdziora@ts.fujitsu.coom
 
Update of PR28694 
