### PR TITLE
mgr/dashboard: CephFS client tab switch

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
@@ -34,11 +34,8 @@
     </div>
   </tab>
   <tab i18n-heading
-       heading="Clients: {{ clientCount }}"
-       (selectTab)="clientsSelect=true"
-       (deselect)="clientsSelect=false">
-    <cd-cephfs-clients [id]="id"
-                       *ngIf="clientsSelect">
+       heading="Clients: {{ clientCount }}">
+    <cd-cephfs-clients [id]="id">
     </cd-cephfs-clients>
   </tab>
   <tab i18n-heading

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
@@ -37,7 +37,6 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
   grafanaPermission: Permission;
 
   objectValues = Object.values;
-  clientsSelect = false;
 
   constructor(
     private authStorageService: AuthStorageService,


### PR DESCRIPTION
The problem was that it was not possible to click on the clients tab
inside the CephFS details and switch to it. This commit fixes this.

Fixes: https://tracker.ceph.com/issues/41165
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
