### PR TITLE
cmake: update FindBoost.cmake

### DIFF
--- a/cmake/modules/FindBoost.cmake
+++ b/cmake/modules/FindBoost.cmake
@@ -1,244 +1,251 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 
-#.rst:
-# FindBoost
-# ---------
-#
-# Find Boost include dirs and libraries
-#
-# Use this module by invoking find_package with the form::
-#
-#   find_package(Boost
-#     [version] [EXACT]      # Minimum or EXACT version e.g. 1.67.0
-#     [REQUIRED]             # Fail with error if Boost is not found
-#     [COMPONENTS <libs>...] # Boost libraries by their canonical name
-#                            # e.g. "date_time" for "libboost_date_time"
-#     [OPTIONAL_COMPONENTS <libs>...]
-#                            # Optional Boost libraries by their canonical name)
-#     )                      # e.g. "date_time" for "libboost_date_time"
-#
-# This module finds headers and requested component libraries OR a CMake
-# package configuration file provided by a "Boost CMake" build.  For the
-# latter case skip to the "Boost CMake" section below.  For the former
-# case results are reported in variables::
-#
-#   Boost_FOUND            - True if headers and requested libraries were found
-#   Boost_INCLUDE_DIRS     - Boost include directories
-#   Boost_LIBRARY_DIRS     - Link directories for Boost libraries
-#   Boost_LIBRARIES        - Boost component libraries to be linked
-#   Boost_<C>_FOUND        - True if component <C> was found (<C> is upper-case)
-#   Boost_<C>_LIBRARY      - Libraries to link for component <C> (may include
-#                            target_link_libraries debug/optimized keywords)
-#   Boost_VERSION          - BOOST_VERSION value from boost/version.hpp
-#   Boost_LIB_VERSION      - Version string appended to library filenames
-#   Boost_MAJOR_VERSION    - Boost major version number (X in X.y.z)
-#   Boost_MINOR_VERSION    - Boost minor version number (Y in x.Y.z)
-#   Boost_SUBMINOR_VERSION - Boost subminor version number (Z in x.y.Z)
-#   Boost_LIB_DIAGNOSTIC_DEFINITIONS (Windows)
-#                          - Pass to add_definitions() to have diagnostic
-#                            information about Boost's automatic linking
-#                            displayed during compilation
-#
-# Note that Boost Python components require a Python version suffix
-# (Boost 1.67 and later), e.g. ``python36`` or ``python27`` for the
-# versions built against Python 3.6 and 2.7, respectively.  This also
-# applies to additional components using Python including
-# ``mpi_python`` and ``numpy``.  Earlier Boost releases may use
-# distribution-specific suffixes such as ``2``, ``3`` or ``2.7``.
-# These may also be used as suffixes, but note that they are not
-# portable.
-#
-# This module reads hints about search locations from variables::
-#
-#   BOOST_ROOT             - Preferred installation prefix
-#    (or BOOSTROOT)
-#   BOOST_INCLUDEDIR       - Preferred include directory e.g. <prefix>/include
-#   BOOST_LIBRARYDIR       - Preferred library directory e.g. <prefix>/lib
-#   Boost_NO_SYSTEM_PATHS  - Set to ON to disable searching in locations not
-#                            specified by these hint variables. Default is OFF.
-#   Boost_ADDITIONAL_VERSIONS
-#                          - List of Boost versions not known to this module
-#                            (Boost install locations may contain the version)
-#
-# and saves search results persistently in CMake cache entries::
-#
-#   Boost_INCLUDE_DIR         - Directory containing Boost headers
-#   Boost_LIBRARY_DIR_RELEASE - Directory containing release Boost libraries
-#   Boost_LIBRARY_DIR_DEBUG   - Directory containing debug Boost libraries
-#   Boost_<C>_LIBRARY_DEBUG   - Component <C> library debug variant
-#   Boost_<C>_LIBRARY_RELEASE - Component <C> library release variant
-#
-# The following :prop_tgt:`IMPORTED` targets are also defined::
-#
-#   Boost::boost                  - Target for header-only dependencies
-#                                   (Boost include directory)
-#   Boost::<C>                    - Target for specific component dependency
-#                                   (shared or static library); <C> is lower-
-#                                   case
-#   Boost::diagnostic_definitions - interface target to enable diagnostic
-#                                   information about Boost's automatic linking
-#                                   during compilation (adds BOOST_LIB_DIAGNOSTIC)
-#   Boost::disable_autolinking    - interface target to disable automatic
-#                                   linking with MSVC (adds BOOST_ALL_NO_LIB)
-#   Boost::dynamic_linking        - interface target to enable dynamic linking
-#                                   linking with MSVC (adds BOOST_ALL_DYN_LINK)
-#
-# Implicit dependencies such as Boost::filesystem requiring
-# Boost::system will be automatically detected and satisfied, even
-# if system is not specified when using find_package and if
-# Boost::system is not added to target_link_libraries.  If using
-# Boost::thread, then Threads::Threads will also be added automatically.
-#
-# It is important to note that the imported targets behave differently
-# than variables created by this module: multiple calls to
-# find_package(Boost) in the same directory or sub-directories with
-# different options (e.g. static or shared) will not override the
-# values of the targets created by the first call.
-#
-# Users may set these hints or results as cache entries.  Projects
-# should not read these entries directly but instead use the above
-# result variables.  Note that some hint names start in upper-case
-# "BOOST".  One may specify these as environment variables if they are
-# not specified as CMake variables or cache entries.
-#
-# This module first searches for the Boost header files using the above
-# hint variables (excluding BOOST_LIBRARYDIR) and saves the result in
-# Boost_INCLUDE_DIR.  Then it searches for requested component libraries
-# using the above hints (excluding BOOST_INCLUDEDIR and
-# Boost_ADDITIONAL_VERSIONS), "lib" directories near Boost_INCLUDE_DIR,
-# and the library name configuration settings below.  It saves the
-# library directories in Boost_LIBRARY_DIR_DEBUG and
-# Boost_LIBRARY_DIR_RELEASE and individual library
-# locations in Boost_<C>_LIBRARY_DEBUG and Boost_<C>_LIBRARY_RELEASE.
-# When one changes settings used by previous searches in the same build
-# tree (excluding environment variables) this module discards previous
-# search results affected by the changes and searches again.
-#
-# Boost libraries come in many variants encoded in their file name.
-# Users or projects may tell this module which variant to find by
-# setting variables::
-#
-#   Boost_USE_DEBUG_LIBS     - Set to ON or OFF to specify whether to search
-#                              and use the debug libraries.  Default is ON.
-#   Boost_USE_RELEASE_LIBS   - Set to ON or OFF to specify whether to search
-#                              and use the release libraries.  Default is ON.
-#   Boost_USE_MULTITHREADED  - Set to OFF to use the non-multithreaded
-#                              libraries ('mt' tag).  Default is ON.
-#   Boost_USE_STATIC_LIBS    - Set to ON to force the use of the static
-#                              libraries.  Default is OFF.
-#   Boost_USE_STATIC_RUNTIME - Set to ON or OFF to specify whether to use
-#                              libraries linked statically to the C++ runtime
-#                              ('s' tag).  Default is platform dependent.
-#   Boost_USE_DEBUG_RUNTIME  - Set to ON or OFF to specify whether to use
-#                              libraries linked to the MS debug C++ runtime
-#                              ('g' tag).  Default is ON.
-#   Boost_USE_DEBUG_PYTHON   - Set to ON to use libraries compiled with a
-#                              debug Python build ('y' tag). Default is OFF.
-#   Boost_USE_STLPORT        - Set to ON to use libraries compiled with
-#                              STLPort ('p' tag).  Default is OFF.
-#   Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS
-#                            - Set to ON to use libraries compiled with
-#                              STLPort deprecated "native iostreams"
-#                              ('n' tag).  Default is OFF.
-#   Boost_COMPILER           - Set to the compiler-specific library suffix
-#                              (e.g. "-gcc43").  Default is auto-computed
-#                              for the C++ compiler in use.  A list may be
-#                              used if multiple compatible suffixes should
-#                              be tested for, in decreasing order of
-#                              preference.
-#   Boost_ARCHITECTURE       - Set to the architecture-specific library suffix
-#                              (e.g. "-x64").  Default is auto-computed for the
-#                              C++ compiler in use.
-#   Boost_THREADAPI          - Suffix for "thread" component library name,
-#                              such as "pthread" or "win32".  Names with
-#                              and without this suffix will both be tried.
-#   Boost_NAMESPACE          - Alternate namespace used to build boost with
-#                              e.g. if set to "myboost", will search for
-#                              myboost_thread instead of boost_thread.
-#
-# Other variables one may set to control this module are::
-#
-#   Boost_DEBUG              - Set to ON to enable debug output from FindBoost.
-#                              Please enable this before filing any bug report.
-#   Boost_DETAILED_FAILURE_MSG
-#                            - Set to ON to add detailed information to the
-#                              failure message even when the REQUIRED option
-#                              is not given to the find_package call.
-#   Boost_REALPATH           - Set to ON to resolve symlinks for discovered
-#                              libraries to assist with packaging.  For example,
-#                              the "system" component library may be resolved to
-#                              "/usr/lib/libboost_system.so.1.67.0" instead of
-#                              "/usr/lib/libboost_system.so".  This does not
-#                              affect linking and should not be enabled unless
-#                              the user needs this information.
-#   Boost_LIBRARY_DIR        - Default value for Boost_LIBRARY_DIR_RELEASE and
-#                              Boost_LIBRARY_DIR_DEBUG.
-#
-# On Visual Studio and Borland compilers Boost headers request automatic
-# linking to corresponding libraries.  This requires matching libraries
-# to be linked explicitly or available in the link library search path.
-# In this case setting Boost_USE_STATIC_LIBS to OFF may not achieve
-# dynamic linking.  Boost automatic linking typically requests static
-# libraries with a few exceptions (such as Boost.Python).  Use::
-#
-#   add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
-#
-# to ask Boost to report information about automatic linking requests.
-#
-# Example to find Boost headers only::
-#
-#   find_package(Boost 1.36.0)
-#   if(Boost_FOUND)
-#     include_directories(${Boost_INCLUDE_DIRS})
-#     add_executable(foo foo.cc)
-#   endif()
-#
-# Example to find Boost libraries and use imported targets::
-#
-#   find_package(Boost 1.56 REQUIRED COMPONENTS
-#                date_time filesystem iostreams)
-#   add_executable(foo foo.cc)
-#   target_link_libraries(foo Boost::date_time Boost::filesystem
-#                             Boost::iostreams)
-#
-# Example to find Boost Python 3.6 libraries and use imported targets::
-#
-#   find_package(Boost 1.67 REQUIRED COMPONENTS
-#                python36 numpy36)
-#   add_executable(foo foo.cc)
-#   target_link_libraries(foo Boost::python36 Boost::numpy36)
-#
-# Example to find Boost headers and some *static* (release only) libraries::
-#
-#   set(Boost_USE_STATIC_LIBS        ON)  # only find static libs
-#   set(Boost_USE_DEBUG_LIBS         OFF) # ignore debug libs and
-#   set(Boost_USE_RELEASE_LIBS       ON)  # only find release libs
-#   set(Boost_USE_MULTITHREADED      ON)
-#   set(Boost_USE_STATIC_RUNTIME    OFF)
-#   find_package(Boost 1.66.0 COMPONENTS date_time filesystem system ...)
-#   if(Boost_FOUND)
-#     include_directories(${Boost_INCLUDE_DIRS})
-#     add_executable(foo foo.cc)
-#     target_link_libraries(foo ${Boost_LIBRARIES})
-#   endif()
-#
-# Boost CMake
-# ^^^^^^^^^^^
-#
-# If Boost was built using the boost-cmake project it provides a package
-# configuration file for use with find_package's Config mode.  This
-# module looks for the package configuration file called
-# BoostConfig.cmake or boost-config.cmake and stores the result in cache
-# entry "Boost_DIR".  If found, the package configuration file is loaded
-# and this module returns with no further action.  See documentation of
-# the Boost CMake package configuration for details on what it provides.
-#
-# Set Boost_NO_BOOST_CMAKE to ON to disable the search for boost-cmake.
+#[=======================================================================[.rst:
+FindBoost
+---------
+
+Find Boost include dirs and libraries
+
+Use this module by invoking find_package with the form::
+
+  find_package(Boost
+    [version] [EXACT]      # Minimum or EXACT version e.g. 1.67.0
+    [REQUIRED]             # Fail with error if Boost is not found
+    [COMPONENTS <libs>...] # Boost libraries by their canonical name
+                           # e.g. "date_time" for "libboost_date_time"
+    [OPTIONAL_COMPONENTS <libs>...]
+                           # Optional Boost libraries by their canonical name)
+    )                      # e.g. "date_time" for "libboost_date_time"
+
+This module finds headers and requested component libraries OR a CMake
+package configuration file provided by a "Boost CMake" build.  For the
+latter case skip to the "Boost CMake" section below.  For the former
+case results are reported in variables::
+
+  Boost_FOUND            - True if headers and requested libraries were found
+  Boost_INCLUDE_DIRS     - Boost include directories
+  Boost_LIBRARY_DIRS     - Link directories for Boost libraries
+  Boost_LIBRARIES        - Boost component libraries to be linked
+  Boost_<C>_FOUND        - True if component <C> was found (<C> is upper-case)
+  Boost_<C>_LIBRARY      - Libraries to link for component <C> (may include
+                           target_link_libraries debug/optimized keywords)
+  Boost_VERSION          - BOOST_VERSION value from boost/version.hpp
+  Boost_LIB_VERSION      - Version string appended to library filenames
+  Boost_MAJOR_VERSION    - Boost major version number (X in X.y.z)
+  Boost_MINOR_VERSION    - Boost minor version number (Y in x.Y.z)
+  Boost_SUBMINOR_VERSION - Boost subminor version number (Z in x.y.Z)
+  Boost_VERSION_STRING   - Boost version number in x.y.z format
+  Boost_LIB_DIAGNOSTIC_DEFINITIONS (Windows)
+                         - Pass to add_definitions() to have diagnostic
+                           information about Boost's automatic linking
+                           displayed during compilation
+
+Note that Boost Python components require a Python version suffix
+(Boost 1.67 and later), e.g. ``python36`` or ``python27`` for the
+versions built against Python 3.6 and 2.7, respectively.  This also
+applies to additional components using Python including
+``mpi_python`` and ``numpy``.  Earlier Boost releases may use
+distribution-specific suffixes such as ``2``, ``3`` or ``2.7``.
+These may also be used as suffixes, but note that they are not
+portable.
+
+This module reads hints about search locations from variables::
+
+  BOOST_ROOT             - Preferred installation prefix
+   (or BOOSTROOT)
+  BOOST_INCLUDEDIR       - Preferred include directory e.g. <prefix>/include
+  BOOST_LIBRARYDIR       - Preferred library directory e.g. <prefix>/lib
+  BOOST_PYTHON_SUFFIX    - Preferred Python version
+
+  Boost_NO_SYSTEM_PATHS  - Set to ON to disable searching in locations not
+                           specified by these hint variables. Default is OFF.
+  Boost_ADDITIONAL_VERSIONS
+                         - List of Boost versions not known to this module
+                           (Boost install locations may contain the version)
+
+and saves search results persistently in CMake cache entries::
+
+  Boost_INCLUDE_DIR         - Directory containing Boost headers
+  Boost_LIBRARY_DIR_RELEASE - Directory containing release Boost libraries
+  Boost_LIBRARY_DIR_DEBUG   - Directory containing debug Boost libraries
+  Boost_<C>_LIBRARY_DEBUG   - Component <C> library debug variant
+  Boost_<C>_LIBRARY_RELEASE - Component <C> library release variant
+
+The following :prop_tgt:`IMPORTED` targets are also defined::
+
+  Boost::boost                  - Target for header-only dependencies
+                                  (Boost include directory)
+  Boost::<C>                    - Target for specific component dependency
+                                  (shared or static library); <C> is lower-
+                                  case
+  Boost::diagnostic_definitions - interface target to enable diagnostic
+                                  information about Boost's automatic linking
+                                  during compilation (adds BOOST_LIB_DIAGNOSTIC)
+  Boost::disable_autolinking    - interface target to disable automatic
+                                  linking with MSVC (adds BOOST_ALL_NO_LIB)
+  Boost::dynamic_linking        - interface target to enable dynamic linking
+                                  linking with MSVC (adds BOOST_ALL_DYN_LINK)
+
+Implicit dependencies such as Boost::filesystem requiring
+Boost::system will be automatically detected and satisfied, even
+if system is not specified when using find_package and if
+Boost::system is not added to target_link_libraries.  If using
+Boost::thread, then Threads::Threads will also be added automatically.
+
+It is important to note that the imported targets behave differently
+than variables created by this module: multiple calls to
+find_package(Boost) in the same directory or sub-directories with
+different options (e.g. static or shared) will not override the
+values of the targets created by the first call.
+
+Users may set these hints or results as cache entries.  Projects
+should not read these entries directly but instead use the above
+result variables.  Note that some hint names start in upper-case
+"BOOST".  One may specify these as environment variables if they are
+not specified as CMake variables or cache entries.
+
+This module first searches for the Boost header files using the above
+hint variables (excluding BOOST_LIBRARYDIR) and saves the result in
+Boost_INCLUDE_DIR.  Then it searches for requested component libraries
+using the above hints (excluding BOOST_INCLUDEDIR and
+Boost_ADDITIONAL_VERSIONS), "lib" directories near Boost_INCLUDE_DIR,
+and the library name configuration settings below.  It saves the
+library directories in Boost_LIBRARY_DIR_DEBUG and
+Boost_LIBRARY_DIR_RELEASE and individual library
+locations in Boost_<C>_LIBRARY_DEBUG and Boost_<C>_LIBRARY_RELEASE.
+When one changes settings used by previous searches in the same build
+tree (excluding environment variables) this module discards previous
+search results affected by the changes and searches again.
+
+Boost libraries come in many variants encoded in their file name.
+Users or projects may tell this module which variant to find by
+setting variables::
+
+  Boost_USE_DEBUG_LIBS     - Set to ON or OFF to specify whether to search
+                             and use the debug libraries.  Default is ON.
+  Boost_USE_RELEASE_LIBS   - Set to ON or OFF to specify whether to search
+                             and use the release libraries.  Default is ON.
+  Boost_USE_MULTITHREADED  - Set to OFF to use the non-multithreaded
+                             libraries ('mt' tag).  Default is ON.
+  Boost_USE_STATIC_LIBS    - Set to ON to force the use of the static
+                             libraries.  Default is OFF.
+  Boost_USE_STATIC_RUNTIME - Set to ON or OFF to specify whether to use
+                             libraries linked statically to the C++ runtime
+                             ('s' tag).  Default is platform dependent.
+  Boost_USE_DEBUG_RUNTIME  - Set to ON or OFF to specify whether to use
+                             libraries linked to the MS debug C++ runtime
+                             ('g' tag).  Default is ON.
+  Boost_USE_DEBUG_PYTHON   - Set to ON to use libraries compiled with a
+                             debug Python build ('y' tag). Default is OFF.
+  Boost_USE_STLPORT        - Set to ON to use libraries compiled with
+                             STLPort ('p' tag).  Default is OFF.
+  Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS
+                           - Set to ON to use libraries compiled with
+                             STLPort deprecated "native iostreams"
+                             ('n' tag).  Default is OFF.
+  Boost_COMPILER           - Set to the compiler-specific library suffix
+                             (e.g. "-gcc43").  Default is auto-computed
+                             for the C++ compiler in use.  A list may be
+                             used if multiple compatible suffixes should
+                             be tested for, in decreasing order of
+                             preference.
+  Boost_ARCHITECTURE       - Set to the architecture-specific library suffix
+                             (e.g. "-x64").  Default is auto-computed for the
+                             C++ compiler in use.
+  Boost_THREADAPI          - Suffix for "thread" component library name,
+                             such as "pthread" or "win32".  Names with
+                             and without this suffix will both be tried.
+  Boost_NAMESPACE          - Alternate namespace used to build boost with
+                             e.g. if set to "myboost", will search for
+                             myboost_thread instead of boost_thread.
+
+Other variables one may set to control this module are::
+
+  Boost_DEBUG              - Set to ON to enable debug output from FindBoost.
+                             Please enable this before filing any bug report.
+  Boost_DETAILED_FAILURE_MSG
+                           - Set to ON to add detailed information to the
+                             failure message even when the REQUIRED option
+                             is not given to the find_package call.
+  Boost_REALPATH           - Set to ON to resolve symlinks for discovered
+                             libraries to assist with packaging.  For example,
+                             the "system" component library may be resolved to
+                             "/usr/lib/libboost_system.so.1.67.0" instead of
+                             "/usr/lib/libboost_system.so".  This does not
+                             affect linking and should not be enabled unless
+                             the user needs this information.
+  Boost_LIBRARY_DIR        - Default value for Boost_LIBRARY_DIR_RELEASE and
+                             Boost_LIBRARY_DIR_DEBUG.
+
+On Visual Studio and Borland compilers Boost headers request automatic
+linking to corresponding libraries.  This requires matching libraries
+to be linked explicitly or available in the link library search path.
+In this case setting Boost_USE_STATIC_LIBS to OFF may not achieve
+dynamic linking.  Boost automatic linking typically requests static
+libraries with a few exceptions (such as Boost.Python).  Use::
+
+  add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
+
+to ask Boost to report information about automatic linking requests.
+
+Example to find Boost headers only::
+
+  find_package(Boost 1.36.0)
+  if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS})
+    add_executable(foo foo.cc)
+  endif()
+
+Example to find Boost libraries and use imported targets::
+
+  find_package(Boost 1.56 REQUIRED COMPONENTS
+               date_time filesystem iostreams)
+  add_executable(foo foo.cc)
+  target_link_libraries(foo Boost::date_time Boost::filesystem
+                            Boost::iostreams)
+
+Example to find Boost Python 3.6 libraries and use imported targets::
+
+  find_package(Boost 1.67 REQUIRED COMPONENTS
+               python36 numpy36)
+  add_executable(foo foo.cc)
+  target_link_libraries(foo Boost::python36 Boost::numpy36)
+
+Example to find Boost headers and some *static* (release only) libraries::
+
+  set(Boost_USE_STATIC_LIBS        ON)  # only find static libs
+  set(Boost_USE_DEBUG_LIBS         OFF) # ignore debug libs and
+  set(Boost_USE_RELEASE_LIBS       ON)  # only find release libs
+  set(Boost_USE_MULTITHREADED      ON)
+  set(Boost_USE_STATIC_RUNTIME    OFF)
+  find_package(Boost 1.66.0 COMPONENTS date_time filesystem system ...)
+  if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS})
+    add_executable(foo foo.cc)
+    target_link_libraries(foo ${Boost_LIBRARIES})
+  endif()
+
+Boost CMake
+^^^^^^^^^^^
+
+If Boost was built using the boost-cmake project it provides a package
+configuration file for use with find_package's Config mode.  This
+module looks for the package configuration file called
+BoostConfig.cmake or boost-config.cmake and stores the result in cache
+entry "Boost_DIR".  If found, the package configuration file is loaded
+and this module returns with no further action.  See documentation of
+the Boost CMake package configuration for details on what it provides.
+
+Set Boost_NO_BOOST_CMAKE to ON to disable the search for boost-cmake.
+#]=======================================================================]
 
 # Save project's policies
 cmake_policy(PUSH)
 cmake_policy(SET CMP0057 NEW) # if IN_LIST
