### PR TITLE
rgw:  when you abort a multipart upload request, the quota may be not updated

### DIFF
--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -212,6 +212,7 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
   bool truncated;
   int marker = 0;
   int ret;
+  uint64_t parts_accounted_size = 0;
 
   do {
     ret = list_multipart_parts(store, bucket_info, cct,
@@ -248,6 +249,7 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
           remove_objs.push_back(key);
         }
       }
+      parts_accounted_size += obj_part.accounted_size;
     }
   } while (truncated);
 
@@ -265,6 +267,9 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
   if (!remove_objs.empty()) {
     del_op.params.remove_objs = &remove_objs;
   }
+  
+  del_op.params.abortmp = true;
+  del_op.params.parts_accounted_size = parts_accounted_size;
 
   // and also remove the metadata obj
   ret = del_op.delete_obj(null_yield);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4771,6 +4771,10 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
   }
   uint64_t obj_accounted_size = state->accounted_size;
 
+  if(params.abortmp) {
+    obj_accounted_size = params.parts_accounted_size;
+  }
+
   if (!real_clock::is_zero(params.expiration_time)) {
     bufferlist bl;
     real_time delete_at;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -814,8 +814,10 @@ public:
         ceph::real_time mtime; /* for setting delete marker mtime */
         bool high_precision_time;
         rgw_zone_set *zones_trace;
+	bool abortmp;
+	uint64_t parts_accounted_size;
 
-        DeleteParams() : versioning_status(0), olh_epoch(0), bilog_flags(0), remove_objs(NULL), high_precision_time(false), zones_trace(nullptr) {}
+        DeleteParams() : versioning_status(0), olh_epoch(0), bilog_flags(0), remove_objs(NULL), high_precision_time(false), zones_trace(nullptr), abortmp(false), parts_accounted_size(0) {}
       } params;
 
       struct DeleteResult {


### PR DESCRIPTION
rgw: when you abort a multipart upload request, the quota may be not updated

You can get the problem do like this:

1. s3cmd put 30M s3://bucket
2. Ctrl + C
3. s3cmd abortmp s3://bucket/30M $upload_id

Fixes: https://tracker.ceph.com/issues/41606
Signed-off-by: Richard Bai(白学余)  baixueyu@inspur.com



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
