### PR TITLE
rgw: fix potential realm watch lost

### DIFF
--- a/src/rgw/rgw_realm_watcher.cc
+++ b/src/rgw/rgw_realm_watcher.cc
@@ -71,13 +71,11 @@ void RGWRealmWatcher::handle_notify(uint64_t notify_id, uint64_t cookie,
 
 void RGWRealmWatcher::handle_error(uint64_t cookie, int err)
 {
+  lderr(cct) << "RGWRealmWatcher::handle_error oid=" << watch_oid << " err=" << err << dendl;
   if (cookie != watch_handle)
     return;
 
-  if (err == -ENOTCONN) {
-    ldout(cct, 4) << "Disconnected watch on " << watch_oid << dendl;
-    watch_restart();
-  }
+  watch_restart();
 }
 
 int RGWRealmWatcher::watch_start(const RGWRealm& realm)


### PR DESCRIPTION
realm watch only restart on -ENOTCONN, but if we fail to maintain the watch ping, the OSD will return -ETIMEDOUT.
The objecter will keep the watch err on last_error, if last_error not empty, it will not call handle_error in future error,
so it will never get the chance to rewatch on following -ENOTCONN error.

Fixes: http://tracker.ceph.com/issues/40991

Signed-off-by: Tianshan Qu <tianshan@xsky.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

