### PR TITLE
osd/PG.h: Fix pg stuck in waitactingchange

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2010,8 +2010,7 @@ protected:
 
       typedef boost::mpl::list <
 	boost::statechart::custom_reaction< ActMap >,
-	boost::statechart::custom_reaction< MNotifyRec >,
-	boost::statechart::transition< NeedActingChange, WaitActingChange >
+	boost::statechart::custom_reaction< MNotifyRec >
 	> reactions;
       boost::statechart::result react(const ActMap&);
       boost::statechart::result react(const MNotifyRec&);
@@ -2395,6 +2394,7 @@ protected:
 	boost::statechart::custom_reaction< MLogRec >,
 	boost::statechart::custom_reaction< GotLog >,
 	boost::statechart::custom_reaction< AdvMap >,
+        boost::statechart::transition< NeedActingChange, WaitActingChange >,
 	boost::statechart::transition< IsIncomplete, Incomplete >
 	> reactions;
       boost::statechart::result react(const AdvMap&);


### PR DESCRIPTION
move primary reaction <NeedActingChange, WaitActingChange> to GetLog reaction would solve
pg stuck in waitactingchange

Fixes: https://tracker.ceph.com/issues/41190

Signed-off-by: chen qiuzhang <chen.qiuzhang@h3c.com>