### PR TITLE
nautilus: cephfs: client: set snapdir's link count to 1

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10582,6 +10582,7 @@ Inode *Client::open_snapdir(Inode *diri)
     in->mode = diri->mode;
     in->uid = diri->uid;
     in->gid = diri->gid;
+    in->nlink = 1;
     in->mtime = diri->mtime;
     in->ctime = diri->ctime;
     in->btime = diri->btime;


### PR DESCRIPTION
http://tracker.ceph.com/issues/40443