### PR TITLE
rgw: sanitize the HTTP_* http header elements

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -101,7 +101,13 @@ int RGWCivetWeb::init_env(CephContext *cct)
     }
 
     const boost::string_ref name(header->name);
-    const auto& value = header->value;
+    string value = header->value;
+    value.erase(
+      std::remove_if(
+        std::begin(value),
+        std::end(value),
+        [](char c) {return c == '\x0d' || c == '\x0a';}),
+      std::end(value));
 
     if (boost::algorithm::iequals(name, "content-length")) {
       env.set("CONTENT_LENGTH", value);


### PR DESCRIPTION
to remove trailing `<CR>` and `<LF>` characters
which can cause swift requests to fail authentication
when present in the HTTP_X_AUTH_TOKEN

in addition, will sanitize also the following headers for example:
HTTP_HOST
HTTP_USER_AGENT
HTTP_ACCEPT

Fixes: https://tracker.ceph.com/issues/41376

Signed-off-by: Mark Kogan <mkogan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
