### PR TITLE
journal: delete recorders before m_handler

### DIFF
--- a/src/test/journal/test_ObjectRecorder.cc
+++ b/src/test/journal/test_ObjectRecorder.cc
@@ -114,10 +114,10 @@ public:
     uint64_t m_flush_bytes = std::numeric_limits<uint64_t>::max();
     double m_flush_age = 600;
     uint64_t m_max_in_flight_appends = 0;
+    Handler m_handler;
     using ObjectRecorders =
       std::list<std::pair<journal::ObjectRecorderPtr, ceph::mutex*>>;
     ObjectRecorders m_object_recorders;
-    Handler m_handler;
   };
 
   journal::AppendBuffer create_append_buffer(uint64_t tag_tid, uint64_t entry_tid,


### PR DESCRIPTION
to make sure that nobody is referencing handler when it's being
destructed.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
