### PR TITLE
osd, osdc: drop the unused outdata feature of PGLSFilter.

### DIFF
--- a/src/cls/cephfs/cls_cephfs.cc
+++ b/src/cls/cephfs/cls_cephfs.cc
@@ -146,12 +146,10 @@ public:
 
   ~PGLSCephFSFilter() override {}
   bool reject_empty_xattr() override { return false; }
-  bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata) override;
+  bool filter(const hobject_t &obj, bufferlist& xattr_data) override;
 };
 
-bool PGLSCephFSFilter::filter(const hobject_t &obj,
-                             bufferlist& xattr_data, bufferlist& outdata)
+bool PGLSCephFSFilter::filter(const hobject_t &obj, bufferlist& xattr_data)
 {
   const std::string need_ending = ".00000000";
   const std::string &obj_name = obj.oid.name;

--- a/src/cls/hello/cls_hello.cc
+++ b/src/cls/hello/cls_hello.cc
@@ -266,8 +266,7 @@ public:
   }
 
   ~PGLSHelloFilter() override {}
-  bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata) override
+  bool filter(const hobject_t &obj, ceph::bufferlist& xattr_data) override
   {
     if (val.size() != xattr_data.length())
       return false;

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -81,8 +81,7 @@ protected:
 public:
   PGLSFilter();
   virtual ~PGLSFilter();
-  virtual bool filter(const hobject_t &obj, ceph::buffer::list& xattr_data,
-                      ceph::buffer::list& outdata) = 0;
+  virtual bool filter(const hobject_t &obj, ceph::buffer::list& xattr_data) = 0;
 
   /**
    * Arguments passed from the RADOS client.  Implementations must

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -776,8 +776,7 @@ public:
     return 0;
   }
   ~PGLSPlainFilter() override {}
-  bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata) override;
+  bool filter(const hobject_t &obj, bufferlist& xattr_data) override;
 };
 
 class PGLSParentFilter : public PGLSFilter {
@@ -799,12 +798,10 @@ public:
     return 0;
   }
   ~PGLSParentFilter() override {}
-  bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata) override;
+  bool filter(const hobject_t &obj, bufferlist& xattr_data) override;
 };
 
-bool PGLSParentFilter::filter(const hobject_t &obj,
-                              bufferlist& xattr_data, bufferlist& outdata)
+bool PGLSParentFilter::filter(const hobject_t &obj, bufferlist& xattr_data)
 {
   auto iter = xattr_data.cbegin();
   inode_backtrace_t bt;
@@ -815,9 +812,9 @@ bool PGLSParentFilter::filter(const hobject_t &obj,
 
   vector<inode_backpointer_t>::iterator vi;
   for (vi = bt.ancestors.begin(); vi != bt.ancestors.end(); ++vi) {
-    generic_dout(0) << "vi->dirino=" << vi->dirino << " parent_ino=" << parent_ino << dendl;
+    generic_dout(0) << "vi->dirino=" << vi->dirino << " parent_ino="
+                    << parent_ino << dendl;
     if (vi->dirino == parent_ino) {
-      encode(*vi, outdata);
       return true;
     }
   }
@@ -825,8 +822,7 @@ bool PGLSParentFilter::filter(const hobject_t &obj,
   return false;
 }
 
-bool PGLSPlainFilter::filter(const hobject_t &obj,
-                             bufferlist& xattr_data, bufferlist& outdata)
+bool PGLSPlainFilter::filter(const hobject_t &obj, bufferlist& xattr_data)
 {
   if (val.size() != xattr_data.length())
     return false;
@@ -837,7 +833,7 @@ bool PGLSPlainFilter::filter(const hobject_t &obj,
   return true;
 }
 
-bool PrimaryLogPG::pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& outdata)
+bool PrimaryLogPG::pgls_filter(PGLSFilter* filter, hobject_t& sobj)
 {
   bufferlist bl;
 
@@ -855,7 +851,7 @@ bool PrimaryLogPG::pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& 
     }
   }
 
-  return filter->filter(sobj, bl, outdata);
+  return filter->filter(sobj, bl);
 }
 
 int PrimaryLogPG::get_pgls_filter(bufferlist::const_iterator& iter, PGLSFilter **pfilter)
@@ -1083,7 +1079,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
   int result = 0;
   string cname, mname;
   PGLSFilter *filter = NULL;
-  bufferlist filter_out;
 
   snapid_t snapid = m->get_snapid();
 
@@ -1229,7 +1224,7 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
                candidate.get_namespace() != m->get_hobj().nspace)
 	    continue;
 
-	  if (filter && !pgls_filter(filter, candidate, filter_out))
+	  if (filter && !pgls_filter(filter, candidate))
 	    continue;
 
           dout(20) << "pgnls item 0x" << std::hex
@@ -1258,8 +1253,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
         }
         dout(10) << "pgnls handle=" << response.handle << dendl;
 	encode(response, osd_op.outdata);
-	if (filter)
-	  encode(filter_out, osd_op.outdata);
 	dout(10) << " pgnls result=" << result << " outdata.length()="
 		 << osd_op.outdata.length() << dendl;
       }
@@ -1379,7 +1372,7 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	  if (recovery_state.get_missing_loc().is_deleted(candidate))
 	    continue;
 
-	  if (filter && !pgls_filter(filter, candidate, filter_out))
+	  if (filter && !pgls_filter(filter, candidate))
 	    continue;
 
 	  response.entries.push_back(make_pair(candidate.oid,
@@ -1392,8 +1385,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	}
 	response.handle = next;
 	encode(response, osd_op.outdata);
-	if (filter)
-	  encode(filter_out, osd_op.outdata);
 	dout(10) << " pgls result=" << result << " outdata.length()="
 		 << osd_op.outdata.length() << dendl;
       }

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1410,7 +1410,7 @@ protected:
   int do_sparse_read(OpContext *ctx, OSDOp& osd_op);
   int do_writesame(OpContext *ctx, OSDOp& osd_op);
 
-  bool pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& outdata);
+  bool pgls_filter(PGLSFilter *filter, hobject_t& sobj);
   int get_pgls_filter(bufferlist::const_iterator& iter, PGLSFilter **pfilter);
 
   map<hobject_t, list<OpRequestRef>> in_progress_proxy_ops;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3798,10 +3798,11 @@ void Objecter::_nlist_reply(NListContext *list_context, int r,
 
   auto iter = list_context->bl.cbegin();
   pg_nls_response_t response;
-  ceph::buffer::list extra_info;
   decode(response, iter);
   if (!iter.end()) {
-    decode(extra_info, iter);
+    // we do this as legacy.
+    ceph::buffer::list legacy_extra_info;
+    decode(legacy_extra_info, iter);
   }
 
   // if the osd returns 1 (newer code), or handle MAX, it means we
@@ -3828,7 +3829,6 @@ void Objecter::_nlist_reply(NListContext *list_context, int r,
 		 << ", response.entries " << response.entries
 		 << ", handle " << response.handle
 		 << ", tentative new pos " << list_context->pos << dendl;
-  list_context->extra_info.append(extra_info);
   if (response_size) {
     list_context->list.splice(list_context->list.end(), response.entries);
   }
@@ -5156,11 +5156,12 @@ void Objecter::_enumerate_reply(
   auto iter = bl.cbegin();
   pg_nls_response_t response;
 
-  // XXX extra_info doesn't seem used anywhere?
-  ceph::buffer::list extra_info;
   decode(response, iter);
   if (!iter.end()) {
-    decode(extra_info, iter);
+    // extra_info isn't used anywhere. We do this solely to preserve
+    // backward compatibility
+    ceph::buffer::list legacy_extra_info;
+    decode(legacy_extra_info, iter);
   }
 
   ldout(cct, 10) << __func__ << ": got " << response.entries.size()

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1610,8 +1610,6 @@ public:
 
     ceph::buffer::list filter;
 
-    ceph::buffer::list extra_info;
-
     // The budget associated with this context, once it is set (>= 0),
     // the budget is not get/released on OP basis, instead the budget
     // is acquired before sending the first OP and released upon receiving


### PR DESCRIPTION
Before this commit `PGLSFilter` interface was offering the `outdata` parameter in its `filter()` method:
```
  filter(..., bufferlist& outdata)
```
OSD was serializing and appending the bufferlist to response to `CEPH_OSD_OP_PGLS_FILTER` and `CEPH_OSD_OP_PGNLS_FILTER` operations. At the `Objecter`'s side these extra bits were being parsed and finally stored in `NListContext::extra_info`. However, it really looks this member is not used anywhere.

The commit removes the `outdata` handling on multiple layers: from `PGLSFilter` implementations, through OSD till `Objecter`.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>