### PR TITLE
os/bluestore: prefix omap of temp objects by real pool

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3289,7 +3289,7 @@ const string& BlueStore::Onode::get_omap_prefix()
 void BlueStore::Onode::get_omap_header(string *out)
 {
   if (onode.is_perpool_omap() && !onode.is_pgmeta_omap()) {
-    _key_encode_u64(oid.hobj.pool, out);
+    _key_encode_u64(c->pool(), out);
   }
   _key_encode_u64(onode.nid, out);
   out->push_back('-');
@@ -3298,7 +3298,7 @@ void BlueStore::Onode::get_omap_header(string *out)
 void BlueStore::Onode::get_omap_key(const string& key, string *out)
 {
   if (onode.is_perpool_omap() && !onode.is_pgmeta_omap()) {
-    _key_encode_u64(oid.hobj.pool, out);
+    _key_encode_u64(c->pool(), out);
   }
   _key_encode_u64(onode.nid, out);
   out->push_back('.');
@@ -3308,7 +3308,7 @@ void BlueStore::Onode::get_omap_key(const string& key, string *out)
 void BlueStore::Onode::rewrite_omap_key(const string& old, string *out)
 {
   if (onode.is_perpool_omap() && !onode.is_pgmeta_omap()) {
-    _key_encode_u64(oid.hobj.pool, out);
+    _key_encode_u64(c->pool(), out);
   }
   _key_encode_u64(onode.nid, out);
   out->append(old.c_str() + out->length(), old.size() - out->length());
@@ -3317,7 +3317,7 @@ void BlueStore::Onode::rewrite_omap_key(const string& old, string *out)
 void BlueStore::Onode::get_omap_tail(string *out)
 {
   if (onode.is_perpool_omap() && !onode.is_pgmeta_omap()) {
-    _key_encode_u64(oid.hobj.pool, out);
+    _key_encode_u64(c->pool(), out);
   }
   _key_encode_u64(onode.nid, out);
   out->push_back('~');

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1292,6 +1292,10 @@ public:
       return false;
     }
 
+    int64_t pool() const {
+      return cid.pool();
+    }
+
     void split_cache(Collection *dest);
 
     bool flush_commit(Context *c) override;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -742,6 +742,9 @@ public:
     }
     return false;
   }
+  int64_t pool() const {
+    return pgid.pool();
+  }
 
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);


### PR DESCRIPTION
For recovery or backfill, we use temp object at destination
if the whole object context can not sent in one shot.
And since https://github.com/ceph/ceph/pull/29292, we now segregate
omap keys by object's binding pool.
However, https://github.com/ceph/ceph/pull/29292 does not
work well for recovery or backfill process that need
to manipulate temp objects because we always (deliberately)
assign a negative pool id for each temp object which is
(obviously) different from the corresponding target object,
and we do not fix it when trying to rename the temp object
back to the target object at the end of recovery/backfill,
as a result of which we totally lose track of the omap
portion of the recovered object.

Fix by prefixing all omap-related stuff of temp objects
by using its real(pg's) pool.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
