### PR TITLE
nautilus: doc: Update 'ceph-iscsi' min version

### DIFF
--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -21,7 +21,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
    -  ``tcmu-runner-1.3.0`` or newer package
 
-   -  ``ceph-iscsi-2.7`` or newer package
+   -  ``ceph-iscsi-3.2`` or newer package
 
      .. important::
         If previous versions of these packages exist, then they must


### PR DESCRIPTION
This PR is the backport of https://github.com/ceph/ceph/pull/29195/ and should be merged after https://github.com/ceph/ceph/pull/28974.

Signed-off-by: Ricardo Marques <rimarques@suse.com>
(cherry picked from commit b434c2910acfdceda7fd005bcc6285ba98f008d2)