### PR TITLE
mgr/dashboard: fix HACKING.rst is not rendered on github

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -185,7 +185,7 @@ Writing End-to-End Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The PagerHelper class
-^^^^^^^^^^^^^^^^^^^^^
+.....................
 
 The ``PageHelper`` class is supposed to be used for general purpose code that
 can be used on various pages or suites. Examples are
@@ -197,7 +197,7 @@ method implemented in a subclass of PageHelper is called on the correct page.
 It will also show a developer-friendly warning if this is not the case.
 
 Subclasses of PageHelper
-^^^^^^^^^^^^^^^^^^^^^^^^
+........................
 
 Helper Methods
 """"""""""""""
@@ -254,7 +254,7 @@ PageHelpers available to all suites.
   });
 
 Code Style
-^^^^^^^^^^
+..........
 
 Please refer to the official `Protractor style-guide
 <https://www.protractortest.org/#/style-guide>`__ for a better insight on how


### PR DESCRIPTION
The file is not rendered because of inconsistent section markers.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
