### PR TITLE
 librbd: skip stale child with non-existent pool for list descendants

### DIFF
--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -127,8 +127,8 @@ int create_ioctx(librados::IoCtx& src_io_ctx, const std::string& pool_desc,
   librados::Rados rados(src_io_ctx);
   int r = rados.ioctx_create2(pool_id, *dst_io_ctx);
   if (r == -ENOENT) {
-    lderr(cct) << pool_desc << " pool " << pool_id << " no longer exists"
-               << dendl;
+    ldout(cct, 1) << pool_desc << " pool " << pool_id << " no longer exists"
+                  << dendl;
     return r;
   } else if (r < 0) {
     lderr(cct) << "error accessing " << pool_desc << " pool " << pool_id

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -394,7 +394,7 @@ int Image<I>::list_descendants(
     for (auto& image_id : image_ids) {
       images->push_back({
         it.first, "", ictx->md_ctx.get_namespace(), image_id, "", false});
-      r = list_descendants(ictx->md_ctx, image_id, child_max_level, images);
+      r = list_descendants(ioctx, image_id, child_max_level, images);
       if (r < 0) {
         return r;
       }

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -450,7 +450,11 @@ int Image<I>::list_descendants(
         child_io_ctx.get_namespace() != image.pool_namespace) {
       r = util::create_ioctx(ictx->md_ctx, "child image", image.pool_id,
                              image.pool_namespace, &child_io_ctx);
-      if (r < 0) {
+      if (r == -ENOENT) {
+        image.pool_name = "";
+        image.image_name = "";
+        continue;
+      } else if (r < 0) {
         return r;
       }
       child_pool_id = image.pool_id;

--- a/src/librbd/operation/SnapshotRemoveRequest.h
+++ b/src/librbd/operation/SnapshotRemoveRequest.h
@@ -32,6 +32,12 @@ public:
    * GET_SNAP
    *    |
    *    v (skip if unnecessary)
+   * LIST_CHILDREN <-------------\
+   *    |                        |
+   *    v (skip if unnecessary)  | (repeat as needed)
+   * DETACH_STALE_CHILD ---------/
+   *    |
+   *    v (skip if unnecessary)
    * DETACH_CHILD
    *    |
    *    v (skip if disabled/in-use)
@@ -71,6 +77,7 @@ protected:
 
 private:
   cls::rbd::SnapshotNamespace m_snap_namespace;
+  cls::rbd::ChildImageSpecs m_child_images;
   std::string m_snap_name;
   uint64_t m_snap_id;
   bool m_trashed_snapshot = false;
@@ -83,6 +90,12 @@ private:
 
   void get_snap();
   void handle_get_snap(int r);
+
+  void list_children();
+  void handle_list_children(int r);
+
+  void detach_stale_child();
+  void handle_detach_stale_child(int r);
 
   void detach_child();
   void handle_detach_child(int r);

--- a/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
@@ -112,6 +112,36 @@ public:
                            })));
   }
 
+  void expect_children_list(MockImageCtx &mock_image_ctx,
+                            const cls::rbd::ChildImageSpecs& child_images, int r) {
+    if (mock_image_ctx.old_format) {
+      return;
+    }
+
+    using ceph::encode;
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                     StrEq("children_list"), _, _, _))
+      .WillOnce(WithArg<5>(Invoke([child_images, r](bufferlist* bl) {
+                             encode(child_images, *bl);
+                             return r;
+                           })));
+  }
+
+  void expect_detach_stale_child(MockImageCtx &mock_image_ctx, int r) {
+    auto& parent_spec = mock_image_ctx.parent_md.spec;
+
+    bufferlist bl;
+    encode(parent_spec.snap_id, bl);
+    encode(cls::rbd::ChildImageSpec{mock_image_ctx.md_ctx.get_id(), "",
+                                    mock_image_ctx.id}, bl);
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(util::header_name(parent_spec.image_id),
+                     _, StrEq("rbd"), StrEq("child_detach"), ContentsEqual(bl),
+                     _, _))
+      .WillOnce(Return(r));
+  }
+
   void expect_object_map_snap_remove(MockImageCtx &mock_image_ctx, int r) {
     if (mock_image_ctx.object_map != nullptr) {
       EXPECT_CALL(*mock_image_ctx.object_map, snapshot_remove(_, _))
@@ -241,6 +271,8 @@ TEST_F(TestMockOperationSnapshotRemoveRequest, SuccessCloneParent) {
                       {snap_id, {cls::rbd::UserSnapshotNamespace{}},
                        "snap1", 123, {}, 1}, 0);
 
+  const cls::rbd::ChildImageSpecs child_images;
+  expect_children_list(mock_image_ctx, child_images, 0);
   expect_get_parent_spec(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
@@ -397,6 +429,8 @@ TEST_F(TestMockOperationSnapshotRemoveRequest, TrashCloneParent) {
   expect_snapshot_get(mock_image_ctx,
                       {snap_id, {cls::rbd::TrashSnapshotNamespace{}},
                        "snap1", 123, {}, 1}, 0);
+  const cls::rbd::ChildImageSpecs child_images;
+  expect_children_list(mock_image_ctx, child_images, 0);
   expect_get_parent_spec(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
@@ -709,6 +743,90 @@ TEST_F(TestMockOperationSnapshotRemoveRequest, MissingSnap) {
     req->send();
   }
   ASSERT_EQ(-ENOENT, cond_ctx.wait());
+}
+
+TEST_F(TestMockOperationSnapshotRemoveRequest, ListChildrenError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ASSERT_EQ(0, snap_create(*ictx, "snap1"));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+    mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  }
+
+  MockObjectMap mock_object_map;
+  if (ictx->test_features(RBD_FEATURE_OBJECT_MAP)) {
+    mock_image_ctx.object_map = &mock_object_map;
+  }
+
+  expect_op_work_queue(mock_image_ctx);
+
+  ::testing::InSequence seq;
+  expect_snapshot_trash_add(mock_image_ctx, 0);
+
+  uint64_t snap_id = ictx->snap_info.rbegin()->first;
+  expect_snapshot_get(mock_image_ctx,
+                      {snap_id, {cls::rbd::UserSnapshotNamespace{}},
+                       "snap1", 123, {}, 1}, 0);
+  const cls::rbd::ChildImageSpecs child_images;
+  expect_children_list(mock_image_ctx, child_images, -EINVAL);
+
+  C_SaferCond cond_ctx;
+  MockSnapshotRemoveRequest *req = new MockSnapshotRemoveRequest(
+    mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(), "snap1",
+    snap_id);
+  {
+    std::shared_lock owner_locker{mock_image_ctx.owner_lock};
+    req->send();
+  }
+  ASSERT_EQ(-EINVAL, cond_ctx.wait());
+}
+
+TEST_F(TestMockOperationSnapshotRemoveRequest, DetachStaleChildError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  ASSERT_EQ(0, create_snapshot("snap1"));
+
+  int order = 22;
+  uint64_t features;
+  ASSERT_TRUE(::get_features(&features));
+  std::string clone_name = get_temp_image_name();
+  ASSERT_EQ(0, librbd::clone(m_ioctx, m_image_name.c_str(), "snap1", m_ioctx,
+                             clone_name.c_str(), features, &order, 0, 0));
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(clone_name, &ictx));
+  ASSERT_EQ(0, snap_create(*ictx, "snap1"));
+  ASSERT_EQ(0, ictx->state->refresh_if_required());
+
+  MockImageCtx mock_image_ctx(*ictx);
+  expect_op_work_queue(mock_image_ctx);
+
+  ::testing::InSequence seq;
+  expect_snapshot_trash_add(mock_image_ctx, 0);
+
+  uint64_t snap_id = ictx->snap_info.rbegin()->first;
+  expect_snapshot_get(mock_image_ctx,
+                      {snap_id, {cls::rbd::UserSnapshotNamespace{}},
+                       "snap1", 123, {}, 1}, 0);
+  const cls::rbd::ChildImageSpecs child_images;
+  expect_children_list(mock_image_ctx, child_images, -EINVAL);
+
+  C_SaferCond cond_ctx;
+  MockSnapshotRemoveRequest *req = new MockSnapshotRemoveRequest(
+    mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(), "snap1",
+    snap_id);
+  {
+    std::shared_lock owner_locker{mock_image_ctx.owner_lock};
+    req->send();
+  }
+  ASSERT_EQ(-EINVAL, cond_ctx.wait());
 }
 
 } // namespace operation

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -7970,6 +7970,98 @@ TEST_F(TestLibRBD, DISABLED_TestSeqWriteAIOPP)
   ioctx.close();
 }
 
