### PR TITLE
mgr/dashboard: Explicitly type page variables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/block/images.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/images.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Images page', () => {
-  let images;
+  let images: Helper['images'];
 
   beforeAll(() => {
     images = new Helper().images;

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/iscsi.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/iscsi.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Iscsi Page', () => {
-  let iscsi;
+  let iscsi: Helper['iscsi'];
 
   beforeAll(() => {
     iscsi = new Helper().iscsi;

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/mirroring.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Mirroring page', () => {
-  let mirroring;
+  let mirroring: Helper['mirroring'];
 
   beforeAll(() => {
     mirroring = new Helper().mirroring;

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/alerts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/alerts.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Alerts page', () => {
-  let alerts;
+  let alerts: Helper['alerts'];
 
   beforeAll(() => {
     alerts = new Helper().alerts;

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Configuration page', () => {
-  let configuration;
+  let configuration: Helper['configuration'];
 
   beforeAll(() => {
     configuration = new Helper().configuration;

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/crush-map.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/crush-map.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('CRUSH map page', () => {
-  let crushmap;
+  let crushmap: Helper['crushmap'];
 
   beforeAll(() => {
     crushmap = new Helper().crushmap;

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Hosts page', () => {
-  let hosts;
+  let hosts: Helper['hosts'];
 
   beforeAll(() => {
     hosts = new Helper().hosts;

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Logs page', () => {
-  let logs;
+  let logs: Helper['logs'];
 
   beforeAll(() => {
     logs = new Helper().logs;

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/mgr-modules.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/mgr-modules.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Manager modules page', () => {
-  let mgrmodules;
+  let mgrmodules: Helper['mgrmodules'];
 
   beforeAll(() => {
     mgrmodules = new Helper().mgrmodules;

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Monitors page', () => {
-  let monitors;
+  let monitors: Helper['monitors'];
 
   beforeAll(() => {
     monitors = new Helper().monitors;

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('OSDs page', () => {
-  let osds;
+  let osds: Helper['osds'];
 
   beforeAll(() => {
     osds = new Helper().osds;

--- a/src/pybind/mgr/dashboard/frontend/e2e/filesystems/filesystems.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/filesystems/filesystems.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Filesystems page', () => {
-  let filesystems;
+  let filesystems: Helper['filesystems'];
 
   beforeAll(() => {
     filesystems = new Helper().filesystems;

--- a/src/pybind/mgr/dashboard/frontend/e2e/nfs/nfs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/nfs/nfs.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Nfs page', () => {
-  let nfs;
+  let nfs: Helper['nfs'];
 
   beforeAll(() => {
     nfs = new Helper().nfs;

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('Pools page', () => {
-  let pools;
+  let pools: Helper['pools'];
   const poolName = 'pool_e2e_pool_test';
 
   beforeAll(() => {

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('RGW buckets page', () => {
-  let buckets;
+  let buckets: Helper['buckets'];
 
   beforeAll(() => {
     buckets = new Helper().buckets;

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('RGW daemons page', () => {
-  let daemons;
+  let daemons: Helper['daemons'];
 
   beforeAll(() => {
     daemons = new Helper().daemons;

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Helper } from '../helper.po';
 
 describe('RGW users page', () => {
-  let users;
+  let users: Helper['users'];
   const user_name = '000user_create_edit_delete';
 
   beforeAll(() => {


### PR DESCRIPTION
Explicitly gives a type to page variables.
Helps make better use of Typescript's static type checking.
Undoes mistake from #29070.

Fixes: https://tracker.ceph.com/issues/40961

Signed-off-by: Adam King <adking@redhat.com>
Signed-off-by: Rafael Quintero <rquinter@redhat.com>