### PR TITLE
mgr/dashboard: progress: support rbd_support module async tasks

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -63,6 +63,8 @@ export class RbdListComponent implements OnInit {
   builders = {
     'rbd/create': (metadata) =>
       this.createRbdFromTask(metadata['pool_name'], metadata['image_name']),
+    'rbd/delete': (metadata) =>
+      this.createRbdFromTask(metadata['pool_name'], metadata['image_name']),
     'rbd/clone': (metadata) =>
       this.createRbdFromTask(metadata['child_pool_name'], metadata['child_image_name']),
     'rbd/copy': (metadata) =>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -204,7 +204,7 @@ export class PoolListComponent implements OnInit {
       },
       (task) => task.name.startsWith(`${BASE_URL}/`),
       (pool, task) => task.metadata['pool_name'] === pool.pool_name,
-      { default: (task: ExecutingTask) => new Pool(task.metadata['pool_name']) }
+      { default: (metadata: any) => new Pool(metadata['pool_name']) }
     );
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
@@ -57,7 +57,7 @@ describe('TaskListService', () => {
       (task) => task.name.startsWith('test'),
       (item, task) => item.name === task.metadata['name'],
       {
-        default: (task) => ({ name: task.metadata['name'] })
+        default: (metadata) => ({ name: metadata['name'] })
       }
     );
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
@@ -81,7 +81,7 @@ export class TaskListService implements OnDestroy {
       const existing = data.find((item) => this.itemFilter(item, task));
       const builder = this.builders[task.name];
       if (!existing && (builder || defaultBuilder)) {
-        data.push(builder ? builder(task.metadata) : defaultBuilder(task));
+        data.push(builder ? builder(task.metadata) : defaultBuilder(task.metadata));
       }
     });
   }

--- a/src/pybind/mgr/dashboard/services/progress.py
+++ b/src/pybind/mgr/dashboard/services/progress.py
@@ -14,6 +14,56 @@ from datetime import datetime
 from .. import mgr, logger
 
 
+def _progress_event_to_dashboard_task_common(event, task):
+    if event['refs'] and isinstance(event['refs'], dict):
+        refs = event['refs']
+        if refs['origin'] == "rbd_support":
+            # rbd mgr module event, we can transform this event into an rbd dashboard task
+            action_map = {
+                'remove': "delete",
+                'flatten': "flatten",
+                'trash remove': "trash/remove"
+            }
+            action = action_map.get(refs['action'], refs['action'])
+            task.update({
+                'name': "rbd/{}".format(action),
+                'metadata': refs,
+                'begin_time': "{}Z".format(datetime.fromtimestamp(event["started_at"])
+                                           .isoformat()),
+            })
+            return
+
+    task.update({
+        # we're prepending the "progress/" prefix to tag tasks that come
+        # from the progress module
+        'name': "progress/{}".format(event['message']),
+        'metadata': dict(event.get('refs', {})),
+        'begin_time': "{}Z".format(datetime.fromtimestamp(event["started_at"])
+                                   .isoformat()),
+    })
+
+
+
+def _progress_event_to_dashboard_task(event, completed=False):
+    task = {}
+    _progress_event_to_dashboard_task_common(event, task)
+    if not completed:
+        task.update({
+            'progress': int(100 * event['progress'])
+        })
+    else:
+        task.update({
+            'end_time': "{}Z".format(datetime.fromtimestamp(event['finished_at'])
+                                     .isoformat()),
+            'duration': event['finished_at'] - event['started_at'],
+            'progress': 100,
+            'success': 'failed' not in event,
+            'ret_value': None,
+            'exception': {'detail': event['failure_message']} if 'failed' in event else None
+        })
+    return task
+
+
 def get_progress_tasks():
     executing_t = []
     finished_t = []
@@ -21,30 +71,10 @@ def get_progress_tasks():
 
     for ev in progress_events['events']:
         logger.debug("[Progress] event=%s", ev)
-        executing_t.append({
-            # we're prepending the "progress/" prefix to tag tasks that come
-            # from the progress module
-            'name': "progress/{}".format(ev['message']),
-            'metadata': dict(ev['refs']),
-            'begin_time': "{}Z".format(datetime.fromtimestamp(ev["started_at"])
-                                       .isoformat()),
-            'progress': int(100 * ev['progress'])
-        })
+        executing_t.append(_progress_event_to_dashboard_task(ev))
 
     for ev in progress_events['completed']:
         logger.debug("[Progress] finished event=%s", ev)
-        finished_t.append({
-            'name': "progress/{}".format(ev['message']),
-            'metadata': dict(ev['refs']),
-            'begin_time': "{}Z".format(datetime.fromtimestamp(ev["started_at"])
-                                       .isoformat()),
-            'end_time': "{}Z".format(datetime.fromtimestamp(ev['finished_at'])
-                                     .isoformat()),
-            'duration': ev['finished_at'] - ev['started_at'],
-            'progress': 100,
-            'success': True,
-            'ret_value': None,
-            'exception': None
-        })
+        finished_t.append(_progress_event_to_dashboard_task(ev, True))
 
     return executing_t, finished_t


### PR DESCRIPTION
This PR adds the support for rbd_support module async tasks by showing those tasks events (from the progress module) as dashboard rbd tasks.

In practice, when the user deletes an RBD image from the CLI using the async task from the rbd_support module, the dashboard frontend automatically shows that operation and it's progress in the rbd list page.

Signed-off-by: Ricardo Dias <rdias@suse.com>
