### PR TITLE
rgw: datalog/mdlog trim commands loop until done

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7718,8 +7718,20 @@ next:
     if (ret < 0)
       return -ret;
 
-    ret = store->svc()->datalog_rados->trim_entries(start_time.to_real_time(), end_time.to_real_time(), start_marker, end_marker);
-    if (ret < 0) {
+    if (!specified_shard_id) {
+      cerr << "ERROR: requires a --shard-id" << std::endl;
+      return EINVAL;
+    }
+
+    // loop until -ENODATA
+    do {
+      auto datalog = store->svc()->datalog_rados;
+      ret = datalog->trim_entries(shard_id, start_time.to_real_time(),
+                                  end_time.to_real_time(),
+                                  start_marker, end_marker);
+    } while (ret == 0);
+
+    if (ret < 0 && ret != -ENODATA) {
       cerr << "ERROR: trim_entries(): " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7078,8 +7078,12 @@ next:
     }
     RGWMetadataLog *meta_log = store->svc()->mdlog->get_log(period_id);
 
-    ret = meta_log->trim(shard_id, start_time.to_real_time(), end_time.to_real_time(), start_marker, end_marker);
-    if (ret < 0) {
+    // trim until -ENODATA
+    do {
+      ret = meta_log->trim(shard_id, start_time.to_real_time(),
+                           end_time.to_real_time(), start_marker, end_marker);
+    } while (ret == 0);
+    if (ret < 0 && ret != -ENODATA) {
       cerr << "ERROR: meta_log->trim(): " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2310,32 +2310,11 @@ int RGWDataChangesLog::get_info(int shard_id, RGWDataChangesLogInfo *info)
 int RGWDataChangesLog::trim_entries(int shard_id, const real_time& start_time, const real_time& end_time,
                                     const string& start_marker, const string& end_marker)
 {
-  int ret;
-
   if (shard_id > num_shards)
     return -EINVAL;
 
-  ret = svc.cls->timelog.trim(oids[shard_id], start_time, end_time, start_marker, end_marker, nullptr, null_yield);
-
-  if (ret == -ENOENT || ret == -ENODATA)
-    ret = 0;
-
-  return ret;
-}
-
-int RGWDataChangesLog::trim_entries(const real_time& start_time, const real_time& end_time,
-                                    const string& start_marker, const string& end_marker)
-{
-  for (int shard = 0; shard < num_shards; shard++) {
-    int ret = svc.cls->timelog.trim(oids[shard], start_time, end_time, start_marker, end_marker, nullptr, null_yield);
-    if (ret == -ENOENT || ret == -ENODATA) {
-      continue;
-    }
-    if (ret < 0)
-      return ret;
-  }
-
-  return 0;
+  return svc.cls->timelog.trim(oids[shard_id], start_time, end_time,
+                               start_marker, end_marker, nullptr, null_yield);
 }
 
 bool RGWDataChangesLog::going_down()

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -543,8 +543,6 @@ public:
 		   bool *truncated);
   int trim_entries(int shard_id, const real_time& start_time, const real_time& end_time,
                    const string& start_marker, const string& end_marker);
-  int trim_entries(const real_time& start_time, const real_time& end_time,
-                   const string& start_marker, const string& end_marker);
   int get_info(int shard_id, RGWDataChangesLogInfo *info);
 
   using LogMarker = RGWDataChangesLogMarker;

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -240,14 +240,8 @@ int RGWMetadataLog::trim(int shard_id, const real_time& from_time, const real_ti
   string oid;
   get_shard_oid(shard_id, oid);
 
-  int ret;
-
-  ret = svc.cls->timelog.trim(oid, from_time, end_time, start_marker, end_marker, nullptr, null_yield);
-
-  if (ret == -ENOENT || ret == -ENODATA)
-    ret = 0;
-
-  return ret;
+  return svc.cls->timelog.trim(oid, from_time, end_time, start_marker,
+                               end_marker, nullptr, null_yield);
 }
   
 int RGWMetadataLog::lock_exclusive(int shard_id, timespan duration, string& zone_id, string& owner_id) {

--- a/src/rgw/services/svc_datalog_rados.cc
+++ b/src/rgw/services/svc_datalog_rados.cc
@@ -80,10 +80,3 @@ int RGWSI_DataLog_RADOS::trim_entries(int shard_id, const real_time& start_time,
 {
   return log->trim_entries(shard_id, start_time, end_time, start_marker, end_marker);
 }
-
-int RGWSI_DataLog_RADOS::trim_entries(const real_time& start_time, const real_time& end_time,
-                                      const string& start_marker, const string& end_marker)
-{
-  return log->trim_entries(start_time, end_time, start_marker, end_marker);
-}
-

--- a/src/rgw/services/svc_datalog_rados.h
+++ b/src/rgw/services/svc_datalog_rados.h
@@ -68,7 +68,5 @@ public:
 		   list<rgw_data_change_log_entry>& entries, RGWDataChangesLogMarker& marker, bool *ptruncated);
   int trim_entries(int shard_id, const real_time& start_time, const real_time& end_time,
                    const string& start_marker, const string& end_marker);
-  int trim_entries(const real_time& start_time, const real_time& end_time,
-                   const string& start_marker, const string& end_marker);
 };
 


### PR DESCRIPTION
these commands will only send a single osd request and trim at max 1000 entries, and not all the way to the given --end-marker. the commands should keep sending these requests until a -ENODATA error code indicates there's nothing more to trim

Fixes: https://tracker.ceph.com/issues/41045