### PR TITLE
do_cmake.sh: optionally specify build dir with $BUILD_DIR env var

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -x
+
 git submodule update --init --recursive
-if test -e build; then
-    echo 'build dir already exists; rm -rf build and re-run'
+
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
+if [ -e $BUILD_DIR ]; then
+    echo "'$BUILD_DIR' dir already exists; either rm -rf '$BUILD_DIR' and re-run, or set BUILD_DIR env var to a different directory name"
     exit 1
 fi
 
@@ -46,8 +50,8 @@ if [ -n "$WITH_RADOSGW_AMQP_ENDPOINT" ] ; then
     ARGS="$ARGS -DWITH_RADOSGW_AMQP_ENDPOINT=$WITH_RADOSGW_AMQP_ENDPOINT"
 fi
 
-mkdir build
-cd build
+mkdir $BUILD_DIR
+cd $BUILD_DIR
 if type cmake3 > /dev/null 2>&1 ; then
     CMAKE=cmake3
 else

--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -24,16 +24,18 @@ CMAKE_C_FLAGS_DEBUG="$C_FLAGS_DEBUG $COMPILE_FLAGS"
 #   dashboard, because versions fetched are not working on FreeBSD.
  
 
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
 echo Keeping the old build
-if [ -d build.old ]; then
-    sudo mv build.old build.del
-    sudo rm -rf build.del &
+if [ -d ${BUILD_DIR}.old ]; then
+    sudo mv ${BUILD_DIR}.old ${BUILD_DIR}.del
+    sudo rm -rf ${BUILD_DIR}.del &
 fi
-if [ -d build ]; then
-    sudo mv build build.old
+if [ -d ${BUILD_DIR} ]; then
+    sudo mv ${BUILD_DIR} ${BUILD_DIR}.old
 fi
 
-mkdir build
+mkdir ${BUILD_DIR}
 ./do_cmake.sh "$*" \
 	-D WITH_CCACHE=ON \
 	-D CMAKE_BUILD_TYPE=Debug \
@@ -61,7 +63,7 @@ mkdir build
 echo -n "start building: "; date
 printenv
 
-cd build
+cd ${BUILD_DIR}
   gmake -j$CPUS V=1 VERBOSE=1 
   gmake tests 
   echo -n "start testing: "; date ;

--- a/examples/rbd-replay/trace
+++ b/examples/rbd-replay/trace
@@ -5,6 +5,7 @@ lttng create -o traces librbd
 lttng enable-event -u 'librbd:*'
 lttng add-context -u -t pthread_id
 lttng start
-LD_LIBRARY_PATH=../../build/lib qemu-system-i386 -m 1024 rbd:rbd/my-image:conf=../../src/ceph.conf
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+LD_LIBRARY_PATH=../../${BUILD_DIR}/lib qemu-system-i386 -m 1024 rbd:rbd/my-image:conf=../../src/ceph.conf
 lttng stop
 lttng view > trace.log

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -72,7 +72,9 @@ if type cmake3 > /dev/null 2>&1 ; then
 else
     CMAKE=cmake
 fi
-mkdir build && cd build && ${CMAKE} -DWITH_LIBRADOS=ON -DWITH_SNAPPY=ON -DWITH_GFLAGS=OFF -DFAIL_ON_WARNINGS=OFF ..
+
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+mkdir ${BUILD_DIR} && cd ${BUILD_DIR} && ${CMAKE} -DWITH_LIBRADOS=ON -DWITH_SNAPPY=ON -DWITH_GFLAGS=OFF -DFAIL_ON_WARNINGS=OFF ..
 make rocksdb_env_librados_test -j8
 
 echo "Copy ceph.conf"

--- a/qa/workunits/rgw/run-s3tests.sh
+++ b/qa/workunits/rgw/run-s3tests.sh
@@ -12,10 +12,12 @@ port=$2
 
 ##
 
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
 if [ -e CMakeCache.txt ]; then
     BIN_PATH=$PWD/bin
-elif [ -e $root_path/../build/CMakeCache.txt ]; then
-    cd $root_path/../build
+elif [ -e $root_path/../${BUILD_DIR}/CMakeCache.txt ]; then
+    cd $root_path/../${BUILD_DIR}
     BIN_PATH=$PWD/bin
 fi
 PATH=$PATH:$BIN_PATH

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -17,6 +17,8 @@ if [ -e /lib/lsb/init-functions ]; then
     . /lib/lsb/init-functions
 fi
 
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
 if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
     # looks like an autotools src dir build
     BINDIR=.
@@ -33,7 +35,7 @@ else
 	LIBEXECDIR=$CEPH_ROOT/src
 	ETCDIR=.
 	ASSUME_DEV=1
-	CEPH_LIB=$CEPH_ROOT/build/lib
+	CEPH_LIB=$CEPH_ROOT/${BUILD_DIR}/lib
 	echo "$PYTHONPATH" | grep -q $CEPH_LIB || export PYTHONPATH=$CEPH_LIB/cython_modules/lib.@MGR_PYTHON_VERSION_MAJOR@:$PYTHONPATH
 	echo "$LD_LIBRARY_PATH" | grep -q $CEPH_LIB || export LD_LIBRARY_PATH=$CEPH_LIB:$LD_LIBRARY_PATH
 	echo "$DYLD_LIBRARY_PATH" | grep -q $CEPH_LIB || export DYLD_LIBRARY_PATH=$CEPH_LIB:$DYLD_LIBRARY_PATH

--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -5,10 +5,11 @@ set -e
 rgw_frontend=${RGW_FRONTEND:-"beast"}
 script_root=`dirname $0`
 script_root=`(cd $script_root;pwd)`
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
 if [ -e CMakeCache.txt ]; then
     script_root=$PWD
