### PR TITLE
mgr/telemetry: re-opt-in when telemetry content changes; nag on major releases

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -47,15 +47,6 @@ the way Ceph is used.
 
 Data is sent over HTTPS to *telemetry.ceph.com*.
 
-Enabling the module
--------------------
-
-The module must first be enabled.  Note that even if the module is
-enabled, telemetry is still "off" by default, so simply enabling the
-module will *NOT* result in any data being shared.::
-
-  ceph mgr module enable telemetry
-
 Sample report
 -------------
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -897,3 +897,32 @@ The time period for what "recent" means is controlled by the option
 These warnings can be disabled entirely with::
 
   ceph config set mgr/crash/warn_recent_interval 0
+
+TELEMETRY_CHANGED
+_________________
+
+Telemetry has been enabled, but the contents of the telemetry report
+have changed since that time, so telemetry reports will not be sent.
+
+The Ceph developers periodically revise the telemetry feature to
+include new and useful information, or to remove information found to
+be useless or sensitive.  If any new information is included in the
+report, Ceph will require the administrator to re-enable telemetry to
+ensure they have an opportunity to (re)review what information will be
+shared.
+
+To review the contents of the telemetry report,::
+
+  ceph telemetry show
+
+Note that the telemetry report consists of several optional channels
+that may be independently enabled or disabled.  For more information, see
+:ref:`telemetry`.
+
+To re-enable telemetry (and make this warning go away),::
+
+  ceph telemetry on
+
+To disable telemetry (and make this warning go away),::
+
+  ceph telemetry off

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -75,6 +75,7 @@
 	debug auth = 20
 	mon reweight min pgs per osd = 4
 	mon reweight min bytes per osd = 10
+	mgr/telemetry/nag = false
 
 [mon]
 	debug ms = 1

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -63,6 +63,7 @@ const static std::map<uint32_t, std::set<std::string>> always_on_modules = {
       "rbd_support",
       "volumes",
       "pg_autoscaler",
+      "telemetry",
     }
   }
 };

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -181,6 +181,8 @@ class Module(MgrModule):
                     opt['name'],
                     self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
+        # wake up serve() thread
+        self.event.set()
 
     def load(self):
         self.last_upload = self.get_store('last_upload', None)

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -445,6 +445,18 @@ class Module(MgrModule):
         self.run = False
         self.event.set()
 
+    def refresh_health_checks(self):
+        health_checks = {}
+        if self.enabled and self.last_opt_revision < LAST_REVISION_RE_OPT_IN:
+            health_checks['TELEMETRY_CHANGED'] = {
+                'severity': 'warning',
+                'summary': 'Telemetry requires re-opt-in',
+                'detail': [
+                    'telemetry report includes new information; must re-opt-in (or out)'
+                ]
+            }
+        self.set_health_checks(health_checks)
+
     def serve(self):
         self.load()
         self.config_notify()
@@ -454,6 +466,12 @@ class Module(MgrModule):
         self.event.wait(10)
 
         while self.run:
+            self.refresh_health_checks()
+
+            if self.last_opt_revision < LAST_REVISION_RE_OPT_IN:
+                self.log.debug('Not sending report until user re-opts-in')
+                self.event.wait(1800)
+                continue
             if not self.enabled:
                 self.log.debug('Not sending report until configured to do so')
                 self.event.wait(1800)

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -24,6 +24,27 @@ LICENSE='sharing-1-0'
 LICENSE_NAME='Community Data License Agreement - Sharing - Version 1.0'
 LICENSE_URL='https://cdla.io/sharing-1-0/'
 
+# If the telemetry revision has changed since this point, re-require
+# an opt-in.  This should happen each time we add new information to
+# the telemetry report.
+LAST_REVISION_RE_OPT_IN = 2
+
+# Latest revision of the telemetry report.  Bump this each time we make
+# *any* change.
+REVISION = 2
+
+# History of revisions
+# --------------------
+#
+# Version 1:
+#   Mimic and/or nautilus are lumped together here, since
+#   we didn't track revisions yet.
+#
+# Version 2:
+#   - added revision tracking, nagging, etc.
+#   - added config option changes
+#   - added channels
+#   - added explicit license acknowledgement to the opt-in process
 
 class Module(MgrModule):
     config = dict()
@@ -49,6 +70,11 @@ class Module(MgrModule):
             'name': 'enabled',
             'type': 'bool',
             'default': False
+        },
+        {
+            'name': 'last_opt_revision',
+            'type': 'int',
+            'default': 1,
         },
         {
             'name': 'leaderboard',
@@ -378,9 +404,11 @@ class Module(MgrModule):
             if command.get('license') != LICENSE:
                 return -errno.EPERM, '', "Telemetry data is licensed under the " + LICENSE_NAME + " (" + LICENSE_URL + ").\nTo enable, add '--license " + LICENSE + "' to the 'ceph telemetry on' command."
             self.set_module_option('enabled', True)
+            self.set_module_option('last_opt_revision', REVISION)
             return 0, '', ''
         elif command['prefix'] == 'telemetry off':
             self.set_module_option('enabled', False)
+            self.set_module_option('last_opt_revision', REVISION)
             return 0, '', ''
         elif command['prefix'] == 'telemetry send':
             self.last_report = self.compile_report()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -455,7 +455,7 @@ class Module(MgrModule):
 
         while self.run:
             if not self.enabled:
-                self.log.info('Not sending report until configured to do so')
+                self.log.debug('Not sending report until configured to do so')
                 self.event.wait(1800)
                 continue
 
@@ -480,7 +480,7 @@ class Module(MgrModule):
                 except:
                     self.log.exception('Exception while sending report:')
             else:
-                self.log.info('Interval for sending new report has not expired')
+                self.log.debug('Interval for sending new report has not expired')
 
             sleep = 3600
             self.log.debug('Sleeping for %d seconds', sleep)

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1104,6 +1104,10 @@ mds_debug_frag = true
 mds_debug_auth_pins = true
 mds_debug_subtrees = true
 
+[mgr]
+mgr/telemetry/nag = false
+mgr/telemetry/enable = false
+
 EOF
 
     if [ "$debug" -ne 0 ]; then


### PR DESCRIPTION
- If telemetry is enabled, but we then add more info to the report, raise TELEMETRY_CHANGED and ask the user to re-opt-in (or out)

I dropped the warning that straight-up nags users to opt-in... I think it's too annoying for the CLI and for 'ceph health'.  I think something similar on the dashboard would work better where it can be a one-time pop-up or something? 