### PR TITLE
Doc: Add Nautilus 14.2.2 to schedule and releases

### DIFF
--- a/doc/releases/releases.yml
+++ b/doc/releases/releases.yml
@@ -14,6 +14,8 @@
 releases:
   nautilus:
     releases:
+      - version: 14.2.2
+        released: 2019-07-17
       - version: 14.2.1
         released: 2019-04-29
       - version: 14.2.0

--- a/doc/releases/schedule.rst
+++ b/doc/releases/schedule.rst
@@ -13,6 +13,7 @@ Timeline
 .. ceph_timeline:: releases.yml development nautilus mimic luminous kraken jewel infernalis hammer giant firefly emperor dumpling
 
 .. _Nautilus: ../nautilus
+.. _14.2.2: ../nautilus#v14-2-2-nautilus
 .. _14.2.1: ../nautilus#v14-2-1-nautilus
 .. _14.2.0: ../nautilus#v14-2-0-nautilus
 


### PR DESCRIPTION
"""
Doc: Add Nautilus 14.2.2 to releases.

The releases and schedule documentation needed to be updated
to include the Nautilus 14.2.2 release.

Fixes: http://tracker.ceph.com/issues/40988
Signed-off-by: JuanJose Galvez <juanjose.galvez@gmail.com>
"""
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

