### PR TITLE
[DNM] common/condition_variable_debug: Fix logic in asserts

### DIFF
--- a/src/common/condition_variable_debug.cc
+++ b/src/common/condition_variable_debug.cc
@@ -20,8 +20,8 @@ condition_variable_debug::~condition_variable_debug()
 void condition_variable_debug::wait(std::unique_lock<mutex_debug>& lock)
 {
   // make sure this cond is used with one mutex only
-  ceph_assert(waiter_mutex == nullptr ||
-         waiter_mutex == lock.mutex());
+  ceph_assert(waiter_mutex != nullptr);
+  ceph_assert(waiter_mutex == lock.mutex());
   waiter_mutex = lock.mutex();
   ceph_assert(waiter_mutex->is_locked());
   waiter_mutex->_pre_unlock();
@@ -35,8 +35,8 @@ void condition_variable_debug::wait(std::unique_lock<mutex_debug>& lock)
 void condition_variable_debug::notify_one()
 {
   // make sure signaler is holding the waiter's lock.
-  ceph_assert(waiter_mutex == nullptr ||
-         waiter_mutex->is_locked());
+  ceph_assert(waiter_mutex != nullptr);
+  ceph_assert(waiter_mutex->is_locked());
   if (int r = pthread_cond_signal(&cond); r != 0) {
     throw std::system_error(r, std::generic_category());
   }
@@ -45,8 +45,8 @@ void condition_variable_debug::notify_one()
 void condition_variable_debug::notify_all(bool sloppy)
 {
   // make sure signaler is holding the waiter's lock.
-  ceph_assert(waiter_mutex == NULL ||
-         waiter_mutex->is_locked());
+  ceph_assert(waiter_mutex != nullptr);
+  ceph_assert(waiter_mutex->is_locked());
   if (int r = pthread_cond_broadcast(&cond); r != 0 && !sloppy) {
     throw std::system_error(r, std::generic_category());
   }
@@ -56,8 +56,8 @@ std::cv_status condition_variable_debug::_wait_until(mutex_debug* mutex,
                                                      timespec* ts)
 {
   // make sure this cond is used with one mutex only
-  ceph_assert(waiter_mutex == nullptr ||
-         waiter_mutex == mutex);
+  ceph_assert(waiter_mutex != nullptr);
+  ceph_assert(waiter_mutex == mutex);
   waiter_mutex = mutex;
   ceph_assert(waiter_mutex->is_locked());
 


### PR DESCRIPTION
Inital tests in functions look like:
ceph_assert(waiter_mutex == nullptr ||
	waiter_mutex == mutex);

But this does not assert if `waiter_mutex == nullptr`.
Which it should.

So replace this with the correct logic in 2 asserts,
so it is clear which part of the test failed.

Found this, because on FreeBSD I ran in to waiter_mutex being NULL.
But from the assert info it was not clear.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>