### PR TITLE
admin/build-doc: use python3

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -20,7 +20,7 @@ if command -v dpkg >/dev/null; then
         exit 1
     fi
 elif command -v yum >/dev/null; then
-    for package in python-devel python-pip python-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel Cython graphviz; do
+    for package in python36-devel python36-pip python36-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel python36-Cython graphviz; do
 	if ! rpm -q --whatprovides $package >/dev/null ; then
 		missing="${missing:+$missing }$package"
 	fi
@@ -57,7 +57,7 @@ cd build-doc
 [ -z "$vdir" ] && vdir="$TOPDIR/build-doc/virtualenv"
 
 if [ ! -e $vdir ]; then
-    virtualenv --system-site-packages $vdir
+    virtualenv --python=python3 --system-site-packages $vdir
 fi
 $vdir/bin/pip install --quiet -r $TOPDIR/admin/doc-requirements.txt
 

--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,7 +1,4 @@
-Sphinx == 1.8.3
+Sphinx == 2.1.2
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
-# newer versions of breathe will require Sphinx >= 2.0.0 and are Python3 only
-breathe==4.12.0
-# 4.2 is not yet release at the time of writing, to address CVE-2017-18342,
-# we have to use its beta release.
-pyyaml>=4.2b1
+breathe == 4.13.1
+pyyaml >= 5.1.2

--- a/doc_deps.deb.txt
+++ b/doc_deps.deb.txt
@@ -1,8 +1,8 @@
 git
 gcc
-python-dev
-python-pip
-python-virtualenv
+python3-dev
+python3-pip
+python3-virtualenv
 doxygen
 ditaa
 libxml2-dev
@@ -10,4 +10,4 @@ libxslt1-dev
 graphviz
 ant
 zlib1g-dev
-cython
+cython3


### PR DESCRIPTION
to address https://github.com/sphinx-doc/sphinx/issues/3620, we need to
use sphinx with its fix at
https://github.com/sphinx-doc/sphinx/commit/e049f86b2de1cfdf8a74c88dc9593d047c85d5cb
in other words, we need to use sphinx v2.0.0 and up. but sphinx 2.0
requires python >= 3.5, so we have to use python3 for building the
documents.

in this change:

* doc-requirements.txt: install python3 packages on debian derivatives
* build-doc: install python3.6 packages from EPEL7, and use python3
  venv for using sphinx2
* doc-requirements.txt: bump up all python packages to latest
  stable.

Signed-off-by: Kefu Chai <kchai@redhat.com>

see also https://tracker.ceph.com/issues/41160

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
