### PR TITLE
client: fix lazyio_synchronize() to update file size

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10512,8 +10512,11 @@ int Client::lazyio_synchronize(int fd, loff_t offset, size_t count)
   Inode *in = f->inode.get();
   
   _fsync(f, true);
-  if (_release(in))
-    check_caps(in, 0);
+  if (_release(in)) {
+    int r =_getattr(in, CEPH_STAT_CAP_SIZE, f->actor_perms);
+    if (r < 0) 
+      return r;
+  }
   return 0;
 }
 


### PR DESCRIPTION
lazyio_synchronize() does not update `Inode.size` . This causes the subsequent read to fail.
See https://tracker.ceph.com/issues/41310 for more details.

Fixes: https://tracker.ceph.com/issues/41310
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>
