### PR TITLE
rgw: Extend SSE-KMS to support HashiCorp Vault (WIP)

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -893,6 +893,26 @@ Keystone Settings
 :Type: Boolean
 :Default: ``true``
 
+
+Server-side encryption Settings
+===============================
+
+``rgw crypt s3 kms backend``
+:Description: Where the SSE-KMS encryption keys are stored. Supported KMS
+              systems are OpenStack Barbican (`barbican`) and HashiCorp Vault
+              (`vault`). Use ``local`` if keys are stored in `ceph.conf` (see
+              ``rgw crypt s3 kms encryption keys``).
+:Type: String
+:Default: ``local``
+
+``rgw crypt s3 kms encryption keys``
+:Description: KMS encryption keys if ``rgw crypt s3 kms backend`` is set to
+              ``local``. Format is a space-separated list of key name/value
+              pairs, e.g. ``key-1=... key-2=...```.
+:Type: String
+:Default: None
+
+
 Barbican Settings
 =================
 
@@ -936,6 +956,39 @@ Barbican Settings
 :Type: String
 :Default: None
 
+
+HashiCorp Vault Settings
+========================
+
+``rgw crypt s3 kms vault namespace``
+:Description: Namespace in Vault where SSE-KMS keys are stored.
+:Type: String
+:Default: None
+
+``rgw crypt s3 kms vault auth```
+:Description: Type of authentication method to be used. Supported methods are
+              ``token`` and ``agent``.
+:Type: String
+:Default: ``token``
+
+```rgw crypt s3 kms vault token file```
+:Description: If authentication method is ``token``, provide a path to the token
+              file readable only by Rados Gateway.
+:Type: String
+:Default: None
+
+```rgw crypt s3 kms vault url```
+:Description: If authentication method is ``token``, provide a URL to the Vault
+              server endpoint.
+:Type: String
+:Default: None
+
+```rgw crypt s3 kms vault agent```
+:Description: If authentication method is ``agent``, provide a path to a Unix
+              socket (``unix://path/to/socket_file``) or URL to Vault agent
+              (``http://127.0.0.1:8100``).
+:Type: String
+:Default: None
 
 QoS settings
 ------------

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -36,9 +36,9 @@ or decrypt data.
 This is implemented in S3 according to the `Amazon SSE-KMS`_ specification.
 
 In principle, any key management service could be used here, but currently
-only integration with `Barbican`_ is implemented.
+only integration with `Barbican`_ and `Vault`_ are implemented.
 
-See `OpenStack Barbican Integration`_.
+See `OpenStack Barbican Integration`_ and `HashiCorp Vault Integration`_.
 
 Automatic Encryption (for testing only)
 =======================================
@@ -58,4 +58,6 @@ The configuration expects a base64-encoded 256 bit key. For example::
 .. _Amazon SSE-C: https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html
 .. _Amazon SSE-KMS: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
 .. _Barbican: https://wiki.openstack.org/wiki/Barbican
+.. _Vault: https://www.vaultproject.io/docs/
 .. _OpenStack Barbican Integration: ../barbican
+.. _HashiCorp Vault Integration: ../vault

--- a/doc/radosgw/index.rst
+++ b/doc/radosgw/index.rst
@@ -52,6 +52,7 @@ you may write data with one API and retrieve it with the other.
    Export over NFS <nfs>
    OpenStack Keystone Integration <keystone>
    OpenStack Barbican Integration <barbican>
+   HashiCorp Vault Integration <vault>
    Open Policy Agent Integration <opa>
    Multi-tenancy <multitenancy>
    Compression <compression>

--- a/doc/radosgw/vault.rst
+++ b/doc/radosgw/vault.rst
@@ -1,0 +1,6 @@
+===========================
+HashiCorp Vault Integration
+===========================
+
+HashiCorp Vault can be used as a secure key management service for
+`Server-Side Encryption`_.

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1518,6 +1518,14 @@ OPTION(rgw_swift_versioning_enabled, OPT_BOOL) // whether swift object versionin
 OPTION(rgw_trust_forwarded_https, OPT_BOOL) // trust Forwarded and X-Forwarded-Proto headers for ssl termination
 OPTION(rgw_crypt_require_ssl, OPT_BOOL) // requests including encryption key headers must be sent over ssl
 OPTION(rgw_crypt_default_encryption_key, OPT_STR) // base64 encoded key for encryption of rgw objects
+
+OPTION(rgw_crypt_s3_kms_backend, OPT_STR) // Where SSE-KMS encryption keys are stored
+OPTION(rgw_crypt_s3_kms_vault_namespace, OPT_STR) // Namespace in Vault where SSE-KMS keys are stored
+OPTION(rgw_crypt_s3_kms_vault_auth, OPT_STR) // Type of authentication method to be used
+OPTION(rgw_crypt_s3_kms_vault_token_file, OPT_STR) // Path to the token file for Vault authentication
+OPTION(rgw_crypt_s3_kms_vault_url, OPT_STR) // URL to Vault server endpoint
+OPTION(rgw_crypt_s3_kms_vault_agent, OPT_STR) // URL or path to the Vault agent Unix socket
+
 OPTION(rgw_crypt_s3_kms_encryption_keys, OPT_STR) // extra keys that may be used for aws:kms
                                                       // defined as map "key1=YmluCmJvb3N0CmJvb3N0LQ== key2=b3V0CnNyYwpUZXN0aW5nCg=="
 OPTION(rgw_crypt_suppress_logs, OPT_BOOL)   // suppress logs that might print customer key

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6883,9 +6883,64 @@ std::vector<Option> get_rgw_options() {
     .set_default("")
     .set_description(""),
 
+    Option("rgw_crypt_s3_kms_backend", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("local")
+    .set_description(
+        "Where the SSE-KMS encryption keys are stored. Supported KMS "
+        "systems are OpenStack Barbican ('barbican') and HashiCorp Vault "
+        "('vault'). Use 'local' if keys are stored in ceph.conf.")
+    .add_see_also("rgw_crypt_s3_kms_encryption_keys"),
+
     Option("rgw_crypt_s3_kms_encryption_keys", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("")
-    .set_description(""),
+    .set_description(
+        "KMS encryption keys if rgw_crypt_s3_kms_backend is set to local. "
+        "Format is a space-separated list of key name/value pairs, e.g. "
+        "'key-1=... key-2=...'.")
+    .add_see_also("rgw_crypt_s3_kms_backend"),
+
+    Option("rgw_crypt_s3_kms_vault_namespace", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description("Namespace in Vault where SSE-KMS keys are stored.")
+    .add_see_also({"rgw_crypt_s3_kms_backend", "rgw_crypt_s3_kms_vault_auth"}),
+
+    Option("rgw_crypt_s3_kms_vault_auth", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("token")
+    .set_description(
+        "Type of authentication method to be used with Vault. "
+        "Supported methods are 'token' and 'agent'.")
+    .add_see_also({
+        "rgw_crypt_s3_kms_backend",
+        "rgw_crypt_s3_kms_vault_token_file",
+        "rgw_crypt_s3_kms_vault_agent"}),
+
+    Option("rgw_crypt_s3_kms_vault_token_file", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description(
+        "If authentication method is 'token', provide a path to the token file "
+        "readable only by Rados Gateway.")
+    .add_see_also({
+      "rgw_crypt_s3_kms_backend",
+      "rgw_crypt_s3_kms_vault_auth",
+      "rgw_crypt_s3_kms_vault_url"}),
+
+    Option("rgw_crypt_s3_kms_vault_url", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description(
+        "If authentication method is 'token', provide a URL to the Vault server "
+        "endpoint.")
+    .add_see_also({
+      "rgw_crypt_s3_kms_backend",
+      "rgw_crypt_s3_kms_vault_auth",
+      "rgw_crypt_s3_kms_vault_token_file"}),
+
+    Option("rgw_crypt_s3_kms_vault_agent", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description(
+        "If authentication method is 'agent', provide a path to a Unix socket "
+        "('unix://path/to/socket_file') or URL to Vault agent "
+        "('http://127.0.0.1:8100').")
+    .add_see_also({"rgw_crypt_s3_kms_backend", "rgw_crypt_s3_kms_vault_auth"}),
 
     Option("rgw_crypt_suppress_logs", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -136,7 +136,8 @@ set(librgw_common_srcs
   rgw_rest_sts.cc
   rgw_perf_counters.cc
   rgw_rest_iam.cc
-  rgw_object_lock.cc)
+  rgw_object_lock.cc
+  rgw_kms.cc)
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -1,0 +1,275 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/**
+ * Server-side encryption integrations with Key Management Systems (SSE-KMS)
+ */
+
+#include <rgw/rgw_crypt.h>
+#include <rgw/rgw_keystone.h>
+#include <rgw/rgw_b64.h>
+#include "include/str_map.h"
+#include "common/safe_io.h"
+#include "rgw/rgw_kms.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rgw
+
+using namespace rgw;
+
+
+map<string,string> get_str_map(const string &str) {
+  map<string,string> m;
+  get_str_map(str, &m, ";, \t");
+  return m;
+}
+
+int get_actual_key_from_conf(CephContext *cct,
+                             boost::string_view key_id,
+                             boost::string_view key_selector,
+                             std::string& actual_key)
+{
+  int res = 0;
+
+  static map<string,string> str_map = get_str_map(
+      cct->_conf->rgw_crypt_s3_kms_encryption_keys);
+
+  map<string, string>::iterator it = str_map.find(std::string(key_id));
+  if (it == str_map.end())
+    return -ERR_INVALID_ACCESS_KEY;
+
+  std::string master_key;
+  try {
+    master_key = from_base64((*it).second);
+  } catch (...) {
+    ldout(cct, 5) << "ERROR: get_actual_key_from_conf invalid encryption key id "
+                  << "which contains character that is not base64 encoded."
+                  << dendl;
+    return -EINVAL;
+  }
+
+  if (master_key.length() == AES_256_KEYSIZE) {
+    uint8_t _actual_key[AES_256_KEYSIZE];
+    if (AES_256_ECB_encrypt(cct,
+        reinterpret_cast<const uint8_t*>(master_key.c_str()), AES_256_KEYSIZE,
+        reinterpret_cast<const uint8_t*>(key_selector.data()),
+        _actual_key, AES_256_KEYSIZE)) {
+      actual_key = std::string((char*)&_actual_key[0], AES_256_KEYSIZE);
+    } else {
+      res = -EIO;
+    }
+    memset(_actual_key, 0, sizeof(_actual_key));
+  } else {
+    ldout(cct, 20) << "Wrong size for key=" << key_id << dendl;
+    res = -EIO;
+  }
+
+  return res;
+}
+
+int get_barbican_url(CephContext * const cct,
+                     std::string& url)
+{
+  url = cct->_conf->rgw_barbican_url;
+  if (url.empty()) {
+    ldout(cct, 0) << "ERROR: conf rgw_barbican_url is not set" << dendl;
+    return -EINVAL;
+  }
+
+  if (url.back() != '/') {
+    url.append("/");
+  }
+
+  return 0;
+}
+
+int request_key_from_barbican(CephContext *cct,
+                              boost::string_view key_id,
+                              const std::string& barbican_token,
+                              std::string& actual_key) {
+  std::string secret_url;
+  int res;
+  res = get_barbican_url(cct, secret_url);
+  if (res < 0) {
+     return res;
+  }
+  secret_url += "v1/secrets/" + std::string(key_id);
+
+  bufferlist secret_bl;
+  RGWHTTPTransceiver secret_req(cct, "GET", secret_url, &secret_bl);
+  secret_req.append_header("Accept", "application/octet-stream");
+  secret_req.append_header("X-Auth-Token", barbican_token);
+
+  res = secret_req.process(null_yield);
+  if (res < 0) {
+    return res;
+  }
+  if (secret_req.get_http_status() ==
+      RGWHTTPTransceiver::HTTP_STATUS_UNAUTHORIZED) {
+    return -EACCES;
+  }
+
+  if (secret_req.get_http_status() >=200 &&
+      secret_req.get_http_status() < 300 &&
+      secret_bl.length() == AES_256_KEYSIZE) {
+    actual_key.assign(secret_bl.c_str(), secret_bl.length());
+    memset(secret_bl.c_str(), 0, secret_bl.length());
+    } else {
+      res = -EACCES;
+    }
+  return res;
+}
+
+static int get_actual_key_from_barbican(CephContext *cct,
+                                        boost::string_view key_id,
+                                        std::string& actual_key)
+{
+  int res = 0;
+  std::string token;
+
+  if (rgw::keystone::Service::get_keystone_barbican_token(cct, token) < 0) {
+    ldout(cct, 5) << "Failed to retrieve token for Barbican" << dendl;
+    return -EINVAL;
+  }
+
+  res = request_key_from_barbican(cct, key_id, token, actual_key);
+  if (res != 0) {
+    ldout(cct, 5) << "Failed to retrieve secret from Barbican:" << key_id << dendl;
+  }
+  return res;
+}
+
+int request_key_from_vault_with_agent(CephContext *cct,
+                                      boost::string_view key_id,
+                                      bufferlist *secret_bl)
+{
+  // TODO: implement
+  return -1;
+}
+
+int request_key_from_vault_with_token(CephContext *cct,
+                                      boost::string_view key_id,
+                                      bufferlist *secret_bl)
+{
+  // These conf settings are static strings so they're read only once from disk
+  static std::string token_file, vault_url;
+  // The actual Vault token is read from file on every request
+  std::string vault_token;
+  int res = 0;
+
+  token_file = cct->_conf->rgw_crypt_s3_kms_vault_token_file;
+  if (token_file.empty()) {
+    ldout(cct, 0) << "ERROR: Vault token file is not set" << dendl;
+    return -EINVAL;
+  }
+  ldout(cct, 20) << "Vault token file: " << token_file << dendl;
+
+  char buf[2048];
+  res = safe_read_file("", token_file.c_str(), buf, sizeof(buf));
+  if (res < 0) {
+    if (-ENOENT == res) {
+      ldout(cct, 0) << "ERROR: Token file '" << token_file << "' not found  " << dendl;
+    } else if (-EACCES == res) {
+      ldout(cct, 0) << "ERROR: Permission denied reading token file" << dendl;
+    } else {
+      ldout(cct, 0) << "ERROR: Failed to read token file with error " << res << dendl;
+    }
+    return res;
+  }
+  // drop trailing newlines
+  while (res && isspace(buf[res-1])) {
+    --res;
+  }
+  vault_token = std::string{buf, static_cast<size_t>(res)};
+
+  vault_url = cct->_conf->rgw_crypt_s3_kms_vault_url;
+  if (vault_url.empty()) {
+    ldout(cct, 0) << "ERROR: Vault URL is not set" << dendl;
+    return -EINVAL;
+  }
+
+  std::string secret_url = vault_url + std::string(key_id);
+  RGWHTTPTransceiver secret_req(cct, "GET", secret_url, secret_bl);
+  secret_req.append_header("X-Vault-Token", vault_token);
+  res = secret_req.process(null_yield);
+  if (res <= 0) {
+    ldout(cct, 0) << "ERROR: Request to Vault failed with error " << res << dendl;
+    return res;
+  }
+
+  if (secret_req.get_http_status() ==
+      RGWHTTPTransceiver::HTTP_STATUS_UNAUTHORIZED) {
+    ldout(cct, 0) << "ERROR: Vault request failed authorization" << dendl;
+    return -EACCES;
+  }
+
+  ldout(cct, 20) << "Request to Vault returned " << res << " and HTTP status "
+    << secret_req.get_http_status() << dendl;
+  return res;
+}
+
+int get_actual_key_from_vault(CephContext *cct,
+                              boost::string_view key_id,
+                              std::string& actual_key)
+{
+  int res = 0;
+  std::string auth;
+  bufferlist secret_bl;
+
+  auth = cct->_conf->rgw_crypt_s3_kms_vault_auth;
+  ldout(cct, 20) << "Vault auhentication method " << auth << dendl;
+
+  if ("token" == auth) {
+    res = request_key_from_vault_with_token(cct, key_id, &secret_bl);
+  } else if ("agent" == auth) {
+    res = request_key_from_vault_with_agent(cct, key_id, &secret_bl);
+  } else {
+    ldout(cct, 0) << "ERROR: Unsupported authentication method " << auth << dendl;
+    return -EINVAL;
+  }
+
+  if (res < 0) {
+    return res;
+  }
+
+  JSONParser parser;
+  if (!parser.parse(secret_bl.c_str(), secret_bl.length())) {
+    ldout(cct, 0) << "ERROR: Failed to parse JSON response from Vault" << dendl;
+    return -EINVAL;
+  }
+
+  // TODO: handle possible missing structures in the JSON response
+  JSONObj *data_obj = parser.find_obj("data");
+  string secret = from_base64(data_obj->find_obj("data")->find_obj("key")->get_data());
+
+  // TODO: remove this log entry
+  ldout(cct, 20) << "Vault secret length: " << secret.length() << dendl;
+
+  actual_key.assign(secret.c_str(), secret.length());
+  memset(secret_bl.c_str(), 0, secret_bl.length());
+
+  return res;
+}
+
+int get_actual_key_from_kms(CephContext *cct,
+                            boost::string_view key_id,
+                            boost::string_view key_selector,
+                            std::string& actual_key)
+{
+  std::string kms_backend;
+
+  kms_backend = cct->_conf->rgw_crypt_s3_kms_backend;
+  ldout(cct, 20) << "Getting KMS encryption key for key=" << key_id << dendl;
+  ldout(cct, 20) << "SSE-KMS backend is " << kms_backend << dendl;
+
+  if (RGW_SSE_KMS_BACKEND_BARBICAN == kms_backend)
+    return get_actual_key_from_barbican(cct, key_id, actual_key);
+
+  if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend)
+    return get_actual_key_from_vault(cct, key_id, actual_key);
+
+  if (RGW_SSE_KMS_BACKEND_LOCAL != kms_backend)
+    ldout(cct, 10) << "Unknown SSE-KMS backend, reverting to local" << dendl;
+
+  return get_actual_key_from_conf(cct, key_id, key_selector, actual_key);
+}

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -1,0 +1,30 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/**
+ * Server-side encryption integrations with Key Management Systems (SSE-KMS)
+ */
+
+#ifndef CEPH_RGW_KMS_H
+#define CEPH_RGW_KMS_H
+
+static const std::string RGW_SSE_KMS_BACKEND_LOCAL = "local";
+static const std::string RGW_SSE_KMS_BACKEND_BARBICAN = "barbican";
+static const std::string RGW_SSE_KMS_BACKEND_VAULT = "vault";
+
+/**
+ * Retrieves the actual server-side encryption key from a KMS system given a
+ * key ID. Currently supported KMS systems are OpenStack Barbican and HashiCorp
+ * Vault, but keys can also be retrieved from Ceph configuration file (if
+ * kms is set to 'local').
+ *
+ * \params
+ * TODO
+ * \return
+ */
+int get_actual_key_from_kms(CephContext *cct,
+                            boost::string_view key_id,
+                            boost::string_view key_selector,
+                            std::string& actual_key);
+
+#endif

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -657,11 +657,17 @@ EOF
 
 [client.rgw]
         ; needed for s3tests
+        rgw crypt s3 kms backend = local
         rgw crypt s3 kms encryption keys = testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl = false
         ; uncomment the following to set LC days as the value in seconds;
         ; needed for passing lc time based s3-tests (can be verbose)
         ; rgw lc debug interval = 10
+        ; The following settings are for SSE-KMS with Vault
+        ; rgw crypt s3 kms vault auth = token | agent
+        ; rgw crypt s3 kms vault url = http://127.0.0.1:8200/v1/secret/data/
+        ; rgw crypt s3 kms vault token file = /path/to/token.file
+
 $extra_conf
 EOF
 


### PR DESCRIPTION
WORK IN PROGRESS - This is in early stages of development but comments
and guidance would be greatly appreciated.

Extend server-side encryption functionality in Rados Gateway to support
HashiCorp Vault as a Key Management System in addition to existing
support for OpenStack Barbican.

Fixes: https://tracker.ceph.com/issues/41062

Implemented so far:
* Move existing SSE-KMS functions from rgw_crypt.cc to rgw_kms.cc
* Vault authentication with a token read from file
* Add new ceph.conf settings for Vault
* Document new ceph.conf settings
* Update encryption documentation page
* Add skeleton page for Vault documentation

Signed-off-by: Andrea Baglioni <andrea.baglioni@workday.com>
Signed-off-by: Sergio de Carvalho <sergio.carvalho@workday.com>
