### PR TITLE
os/bluestore: no need to add tail length (revert PR#29185)

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1423,7 +1423,7 @@ int BlueStore::BufferSpace::_discard(BufferCacheShard* cache, uint32_t offset, u
 		      0, b);
 	}
 	if (!b->is_writing()) {
-	  cache->_adjust_size(b, tail + front - (int64_t)b->length);
+	  cache->_adjust_size(b, front - (int64_t)b->length);
 	}
 	b->truncate(front);
 	b->maybe_rebuild();


### PR DESCRIPTION
Tail length is already caculated in add_buffer forward, so do not need to add tail length in adjust buffer size again.

Signed-off-by: Xiangyang Yu <penglaiyxy@gmail.com>