### PR TITLE
ceph.spec.in: modify tar.bz2 to tar.gz

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -119,7 +119,7 @@ License:	LGPL-2.1 and LGPL-3.0 and CC-BY-SA-3.0 and GPL-2.0 and BSL-1.0 and BSD-
 Group:		System/Filesystems
 %endif
 URL:		http://ceph.com/
-Source0:	%{?_remote_tarball_prefix}@TARBALL_BASENAME@.tar.bz2
+Source0:	%{?_remote_tarball_prefix}@TARBALL_BASENAME@.tar.gz
 %if 0%{?suse_version}
 # _insert_obs_source_lines_here
 ExclusiveArch:  x86_64 aarch64 ppc64le s390x


### PR DESCRIPTION
Now Ceph package fetched from the source tarball is tar.gz after v10, but the ceph.spec.in file still use tar.bz2. While building rpm packages use tar.gz, we would modify the ceph.spec.

Signed-off-by: Ye Hu <yehu5@huawei.com>