### PR TITLE
nautilus: msg/simple: reset in_seq_acked to zero when session is reset

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1606,6 +1606,7 @@ void Pipe::was_session_reset()
   randomize_out_seq();
 
   in_seq = 0;
+  in_seq_acked = 0;
   connect_seq = 0;
 }
 


### PR DESCRIPTION
SimpleMessenger module  has been removed from master branch in e57af1d, so I picked the nautilus branch to merge in.

Fixes:  https://tracker.ceph.com/issues/41195
Signed-off-by:  Xiangyang Yu penglaiyxy@gmail.com