### PR TITLE
common/buffer: avoid extra assignment

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -164,8 +164,7 @@ static ceph::spinlock debug_lock;
   public:
     MEMPOOL_CLASS_HELPERS();
 
-    raw_posix_aligned(unsigned l, unsigned _align) : raw(l) {
-      align = _align;
+    raw_posix_aligned(unsigned l, unsigned _align) : raw(l), align(_align) {
       ceph_assert((align >= sizeof(void *)) && (align & (align - 1)) == 0);
 #ifdef DARWIN
       data = (char *) valloc(len);
@@ -194,8 +193,7 @@ static ceph::spinlock debug_lock;
     unsigned align;
     char *realdata;
   public:
-    raw_hack_aligned(unsigned l, unsigned _align) : raw(l) {
-      align = _align;
+    raw_hack_aligned(unsigned l, unsigned _align) : raw(l), align(_align) {
       realdata = new char[len+align-1];
       unsigned off = ((unsigned)realdata) & (align-1);
       if (off)


### PR DESCRIPTION
Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

