### PR TITLE
doc: indicate imperative mood for commit titles

### DIFF
--- a/SubmittingPatches.rst
+++ b/SubmittingPatches.rst
@@ -397,12 +397,20 @@ could be "doc:", "osd:", or "common:". One can use::
 
      git log
 
-for more examples. Please use this "subsystem: short description"
-convention for naming pull requests (PRs) also, as it feeds directly
-into the script that generates release notes and it's tedious to clean
-up at release time. This document places no limit on the length of PR
-titles, but be aware that they are subject to editing as part of the
-release process.
+for more examples. It is also conventional to use the imperative mood in the
+commit title. For example::
+
+     mds: add perf counter for finisher of MDSRank
+
+or::
+
+     osd: make the ClassHandler::mutex private
+
+For GitHub, please use this "subsystem: short description" convention for
+naming pull requests (PRs). These titles feed directly into the script that
+generates release notes and it is tedious to clean up non-conformant PR titles
+at release time.  This document places no limit on the length of PR titles, but
+be aware that they are subject to editing as part of the release process.
 
 Commit message
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
This is convention in the kernel and Ceph but is not clearly documented.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
