### PR TITLE
doc: pg_num should always be a power of two

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -434,11 +434,12 @@ You should then check if the result makes sense with the way you
 designed your Ceph cluster to maximize `data durability`_,
 `object distribution`_ and minimize `resource usage`_.
 
-The result should always be **rounded up to the nearest power of two.**
-A power of two will evenly balance the number of objects among placement groups. 
-You could set it to a different value but you should be aware that this could result in 
-an uneven distribution of data across your OSDs. Use of such values shoud be limited to 
-incrementally stepping from one power of two to another.
+The result should always be **rounded up to the nearest power of two**.
+
+Only a power of two will evenly balance the number of objects among
+placement groups. Other values will result in an uneven distribution of
+data across your OSDs. Their use should be limited to incrementally
+stepping from one power of two to another.
 
 As an example, for a cluster with 200 OSDs and a pool size of 3
 replicas, you would estimate your number of PGs as follows::

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -433,9 +433,11 @@ You should then check if the result makes sense with the way you
 designed your Ceph cluster to maximize `data durability`_,
 `object distribution`_ and minimize `resource usage`_.
 
-The result should be **rounded up to the nearest power of two.**
-Rounding up is optional, but recommended for CRUSH to more evenly balance
-the number of objects among placement groups.
+The result should always be **rounded up to the nearest power of two.**
+A power of two will evenly balance the number of objects among placement groups. 
+You could set it to a different value but you should be aware that this could result in 
+an uneven distribution of data across your OSDs. Use of such values shoud be limited to 
+incrementally stepping from one power of two to another.
 
 As an example, for a cluster with 200 OSDs and a pool size of 3
 replicas, you would estimate your number of PGs as follows::

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -382,14 +382,15 @@ makes every effort to evenly spread OSDs among all existing Placement
 Groups.
 
 As long as there are one or two orders of magnitude more Placement
-Groups than OSDs, the distribution should be even. For instance, 300
-placement groups for 3 OSDs, 1000 placement groups for 10 OSDs etc.
+Groups than OSDs, the distribution should be even. For instance, 256
+placement groups for 3 OSDs, 512 or 1024 placement groups for 10 OSDs
+etc.
 
 Uneven data distribution can be caused by factors other than the ratio
 between OSDs and placement groups. Since CRUSH does not take into
 account the size of the objects, a few very large objects may create
 an imbalance. Let say one million 4K objects totaling 4GB are evenly
-spread among 1000 placement groups on 10 OSDs. They will use 4GB / 10
+spread among 1024 placement groups on 10 OSDs. They will use 4GB / 10
 = 400MB on each OSD. If one 400MB object is added to the pool, the
 three OSDs supporting the placement group in which the object has been
 placed will be filled with 400MB + 400MB = 800MB while the seven


### PR DESCRIPTION
Hi,

I updated the pg_num section in the docs just a little to be more strict.
I think we should make it crystal clear that pg num should be a power of two and only if there's a real good reason and someone knows exactly why they need a different value they can proceed. 

I think this is the first step of several to make this clearer to the end user. Next step would be to show a Health WARN and also to flag the pool creation red in the dashboard if someone would like to add a pool and the pg count isn't a power of two.

Why do I would like to be more strict about it? We've seen more and more clusters were the osd variation was really high. The fix to that was always to set the pg_num + balancer. Also the pg autoscaler only uses power of two so we shouldn't even encourage people to use something different right from the beginning or to phrase i differently, we should protect the end-user right away.

FIxes: https://tracker.ceph.com/issues/41004
Signed-off-by: Kai Wagner <kwagner@suse.com>




