### PR TITLE
qa/tests: added rgw into upgrade sequence to improve coverage

### DIFF
--- a/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
@@ -44,6 +44,9 @@ tasks:
     mon.b:
     mon.c:
 - print: "**** done install.upgrade non-client hosts"
+- rgw:
+   - client.1
+- print: "**** done => started rgw client.1"
 - parallel:
     - workload
     - upgrade-sequence

--- a/qa/suites/upgrade/mimic-x/parallel/2-workload/rgw_ragweed_prepare.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/2-workload/rgw_ragweed_prepare.yaml
@@ -4,8 +4,6 @@ meta:
 workload:
   full_sequential:
   - sequential:
-    - rgw:
-      - client.1
     - ragweed:
         client.1:
           default-branch: ceph-master

--- a/qa/suites/upgrade/mimic-x/parallel/3-upgrade-sequence/upgrade-all.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/3-upgrade-sequence/upgrade-all.yaml
@@ -16,7 +16,7 @@ upgrade-sequence:
        wait-for-healthy: false
        wait-for-osds-up: true
    - ceph.restart:
-       daemons: [mds.a, mds.b]
+       daemons: [mds.a, mds.b,rgw.*]
        wait-for-healthy: false
        wait-for-osds-up: true
    - print: "**** done ceph.restart all"

--- a/qa/suites/upgrade/mimic-x/parallel/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
@@ -2,8 +2,14 @@ meta:
 - desc: |
    upgrade the ceph cluster,
    upgrate in two steps
-   step one ordering: mon.a, osd.0, osd.1, mds.a
-   step two ordering: mon.b, mon.c, osd.2, osd.3
+   step one ordering: mon.a
+   step two ordering: mon.b,mgr.x
+   step three ordering: mon.c
+   step four ordering: osd.0, osd.1
+   step five ordering: mds.a, msd.b
+   step six ordering: osd.4, osd.5
+   step seven ordering: osd.2, osd.3
+   step eight ordering: rgw.*
    ceph expected to be healthy state after each step
 upgrade-sequence:
    sequential:
@@ -13,7 +19,7 @@ upgrade-sequence:
    - sleep:
        duration: 60
    - ceph.restart:
-       daemons: [mon.b, mgr.x]
+       daemons: [mon.b, mgr.x,rgw.*]
        wait-for-healthy: true
        mon-health-to-clog: false
    - sleep:
@@ -49,3 +55,10 @@ upgrade-sequence:
        wait-for-osds-up: true
    - sleep:
        duration: 60
+   - ceph.restart:
+       daemons: [rgw.*]
+       wait-for-healthy: false
+       wait-for-osds-up: true
+   - sleep:
+       duration: 60
+

--- a/qa/suites/upgrade/mimic-x/parallel/5-final-workload/rgw.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/5-final-workload/rgw.yaml
@@ -3,6 +3,5 @@ overrides:
     frontend: civetweb
 tasks:
   - sequential:
-    - rgw: [client.1]
-    - print: "**** done rgw 4-final-workload"
     - rgw-final-workload
+    - print: "**** done rgw 4-final-workload"

--- a/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
@@ -21,6 +21,9 @@ tasks:
       - ceph osd require-osd-release mimic
       - ceph osd set-require-min-compat-client mimic
 - print: "**** done ceph"
+- rgw:
+   - client.0
+- print: "**** done => started rgw client.0"
 overrides:
   ceph:
     conf:

--- a/qa/suites/upgrade/mimic-x/stress-split/4-workload/rgw_ragweed_prepare.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/4-workload/rgw_ragweed_prepare.yaml
@@ -4,8 +4,6 @@ meta:
 stress-tasks:
   - full_sequential:
      - sequential:
-       - rgw:
-         - client.0
        - ragweed:
            client.0:
              default-branch: ceph-nautilus

--- a/qa/suites/upgrade/mimic-x/stress-split/5-finish-upgrade.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/5-finish-upgrade.yaml
@@ -3,12 +3,13 @@ tasks:
     osd.8:
     client.0:
 - ceph.restart:
-    daemons: [osd.8, osd.9, osd.10, osd.11]
+    daemons: [osd.8, osd.9, osd.10, osd.11,rgw.*]
     wait-for-healthy: false
     wait-for-osds-up: true
+- print: "**** done restarted/upgraded => osd.8, osd.9, osd.10, osd.11, rgw.*"
 - exec:
     osd.0:
       - ceph osd set pglog_hardlimit
       - ceph osd dump --format=json-pretty | grep "flags"
-- print: "**** try to set pglog_hardlimit again, should succeed"
+- print: "**** done try to set pglog_hardlimit again, should succeed"
 

--- a/qa/suites/upgrade/mimic-x/stress-split/7-final-workload/rgw-swift-ragweed_check.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/7-final-workload/rgw-swift-ragweed_check.yaml
@@ -3,9 +3,6 @@ meta:
    swift api tests for rgw
    rgw ragweed check after upgrade
 tasks:
-- rgw:
-    client.0:
-- print: "**** done rgw 7-workload"
 - swift:
     client.0:
       rgw_server: client.0


### PR DESCRIPTION
added rgw into upgrade sequence to improve coverage - splits
See https://github.com/ceph/ceph/pull/29234 https://github.com/ceph/ceph/pull/29282

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

