### PR TITLE
OSD: modify n.cookie to op.notify.cookie

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6221,7 +6221,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	notify_info_t n;
 	n.timeout = timeout;
 	n.notify_id = osd->get_next_id(get_osdmap_epoch());
-	n.cookie = op.watch.cookie;
+	n.cookie = op.notify.cookie;
         n.bl = bl;
 	ctx->notifies.push_back(n);
 


### PR DESCRIPTION
In the condition of "CEPH_OSD_OP_NOTIFY", "n.cookie"should be "op.notify.cookie"  instead of "op.watch.cookie",  it's easier to be understood.