### PR TITLE
mds: make ScatterLock::clear_dirty check whether there are children with dirty rstat

### DIFF
--- a/src/mds/ScatterLock.h
+++ b/src/mds/ScatterLock.h
@@ -88,6 +88,35 @@ public:
     return state_flags & UNSCATTER_WANTED;
   }
 
+  // In the following scenario, the current lock's dirty state could be lost:
+  // 1. current lock's state is LOCK_LOCK;
+  // 2. auth send LOCK_AC_MIX, and the current lock do finish_scatter_update, which
+  //    wrlock_force the current lock;
+  // 3. auth send LOCK_AC_LOCK, and would be forced to wait, since the current lock
+  //    is wrlocked;
+  // 4. the child inode want to pop rstat up to the current lock's parent, which would
+  //    also be forced to wait since the current lock state is LOCK_MIX_LOCK; the current
+  //    lock would be marked dirty, and the child inode would be attached to the corresponding
+  //    dir's dirty_rstat_inodes;
+  // 5. the previous finish_scatter_update finishes, the codes reaches here and "start_flush"
+  //    the current lock, which would clear the dirty flag of the current lock.
+  // As the CInode::encode_lock_state method doesn't pop dirty_rstat_inodes' rstat to the corresponding
+  // dir, step 5 actually lead to the lost of the dirty state marked by step 4.
+  //
+  // So we check whether there exists children with dirty rstat, if so, ScatterLock::clear_dirty() just
+  // do nothing.
+  void new_dirty_childrstat() {
+    dirtied_childrstats++;
+  }
+  bool exists_dirty_childrstat() const {
+    ceph_assert(dirtied_childrstats >= 0);
+    return dirtied_childrstats > 0;
+  }
+  void dirty_childrstat_cleaned() {
+    ceph_assert(dirtied_childrstats >= 0);
+    if (dirtied_childrstats)
+      dirtied_childrstats--;
+  }
   bool is_dirty() const override {
     return state_flags & DIRTY;
   }
@@ -99,6 +128,9 @@ public:
   }
   bool is_dirty_or_flushing() const {
     return is_dirty() || is_flushing();
+  }
+  void clear_dirty_childrstats() {
+    dirtied_childrstats = 0;
   }
 
   void mark_dirty() { 
@@ -128,6 +160,7 @@ public:
     state_flags &= ~FLUSHED;
   }
   void remove_dirty() {
+    clear_dirty_childrstats();
     start_flush();
     finish_flush();
     clear_flushed();
@@ -201,6 +234,8 @@ public:
       out << " flushed";
     if (get_scatter_wanted())
       out << " scatter_wanted";
+    if (exists_dirty_childrstat())
+      out << " dirtied_childrstats:" << dirtied_childrstats;
     out << ")";
   }
 
@@ -241,12 +276,16 @@ private:
     state_flags |= DIRTY;
   }
   void clear_dirty() {
-    state_flags &= ~DIRTY;
-    if (_more) {
-      _more->item_updated.remove_myself();
-      _more.reset();
+    if (!exists_dirty_childrstat()) {
+      state_flags &= ~DIRTY;
+      if (_more) {
+	_more->item_updated.remove_myself();
+	_more.reset();
+      }
     }
   }
+
+  int64_t dirtied_childrstats = 0;
 
   mutable std::unique_ptr<more_bits_t> _more;
 };


### PR DESCRIPTION
In the following scenario, the current lock's dirty state could be lost:
1. current lock's state is LOCK_LOCK;
2. auth send LOCK_AC_MIX, and the current lock do finish_scatter_update, which
   wrlock_force the current lock;
3. auth send LOCK_AC_LOCK, and would be forced to wait, since the current lock
   is wrlocked;
4. the child inode want to pop rstat up to the current lock's parent, which would
   also be forced to wait since the current lock state is LOCK_MIX_LOCK; the current
   lock would be marked dirty, and the child inode would be attached to the corresponding
   dir's dirty_rstat_inodes;
5. the previous finish_scatter_update finishes, the codes reaches here and "start_flush"
   the current lock, which would clear the dirty flag of the current lock.
As the CInode::encode_lock_state method doesn't pop dirty_rstat_inodes' rstat to the corresponding
dir, step 5 actually lead to the lost of the dirty state marked by step 4.

So we check whether there exists children with dirty rstat, if so, ScatterLock::clear_dirty() just
do nothing.

Fixes: https://tracker.ceph.com/issues/41327
Signed-off-by: Xuehan Xu <xxhdx1985126@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