+
+# https://gitlab.kitware.com/cmake/cmake/issues/18865
+set(Boost_NO_BOOST_CMAKE ON CACHE BOOL "Disable the search for boost-cmake")
 
 #-------------------------------------------------------------------------------
 # Before we go searching, check whether boost-cmake is available, unless the
@@ -464,8 +471,17 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
   elseif (GHSMULTI)
     set(_boost_COMPILER "-ghs")
   elseif("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
-    if(MSVC_TOOLSET_VERSION GREATER_EQUAL 141)
-      set(_boost_COMPILER "-vc141;-vc140")
+    if(MSVC_TOOLSET_VERSION GREATER_EQUAL 150)
+      # Not yet known.
+      set(_boost_COMPILER "")
+    elseif(MSVC_TOOLSET_VERSION GREATER_EQUAL 140)
+      # MSVC toolset 14.x versions are forward compatible.
+      set(_boost_COMPILER "")
+      foreach(v 9 8 7 6 5 4 3 2 1 0)
+        if(MSVC_TOOLSET_VERSION GREATER_EQUAL 14${v})
+          list(APPEND _boost_COMPILER "-vc14${v}")
+        endif()
+      endforeach()
     elseif(MSVC_TOOLSET_VERSION GREATER_EQUAL 80)
       set(_boost_COMPILER "-vc${MSVC_TOOLSET_VERSION}")
     elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.10)
