### PR TITLE
cmake: add add_tox_test()

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -50,3 +50,27 @@ function(add_ceph_unittest unittest_name)
   add_ceph_test(${unittest_name} "${UNITTEST}")
   target_link_libraries(${unittest_name} ${UNITTEST_LIBS})
 endfunction()
+
+function(add_tox_test name tox_path)
+  set(test_name run-tox-${name})
+  add_test(
+    NAME ${test_name}
+    COMMAND ${CMAKE_SOURCE_DIR}/src/script/run_tox.sh
+              --source-dir ${CMAKE_SOURCE_DIR}
+              --build-dir ${CMAKE_BINARY_DIR}
+              --with-python2 ${WITH_PYTHON2}
+              --with-python3 ${WITH_PYTHON3}
+              --tox-path ${tox_path}
+              --venv-path ${CEPH_BUILD_VIRTUALENV}/${name})
+  set_property(
+    TEST ${test_name}
+    PROPERTY ENVIRONMENT
+    CEPH_ROOT=${CMAKE_SOURCE_DIR}
+    CEPH_BIN=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    CEPH_LIB=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV}
+    LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
+    PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src:$ENV{PATH}
+    PYTHONPATH=${CMAKE_SOURCE_DIR}/src/pybind)
+  list(APPEND tox_test run-tox-${name})
+endfunction()

--- a/src/script/run_tox.sh
+++ b/src/script/run_tox.sh
@@ -1,44 +1,107 @@
 #!/usr/bin/env bash
 
-function dump_envvars {
-  echo "WITH_PYTHON2: ->$WITH_PYTHON2<-"
-  echo "WITH_PYTHON3: ->$WITH_PYTHON3<-"
-  echo "ENV_LIST: ->$ENV_LIST<-"
-}
+set -e
 
-get_cmake_variable() {
-    grep "$1" $CEPH_BUILD_DIR/CMakeCache.txt | cut -d "=" -f 2
-}
-
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-: ${CEPH_BUILD_DIR:=$script_dir/../../build}
-: ${WITH_PYTHON2:=$(get_cmake_variable WITH_PYTHON2)}
-: ${WITH_PYTHON3:=$(get_cmake_variable WITH_PYTHON3)}
-
-if [ -f ${TOX_VIRTUALENV}/bin/activate ]
-then
-  source ${TOX_VIRTUALENV}/bin/activate
+if [ `uname` = FreeBSD ]; then
+    GETOPT=/usr/local/bin/getopt
 else
-  $script_dir/../tools/setup-virtualenv.sh tox_virtualenv
-  source tox_virtualenv/bin/activate
-  pip install tox
+    GETOPT=getopt
 fi
 
-# tox.ini will take care of this.
-export CEPH_BUILD_DIR=$CEPH_BUILD_DIR
+function get_cmake_variable() {
+    local cmake_cache=$1/CMakeCache.txt
+    shift
+    local variable=$1
+    shift
+    if [ -e $cmake_cache ]; then
+        grep "$variable" $cmake_cache | cut -d "=" -f 2
+    fi
+}
 
-if [ "$WITH_PYTHON2" = "ON" ]; then
-  ENV_LIST+="py27,"
-fi
-# WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
-# prevailing on the system - e.g. "3", "36"
-if [[ "$WITH_PYTHON3" =~ (^3|^ON) ]]; then
-  ENV_LIST+="py3,"
-fi
-# use bash string manipulation to strip off any trailing comma
-ENV_LIST=${ENV_LIST%,}
+function get_tox_path() {
+    local test_name=$1
+    if [ -n "$test_name" ]; then
+        local found=$(find $source_dir -path "*/$test_name/tox.ini")
+        echo $(dirname $found)
+    elif [ -e tox.ini ]; then
+        echo $(pwd)
+    fi
+}
 
