### PR TITLE
mgr/dashboard: Editing RGW bucket fails because of name is already in use

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -48,7 +48,7 @@
                    placeholder="Name..."
                    formControlName="bid"
                    [readonly]="editing"
-                   autofocus>
+                   [autofocus]="!editing">
             <span class="invalid-feedback"
                   *ngIf="bucketForm.showError('bid', frm, 'required')"
                   i18n>This field is required.</span>
@@ -72,7 +72,8 @@
             <select id="owner"
                     name="owner"
                     class="form-control custom-select"
-                    formControlName="owner">
+                    formControlName="owner"
+                    [autofocus]="editing">
               <option i18n
                       *ngIf="owners === null"
                       [ngValue]="null">Loading...</option>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -4,6 +4,7 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import * as _ from 'lodash';
 import { ToastrModule } from 'ngx-toastr';
 import { of as observableOf } from 'rxjs';
 
@@ -134,6 +135,20 @@ describe('RgwBucketFormComponent', () => {
       spyOn(TestBed.get(Router), 'navigate').and.stub();
       notificationService = TestBed.get(NotificationService);
       spyOn(notificationService, 'show');
+    });
+
+    it('should validate name', () => {
+      component.editing = false;
+      component.createForm();
+      const control = component.bucketForm.get('bid');
+      expect(_.isFunction(control.asyncValidator)).toBeTruthy();
+    });
+
+    it('should not validate name', () => {
+      component.editing = true;
+      component.createForm();
+      const control = component.bucketForm.get('bid');
+      expect(control.asyncValidator).toBeNull();
     });
 
     it('tests create success notification', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -50,7 +50,7 @@ export class RgwBucketFormComponent implements OnInit {
   createForm() {
     this.bucketForm = this.formBuilder.group({
       id: [null],
-      bid: [null, [Validators.required], [this.bucketNameValidator()]],
+      bid: [null, [Validators.required], this.editing ? [] : [this.bucketNameValidator()]],
       owner: [null, [Validators.required]],
       'placement-target': [null, this.editing ? [] : [Validators.required]]
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/autofocus.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/autofocus.directive.spec.ts
@@ -18,16 +18,36 @@ export class PasswordFormComponent {}
 @Component({
   template: `
     <form>
-      <input id="x" type="checkbox" autofocus />
+      <input id="x" type="checkbox" [autofocus]="edit" />
       <input id="y" type="text" />
     </form>
   `
 })
-export class CheckboxFormComponent {}
+export class CheckboxFormComponent {
+  public edit = true;
+}
+
+@Component({
+  template: `
+    <form>
+      <input id="x" type="text" [autofocus]="foo" />
+    </form>
+  `
+})
+export class TextFormComponent {
+  foo() {
+    return false;
+  }
+}
 
 describe('AutofocusDirective', () => {
   configureTestBed({
-    declarations: [AutofocusDirective, CheckboxFormComponent, PasswordFormComponent]
+    declarations: [
+      AutofocusDirective,
+      CheckboxFormComponent,
+      PasswordFormComponent,
+      TextFormComponent
+    ]
   });
 
   it('should create an instance', () => {
@@ -57,5 +77,14 @@ describe('AutofocusDirective', () => {
     expect(focused.attributes.type).toBe('checkbox');
     const element = document.getElementById('x');
     expect(element === document.activeElement).toBeTruthy();
+  });
+
+  it('should not focus the text form field', () => {
+    const fixture: ComponentFixture<TextFormComponent> = TestBed.createComponent(TextFormComponent);
+    fixture.detectChanges();
+    const focused = fixture.debugElement.query(By.css(':focus'));
+    expect(focused).toBeNull();
+    const element = document.getElementById('x');
+    expect(element !== document.activeElement).toBeTruthy();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/autofocus.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/autofocus.directive.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Directive, ElementRef } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input } from '@angular/core';
 
 import * as _ from 'lodash';
 
@@ -6,12 +6,23 @@ import * as _ from 'lodash';
   selector: '[autofocus]' // tslint:disable-line
 })
 export class AutofocusDirective implements AfterViewInit {
+  private focus = true;
+
   constructor(private elementRef: ElementRef) {}
 
   ngAfterViewInit() {
     const el: HTMLInputElement = this.elementRef.nativeElement;
-    if (_.isFunction(el.focus)) {
+    if (this.focus && _.isFunction(el.focus)) {
       el.focus();
+    }
+  }
+
+  @Input()
+  public set autofocus(condition: any) {
+    if (_.isBoolean(condition)) {
+      this.focus = condition;
+    } else if (_.isFunction(condition)) {
+      this.focus = condition();
     }
   }
 }


### PR DESCRIPTION
- Validate name only when creating a new bucket
- Set field autofocus depending on whether a bucket is created/edited
- Improve autofocus directive

Fixes: https://tracker.ceph.com/issues/41314

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
