### PR TITLE
rgw: Make more compatibility on radosgw processing request.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3991,6 +3991,8 @@ int RGWHandler_REST_S3::init(RGWRados *store, struct req_state *s,
   const char *sc = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS");
   if (sc) {
     s->info.storage_class = sc;
+  } else {
+    s->info.storage_class = RGW_STORAGE_CLASS_STANDARD;
   }
 
   return RGWHandler_REST::init(store, s, cio);


### PR DESCRIPTION
Client service send request to radosgw by S3 script.
If request-content did not contain "HTTP_X_AMZ_STORAGE_CLASS=STANDARD", putting-object was success but compression didn't work.
This causes when using python-boto3 and cosbench to test rgw-compression-put/get , compression didn't take effect.


Fixes: https://tracker.ceph.com/issues/41304
Signed-off-by: Han Fengzhe  <hanfengzhe@hisilicon.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
