### PR TITLE
mgr/dashboard: Enforce change password after first login

### DIFF
--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -44,7 +44,8 @@ class AuthTest(DashboardTestCase):
             'token': JLeaf(str),
             'username': JLeaf(str),
             'permissions': JObj(sub_elems={}, allow_unknown=True),
-            'sso': JLeaf(bool)
+            'sso': JLeaf(bool),
+            'force_change_pwd': JLeaf(bool)
         }, allow_unknown=False))
         self._validate_jwt_token(data['token'], "admin", data['permissions'])
 

--- a/qa/tasks/mgr/dashboard/test_user.py
+++ b/qa/tasks/mgr/dashboard/test_user.py
@@ -48,6 +48,7 @@ class UserTest(DashboardTestCase):
             'email': 'my@email.com',
             'roles': ['administrator'],
             'lastUpdate': user['lastUpdate'],
+            'last_pwd_update': user['last_pwd_update'],
             'enabled': True
         })
 
@@ -64,6 +65,7 @@ class UserTest(DashboardTestCase):
             'email': 'mynew@email.com',
             'roles': ['block-manager'],
             'lastUpdate': user['lastUpdate'],
+            'last_pwd_update': user['last_pwd_update'],
             'enabled': True
         })
 
@@ -93,6 +95,7 @@ class UserTest(DashboardTestCase):
             'email': 'klara@musterfrau.com',
             'roles': ['administrator'],
             'lastUpdate': user['lastUpdate'],
+            'last_pwd_update': user['last_pwd_update'],
             'enabled': False
         })
 
@@ -111,6 +114,7 @@ class UserTest(DashboardTestCase):
             'email': None,
             'roles': ['administrator'],
             'lastUpdate': user['lastUpdate'],
+            'last_pwd_update': user['last_pwd_update'],
             'enabled': True
         }])
 

--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -502,7 +502,7 @@ valid-metaclass-classmethod-first-arg=mcs
 max-args=5
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -30,7 +30,8 @@ class Auth(RESTController):
                 'token': token,
                 'username': username,
                 'permissions': user_perms,
-                'sso': mgr.SSO_DB.protocol == 'saml2'
+                'sso': mgr.SSO_DB.protocol == 'saml2',
+                'force_change_pwd': AuthManager.check_force_change_pwd(username)
             }
 
         logger.debug('Login failed')

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
@@ -54,7 +54,13 @@ export class LoginComponent implements OnInit {
             window.location.replace(login.login_url);
           }
         } else {
-          this.authStorageService.set(login.username, token, login.permissions, login.sso);
+          this.authStorageService.set(
+            login.username,
+            token,
+            login.permissions,
+            login.sso,
+            login.force_change_pwd
+          );
           this.router.navigate(['']);
         }
       });
