### PR TITLE
mgr/dashboard: Verify webdriver-manager version

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -67,6 +67,8 @@ jq .[].target=\"$BASE_URL\" proxy.conf.json.sample > proxy.conf.json
 . $BUILD_DIR/src/pybind/mgr/dashboard/node-env/bin/activate
 
 if [ "$DEVICE" == "chrome" ]; then
+    npm list webdriver-manager
+    npm info webdriver-manager
     npm run e2e:ci || stop 1
     stop 0
 elif [ "$DEVICE" == "docker" ]; then


### PR DESCRIPTION
Note that this PR is not supposed to get merged, it's just
a test to verify the webdriver-manager version which is
installed on the Jenkins node in combination with protractor
version 5.4.2

Signed-off-by: Laura Paduano <lpaduano@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
