### PR TITLE
mount.ceph: properly handle -o strictatime

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -149,7 +149,8 @@ static char *parse_options(const char *data, int *filesys_flags)
 			*filesys_flags |= MS_NODIRATIME;
 		} else if (strncmp(data, "relatime", 8) == 0) {
 			*filesys_flags |= MS_RELATIME;
-
+		} else if (strncmp(data, "strictatime", 11) == 0) {
+			*filesys_flags |= MS_STRICTATIME;
 		} else if (strncmp(data, "noauto", 6) == 0) {
 			skip = 1;  /* ignore */
 		} else if (strncmp(data, "_netdev", 7) == 0) {


### PR DESCRIPTION
Otherwise, we get -EINVAL when a mount is attempted.

Fixes: https://tracker.ceph.com/issues/41144
Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
