### PR TITLE
nautilus: rbd-nbd: sscanf return 0 mean not-match.

### DIFF
--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -89,7 +89,7 @@ static void usage()
             << "               unmap <device|image-or-snap-spec>   Unmap nbd device\n"
             << "               [options] list-mapped               List mapped nbd devices\n"
             << "Map options:\n"
-            << "  --device <device path>  Specify nbd device path\n"
+            << "  --device <device path>  Specify nbd device path (/dev/nbd{num})\n"
             << "  --read-only             Map read-only\n"
             << "  --nbds_max <limit>      Override for module param nbds_max\n"
             << "  --max_part <limit>      Override for module param max_part\n"
@@ -782,7 +782,10 @@ static int do_map(int argc, const char *argv[], Config *cfg)
     }
   } else {
     r = sscanf(cfg->devpath.c_str(), "/dev/nbd%d", &index);
-    if (r < 0) {
+    if (r <= 0) {
+      // mean an early matching failure. But some cases need a negative value.
+      if (r == 0)
+	r = -EINVAL;
       cerr << "rbd-nbd: invalid device path: " << cfg->devpath
            << " (expected /dev/nbd{num})" << std::endl;
       goto close_fd;


### PR DESCRIPTION
http://tracker.ceph.com/issues/40293