### PR TITLE
rgw: when you abort a multipart upload request, the quota will not update

### DIFF
--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -236,6 +236,7 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
   bool truncated;
   int marker = 0;
   int ret;
+  uint64_t parts_accounted_size = 0;
 
   do {
     ret = list_multipart_parts(store, bucket_info, cct,
@@ -272,6 +273,7 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
           remove_objs.push_back(key);
         }
       }
+      parts_accounted_size += obj_part.size;
     }
   } while (truncated);
 
@@ -289,6 +291,9 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
   if (!remove_objs.empty()) {
     del_op.params.remove_objs = &remove_objs;
   }
+  
+  del_op.params.abortmp = true;
+  del_op.params.parts_accounted_size = parts_accounted_size;
 
   // and also remove the metadata obj
   ret = del_op.delete_obj(null_yield);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5543,6 +5543,10 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
   }
   uint64_t obj_accounted_size = state->accounted_size;
 
+  if(params.abortmp) {
+    obj_accounted_size = params.parts_accounted_size;
+  }
+
   if (!real_clock::is_zero(params.expiration_time)) {
     bufferlist bl;
     real_time delete_at;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1645,8 +1645,10 @@ public:
         ceph::real_time mtime; /* for setting delete marker mtime */
         bool high_precision_time;
         rgw_zone_set *zones_trace;
+	bool abortmp;
+	uint64_t parts_accounted_size;
 
-        DeleteParams() : versioning_status(0), olh_epoch(0), bilog_flags(0), remove_objs(NULL), high_precision_time(false), zones_trace(nullptr) {}
+        DeleteParams() : versioning_status(0), olh_epoch(0), bilog_flags(0), remove_objs(NULL), high_precision_time(false), zones_trace(nullptr), abortmp(false), parts_accounted_size(0) {}
       } params;
 
       struct DeleteResult {


### PR DESCRIPTION
rgw: when you abort a multipart upload request, the quota will not update

You can get the problem do like this:
1. s3cmd put 30M s3://bucket
2. Ctrl + C 
3. s3cmd abortmp s3://bucket/30M $upload_id

Signed-off-by: baixueyu baixueyu@inspur.com