### PR TITLE
mon: make 'ceph -s' much  more concise

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -101,5 +101,6 @@
   on all osds, or provided osds, thus simplifying the process of having to
   parse `osd dump` for the same information.
 
-* The `mgrmap` metadata included in the structured ``ceph status`` (``ceph -s``)
-  output is now more concise.
+* The structured output of ``ceph status`` or ``ceph -s`` is now more
+  concise, particularly the `mgrmap` and `monmap` sections, and the
+  structure of the `osdmap` section has been cleaned up.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -100,3 +100,6 @@
 * monitors now have a `ceph osd info` command that will provide information
   on all osds, or provided osds, thus simplifying the process of having to
   parse `osd dump` for the same information.
+
+* The `mgrmap` metadata included in the structured ``ceph status`` (``ceph -s``)
+  output is now more concise.

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1612,7 +1612,7 @@ class CephManager:
         """
         Get status from cluster
         """
-        status = self.raw_cluster_cmd('status', '--format=json-pretty')
+        status = self.raw_cluster_cmd('status', '--format=json')
         return json.loads(status)
 
     def raw_osd_status(self):

--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -34,10 +34,8 @@ class MgrCluster(CephCluster):
         self.mgr_daemons[mgr_id].restart()
 
     def get_mgr_map(self):
-        status = json.loads(
-            self.mon_manager.raw_cluster_cmd("status", "--format=json-pretty"))
-
-        return status["mgrmap"]
+        return json.loads(
+            self.mon_manager.raw_cluster_cmd("mgr", "dump", "--format=json-pretty"))
 
     def get_active_id(self):
         return self.get_mgr_map()["active_name"]

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -490,7 +490,18 @@ public:
     // One or the other, not both
     ceph_assert((ss != nullptr) != (f != nullptr));
     if (f) {
-      dump(f);
+      f->dump_bool("available", available);
+      f->dump_int("num_standbys", standbys.size());
+      f->open_array_section("modules");
+      for (auto& i : modules) {
+	f->dump_string("module", i);
+      }
+      f->close_section();
+      f->open_object_section("services");
+      for (const auto &i : services) {
+	f->dump_string(i.first.c_str(), i.second);
+      }
+      f->close_section();
     } else {
       utime_t now = ceph_clock_now();
       if (get_active_gid() != 0) {

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -34,6 +34,7 @@ void MgrStatMonitor::create_initial()
   dout(10) << __func__ << dendl;
   version = 0;
   service_map.epoch = 1;
+  service_map.modified = ceph_clock_now();
   pending_service_map_bl.clear();
   encode(service_map, pending_service_map_bl, CEPH_FEATURES_ALL);
 }

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -356,6 +356,14 @@ void MonMap::dump(Formatter *f) const
   f->close_section();
 }
 
+void MonMap::dump_summary(Formatter *f) const
+{
+  f->dump_unsigned("epoch", epoch);
+  f->dump_string("min_mon_release_name", ceph::to_string(min_mon_release));
+  f->dump_unsigned("num_mons", ranks.size());
+}
+
+
 // an ambiguous mon addr may be legacy or may be msgr2--we aren' sure.
 // when that happens we need to try them both (unless we can
 // reasonably infer from the port number which it is).

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -452,6 +452,7 @@ public:
   void print(std::ostream& out) const;
   void print_summary(std::ostream& out) const;
   void dump(ceph::Formatter *f) const;
+  void dump_summary(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<MonMap*>& o);
 protected:

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2950,7 +2950,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
 	  mono_clock::now() - quorum_since).count());
     }
     f->open_object_section("monmap");
-    monmap->dump(f);
+    monmap->dump_summary(f);
     f->close_section();
     f->open_object_section("osdmap");
     osdmon()->osdmap.print_summary(f, cout, string(12, ' '));

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3965,7 +3965,6 @@ void OSDMap::print_summary(Formatter *f, ostream& out,
 			   const string& prefix, bool extra) const
 {
   if (f) {
-    f->open_object_section("osdmap");
     f->dump_int("epoch", get_epoch());
     f->dump_int("num_osds", get_num_osds());
     f->dump_int("num_up_osds", get_num_up_osds());
@@ -3973,7 +3972,6 @@ void OSDMap::print_summary(Formatter *f, ostream& out,
     f->dump_bool("full", test_flag(CEPH_OSDMAP_FULL) ? true : false);
     f->dump_bool("nearfull", test_flag(CEPH_OSDMAP_NEARFULL) ? true : false);
     f->dump_unsigned("num_remapped_pgs", get_num_pg_temp());
-    f->close_section();
   } else {
     utime_t now = ceph_clock_now();
     out << get_num_osds() << " osds: "


### PR DESCRIPTION
We were dumping full mon and mgr maps, which have a tendency to expand.

Also, fix the initial ServiceMap's modified stamp.