### PR TITLE
doc: Fix rbd namespace documentation

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -537,13 +537,13 @@ Commands
 :command:`mv` *src-image-spec* *dest-image-spec*
   Rename an image.  Note: rename across pools is not supported.
 
-:command:`namespace create` *pool-name* *namespace-name*
+:command:`namespace create` *pool-name*/*namespace-name*
   Create a new image namespace within the pool.
 
 :command:`namespace list` *pool-name*
   List image namespaces defined within the pool.
 
-:command:`namespace remove` *pool-name* *namespace-name*
+:command:`namespace remove` *pool-name*/*namespace-name*
   Remove an empty image namespace from the pool.
 
 :command:`object-map check` *image-spec* | *snap-spec*


### PR DESCRIPTION
Pool and namespace should be separated by a `slash`.

If a `space` is used, the following error is displayed:
```
# rbd namespace create rbd1 test1
rbd: too many arguments

# rbd namespace remove rbd1 test1
rbd: too many arguments
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>
