### PR TITLE
mgr/ansible: Change default realm and zonegroup

### DIFF
--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -722,9 +722,9 @@ class Module(MgrModule, orchestrator.Orchestrator):
             spec.rgw_frontend_port = spec.rgw_frontend_port \
                 if spec.rgw_frontend_port is not None else 8080
 
-            spec.rgw_zonegroup = spec.rgw_zonegroup if spec.rgw_zonegroup is not None else "Main"
+            spec.rgw_zonegroup = spec.rgw_zonegroup if spec.rgw_zonegroup is not None else "default"
             spec.rgw_zone_user = spec.rgw_zone_user if spec.rgw_zone_user is not None else "zone.user"
-            spec.rgw_realm = spec.rgw_realm if spec.rgw_realm is not None else "RGW_Realm"
+            spec.rgw_realm = spec.rgw_realm if spec.rgw_realm is not None else "default"
 
             spec.system_access_key = spec.system_access_key \
                 if spec.system_access_key is not None else spec.genkey(20)


### PR DESCRIPTION
By default, the default realm and zonegrup is called default.

I'd prefer to omit any default values in the orchestrators, but having default values that match the orchestrator defaults is preferable, still.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
