### PR TITLE
nautilus: ceph-crash: use open(..,'rb') to read bytes for Python3

### DIFF
--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -32,7 +32,7 @@ def post_crash(path):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    f = open(os.path.join(path, 'meta'), 'r')
+    f = open(os.path.join(path, 'meta'), 'rb')
     stdout, stderr = pr.communicate(input=f.read())
     rc = pr.wait()
     f.close()


### PR DESCRIPTION
https://tracker.ceph.com/issues/40946