### PR TITLE
rgw: housekeeping of reset stats operation in radosgw-admin and cls back-end

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -370,11 +370,12 @@ static int cls_user_get_header(cls_method_context_t hctx, bufferlist *in, buffer
   return 0;
 }
 
-/// A method to reset the user.buckets header stats in accordance to the values
-/// seen in the user.buckets omap keys. This will not be equivalent to --sync-stats
-/// which requires comparing the values with actual bucket meta stats supplied
-/// by RGW
-static int cls_user_reset_stats(cls_method_context_t hctx, bufferlist *in, bufferlist *out /*ignore*/)
+/// A method to reset the user.buckets header stats in accordance to
+/// the values seen in the user.buckets omap keys. This is not be
+/// equivalent to --sync-stats which also re-calculates the stats for
+/// each bucket.
+static int cls_user_reset_stats(cls_method_context_t hctx,
+				bufferlist *in, bufferlist *out /*ignore*/)
 {
   cls_user_reset_stats_op op;
 
@@ -382,27 +383,33 @@ static int cls_user_reset_stats(cls_method_context_t hctx, bufferlist *in, buffe
     auto bliter = in->cbegin();
     decode(op, bliter);
   } catch (buffer::error& err) {
-    CLS_LOG(0, "ERROR: cls_user_reset_op(): failed to decode op");
+    CLS_LOG(0, "ERROR: %s failed to decode op", __func__);
     return -EINVAL;
   }
+
   cls_user_header header;
   bool truncated = false;
   string from_index, prefix;
   do {
     map<string, bufferlist> keys;
-    int rc = cls_cxx_map_get_vals(hctx, from_index, prefix, MAX_ENTRIES, &keys, &truncated);
-
-    if (rc < 0)
+    int rc = cls_cxx_map_get_vals(hctx, from_index, prefix, MAX_ENTRIES,
+				  &keys, &truncated);
+    if (rc < 0) {
+      CLS_LOG(0, "ERROR: %s failed to retrieve omap key-values", __func__);
       return rc;
+    }
+    CLS_LOG(20, "%s: read %lu key-values, truncated=%d",
+	    __func__, keys.size(), truncated);
 
-    for (const auto&kv : keys){
+    for (const auto& kv : keys) {
       cls_user_bucket_entry e;
       try {
 	auto bl = kv.second;
 	auto bliter = bl.cbegin();
 	decode(e, bliter);
       } catch (buffer::error& err) {
-	CLS_LOG(0, "ERROR: failed to decode bucket entry for %s", kv.first.c_str());
+	CLS_LOG(0, "ERROR: %s failed to decode bucket entry for %s",
+		__func__, kv.first.c_str());
 	return -EIO;
       }
       add_header_stats(&header.stats, e);
@@ -413,6 +420,7 @@ static int cls_user_reset_stats(cls_method_context_t hctx, bufferlist *in, buffe
   header.last_stats_update = op.time;
   encode(header, bl);
 
+  CLS_LOG(20, "%s: updating header", __func__);
   return cls_cxx_map_write_header(hctx, &bl);
 }
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6754,13 +6754,20 @@ next:
 
     string user_str = user_id.to_str();
     if (reset_stats) {
-      if (!bucket_name.empty()){
-	cerr << "ERROR: recalculate doesn't work on buckets" << std::endl;
+      if (!bucket_name.empty()) {
+	cerr << "ERROR: --reset-stats does not work on buckets and "
+	  "bucket specified" << std::endl;
+	return EINVAL;
+      }
+      if (sync_stats) {
+	cerr << "ERROR: sync-stats includes the reset-stats functionality, "
+	  "so at most one of the two should be specified" << std::endl;
 	return EINVAL;
       }
       ret = store->cls_user_reset_stats(user_str);
       if (ret < 0) {
-	cerr << "ERROR: could not clear user stats: " << cpp_strerror(-ret) << std::endl;
+	cerr << "ERROR: could not reset user stats: " << cpp_strerror(-ret) <<
+	  std::endl;
 	return -ret;
       }
     }
@@ -6769,13 +6776,15 @@ next:
       if (!bucket_name.empty()) {
         int ret = rgw_bucket_sync_user_stats(store, tenant, bucket_name);
         if (ret < 0) {
-          cerr << "ERROR: could not sync bucket stats: " << cpp_strerror(-ret) << std::endl;
+          cerr << "ERROR: could not sync bucket stats: " <<
+	    cpp_strerror(-ret) << std::endl;
           return -ret;
         }
       } else {
         int ret = rgw_user_sync_all_stats(store, user_id);
         if (ret < 0) {
-          cerr << "ERROR: failed to sync user stats: " << cpp_strerror(-ret) << std::endl;
+          cerr << "ERROR: could not sync user stats: " <<
+	    cpp_strerror(-ret) << std::endl;
           return -ret;
         }
       }


### PR DESCRIPTION
Made error messages more consistent.

In radosgw-admin error out when --reset-stats was used in conjunction with --sync-stats since the latter does a superset of the former.

Informational logging regarding the reset-stats op is added at logging level 20.

Tracker: https://tracker.ceph.com/issues/41143