### PR TITLE
os/bluestore, common: make bluefs_alloc_size default to bluestore_min_alloc_size

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -652,6 +652,7 @@ function run_osd() {
     ceph_args+=" --pid-file=$dir/\$name.pid"
     ceph_args+=" --osd-max-object-name-len=460"
     ceph_args+=" --osd-max-object-namespace-len=64"
+    ceph_args+=" --bluefs-alloc-size=1048576"
     ceph_args+=" --enable-experimental-unrecoverable-data-corrupting-features=*"
     ceph_args+=" "
     ceph_args+="$@"

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4251,8 +4251,8 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluefs_alloc_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
-    .set_default(1_M)
-    .set_description(""),
+    .set_default(0)
+    .set_description("Defaults to bluestore_min_alloc_size, if this value is set to 0"),
 
     Option("bluefs_max_prefetch", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(1_M)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -42,21 +42,9 @@ static void slow_discard_cb(void *priv, void* priv2) {
   bluefs->handle_discard(BlueFS::BDEV_SLOW, *tmp);
 }
 
-BlueFS::BlueFS(CephContext* cct)
-  : cct(cct),
-    bluefs_alloc_size(_default_bluefs_alloc_size()),
-    bdev(MAX_BDEV),
-    ioc(MAX_BDEV),
-    block_all(MAX_BDEV)
-{
-  discard_cb[BDEV_WAL] = wal_discard_cb;
-  discard_cb[BDEV_DB] = db_discard_cb;
-  discard_cb[BDEV_SLOW] = slow_discard_cb;
-}
-
 BlueFS::BlueFS(CephContext* cct, uint64_t bluestore_min_alloc_size)
   : cct(cct),
-    bluefs_alloc_size(bluestore_min_alloc_size),
+    bluefs_alloc_size(_default_bluefs_alloc_size(bluestore_min_alloc_size)),
     bdev(MAX_BDEV),
     ioc(MAX_BDEV),
     block_all(MAX_BDEV)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -441,6 +441,7 @@ void BlueFS::_init_alloc()
       continue;
     }
     ceph_assert(bdev[id]->get_size());
+    ceph_assert(bluefs_alloc_size != 0);
     alloc[id] = Allocator::create(cct, cct->_conf->bluefs_allocator,
 				  bdev[id]->get_size(),
 				  bluefs_alloc_size);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -341,10 +341,13 @@ private:
 			  uint64_t jump_to = 0);
   uint64_t _estimate_log_size();
   bool _should_compact_log();
