### PR TITLE
mds: fix InoTable::force_consume_to()

### DIFF
--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -226,15 +226,10 @@ bool InoTable::repair(inodeno_t id)
 
 bool InoTable::force_consume_to(inodeno_t ino)
 {
-  auto it = free.begin();
-  if (it != free.end() && it.get_start() <= ino) {
-    inodeno_t min = it.get_start();
-    derr << "erasing " << min << " to " << ino << dendl;
-    free.erase(min, ino - min + 1);
-    projected_free = free;
-    projected_version = ++version;
-    return true;
-  } else {
+  inodeno_t first = free.range_start();
+  if (first > ino)
     return false;
-  }
+
+  skip_inos(inodeno_t(ino + 1 - first));
+  return true;
 }


### PR DESCRIPTION
original code assumes free inode numbers are contiguous

Fixes: https://tracker.ceph.com/issues/41006
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

