### PR TITLE
journal: always shutdown JournalRecoreder before destructing it

### DIFF
--- a/src/test/journal/test_JournalRecorder.cc
+++ b/src/test/journal/test_JournalRecorder.cc
@@ -7,30 +7,26 @@
 #include "test/journal/RadosTestFixture.h"
 #include <limits>
 #include <list>
+#include <memory>
 
 class TestJournalRecorder : public RadosTestFixture {
 public:
-
-  void TearDown() override {
-    for (std::list<journal::JournalRecorder*>::iterator it = m_recorders.begin();
-         it != m_recorders.end(); ++it) {
-      delete *it;
-    }
-    RadosTestFixture::TearDown();
-  }
-
-  journal::JournalRecorder *create_recorder(
+  using JournalRecorderPtr = std::unique_ptr<journal::JournalRecorder,
+					     std::function<void(journal::JournalRecorder*)>>;
+  JournalRecorderPtr create_recorder(
       const std::string &oid, const journal::JournalMetadataPtr &metadata) {
-    journal::JournalRecorder *recorder(new journal::JournalRecorder(
-        m_ioctx, oid + ".", metadata, 0));
-    recorder->set_append_batch_options(0, std::numeric_limits<uint32_t>::max(),
-                                       0);
-    m_recorders.push_back(recorder);
+    JournalRecorderPtr recorder{
+      new journal::JournalRecorder(m_ioctx, oid + ".", metadata, 0),
+      [](journal::JournalRecorder* recorder) {
+	C_SaferCond cond;
+	recorder->shut_down(&cond);
+	cond.wait();
+	delete recorder;
+      }
+    };
+    recorder->set_append_batch_options(0, std::numeric_limits<uint32_t>::max(), 0);
     return recorder;
   }
-
-  std::list<journal::JournalRecorder*> m_recorders;
-
 };
 
 TEST_F(TestJournalRecorder, Append) {
@@ -41,7 +37,7 @@ TEST_F(TestJournalRecorder, Append) {
   journal::JournalMetadataPtr metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::JournalRecorder *recorder = create_recorder(oid, metadata);
+  JournalRecorderPtr recorder = create_recorder(oid, metadata);
 
   journal::Future future1 = recorder->append(123, create_payload("payload"));
 
@@ -59,7 +55,7 @@ TEST_F(TestJournalRecorder, AppendKnownOverflow) {
   ASSERT_EQ(0, init_metadata(metadata));
   ASSERT_EQ(0U, metadata->get_active_set());
 
-  journal::JournalRecorder *recorder = create_recorder(oid, metadata);
+  JournalRecorderPtr recorder = create_recorder(oid, metadata);
 
   recorder->append(123, create_payload(std::string(metadata->get_object_size() -
                                                    journal::Entry::get_fixed_size(), '1')));
@@ -81,8 +77,8 @@ TEST_F(TestJournalRecorder, AppendDelayedOverflow) {
   ASSERT_EQ(0, init_metadata(metadata));
   ASSERT_EQ(0U, metadata->get_active_set());
 
-  journal::JournalRecorder *recorder1 = create_recorder(oid, metadata);
-  journal::JournalRecorder *recorder2 = create_recorder(oid, metadata);
+  JournalRecorderPtr recorder1 = create_recorder(oid, metadata);
+  JournalRecorderPtr recorder2 = create_recorder(oid, metadata);
 
   recorder1->append(234, create_payload(std::string(1, '1')));
   recorder2->append(123, create_payload(std::string(metadata->get_object_size() -
@@ -105,7 +101,7 @@ TEST_F(TestJournalRecorder, FutureFlush) {
   journal::JournalMetadataPtr metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::JournalRecorder *recorder = create_recorder(oid, metadata);
+  JournalRecorderPtr recorder = create_recorder(oid, metadata);
 
   journal::Future future1 = recorder->append(123, create_payload("payload1"));
   journal::Future future2 = recorder->append(123, create_payload("payload2"));
@@ -125,7 +121,7 @@ TEST_F(TestJournalRecorder, Flush) {
   journal::JournalMetadataPtr metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::JournalRecorder *recorder = create_recorder(oid, metadata);
+  JournalRecorderPtr recorder = create_recorder(oid, metadata);
 
   journal::Future future1 = recorder->append(123, create_payload("payload1"));
   journal::Future future2 = recorder->append(123, create_payload("payload2"));
@@ -150,7 +146,7 @@ TEST_F(TestJournalRecorder, OverflowCommitObjectNumber) {
   ASSERT_EQ(0, init_metadata(metadata));
   ASSERT_EQ(0U, metadata->get_active_set());
 
-  journal::JournalRecorder *recorder = create_recorder(oid, metadata);
+  JournalRecorderPtr recorder = create_recorder(oid, metadata);
 
   recorder->append(123, create_payload(std::string(metadata->get_object_size() -
                                                    journal::Entry::get_fixed_size(), '1')));


### PR DESCRIPTION
otherwise when we destruct `journal::JournalRecorder::m_object_locks`,
it/they would be still being waited by some condition variable.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
