### PR TITLE
osd/PrimaryLogPG: remove unused "parent" pgls-filter

### DIFF
--- a/src/cls/cephfs/cls_cephfs.cc
+++ b/src/cls/cephfs/cls_cephfs.cc
@@ -146,12 +146,10 @@ public:
 
   ~PGLSCephFSFilter() override {}
   bool reject_empty_xattr() override { return false; }
-  bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata) override;
+  bool filter(const hobject_t &obj, bufferlist& xattr_data) override;
 };
 
-bool PGLSCephFSFilter::filter(const hobject_t &obj,
-                             bufferlist& xattr_data, bufferlist& outdata)
+bool PGLSCephFSFilter::filter(const hobject_t &obj, bufferlist& xattr_data)
 {
   const std::string need_ending = ".00000000";
   const std::string &obj_name = obj.oid.name;

--- a/src/cls/hello/cls_hello.cc
+++ b/src/cls/hello/cls_hello.cc
@@ -266,8 +266,7 @@ public:
   }
 
   ~PGLSHelloFilter() override {}
-  bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata) override
+  bool filter(const hobject_t &obj, ceph::bufferlist& xattr_data) override
   {
     if (val.size() != xattr_data.length())
       return false;

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -81,8 +81,7 @@ protected:
 public:
   PGLSFilter();
   virtual ~PGLSFilter();
-  virtual bool filter(const hobject_t &obj, ceph::buffer::list& xattr_data,
-                      ceph::buffer::list& outdata) = 0;
+  virtual bool filter(const hobject_t &obj, ceph::buffer::list& xattr_data) = 0;
 
   /**
    * Arguments passed from the RADOS client.  Implementations must

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -776,12 +776,10 @@ public:
     return 0;
   }
   ~PGLSPlainFilter() override {}
-  bool filter(const hobject_t &obj, bufferlist& xattr_data,
-                      bufferlist& outdata) override;
+  bool filter(const hobject_t &obj, bufferlist& xattr_data) override;
 };
 
-bool PGLSPlainFilter::filter(const hobject_t &obj,
-                             bufferlist& xattr_data, bufferlist& outdata)
+bool PGLSPlainFilter::filter(const hobject_t &obj, bufferlist& xattr_data)
 {
   if (val.size() != xattr_data.length())
     return false;
@@ -792,7 +790,7 @@ bool PGLSPlainFilter::filter(const hobject_t &obj,
   return true;
 }
 
-bool PrimaryLogPG::pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& outdata)
+bool PrimaryLogPG::pgls_filter(PGLSFilter* filter, hobject_t& sobj)
 {
   bufferlist bl;
 
@@ -810,7 +808,7 @@ bool PrimaryLogPG::pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& 
     }
   }
 
-  return filter->filter(sobj, bl, outdata);
+  return filter->filter(sobj, bl);
 }
 
 int PrimaryLogPG::get_pgls_filter(bufferlist::const_iterator& iter, PGLSFilter **pfilter)
@@ -1036,7 +1034,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
   int result = 0;
   string cname, mname;
   PGLSFilter *filter = NULL;
-  bufferlist filter_out;
 
   snapid_t snapid = m->get_snapid();
 
@@ -1182,7 +1179,7 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
                candidate.get_namespace() != m->get_hobj().nspace)
 	    continue;
 
-	  if (filter && !pgls_filter(filter, candidate, filter_out))
+	  if (filter && !pgls_filter(filter, candidate))
 	    continue;
 
           dout(20) << "pgnls item 0x" << std::hex
@@ -1211,8 +1208,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
         }
         dout(10) << "pgnls handle=" << response.handle << dendl;
 	encode(response, osd_op.outdata);
-	if (filter)
-	  encode(filter_out, osd_op.outdata);
 	dout(10) << " pgnls result=" << result << " outdata.length()="
 		 << osd_op.outdata.length() << dendl;
       }
@@ -1332,7 +1327,7 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	  if (recovery_state.get_missing_loc().is_deleted(candidate))
 	    continue;
 
-	  if (filter && !pgls_filter(filter, candidate, filter_out))
+	  if (filter && !pgls_filter(filter, candidate))
 	    continue;
 
 	  response.entries.push_back(make_pair(candidate.oid,
@@ -1345,8 +1340,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	}
 	response.handle = next;
 	encode(response, osd_op.outdata);
-	if (filter)
-	  encode(filter_out, osd_op.outdata);
 	dout(10) << " pgls result=" << result << " outdata.length()="
 		 << osd_op.outdata.length() << dendl;
       }

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1410,7 +1410,7 @@ protected:
   int do_sparse_read(OpContext *ctx, OSDOp& osd_op);
   int do_writesame(OpContext *ctx, OSDOp& osd_op);
 
-  bool pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& outdata);
+  bool pgls_filter(PGLSFilter *filter, hobject_t& sobj);
   int get_pgls_filter(bufferlist::const_iterator& iter, PGLSFilter **pfilter);
 
   map<hobject_t, list<OpRequestRef>> in_progress_proxy_ops;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3798,10 +3798,11 @@ void Objecter::_nlist_reply(NListContext *list_context, int r,
 
   auto iter = list_context->bl.cbegin();
   pg_nls_response_t response;
-  ceph::buffer::list extra_info;
   decode(response, iter);
   if (!iter.end()) {
-    decode(extra_info, iter);
+    // we do this as legacy.
+    ceph::buffer::list legacy_extra_info;
+    decode(legacy_extra_info, iter);
   }
 
   // if the osd returns 1 (newer code), or handle MAX, it means we
@@ -3828,7 +3829,6 @@ void Objecter::_nlist_reply(NListContext *list_context, int r,
 		 << ", response.entries " << response.entries
 		 << ", handle " << response.handle
 		 << ", tentative new pos " << list_context->pos << dendl;
-  list_context->extra_info.append(extra_info);
   if (response_size) {
     list_context->list.splice(list_context->list.end(), response.entries);
   }
@@ -5156,11 +5156,12 @@ void Objecter::_enumerate_reply(
   auto iter = bl.cbegin();
   pg_nls_response_t response;
 
-  // XXX extra_info doesn't seem used anywhere?
-  ceph::buffer::list extra_info;
   decode(response, iter);
   if (!iter.end()) {
-    decode(extra_info, iter);
+    // extra_info isn't used anywhere. We do this solely to preserve
+    // backward compatibility
+    ceph::buffer::list legacy_extra_info;
+    decode(legacy_extra_info, iter);
   }
 
   ldout(cct, 10) << __func__ << ": got " << response.entries.size()

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1610,8 +1610,6 @@ public:
 
     ceph::buffer::list filter;
 
-    ceph::buffer::list extra_info;
-
     // The budget associated with this context, once it is set (>= 0),
     // the budget is not get/released on OP basis, instead the budget
     // is acquired before sending the first OP and released upon receiving


### PR DESCRIPTION
it's implemented using `PGLSParentFilter`, and this filter has never been
used. the only possible user would be `cephfs-data-scan`, but it's using
`PGLSCephFSFilter` which is referened with "cephfs.inode_tag".

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
