### PR TITLE
rgw: http client drops lock before suspending coroutine

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -60,12 +60,14 @@ struct rgw_http_req_data : public RefCountedObject {
   auto async_wait(ExecutionContext& ctx, CompletionToken&& token) {
     boost::asio::async_completion<CompletionToken, Signature> init(token);
     auto& handler = init.completion_handler;
-    completion = Completion::create(ctx.get_executor(), std::move(handler));
+    {
+      std::unique_lock l{lock};
+      completion = Completion::create(ctx.get_executor(), std::move(handler));
+    }
     return init.result.get();
   }
 
   int wait(optional_yield y) {
-    std::unique_lock l{lock};
     if (done) {
       return ret;
     }
@@ -82,6 +84,7 @@ struct rgw_http_req_data : public RefCountedObject {
       dout(20) << "WARNING: blocking http request" << dendl;
     }
 #endif
+    std::unique_lock l{lock};
     cond.wait(l);
     return ret;
   }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -108,12 +108,7 @@ struct rgw_http_req_data : public RefCountedObject {
     }
   }
 
-  bool _is_done() {
-    return done;
-  }
-
   bool is_done() {
-    std::lock_guard l{lock};
     return done;
   }
 
@@ -895,7 +890,7 @@ void RGWHTTPManager::_unlink_request(rgw_http_req_data *req_data)
   if (req_data->curl_handle) {
     curl_multi_remove_handle((CURLM *)multi_handle, req_data->get_easy_handle());
   }
-  if (!req_data->_is_done()) {
+  if (!req_data->is_done()) {
     _finish_request(req_data, -ECANCELED);
   }
 }


### PR DESCRIPTION
the lock can't be held over async_wait(), because the call to finish() won't be able to reacquire the lock in order to fire the completion. coroutines may also resume on a different thread, and you can't unlock a mutex that was locked on another thread