### PR TITLE
mgr/dashboard: fix tox missing bits and add lint-fixer

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -575,7 +575,7 @@ Alternatively, you can use Python's native package installation method::
   $ pip install tox
   $ pip install coverage
 
-To run the tests, run ``run_tox.sh`` in the dashboard directory (where
+To run the tests, run ``src/script/run_tox.sh`` in the dashboard directory (where
 ``tox.ini`` is located)::
 
   ## Run Python 2+3 tests+lint commands:
@@ -594,6 +594,9 @@ You can also run tox instead of ``run_tox.sh``::
 
   ## Run Python 3 arbitrary command (e.g. 1 single test):
   $ tox -e py3 tests/test_rgw_client.py::RgwClientTest::test_ssl_verify
+
+Python files can be automatically fixed and formatted according to PEP8
+standards by using ``run_tox.sh --tox-env fix`` or ``tox -e fix``.
 
 We also collect coverage information from the backend code when you run tests. You can check the
 coverage information provided by the tox output, or by running the following

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -1,9 +1,10 @@
-pylint
-flake8
-flake8-colors
+pylint==2.3.1; python_version >= '3'
+flake8==3.7.8; python_version >= '3'
+flake8-colors==0.1.6; python_version >= '3'
 #TODO: Fix docstring issues: https://tracker.ceph.com/issues/41224
 #flake8-docstrings
 #flake8-import-order
 #flake8-typing-imports; python_version >= '3'
 #pep8-naming
-rstcheck
+rstcheck==3.3.1; python_version >= '3'
+autopep8; python_version >= '3'

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{27,3},
     lint,
+    fix,
     check,
     run,
 skipsdist = true
@@ -35,7 +36,18 @@ commands = {posargs}
 [flake8]
 max-line-length = 100
 ignore = E123 E126 E226 E402 W503 E741 F812
-exclude = venv, frontend, .*
+exclude =
+    .tox,
+    .git,
+    __pycache__,
+    build,
+    dist,
+    *.egg-info,
+    .cache,
+    *.pyc,
+    .eggs,
+    venv,
+    frontend,
 statistics = True
 #TODO: Uncomment and refactor (https://tracker.ceph.com/issues/41221)
 #max-complexity = 10
@@ -58,13 +70,32 @@ dirs =
     HACKING.rst
 
 [testenv:lint]
-basepython = python3
+basepython=python3
 deps =
     -rrequirements-lint.txt
 commands =
-    rstcheck --report info --debug {posargs:{[rstlint]dirs}}
-    flake8 {posargs}
-    pylint {[pylint]addopts} {posargs:{[pylint]dirs}}
+    lint: flake8 {posargs}
+    lint: pylint {[pylint]addopts} {posargs:{[pylint]dirs}}
+    lint: rstcheck --report info --debug {posargs:{[rstlint]dirs}}
+
+
+[autopep8]
+addopts =
+    --max-line-length {[flake8]max-line-length}
+    --exclude "{[flake8]exclude}"
+    --in-place
+    --recursive
+# TODO: we should progressively increase the level of compliance with PEP8
+#    --aggressive
+#    --aggressive
+
+[testenv:fix]
+basepython=python3
+deps =
+    -rrequirements-lint.txt
+commands =
+    python --version
+    autopep8 {[autopep8]addopts} {posargs:.}
 
 
 [testenv:check]


### PR DESCRIPTION
Fixes missing config settings around tox and flake8. Improves #28696.

Fixes: https://tracker.ceph.com/issues/41379
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
