### PR TITLE
mgr/dashboard: fix MDS counter chart is not displayed

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -73,12 +73,16 @@ class CephFS(RESTController):
         result = {}
         mds_names = self._get_mds_names(fs_id)
 
+        def __to_second(point):
+            return (point[0] // 1000000000, point[1])
+
         for mds_name in mds_names:
             result[mds_name] = {}
             for counter in counters:
                 data = mgr.get_counter("mds", mds_name, counter)
                 if data is not None:
-                    result[mds_name][counter] = data[counter]
+                    result[mds_name][counter] = list(
+                        map(__to_second, data[counter]))
                 else:
                     result[mds_name][counter] = []
 


### PR DESCRIPTION
Unit of timetamp for performance counters is changed to nanoseconds [1].
Adapt this for CephFS MDS performance counters in backend.

[1]: https://github.com/ceph/ceph/pull/28882

Fixes: https://tracker.ceph.com/issues/40971

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

