### PR TITLE
scripts: use https url for redmine

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -34,7 +34,7 @@ import re
 import time
 from redminelib import Redmine  # https://pypi.org/project/python-redmine/
 
-redmine_endpoint = "http://tracker.ceph.com"
+redmine_endpoint = "https://tracker.ceph.com"
 project_name = "Ceph"
 release_id = 16
 delay_seconds = 5


### PR DESCRIPTION
This resolves an error I came across:

	(venv-redmine) pdonnell@senta02 ~/ceph$ python3 src/script/backport-create-issue --key 46ba4c140bd62d25ca83a6f0d40f06ef1a4384d0 37531
	WARNING:root:Missing issues will be created in Backport tracker of the relevant Redmine project
	INFO:root:Redmine key was provided; using it
	Traceback (most recent call last):
  	  File "src/script/backport-create-issue", line 242, in <module>
    	    project = redmine.project.get(project_name)
  	  File "/home/pdonnell/venv-redmine/lib/python3.5/site-packages/redminelib/managers/base.py", line 83, in get
    	    return self.to_resource(self.redmine.engine.request('get', self.url, params=self.params)[self.container])
  	  File "/home/pdonnell/venv-redmine/lib/python3.5/site-packages/redminelib/engines/base.py", line 76, in request
    	    return self.process_response(self.session.request(method, url, **kwargs))
  	  File "/home/pdonnell/venv-redmine/lib/python3.5/site-packages/redminelib/engines/base.py", line 138, in process_response
    	    raise exceptions.HTTPProtocolError
	  redminelib.exceptions.HTTPProtocolError: Redmine url should start with HTTPS and not with HTTP

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
