### PR TITLE
mgr/test_orchestrator: Allow initializing dummy data

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator_cli/test_orchestrator.py
@@ -1,16 +1,58 @@
 from __future__ import absolute_import
-
 import json
 
 import pytest
 
+from orchestrator import ReadCompletion, raise_if_exception, RGWSpec
+from orchestrator import InventoryNode, InventoryDevice, ServiceDescription
+from orchestrator import OrchestratorValidationError
 
-from orchestrator import InventoryDevice, ReadCompletion, raise_if_exception, RGWSpec
 
-def test_inventory_device():
-    i_d = InventoryDevice()
-    s = i_d.pretty_print()
-    assert len(s)
+def _test_resource(data, resource_class, extra):
+    # create the instance with normal way
+    rsc = resource_class(**data)
+    if hasattr(rsc, 'pretty_print'):
+        assert rsc.pretty_print()
+
+    # ensure we can deserialize and serialize
+    rsc = resource_class.from_json(data)
+    rsc.to_json()
+
+    # if there is an unexpected data provided
+    data.update(extra)
+    with pytest.raises(OrchestratorValidationError):
+        resource_class.from_json(data)
+
+
+def test_inventory():
+    json_data = {
+        'name': 'host0',
+        'devices': [
+            {
+                'type': 'hdd',
+                'id': '/dev/sda',
+                'size': 1024,
+                'rotates': True
+            }
+        ]
+    }
+    _test_resource(json_data, InventoryNode, {'abc': False})
+    for devices in json_data['devices']:
+        _test_resource(devices, InventoryDevice, {'abc': False})
+
+    json_data = [{}, {'name': 'host0'}, {'devices': []}]
+    for data in json_data:
+        with pytest.raises(OrchestratorValidationError):
+            InventoryNode.from_json(data)
+
+
+def test_service_description():
+    json_data = {
+        'nodename': 'test',
+        'service_type': 'mon',
+        'service_instance': 'a'
+    }
+    _test_resource(json_data, ServiceDescription, {'abc': False})
 
 
 def test_raise():


### PR DESCRIPTION
- Add test_orchestrator load_data command
- Add QA tests for loading data

Fixes: https://tracker.ceph.com/issues/41151

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
