### PR TITLE
nautilus: os/bluestore: do not set osd_memory_target default from cgroup limit

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4247,23 +4247,6 @@ void BlueStore::_set_blob_size()
 
 int BlueStore::_set_cache_sizes()
 {
-  // set osd_memory_target *default* based on cgroup limit?
-  // (do this before we fetch the osd_memory_target value!)
-  double cgroup_ratio = cct->_conf.get_val<double>(
-    "osd_memory_target_cgroup_limit_ratio");
-  if (cgroup_ratio > 0.0) {
-    uint64_t cgroup_limit = 0;
-    if (get_cgroup_memory_limit(&cgroup_limit) == 0 &&
-	cgroup_limit) {
-      uint64_t def = cgroup_limit * cgroup_ratio;
-      dout(10) << __func__ << " osd_memory_target_cgroup_limit_ratio "
-	       << cgroup_ratio << ", cgroup_limit " << cgroup_limit
-	       << ", defaulting osd_memory_target to " << def
-	       << dendl;
-      cct->_conf.set_val_default("osd_memory_target", stringify(def));
-    }
-  }
-
   ceph_assert(bdev);
   cache_autotune = cct->_conf.get_val<bool>("bluestore_cache_autotune");
   cache_autotune_interval =


### PR DESCRIPTION
On the aarch64 box I'm testing, this gives us a value of
7378697629483768832, which is not what we want.

I think we are better off relying on this limit being explicitly set via
environment variables (POD_* by kuberentes/rook) or via the command line.

This partially reverts 5c6b533697814af8acfd9e731a2599b2294687ef, but not
all of it, since we wan to keep the option itself, as it is now used by
common/config.cc when dealing with the POD_MEMORY_LIMIT env var.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 9346d3c3bcde7d0a68e21a554eb7fc836df78ba9)