### PR TITLE
objclass, osd: clean up the cls-host interface. Turn ClassHandler into singleton

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -512,6 +512,9 @@ add_subdirectory(os)
 add_subdirectory(osd)
 
 set(ceph_osd_srcs
+  # Link the Object Class API implementation directly as intermediary
+  # static library (like libosd.a) nullifies the effect of `-rdynamic`.
+  objclass/class_api.cc
   ceph_osd.cc)
 add_executable(ceph-osd ${ceph_osd_srcs})
 add_dependencies(ceph-osd erasure_code_plugins)

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -22,11 +22,6 @@ void cls_initialize(ClassHandler *h)
   ch = h;
 }
 
-void cls_finalize()
-{
-  ch = NULL;
-}
-
 
 void *cls_alloc(size_t size)
 {

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -38,7 +38,6 @@ set(osd_srcs
   MissingLoc.cc
   osd_perf_counters.cc
   ${CMAKE_SOURCE_DIR}/src/common/TrackedOp.cc
-  ${CMAKE_SOURCE_DIR}/src/objclass/class_api.cc
   ${CMAKE_SOURCE_DIR}/src/mgr/OSDPerfMetricTypes.cc
   ${osd_cyg_functions_src}
   ${osdc_osd_srcs})

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -327,3 +327,8 @@ int ClassHandler::ClassMethod::exec(cls_method_context_t ctx, bufferlist& indata
   return ret;
 }
 
+ClassHandler& ClassHandler::get_instance()
+{
+  static ClassHandler single(g_ceph_context);
+  return single;
+}

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -127,6 +127,8 @@ public:
   void unregister_class(ClassData *cls);
 
   void shutdown();
+
+  static ClassHandler& get_instance();
 };
 
 

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -115,9 +115,9 @@ private:
   static bool in_class_list(const std::string& cname,
       const std::string& list);
 
-public:
   ceph::mutex mutex = ceph::make_mutex("ClassHandler");
 
+public:
   explicit ClassHandler(CephContext *cct_) : cct(cct_) {}
 
   int open_all_classes();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -121,7 +121,6 @@ public:
   PerfCounters *&logger;
   PerfCounters *&recoverystate_perf;
   MonClient   *&monc;
-  ClassHandler  *&class_handler;
 
   md_config_cacher_t<Option::size_t> osd_max_object_size;
   md_config_cacher_t<bool> osd_skip_data_digest;
@@ -1163,7 +1162,6 @@ protected:
 		    std::string_view format, std::ostream& ss);
 
 public:
-  ClassHandler  *class_handler = nullptr;
   int get_nodeid() { return whoami; }
   
   static ghobject_t get_osdmap_pobject_name(epoch_t epoch) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -887,7 +887,7 @@ int PrimaryLogPG::get_pgls_filter(bufferlist::const_iterator& iter, PGLSFilter *
     const std::string class_name = type.substr(0, dot);
     const std::string filter_name = type.substr(dot + 1);
     ClassHandler::ClassData *cls = NULL;
-    int r = osd->class_handler->open_class(class_name, &cls);
+    int r = ClassHandler::get_instance().open_class(class_name, &cls);
     if (r != 0) {
       derr << "Error opening class '" << class_name << "': "
            << cpp_strerror(r) << dendl;
@@ -5767,7 +5767,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	tracepoint(osd, do_osd_op_pre_call, soid.oid.name.c_str(), soid.snap.val, cname.c_str(), mname.c_str());
 
 	ClassHandler::ClassData *cls;
-	result = osd->class_handler->open_class(cname, &cls);
+	result = ClassHandler::get_instance().open_class(cname, &cls);
 	ceph_assert(result == 0);   // init_op_flags() already verified this works.
 
 	ClassHandler::ClassMethod *method = cls->get_method(mname.c_str());


### PR DESCRIPTION
This clean-up is the zeroth step to bring the support for Ceph Classes to crimson-osd. The path that will be followed has been roughly described in [the gist](https://gist.github.com/rzarzynski/0c66b60913c308cc262e556af8e18f7e#the-idea).