### PR TITLE
[RFC][DNM] change order of notify_one.

### DIFF
--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -69,52 +69,57 @@ class Finisher {
     std::unique_lock ul(finisher_lock);
     bool was_empty = finisher_queue.empty();
     finisher_queue.push_back(std::make_pair(c, r));
+    if (logger)
+      logger->inc(l_finisher_queue_len);
     if (was_empty) {
       finisher_cond.notify_one();
     }
-    if (logger)
-      logger->inc(l_finisher_queue_len);
+
   }
 
   void queue(std::list<Context*>& ls) {
     {
       std::unique_lock ul(finisher_lock);
-      if (finisher_queue.empty()) {
-	finisher_cond.notify_all();
-      }
+      bool was_empty = finisher_queue.empty();
       for (auto i : ls) {
 	finisher_queue.push_back(std::make_pair(i, 0));
       }
       if (logger)
 	logger->inc(l_finisher_queue_len, ls.size());
+      if (finisher_queue.empty()) {
+	finisher_cond.notify_all();
+      }
     }
     ls.clear();
   }
   void queue(std::deque<Context*>& ls) {
     {
       std::unique_lock ul(finisher_lock);
-      if (finisher_queue.empty()) {
-	finisher_cond.notify_all();
-      }
+      bool was_empty = finisher_queue.empty();
       for (auto i : ls) {
 	finisher_queue.push_back(std::make_pair(i, 0));
       }
       if (logger)
 	logger->inc(l_finisher_queue_len, ls.size());
+      if (finisher_queue.empty()) {
+	finisher_cond.notify_all();
+      }
+
     }
     ls.clear();
   }
   void queue(std::vector<Context*>& ls) {
     {
       std::unique_lock ul(finisher_lock);
-      if (finisher_queue.empty()) {
-	finisher_cond.notify_all();
-      }
+      bool was_empty = finisher_queue.empty();
       for (auto i : ls) {
 	finisher_queue.push_back(std::make_pair(i, 0));
       }
       if (logger)
 	logger->inc(l_finisher_queue_len, ls.size());
+      if (empty) {
+	finisher_cond.notify_all();
+      }
     }
     ls.clear();
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10071,10 +10071,6 @@ void BlueStore::_txc_state_proc(TransContext *txc)
       {
 	std::lock_guard l(kv_lock);
 	kv_queue.push_back(txc);
-	if (!kv_sync_in_progress) {
-	  kv_sync_in_progress = true;
-	  kv_cond.notify_one();
-	}
 	if (txc->state != TransContext::STATE_KV_SUBMITTED) {
 	  kv_queue_unsubmitted.push_back(txc);
 	  ++txc->osr->kv_committing_serially;
@@ -10082,6 +10078,11 @@ void BlueStore::_txc_state_proc(TransContext *txc)
 	if (txc->had_ios)
 	  kv_ios++;
 	kv_throttle_costs += txc->cost;
+
+	if (!kv_sync_in_progress) {
+	  kv_sync_in_progress = true;
+	  kv_cond.notify_one();
+	}
       }
       return;
     case TransContext::STATE_KV_SUBMITTED:


### PR DESCRIPTION
When we call notify_one, the wait-thread will re-obtain the lock. If
wakeup-thread still obtained this lock and do something. This will
incrase the chance which wait-thread be blocked by lock.
So we should move notify_one at the end.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
