### PR TITLE
mgr/volumes: handle exceptions in purge thread with retry

### DIFF
--- a/src/pybind/mgr/volumes/fs/purge_queue.py
+++ b/src/pybind/mgr/volumes/fs/purge_queue.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import logging
 import threading
@@ -10,6 +11,13 @@ class PurgeQueueBase(object):
     """
     Base class for implementing purge queue strategies.
     """
+
+    # this is "not" configurable and there is no need for it to be
+    # configurable. if a purge thread encounters an exception, we
+    # retry, till it hits this many consecutive exceptions after
+    # which a warning is sent to `ceph status`.
+    MAX_RETRIES_ON_EXCEPTION = 10
+
     class PurgeThread(threading.Thread):
         def __init__(self, name, purge_fn):
             self.purge_fn = purge_fn
@@ -18,11 +26,22 @@ class PurgeQueueBase(object):
             threading.Thread.__init__(self, name=name)
 
         def run(self):
-            try:
-                self.purge_fn()
-            except Exception as e:
-                trace = "".join(traceback.format_exception(None, e, e.__traceback__))
-                log.error("purge queue thread encountered fatal error:\n"+trace)
+            retries = 0
+            thread_name = threading.currentThread().getName()
+            while retries < PurgeQueueBase.MAX_RETRIES_ON_EXCEPTION:
+                try:
+                    self.purge_fn()
+                    retries = 0
+                except Exception:
+                    retries += 1
+                    log.warning("purge thread [{0}] encountered fatal error: (attempt#" \
+                                " {1}/{2})".format(thread_name, retries,
+                                                   PurgeQueueBase.MAX_RETRIES_ON_EXCEPTION))
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    log.warning("traceback: {0}".format("".join(
+                        traceback.format_exception(exc_type, exc_value, exc_traceback))))
+                    time.sleep(1)
+            log.error("purge thread [{0}] reached exception limit, bailing out...".format(thread_name))
 
         def cancel_job(self):
             self.cancel_event.set()

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -175,6 +175,14 @@ class VolumeClient(object):
         for fs in fs_map['filesystems']:
             self.purge_queue.queue_purge_job(fs['mdsmap']['fs_name'])
 
+    def cluster_log(self, msg, lvl=None):
+        """
+        log to cluster log with default log level as WARN.
+        """
+        if not lvl:
+            lvl = self.mgr.CLUSTER_LOG_PRIO_WARN
+        self.mgr.cluster_log("cluster", lvl, msg)
+
     def gen_pool_names(self, volname):
         """
         return metadata and data pool name (from a filesystem/volume name) as a tuple


### PR DESCRIPTION
and in case a thread hits max retry limit, bailout and send a health update for `ceph status`

sample:

```
$ ceph -s
  cluster:
    id:     91e5c2ac-6fb3-4460-aafb-3b5fc027b75b
    health: HEALTH_WARN
            Module 'volumes' has 4 failed purge thread(s)
 
  services:
    mon: 1 daemons, quorum a (age 4m)
    mgr: x(active, since 4m)
    mds: a:1 {0=a=up:active}
    osd: 3 osds: 3 up (since 4m), 3 in (since 2d)
 
  data:
    pools:   2 pools, 24 pgs
    objects: 22 objects, 9.0 KiB
    usage:   6.0 GiB used, 3.0 TiB / 3.0 TiB avail
    pgs:     24 active+clean
```

fixes:
http://tracker.ceph.com/issues/41218
http://tracker.ceph.com/issues/41219