### PR TITLE
mgr/telemetry: salt osd ids too

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -212,12 +212,11 @@ class Module(MgrModule):
             c = json.loads(crashinfo)
             del c['utsname_hostname']
             (etype, eid) = c.get('entity_name', '').split('.')
-            if etype != 'osd':
-                m = hashlib.sha1()
-                m.update(self.salt.encode('utf-8'))
-                m.update(eid.encode('utf-8'))
-                m.update(self.salt.encode('utf-8'))
-                c['entity_name'] = etype + '.' + m.hexdigest()
+            m = hashlib.sha1()
+            m.update(self.salt.encode('utf-8'))
+            m.update(eid.encode('utf-8'))
+            m.update(self.salt.encode('utf-8'))
+            c['entity_name'] = etype + '.' + m.hexdigest()
             crashlist.append(c)
         return crashlist
 


### PR DESCRIPTION
Better to fully obfuscate here.

This has a nice side-effect of assigning entity names that are *globally*
unique across the full telemetry data set, since the salts are unique and
sha1 is (sufficiently) collision-free.

Signed-off-by: Sage Weil <sage@redhat.com>