### PR TITLE
luminous: batch functional idempotency test fails since message is now on stderr

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test.yml
@@ -46,7 +46,7 @@
         msg: "lvm batch failed idempotency check"
       when:
          - batch_cmd.rc != 0
-         - "'strategy changed' not in batch_cmd.stdout"
+         - "'strategy changed' not in batch_cmd.stderr"
 
     - name: run batch --report to see if devices get filtered
       command: "ceph-volume --cluster {{ cluster }} lvm batch --report --format=json --{{ osd_objectstore|default('bluestore') }} {{ '--dmcrypt' if dmcrypt|default(false) else '' }} {{ devices | join(' ') }}"
@@ -59,5 +59,5 @@
       fail:
         msg: "lvm batch --report failed idempotency check"
       when:
-         - batch_cmd.rc != 0
-         - "'strategy changed' not in batch_cmd.stdout"
+         - report_cmd.rc != 0
+         - "'strategy changed' not in report_cmd.stderr"


### PR DESCRIPTION
https://tracker.ceph.com/issues/41373