### PR TITLE
luminous: msg/async: do not bump connect_seq for fault during ACCEPTING_SESSION

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2154,6 +2154,7 @@ void AsyncConnection::fault()
 
   write_lock.unlock();
   if (!(state >= STATE_CONNECTING && state < STATE_CONNECTING_READY) &&
+      !(state >= STATE_ACCEPTING && state < STATE_ACCEPTING_READY) &&
       state != STATE_WAIT) { // STATE_WAIT is coming from STATE_CONNECTING_*
     // policy maybe empty when state is in accept
     if (policy.server) {


### PR DESCRIPTION
backport tracker issue: https://tracker.ceph.com/issues/42318

---

partial backport (1 commit) of: https://github.com/ceph/ceph/pull/24546

parent tracker: https://tracker.ceph.com/issues/42316