### PR TITLE
nautilus: mgr/dashboard: change bucket owner between owners fr…

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -121,6 +121,26 @@ class RgwBucket(RgwRESTController):
                 if bucket['tenant'] else bucket['bucket']
         return bucket
 
+    @staticmethod
+    def strip_tenant_from_bucket_name(bucket_name, uid):
+        # type (str, str) => str
+        """
+        When linking a bucket to a new user belonging to same tenant
+        as the previous owner, tenant must be removed from the bucket name.
+        >>> RgwBucket.strip_tenant_from_bucket_name('tenant/bucket-name', 'tenant$user1')
+        'bucket-name'
+        >>> RgwBucket.strip_tenant_from_bucket_name('tenant/bucket-name', 'tenant2$user2')
+        'tenant/bucket-name'
+        >>> RgwBucket.strip_tenant_from_bucket_name('bucket-name', 'user1')
+        'bucket-name'
+        """
+        bucket_tenant = bucket_name[:bucket_name.find('/')] if bucket_name.find('/') >= 0 else None
+        uid_tenant = uid[:uid.find('$')] if uid.find('$') >= 0 else None
+        if bucket_tenant and uid_tenant and bucket_tenant == uid_tenant:
+            return bucket_name[bucket_name.find('/') + 1:]
+
+        return bucket_name
+
     def list(self):
         return self.proxy('GET', 'bucket')
 
@@ -137,7 +157,7 @@ class RgwBucket(RgwRESTController):
 
     def set(self, bucket, bucket_id, uid):
         result = self.proxy('PUT', 'bucket', {
-            'bucket': bucket,
+            'bucket': RgwBucket.strip_tenant_from_bucket_name(bucket, uid),
             'bucket-id': bucket_id,
             'uid': uid
         }, json_response=False)

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -20,7 +20,7 @@ commands=
     py27: pip install -r {toxinidir}/requirements-py27.txt
     py3: pip install -r {toxinidir}/requirements-py3.txt
     cov: coverage erase
-    cov: {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml --doctest-modules controllers/rbd.py services/ tests/ tools.py
+    cov: {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml --doctest-modules controllers services/ tests/ tools.py
     cov: coverage combine {toxinidir}/{env:COVERAGE_FILE}
     cov: coverage report
     cov: coverage xml


### PR DESCRIPTION
Since https://github.com/ceph/ceph/pull/28813 is in master, the bucket operations (with tenanted owners) behaviour has changed regarding nautilus, so this fix is applied directly.

Fixes: https://tracker.ceph.com/issues/41067
Signed-off-by: alfonsomthd <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
