### PR TITLE
mgr/dashboard: Fixes 'defaultBuilder' is not a function

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
@@ -76,7 +76,7 @@ export class TaskListService implements OnDestroy {
   }
 
   private addMissing(data: any[], tasks: ExecutingTask[]) {
-    const defaultBuilder = this.builders['default'] || {};
+    const defaultBuilder = this.builders['default'];
     tasks.forEach((task) => {
       const existing = data.find((item) => this.itemFilter(item, task));
       const builder = this.builders[task.name];


### PR DESCRIPTION
This PR fixes the following error that sometimes pops up on my browser console:

![Screenshot from 2019-07-30 14-33-35](https://user-images.githubusercontent.com/14297426/62201932-3f423480-b380-11e9-86a8-29349251d1af.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>