@@ -860,8 +876,22 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+  elseif(NOT Boost_VERSION VERSION_LESS 106900 AND Boost_VERSION VERSION_LESS 107000)
+    set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
+    set(_Boost_COROUTINE_DEPENDENCIES context)
+    set(_Boost_FIBER_DEPENDENCIES context)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+    set(_Boost_THREAD_DEPENDENCIES chrono date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono system)
+    set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
   else()
-    if(NOT Boost_VERSION VERSION_LESS 106900)
+    if(NOT Boost_VERSION VERSION_LESS 107000)
       set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
       set(_Boost_COROUTINE_DEPENDENCIES context)
       set(_Boost_FIBER_DEPENDENCIES context)
@@ -876,7 +906,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
       set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
       set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
     endif()
-    if(NOT Boost_VERSION VERSION_LESS 107000)
+    if(NOT Boost_VERSION VERSION_LESS 107100)
       message(WARNING "New Boost version may have incorrect or missing dependencies and imported targets")
     endif()
   endif()
@@ -1023,11 +1053,17 @@ endfunction()
 # Some boost libraries may require particular set of compler features.
 # The very first one was `boost::fiber` introduced in Boost 1.62.
 # One can check required compiler features of it in
-# `${Boost_ROOT}/libs/fiber/build/Jamfile.v2`.
+# - `${Boost_ROOT}/libs/fiber/build/Jamfile.v2`;
+# - `${Boost_ROOT}/libs/context/build/Jamfile.v2`.
+#
+# TODO (Re)Check compiler features on (every?) release ???
+# One may use the following command to get the files to check:
+#
+#   $ find . -name Jamfile.v2 | grep build | xargs grep -l cxx1
 #
 function(_Boost_COMPILER_FEATURES component _ret)
