### PR TITLE
mgr/prometheus: Cast collect_timeout (scrape_interval) to float

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1061,8 +1061,8 @@ class Module(MgrModule):
                     raise cherrypy.HTTPError(503, 'No MON connection')
 
         # Make the cache timeout for collecting configurable
-        self.collect_timeout = self.get_localized_module_option(
-            'scrape_interval', 5.0)
+        self.collect_timeout = float(self.get_localized_module_option(
+            'scrape_interval', 5.0))
 
         server_addr = self.get_localized_module_option(
             'server_addr', get_default_addr())


### PR DESCRIPTION
If set by user scrape_interval option is returned as non-float by get_localized_module_option.
Metric cache timeout comparison always returns true and data is never refreshed.

Fixes:  https://tracker.ceph.com/issues/40997
Signed-off-by: Ben Meekhof <bmeekhof@umich.edu>

