### PR TITLE
cmake: some executables need to link agains rados_test_stub

### DIFF
--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -39,3 +39,6 @@ add_executable(unittest_mon_montypes
   )
 add_ceph_unittest(unittest_mon_montypes)
 target_link_libraries(unittest_mon_montypes mon global)
+if(FREEBSD)
+  target_link_libraries(unittest_mon_montypes rados_test_stub)
+endif()

--- a/src/tools/immutable_object_cache/CMakeLists.txt
+++ b/src/tools/immutable_object_cache/CMakeLists.txt
@@ -16,4 +16,7 @@ target_link_libraries(ceph-immutable-object-cache
   librados
   StdFilesystem::filesystem
   global)
+if(FREEBSD)
+  target_link_libraries(ceph-immutable-object-cache rados_test_stub)
+endif()
 install(TARGETS ceph-immutable-object-cache DESTINATION bin)


### PR DESCRIPTION
Otherwise Clang/LLVM linker will complain about missing exactly those
functions that are flattened in rados_test_stub




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug