### PR TITLE
osd: pg as a mutex

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2978,7 +2978,7 @@ int OSD::init()
       pgs.insert(pg);
     }
     for (auto pg : pgs) {
-      pg->lock();
+      std::scoped_lock l{*pg};
       set<pair<spg_t,epoch_t>> new_children;
       set<pair<spg_t,epoch_t>> merge_pgs;
       service.identify_splits_and_merges(pg->get_osdmap(), osdmap, pg->pg_id,
@@ -2995,7 +2995,6 @@ int OSD::init()
 	}
 	assert(merge_pgs.empty());
       }
-      pg->unlock();
     }
   }
 
@@ -9994,9 +9993,8 @@ void OSD::set_perf_queries(
   _get_pgs(&pgs);
   for (auto& pg : pgs) {
     if (pg->is_primary()) {
-      pg->lock();
+      std::scoped_lock l{*pg};
       pg->set_dynamic_perf_stats_queries(supported_queries);
-      pg->unlock();
     }
   }
 }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -493,11 +493,10 @@ Context *PG::finish_recovery()
 
 void PG::_finish_recovery(Context *c)
 {
-  lock();
+  std::scoped_lock locker{*this};
   // When recovery is initiated by a repair, that flag is left on
   state_clear(PG_STATE_REPAIR);
   if (recovery_state.is_deleting()) {
-    unlock();
     return;
   }
   if (c == finish_sync_event) {
@@ -517,7 +516,6 @@ void PG::_finish_recovery(Context *c)
   } else {
     dout(10) << "_finish_recovery -- stale" << dendl;
   }
-  unlock();
 }
 
 void PG::start_recovery_op(const hobject_t& soid)
@@ -885,10 +883,9 @@ void PG::init(
 void PG::shutdown()
 {
   ch->flush();
-  lock();
+  std::scoped_lock l{*this};
   recovery_state.shutdown();
   on_shutdown();
-  unlock();
 }
 
 #pragma GCC diagnostic ignored "-Wpragmas"
@@ -3308,11 +3305,10 @@ struct FlushState {
   epoch_t epoch;
   FlushState(PG *pg, epoch_t epoch) : pg(pg), epoch(epoch) {}
   ~FlushState() {
-    pg->lock();
+    std::scoped_lock l{*pg};
     if (!pg->pg_has_reset_since(epoch)) {
       pg->recovery_state.complete_flush();
     }
-    pg->unlock();
   }
 };
 typedef std::shared_ptr<FlushState> FlushStateRef;
@@ -3739,12 +3735,11 @@ void PG::do_delete_work(ObjectStore::Transaction &t)
         dout(20) << __func__ << " wake up at "
                  << ceph_clock_now()
 	         << ", re-queuing delete" << dendl;
-        lock();
+        std::scoped_lock locker{*this};
         delete_needs_sleep = false;
         if (!pg_has_reset_since(e)) {
           osd->queue_for_pg_delete(get_pgid(), e);
         }
-        unlock();
       });
 
       auto delete_schedule_time = ceph::real_clock::now();
@@ -3871,9 +3866,8 @@ ostream& operator<<(ostream& out, const PG::BackfillInterval& bi)
 
 void PG::dump_pgstate_history(Formatter *f)
 {
-  lock();
+  std::scoped_lock l{*this};
   recovery_state.dump_history(f);
-  unlock();
 }
 
 void PG::dump_missing(Formatter *f)


### PR DESCRIPTION
since `PG` satisfies `BasicLockable`, we can just use lockers from
standard library along with it.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
