### PR TITLE
mds: update atime with newer one when Fwr caps are flushed

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3322,7 +3322,8 @@ void Locker::_update_cap_fields(CInode *in, int dirty, const cref_t<MClientCaps>
       else
 	pi->inline_data.free_data();
     }
-    if ((dirty & CEPH_CAP_FILE_EXCL) && atime != pi->atime) {
+    if (((dirty & CEPH_CAP_FILE_EXCL) && atime != pi->atime) ||
+	((dirty & CEPH_CAP_FILE_RD|CEPH_CAP_FILE_WR) && atime > pi->atime)) {
       dout(7) << "  atime " << pi->atime << " -> " << atime
 	      << " for " << *in << dendl;
       pi->atime = atime;


### PR DESCRIPTION
Currently, xfstest generic/192 fails when run under kcephfs. It
creates a file on cephfs, and then reads it after a delay to ensure
that the atime is updated. It then unmounts and remounts the fs
and checks it again. cephfs fails at this point because the atime
reverts to its original value.

Fix this by updating the atime not only when we're flushing Fx caps,
but also when flushing Fw or Fr as well, and the atime is newer than
the one currently set on the inode.

Fixes: https://tracker.ceph.com/issues/41192
Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