-  # Boost >= 1.62 and < 1.67
-  if(NOT Boost_VERSION VERSION_LESS 106200 AND Boost_VERSION VERSION_LESS 106700)
+  # Boost >= 1.62
+  if(NOT Boost_VERSION VERSION_LESS 106200)
     set(_Boost_FIBER_COMPILER_FEATURES
         cxx_alias_templates
         cxx_auto_type
@@ -1041,7 +1077,19 @@ function(_Boost_COMPILER_FEATURES component _ret)
         cxx_thread_local
         cxx_variadic_templates
     )
+    # Compiler feature for `context` same as for `fiber`.
+    set(_Boost_CONTEXT_COMPILER_FEATURES ${_Boost_FIBER_COMPILER_FEATURES})
   endif()
+
+  # Boost Contract library available in >= 1.67
+  if(NOT Boost_VERSION_STRING VERSION_LESS 1.67.0)
+    # From `libs/contract/build/boost_contract_build.jam`
+    set(_Boost_CONTRACT_COMPILER_FEATURES
+        cxx_lambdas
+        cxx_variadic_templates
+    )
+  endif()
+
   string(TOUPPER ${component} uppercomponent)
   set(${_ret} ${_Boost_${uppercomponent}_COMPILER_FEATURES} PARENT_SCOPE)
 endfunction()
