### PR TITLE
rgw: Fix expiration header does not return the earliest rule

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1626,22 +1626,21 @@ std::string s3_expiration_header(
       rule_expiration_date =
 	boost::optional<ceph::real_time>(
 	  ceph::from_iso_8601(rule.get_expiration().get_date()));
-      rule_id = boost::optional<std::string>(id);
     } else {
       if (rule_expiration.has_days()) {
 	rule_expiration_date =
 	  boost::optional<ceph::real_time>(
 	    mtime + make_timespan(rule_expiration.get_days()*24*60*60));
-	rule_id = boost::optional<std::string>(id);
       }
     }
 
     // update earliest expiration
     if (rule_expiration_date) {
       if ((! expiration_date) ||
-	  (*expiration_date < *rule_expiration_date)) {
+	  (*expiration_date > *rule_expiration_date)) {
       expiration_date =
 	boost::optional<ceph::real_time>(rule_expiration_date);
+      rule_id = boost::optional<std::string>(id);
       }
     }
   }


### PR DESCRIPTION
Fix s3 lifecycle expiration header does not return the earliest rule that will be applied

Fixes: https://tracker.ceph.com/issues/41010
Signed-off-by: Or Friedmann <ofriedma@redhat.com>