+TEST_F(TestLibRBD, SnapRemoveWithChildMissing)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+  ASSERT_EQ(0, rados_conf_set(_cluster, "rbd_default_clone_format", "2"));
+  BOOST_SCOPE_EXIT_ALL(&) {
+    ASSERT_EQ(0, rados_conf_set(_cluster, "rbd_default_clone_format", "auto"));
+  };
+
+  librbd::RBD rbd;
+  rados_ioctx_t ioctx1, ioctx2;
+  string pool_name1 = create_pool(true);
+  rados_ioctx_create(_cluster, pool_name1.c_str(), &ioctx1);
+  ASSERT_EQ(0, rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx2));
+
+  bool old_format;
+  uint64_t features;
+  rbd_image_t parent, child1, child2, child3;
+  int order = 0;
+  char child_id1[4096];
+  char child_id2[4096];
+  char child_id3[4096];
+
+  ASSERT_EQ(0, get_features(&old_format, &features));
+  ASSERT_FALSE(old_format);
+  std::string parent_name = get_temp_image_name();
+  std::string child_name1 = get_temp_image_name();
+  std::string child_name2 = get_temp_image_name();
+  std::string child_name3 = get_temp_image_name();
+  ASSERT_EQ(0, create_image_full(ioctx1, parent_name.c_str(), 4<<20, &order,
+            false, features));
+  ASSERT_EQ(0, rbd_open(ioctx1, parent_name.c_str(), &parent, NULL));
+  ASSERT_EQ(0, rbd_snap_create(parent, "snap1"));
+  ASSERT_EQ(0, rbd_snap_create(parent, "snap2"));
+
+  ASSERT_EQ(0, clone_image(ioctx1, parent, parent_name.c_str(), "snap1",
+                           ioctx2, child_name1.c_str(), features, &order));
+  ASSERT_EQ(0, clone_image(ioctx1, parent, parent_name.c_str(), "snap2",
+                           ioctx1, child_name2.c_str(), features, &order));
+  ASSERT_EQ(0, clone_image(ioctx1, parent, parent_name.c_str(), "snap2",
+                           ioctx2, child_name3.c_str(), features, &order));
+
+  ASSERT_EQ(0, rbd_open(ioctx2, child_name1.c_str(), &child1, NULL));
+  ASSERT_EQ(0, rbd_open(ioctx1, child_name2.c_str(), &child2, NULL));
+  ASSERT_EQ(0, rbd_open(ioctx2, child_name3.c_str(), &child3, NULL));
+  ASSERT_EQ(0, rbd_get_id(child1, child_id1, sizeof(child_id1)));
+  ASSERT_EQ(0, rbd_get_id(child2, child_id2, sizeof(child_id2)));
+  ASSERT_EQ(0, rbd_get_id(child3, child_id3, sizeof(child_id3)));
+  test_list_children2(parent, 3,
+                      child_id1, m_pool_name.c_str(), child_name1.c_str(), false,
+                      child_id2, pool_name1.c_str(), child_name2.c_str(), false,
+                      child_id3, m_pool_name.c_str(), child_name3.c_str(), false);
+
+  size_t max_size = 10;
+  rbd_linked_image_spec_t children[max_size];
+  ASSERT_EQ(0, rbd_list_children3(parent, children, &max_size));
+  ASSERT_EQ(3, static_cast<int>(max_size));
+  rbd_linked_image_spec_list_cleanup(children, max_size);
+
+  ASSERT_EQ(0, rbd_close(child1));
+  ASSERT_EQ(0, rbd_close(child2));
+  ASSERT_EQ(0, rbd_close(child3));
+  rados_ioctx_destroy(ioctx2);
+  ASSERT_EQ(0, rados_pool_delete(_cluster, m_pool_name.c_str()));
+  _pool_names.erase(std::remove(_pool_names.begin(),
+                                _pool_names.end(), m_pool_name),
+                    _pool_names.end());
+  EXPECT_EQ(0, rados_wait_for_latest_osdmap(_cluster));
+
+  ASSERT_EQ(0, rbd_list_children3(parent, children, &max_size));
+  ASSERT_EQ(3, static_cast<int>(max_size));
+  rbd_linked_image_spec_list_cleanup(children, max_size);
+  ASSERT_EQ(0, rbd_snap_remove(parent, "snap1"));
+  ASSERT_EQ(0, rbd_list_children3(parent, children, &max_size));
+  ASSERT_EQ(2, static_cast<int>(max_size));
+  rbd_linked_image_spec_list_cleanup(children, max_size);
+
+  ASSERT_EQ(0, rbd_remove(ioctx1, child_name2.c_str()));
+  ASSERT_EQ(0, rbd_list_children3(parent, children, &max_size));
+  ASSERT_EQ(1, static_cast<int>(max_size));
+  rbd_linked_image_spec_list_cleanup(children, max_size);
+
+  ASSERT_EQ(0, rbd_snap_remove(parent, "snap2"));
+  ASSERT_EQ(0, rbd_list_children3(parent, children, &max_size));
+  ASSERT_EQ(0, static_cast<int>(max_size));
+  rbd_linked_image_spec_list_cleanup(children, max_size);
+  test_list_children2(parent, 0);
+  ASSERT_EQ(0, test_ls_snaps(parent, 0));
+
+  ASSERT_EQ(0, rbd_close(parent));
+  rados_ioctx_destroy(ioctx1);
+}
+
 // poorman's ceph_assert()
 namespace ceph {
   void __ceph_assert_fail(const char *assertion, const char *file, int line,

--- a/src/tools/rbd/action/Children.cc
+++ b/src/tools/rbd/action/Children.cc
@@ -52,13 +52,21 @@ int do_list_children(librados::IoCtx &io_ctx, librbd::Image &image,
         f->close_section();
       }
     } else if (all_flag || !trash) {
-      std::cout << child.pool_name << "/";
+      if (child.pool_name.empty()) {
+        std::cout << "(child missing " << child.pool_id << "/";
+      } else {
+        std::cout << child.pool_name << "/";
+      }
       if (!child.pool_namespace.empty()) {
         std::cout << child.pool_namespace << "/";
       }
-      std::cout << child.image_name;
-      if (trash) {
-        std::cout << " (trash " << child.image_id << ")";
+      if (child.image_name.empty()) {
+        std::cout << child.image_id << ")";
+      } else {
+        std::cout << child.image_name;
+        if (trash) {
+          std::cout << " (trash " << child.image_id << ")";
+	}
       }
       std::cout << std::endl;
     }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41241
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>