### PR TITLE
qa/tests: added more clients into test mix

### DIFF
--- a/qa/suites/upgrade/nautilus-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/0-cluster/start.yaml
@@ -12,6 +12,7 @@ roles:
   - osd.1
   - osd.2
   - osd.3
+  - client.1
 - - mon.b
   - osd.4
   - osd.5
@@ -23,7 +24,6 @@ roles:
   - osd.10
   - osd.11
 - - client.0
-  - client.1
   - client.2
   - client.3
 overrides:

--- a/qa/suites/upgrade/nautilus-x/parallel/1-ceph-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/1-ceph-install/nautilus.yaml
@@ -3,6 +3,7 @@ meta:
    install ceph/nautilus latest
    run workload and upgrade-sequence in parallel
    upgrade the client node
+   start rgw on client.0 and client.1
 tasks:
 - install:
     branch: nautilus
@@ -36,8 +37,9 @@ tasks:
     mon.c:
 - print: "**** done install.upgrade non-client hosts"
 - rgw:
+   - client.0
    - client.1
-- print: "**** done => started rgw client.1"
+- print: "**** done => started rgw client.0 & client.1"
 - parallel:
     - workload
     - upgrade-sequence

--- a/qa/suites/upgrade/nautilus-x/parallel/3-upgrade-sequence/upgrade-all.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/3-upgrade-sequence/upgrade-all.yaml
@@ -16,7 +16,7 @@ upgrade-sequence:
        wait-for-healthy: false
        wait-for-osds-up: true
    - ceph.restart:
-       daemons: [mds.a, rgw.*]
+       daemons: [mds.a, ceph.rgw.client.1]
        wait-for-healthy: false
        wait-for-osds-up: true
    - print: "**** done ceph.restart all"

--- a/qa/suites/upgrade/nautilus-x/parallel/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
@@ -2,9 +2,15 @@ meta:
 - desc: |
    upgrade the ceph cluster,
    upgrate in two steps
-   step one ordering: mon.a, osd.0, osd.1, mds.a
-   step two ordering: mon.b, mon.c, osd.2, osd.3
-   step three ordering: client.1
+   ordering: 
+   mon.a
+   mon.b, mgr.x
+   mon.c
+   osd.0, osd.1, osd.2, osd.3
+   mds.a
+   osd.4, osd.5, osd.6, osd.7
+   osd.8, osd.9, osd.10, osd.11
+   ceph.rgw.client.1
    ceph expected to be healthy state after each step
 upgrade-sequence:
    sequential:
@@ -47,7 +53,8 @@ upgrade-sequence:
    - sleep:
        duration: 60
    - ceph.restart:
-       daemons: [rgw.*]
+       # restart all rgw clients as rgw.* 
+       daemons: [ceph.rgw.client.1]
        wait-for-healthy: true
    - sleep:
        duration: 60

--- a/qa/suites/upgrade/nautilus-x/parallel/5-final-workload/rgw_ragweed_check.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/5-final-workload/rgw_ragweed_check.yaml
@@ -4,8 +4,8 @@ meta:
 rgw-final-workload:
   full_sequential:
   - ragweed:
-      client.1:
+      client.0:
         default-branch: ceph-master
-        rgw_server: client.1
+        rgw_server: client.0
         stages: check
   - print: "**** done ragweed check 4-final-workload"

--- a/qa/suites/upgrade/nautilus-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/0-cluster/start.yaml
@@ -27,6 +27,7 @@ roles:
   - osd.1
   - osd.2
   - osd.3
+  - client.1
 - - mon.b
   - osd.4
   - osd.5

--- a/qa/suites/upgrade/nautilus-x/stress-split/1-ceph-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/1-ceph-install/nautilus.yaml
@@ -15,7 +15,8 @@ tasks:
 - print: "**** done ceph"
 - rgw:
    - client.0
-- print: "**** done => started rgw client.0"
+   - client.1
+- print: "**** done => started rgw client.0 & client.1"
 overrides:
   ceph:
     conf:

--- a/qa/suites/upgrade/nautilus-x/stress-split/4-workload/rgw_ragweed_prepare.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/4-workload/rgw_ragweed_prepare.yaml
@@ -5,8 +5,8 @@ stress-tasks:
   - full_sequential:
      - sequential:
        - ragweed:
-           client.0:
+           client.1:
              default-branch: ceph-nautilus
-             rgw_server: client.0
+             rgw_server: client.1
              stages: prepare
-       - print: "**** done rgw ragweed prepare 4-workload"
+       - print: "**** done rgw ragweed prepare 4-workload on client.1"

--- a/qa/suites/upgrade/nautilus-x/stress-split/5-finish-upgrade.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/5-finish-upgrade.yaml
@@ -3,10 +3,11 @@ tasks:
     osd.8:
     client.0:
 - ceph.restart:
-    daemons: [mon.c, osd.8, osd.9, osd.10, osd.11, rgw.*]
+    daemons: [mon.c, osd.8, osd.9, osd.10, osd.11, ceph.rgw.client.1]
     wait-for-healthy: false
     wait-for-osds-up: true
-- print: "**** restarted/upgrated => mon.c, osd.8, osd.9, osd.10, osd.11, rgw.*"
+# restart all rgw clients as rgw.*
+- print: "**** restarted/upgrated => mon.c, osd.8, osd.9, osd.10, osd.11, ceph.rgw.client.1"
 - exec:
     osd.0:
       - ceph osd set pglog_hardlimit

--- a/qa/suites/upgrade/nautilus-x/stress-split/7-final-workload/rgw-swift-ragweed_check.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/7-final-workload/rgw-swift-ragweed_check.yaml
@@ -12,4 +12,4 @@ tasks:
       default-branch: ceph-nautilus
       rgw_server: client.0
       stages: check
-- print: "**** done rgw ragweed check 7-workload"
+- print: "**** done rgw ragweed check 7-workload on client.0 - old, client.1 was upgraded"


### PR DESCRIPTION
Logic: start rgw on client.0 and client.1,
upgrade client.1,
run ragweed prepare against upgraded client.1,
run ragweed check on old client.0

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

