### PR TITLE
cephfs-shell: Fix multiple flake8 errors

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1239,7 +1239,7 @@ sub-directories, files')
         return self.complete_filenames(text, line, begidx, endidx)
 
     stat_parser = argparse.ArgumentParser(
-                  description='Display file or file system status')
+        description='Display file or file system status')
     stat_parser.add_argument('paths', type=str, help='file paths',
                              nargs='+')
 

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -767,17 +767,17 @@ exists.')
                     print_long(cephfs.getcwd().decode(
                         'utf-8') + path + '/' + path, is_dir, True)
                 elif args.long:
-                    print_long(cephfs.getcwd().decode('utf-8') +
-                               path +
-                               '/' +
-                               path,
+                    print_long(cephfs.getcwd().decode('utf-8')
+                               + path
+                               + '/'
+                               + path,
                                is_dir, False)
                 elif is_dir:
-                    values.append(colorama.Style.BRIGHT +
-                                  colorama.Fore.CYAN +
-                                  path +
-                                  '/' +
-                                  colorama.Style.RESET_ALL)
+                    values.append(colorama.Style.BRIGHT
+                                  + colorama.Fore.CYAN
+                                  + path
+                                  + '/'
+                                  + colorama.Style.RESET_ALL)
                 else:
                     values.append(path)
             if not args.long:

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -182,7 +182,8 @@ def print_long(path, is_dir, human_readable):
     info = cephfs.stat(path)
     pretty = os.path.basename(path.decode('utf-8'))
     if is_dir:
-        pretty = colorama.Style.BRIGHT + colorama.Fore.CYAN + pretty + '/' + colorama.Style.RESET_ALL
+        pretty = colorama.Style.BRIGHT + colorama.Fore.CYAN + pretty + '/'
+        pretty += colorama.Style.RESET_ALL
     if human_readable:
         poutput('{}\t{:10s} {} {} {} {}'.format(
             mode_notation(info.st_mode),

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -168,7 +168,7 @@ suffixes = ['B', 'K', 'M', 'G', 'T', 'P']
 
 def humansize(nbytes):
     i = 0
-    while nbytes >= 1024 and i < len(suffixes)-1:
+    while nbytes >= 1024 and i < len(suffixes) - 1:
         nbytes /= 1024.
         i += 1
     nbytes = math.ceil(nbytes)
@@ -1067,11 +1067,11 @@ sub-directories, files')
             if not is_dir_exists(i.d_name):
                 statfs = cephfs.statfs(i.d_name)
                 stat = cephfs.stat(i.d_name)
-                block_size = statfs['f_blocks']*statfs['f_bsize'] // 1024
+                block_size = statfs['f_blocks'] * statfs['f_bsize'] // 1024
                 available = block_size - stat.st_size
                 use = 0
                 if block_size > 0:
-                    use = (stat.st_size*100 // block_size)
+                    use = (stat.st_size * 100 // block_size)
                 self.poutput('{:25d}\t{:5d}\t{:10d}\t{:5s} {}'.format(
                     statfs['f_fsid'], stat.st_size, available,
                     str(int(use)) + '%', i.d_name.decode('utf-8')))
@@ -1223,7 +1223,7 @@ sub-directories, files')
         if line == 'all':
             for k in dir(self):
                 if k.startswith('do_'):
-                    self.poutput('-'*80)
+                    self.poutput('-' * 80)
                     super().do_help(k[3:])
             return
         parser = self.create_argparser(line)
@@ -1286,7 +1286,7 @@ if __name__ == '__main__':
     if args.batch:
         args.commands = ['load ' + args.batch, ',quit']
     if args.test:
-        args.commands.extend(['-t,'] + [arg+',' for arg in args.test])
+        args.commands.extend(['-t,'] + [arg + ',' for arg in args.test])
     sys.argv.clear()
     sys.argv.append(exe)
     sys.argv.extend([i.strip() for i in ' '.join(args.commands).split(',')])

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -77,7 +77,7 @@ def mode_notation(mode):
     permission_bits = {'0': '---',
                        '1': '--x',
                        '2': '-w-',
-                       '3':  '-wx',
+                       '3': '-wx',
                        '4': 'r--',
                        '5': 'r-x',
                        '6': 'rw-',


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
After ignoring line break before binary operator (W503) flake8 errors and limiting line length to 100. This patch series fixes the following errors:
```
[root@localhost ceph]# flake8 --ignore=W503 --max-line-length=100 src/tools/cephfs/cephfs-shell
cephfs-shell:80:28: E241 multiple spaces after ':'
cephfs-shell:171:47: E226 missing whitespace around arithmetic operator
cephfs-shell:185:101: E501 line too long (101 > 100 characters)
cephfs-shell:770:64: W504 line break after binary operator
cephfs-shell:771:37: W504 line break after binary operator
cephfs-shell:772:36: W504 line break after binary operator
cephfs-shell:776:57: W504 line break after binary operator
cephfs-shell:777:54: W504 line break after binary operator
cephfs-shell:778:40: W504 line break after binary operator
cephfs-shell:779:39: W504 line break after binary operator
cephfs-shell:1070:48: E226 missing whitespace around arithmetic operator
cephfs-shell:1074:40: E226 missing whitespace around arithmetic operator
cephfs-shell:1226:37: E226 missing whitespace around arithmetic operator
cephfs-shell:1242:19: E126 continuation line over-indented for hanging indent
cephfs-shell:1289:44: E226 missing whitespace around arithmetic operator
```



