### PR TITLE
mgr/progress: Global Recovery Event in ceph -s

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -948,12 +948,14 @@ void ActivePyModules::get_health_checks(health_check_map_t *checks)
 void ActivePyModules::update_progress_event(
   const std::string& evid,
   const std::string& desc,
-  float progress)
+  float progress,
+  bool add_to_ceph_s)
 {
   std::lock_guard l(lock);
   auto& pe = progress_events[evid];
   pe.message = desc;
   pe.progress = progress;
+  pe.add_to_ceph_s = add_to_ceph_s;
 }
 
 void ActivePyModules::complete_progress_event(const std::string& evid)

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -127,7 +127,8 @@ public:
 
   void update_progress_event(const std::string& evid,
 			     const std::string& desc,
-			     float progress);
+			     float progress, 
+			     bool add_to_ceph_s);
   void complete_progress_event(const std::string& evid);
   void clear_all_progress_events();
   void get_progress_events(std::map<std::string,ProgressEvent>* events);

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -649,13 +649,14 @@ ceph_update_progress_event(BaseMgrModule *self, PyObject *args)
   char *evid = nullptr;
   char *desc = nullptr;
   float progress = 0.0;
-  if (!PyArg_ParseTuple(args, "ssf:ceph_update_progress_event",
-			&evid, &desc, &progress)) {
+  bool add_to_ceph_s = false;
+  if (!PyArg_ParseTuple(args, "ssfb:ceph_update_progress_event",
+			&evid, &desc, &progress, &add_to_ceph_s)) {
     return nullptr;
   }
 
   PyThreadState *tstate = PyEval_SaveThread();
-  self->py_modules->update_progress_event(evid, desc, progress);
+  self->py_modules->update_progress_event(evid, desc, progress, add_to_ceph_s);
   PyEval_RestoreThread(tstate);
 
   Py_RETURN_NONE;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3030,6 +3030,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     if (!pem.empty()) {
       ss << "\n \n  progress:\n";
       for (auto& i : pem) {
+	if (i.second.add_to_ceph_s){
 	ss << "    " << i.second.message << "\n";
 	ss << "      [";
 	unsigned j;
@@ -3040,6 +3041,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
 	  ss << '.';
 	}
 	ss << "]\n";
+	}
       }
     }
     ss << "\n ";

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -623,22 +623,32 @@ inline std::ostream& operator<<(std::ostream& out, const mon_feature_t& f) {
 struct ProgressEvent {
   std::string message;                  ///< event description
   float progress;                  ///< [0..1]
-
+  bool add_to_ceph_s;
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(message, bl);
     encode(progress, bl);
+    encode(add_to_ceph_s, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& p) {
-    DECODE_START(1, p);
+    DECODE_START(2, p);
     decode(message, p);
     decode(progress, p);
+    if (struct_v >= 2) {
+      decode(add_to_ceph_s, p);
+    } else {
+      if (message.size()) {
+	add_to_ceph_s = true;
+      }
+    }
     DECODE_FINISH(p);
   }
   void dump(ceph::Formatter *f) const {
     f->dump_string("message", message);
     f->dump_float("progress", progress);
+    f->dump_bool("add_to_ceph_s", add_to_ceph_s);
+
   }
 };
 WRITE_CLASS_ENCODER(ProgressEvent)

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1208,8 +1208,8 @@ class MgrModule(ceph_module.BaseMgrModule):
 
         return self._ceph_have_mon_connection()
 
-    def update_progress_event(self, evid, desc, progress, duration):
-        return self._ceph_update_progress_event(str(evid), str(desc+" "+duration), float(progress))
+    def update_progress_event(self, evid, desc, progress, duration, add_to_ceph_s):
+        return self._ceph_update_progress_event(str(evid), str(desc+" "+duration), float(progress), bool(add_to_ceph_s))
 
     def complete_progress_event(self, evid):
         return self._ceph_complete_progress_event(str(evid))


### PR DESCRIPTION
Only show Global Progress event in ceph -s
Right now if you want to see all the sub events
You have to do ceph progress.

Todo: add the command ceph progress detail and json version
update qa test case for test_progress.py

Signed-off-by: Kamoltat (Junior) Sirivadhna <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
