### PR TITLE
ceph-volume  simple: better detection when 'type' file is not present

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/activate.py
@@ -35,8 +35,16 @@ class Activate(object):
         try:
             objectstore = json_config['type']
         except KeyError:
-            logger.warning('"type" was not defined, will assume "bluestore"')
-            objectstore = 'bluestore'
+            if {'data', 'journal'}.issubset(set(devices)):
+                logger.warning(
+                    '"type" key not found, assuming "filestore" since journal key is present'
+                )
+                objectstore = 'filestore'
+            else:
+                logger.warning(
+                    '"type" key not found, assuming "bluestore" since journal key is not present'
+                )
+                objectstore = 'bluestore'
 
         # Go through all the device combinations that are absolutely required,
         # raise an error describing what was expected and what was found

--- a/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
@@ -159,9 +159,19 @@ class TestValidateDevices(object):
         result = activation.validate_devices({'type': 'filestore', 'journal': {}, 'data': {}})
         assert result is True
 
+    def test_filestore_without_type(self):
+        activation = activate.Activate([])
+        result = activation.validate_devices({'journal': {}, 'data': {}})
+        assert result is True
+
     def test_bluestore_with_all_devices(self):
         activation = activate.Activate([])
         result = activation.validate_devices({'type': 'bluestore', 'data': {}, 'block': {}})
+        assert result is True
+
+    def test_bluestore_without_type(self):
+        activation = activate.Activate([])
+        result = activation.validate_devices({'data': {}, 'block': {}})
         assert result is True
 
     def test_bluestore_is_default(self):


### PR DESCRIPTION
The heuristics when missing the `type` file is bad, it just defaults to bluestore. This fix detects if there is a journal link or not if `type` is missing.

The 'type' file is not present in older OSDs deployed by ceph-disk

Fixes: https://tracker.ceph.com/issues/40987