### PR TITLE
mgr/dashboard: clean-up python unit-tests

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -411,7 +411,8 @@ function populate_wheelhouse() {
 
     # although pip comes with virtualenv, having a recent version
     # of pip matters when it comes to using wheel packages
-    pip --timeout 300 $install 'setuptools >= 0.8' 'pip >= 7.0' 'wheel >= 0.24' || return 1
+    pip --timeout 300 $install 'setuptools >= 0.8' 'pip >= 7.0' 'wheel >= 0.24' 'tox >= 2.9.1' \
+      || return 1
     if test $# != 0 ; then
         pip --timeout 300 $install $@ || return 1
     fi
@@ -457,10 +458,13 @@ wip_wheelhouse=wheelhouse-wip
 find . -name tox.ini | while read ini ; do
     (
         cd $(dirname $ini)
-        require=$(ls *requirements.txt 2>/dev/null | sed -e 's/^/-r /')
+        require_files=$(ls *requirements*.txt 2>/dev/null) || true
+        constraint_files=$(ls *constraints*.txt 2>/dev/null) || true
+        require=$(echo -n "$require_files" | sed -e 's/^/-r /')
+        constraint=$(echo -n "$constraint_files" | sed -e 's/^/-c /')
         md5=wheelhouse/md5
         if test "$require"; then
-            if ! test -f $md5 || ! md5sum -c $md5 ; then
+            if ! test -f $md5 || ! md5sum -c $md5 > /dev/null; then
                 rm -rf wheelhouse
             fi
         fi
@@ -468,10 +472,10 @@ find . -name tox.ini | while read ini ; do
             for interpreter in python2.7 python3 ; do
                 type $interpreter > /dev/null 2>&1 || continue
                 activate_virtualenv $top_srcdir $interpreter || exit 1
-                populate_wheelhouse "wheel -w $wip_wheelhouse" $require || exit 1
+                populate_wheelhouse "download -d $wip_wheelhouse" $require $constraint || exit 1
             done
             mv $wip_wheelhouse wheelhouse
-            md5sum *requirements.txt > $md5
+            md5sum $require_files $constraint_files > $md5
         fi
     )
 done

--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -393,7 +393,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=cherrypy,distutils
+ignored-modules=cherrypy,distutils,rados,rbd,cephfs
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.
@@ -432,7 +432,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4

--- a/src/pybind/mgr/dashboard/conftest.py
+++ b/src/pybind/mgr/dashboard/conftest.py
@@ -1,0 +1,21 @@
+import sys
+from mock import Mock
+
+
+class MockRadosError(Exception):
+    def __init__(self, message, errno=None):
+        super(MockRadosError, self).__init__(message)
+        self.errno = errno
+
+    def __str__(self):
+        msg = super(MockRadosError, self).__str__()
+        if self.errno is None:
+            return msg
+        return '[errno {0}] {1}'.format(self.errno, msg)
+
+
+sys.modules.update({
+    'rados': Mock(Error=MockRadosError, OSError=MockRadosError),
+    'rbd': Mock(),
+    'cephfs': Mock(),
+})

--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -1,0 +1,1 @@
+CherryPy<18; python_version<'3'

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -30,13 +30,13 @@ def EndpointDoc(description="", group="", parameters=None, responses=None):
     if not isinstance(description, str):
         raise Exception("%s has been called with a description that is not a string: %s"
                         % (EndpointDoc.__name__, description))
-    elif not isinstance(group, str):
+    if not isinstance(group, str):
         raise Exception("%s has been called with a groupname that is not a string: %s"
                         % (EndpointDoc.__name__, group))
-    elif parameters and not isinstance(parameters, dict):
+    if parameters and not isinstance(parameters, dict):
         raise Exception("%s has been called with parameters that is not a dict: %s"
                         % (EndpointDoc.__name__, parameters))
-    elif responses and not isinstance(responses, dict):
+    if responses and not isinstance(responses, dict):
         raise Exception("%s has been called with responses that is not a dict: %s"
                         % (EndpointDoc.__name__, responses))
 

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -12,6 +12,8 @@ import rbd
 
 from . import ApiController, Endpoint, Task, BaseController, ReadPermission, \
     RESTController
+from .rbd import _rbd_call
+
 from .. import logger, mgr
 from ..security import Scope
 from ..services.ceph_service import CephService
@@ -35,11 +37,6 @@ def RbdMirroringTask(name, metadata, wait_for):
         return Task("rbd/mirroring/{}".format(name), metadata, wait_for,
                     partial(serialize_dashboard_exception, include_http_status=True))(func)
     return composed_decorator
-
-
-def _rbd_call(pool_name, func, *args, **kwargs):
-    with mgr.rados.open_ioctx(pool_name) as ioctx:
-        func(ioctx, *args, **kwargs)
 
 
 @ViewCache()

--- a/src/pybind/mgr/dashboard/controllers/saml2.py
+++ b/src/pybind/mgr/dashboard/controllers/saml2.py
@@ -75,12 +75,12 @@ class Saml2(BaseController):
             token = token.decode('utf-8')
             logger.debug("JWT Token: %s", token)
             raise cherrypy.HTTPRedirect("{}/#/login?access_token={}".format(url_prefix, token))
-        else:
-            return {
-                'is_authenticated': auth.is_authenticated(),
-                'errors': errors,
-                'reason': auth.get_last_error_reason()
-            }
+
+        return {
+            'is_authenticated': auth.is_authenticated(),
+            'errors': errors,
+            'reason': auth.get_last_error_reason()
+        }
 
     @Endpoint(xml=True)
     def metadata(self):

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -42,7 +42,7 @@ class DashboardException(Exception):
     def code(self):
         if self._code:
             return str(self._code)
-        return str(abs(self.errno))
+        return str(abs(self.errno)) if self.errno is not None else 'Error'
 
 
 # access control module exceptions

--- a/src/pybind/mgr/dashboard/plugins/__init__.py
+++ b/src/pybind/mgr/dashboard/plugins/__init__.py
@@ -59,4 +59,4 @@ class DashboardPluginManager(object):
 PLUGIN_MANAGER = DashboardPluginManager("ceph-mgr.dashboard")
 
 # Load all interfaces and their hooks
-from . import interfaces
+from . import interfaces  # pylint: disable=wrong-import-position,cyclic-import

--- a/src/pybind/mgr/dashboard/plugins/feature_toggles.py
+++ b/src/pybind/mgr/dashboard/plugins/feature_toggles.py
@@ -44,6 +44,7 @@ class Actions(Enum):
     STATUS = 'status'
 
 
+# pylint: disable=too-many-ancestors
 @PM.add_plugin
 class FeatureToggles(I.CanMgr, I.CanLog, I.Setupable, I.HasOptions,
                      I.HasCommands, I.FilterRequest.BeforeHandler,
@@ -54,6 +55,7 @@ class FeatureToggles(I.CanMgr, I.CanLog, I.Setupable, I.HasOptions,
 
     @PM.add_hook
     def setup(self):
+        # pylint: disable=attribute-defined-outside-init
         self.Controller2Feature = {
             controller: feature
             for feature, controllers in Feature2Controller.items()
@@ -132,8 +134,9 @@ class FeatureToggles(I.CanMgr, I.CanLog, I.Setupable, I.HasOptions,
         @ApiController('/feature_toggles')
         class FeatureTogglesEndpoint(RESTController):
 
-            def list(_):
+            def list(_):  # pylint: disable=no-self-argument
                 return {
+                    # pylint: disable=protected-access
                     feature.value: self._is_feature_enabled(feature)
                     for feature in Features
                 }

--- a/src/pybind/mgr/dashboard/plugins/interfaces.py
+++ b/src/pybind/mgr/dashboard/plugins/interfaces.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import PLUGIN_MANAGER as PM, Interface
+from . import PLUGIN_MANAGER as PM, Interface  # pylint: disable=cyclic-import
 
 
 class CanMgr(Interface):
@@ -22,29 +22,32 @@ class Setupable(Interface):
         Placeholder for plugin setup, right after server start.
         CanMgr.mgr and CanLog.log are initialized by then.
         """
-        pass
 
 
 @PM.add_interface
 class HasOptions(Interface):
     @PM.add_abcspec
-    def get_options(self): pass
+    def get_options(self):
+        pass
 
 
 @PM.add_interface
 class HasCommands(Interface):
     @PM.add_abcspec
-    def register_commands(self): pass
+    def register_commands(self):
+        pass
 
 
 @PM.add_interface
 class HasControllers(Interface):
     @PM.add_abcspec
-    def get_controllers(self): pass
+    def get_controllers(self):
+        pass
 
 
-class FilterRequest:
+class FilterRequest(object):
     @PM.add_interface
     class BeforeHandler(Interface):
         @PM.add_abcspec
-        def filter_request_before_handler(self, request): pass
+        def filter_request_before_handler(self, request):
+            pass

--- a/src/pybind/mgr/dashboard/plugins/lru_cache.py
+++ b/src/pybind/mgr/dashboard/plugins/lru_cache.py
@@ -19,12 +19,9 @@ def lru_cache(maxsize=128, typed=False):
         cache = OrderedDict()
         stats = [0, 0]
         rlock = RLock()
-        setattr(
-            function,
-            'cache_info',
-            lambda:
-            "hits={}, misses={}, maxsize={}, currsize={}".format(
-                stats[0], stats[1], maxsize, len(cache)))
+        setattr(function, 'cache_info', lambda:
+                "hits={}, misses={}, maxsize={}, currsize={}".format(
+                    stats[0], stats[1], maxsize, len(cache)))
 
         @wraps(function)
         def wrapper(*args, **kwargs):

--- a/src/pybind/mgr/dashboard/plugins/pluggy.py
+++ b/src/pybind/mgr/dashboard/plugins/pluggy.py
@@ -21,8 +21,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-"""
-
+"""\
 """
 CAVEAT:
 This is a minimal implementation of python-pluggy (based on 0.8.0 interface:
@@ -103,9 +102,9 @@ class PluginManager(object):
 
     def add_hookspecs(self, module_or_class):
         """ Dummy method"""
-        pass
 
-    def register(self, plugin, name=None):
+    def register(self, plugin, name=None):  # pylint: disable=unused-argument
         for attr in dir(plugin):
             if self.parse_hookimpl_opts(plugin, attr) is not None:
+                # pylint: disable=protected-access
                 self.hook._add_hookimpl(attr, getattr(plugin, attr))

--- a/src/pybind/mgr/dashboard/plugins/ttl_cache.py
+++ b/src/pybind/mgr/dashboard/plugins/ttl_cache.py
@@ -19,12 +19,9 @@ def ttl_cache(ttl, maxsize=128, typed=False):
         cache = OrderedDict()
         stats = [0, 0, 0]
         rlock = RLock()
-        setattr(
-            function,
-            'cache_info',
-            lambda:
-            "hits={}, misses={}, expired={}, maxsize={}, currsize={}".format(
-                stats[0], stats[1], stats[2], maxsize, len(cache)))
+        setattr(function, 'cache_info', lambda:
+                "hits={}, misses={}, expired={}, maxsize={}, currsize={}".format(
+                    stats[0], stats[1], stats[2], maxsize, len(cache)))
 
         @wraps(function)
         def wrapper(*args, **kwargs):

--- a/src/pybind/mgr/dashboard/requirements-py27.txt
+++ b/src/pybind/mgr/dashboard/requirements-py27.txt
@@ -1,3 +1,0 @@
-astroid==1.6.1
-pylint==1.8.2
-python-saml==2.4.2

--- a/src/pybind/mgr/dashboard/requirements-py3.txt
+++ b/src/pybind/mgr/dashboard/requirements-py3.txt
@@ -1,3 +1,0 @@
-astroid==2.1.0
-pylint==2.2.2
-python3-saml==1.4.1

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -1,35 +1,13 @@
-attrs==17.4.0
-backports.functools-lru-cache==1.4
-bcrypt==3.1.4
-cheroot==6.0.0
-CherryPy==13.1.0
-configparser==3.5.0
-coverage==4.5.2
-enum34==1.1.6
-funcsigs==1.0.2
-isort==4.2.15
-lazy-object-proxy==1.3.1
-mccabe==0.6.1
-mock==2.0.0
-more-itertools==4.1.0
-pbr==3.1.1
-pluggy==0.6.0
-portend==2.2
-py==1.5.2
-pycodestyle==2.4.0
-pycparser==2.18
-PyJWT==1.6.4
-pyopenssl==17.5.0
-pytest==3.3.2
-pytest-cov==2.5.1
-pytest-faulthandler==1.0.1
-pytz==2017.3
-requests==2.20.0
-Routes==2.4.1
-singledispatch==3.4.0.3
-six==1.11.0
-tempora==1.10
-tox==2.9.1
-virtualenv==15.1.0
-werkzeug==0.14.1
-wrapt==1.10.11
+backports.functools-lru-cache; python_version<'3.3'
+bcrypt
+CherryPy
+enum34; python_version<'3.4'
+more-itertools
+pluggy
+PyJWT
+pyopenssl
+python-saml; python_version<'3'
+python3-saml; python_version>='3'
+requests
+Routes
+six

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -167,11 +167,11 @@ class CephService(object):
                                                                                     kwargs)
             logger.error(msg)
             raise SendCommandError(outs, prefix, argdict, r)
-        else:
-            try:
-                return json.loads(outb)
-            except Exception:  # pylint: disable=broad-except
-                return outb
+
+        try:
+            return json.loads(outb)
+        except Exception:  # pylint: disable=broad-except
+            return outb
 
     @classmethod
     def get_rates(cls, svc_type, svc_name, path):

--- a/src/pybind/mgr/dashboard/services/ganesha.py
+++ b/src/pybind/mgr/dashboard/services/ganesha.py
@@ -429,8 +429,7 @@ class RGWFSal(FSal):
                 raise NFSException('Cannot create bucket "{}" as it already '
                                    'exists, and belongs to other user.'
                                    .format(path))
-            else:
-                raise exp
+            raise exp
         if not exists:
             logger.info('Creating new RGW bucket "%s" for user "%s"', path,
                         self.rgw_user_id)

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -25,7 +25,7 @@ def format_bitmask(features):
     """
     Formats the bitmask:
 
-    >>> format_bitmask(45)
+    @DISABLEDOCTEST: >>> format_bitmask(45)
     ['deep-flatten', 'exclusive-lock', 'layering', 'object-map']
     """
     names = [val for key, val in RBD_FEATURES_NAME_MAPPING.items()
@@ -37,13 +37,14 @@ def format_features(features):
     """
     Converts the features list to bitmask:
 
-    >>> format_features(['deep-flatten', 'exclusive-lock', 'layering', 'object-map'])
+    @DISABLEDOCTEST: >>> format_features(['deep-flatten', 'exclusive-lock',
+        'layering', 'object-map'])
     45
 
-    >>> format_features(None) is None
+    @DISABLEDOCTEST: >>> format_features(None) is None
     True
 
-    >>> format_features('deep-flatten, exclusive-lock')
+    @DISABLEDOCTEST: >>> format_features('deep-flatten, exclusive-lock')
     32
     """
     if isinstance(features, six.string_types):

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -201,13 +201,13 @@ class ControllerTestCase(helper.CPWebCase):
             elif method == 'DELETE':
                 self.status = '204 No Content'
             return
+
+        if 'status' in thread.res_task['exception']:
+            self.status = thread.res_task['exception']['status']
         else:
-            if 'status' in thread.res_task['exception']:
-                self.status = thread.res_task['exception']['status']
-            else:
-                self.status = 500
-            self.body = json.dumps(thread.res_task['exception'])
-            return
+            self.status = 500
+        self.body = json.dumps(thread.res_task['exception'])
+        return
 
     def _task_post(self, url, data=None, timeout=60):
         self._task_request('POST', url, data, timeout)

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -1,30 +1,68 @@
 [tox]
-envlist = py27-{cov,lint,run,check},py3-{cov,lint,run,check}
+envlist =
+   clean,
+   py{27,36}-{cov,lint,run,check},
+   report,
 skipsdist = true
-toxworkdir = {env:CEPH_BUILD_DIR}/dashboard
 minversion = 2.8.1
 
+[pytest]
+addopts =
+    --cov --cov-append --cov-report=term-missing
+    --doctest-modules --doctest-continue-on-failure
+    --ignore=frontend/ --ignore=module.py
+
 [testenv]
+deps =
+    -rrequirements.txt
+    -cconstraints.txt
+    cov,lint: mock
+    cov: pytest<4
+    cov: pytest-cov
 setenv=
+    PYTHONUNBUFFERED=1
     CFLAGS = -DXMLSEC_NO_SIZE_T
     UNITTEST = true
     WEBTEST_INTERACTIVE = false
     LD_LIBRARY_PATH = {toxinidir}/../../../../build/lib
     PATH = {toxinidir}/../../../../build/bin:$PATH
-    py27: PYTHONPATH = {toxinidir}/../../../../build/lib/cython_modules/lib.2
-    py3:  PYTHONPATH = {toxinidir}/../../../../build/lib/cython_modules/lib.3
-    cov:  UNITTEST = true
-    cov:  COVERAGE_FILE = .coverage.{envname}
-commands=
-    pip install -r {toxinidir}/requirements.txt
-    py27: pip install -r {toxinidir}/requirements-py27.txt
-    py3: pip install -r {toxinidir}/requirements-py3.txt
-    cov: coverage erase
-    cov: {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml --doctest-modules controllers/rbd.py services/ tests/ tools.py
-    cov: coverage combine {toxinidir}/{env:COVERAGE_FILE}
-    cov: coverage report
-    cov: coverage xml
-    lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services exceptions.py grafana.py ci/check_grafana_uids.py
-    lint: pycodestyle --max-line-length=100 --exclude=.tox,venv,frontend,.vscode --ignore=E402,E121,E123,E126,E226,E24,E704,W503,E741 .
-    check: python ci/check_grafana_uids.py frontend/src/app ../../../../monitoring/grafana/dashboards
+commands =
+    cov: pytest {posargs}
     run: {posargs}
+    check: python ci/check_grafana_uids.py frontend/src/app ../../../../monitoring/grafana/dashboards
+depends =
+    cov: clean
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
+    coverage html
+    coverage xml
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[pycodestyle]
+max-line-length = 100
+ignore = E402, E121, E123, E126, E226, E24, E704, W503, E741
+exclude = .tox, venv, frontend, .vscode
+statistics = True
+
+[pylint]
+# To allow for similarity/code duplication detection
+jobs = 1
+dirs = . controllers plugins services tests
+
+[testenv:lint]
+deps =
+    {[testenv]deps}
+    pycodestyle
+    pylint
+skip_install = true
+commands =
+    pycodestyle {posargs:.}
+    pylint -rn --rcfile=.pylintrc --jobs={[pylint]jobs} {posargs:{[pylint]dirs}}

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -82,9 +82,16 @@ if test -d wheelhouse ; then
 fi
 
 pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse 'tox >=2.9.1'
-if test -f requirements.txt ; then
-    if ! test -f wheelhouse/md5 || ! md5sum -c wheelhouse/md5 > /dev/null; then
+
+require_files=$(ls *requirements*.txt 2>/dev/null) || true
+constraint_files=$(ls *constraints*.txt 2>/dev/null) || true
+require=$(echo -n "$require_files" | sed -e 's/^/-r /')
+constraint=$(echo -n "$constraint_files" | sed -e 's/^/-c /')
+md5=wheelhouse/md5
+if test "$require"; then
+    if ! test -f $md5 || ! md5sum -c wheelhouse/md5 > /dev/null; then
         NO_INDEX=''
     fi
-    pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse -r requirements.txt
+    pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX \
+      --find-links=file://$(pwd)/wheelhouse $require $constraint 
 fi


### PR DESCRIPTION
- Fix pylint issues.
- Refactor JwtManager check to avoid code duplication (found by pylint when --jobs=1).
- Fix issue with DashboardException.code property, using abs() on potentially None attribute.
- Disables Doctests in services/rbd.py that are actually integration tests (they check the value of rbd.RBD_FEATURES_NAME_MAPPING). Ideally, these kind of tests should be explicitly executed in an integration testing stage, rather that unit-testing. Disabled tests have been prepended with @DISABLEDOCTEST token.
- Refactor tox.ini:
  - Remove requirements-{py27,py3}.txt, as python release dependant packages can be handled with PEP 508 syntax.
  - Remove develepment dependencies from requirements.
  - Move pycodestyle settings to separate section.
- Add conftest.py to mock imported modules (rados, rbd, cephfs), and mock also rados Error and OSError Exceptions.

Fixes: https://tracker.ceph.com/issues/40487
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

