### PR TITLE
mgr/dashboard: CephFS tab component

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cephfs.py
+++ b/qa/tasks/mgr/dashboard/test_cephfs.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import six
+
 from .helper import DashboardTestCase
 
 
@@ -8,6 +10,10 @@ class CephfsTest(DashboardTestCase):
     CEPHFS = True
 
     AUTH_ROLES = ['cephfs-manager']
+
+    def assertToHave(self, data, key):
+        self.assertIn(key, data)
+        self.assertIsNotNone(data[key])
 
     @DashboardTestCase.RunAs('test', 'test', ['block-manager'])
     def test_access_permissions(self):
@@ -17,6 +23,8 @@ class CephfsTest(DashboardTestCase):
         self._get("/api/cephfs/{}".format(fs_id))
         self.assertStatus(403)
         self._get("/api/cephfs/{}/mds_counters".format(fs_id))
+        self.assertStatus(403)
+        self._get("/ui-api/cephfs/{}/tabs".format(fs_id))
         self.assertStatus(403)
 
     def test_cephfs_clients(self):
@@ -37,12 +45,9 @@ class CephfsTest(DashboardTestCase):
         data = self._get("/api/cephfs/{}/".format(fs_id))
         self.assertStatus(200)
 
-        self.assertIn('cephfs', data)
-        self.assertIn('standbys', data)
-        self.assertIn('versions', data)
-        self.assertIsNotNone(data['cephfs'])
-        self.assertIsNotNone(data['standbys'])
-        self.assertIsNotNone(data['versions'])
+        self.assertToHave(data, 'cephfs')
+        self.assertToHave(data, 'standbys')
+        self.assertToHave(data, 'versions')
 
     def test_cephfs_mds_counters(self):
         fs_id = self.fs.get_namespace_id()
@@ -64,10 +69,48 @@ class CephfsTest(DashboardTestCase):
     def test_cephfs_list(self):
         data = self._get("/api/cephfs/")
         self.assertStatus(200)
-        self.assertIsInstance(data, list)
 
+        self.assertIsInstance(data, list)
         cephfs = data[0]
-        self.assertIn('id', cephfs)
-        self.assertIn('mdsmap', cephfs)
-        self.assertIsNotNone(cephfs['id'])
-        self.assertIsNotNone(cephfs['mdsmap'])
+        self.assertToHave(cephfs, 'id')
+        self.assertToHave(cephfs, 'mdsmap')
+
+    def test_cephfs_tabs(self):
+        fs_id = self.fs.get_namespace_id()
+        data = self._get("/ui-api/cephfs/{}/tabs".format(fs_id))
+        self.assertStatus(200)
+        self.assertIsInstance(data, dict)
+
+        # Pools
+        pools = data['pools']
+        self.assertIsInstance(pools, list)
+        self.assertGreater(len(pools), 0)
+        for pool in pools:
+            self.assertEqual(pool['size'], pool['used'] + pool['avail'])
+
+        # Ranks
+        self.assertToHave(data, 'ranks')
+        self.assertIsInstance(data['ranks'], list)
+
+        # Name
+        self.assertToHave(data, 'name')
+        self.assertIsInstance(data['name'], six.string_types)
+
+        # Standbys
+        self.assertToHave(data, 'standbys')
+        self.assertIsInstance(data['standbys'], six.string_types)
+
+        # MDS counters
+        counters = data['mds_counters']
+        self.assertIsInstance(counters, dict)
+        self.assertGreater(len(counters.keys()), 0)
+        for k, v in counters.items():
+            self.assertEqual(v['name'], k)
+
+        # Clients
+        self.assertToHave(data, 'clients')
+        clients = data['clients']
+        self.assertToHave(clients, 'data')
+        self.assertIsInstance(clients['data'], list)
+        self.assertToHave(clients, 'status')
+        self.assertIsInstance(clients['status'], int)

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -121,6 +121,12 @@ class CephFS(RESTController):
 
         return names
 
+    def _append_mds_metadata(self, mds_versions, metadata_key):
+        metadata = mgr.get_metadata('mds', metadata_key)
+        if metadata is None:
+            return
+        mds_versions[metadata.get('ceph_version', 'unknown')].append(metadata_key)
+
     # pylint: disable=too-many-statements,too-many-branches
     def fs_status(self, fs_id):
         mds_versions = defaultdict(list)
@@ -175,9 +181,7 @@ class CephFS(RESTController):
                 else:
                     activity = 0.0
 
