### PR TITLE
osd/PeeringState.h: Fix pg stuck in WaitActingChange

### DIFF
--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -720,7 +720,6 @@ public:
     typedef boost::mpl::list <
       boost::statechart::custom_reaction< ActMap >,
       boost::statechart::custom_reaction< MNotifyRec >,
-      boost::statechart::transition< NeedActingChange, WaitActingChange >,
       boost::statechart::custom_reaction<SetForceRecovery>,
       boost::statechart::custom_reaction<UnsetForceRecovery>,
       boost::statechart::custom_reaction<SetForceBackfill>,
@@ -1222,6 +1221,7 @@ public:
       boost::statechart::custom_reaction< MLogRec >,
       boost::statechart::custom_reaction< GotLog >,
       boost::statechart::custom_reaction< AdvMap >,
+      boost::statechart::transition< NeedActingChange, WaitActingChange >,
       boost::statechart::transition< IsIncomplete, Incomplete >
       > reactions;
     boost::statechart::result react(const AdvMap&);


### PR DESCRIPTION
move primary reaction <NeedActingChange, WaitActingChange> to GetLog reaction would solve
  pg stuck in waitactingchange, it will avoid want_acting clear in exit Primary state.

Fixes: https://tracker.ceph.com/issues/40117

Signed-off-by: chen qiuzhang <chen.qiuzhang@h3c.com>