### PR TITLE
common/Finisher: reduce unnecessary notify_one/all.

### DIFF
--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -74,8 +74,8 @@ void *Finisher::finisher_thread_entry()
       }
 
       ul.lock();
-      finisher_running = false;
     }
+    finisher_running = false;
     ldout(cct, 10) << "finisher_thread empty" << dendl;
     if (unlikely(finisher_empty_wait))
       finisher_empty_cond.notify_all();

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -69,7 +69,7 @@ class Finisher {
     std::unique_lock ul(finisher_lock);
     bool was_empty = finisher_queue.empty();
     finisher_queue.push_back(std::make_pair(c, r));
-    if (was_empty) {
+    if (was_empty && !finisher_running) {
       finisher_cond.notify_one();
     }
     if (logger)
@@ -79,7 +79,7 @@ class Finisher {
   void queue(std::list<Context*>& ls) {
     {
       std::unique_lock ul(finisher_lock);
-      if (finisher_queue.empty()) {
+      if (finisher_queue.empty() && !finisher_running) {
 	finisher_cond.notify_all();
       }
       for (auto i : ls) {
@@ -93,7 +93,7 @@ class Finisher {
   void queue(std::deque<Context*>& ls) {
     {
       std::unique_lock ul(finisher_lock);
-      if (finisher_queue.empty()) {
+      if (finisher_queue.empty() && !finisher_running) {
 	finisher_cond.notify_all();
       }
       for (auto i : ls) {
@@ -107,7 +107,7 @@ class Finisher {
   void queue(std::vector<Context*>& ls) {
     {
       std::unique_lock ul(finisher_lock);
-      if (finisher_queue.empty()) {
+      if (finisher_queue.empty() && !finisher_running) {
 	finisher_cond.notify_all();
       }
       for (auto i : ls) {


### PR DESCRIPTION
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
