### PR TITLE
mgr/dashboard: Daemons Page Tables Test

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.e2e-spec.ts
@@ -32,4 +32,14 @@ describe('RGW daemons page', () => {
       expect(daemons.getTabText(1)).toEqual('Overall Performance');
     });
   });
+
+  describe('details and performance counters table tests', () => {
+    beforeAll(() => {
+      daemons.navigateTo();
+    });
+
+    it('should check that details/performance tables are visible when daemon is selected', () => {
+      daemons.checkTables();
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.po.ts
@@ -1,5 +1,41 @@
+import { $$, by, element } from 'protractor';
 import { PageHelper } from '../page-helper.po';
 
 export class DaemonsPageHelper extends PageHelper {
   pages = { index: '/#/rgw/daemon' };
+
+  checkTables() {
+    this.navigateTo();
+
+    // click on a daemon so details table appears
+    $$('.datatable-body-cell-label')
+      .first()
+      .click();
+
+    const tab_container = $$('.tab-container').last();
+    const details_table = tab_container.all(by.css('cd-table')).get(0);
+    const performance_counters_table = tab_container.all(by.css('cd-table')).get(1);
+
+    // check details table is visible
+    expect(details_table.isDisplayed()).toBe(true);
+    // check at least one field is present
+    expect(details_table.getText()).toMatch('ceph_version');
+    // check performance counters table is not currently visible
+    expect(performance_counters_table.isDisplayed()).toBe(false);
+
+    // click on performance counters tab and check table is loaded
+    element(by.cssContainingText('.nav-link', 'Performance Counters')).click();
+    expect(performance_counters_table.isDisplayed()).toBe(true);
+    // check at least one field is present
+    expect(performance_counters_table.getText()).toMatch('objecter.op_r');
+    // check details table is not currently visible
+    expect(details_table.isDisplayed()).toBe(false);
+
+    // click on performance details tab
+    element(by.cssContainingText('.nav-link', 'Performance Details')).click();
+    // checks the other tabs' content isn't visible
+    expect(details_table.isDisplayed()).toBe(false);
+    expect(performance_counters_table.isDisplayed()).toBe(false);
+    // TODO: Expect Grafana iFrame
+  }
 }


### PR DESCRIPTION
Selects daemon from list (if at least one is present) and checks details table is displayed
Clicks performance counters tab and checks performance counters table is displayed

Fixes: https://tracker.ceph.com/issues/41063

Signed-off-by: Adam King <adking@redhat.com>
Signed-off-by: Rafael Quintero <rquinter@redhat.com>