### PR TITLE
mimic ceph-volume: use the OSD identifier when reporting success

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -243,8 +243,9 @@ class Zap(object):
                 "Zapping successful for: %s" % ", ".join([str(d) for d in self.args.devices])
             )
         else:
+            identifier = self.args.osd_id or self.args.osd_fsid
             terminal.success(
-                "Zapping successful for OSD: %s" % self.args.osd_id or self.args.osd_fsid
+                "Zapping successful for OSD: %s" % identifier
             )
 
     @decorators.needs_root

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_zap.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_zap.py
@@ -90,6 +90,22 @@ class TestEnsureAssociatedLVs(object):
         result = zap.ensure_associated_lvs(volumes)
         assert result == ['/dev/VolGroup/block']
 
+    def test_success_message_for_fsid(self, factory, is_root, capsys):
+        cli_zap = zap.Zap([])
+        args = factory(devices=[], osd_id=None, osd_fsid='asdf-lkjh')
+        cli_zap.args = args
+        cli_zap.zap()
+        out, err = capsys.readouterr()
+        assert "Zapping successful for OSD: asdf-lkjh" in err
+
+    def test_success_message_for_id(self, factory, is_root, capsys):
+        cli_zap = zap.Zap([])
+        args = factory(devices=[], osd_id='1', osd_fsid=None)
+        cli_zap.args = args
+        cli_zap.zap()
+        out, err = capsys.readouterr()
+        assert "Zapping successful for OSD: 1" in err
+
     def test_block_and_partition_are_found(self, volumes, monkeypatch):
         monkeypatch.setattr(zap.disk, 'get_device_from_partuuid', lambda x: '/dev/sdb1')
         tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=block'


### PR DESCRIPTION
It was otherwise failing to use ID or FSID and reporting `None`, because Python evaluated the string with the first `None` as `True` even when `FSID` had an actual value. 

```
In [2]: "Successful zap for OSD: %s" % None or "asdf-lkjh"                                                                                                                                                         
Out[2]: 'Successful zap for OSD: None'
```

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1738379
Backport of: https://github.com/ceph/ceph/pull/29762