### PR TITLE
mgr/dashboard: Logs Page E2E Tests

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.po.ts
@@ -14,6 +14,10 @@ export class ConfigurationPageHelper extends PageHelper {
     this.navigateTo();
     const valList = ['global', 'mon', 'mgr', 'osd', 'mds', 'client']; // Editable values
 
+    // Enter config setting name into filter box
+    $('input.form-control.ng-valid').clear();
+    $('input.form-control.ng-valid').sendKeys(name);
+
     // Selects config that we want to clear
     browser.wait(Helper.EC.elementToBeClickable(this.getTableCell(name)), Helper.TIMEOUT); // waits for config to be clickable
     this.getTableCell(name).click(); // click on the config to edit
@@ -28,6 +32,10 @@ export class ConfigurationPageHelper extends PageHelper {
     element(by.cssContainingText('button', 'Save'))
       .click()
       .then(() => {
+        // Enter config setting name into filter box
+        $('input.form-control.ng-valid').clear();
+        $('input.form-control.ng-valid').sendKeys(name);
+
         browser
           .wait(Helper.EC.elementToBeClickable(this.getTableCell(name)), Helper.TIMEOUT)
           .then(() => {
@@ -64,6 +72,11 @@ export class ConfigurationPageHelper extends PageHelper {
     // with the number tehey want for that value. Ex: [global, '2'] is the global value with an input of 2
 
     this.navigateTo();
+
+    // Enter config setting name into filter box
+    $('input.form-control.ng-valid').clear();
+    $('input.form-control.ng-valid').sendKeys(name);
+
     // Selects config that we want to edit
     browser.wait(Helper.EC.elementToBeClickable(this.getTableCell(name)), Helper.TIMEOUT); // waits for config to be clickable
     this.getTableCell(name).click(); // click on the config to edit
@@ -82,6 +95,11 @@ export class ConfigurationPageHelper extends PageHelper {
       .click()
       .then(() => {
         this.navigateTo();
+
+        // Enter config setting name into filter box
+        $('input.form-control.ng-valid').clear();
+        $('input.form-control.ng-valid').sendKeys(name);
+
         browser.wait(Helper.EC.visibilityOf(this.getTableCell(name)), Helper.TIMEOUT).then(() => {
           // Checks for visibility of config in table
           this.getTableCell(name)

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
@@ -2,9 +2,22 @@ import { Helper } from '../helper.po';
 
 describe('Logs page', () => {
   let logs: Helper['logs'];
+  let pools: Helper['pools'];
+  let configuration: Helper['configuration'];
+
+  const poolname = 'logs_e2e_test_pool';
+  const configname = 'log_graylog_port';
+  const today = new Date();
+  let hour = today.getHours();
+  if (hour > 12) {
+    hour = hour - 12;
+  }
+  const minute = today.getMinutes();
 
   beforeAll(() => {
     logs = new Helper().logs;
+    pools = new Helper().pools;
+    configuration = new Helper().configuration;
   });
 
   afterEach(() => {
@@ -30,6 +43,43 @@ describe('Logs page', () => {
 
     it('should show audit logs as a second tab', () => {
       expect(logs.getTabText(1)).toEqual('Audit Logs');
+    });
+  });
+
+  describe('audit logs respond to pool creation and deletion test', () => {
+    it('should create pool and check audit logs reacted', () => {
+      pools.navigateTo('create');
+      pools.create(poolname, 8);
+
+      pools.navigateTo();
+      pools.exist(poolname, true);
+
+      logs.navigateTo();
+      logs.checkAuditForPoolFunction(poolname, 'create', hour, minute);
+    });
+
+    it('should delete pool and check audit logs reacted', () => {
+      pools.navigateTo();
+      pools.delete(poolname);
+
+      pools.navigateTo();
+      pools.exist(poolname, false);
+
+      logs.navigateTo();
+      logs.checkAuditForPoolFunction(poolname, 'delete', hour, minute);
+    });
+  });
+
+  describe('audit logs respond to editing configuration setting test', () => {
+    it('should change config settings and check audit logs reacted', () => {
+      configuration.navigateTo();
+      configuration.edit(configname, ['global', '5']);
+
+      logs.navigateTo();
+      logs.checkAuditForConfigChange(configname, 'global', hour, minute);
+
+      configuration.navigateTo();
+      configuration.configClear(configname);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.po.ts
@@ -1,8 +1,130 @@
-import { browser } from 'protractor';
+import { $, $$, browser, by, element, protractor } from 'protractor';
+import { Helper } from '../helper.po';
 import { PageHelper } from '../page-helper.po';
 
 browser.ignoreSynchronization = true;
 
 export class LogsPageHelper extends PageHelper {
   pages = { index: '/#/logs' };
+
+  checkAuditForPoolFunction(poolname, poolfunction, hour, minute) {
+    this.navigateTo();
+
+    // sometimes the modal from deleting pool is still present at this point.
+    // This wait makes sure it isn't
+    browser.wait(
+      Helper.EC.stalenessOf(element(by.cssContainingText('.modal-dialog', 'Delete Pool'))),
+      Helper.TIMEOUT
+    );
+
+    // go to audit logs tab
+    element(by.cssContainingText('.nav-link', 'Audit Logs')).click();
+
+    // Enter an earliest time so that no old messages with the same pool name show up
+    $$('.bs-timepicker-field')
+      .get(0)
+      .sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+    $$('.bs-timepicker-field')
+      .get(0)
+      .sendKeys(protractor.Key.BACK_SPACE);
+    if (hour < 10) {
+      $$('.bs-timepicker-field')
+        .get(0)
+        .sendKeys('0');
+    }
+    $$('.bs-timepicker-field')
+      .get(0)
+      .sendKeys(hour);
+
+    $$('.bs-timepicker-field')
+      .get(1)
+      .sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+    $$('.bs-timepicker-field')
+      .get(1)
+      .sendKeys(protractor.Key.BACK_SPACE);
+    if (minute < 10) {
+      $$('.bs-timepicker-field')
+        .get(1)
+        .sendKeys('0');
+    }
+    $$('.bs-timepicker-field')
+      .get(1)
+      .sendKeys(minute);
+
+    // Enter the pool name into the filter box
+    $$('input.form-control.ng-valid')
+      .first()
+      .click();
+    $$('input.form-control.ng-valid')
+      .first()
+      .clear();
+    $$('input.form-control.ng-valid')
+      .first()
+      .sendKeys(poolname);
+
+    const audit_logs_tab = $('.tab-pane.active');
+    const audit_logs_body = audit_logs_tab.element(by.css('.card-body'));
+    const logs = audit_logs_body.all(by.cssContainingText('.ng-star-inserted', poolname));
+
+    expect(logs.getText()).toMatch(poolname);
+    expect(logs.getText()).toMatch(`pool ${poolfunction}`);
+  }
+
+  checkAuditForConfigChange(configname, setting, hour, minute) {
+    this.navigateTo();
+
+    // go to audit logs tab
+    element(by.cssContainingText('.nav-link', 'Audit Logs')).click();
+
+    // Enter an earliest time so that no old messages with the same config name show up
+    $$('.bs-timepicker-field')
+      .get(0)
+      .sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+    $$('.bs-timepicker-field')
+      .get(0)
+      .sendKeys(protractor.Key.BACK_SPACE);
+    if (hour < 10) {
+      $$('.bs-timepicker-field')
+        .get(0)
+        .sendKeys('0');
+    }
+    $$('.bs-timepicker-field')
+      .get(0)
+      .sendKeys(hour);
+
+    $$('.bs-timepicker-field')
+      .get(1)
+      .sendKeys(protractor.Key.chord(protractor.Key.CONTROL, 'a'));
+    $$('.bs-timepicker-field')
+      .get(1)
+      .sendKeys(protractor.Key.BACK_SPACE);
+    if (minute < 10) {
+      $$('.bs-timepicker-field')
+        .get(1)
+        .sendKeys('0');
+    }
+    $$('.bs-timepicker-field')
+      .get(1)
+      .sendKeys(minute);
+
+    // Enter the config name into the filter box
+    $$('input.form-control.ng-valid')
+      .first()
+      .click();
+    $$('input.form-control.ng-valid')
+      .first()
+      .clear();
+    $$('input.form-control.ng-valid')
+      .first()
+      .sendKeys(configname);
+
+    const audit_logs_tab = $('.tab-pane.active');
+    const audit_logs_body = audit_logs_tab.element(by.css('.card-body'));
+    const logs = audit_logs_body.all(by.cssContainingText('.ng-star-inserted', configname));
+
+    browser.wait(Helper.EC.presenceOf(logs.first()), Helper.TIMEOUT);
+
+    expect(logs.getText()).toMatch(configname);
+    expect(logs.getText()).toMatch(setting);
+  }
 }


### PR DESCRIPTION
Tests that logs page creates audit logs in response to pool creation/deletion
Tests that logs page creates audit logs in response to configuration changes
Alter configuration po to put config name in filter box so you can edit configs not on first page (first 10)

Fixes: https://tracker.ceph.com/issues/41035

Signed-off-by: Adam King <adking@redhat.com>
Signed-off-by: Rafael Quintero <rquinter@redhat.com>