-tox -c tox.ini -e "${ENV_LIST}" "$@"
-TOX_STATUS="$?"
-test "$TOX_STATUS" -ne "0" && dump_envvars
-exit $TOX_STATUS
+function main() {
+    local tox_path
+    local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    local build_dir=$script_dir/../../build
+    local source_dir=$(get_cmake_variable $build_dir ceph_SOURCE_DIR)
+    local with_python2=$(get_cmake_variable $build_dir WITH_PYTHON2)
+    local with_python3=$(get_cmake_variable $build_dir WITH_PYTHON3)
+    local parsed
+
+    options=$(${GETOPT} --name "$0" --options '' --longoptions "source-dir:,build-dir:,with-python2:,with-python3:,tox-path:,venv-path:" -- "$@")
+    if [ $? -ne 0 ]; then
+        exit 2
+    fi
+    eval set -- "${options}"
+    while true; do
+        case "$1" in
+            --source-dir)
+                source_dir=$2
+                shift 2;;
+            --build-dir)
+                build_dir=$2
+                shift 2;;
+            --with-python2)
+                with_python2=$2
+                shift 2;;
+            --with-python3)
+                with_python3=$2
+                shift 2;;
+            --tox-path)
+                tox_path=$2
+                shift 2;;
+            --venv-path)
+                venv_path=$2
+                shift 2;;
+            --)
+                shift
+                break;;
+            *)
+                echo "bad option $1" >& 2
+                exit 2;;
+        esac
+    done
+
+    if [ -z "$tox_path" ]; then
+        # try harder
+        local test_name
+        if [ $# -gt 0 ]; then
+            test_name=$1
+            shift
+        fi
+        tox_path=$(get_tox_path $test_name)
+        venv_path="$build_dir/$test_name"
+    fi
+
+    if [ ! -f ${venv_path}/bin/activate ]; then
+        $source_dir/src/tools/setup-virtualenv.sh ${venv_path}
+    fi
+    source ${venv_path}/bin/activate
+    pip install tox
+
+    # tox.ini will take care of this.
+    export CEPH_BUILD_DIR=$build_dir
+
+    if [ "$with_python2" = "ON" ]; then
+        ENV_LIST+="py27,"
+    fi
+    # WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
+    # prevailing on the system - e.g. "3", "36"
+    if [[ "$with_python3" =~ (^3|^ON) ]]; then
+        ENV_LIST+="py3,"
+    fi
+    # use bash string manipulation to strip off any trailing comma
+    ENV_LIST=${ENV_LIST%,}
+    tox -c $tox_path/tox.ini -e "${ENV_LIST}" "$@"
+}
+
+main "$@"

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -559,32 +559,22 @@ if(WITH_MGR)
   set(MGR_DASHBOARD_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/mgr-dashboard-virtualenv)
   list(APPEND env_vars_for_tox_tests MGR_DASHBOARD_VIRTUALENV=${MGR_DASHBOARD_VIRTUALENV})
 
-  add_test(NAME run-tox-mgr-insights COMMAND bash ${CMAKE_SOURCE_DIR}/src/pybind/mgr/insights/run-tox.sh)
-  list(APPEND tox_tests run-tox-mgr-insights)
-  set(MGR_INSIGHTS_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/mgr-insights-virtualenv)
-  list(APPEND env_vars_for_tox_tests MGR_INSIGHTS_VIRTUALENV=${MGR_INSIGHTS_VIRTUALENV})
+  add_tox_test(mgr-insights
+    ${CMAKE_SOURCE_DIR}/src/pybind/mgr/insights)
 
-  add_test(NAME run-tox-mgr-ansible COMMAND bash ${CMAKE_SOURCE_DIR}/src/pybind/mgr/ansible/run-tox.sh)
-  list(APPEND tox_tests run-tox-mgr-ansible)
-  set(MGR_ANSIBLE_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/mgr-ansible-virtualenv)
-  list(APPEND env_vars_for_tox_tests MGR_ANSIBLE_VIRTUALENV=${MGR_ANSIBLE_VIRTUALENV})
+  add_tox_test(mgr-ansible
+    ${CMAKE_SOURCE_DIR}/src/pybind/mgr/ansible)
 
-  add_test(NAME run-tox-mgr-orchestrator_cli COMMAND bash ${CMAKE_SOURCE_DIR}/src/pybind/mgr/orchestrator_cli/run-tox.sh)
-  list(APPEND tox_tests run-tox-mgr-orchestrator_cli)
-  set(MGR_ORCHESTRATOR_CLI_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/mgr-orchestrator_cli-virtualenv)
-  list(APPEND env_vars_for_tox_tests MGR_ORCHESTRATOR_CLI_VIRTUALENV=${MGR_ORCHESTRATOR_CLI_VIRTUALENV})
+  add_tox_test(mgr-orchestrator_cli
+    ${CMAKE_SOURCE_DIR}/src/pybind/mgr/orchestrator_cli)
 
-  add_test(NAME run-tox-python-common
-           COMMAND bash ${CMAKE_SOURCE_DIR}/src/script/run_tox.sh
-           WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/python-common )
-  list(APPEND tox_tests run-tox-python-common)
+  add_tox_test(python-common
+    ${CMAKE_SOURCE_DIR}/src/python-common)
 endif()
 
 if(WITH_CEPHFS_SHELL)
-  add_test(NAME run-tox-cephfs-shell COMMAND bash ${CMAKE_SOURCE_DIR}/src/tools/cephfs/run-tox.sh)
-  list(APPEND tox_tests run-tox-cephfs-shell)
-  set(CEPHFS_SHELL_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/cephfs-shell-virtualenv)
-  list(APPEND env_vars_for_tox_tests CEPHFS_SHELL_VIRTUALENV=${CEPHFS_SHELL_VIRTUALENV})
+  add_tox_test(cephfs-shell
+    ${CMAKE_SOURCE_DIR}/src/tools/cephfs)
 endif()
 
 set_property(


### PR DESCRIPTION
to consolidate the tox tests

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

