### PR TITLE
ObjectCacher:fix osd timeout error,when there are many discrete write operations on an object ,and the length of those operations are all only a few bytes.

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -353,6 +353,7 @@ OPTION(client_oc_size, OPT_INT)    // MB * n
 OPTION(client_oc_max_dirty, OPT_INT)    // MB * n  (dirty OR tx.. bigish)
 OPTION(client_oc_target_dirty, OPT_INT) // target dirty (keep this smallish)
 OPTION(client_oc_max_dirty_age, OPT_DOUBLE)      // max age in cache before writeback
+OPTION(client_oc_max_object_ops,OPT_INT) //max number ops on an object
 OPTION(client_oc_max_objects, OPT_INT)      // max objects in cache
 OPTION(client_debug_getattr_caps, OPT_BOOL) // check if MDS reply contains wanted caps
 OPTION(client_debug_force_sync_read, OPT_BOOL)     // always read synchronously (go to osds)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8240,6 +8240,10 @@ std::vector<Option> get_mds_client_options() {
     .set_default(5.0)
     .set_description("maximum age of dirty pages in object cache (seconds)"),
 
+    Option("client_oc_max_object_ops", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(10000)
+    .set_description("maximum number of ops on an object"),
+
     Option("client_oc_max_objects", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1000)
     .set_description("maximum number of objects in cache"),

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1778,6 +1778,11 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
     bh->last_write = now;
 
     o->try_merge_bh(bh);
+    if (o->data.size() >= cct->_conf->client_oc_max_object_ops
+      && !(o->data.size() % cct->_Conf->client_oc_max_object_ops)) {
+      ldout(cct,10) << "object:" << o << "ops on an object:" << o->data.size() <<dendl;
+      flush(o,0,0);
+    }
   }
 
   if (perfcounter) {

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -402,7 +402,7 @@ class ObjectCacher {
   string name;
   ceph::mutex& lock;
 
-  uint64_t max_dirty, target_dirty, max_size, max_objects;
+  uint64_t max_dirty, target_dirty, max_size, max_objects, max_object_ops;
   ceph::timespan max_dirty_age;
   bool block_writes_upfront;
 
@@ -666,6 +666,9 @@ public:
   }
   void set_max_dirty_age(double a) {
     max_dirty_age = make_timespan(a);
+  }
+  void set_max_object_ops(int64_t v) {
+    max_object_ops = v;
   }
   void set_max_objects(int64_t v) {
     max_objects = v;


### PR DESCRIPTION
Signed-off-by: houbin0504 houbinbj@inspur.com

If there are tens of thousands or even hundreds of thousands discrete write operations on an object ,and the length of those operations are all only a few bytes,when the object is flushed to OSD from OC,it will cause the OSD handles the request timeout,and cause the OSD suicide ultimately.Meantime, if the number of operations is greater than 65535,it will cause the message decode incompletely on the OSD,because the variable that represents the number of operations is uint16 in the finish_decode() function.
So based on the above situation,I suggest we can add a config option to limit the number of write operations on a single object in OC, once the number exceeds the limit, we make the object flushed to OSD by force rather than waiting for concentrated flush.Now,suggested default value of the config option is 10000.

fix bug 41198:https://tracker.ceph.com/issues/41198
Signed-off-by: houbin0504 <houbinbj@inspur.com>