-                metadata = mgr.get_metadata('mds', info['name'])
-                mds_versions[metadata.get('ceph_version', 'unknown')].append(
-                    info['name'])
+                self._append_mds_metadata(mds_versions, info['name'])
                 rank_table.append(
                     {
                         "rank": rank,
@@ -244,10 +248,7 @@ class CephFS(RESTController):
 
         standby_table = []
         for standby in fsmap['standbys']:
-            metadata = mgr.get_metadata('mds', standby['name'])
-            mds_versions[metadata.get('ceph_version', 'unknown')].append(
-                standby['name'])
-
+            self._append_mds_metadata(mds_versions, standby['name'])
             standby_table.append({
                 'name': standby['name']
             })
@@ -324,7 +325,7 @@ class CephFSClients(object):
 
 @UiApiController('/cephfs', Scope.CEPHFS)
 class CephFsUi(CephFS):
-    RESOURCE_ID='fs_id'
+    RESOURCE_ID = 'fs_id'
 
     @RESTController.Resource('GET')
     def tabs(self, fs_id):
@@ -348,5 +349,3 @@ class CephFsUi(CephFS):
         data['clients'] = self._clients(fs_id)
 
         return data
-
-

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import cherrypy
 
-from . import ApiController, RESTController
+from . import ApiController, RESTController, UiApiController
 from .. import mgr
 from ..exceptions import DashboardException
 from ..security import Scope
@@ -28,7 +28,6 @@ class CephFS(RESTController):
 
     def get(self, fs_id):
         fs_id = self.fs_id_to_int(fs_id)
-
         return self.fs_status(fs_id)
 
     @RESTController.Resource('GET')
@@ -45,30 +44,31 @@ class CephFS(RESTController):
         return self._evict(fs_id, client_id)
 
     @RESTController.Resource('GET')
-    def mds_counters(self, fs_id):
+    def mds_counters(self, fs_id, counters=None):
+        fs_id = self.fs_id_to_int(fs_id)
+        return self._mds_counters(fs_id, counters)
+
+    def _mds_counters(self, fs_id, counters=None):
         """
         Result format: map of daemon name to map of counter to list of datapoints
         rtype: dict[str, dict[str, list]]
         """
 
-        # Opinionated list of interesting performance counters for the GUI --
-        # if you need something else just add it.  See how simple life is
-        # when you don't have to write general purpose APIs?
-        counters = [
-            "mds_server.handle_client_request",
-            "mds_log.ev",
-            "mds_cache.num_strays",
-            "mds.exported",
-            "mds.exported_inodes",
-            "mds.imported",
-            "mds.imported_inodes",
-            "mds.inodes",
-            "mds.caps",
-            "mds.subtrees",
-            "mds_mem.ino"
-        ]
-
-        fs_id = self.fs_id_to_int(fs_id)
+        if counters is None:
+            # Opinionated list of interesting performance counters for the GUI
+            counters = [
+                "mds_server.handle_client_request",
+                "mds_log.ev",
+                "mds_cache.num_strays",
+                "mds.exported",
+                "mds.exported_inodes",
+                "mds.imported",
+                "mds.imported_inodes",
+                "mds.inodes",
+                "mds.caps",
+                "mds.subtrees",
+                "mds_mem.ino"
+            ]
 
         result = {}
         mds_names = self._get_mds_names(fs_id)
@@ -320,3 +320,33 @@ class CephFSClients(object):
     @ViewCache()
     def get(self):
         return CephService.send_command('mds', 'session ls', srv_spec='{0}:0'.format(self.fscid))
+
+
+@UiApiController('/cephfs', Scope.CEPHFS)
+class CephFsUi(CephFS):
+    RESOURCE_ID='fs_id'
+
+    @RESTController.Resource('GET')
+    def tabs(self, fs_id):
+        data = {}
+        fs_id = self.fs_id_to_int(fs_id)
+
+        # Needed for detail tab
+        fs_status = self.fs_status(fs_id)
+        for pool in fs_status['cephfs']['pools']:
+            pool['size'] = pool['used'] + pool['avail']
+        data['pools'] = fs_status['cephfs']['pools']
+        data['ranks'] = fs_status['cephfs']['ranks']
+        data['name'] = fs_status['cephfs']['name']
+        data['standbys'] = ', '.join([x['name'] for x in fs_status['standbys']])
+        counters = self._mds_counters(fs_id)
+        for k, v in counters.items():
+            v['name'] = k
+        data['mds_counters'] = counters
+
+        # Needed for client tab
+        data['clients'] = self._clients(fs_id)
+
+        return data
+
+

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.html
@@ -1,8 +1,7 @@
-<cd-view-cache [status]="viewCacheStatus"></cd-view-cache>
+<cd-view-cache [status]="clients.status"></cd-view-cache>
 
 <cd-table [data]="clients.data"
-          [columns]="clients.columns"
-          (fetchData)="refresh($event)"
+          [columns]="columns"
           selectionType="single"
           (updateSelection)="updateSelection($event)">
   <cd-table-actions class="table-actions"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.spec.ts
@@ -1,16 +1,15 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 import { ToastrModule } from 'ngx-toastr';
+
 import {
   configureTestBed,
   i18nProviders,
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
 import { TableActionsComponent } from '../../../shared/datatable/table-actions/table-actions.component';
+import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
 import { SharedModule } from '../../../shared/shared.module';
 import { CephfsClientsComponent } from './cephfs-clients.component';
 
@@ -19,13 +18,7 @@ describe('CephfsClientsComponent', () => {
   let fixture: ComponentFixture<CephfsClientsComponent>;
 
   configureTestBed({
-    imports: [
-      RouterTestingModule,
-      ToastrModule.forRoot(),
-      BsDropdownModule.forRoot(),
-      SharedModule,
-      HttpClientTestingModule
-    ],
+    imports: [ToastrModule.forRoot(), SharedModule, HttpClientTestingModule],
     declarations: [CephfsClientsComponent],
     providers: i18nProviders
   });
@@ -33,6 +26,10 @@ describe('CephfsClientsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CephfsClientsComponent);
     component = fixture.componentInstance;
+    component.clients = {
+      status: ViewCacheStatus.ValueOk,
+      data: [{}, {}, {}, {}]
+    };
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.ts
@@ -1,8 +1,8 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
-
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
+
 import { CephfsService } from '../../../shared/api/cephfs.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
 import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
@@ -10,7 +10,7 @@ import { Icons } from '../../../shared/enum/icons.enum';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
 import { CdTableAction } from '../../../shared/models/cd-table-action';
-import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
+import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permission } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
@@ -25,11 +25,21 @@ export class CephfsClientsComponent implements OnInit {
   @Input()
   id: number;
 
+  @Input()
+  clients: {
+    data: any[];
+    status: ViewCacheStatus;
+  };
+
+  @Output()
+  triggerApiUpdate = new EventEmitter();
+
+  columns: CdTableColumn[];
+
   permission: Permission;
   tableActions: CdTableAction[];
   modalRef: BsModalRef;
-  clients: any;
-  viewCacheStatus: ViewCacheStatus;
+
   selection = new CdTableSelection();
 
   constructor(
@@ -51,35 +61,14 @@ export class CephfsClientsComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.clients = {
-      columns: [
-        { prop: 'id', name: this.i18n('id') },
-        { prop: 'type', name: this.i18n('type') },
-        { prop: 'state', name: this.i18n('state') },
-        { prop: 'version', name: this.i18n('version') },
-        { prop: 'hostname', name: this.i18n('Host') },
-        { prop: 'root', name: this.i18n('root') }
-      ],
-      data: []
-    };
-
-    this.clients.data = [];
-    this.viewCacheStatus = ViewCacheStatus.ValueNone;
-  }
-
-  refresh(context?: CdTableFetchDataContext) {
-    this.cephfsService.getClients(this.id).subscribe(
-      (data: any) => {
-        this.viewCacheStatus = data.status;
-        this.clients.data = data.data;
-      },
-      () => {
-        this.viewCacheStatus = ViewCacheStatus.ValueException;
-        if (context) {
-          context.error();
-        }
-      }
-    );
+    this.columns = [
+      { prop: 'id', name: this.i18n('id') },
+      { prop: 'type', name: this.i18n('type') },
+      { prop: 'state', name: this.i18n('state') },
+      { prop: 'version', name: this.i18n('version') },
+      { prop: 'hostname', name: this.i18n('Host') },
+      { prop: 'root', name: this.i18n('root') }
+    ];
   }
 
   updateSelection(selection: CdTableSelection) {
@@ -89,7 +78,7 @@ export class CephfsClientsComponent implements OnInit {
   evictClient(clientId: number) {
     this.cephfsService.evictClient(this.id, clientId).subscribe(
       () => {
-        this.refresh();
+        this.triggerApiUpdate.emit();
         this.modalRef.hide();
         this.notificationService.show(
           NotificationType.success,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
@@ -1,51 +1,32 @@
-<tabset *ngIf="selectedItem">
-  <tab i18n-heading
-       heading="Details">
-    <div class="row">
-      <div class="col-sm-6">
-        <legend i18n>Ranks</legend>
-        <cd-table [data]="ranks.data"
-                  [columns]="ranks.columns"
-                  (fetchData)="refresh()"
-                  [toolHeader]="false">
-        </cd-table>
+<div class="row">
+  <div class="col-sm-6">
+    <legend i18n>Ranks</legend>
+    <cd-table [data]="data.ranks"
+              [columns]="columns.ranks"
+              [toolHeader]="false">
+    </cd-table>
 
-        <legend i18n>Standbys</legend>
-        <cd-table-key-value [data]="standbys">
-        </cd-table-key-value>
-      </div>
+    <legend i18n>Standbys</legend>
+    <cd-table-key-value [data]="standbys">
+    </cd-table-key-value>
+  </div>
 
-      <div class="col-sm-6">
-        <legend i18n>Pools</legend>
-        <cd-table [data]="pools.data"
-                  [columns]="pools.columns"
-                  [toolHeader]="false">
-        </cd-table>
-      </div>
-    </div>
+  <div class="col-sm-6">
+    <legend i18n>Pools</legend>
+    <cd-table [data]="data.pools"
+              [columns]="columns.pools"
+              [toolHeader]="false">
+    </cd-table>
+  </div>
+</div>
 
-    <legend i18n>MDS performance counters</legend>
-    <div class="row"
-         *ngFor="let mdsCounter of objectValues(mdsCounters); trackBy: trackByFn">
-      <div class="col-md-12">
-        <cd-cephfs-chart [mdsCounter]="mdsCounter"></cd-cephfs-chart>
-      </div>
-    </div>
-  </tab>
-  <tab i18n-heading
-       heading="Clients: {{ clientCount }}">
-    <cd-cephfs-clients [id]="id">
-    </cd-cephfs-clients>
-  </tab>
-  <tab i18n-heading
-       *ngIf="grafanaPermission.read"
-       heading="Performance Details">
-    <cd-grafana [grafanaPath]="'mds-performance?var-mds_servers=mds.' + grafanaId"
-                uid="tbO9LAiZz"
-                grafanaStyle="one">
-    </cd-grafana>
-  </tab>
-</tabset>
+<legend i18n>MDS performance counters</legend>
+<div class="row"
+     *ngFor="let mdsCounter of objectValues(data.mdsCounters); trackBy: trackByFn">
+  <div class="col-md-12">
+    <cd-cephfs-chart [mdsCounter]="mdsCounter"></cd-cephfs-chart>
+  </div>
+</div>
 
 <!-- templates -->
 <ng-template #poolUsageTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.spec.ts
@@ -1,15 +1,7 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-
-import * as _ from 'lodash';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
-import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
 import { CephfsDetailComponent } from './cephfs-detail.component';
 
@@ -19,50 +11,40 @@ class CephfsChartStubComponent {
   mdsCounter: any;
 }
 
-@Component({ selector: 'cd-cephfs-clients', template: '' })
-class CephfsClientsStubComponent {
-  @Input()
-  mdsCounter: any;
-}
-
 describe('CephfsDetailComponent', () => {
   let component: CephfsDetailComponent;
   let fixture: ComponentFixture<CephfsDetailComponent>;
 
+  const updateDetails = (standbys, pools, ranks, mdsCounters, name) => {
+    component.data = {
+      standbys,
+      pools,
+      ranks,
+      mdsCounters,
+      name
+    };
+    fixture.detectChanges();
+  };
+
   configureTestBed({
-    imports: [
-      SharedModule,
-      RouterTestingModule,
-      BsDropdownModule.forRoot(),
-      ProgressbarModule.forRoot(),
-      TabsModule.forRoot(),
-      HttpClientTestingModule
-    ],
-    declarations: [CephfsDetailComponent, CephfsChartStubComponent, CephfsClientsStubComponent],
+    imports: [SharedModule],
+    declarations: [CephfsDetailComponent, CephfsChartStubComponent],
     providers: i18nProviders
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CephfsDetailComponent);
     component = fixture.componentInstance;
+    updateDetails('b', [], [], { a: { name: 'a', x: [0], y: [0, 1] } }, 'someFs');
     fixture.detectChanges();
+    component.ngOnChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should resist invalid mds info', () => {
-    component.selection = new CdTableSelection();
-    component.selection.selected = [
-      {
-        mdsmap: {
-          info: {}
-        }
-      }
-    ];
-    component.selection.update();
-    component.ngOnChanges();
-    expect(_.isUndefined(component.grafanaId)).toBeTruthy();
+  it('prepares standby on change', () => {
+    expect(component.standbys).toEqual([{ key: 'Standby daemons', value: 'b' }]);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
@@ -3,12 +3,9 @@ import { Component, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@an
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import * as _ from 'lodash';
 
-import { CephfsService } from '../../../shared/api/cephfs.service';
-import { CdTableSelection } from '../../../shared/models/cd-table-selection';
-import { Permission } from '../../../shared/models/permissions';
+import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
 import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
-import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 
 @Component({
   selector: 'cd-cephfs-detail',
@@ -22,57 +19,44 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
   activityTmpl: TemplateRef<any>;
 
   @Input()
-  selection: CdTableSelection;
+  data: {
+    standbys: string;
+    pools: any[];
+    ranks: any[];
+    mdsCounters: object;
+    name: string;
+  };
 
-  selectedItem: any;
-
-  id: number;
-  name: string;
-  ranks: any;
-  pools: any;
+  columns: {
+    ranks: CdTableColumn[];
+    pools: CdTableColumn[];
+  };
   standbys = [];
-  clientCount: number;
-  mdsCounters = {};
-  grafanaId: any;
-  grafanaPermission: Permission;
 
   objectValues = Object.values;
 
   constructor(
-    private authStorageService: AuthStorageService,
-    private cephfsService: CephfsService,
     private dimlessBinary: DimlessBinaryPipe,
     private dimless: DimlessPipe,
     private i18n: I18n
-  ) {
-    this.grafanaPermission = this.authStorageService.getPermissions().grafana;
-  }
+  ) {}
 
   ngOnChanges() {
-    if (this.selection.hasSelection) {
-      this.selectedItem = this.selection.first();
-      const mdsInfo: any[] = this.selectedItem.mdsmap.info;
-      const values = Object.values(mdsInfo);
-      this.grafanaId = values.length ? _.first(values).name : undefined;
+    this.setStandbys();
+  }
 
-      if (this.id !== this.selectedItem.id) {
-        this.id = this.selectedItem.id;
-        this.ranks.data = [];
-        this.pools.data = [];
-        this.standbys = [];
-        this.mdsCounters = {};
-        this.clientCount = 0;
+  private setStandbys() {
+    this.standbys = [
+      {
+        key: this.i18n('Standby daemons'),
+        value: this.data.standbys
       }
-
-      // Immediately refresh the displayed data, don't wait until the
-      // table refreshes the data itself.
-      this.refresh();
-    }
+    ];
   }
 
   ngOnInit() {
-    this.ranks = {
-      columns: [
+    this.columns = {
+      ranks: [
         { prop: 'rank', name: this.i18n('Rank') },
         { prop: 'state', name: this.i18n('State') },
         { prop: 'mds', name: this.i18n('Daemon') },
@@ -80,11 +64,7 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
         { prop: 'dns', name: this.i18n('Dentries'), pipe: this.dimless },
         { prop: 'inos', name: this.i18n('Inodes'), pipe: this.dimless }
       ],
-      data: []
-    };
-
-    this.pools = {
-      columns: [
+      pools: [
         { prop: 'pool', name: this.i18n('Pool') },
         { prop: 'type', name: this.i18n('Type') },
         { prop: 'size', name: this.i18n('Size'), pipe: this.dimlessBinary },
@@ -105,41 +85,9 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
               return -1;
             }
           }
-        }
-      ],
-      data: []
+        } as CdTableColumn
+      ]
     };
-  }
-
-  refresh() {
-    this.cephfsService.getCephfs(this.id).subscribe((data: any) => {
-      this.ranks.data = data.cephfs.ranks;
-      this.pools.data = data.cephfs.pools;
-      this.pools.data.forEach((pool) => {
-        pool.size = pool.used + pool.avail;
-      });
-      this.standbys = [
-        {
-          key: this.i18n('Standby daemons'),
-          value: data.standbys.map((value) => value.name).join(', ')
-        }
-      ];
-      this.name = data.cephfs.name;
-      this.clientCount = data.cephfs.client_count;
-    });
-
-    this.cephfsService.getMdsCounters(this.id).subscribe((data) => {
-      _.each(this.mdsCounters, (_value, key) => {
-        if (data[key] === undefined) {
-          delete this.mdsCounters[key];
-        }
-      });
-
-      _.each(data, (mdsData: any, mdsName) => {
-        mdsData.name = mdsName;
-        this.mdsCounters[mdsName] = mdsData;
-      });
-    });
   }
 
   trackByFn(_index, item) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
@@ -6,7 +6,7 @@
           forceIdentifier="true"
           selectionType="single"
           (updateSelection)="updateSelection($event)">
-  <cd-cephfs-detail cdTableDetail
-                    [selection]="selection">
-  </cd-cephfs-detail>
+  <cd-cephfs-tabs cdTableDetail
+                  [selection]="selection">
+  </cd-cephfs-tabs>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.spec.ts
@@ -7,8 +7,8 @@ import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
 import { CephfsListComponent } from './cephfs-list.component';
 
-@Component({ selector: 'cd-cephfs-detail', template: '' })
-class CephfsDetailStubComponent {
+@Component({ selector: 'cd-cephfs-tabs', template: '' })
+class CephfsTabsStubComponent {
   @Input()
   selection: CdTableSelection;
 }
@@ -19,7 +19,7 @@ describe('CephfsListComponent', () => {
 
   configureTestBed({
     imports: [SharedModule, HttpClientTestingModule],
-    declarations: [CephfsListComponent, CephfsDetailStubComponent],
+    declarations: [CephfsListComponent, CephfsTabsStubComponent],
     providers: i18nProviders
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
@@ -1,0 +1,25 @@
+<tabset *ngIf="selectedItem">
+  <tab i18n-heading
+       (selectTab)="softRefresh()"
+       heading="Details">
+    <cd-cephfs-detail [data]="details">
+    </cd-cephfs-detail>
+  </tab>
+  <tab i18n-heading
+       (selectTab)="softRefresh()"
+       heading="Clients: {{ clients.data.length }}">
+    <cd-cephfs-clients [id]="id"
+                       [clients]="clients"
+                       (triggerApiUpdate)="refresh()">
+    </cd-cephfs-clients>
+  </tab>
+  <tab i18n-heading
+       *ngIf="grafanaPermission.read && grafanaId"
+       heading="Performance Details">
+    <cd-grafana [grafanaPath]="'mds-performance?var-mds_servers=mds.' + grafanaId"
+                uid="tbO9LAiZz"
+                grafanaStyle="one">
+    </cd-grafana>
+  </tab>
+</tabset>
+

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.spec.ts
@@ -1,0 +1,203 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Component, Input, NgZone } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import * as _ from 'lodash';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+import { ToastrModule } from 'ngx-toastr';
+import { of } from 'rxjs';
+
+import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { CephfsService } from '../../../shared/api/cephfs.service';
+import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
+import { CdTableSelection } from '../../../shared/models/cd-table-selection';
+import { SharedModule } from '../../../shared/shared.module';
+import { CephfsClientsComponent } from '../cephfs-clients/cephfs-clients.component';
+import { CephfsDetailComponent } from '../cephfs-detail/cephfs-detail.component';
+import { CephfsTabsComponent } from './cephfs-tabs.component';
+
+describe('CephfsTabsComponent', () => {
+  let component: CephfsTabsComponent;
+  let fixture: ComponentFixture<CephfsTabsComponent>;
+  let service: CephfsService;
+  let data: {
+    standbys: string;
+    pools: any[];
+    ranks: any[];
+    mdsCounters: object;
+    name: string;
+    clients: { status: ViewCacheStatus; data: any[] };
+  };
+
+  const setSelection = (selection: object[]) => {
+    component.selection.selected = selection;
+    component.selection.update();
+    component.ngOnChanges();
+  };
+
+  const selectFs = (id: number, name: string) => {
+    setSelection([
+      {
+        id,
+        mdsmap: {
+          info: {
+            something: {
+              name
+            }
+          }
+        }
+      }
+    ]);
+  };
+
+  const updateData = () => {
+    component['data'] = _.cloneDeep(data);
+    component.softRefresh();
+  };
+
+  @Component({ selector: 'cd-cephfs-chart', template: '' })
+  class CephfsChartStubComponent {
+    @Input()
+    mdsCounter: any;
+  }
+
+  configureTestBed({
+    imports: [SharedModule, TabsModule.forRoot(), HttpClientTestingModule, ToastrModule.forRoot()],
+    declarations: [
+      CephfsTabsComponent,
+      CephfsChartStubComponent,
+      CephfsDetailComponent,
+      CephfsClientsComponent
+    ],
+    providers: [i18nProviders]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CephfsTabsComponent);
+    component = fixture.componentInstance;
+    component.selection = new CdTableSelection();
+    data = {
+      standbys: 'b',
+      pools: [{}, {}],
+      ranks: [{}, {}, {}],
+      mdsCounters: { a: { name: 'a', x: [], y: [] } },
+      name: 'someFs',
+      clients: {
+        status: ViewCacheStatus.ValueOk,
+        data: [{}, {}, {}, {}]
+      }
+    };
+    service = TestBed.get(CephfsService);
+    spyOn(service, 'getTabs').and.callFake(() => of(data));
+    selectFs(1, 'firstMds');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should resist invalid mds info', () => {
+    setSelection([
+      {
+        id: 3,
+        mdsmap: {
+          info: {}
+        }
+      }
+    ]);
+    expect(component.grafanaId).toBe(undefined);
+  });
+
+  it('should find out the grafana id', () => {
+    selectFs(2, 'otherMds');
+    expect(component.grafanaId).toBe('otherMds');
+  });
+
+  it('should set default values on id change before api request', () => {
+    const defaultDetails = {
+      standbys: '',
+      pools: [],
+      ranks: [],
+      mdsCounters: {},
+      name: ''
+    };
+    const defaultClients = {
+      data: [],
+      status: ViewCacheStatus.ValueNone
+    };
+    updateData();
+    expect(component.clients).not.toEqual(defaultClients);
+    expect(component.details).not.toEqual(defaultDetails);
+    selectFs(2, 'otherMds');
+    expect(component.clients).toEqual(defaultClients);
+    expect(component.details).toEqual(defaultDetails);
+  });
+
+  it('should force data updates on tab change without api requests', () => {
+    const oldClients = component.clients;
+    const oldDetails = component.details;
+    updateData();
+    expect(service.getTabs).toHaveBeenCalledTimes(0);
+    expect(component.details).not.toBe(oldDetails);
+    expect(component.clients).not.toBe(oldClients);
+  });
+
+  describe('handling of id change', () => {
+    let old: any;
+    const getReload = () => component['reloadSubscriber'];
+    const setReload = (sth?) => (component['reloadSubscriber'] = sth);
+
+    beforeEach(() => {
+      spyOn(TestBed.get(NgZone), 'runOutsideAngular').and.callFake(() => {
+        // It's mocked because the rxjs timer subscription ins't called through the use of 'tick'.
+        setReload({
+          unsubscribed: false,
+          unsubscribe: () => {
+            old = getReload();
+            getReload().unsubscribed = true;
+            setReload();
+          }
+        });
+        component.refresh();
+      });
+      setReload(); // Clears rxjs timer subscription
+      selectFs(2, 'otherMds');
+      old = getReload(); // Gets current subscription
+    });
+
+    it('should have called getDetails once', () => {
+      expect(component.details.pools.length).toBe(2);
+      expect(service.getTabs).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not subscribe to an new interval for the same selection', () => {
+      selectFs(2, 'otherMds');
+      expect(getReload()).toBe(old);
+    });
+
+    it('should subscribe to an new interval', () => {
+      selectFs(3, 'anotherMds');
+      expect(getReload()).not.toBe(old); // Holds an new object
+    });
+
+    it('should unsubscribe the old interval if it exists', () => {
+      selectFs(3, 'anotherMds');
+      expect(old.unsubscribed).toBe(true);
+    });
+
+    it('should not unsubscribe if no interval exists', () => {
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
+
+    it('should request the details of the new id', () => {
+      expect(service.getTabs).toHaveBeenCalledWith(2);
+    });
+
+    it('should should unsubscribe on deselect', () => {
+      setSelection([]);
+      expect(old.unsubscribed).toBe(true);
+      expect(getReload()).toBe(undefined); // Cleared timer subscription
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.ts
@@ -1,0 +1,131 @@
+import { Component, Input, NgZone, OnChanges, OnDestroy } from '@angular/core';
+
+import * as _ from 'lodash';
+import { timer } from 'rxjs';
+
+import { CephfsService } from '../../../shared/api/cephfs.service';
+import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
+import { CdTableSelection } from '../../../shared/models/cd-table-selection';
+import { Permission } from '../../../shared/models/permissions';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
+
+@Component({
+  selector: 'cd-cephfs-tabs',
+  templateUrl: './cephfs-tabs.component.html',
+  styleUrls: ['./cephfs-tabs.component.scss']
+})
+export class CephfsTabsComponent implements OnChanges, OnDestroy {
+  @Input()
+  selection: CdTableSelection;
+  selectedItem: any;
+
+  // Grafana tab
+  grafanaId: any;
+  grafanaPermission: Permission;
+
+  // Client tab
+  id: number;
+  clients = {
+    data: [],
+    status: ViewCacheStatus.ValueNone
+  };
+
+  // Details tab
+  details = {
+    standbys: '',
+    pools: [],
+    ranks: [],
+    mdsCounters: {},
+    name: ''
+  };
+
+  private data: any;
+  private reloadSubscriber;
+
+  constructor(
+    private ngZone: NgZone,
+    private authStorageService: AuthStorageService,
+    private cephfsService: CephfsService
+  ) {
+    this.grafanaPermission = this.authStorageService.getPermissions().grafana;
+  }
+
+  ngOnChanges() {
+    this.selectedItem = this.selection.first();
+    if (!this.selectedItem) {
+      this.unsubscribeInterval();
+      return;
+    }
+    if (this.selectedItem.id !== this.id) {
+      this.setupSelected(this.selectedItem.id, this.selectedItem.mdsmap.info);
+    }
+  }
+
+  private setupSelected(id, mdsInfo) {
+    this.id = id;
+    const firstMds = _.first(Object.values(mdsInfo));
+    this.grafanaId = firstMds && firstMds['name'];
+    this.details = {
+      standbys: '',
+      pools: [],
+      ranks: [],
+      mdsCounters: {},
+      name: ''
+    };
+    this.clients = {
+      data: [],
+      status: ViewCacheStatus.ValueNone
+    };
+    this.updateInterval();
+  }
+
+  private updateInterval() {
+    this.unsubscribeInterval();
+    this.subscribeInterval();
+  }
+
+  private unsubscribeInterval() {
+    if (this.reloadSubscriber) {
+      this.reloadSubscriber.unsubscribe();
+    }
+  }
+
+  private subscribeInterval() {
+    this.ngZone.runOutsideAngular(
+      () =>
+        (this.reloadSubscriber = timer(0, 5000).subscribe(() =>
+          this.ngZone.run(() => this.refresh())
+        ))
+    );
+  }
+
+  refresh() {
+    this.cephfsService.getTabs(this.id).subscribe(
+      (data: any) => {
+        this.data = data;
+        this.softRefresh();
+      },
+      () => {
+        this.clients.status = ViewCacheStatus.ValueException;
+      }
+    );
+  }
+
+  softRefresh() {
+    const data = _.cloneDeep(this.data); // Forces update of tab tables on tab switch
+    // Clients tab
+    this.clients = data.clients;
+    // Details tab
+    this.details = {
+      standbys: data.standbys,
+      pools: data.pools,
+      ranks: data.ranks,
+      mdsCounters: data.mds_counters,
+      name: data.name
+    };
+  }
+
+  ngOnDestroy() {
+    this.unsubscribeInterval();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -11,6 +11,7 @@ import { CephfsChartComponent } from './cephfs-chart/cephfs-chart.component';
 import { CephfsClientsComponent } from './cephfs-clients/cephfs-clients.component';
 import { CephfsDetailComponent } from './cephfs-detail/cephfs-detail.component';
 import { CephfsListComponent } from './cephfs-list/cephfs-list.component';
+import { CephfsTabsComponent } from './cephfs-tabs/cephfs-tabs.component';
 
 @NgModule({
   imports: [
@@ -25,7 +26,8 @@ import { CephfsListComponent } from './cephfs-list/cephfs-list.component';
     CephfsDetailComponent,
     CephfsClientsComponent,
     CephfsChartComponent,
-    CephfsListComponent
+    CephfsListComponent,
+    CephfsTabsComponent
   ]
 })
 export class CephfsModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -44,6 +44,12 @@ describe('CephfsService', () => {
     expect(req.request.method).toBe('GET');
   });
 
+  it('should call getTabs', () => {
+    service.getTabs(2).subscribe();
+    const req = httpTesting.expectOne('ui-api/cephfs/2/tabs');
+    expect(req.request.method).toBe('GET');
+  });
+
   it('should call getMdsCounters', () => {
     service.getMdsCounters(1).subscribe();
     const req = httpTesting.expectOne('api/cephfs/1/mds_counters');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -19,6 +19,10 @@ export class CephfsService {
     return this.http.get(`${this.baseURL}/${id}`);
   }
 
+  getTabs(id) {
+    return this.http.get(`ui-api/cephfs/${id}/tabs`);
+  }
+
   getClients(id) {
     return this.http.get(`${this.baseURL}/${id}/clients`);
   }

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from collections import defaultdict
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
+
+from .. import mgr
+from . import ControllerTestCase
+from ..controllers.cephfs import CephFS
+
+
+class MetaDataMock(object):
+    def get(self, _x, _y):
+        return 'bar'
+
+
+def get_metadata_mock(key, meta_key):
+    return {
+        'mds': {
+            None: None,  # Unknown key
+            'foo': MetaDataMock()
+        }[meta_key]
+    }[key]
+
+
+class CephFsTest(ControllerTestCase):
+    cephFs = CephFS()
+
+    @classmethod
+    def setup_server(cls):
+        mgr.get_metadata = Mock(side_effect=get_metadata_mock)
+
+    def tearDown(self):
+        mgr.get_metadata.stop()
+
+    def test_append_of_mds_metadata_if_key_is_not_found(self):
+        mds_versions = defaultdict(list)
+        # pylint: disable=protected-access
+        self.cephFs._append_mds_metadata(mds_versions, None)
+        self.assertEqual(len(mds_versions), 0)
+
+    def test_append_of_mds_metadata_with_existing_metadata(self):
+        mds_versions = defaultdict(list)
+        # pylint: disable=protected-access
+        self.cephFs._append_mds_metadata(mds_versions, 'foo')
+        self.assertEqual(len(mds_versions), 1)
+        self.assertEqual(mds_versions['bar'], ['foo'])

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -52,7 +52,7 @@ class RbdMirroringSummaryControllerTest(ControllerTestCase):
     @classmethod
     def setup_server(cls):
         mgr.list_servers.return_value = mock_list_servers
-        mgr.get_metadata.return_value = mock_get_metadata
+        mgr.get_metadata = mock.Mock(return_value=mock_get_metadata)
         mgr.get_daemon_status.return_value = mock_get_daemon_status
         mgr.get.side_effect = lambda key: {
             'osd_map': mock_osd_map,


### PR DESCRIPTION
The problem was that the CephFS details component was entirely responsible for
managing all other tabs besides it's own. Besides that many API requests
were triggered, which now has been reduced to just one request which is
fired inside the tabs component.

I added an endpoint which contains all adaptations that were done in the
frontend before. This limits the request size and increases the
performance (at least a bit).

Fixes: https://tracker.ceph.com/issues/41372
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
