### PR TITLE
rgw: DefaultRetention requires either Days or Years

### DIFF
--- a/src/rgw/rgw_object_lock.h
+++ b/src/rgw/rgw_object_lock.h
@@ -109,7 +109,10 @@ public:
   }
 
   bool retention_period_valid() const {
-    return (get_years() > 0 || get_days() > 0);
+    // DefaultRetention requires either Days or Years.
+    // You can't specify both at the same time.
+    // see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTObjectLockConfiguration.html
+    return get_years() > 0 != get_days() > 0;
   }
 
   bool has_rule() const {


### PR DESCRIPTION
Either Days or Years must be specified, but not both.

see https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_DefaultRetention.html

Signed-off-by: Chang Liu <liuchang0812@gmail.com>

@cbodley @yehudasa mind taking a look?

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
