### PR TITLE
nautilus: ceph-volume: run functional tests without dashboard

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -15,6 +15,7 @@
 
   vars:
     delegate_facts_host: True
+    dashboard_enabled: False
 
   pre_tasks:
     # If we can't get python2 installed before any module is used we will fail
@@ -85,6 +86,8 @@
   gather_facts: false
   become: True
   any_errors_fatal: true
+  vars:
+    dashboard_enabled: False
   tasks:
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
ceph-ansible has started enabling the dashboard by
default as of https://github.com/ceph/ceph-ansible/pull/4268

Disabling the dashboard gets us around needing to run
the grafana_server role which is required for the dashboard
and not needed for ceph-volume functional tests.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>
(cherry picked from commit 7b7ff0d530c5f28e933602505b66efc4df24e62e)

no tracker ticket

