### PR TITLE
mimic: rgw_file: advance_mtime() should consider namespace expiration

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1287,6 +1287,23 @@ namespace rgw {
     }
   }
 
+  void RGWFileHandle::advance_mtime() {
+    /* intended for use on directories, fast-forward mtime so as to
+     * ensure a new, higher value for the change attribute */
+    lock_guard guard(mtx);
+    /* advance mtime only if stored mtime is older than the
+     * configured namespace expiration */
+    auto now = real_clock::now();
+    auto cmptime = state.mtime;
+    cmptime.tv_sec +=
+      fs->get_context()->_conf->rgw_nfs_namespace_expire_secs;
+    if (cmptime < real_clock::to_timespec(now)) {
+      /* sets ctime as well as mtime, to avoid masking updates should
+       * ctime inexplicably hold a higher value */
+      set_times(now);
+    }
+  }
+
   void RGWFileHandle::invalidate() {
     RGWLibFS *fs = get_fs();
     if (fs->invalidate_cb) {

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -229,15 +229,7 @@ namespace rgw {
     };
 
     void clear_state();
-
-    void advance_mtime() {
-      /* intended for use on directories, fast-forward mtime so as to
-       * ensure a new, higher value for the change attribute */
-      lock_guard guard(mtx);
-      /* sets ctime as well as mtime, to avoid masking updates should
-       * ctime inexplicably hold a higher value */
-      set_times(real_clock::now());
-    }
+    void advance_mtime();
 
     boost::variant<file, directory> variant_type;
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/40626