### PR TITLE
common/config: behave when both POD_MEMORY_REQUEST and POD_MEMORY_LIMIT are set

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1485,9 +1485,7 @@ void md_config_t::diff(
   string name) const
 {
   values.for_each([this, f, &values] (auto& name, auto& configs) {
-    if (configs.size() == 1 &&
-	configs.begin()->first == CONF_DEFAULT) {
-      // we only have a default value; exclude from diff
+    if (configs.empty()) {
       return;
     }
     f->open_object_section(std::string{name}.c_str());

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1492,7 +1492,11 @@ void md_config_t::diff(
     }
     f->open_object_section(std::string{name}.c_str());
     const Option *o = find_option(name);
-    dump(f, CONF_DEFAULT, _get_val_default(*o));
+    if (configs.size() &&
+	configs.begin()->first != CONF_DEFAULT) {
+      // show compiled-in default only if an override default wasn't provided
+      dump(f, CONF_DEFAULT, _get_val_default(*o));
+    }
     for (auto& j : configs) {
       dump(f, j.first, j.second);
     }

--- a/src/test/common/test_context.cc
+++ b/src/test/common/test_context.cc
@@ -56,7 +56,7 @@ TEST(CephContext, do_command)
     bufferlist out;
     cct->do_command("config diff get", cmdmap, "xml", &out);
     string s(out.c_str(), out.length());
-    EXPECT_EQ("<config_diff_get><diff><key><default></default><override>" + value + "</override><final>value</final></key></diff></config_diff_get>", s);
+    EXPECT_EQ("<config_diff_get><diff><key><default></default><override>" + value + "</override><final>value</final></key><rbd_default_features><default>61</default><final>61</final></rbd_default_features></diff></config_diff_get>", s);
   }
   cct->put();
 }


### PR DESCRIPTION
- fix some issues with 'ceph daemon <name> config diff'
- if POD_MEMORY_LIMIT is set, apply the cgroup_ratio (default: .8) and make that the 'default' target
- if both POD_MEMORY_LIMIT and POD_MEMORY_REQUEST are set, make sure we take the min of (limit*.8, request)

Fixes: https://tracker.ceph.com/issues/41037