### PR TITLE
 cephfs:The return type of _lseek is loff_t, but int r = _lseek in write may cause an overflow

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9458,7 +9458,7 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
      * change out from under us.
      */
     if (f->flags & O_APPEND) {
-      int r = _lseek(f, 0, SEEK_END);
+      uint64_t r = _lseek(f, 0, SEEK_END);
       if (r < 0) {
         unlock_fh_pos(f);
         return r;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -152,6 +152,17 @@ bool Client::CommandHook::call(std::string_view command,
     m_client->dump_mds_sessions(f.get());
   else if (command == "dump_cache")
     m_client->dump_cache(f.get());
+  else if(command == "dump_inode"){
+        std::string str_inode_no;
+        cmd_getval(m_client->cct, cmdmap, "inode_no", str_inode_no);
+        uint64_t inode_no = strtoull(str_inode_no.c_str(), NULL, 0);
+        if ((inode_no == 0) && f) {
+            f->open_array_section("cache");
+            f->close_section();
+        } else {
+            m_client->dump_cache(f, inode_no);
+        }
+  }
   else if (command == "kick_stale_sessions")
     m_client->_kick_stale_sessions();
   else if (command == "status")
@@ -416,7 +427,7 @@ void Client::dump_inode(Formatter *f, Inode *in, set<Inode*>& did, bool disconne
   }
 }
 
-void Client::dump_cache(Formatter *f)
+void Client::dump_cache(Formatter *f, uint64_t inode_no)
 {
   set<Inode*> did;
 
@@ -425,18 +436,23 @@ void Client::dump_cache(Formatter *f)
   if (f)
     f->open_array_section("cache");
 
-  if (root)
-    dump_inode(f, root, did, true);
+  if (inode_no) {
+      auto it = inode_map.find(vinodeno_t(inode_no, ICFS_NOSNAP));
+      if (it != inode_map.end())
+          dump_inode(f, it->second, did, true);
+  } else {
+    if (root)
+      dump_inode(f, root, did, true);
 
-  // make a second pass to catch anything disconnected
-  for (ceph::unordered_map<vinodeno_t, Inode*>::iterator it = inode_map.begin();
-       it != inode_map.end();
-       ++it) {
-    if (did.count(it->second))
-      continue;
-    dump_inode(f, it->second, did, true);
+    // make a second pass to catch anything disconnected
+    for (ceph::unordered_map<vinodeno_t, Inode*>::iterator it = inode_map.begin();
+         it != inode_map.end();
+         ++it) {
+      if (did.count(it->second))
+        continue;
+      dump_inode(f, it->second, did, true);
+    }
   }
-
   if (f)
     f->close_section();
 }
@@ -528,6 +544,15 @@ void Client::_finish_init()
   if (ret < 0) {
     lderr(cct) << "error registering admin socket command: "
 	       << cpp_strerror(-ret) << dendl;
+  }
+  
+  ret = admin_socket->register_command("dump_inode",
+			  "dump_inode",
+			  &m_command_hook,
+			  "dump_inode <inode_no>: show signal in-memory metadata cache contents");
+  if (ret < 0) {
+	  lderr(cct) << "error registering admin socket command: "
+		  << cpp_strerror(-ret) << dendl;
   }
   ret = admin_socket->register_command("kick_stale_sessions",
 				       "kick_stale_sessions",

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -909,7 +909,7 @@ protected:
   void _trim_negative_child_dentries(InodeRef& in);
 
   void dump_inode(Formatter *f, Inode *in, set<Inode*>& did, bool disconnected);
-  void dump_cache(Formatter *f);  // debug
+  void dump_cache(Formatter *f,uint64_t inode_no = 0);  // debug
 
   // force read-only
   void force_session_readonly(MetaSession *s);


### PR DESCRIPTION
 cephfs:The return type of _lseek is loff_t, but int r = _lseek in write may cause an overflow
Signed-off-by: wenpengLi  liwenpeng@inspur.com
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
