### PR TITLE
osd: fix ceph_assert(mem_avail >= 0) caused by the unset cgroup memory limit

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4154,6 +4154,11 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description(""),
 
+    Option("osd_memory_target_baseon_cgroup", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .add_see_also("bluestore_cache_autotune")
+    .set_description("Set osd_memory_target based on cgroup limit."),
+
     Option("osd_memory_target", Option::TYPE_SIZE, Option::LEVEL_BASIC)
     .set_default(4_G)
     .add_see_also("bluestore_cache_autotune")

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4127,6 +4127,7 @@ const char **BlueStore::get_tracked_conf_keys() const
     "bluestore_max_blob_size",
     "bluestore_max_blob_size_ssd",
     "bluestore_max_blob_size_hdd",
+    "osd_memory_target_baseon_cgroup",
     "osd_memory_target",
     "osd_memory_target_cgroup_limit_ratio",
     "osd_memory_base",
@@ -4307,9 +4308,11 @@ int BlueStore::_set_cache_sizes()
 {
   // set osd_memory_target *default* based on cgroup limit?
   // (do this before we fetch the osd_memory_target value!)
+  bool osd_memory_target_baseon_cgroup = cct->_conf.get_val<bool>(
+    "osd_memory_target_baseon_group");
   double cgroup_ratio = cct->_conf.get_val<double>(
     "osd_memory_target_cgroup_limit_ratio");
-  if (cgroup_ratio > 0.0) {
+  if (osd_memory_target_baseon_cgroup && cgroup_ratio > 0.0) {
     uint64_t cgroup_limit = 0;
     if (get_cgroup_memory_limit(&cgroup_limit) == 0 &&
 	cgroup_limit) {


### PR DESCRIPTION
osd: fix ceph_assert(mem_avail >= 0) caused by the unset cgroup memory memory.limit_in_bytes
Fixs: https://tracker.ceph.com/issues/41200
Signed-off-by: wangmingshuai <redickwang@qq.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
