### PR TITLE
qa/tasks/mgr/dashboard/test_mgr_module: sync w/ telemetry

### DIFF
--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -111,22 +111,18 @@ class MgrModuleTelemetryTest(MgrModuleTestCase):
             data,
             JObj(
                 sub_elems={
-                    'channel_basic': JLeaf(bool),
-                    'channel_ident': JLeaf(bool),
-                    'channel_crash': JLeaf(bool),
-                    'channel_device': JLeaf(bool),
-                    'contact': JLeaf(str),
-                    'description': JLeaf(str),
-                    'enabled': JLeaf(bool),
-                    'interval': JLeaf(int),
-                    'leaderboard': JLeaf(bool),
-                    'organization': JLeaf(str),
-                    'proxy': JLeaf(str),
-                    'url': JLeaf(str),
-                    'config': JObj(sub_elems={
-                        'cluster_changed': JList(str),
-                        'active_changed': JList(str),
-                    }),
+                    'channel_basic': bool,
+                    'channel_ident': bool,
+                    'channel_crash': bool,
+                    'channel_device': bool,
+                    'contact': str,
+                    'description': str,
+                    'enabled': bool,
+                    'interval': int,
+                    'leaderboard': bool,
+                    'organization': str,
+                    'proxy': str,
+                    'url': str
                 }))
 
     def test_put(self):


### PR DESCRIPTION
only check mandatory fields in report:

* `channels` and `channels_available` are list of `str`
* use primitive types instead of `JLeaf(the_type)` as they are
  equivalent in this context
* remove fields which are added only if certain channels are
  activated.
* allow unknown fields, as we are including various stuff
  in the report, for instance, osdmap, usage, crash info, etc.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
