### PR TITLE
nautilus RGW :set default value to "default_placementstorage_class"

### DIFF
--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -77,6 +77,7 @@ int RGWZoneGroup::create_default(bool old_format)
   placement_target.name = "default-placement";
   placement_targets[placement_target.name] = placement_target;
   default_placement.name = "default-placement";
+  default_placement.storage_class = "STANDARD";
 
   RGWZoneParams zone_params(default_zone_name);
 


### PR DESCRIPTION
When I try to enble zlib compression on rgw, I find the compression does not take effect.

If default_placement.storage_class does not set default value, rgw compression does not take effect.

Fixes: https://tracker.ceph.com/issues/40935#change-142847
Signed-off-by: Han Fengzhe hanfengzhe@hisilicon.com



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
