### PR TITLE
vstart: move [client.rgw] config into [client]

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -655,7 +655,6 @@ EOF
         log file = $CEPH_OUT_DIR/\$name.\$pid.log
         admin socket = $CEPH_ASOK_DIR/\$name.\$pid.asok
 
-[client.rgw]
         ; needed for s3tests
         rgw crypt s3 kms encryption keys = testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl = false


### PR DESCRIPTION
common rgw config was moved into [client.rgw] with the intent to cover radosgw in multisite tests too, but this broke the default case where radosgws are named after [client.rgw.port]. move the common stuff to [client] so it does actually apply to both

Fixes: https://tracker.ceph.com/issues/41212