### PR TITLE
rgw: sanitize HTTP_X_AUTH_TOKEN http header element

### DIFF
--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -186,9 +186,14 @@ class DefaultStrategy : public rgw::auth::Strategy,
 
   /* The method implements TokenExtractor for X-Auth-Token present in req_state. */
   std::string get_token(const req_state* const s) const override {
-    /* Returning a reference here would end in GCC complaining about a reference
-     * to temporary. */
-    return s->info.env->get("HTTP_X_AUTH_TOKEN", "");
+    string auth_token = s->info.env->get("HTTP_X_AUTH_TOKEN", "");
+    auth_token.erase(
+      std::remove_if(
+        std::begin(auth_token),
+        std::end(auth_token),
+        [](char c) {return c == '\x0d' || c == '\x0a';}),
+      std::end(auth_token));
+    return auth_token;
   }
 
   aplptr_t create_apl_remote(CephContext* const cct,


### PR DESCRIPTION
to remove trailing `<CR>` and `<LF>` characters
which cause swift requests to fail authentication

Fixes: https://tracker.ceph.com/issues/41376

Signed-off-by: Mark Kogan <mkogan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
