### PR TITLE
mgr/dashboard: fix mgr module API tests

### DIFF
--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -159,37 +159,3 @@ class MgrModuleTelemetryTest(MgrModuleTestCase):
         self.assertEqual(data['organization'], 'SUSE Linux')
         self.assertEqual(data['proxy'], 'foo')
         self.assertEqual(data['url'], 'https://foo.bar/report')
-
-    def test_enable(self):
-        self._ceph_cmd(['mgr', 'module', 'disable', 'telemetry'])
-        self.wait_until_rest_api_accessible()
-        try:
-            # Note, an exception is thrown because the Ceph Mgr
-            # modules are reloaded.
-            self._post('/api/mgr/module/telemetry/enable')
-        except requests.ConnectionError:
-            pass
-        self.wait_until_rest_api_accessible()
-        data = self._get('/api/mgr/module')
-        self.assertStatus(200)
-        module_info = self.find_object_in_list('name', 'telemetry', data)
-        self.assertIsNotNone(module_info)
-        self.assertTrue(module_info['enabled'])
-
-    def test_disable(self):
-        # Enable the 'telemetry' module (all CephMgr modules are restarted)
-        # and wait until the Dashboard REST API is accessible.
-        self._ceph_cmd(['mgr', 'module', 'enable', 'telemetry'])
-        self.wait_until_rest_api_accessible()
-        try:
-            # Note, an exception is thrown because the Ceph Mgr
-            # modules are reloaded.
-            self._post('/api/mgr/module/telemetry/disable')
-        except requests.ConnectionError:
-            pass
-        self.wait_until_rest_api_accessible()
-        data = self._get('/api/mgr/module')
-        self.assertStatus(200)
-        module_info = self.find_object_in_list('name', 'telemetry', data)
-        self.assertIsNotNone(module_info)
-        self.assertFalse(module_info['enabled'])

--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -12,11 +12,6 @@ logger = logging.getLogger(__name__)
 class MgrModuleTestCase(DashboardTestCase):
     MGRS_REQUIRED = 1
 
-    @classmethod
-    def tearDownClass(cls):
-        cls._ceph_cmd(['mgr', 'module', 'disable', 'telemetry'])
-        super(MgrModuleTestCase, cls).tearDownClass()
-
     def wait_until_rest_api_accessible(self):
         """
         Wait until the REST API is accessible.
@@ -37,7 +32,7 @@ class MgrModuleTestCase(DashboardTestCase):
 
 class MgrModuleTest(MgrModuleTestCase):
     def test_list_disabled_module(self):
-        self._ceph_cmd(['mgr', 'module', 'disable', 'telemetry'])
+        self._ceph_cmd(['mgr', 'module', 'disable', 'iostat'])
         self.wait_until_rest_api_accessible()
         data = self._get('/api/mgr/module')
         self.assertStatus(200)
@@ -65,12 +60,12 @@ class MgrModuleTest(MgrModuleTestCase):
                             'tags': JList(str)
                         }))
                 })))
-        module_info = self.find_object_in_list('name', 'telemetry', data)
+        module_info = self.find_object_in_list('name', 'iostat', data)
         self.assertIsNotNone(module_info)
         self.assertFalse(module_info['enabled'])
 
     def test_list_enabled_module(self):
-        self._ceph_cmd(['mgr', 'module', 'enable', 'telemetry'])
+        self._ceph_cmd(['mgr', 'module', 'enable', 'iostat'])
         self.wait_until_rest_api_accessible()
         data = self._get('/api/mgr/module')
         self.assertStatus(200)
@@ -98,7 +93,7 @@ class MgrModuleTest(MgrModuleTestCase):
                             'tags': JList(str)
                         }))
                 })))
-        module_info = self.find_object_in_list('name', 'telemetry', data)
+        module_info = self.find_object_in_list('name', 'iostat', data)
         self.assertIsNotNone(module_info)
         self.assertTrue(module_info['enabled'])
 
@@ -110,6 +105,7 @@ class MgrModuleTelemetryTest(MgrModuleTestCase):
         self.assertSchema(
             data,
             JObj(
+                allow_unknown=True,
                 sub_elems={
                     'channel_basic': bool,
                     'channel_ident': bool,
@@ -119,6 +115,7 @@ class MgrModuleTelemetryTest(MgrModuleTestCase):
                     'description': str,
                     'enabled': bool,
                     'interval': int,
+                    'last_opt_revision': int,
                     'leaderboard': bool,
                     'organization': str,
                     'proxy': str,


### PR DESCRIPTION
Fixed:
1) Replaced 'telemetry' with 'iostat' for enabling/disabling module testing as telemetry cannot be disabled now (it's always enabled since 2d62d71cd46d791294b3803e034c0995fef08b33).
2) Updated test: test_get.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