@@ -62,8 +68,12 @@ export class LoginComponent implements OnInit {
   }
 
   login() {
-    this.authService.login(this.model).then(() => {
-      this.router.navigate(['']);
+    this.authService.login(this.model).then((forceChangePwd: Boolean) => {
+      if (forceChangePwd) {
+        this.router.navigate(['/user-profile/edit']);
+      } else {
+        this.router.navigate(['']);
+      }
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -164,6 +164,22 @@
           </div>
         </div>
 
+        <!-- Change Password -->
+        <div class="form-group row">
+          <div class="offset-sm-3 col-sm-9">
+            <div class="custom-control custom-checkbox">
+              <input type="checkbox"
+                     class="custom-control-input"
+                     id="force_change_pwd"
+                     name="force_change_pwd"
+                     formControlName="force_change_pwd">
+              <label class="custom-control-label"
+                     for="force_change_pwd"
+                     i18n>Force Change Password</label>
+            </div>
+          </div>
+        </div>
+
       </div>
       <div class="card-footer">
         <div class="button-group text-right">

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -151,7 +151,8 @@ describe('UserFormComponent', () => {
         name: 'User 0',
         email: 'user0@email.com',
         roles: ['administrator'],
-        enabled: true
+        enabled: true,
+        force_change_pwd: false
       };
       formHelper.setMultipleValues(user);
       formHelper.setValue('confirmpassword', user.password);
@@ -171,7 +172,8 @@ describe('UserFormComponent', () => {
       name: 'User 1',
       email: 'user1@email.com',
       roles: ['administrator'],
-      enabled: true
+      enabled: true,
+      force_change_pwd: false
     };
     const roles = [
       {
@@ -262,7 +264,8 @@ describe('UserFormComponent', () => {
         name: 'User 1',
         email: 'user1@email.com',
         roles: ['administrator'],
-        enabled: true
+        enabled: true,
+        force_change_pwd: false
       });
       userReq.flush({});
       expect(router.navigate).toHaveBeenCalledWith(['/user-management/users']);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -91,7 +91,8 @@ export class UserFormComponent implements OnInit {
         roles: new FormControl([]),
         enabled: new FormControl(true, {
           validators: [Validators.required]
-        })
+        }),
+        force_change_pwd: new FormControl(true)
       },
       {
         validators: [CdValidators.match('password', 'confirmpassword')]
@@ -134,14 +135,14 @@ export class UserFormComponent implements OnInit {
   }
 
   setResponse(response: UserFormModel) {
-    ['username', 'name', 'email', 'roles', 'enabled'].forEach((key) =>
+    ['username', 'name', 'email', 'roles', 'enabled', 'force_change_pwd'].forEach((key) =>
       this.userForm.get(key).setValue(response[key])
     );
   }
 
   getRequest(): UserFormModel {
     const userFormModel = new UserFormModel();
-    ['username', 'password', 'name', 'email', 'roles', 'enabled'].forEach(
+    ['username', 'password', 'name', 'email', 'roles', 'enabled', 'force_change_pwd'].forEach(
       (key) => (userFormModel[key] = this.userForm.get(key).value)
     );
     return userFormModel;

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.model.ts
@@ -5,4 +5,5 @@ export class UserFormModel {
   email: string;
   roles: Array<string>;
   enabled: boolean;
+  force_change_pwd: boolean;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.ts
@@ -81,6 +81,13 @@ export class UserPasswordFormComponent {
         validators: [CdValidators.match('newpassword', 'confirmnewpassword')]
       }
     );
+
+    if (this.authStorageService.getForceChangePwd()) {
+      this.notificationService.show(
+        NotificationType.info,
+        this.i18n('You have to change password after the first login.')
+      );
+    }
   }
 
   checkPassword(password: string) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
@@ -26,7 +26,14 @@ export class AuthService {
       .post('api/auth', credentials)
       .toPromise()
       .then((resp: LoginResponse) => {
-        this.authStorageService.set(resp.username, resp.token, resp.permissions, resp.sso);
+        this.authStorageService.set(
+          resp.username,
+          resp.token,
+          resp.permissions,
+          resp.sso,
+          resp.force_change_pwd
+        );
+        return resp.force_change_pwd;
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/login-response.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/login-response.ts
@@ -3,4 +3,5 @@ export class LoginResponse {
   token: string;
   permissions: object;
   sso: boolean;
+  force_change_pwd: boolean;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
@@ -11,7 +11,9 @@ export class AuthGuardService implements CanActivate, CanActivateChild {
 
   canActivate() {
     if (this.authStorageService.isLoggedIn()) {
-      return true;
+      return (
+        this.router.url !== '/user-profile/edit' || !this.authStorageService.getForceChangePwd()
+      );
     }
     this.router.navigate(['/login']);
     return false;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.ts
@@ -8,11 +8,18 @@ import { Permissions } from '../models/permissions';
 export class AuthStorageService {
   constructor() {}
 
-  set(username: string, token: string, permissions: object = {}, sso = false) {
+  set(
+    username: string,
+    token: string,
+    permissions: object = {},
+    sso = false,
+    forceChangePwd = false
+  ) {
     localStorage.setItem('dashboard_username', username);
     localStorage.setItem('access_token', token);
     localStorage.setItem('dashboard_permissions', JSON.stringify(new Permissions(permissions)));
     localStorage.setItem('sso', String(sso));
+    localStorage.setItem('force_change_pwd', String(forceChangePwd));
   }
 
   remove() {
@@ -30,6 +37,10 @@ export class AuthStorageService {
 
   getUsername() {
     return localStorage.getItem('dashboard_username');
+  }
+
+  getForceChangePwd() {
+    return localStorage.getItem('force_change_pwd') === 'true';
   }
 
   getPermissions(): Permissions {

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -150,6 +150,10 @@ class AuthManager(object):
     def authorize(cls, username, scope, permissions):
         return cls.AUTH_PROVIDER.authorize(username, scope, permissions)
 
+    @classmethod
+    def check_force_change_pwd(cls, username):
+        return cls.AUTH_PROVIDER.check_force_change_pwd(username)
+
 
 class AuthManagerTool(cherrypy.Tool):
     def __init__(self):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/24655

Signed-off-by: Dziomdziora, Elżbieta <elzbieta.dziomdziora@ts.fujitsu.coom>

Enforce changing the password. Admin during edition or creating the user is able to check whether the user has to change the password. User after login has to change it.
It will be updated after the ticket 40329 will be done.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
