### PR TITLE
librbd: Remove duplicated AsyncOpTracker in librbd/Utils.h

### DIFF
--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -8,6 +8,7 @@
 #include "include/Context.h"
 #include "include/interval_set.h"
 #include "include/rados/librados_fwd.hpp"
+#include "common/AsyncOpTracker.h"
 #include "common/Cond.h"
 #include "common/WorkQueue.h"
 #include "journal/Future.h"
@@ -301,7 +302,7 @@ private:
 
   journal::Replay<ImageCtxT> *m_journal_replay;
 
-  util::AsyncOpTracker m_async_journal_op_tracker;
+  AsyncOpTracker m_async_journal_op_tracker;
 
   struct MetadataListener : public ::journal::JournalMetadataListener {
     Journal<ImageCtxT> *journal;

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -171,39 +171,6 @@ inline ImageCtx *get_image_ctx(ImageCtx *image_ctx) {
   return image_ctx;
 }
 
-/// helper for tracking in-flight async ops when coordinating
-/// a shut down of the invoking class instance
-class AsyncOpTracker {
-public:
-  void start_op() {
-    m_refs++;
-  }
-
-  void finish_op() {
-    if (--m_refs == 0 && m_on_finish != nullptr) {
-      Context *on_finish = nullptr;
-      std::swap(on_finish, m_on_finish);
-      on_finish->complete(0);
-    }
-  }
-
-  template <typename I>
-  void wait(I &image_ctx, Context *on_finish) {
-    ceph_assert(m_on_finish == nullptr);
-
-    on_finish = create_async_context_callback(image_ctx, on_finish);
-    if (m_refs == 0) {
-      on_finish->complete(0);
-      return;
-    }
-    m_on_finish = on_finish;
-  }
-
-private:
-  std::atomic<uint64_t> m_refs = { 0 };
-  Context *m_on_finish = nullptr;
-};
-
 uint64_t get_rbd_default_features(CephContext* cct);
 
 bool calc_sparse_extent(const bufferptr &bp,


### PR DESCRIPTION
Signed-off-by: Xiaoyan Li <xiaoyan.li@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