-  uint64_t _default_bluefs_alloc_size() {
-    if (cct->_conf->bluefs_alloc_size > 0)
+  uint64_t _default_bluefs_alloc_size(uint64_t bluestore_min_alloc_size) {
+    if (cct->_conf->bluefs_alloc_size > 0) {
+      if (bluestore_min_alloc_size > 0)
+        ceph_assert(cct->_conf->bluefs_alloc_size % bluestore_min_alloc_size == 0);
       return cct->_conf->bluefs_alloc_size;
-    return 1024 * 1024U;
+    }
+    return bluestore_min_alloc_size;
   }
 
   enum {
@@ -407,7 +410,6 @@ private:
   void _add_block_extent(unsigned bdev, uint64_t offset, uint64_t len);
 
 public:
-  BlueFS(CephContext* cct);
   BlueFS(CephContext* cct, uint64_t bluestore_min_alloc_size);
   ~BlueFS();
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5129,10 +5129,7 @@ bool BlueStore::test_mount_in_use()
 int BlueStore::_minimal_open_bluefs(bool create)
 {
   int r;
-  if (cct->_conf->bluefs_alloc_size > 0)
-    bluefs = new BlueFS(cct);
-  else
-    bluefs = new BlueFS(cct, min_alloc_size); // using bluestore min_alloc_size
+  bluefs = new BlueFS(cct, min_alloc_size); // using bluestore min_alloc_size
 
   string bfn;
   struct stat st;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5206,8 +5206,8 @@ int BlueStore::_minimal_open_bluefs(bool create)
     uint64_t start = p2align((bdev->get_size() - initial) / 2,
 			      bluefs_alloc_size);
     //avoiding superblock overwrite
-    ceph_assert(bluefs_alloc_size >= _get_ondisk_reserved());
     start = std::max(bluefs_alloc_size, start);
+    ceph_assert(start >=_get_ondisk_reserved());
 
     bluefs->add_block_extent(bluefs_shared_bdev, start, initial);
     bluefs_extents.insert(start, initial);

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -173,7 +173,7 @@ BlueFS *open_bluefs(
   const vector<string>& devs)
 {
   validate_path(cct, path, true);
-  BlueFS *fs = new BlueFS(cct);
+  BlueFS *fs = new BlueFS(cct, 0);
 
   add_devices(fs, cct, devs);
 

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -173,7 +173,8 @@ BlueFS *open_bluefs(
   const vector<string>& devs)
 {
   validate_path(cct, path, true);
-  BlueFS *fs = new BlueFS(cct, 0);
+  uint64_t alloc_size = 0;
+  BlueFS *fs = new BlueFS(cct, alloc_size);
 
   add_devices(fs, cct, devs);
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -6925,7 +6925,7 @@ TEST_P(StoreTestSpecificAUSize, ExcessiveFragmentation) {
     stringify((uint64_t)2048 * 1024 * 1024).c_str());
 
   ASSERT_EQ(g_conf().get_val<Option::size_t>("bluefs_alloc_size"),
-	    1024 * 1024U);
+	    0);
 
   size_t block_size = 0x10000;
   StartDeferred(block_size);

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -49,7 +49,7 @@ TEST(BlueFS, mkfs) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   uuid_d fsid;
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   ASSERT_EQ(0, fs.mkfs(fsid));
@@ -59,7 +59,7 @@ TEST(BlueFS, mkfs) {
 TEST(BlueFS, mkfs_mount) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -74,7 +74,7 @@ TEST(BlueFS, mkfs_mount) {
 TEST(BlueFS, write_read) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -106,7 +106,7 @@ TEST(BlueFS, write_read) {
 TEST(BlueFS, small_appends) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -139,7 +139,7 @@ TEST(BlueFS, very_large_write) {
   // we'll write a ~3G file, so allocate more than that for the whole fs
   uint64_t size = 1048576 * 1024 * 8ull;
   string fn = get_temp_bdev(size);
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
 
   bool old = g_ceph_context->_conf.get_val<bool>("bluefs_buffered_io");
   g_ceph_context->_conf.set_val("bluefs_buffered_io", "false");
@@ -307,7 +307,7 @@ TEST(BlueFS, test_flush_1) {
     "65536");
   g_ceph_context->_conf.apply_changes(nullptr);
 
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -342,7 +342,7 @@ TEST(BlueFS, test_flush_2) {
     "65536");
   g_ceph_context->_conf.apply_changes(nullptr);
 
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -370,7 +370,7 @@ TEST(BlueFS, test_flush_3) {
     "65536");
   g_ceph_context->_conf.apply_changes(nullptr);
 
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -404,7 +404,7 @@ TEST(BlueFS, test_simple_compaction_sync) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
 
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -457,7 +457,7 @@ TEST(BlueFS, test_simple_compaction_async) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
 
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -513,7 +513,7 @@ TEST(BlueFS, test_compaction_sync) {
     "bluefs_compact_log_sync",
     "true");
 
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -551,7 +551,7 @@ TEST(BlueFS, test_compaction_async) {
     "bluefs_compact_log_sync",
     "false");
 
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -589,7 +589,7 @@ TEST(BlueFS, test_replay) {
     "bluefs_compact_log_sync",
     "false");
 
-  BlueFS fs(g_ceph_context);
+  BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -49,6 +49,10 @@ TEST(BlueFS, mkfs) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   uuid_d fsid;
+  g_ceph_context->_conf.set_val(
+    "bluefs_alloc_size",
+    "1048576");
+  g_ceph_context->_conf.apply_changes(nullptr);
   BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
@@ -59,6 +63,10 @@ TEST(BlueFS, mkfs) {
 TEST(BlueFS, mkfs_mount) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
+  g_ceph_context->_conf.set_val(
+    "bluefs_alloc_size",
+    "1048576");
+  g_ceph_context->_conf.apply_changes(nullptr);
   BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
@@ -74,6 +82,10 @@ TEST(BlueFS, mkfs_mount) {
 TEST(BlueFS, write_read) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
+  g_ceph_context->_conf.set_val(
+    "bluefs_alloc_size",
+    "1048576");
+  g_ceph_context->_conf.apply_changes(nullptr);
   BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
@@ -106,6 +118,10 @@ TEST(BlueFS, write_read) {
 TEST(BlueFS, small_appends) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
+  g_ceph_context->_conf.set_val(
+    "bluefs_alloc_size",
+    "1048576");
+  g_ceph_context->_conf.apply_changes(nullptr);
   BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
@@ -139,6 +155,10 @@ TEST(BlueFS, very_large_write) {
   // we'll write a ~3G file, so allocate more than that for the whole fs
   uint64_t size = 1048576 * 1024 * 8ull;
   string fn = get_temp_bdev(size);
+  g_ceph_context->_conf.set_val(
+    "bluefs_alloc_size",
+    "1048576");
+  g_ceph_context->_conf.apply_changes(nullptr);
   BlueFS fs(g_ceph_context, 0);
 
   bool old = g_ceph_context->_conf.get_val<bool>("bluefs_buffered_io");
@@ -403,6 +423,10 @@ TEST(BlueFS, test_simple_compaction_sync) {
     "true");
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
+  g_ceph_context->_conf.set_val(
+    "bluefs_alloc_size",
+    "1048576");
+  g_ceph_context->_conf.apply_changes(nullptr);
 
   BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));
@@ -456,6 +480,10 @@ TEST(BlueFS, test_simple_compaction_async) {
     "false");
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
+  g_ceph_context->_conf.set_val(
+    "bluefs_alloc_size",
+    "1048576");
+  g_ceph_context->_conf.apply_changes(nullptr);
 
   BlueFS fs(g_ceph_context, 0);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn, false));


### PR DESCRIPTION


Fixes: https://tracker.ceph.com/issues/41014
Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

