### PR TITLE
mgr/pg_autoscaler: fix race with pool deletion

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -256,6 +256,9 @@ class PgAutoscaler(MgrModule):
         # iterate over all pools to determine how they should be sized
         for pool_name, p in iteritems(pools):
             pool_id = p['pool']
+            if pool_id not in pool_stats:
+                # race with pool deletion; skip
+                continue
 
             # FIXME: we assume there is only one take per pool, but that
             # may not be true.


### PR DESCRIPTION
The pool_stats map comes from a get('df') that may not include a pool
because it was just deleted.

Fixes: https://tracker.ceph.com/issues/41386
Signed-off-by: Sage Weil <sage@redhat.com>