### PR TITLE
os/bluestore: Don't assert if bluefs_alloc_size = min_alloc_size

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5205,7 +5205,7 @@ int BlueStore::_minimal_open_bluefs(bool create)
     uint64_t start = p2align((bdev->get_size() - initial) / 2,
 			      cct->_conf->bluefs_alloc_size);
     //avoiding superblock overwrite
-    ceph_assert(cct->_conf->bluefs_alloc_size > _get_ondisk_reserved());
+    ceph_assert(cct->_conf->bluefs_alloc_size >= _get_ondisk_reserved());
     start = std::max(cct->_conf->bluefs_alloc_size, start);
 
     bluefs->add_block_extent(bluefs_shared_bdev, start, initial);


### PR DESCRIPTION
This is required if we want to set the bluefs_alloc_size equal to the bluestore_min_alloc_size.

Signed-off-by: Mark Nelson <mnelson@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

