### PR TITLE
osd: don't carry PGLSFilter between multiple ops in MOSDOp.

### DIFF
--- a/src/cls/cephfs/cls_cephfs.cc
+++ b/src/cls/cephfs/cls_cephfs.cc
@@ -145,11 +145,13 @@ public:
   }
 
   ~PGLSCephFSFilter() override {}
-  bool reject_empty_xattr() override { return false; }
-  bool filter(const hobject_t &obj, bufferlist& xattr_data) override;
+  bool reject_empty_xattr() const override { return false; }
+  bool filter(const hobject_t& obj,
+              const bufferlist& xattr_data) const override;
 };
 
-bool PGLSCephFSFilter::filter(const hobject_t &obj, bufferlist& xattr_data)
+bool PGLSCephFSFilter::filter(const hobject_t &obj,
+                              const bufferlist& xattr_data) const
 {
   const std::string need_ending = ".00000000";
   const std::string &obj_name = obj.oid.name;

--- a/src/cls/hello/cls_hello.cc
+++ b/src/cls/hello/cls_hello.cc
@@ -266,15 +266,10 @@ public:
   }
 
   ~PGLSHelloFilter() override {}
-  bool filter(const hobject_t &obj, ceph::bufferlist& xattr_data) override
+  bool filter(const hobject_t& obj,
+              const bufferlist&  xattr_data) const override
   {
-    if (val.size() != xattr_data.length())
-      return false;
-
-    if (memcmp(val.c_str(), xattr_data.c_str(), val.size()))
-      return false;
-
-    return true;
+    return xattr_data.contents_equal(val.c_str(), val.size());
   }
 };
 

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -13,6 +13,7 @@
  */
 
 #include <atomic>
+#include <cstring>
 #include <errno.h>
 #include <limits.h>
 
@@ -1001,6 +1002,27 @@ static ceph::spinlock debug_lock;
       }
       return true;
     }
+  }
+
+  bool buffer::list::contents_equal(const void* const other,
+                                    size_t length) const
+  {
+    if (this->length() != length) {
+      return false;
+    }
+
+    const auto* other_buf = reinterpret_cast<const char*>(other);
+    for (const auto& bp : buffers()) {
+      const auto round_length = std::min<size_t>(length, bp.length());
+      if (std::memcmp(bp.c_str(), other_buf, round_length) != 0) {
+        return false;
+      } else {
+        length -= round_length;
+        other_buf += round_length;
+      }
+    }
+
+    return true;
   }
 
   bool buffer::list::is_provided_buffer(const char* const dst) const

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1038,6 +1038,7 @@ inline namespace v14_2_0 {
     }
 
     bool contents_equal(const buffer::list& other) const;
+    bool contents_equal(const void* other, size_t length) const;
 
     bool is_provided_buffer(const char *dst) const;
     bool is_aligned(unsigned align) const;

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -81,7 +81,8 @@ protected:
 public:
   PGLSFilter();
   virtual ~PGLSFilter();
-  virtual bool filter(const hobject_t &obj, ceph::buffer::list& xattr_data) = 0;
+  virtual bool filter(const hobject_t &obj,
+                      const ceph::buffer::list& xattr_data) const = 0;
 
   /**
    * Arguments passed from the RADOS client.  Implementations must
@@ -94,13 +95,13 @@ public:
    * xattr key, or empty string.  If non-empty, this xattr will be fetched
    * and the value passed into ::filter
    */
-  virtual std::string& get_xattr() { return xattr; }
+  virtual const std::string& get_xattr() const { return xattr; }
 
   /**
    * If true, objects without the named xattr (if xattr name is not empty)
    * will be rejected without calling ::filter
    */
-  virtual bool reject_empty_xattr() { return true; }
+  virtual bool reject_empty_xattr() const { return true; }
 };
 
 // Classes expose a filter constructor that returns a subclass of PGLSFilter

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1410,9 +1410,9 @@ protected:
   int do_sparse_read(OpContext *ctx, OSDOp& osd_op);
   int do_writesame(OpContext *ctx, OSDOp& osd_op);
 
-  bool pgls_filter(PGLSFilter& filter, hobject_t& sobj);
+  bool pgls_filter(const PGLSFilter& filter, const hobject_t& sobj);
 
-  std::pair<int, std::unique_ptr<PGLSFilter>> get_pgls_filter(
+  std::pair<int, std::unique_ptr<const PGLSFilter>> get_pgls_filter(
     bufferlist::const_iterator& iter);
 
   map<hobject_t, list<OpRequestRef>> in_progress_proxy_ops;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1410,8 +1410,10 @@ protected:
   int do_sparse_read(OpContext *ctx, OSDOp& osd_op);
   int do_writesame(OpContext *ctx, OSDOp& osd_op);
 
-  bool pgls_filter(PGLSFilter *filter, hobject_t& sobj);
-  int get_pgls_filter(bufferlist::const_iterator& iter, PGLSFilter **pfilter);
+  bool pgls_filter(PGLSFilter& filter, hobject_t& sobj);
+
+  std::pair<int, std::unique_ptr<PGLSFilter>> get_pgls_filter(
+    bufferlist::const_iterator& iter);
 
   map<hobject_t, list<OpRequestRef>> in_progress_proxy_ops;
   void kick_proxy_ops_blocked(hobject_t& soid);


### PR DESCRIPTION
Currently result of executing multiple PG listing operations in single `MOSDOp` – if `PGLSFilter` is being used – depends on the order in the sequence. To exemplify:
```
  [ CEPH_OSD_OP_PGNLS, CEPH_OSD_OP_PGNLS_FILTER ]
```
may bring different result for `CEPH_OSD_OP_PGNLS` than
```
  [ CEPH_OSD_OP_PGNLS_FILTER, CEPH_OSD_OP_PGNLS ].
```
This happens because `..._PGNLS_FILTER` sets up `PGLSFilter` which is used also by plain `..._PGNLS`.

The commit changes that. After the filter is set-up separately for each interested operation in `MOSDOp`.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>