### PR TITLE
mgr/volumes: minor fixes

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -132,6 +132,20 @@ class TestVolumes(CephFSTestCase):
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
+    def test_subvolume_create_with_invalid_data_pool_layout(self):
+        subvolume = self._generate_random_subvolume_name()
+        data_pool = "invalid_pool"
+        # create subvolume with invalid data pool layout
+        try:
+            self._fs_cmd("subvolume", "create", self.volname, subvolume, "--pool_layout", data_pool)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise
+        else:
+            raise
+        # clean up
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume, "--force")
+
     def test_nonexistent_subvolume_rm(self):
         # remove non-existing subvolume
         subvolume = "non_existent_subvolume"
@@ -220,6 +234,20 @@ class TestVolumes(CephFSTestCase):
 
         self._fs_cmd("subvolumegroup", "rm", self.volname, group1)
         self._fs_cmd("subvolumegroup", "rm", self.volname, group2)
+
+    def test_subvolume_group_create_with_invalid_data_pool_layout(self):
+        group = self._generate_random_group_name()
+        data_pool = "invalid_pool"
+        # create group with invalid data pool layout
+        try:
+            self._fs_cmd("subvolumegroup", "create", self.volname, group, "--pool_layout", data_pool)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise
+        else:
+            raise
+        # clean up
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group, "--force")
 
     def test_subvolume_create_with_desired_data_pool_layout_in_group(self):
         subvol1 = self._generate_random_subvolume_name()

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -146,6 +146,22 @@ class TestVolumes(CephFSTestCase):
         # clean up
         self._fs_cmd("subvolume", "rm", self.volname, subvolume, "--force")
 
+    def test_subvolume_create_with_auto_cleanup_on_fail(self):
+        subvolume = self._generate_random_subvolume_name()
+        data_pool = "invalid_pool"
+        # create subvolume with invalid data pool layout fails
+        with self.assertRaises(CommandFailedError):
+            self._fs_cmd("subvolume", "create", self.volname, subvolume, "--pool_layout", data_pool)
+
+        # check whether subvol path is cleaned up
+        try:
+            self._fs_cmd("subvolume", "getpath", self.volname, subvolume)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise
+        else:
+            raise
+
     def test_nonexistent_subvolume_rm(self):
         # remove non-existing subvolume
         subvolume = "non_existent_subvolume"
@@ -248,6 +264,22 @@ class TestVolumes(CephFSTestCase):
             raise
         # clean up
         self._fs_cmd("subvolumegroup", "rm", self.volname, group, "--force")
+
+    def test_subvolume_group_create_with_auto_cleanup_on_fail(self):
+        group = self._generate_random_group_name()
+        data_pool = "invalid_pool"
+        # create group with invalid data pool layout
+        with self.assertRaises(CommandFailedError):
+            self._fs_cmd("subvolumegroup", "create", self.volname, group, "--pool_layout", data_pool)
+
+        # check whether group path is cleaned up
+        try:
+            self._fs_cmd("subvolumegroup", "getpath", self.volname, group)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise
+        else:
+            raise
 
     def test_subvolume_create_with_desired_data_pool_layout_in_group(self):
         subvol1 = self._generate_random_subvolume_name()

--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -75,29 +75,40 @@ class SubVolume(object):
 
         self.fs.mkdirs(subvolpath, mode)
 
-        if size is not None:
-            self.fs.setxattr(subvolpath, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
+        try:
+            if size is not None:
+                self.fs.setxattr(subvolpath, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
 
-        if pool:
+            if pool:
+                try:
+                    self.fs.setxattr(subvolpath, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)
+                except cephfs.InvalidValue:
+                    raise VolumeException(-errno.EINVAL,
+                                          "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
+
+            xattr_key = xattr_val = None
+            if namespace_isolated:
+                # enforce security isolation, use separate namespace for this subvolume
+                xattr_key = 'ceph.dir.layout.pool_namespace'
+                xattr_val = spec.fs_namespace
+            elif not pool:
+                # If subvolume's namespace layout is not set, then the subvolume's pool
+                # layout remains unset and will undesirably change with ancestor's
+                # pool layout changes.
+                xattr_key = 'ceph.dir.layout.pool'
+                xattr_val = self._get_ancestor_xattr(subvolpath, "ceph.dir.layout.pool")
+            # TODO: handle error...
+            self.fs.setxattr(subvolpath, xattr_key, xattr_val.encode('utf-8'), 0)
+        except Exception as e:
             try:
-                self.fs.setxattr(subvolpath, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)
-            except cephfs.InvalidValue:
-                raise VolumeException(-errno.EINVAL,
-                                      "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
-
-        xattr_key = xattr_val = None
-        if namespace_isolated:
-            # enforce security isolation, use separate namespace for this subvolume
-            xattr_key = 'ceph.dir.layout.pool_namespace'
-            xattr_val = spec.fs_namespace
-        elif not pool:
-            # If subvolume's namespace layout is not set, then the subvolume's pool
-            # layout remains unset and will undesirably change with ancestor's
-            # pool layout changes.
-            xattr_key = 'ceph.dir.layout.pool'
-            xattr_val = self._get_ancestor_xattr(subvolpath, "ceph.dir.layout.pool")
-        # TODO: handle error...
-        self.fs.setxattr(subvolpath, xattr_key, xattr_val.encode('utf-8'), 0)
+                # cleanup subvol path on best effort basis
+                log.debug("cleaning up subvolume with path: {0}".format(subvolpath))
+                self.fs.rmdir(subvolpath)
+            except Exception:
+                log.debug("failed to clean up subvolume with path: {0}".format(subvolpath))
+                pass
+            finally:
+                raise e
 
     def remove_subvolume(self, spec, force):
         """
@@ -181,13 +192,24 @@ class SubVolume(object):
     def create_group(self, spec, mode=0o755, pool=None):
         path = spec.group_path
         self.fs.mkdirs(path, mode)
-        if not pool:
-            pool = self._get_ancestor_xattr(path, "ceph.dir.layout.pool")
         try:
-            self.fs.setxattr(path, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)
-        except cephfs.InvalidValue:
-            raise VolumeException(-errno.EINVAL,
-                                  "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
+            if not pool:
+                pool = self._get_ancestor_xattr(path, "ceph.dir.layout.pool")
+            try:
+                self.fs.setxattr(path, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)
+            except cephfs.InvalidValue:
+                raise VolumeException(-errno.EINVAL,
+                                      "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
+        except Exception as e:
+            try:
+                # cleanup group path on best effort basis
+                log.debug("cleaning up subvolumegroup with path: {0}".format(path))
+                self.fs.rmdir(path)
+            except Exception:
+                log.debug("failed to clean up subvolumegroup with path: {0}".format(path))
+                pass
+            finally:
+                raise e
 
     def remove_group(self, spec, force):
         path = spec.group_path


### PR DESCRIPTION


    mgr/volumes: cleanup FS subvolume or subvolume group path
    
    ... on best effort basis when FS subvolume or subvolumegroup create
    command fails.
    
    Fixes: https://tracker.ceph.com/issues/41371
    Signed-off-by: Ramana Raja <rraja@redhat.com>


    mgr/volumes: give useful error message
    
    ... when creating FS subvolume or subvolume group with invalid
    data pool layout.
    
    Fixes: https://tracker.ceph.com/issues/41337
    Signed-off-by: Ramana Raja <rraja@redhat.com>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
