### PR TITLE
mgr/orchestrator_cli: allow listing devices by hostname

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -45,10 +45,9 @@ class TestOrchestratorCli(MgrTestCase):
         ret = self._orch_cmd("device", "ls", "--refresh")
         self.assertIn("localhost:", ret)
 
-    def test_device_ls_hoshs(self):
-        ret = self._orch_cmd("device", "ls", "localhost", "host1")
+    def test_device_ls_hosts(self):
+        ret = self._orch_cmd("device", "ls", "localhost")
         self.assertIn("localhost:", ret)
-
 
     def test_device_ls_json(self):
         ret = self._orch_cmd("device", "ls", "--format", "json")

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -77,7 +77,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         return HandleCommandResult(stdout=result)
 
     @_read_cli('orchestrator device ls',
-               "name=host,type=CephString,n=N,req=false "
+               "name=host,type=CephString,req=false "
                "name=format,type=CephChoices,strings=json|plain,req=false "
                "name=refresh,type=CephBool,req=false",
                'List devices on a node')
@@ -90,7 +90,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         date hardware inventory is fine as long as hardware ultimately appears
         in the output of this command.
         """
-        nf = orchestrator.InventoryFilter(nodes=host) if host else None
+        nf = orchestrator.InventoryFilter(nodes=[host]) if host else None
 
         completion = self.get_inventory(node_filter=nf, refresh=refresh)
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41174

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
