### PR TITLE
common: use of malloc.h is deprecated

### DIFF
--- a/src/common/allocator.h
+++ b/src/common/allocator.h
@@ -4,10 +4,13 @@
 #ifndef CEPH_COMMON_ALLOCATOR_H
 #define CEPH_COMMON_ALLOCATOR_H
 
-#include <malloc.h>
-#include <memory>
-#include <new>
 #include "acconfig.h"
+
+#ifdef LIBTCMALLOC_MISSING_ALIGNED_ALLOC
+#include <malloc.h>
+#include <new>
+#endif
+#include <memory>
 
 namespace ceph {
 


### PR DESCRIPTION
And the file no longer exests on FreeBSD.
Usage is only advised for the non-posix parts that are declared
in the Linux variant

Without this, compilation will crash


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug