### PR TITLE
rgw: followup for 'user rename'

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5073,8 +5073,14 @@ int main(int argc, const char **argv)
     output_user_info = false;
     break;
   case OPT_USER_RENAME:
+    if (yes_i_really_mean_it) {
+      user_op.set_overwrite_new_user(true);
+    }
     ret = user.rename(user_op, &err_msg);
     if (ret < 0) {
+      if (ret == -EEXIST) {
+        err_msg += ". to overwrite this user, add --yes-i-really-mean-it";
+      }
       cerr << "could not rename user: " << err_msg << std::endl;
       return -ret;
     }

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -215,8 +215,9 @@ extern int rgw_link_bucket(RGWRados* store,
                            rgw_ep_info *pinfo = nullptr);
 extern int rgw_unlink_bucket(RGWRados *store, const rgw_user& user_id,
                              const string& tenant_name, const string& bucket_name, bool update_entrypoint = true);
-extern int rgw_bucket_chown(RGWRados* const store, RGWUserInfo& user_info, RGWBucketInfo& bucket_info,
-                             const string& marker, map<string, bufferlist>& attrs);
+extern int rgw_bucket_chown(RGWRados* const store, RGWBucketInfo& bucket_info,
+                            const rgw_user& uid, const std::string& display_name,
+                            const string& marker);
 extern int rgw_set_bucket_acl(RGWRados* store, ACLOwner& owner, rgw_bucket& bucket,
                               RGWBucketInfo& bucket_info, bufferlist& bl);
 extern int rgw_remove_object(RGWRados *store, const RGWBucketInfo& bucket_info, const rgw_bucket& bucket, rgw_obj_key& key);
@@ -346,7 +347,7 @@ public:
   int remove(RGWBucketAdminOpState& op_state, optional_yield y, bool bypass_gc = false, bool keep_index_consistent = true, std::string *err_msg = NULL);
   int link(RGWBucketAdminOpState& op_state, map<string, bufferlist>& attrs,
 	std::string *err_msg = NULL);
-  int chown(RGWBucketAdminOpState& op_state,  map<string, bufferlist>& attrs, const string& marker, std::string *err_msg = NULL);
+  int chown(RGWBucketAdminOpState& op_state, const string& marker, std::string *err_msg = NULL);
   int unlink(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
   int set_quota(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2063,15 +2063,10 @@ int RGWUser::execute_user_rename(RGWUserAdminOpState& op_state, std::string *err
 
   // update the 'stub user' with all of the other fields and rewrite all of the
   // associated index objects
-  RGWUserInfo user_info = old_user_info;
-  user_info.user_id = stub_user_info.user_id;
+  op_state.get_user_info().user_id = uid;
+  op_state.objv = objv;
 
-  ret = rgw_store_user_info(store, user_info, &old_user_info, &objv, real_time(), false);
-  if (ret < 0) {
-    set_err_msg(err_msg, "unable to store new user info");
-    return ret;
-  }
-  return 0;
+  return update(op_state, err_msg);
 }
 
 int RGWUser::execute_rename(RGWUserAdminOpState& op_state, RGWUserInfo& old_user_info, std::string *err_msg)

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1969,8 +1969,9 @@ int RGWUser::execute_user_rename(RGWUserAdminOpState& op_state, std::string *err
   stub_user_info.user_id = uid;
 
   RGWObjVersionTracker objv;
+  const bool exclusive = !op_state.get_overwrite_new_user(); // overwrite if requested
 
-  ret = rgw_store_user_info(store, stub_user_info, nullptr, &objv, real_time(), true);
+  ret = rgw_store_user_info(store, stub_user_info, nullptr, &objv, real_time(), exclusive);
   if (ret == -EEXIST) {
     set_err_msg(err_msg, "user name given by --new-uid already exists");
     return ret;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2071,7 +2071,8 @@ int RGWUser::execute_user_rename(RGWUserAdminOpState& op_state, std::string *err
         return ret;
       }
 
-      ret = rgw_bucket_chown(store, user_info, new_bucket_info, obj_marker, attrs);
+      ret = rgw_bucket_chown(store, new_bucket_info, uid,
+                             old_user_info.display_name, obj_marker);
       if (ret < 0) {
         set_err_msg(err_msg, "failed to run bucket chown" + cpp_strerror(-ret));
         return ret;

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -688,8 +688,7 @@ private:
   int execute_remove(RGWUserAdminOpState& op_state, 
                     std::string *err_msg, optional_yield y);
   int execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg);
-  int execute_user_rename(RGWUserAdminOpState& op_state, std::string *err_msg);
-  int execute_rename(RGWUserAdminOpState& op_state, RGWUserInfo& old_user_info, std::string *err_msg);
+  int execute_rename(RGWUserAdminOpState& op_state, std::string *err_msg);
 
 public:
   RGWUser();

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -161,6 +161,7 @@ struct RGWUserAdminOpState {
   std::string user_email;
   std::string display_name;
   rgw_user new_user_id;
+  bool overwrite_new_user = false;
   int32_t max_buckets;
   __u8 suspended;
   __u8 admin;
@@ -264,6 +265,9 @@ struct RGWUserAdminOpState {
       return;
 
     new_user_id = id;
+  }
+  void set_overwrite_new_user(bool b) {
+    overwrite_new_user = b;
   }
 
   void set_user_email(std::string& email) {
@@ -456,6 +460,7 @@ struct RGWUserAdminOpState {
   std::string get_user_email() { return user_email; }
   std::string get_display_name() { return display_name; }
   rgw_user& get_new_uid() { return new_user_id; }
+  bool get_overwrite_new_user() const { return overwrite_new_user; }
   map<int, std::string>& get_temp_url_keys() { return temp_url_keys; }
 
   RGWUserInfo&  get_user_info() { return info; }

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -123,6 +123,7 @@ extern int rgw_delete_user(RGWRados *store, RGWUserInfo& user, RGWObjVersionTrac
  */
 extern int rgw_remove_key_index(RGWRados *store, RGWAccessKey& access_key);
 extern int rgw_remove_uid_index(RGWRados *store, rgw_user& uid);
+extern int rgw_remove_user_buckets_index(RGWRados *store, rgw_user& uid);
 extern int rgw_remove_email_index(RGWRados *store, string& email);
 extern int rgw_remove_swift_name_index(RGWRados *store, string& swift_name);
 


### PR DESCRIPTION
some cleanup and refactoring to make it closer to the new user interfaces in https://github.com/ceph/ceph/pull/29118. allows overwriting the --new-uid user when --yes-i-really-mean-it is given