### PR TITLE
mgr/telemetry: specify license when opting in

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -16,7 +16,13 @@ from collections import defaultdict
 
 from mgr_module import MgrModule
 
+
 ALL_CHANNELS = ['basic', 'ident', 'crash', 'device']
+
+LICENSE='sharing-1-0'
+LICENSE_NAME='Community Data License Agreement - Sharing - Version 1.0'
+LICENSE_URL='https://cdla.io/sharing-1-0/'
+
 
 class Module(MgrModule):
     config = dict()
@@ -118,7 +124,7 @@ class Module(MgrModule):
             "perm": "r"
         },
         {
-            "cmd": "telemetry on",
+            "cmd": "telemetry on name=license,type=CephString,req=false",
             "desc": "Enable telemetry reports from this cluster",
             "perm": "rw",
         },
@@ -233,6 +239,7 @@ class Module(MgrModule):
             'report_id': self.report_id,
             'channels': channels,
             'channels_available': ALL_CHANNELS,
+            'license': LICENSE,
         }
 
         if 'ident' in channels:
@@ -326,6 +333,8 @@ class Module(MgrModule):
                 r[opt['name']] = getattr(self, opt['name'])
             return 0, json.dumps(r, indent=4), ''
         elif command['prefix'] == 'telemetry on':
+            if command.get('license') != LICENSE:
+                return -errno.EPERM, '', "Telemetry data is licensed under the " + LICENSE_NAME + " (" + LICENSE_URL + ").\nTo enable, add '--license " + LICENSE + "' to the 'ceph telemetry on' command."
             self.set_module_option('enabled', True)
             return 0, '', ''
         elif command['prefix'] == 'telemetry off':


### PR DESCRIPTION
Choosing not to include this in the docs so that the user is more likely
to see this interactively.  (That is...probably good?)