### PR TITLE
qa: fixes

### DIFF
--- a/qa/suites/rados/rest/mgr-restful.yaml
+++ b/qa/suites/rados/rest/mgr-restful.yaml
@@ -13,6 +13,7 @@ tasks:
       - \(PG_
       - \(OSD_
       - \(OBJECT_
+      - \(OSDMAP_FLAGS\)
 - exec:
     mon.a:
       - ceph restful create-key admin

--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -111,6 +111,10 @@ class MgrModuleTelemetryTest(MgrModuleTestCase):
             data,
             JObj(
                 sub_elems={
+                    'channel_basic': JLeaf(bool),
+                    'channel_ident': JLeaf(bool),
+                    'channel_crash': JLeaf(bool),
+                    'channel_device': JLeaf(bool),
                     'contact': JLeaf(str),
                     'description': JLeaf(str),
                     'enabled': JLeaf(bool),


### PR DESCRIPTION
`rest/test-restful.sh` calls `test_mgr_rest_api.py`, which in turn
calls

```
    ('patch',  '/config/osd', {'pause': True}),
```

and rest module translates it to `ceph osd set key=pause`

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