@@ -1061,9 +1109,15 @@ function(_Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS component
     else()
       set(_arch_suffix 32)
     endif()
-    if(MSVC_TOOLSET_VERSION GREATER_EQUAL 141)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.1)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.0)
+    if(MSVC_TOOLSET_VERSION GREATER_EQUAL 150)
+      # Not yet known.
+    elseif(MSVC_TOOLSET_VERSION GREATER_EQUAL 140)
+      # MSVC toolset 14.x versions are forward compatible.
+      foreach(v 9 8 7 6 5 4 3 2 1 0)
+        if(MSVC_TOOLSET_VERSION GREATER_EQUAL 14${v})
+          list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.${v})
+        endif()
+      endforeach()
     elseif(MSVC_TOOLSET_VERSION GREATER_EQUAL 80)
       math(EXPR _toolset_major_version "${MSVC_TOOLSET_VERSION} / 10")
       list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-${_toolset_major_version}.0)
@@ -1124,7 +1178,7 @@ else()
   # _Boost_COMPONENT_HEADERS.  See the instructions at the top of
   # _Boost_COMPONENT_DEPENDENCIES.
   set(_Boost_KNOWN_VERSIONS ${Boost_ADDITIONAL_VERSIONS}
-    "1.69.0" "1.69"
+    "1.70.0" "1.70" "1.69.0" "1.69"
     "1.68.0" "1.68" "1.67.0" "1.67" "1.66.0" "1.66" "1.65.1" "1.65.0" "1.65"
     "1.64.0" "1.64" "1.63.0" "1.63" "1.62.0" "1.62" "1.61.0" "1.61" "1.60.0" "1.60"
     "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55"
@@ -1282,7 +1336,7 @@ if(NOT Boost_INCLUDE_DIR)
     list(APPEND _boost_INCLUDE_SEARCH_DIRS NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
   else()
     if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
-      foreach(ver ${_Boost_KNOWN_VERSIONS})
+      foreach(ver ${_boost_TEST_VERSIONS})
         string(REPLACE "." "_" ver "${ver}")
         list(APPEND _boost_INCLUDE_SEARCH_DIRS PATHS "C:/local/boost_${ver}")
       endforeach()
@@ -1367,6 +1421,7 @@ if(Boost_INCLUDE_DIR)
   math(EXPR Boost_MAJOR_VERSION "${Boost_VERSION} / 100000")
   math(EXPR Boost_MINOR_VERSION "${Boost_VERSION} / 100 % 1000")
   math(EXPR Boost_SUBMINOR_VERSION "${Boost_VERSION} % 100")
+  set(Boost_VERSION_STRING "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
 
   string(APPEND Boost_ERROR_REASON
     "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}\nBoost include path: ${Boost_INCLUDE_DIR}")
@@ -1424,6 +1479,13 @@ endif()
 
 if ( NOT Boost_NAMESPACE )
   set(Boost_NAMESPACE "boost")
+endif()
+
+if(Boost_DEBUG)
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "Boost_LIB_PREFIX = ${Boost_LIB_PREFIX}")
+  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
+    "Boost_NAMESPACE = ${Boost_NAMESPACE}")
 endif()
 
 # ------------------------------------------------------------------------
@@ -1601,7 +1663,7 @@ foreach(c DEBUG RELEASE)
     if( Boost_NO_SYSTEM_PATHS )
       list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
     else()
-      foreach(ver ${_Boost_KNOWN_VERSIONS})
+      foreach(ver ${_boost_TEST_VERSIONS})
         string(REPLACE "." "_" ver "${ver}")
         _Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} "C:/local/boost_${ver}")
       endforeach()
