### PR TITLE
mimic: ceph-volume: missing string substitution when reporting mounts

### DIFF
--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -214,9 +214,9 @@ def device_is_mounted(dev, destination=None):
                     )
                     return True
             else:
-                logger.info('%s was found as mounted')
+                logger.info('%s was found as mounted', dev)
                 return True
-    logger.info('%s was not found as mounted')
+    logger.info('%s was not found as mounted', dev)
     return False
 
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/40977