### PR TITLE
cephfs-shell: Fix onecmd TypeError

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -393,12 +393,12 @@ class CephFSShell(Cmd):
             return self.delimiter_complete(text, line, begidx, endidx, completions, '/')
         return completions
 
-    def onecmd(self, line):
+    def onecmd(self, line, **kwargs):
         """
         Global error catcher
         """
         try:
-            res = Cmd.onecmd(self, line)
+            res = Cmd.onecmd(self, line, **kwargs)
             if self.interactive:
                 self.set_prompt()
             return res


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41164
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