@@ -1715,10 +1777,10 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
   # Handle Python version suffixes
   unset(COMPONENT_PYTHON_VERSION_MAJOR)
   unset(COMPONENT_PYTHON_VERSION_MINOR)
-  if(${COMPONENT} MATCHES "^(python|mpi_python|numpy)([0-9])\$")
+  if(${COMPONENT}${BOOST_PYTHON_SUFFIX} MATCHES "^(python|mpi_python|numpy)([0-9])\$")
     set(COMPONENT_UNVERSIONED "${CMAKE_MATCH_1}")
     set(COMPONENT_PYTHON_VERSION_MAJOR "${CMAKE_MATCH_2}")
-  elseif(${COMPONENT} MATCHES "^(python|mpi_python|numpy)([0-9])\\.?([0-9])\$")
+  elseif(${COMPONENT}${BOOST_PYTHON_SUFFIX} MATCHES "^(python|mpi_python|numpy)([0-9])\\.?([0-9])\$")
     set(COMPONENT_UNVERSIONED "${CMAKE_MATCH_1}")
     set(COMPONENT_PYTHON_VERSION_MAJOR "${CMAKE_MATCH_2}")
     set(COMPONENT_PYTHON_VERSION_MINOR "${CMAKE_MATCH_3}")
@@ -1732,7 +1794,7 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
     list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}${COMPONENT_PYTHON_VERSION_MAJOR}-py${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
     list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-py${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
     # Gentoo
-    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
+    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-${COMPONENT_PYTHON_VERSION_MAJOR}.${COMPONENT_PYTHON_VERSION_MINOR}")
     # RPMs
     list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
   endif()
@@ -1783,10 +1845,12 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
     foreach(compiler IN LISTS _boost_COMPILER)
       list(APPEND _boost_RELEASE_NAMES
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG} )
     endforeach()
     list(APPEND _boost_RELEASE_NAMES
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component} )
@@ -1795,10 +1859,12 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
       foreach(compiler IN LISTS _boost_COMPILER)
         list(APPEND _boost_RELEASE_NAMES
           ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+          ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}
           ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG} )
       endforeach()
       list(APPEND _boost_RELEASE_NAMES
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG} )
     endif()
   endforeach()
@@ -1836,10 +1902,12 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
     foreach(compiler IN LISTS _boost_COMPILER)
       list(APPEND _boost_DEBUG_NAMES
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG} )
     endforeach()
     list(APPEND _boost_DEBUG_NAMES
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component} )
@@ -1848,10 +1916,12 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
       foreach(compiler IN LISTS _boost_COMPILER)
         list(APPEND _boost_DEBUG_NAMES
           ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+          ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}
           ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG} )
       endforeach()
       list(APPEND _boost_DEBUG_NAMES
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG} )
     endif()
   endforeach()


### PR DESCRIPTION
FreeBSD is moving to Boost 1.70
we should allow user to use boost 1.70.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug