### PR TITLE
osdc: refine Objecter's perf counter

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -119,6 +119,7 @@ enum {
   l_osdc_osdop_cmpxattr,
   l_osdc_osdop_rmxattr,
   l_osdc_osdop_resetxattrs,
+  l_osdc_osdop_tmap_up,
   l_osdc_osdop_call,
   l_osdc_osdop_watch,
   l_osdc_osdop_notify,
@@ -161,6 +162,9 @@ enum {
   l_osdc_osdop_omap_rd,
   l_osdc_osdop_omap_del,
 
+  l_osdc_write_latency,
+  l_osdc_read_latency,
+  
   l_osdc_last,
 };
 
@@ -310,6 +314,8 @@ void Objecter::init()
 			"Remove xattr operations");
     pcb.add_u64_counter(l_osdc_osdop_resetxattrs, "osdop_resetxattrs",
 			"Reset xattr operations");
+    pcb.add_u64_counter(l_osdc_osdop_tmap_up, "osdop_tmap_up",
+	                "TMAP update operations");
     pcb.add_u64_counter(l_osdc_osdop_call, "osdop_call",
 			"Call (execute) operations");
     pcb.add_u64_counter(l_osdc_osdop_watch, "osdop_watch",
@@ -376,6 +382,9 @@ void Objecter::init()
 			"OSD OMAP read operations");
     pcb.add_u64_counter(l_osdc_osdop_omap_del, "omap_del",
 			"OSD OMAP delete operations");
+
+    pcb.add_time_avg(l_osdc_write_latency, "write_latency", "latency of write ops");
+    pcb.add_time_avg(l_osdc_read_latency, "read_latency", "latency of read ops");
 
     logger = pcb.create_perf_counters();
     cct->get_perfcounters_collection()->add(logger);
@@ -2339,6 +2348,8 @@ void Objecter::_send_op_account(Op *op)
     case CEPH_OSD_OP_CMPXATTR: code = l_osdc_osdop_cmpxattr; break;
     case CEPH_OSD_OP_RMXATTR: code = l_osdc_osdop_rmxattr; break;
     case CEPH_OSD_OP_RESETXATTRS: code = l_osdc_osdop_resetxattrs; break;
+    case CEPH_OSD_OP_TMAPUP: code = l_osdc_osdop_tmap_up; break;
+    
 
     // OMAP read operations
     case CEPH_OSD_OP_OMAPGETVALS:
@@ -3165,6 +3176,32 @@ void Objecter::_finish_op(Op *op, int r)
 
   if (op->ontimeout && r != -ETIMEDOUT)
     timer.cancel_event(op->ontimeout);
+
+  ceph::coarse_mono_time now = ceph::coarse_mono_time::now();
+  auto latency = now - op->init_stamp;
+  int stat_type = 0;
+  for (const auto& p : op->ops) {
+    switch (p.op.op) {
+    case CEPH_OSD_OP_READ:
+    case CEPH_OSD_OP_SPARSE_READ:
+    case CEPH_OSD_OP_SYNC_READ:
+      stat_type = l_osdc_read_latency;
+      break;
+    case CEPH_OSD_OP_WRITE:
+    case CEPH_OSD_OP_WRITEFULL:
+    case CEPH_OSD_OP_APPEND;
+    case CEPH_OSD_OP_WRITESAME;
+      stat_type = l_osdc_write_latency;
+      break;
+    default:
+      break;
+    }
+    if (stat_type) {
+      logger->tinc(stat_type, latency);
+      break;
+    }
+  }
+
 
   if (op->session) {
     _session_op_remove(op->session, op);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1449,6 +1449,7 @@ public:
     epoch_t *reply_epoch;
 
     ceph::coarse_mono_time stamp;
+    ceph::coarse_mono_time init_stamp;
 
     epoch_t map_dne_bound;
 
@@ -1484,6 +1485,7 @@ public:
       attempts(0),
       objver(ov),
       reply_epoch(NULL),
+      init_stamp(ceph::coarse_mono_time::now()),
       map_dne_bound(0),
       budget(-1),
       should_resend(true),


### PR DESCRIPTION
Signed-off-by: houbin0504 houbinbj@inspur.com

Add perf counter for CEPH_OSD_OP_TMAPUP  in osdc,then we can count the numbers of this operation on each objecter send and each OSD received.It is easily to locate the reason of the problem that occured with those three operations.
Add 2 latency perf counters -- 1 for read ops and 1 for write ops. 

Fixes:http://tracker.ceph.com/issues/40564
Signed-off-by: houbin0504 <houbinbj@inspur.com>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
