### PR TITLE
os/bluestore/KernelDevice: handle non-block aligned bdev_block_size

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -387,13 +387,11 @@ private:
   FileWriter *_create_writer(FileRef f);
   void _close_writer(FileWriter *h);
 
-  // always put the super in the second 4k block.  FIXME should this be
-  // block size independent?
-  unsigned get_super_offset() {
-    return 4096;
+  unsigned get_super_offset(uint64_t block_size) {
+    return p2roundup<unsigned>(4096, block_size);
   }
-  unsigned get_super_length() {
-    return 4096;
+  unsigned get_super_length(uint64_t block_size) {
+    return p2roundup<unsigned>(4096, block_size);
   }
 
   void _add_block_extent(unsigned bdev, uint64_t offset, uint64_t len);


### PR DESCRIPTION
aio write in multiple of block size. on some system we found

```
open backing device/file reports st_blksize 65536, using bdev_block_size
4096 anyway
open size 8589934592 (0x200000000, 8 GiB) block_size 4096 (4 KiB)
non-rotational discard supported
...
bdev(0x1a7cec00 ceph_test_bluefs.tmp.block.17983.5) aio to
5242880~2147479552 but returned: 2147418112
```

and then.
```
/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/os/bluestore/KernelDevice.cc:
In function 'void KernelDevice::_aio_thread()' thread ffff9da8c9d0 time
2019-07-27T14:28:51.530002+0000
/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/os/bluestore/KernelDevice.cc:
559: ceph_abort_msg("unexpected aio return value: does not match
length")
 ceph version Development (no_version) octopus (dev)
 1: (ceph::__ceph_abort(char const*, int, char const*, std::string
const&)+0xe0) [0xffffa0d388d4]
 2: (KernelDevice::_aio_thread()+0xc2c) [0x1011b9c]
 3: (KernelDevice::AioCompletionThread::entry()+0x18) [0x1019c0c]
 4: (Thread::entry_wrapper()+0x8c) [0xffffa0cdad68]
 5: (Thread::_entry_func(void*)+0x14) [0xffffa0cdaccc]
 6: (()+0x7bb0) [0xffffaa227bb0]
 7: (()+0xdb4c0) [0xffff9f2ab4c0]
```

so the length of aio size should always be aligned to block size
reported by `fstat()`.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

