### PR TITLE
rgw: don't throw when accept errors are happening on frontend

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -567,7 +567,8 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
   } else if (ec == boost::asio::error::operation_aborted) {
     return;
   } else if (ec) {
-    throw ec;
+    ldout(ctx(), 1) << "accept failed: " << ec.message() << dendl;
+    return;
   }
   auto socket = std::move(l.socket);
   tcp::no_delay options(l.use_nodelay);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41169
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

"accept" may fail due to transient system issues (e.g. too many open file descriptors). in such a case we should fail and log, instead of crashing the rgw.

to reproduce:
* set max FDs to small number (e.g. ```ulimit -n 128```)
* run rgw and and use multiple clients (more than 128) to upload objects at the same time

**before the fix** - rgw would crash
**after the fix** - client connection would fail
after setting limit to 1024, and/or using less clients, rgw should work as usual with no failures.
