### PR TITLE
qa/tasks/mgr/test_progress.py: fix bug in 9b4dbf0

### DIFF
--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -127,7 +127,7 @@ class TestProgress(MgrTestCase):
         self.wait_until_equal(lambda: len(self._events_in_progress()), 1,
                               timeout=self.EVENT_CREATION_PERIOD)
 
-        new_event = self._all_events()[0]
+        new_event = self._events_in_progress()[0]
         log.info(json.dumps(new_event, indent=1))
         self.assertIn("Rebalancing after osd.0 marked in", new_event['message'])    
         

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -433,7 +433,8 @@ class Module(MgrModule):
         # In the case of the osd coming back in, we might need to cancel
         # previous recovery event for that osd
         if marked == "in":
-            for ev_id, ev in self._events.items():
+            for ev_id in list(self._events):
+                ev = self.events[ev_id]
                 if isinstance(ev, PgRecoveryEvent) and osd_id in ev.which_osds:
                     self.log.info("osd.{0} came back in, cancelling event".format(
                         osd_id
@@ -486,7 +487,8 @@ class Module(MgrModule):
             self._osdmap_changed(old_osdmap, self._latest_osdmap)
         elif notify_type == "pg_summary":
             data = self.get("pg_dump")
-            for ev_id, ev in self._events.items():
+            for ev_id in list(self._events):
+                ev = self._events[ev_id]
                 if isinstance(ev, PgRecoveryEvent):
                     ev.pg_update(data, self.log)
                     self.maybe_complete(ev)


### PR DESCRIPTION
follow-up-fix for 9b4dbf0

basically we wanna look at the list that has inprogress events and not the list that has inprogress+complete events

Fixes: http://pulpito.ceph.com/kchai-2019-07-28_14:30:09-rados-wip-kefu2-testing-2019-07-28-1941-distro-basic-mira/4160881/

Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

