### PR TITLE
common/plugin: fix segmentfault caused by PluginRegistry::add()

### DIFF
--- a/src/common/PluginRegistry.cc
+++ b/src/common/PluginRegistry.cc
@@ -93,6 +93,9 @@ int PluginRegistry::add(const std::string& type,
   }
   ldout(cct, 1) << __func__ << " " << type << " " << name
 		<< " " << plugin << dendl;
+  if (!plugins.count(type)){
+    plugins[type] = std::map<std::string,Plugin*>();
+  }
   plugins[type][name] = plugin;
   return 0;
 }


### PR DESCRIPTION
common/plugin: fix segmentfault caused by PluginRegistry::add()

Fixs: https://tracker.ceph.com/issues/41199
Signed-off-by: wangmingshuai <736808191@qq.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