-elif [ -e $script_root/../build/CMakeCache.txt ]; then
-    cd $script_root/../build
+elif [ -e $script_root/../${BUILD_DIR}/CMakeCache.txt ]; then
+    cd $script_root/../${BUILD_DIR}
     script_root=$PWD
 fi
 ceph_bin=$script_root/bin

--- a/src/mrun
+++ b/src/mrun
@@ -8,11 +8,13 @@ command=$2
 CEPH_BIN=$root
 CEPH_CONF_PATH=$root/run/$run_name
 
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
 if [ -e CMakeCache.txt ]; then
     CEPH_BIN=$PWD/bin
     CEPH_CONF_PATH=$PWD/run/$run_name
-elif [ -e $root/../build/CMakeCache.txt ]; then
-    cd $root/../build
+elif [ -e $root/../${BUILD_DIR}/CMakeCache.txt ]; then
+    cd $root/../${BUILD_DIR}
     CEPH_BIN=$PWD/bin
     CEPH_CONF_PATH=$PWD/run/$run_name
 fi

--- a/src/mstart.sh
+++ b/src/mstart.sh
@@ -18,10 +18,12 @@ vstart_path=`dirname $0`
 root_path=`dirname $0`
 root_path=`(cd $root_path; pwd)`
 
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
 if [ -e CMakeCache.txt ]; then
     root_path=$PWD
-elif [ -e $root_path/../build/CMakeCache.txt ]; then
-    cd $root_path/../build
+elif [ -e $root_path/../${BUILD_DIR}/CMakeCache.txt ]; then
+    cd $root_path/../${BUILD_DIR}
     root_path=$PWD
 fi
 RUN_ROOT_PATH=${root_path}/run

--- a/src/mstop.sh
+++ b/src/mstop.sh
@@ -4,10 +4,12 @@ set -e
 
 script_root=`dirname $0`
 
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
 if [ -e CMakeCache.txt ]; then
     script_root=$PWD
-elif [ -e $script_root/../build/CMakeCache.txt ]; then
-    script_root=`(cd $script_root/../build; pwd)`
+elif [ -e $script_root/../${BUILD_DIR}/CMakeCache.txt ]; then
+    script_root=`(cd $script_root/../${BUILD_DIR}; pwd)`
 fi
 
 [ "$#" -lt 1 ] && echo "usage: $0 <name> [entity [id]]" && exit 1

--- a/src/pybind/mgr/dashboard/run-backend-api-request.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-request.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 CURR_DIR=`pwd`
-cd ../../../../build
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+cd ../../../../${BUILD_DIR}
 API_URL=`./bin/ceph mgr services 2>/dev/null | jq .dashboard | sed -e 's/"//g' -e 's!/$!!g'`
 if [ "$API_URL" = "null" ]; then
 	echo "Couldn't retrieve API URL, exiting..." >&2

--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -4,7 +4,7 @@ set -e
 
 stop() {
     if [ "$REMOTE" == "false" ]; then
-        cd $BUILD_DIR
+        cd ${FULL_PATH_BUILD_DIR}
         ../src/stop.sh
     fi
     exit $1
@@ -39,8 +39,10 @@ fi
 
 DASH_DIR=`pwd`
 
-cd ../../../../build
-BUILD_DIR=`pwd`
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
+cd ../../../../${BUILD_DIR}
+FULL_PATH_BUILD_DIR=`pwd`
 
 if [ "$BASE_URL" == "" ]; then
     MGR=2 RGW=1 ../src/vstart.sh -n -d
@@ -64,7 +66,7 @@ export BASE_URL
 cd $DASH_DIR/frontend
 jq .[].target=\"$BASE_URL\" proxy.conf.json.sample > proxy.conf.json
 
-. $BUILD_DIR/src/pybind/mgr/dashboard/node-env/bin/activate
+. ${FULL_PATH_BUILD_DIR}/src/pybind/mgr/dashboard/node-env/bin/activate
 
 if [ "$DEVICE" == "chrome" ]; then
     npm run e2e:ci || stop 1

--- a/src/pybind/mgr/dashboard/run-frontend-unittests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-unittests.sh
@@ -3,8 +3,9 @@
 failed=false
 : ${CEPH_ROOT:=$PWD/../../../../}
 cd $CEPH_ROOT/src/pybind/mgr/dashboard/frontend
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
 if [ `uname` != "FreeBSD" ]; then
-  .  $CEPH_ROOT/build/src/pybind/mgr/dashboard/node-env/bin/activate
+  .  $CEPH_ROOT/${BUILD_DIR}/src/pybind/mgr/dashboard/node-env/bin/activate
 fi
 
 # Build

--- a/src/script/gen-corpus.sh
+++ b/src/script/gen-corpus.sh
@@ -13,6 +13,8 @@ function get_jobs() {
     fi
 }
 
+[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+
 function build() {
     local encode_dump_path=$1
     shift
@@ -22,7 +24,7 @@ function build() {
         -DWITH_DPDK=OFF \
         -DWITH_SPDK=OFF \
         -DCMAKE_CXX_FLAGS="-DENCODE_DUMP_PATH=${encode_dump_path}"
-    cd build
+    cd ${BUILD_DIR}
     cmake --build . -- -j$(get_jobs)
 }
 


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

this should allow for multiple build directories to exist under one ceph root.
would be helpful if trying to use the same code base with different compilation and link flags, without the need to duplicate the entire code base.

change is backward compatible with the current way the script it used, and behavior is modified by setting an env variable: ``BUILD_DIR`` before call ``do_cmake.sh``