### PR TITLE
osd: merge replica log on primary need according to replica log's crt

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -269,11 +269,11 @@ void PGLog::proc_replica_log(
     limit :
     first_non_divergent->version;
 
-  // We need to preserve the original crt before it gets updated in rewind_from_head().
-  // Later, in merge_object_divergent_entries(), we use it to check whether we can rollback
-  // a divergent entry or not.
-  eversion_t original_crt = log.get_can_rollback_to();
-  dout(20) << __func__ << " original_crt = " << original_crt << dendl;
+  // we merge and adjust the replica's log, rollback the rollbackable divergent entry, 
+  // remove the unrollbackable divergent entry and mark the according object as missing. 
+  // the rollback boundary must choose crt of the olog which going to be merged. 
+  // The replica log's(olog) crt will not be modified, so it could get passed
+  // to _merge_divergent_entries() directly.
   IndexedLog folog(olog);
   auto divergent = folog.rewind_from_head(lu);
   _merge_divergent_entries(
@@ -281,7 +281,6 @@ void PGLog::proc_replica_log(
     divergent,
     oinfo,
     olog.get_can_rollback_to(),
-    original_crt,
     omissing,
     0,
     this);
@@ -345,7 +344,6 @@ void PGLog::rewind_divergent_log(eversion_t newhead,
     log,
     divergent,
     info,
-    log.get_can_rollback_to(),
     original_crt,
     missing,
     rollbacker,
@@ -471,7 +469,6 @@ void PGLog::merge_log(pg_info_t &oinfo, pg_log_t &olog, pg_shard_t fromosd,
       log,
       divergent,
       info,
-      log.get_can_rollback_to(),
       original_crt,
       missing,
       rollbacker,

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -898,8 +898,7 @@ protected:
     const hobject_t &hoid,               ///< [in] object we are merging
     const mempool::osd_pglog::list<pg_log_entry_t> &orig_entries, ///< [in] entries for hoid to merge
     const pg_info_t &info,              ///< [in] info for merging entries
-    eversion_t olog_can_rollback_to,     ///< [in] rollback boundary
-    eversion_t original_can_rollback_to,     ///< [in] original rollback boundary
+    eversion_t olog_can_rollback_to,     ///< [in] rollback boundary of input InedexedLog
     missing_type &missing,               ///< [in,out] missing to adjust, use
     LogEntryHandler *rollbacker,         ///< [in] optional rollbacker object
     const DoutPrefixProvider *dpp        ///< [in] logging provider
@@ -1063,17 +1062,11 @@ protected:
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
                        << " olog_can_rollback_to: "
                        << olog_can_rollback_to << dendl;
-    ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-                       << " original_crt: "
-                       << original_can_rollback_to << dendl;
     /// Distinguish between 4) and 5)
     for (list<pg_log_entry_t>::const_reverse_iterator i = entries.rbegin();
 	 i != entries.rend();
 	 ++i) {
-      /// Use original_can_rollback_to instead of olog_can_rollback_to to check
-      //  if we can rollback or not. This is to ensure that we don't try to rollback
-      //  to an object that has been deleted and doesn't exist.
-      if (!i->can_rollback() || i->version <= original_can_rollback_to) {
+      if (!i->can_rollback() || i->version <= olog_can_rollback_to) {
 	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid << " cannot rollback "
 			   << *i << dendl;
 	can_rollback = false;
@@ -1086,7 +1079,7 @@ protected:
       for (list<pg_log_entry_t>::const_reverse_iterator i = entries.rbegin();
 	   i != entries.rend();
 	   ++i) {
-	ceph_assert(i->can_rollback() && i->version > original_can_rollback_to);
+	ceph_assert(i->can_rollback() && i->version > olog_can_rollback_to);
 	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
 			   << " rolling back " << *i << dendl;
 	if (rollbacker)
@@ -1122,8 +1115,7 @@ protected:
     const IndexedLog &log,               ///< [in] log to merge against
     mempool::osd_pglog::list<pg_log_entry_t> &entries,       ///< [in] entries to merge
     const pg_info_t &oinfo,              ///< [in] info for merging entries
-    eversion_t olog_can_rollback_to,     ///< [in] rollback boundary
-    eversion_t original_can_rollback_to, ///< [in] original rollback boundary
+    eversion_t olog_can_rollback_to,     ///< [in] rollback boundary of input IndexedLog
     missing_type &omissing,              ///< [in,out] missing to adjust, use
     LogEntryHandler *rollbacker,         ///< [in] optional rollbacker object
     const DoutPrefixProvider *dpp        ///< [in] logging provider
@@ -1139,7 +1131,6 @@ protected:
 	i->second,
 	oinfo,
 	olog_can_rollback_to,
-        original_can_rollback_to,
 	omissing,
 	rollbacker,
 	dpp);
@@ -1162,7 +1153,6 @@ protected:
       oe.soid,
       entries,
       info,
-      log.get_can_rollback_to(),
       log.get_can_rollback_to(),
       missing,
       rollbacker,

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2931,7 +2931,6 @@ TEST_F(PGLogTest, _merge_object_divergent_entries) {
     _merge_object_divergent_entries(log, hoid,
                                     orig_entries, oinfo,
                                     log.get_can_rollback_to(),
-                                    log.get_can_rollback_to(),
                                     missing, &rollbacker,
                                     this);
     // No core dump
@@ -2957,7 +2956,6 @@ TEST_F(PGLogTest, _merge_object_divergent_entries) {
     LogHandler rollbacker;
     _merge_object_divergent_entries(log, hoid,
                                     orig_entries, oinfo,
-                                    log.get_can_rollback_to(),
                                     log.get_can_rollback_to(),
                                     missing, &rollbacker,
                                     this);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41194

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
