### PR TITLE
github: Add CODEOWNERs for designated code-owner reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Dashboard team to review dashboard related code
+/src/pybind/mgr/dashboard                       @ceph/dashboard
+/qa/suites/rados/mgr/tasks/dashboard.yaml       @ceph/dashboard
+/qa/tasks/mgr/test_dashboard.py                 @ceph/dashboard
+/qa/tasks/mgr/dashboard                         @ceph/dashboard
+/monitoring/grafana                             @ceph/dashboard
+/monitoring/prometheus                          @ceph/dashboard
+/doc/mgr/dashboard.rst                          @ceph/dashboard


### PR DESCRIPTION
Adds [CODEOWNERS](https://help.github.com/en/articles/about-code-owners) file and assigns ownership of /src/pybind/mgr/dashboard to
@ceph/dashboard alias. That will also automatically add @ceph/dashboard
team to all reviews modifying any file in the above location.

![image](https://user-images.githubusercontent.com/37327689/62308713-3471c780-b486-11e9-9234-37d85b89af1d.png)

When a member of the required group approves the PR, the approval will look like this:

> _username_ approved these changes on behalf of _team_ ... 

Besides, if "Require review from Code Owners" is marked in the Branch
Protection Rules of any branch where this CODEOWNERS file is propagated
to, at least one review from a designated CODEOWNER will be mandatory.

If Ceph teams' visibility is changed to public, teams can also be
@mentioned (both from Ceph and other projects), so it's easier to reach
to component-team members.

This can be used both to:
- Ensure everyone is aware of changes affecting code they work on (not everyone always properly "labels" PRs, or sometimes PR messages only define a single component while they affect multiple). 
- Enforce qualified reviews or even "block" sensitive files, dirs or file-types (via extensions).
- Help contributors quickly identify the teams/people impacted by their changes.
- In release branches, this file can be modified to require specific approval from a designated team (e.g.: @ceph/nautilus-release-team).

Fixes: https://tracker.ceph.com/issues/41047
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
