### PR TITLE
rgw: fix missing tenant prefix in bucket name during bucket link

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -653,6 +653,8 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, optional_yield y,
     return -EINVAL;
   }
   rgw_bucket old_bucket = bucket;
+  rgw_user user_id = op_state.get_user_id();
+  bucket.tenant = user_id.tenant;
   if (!op_state.new_bucket_name.empty()) {
     auto pos = op_state.new_bucket_name.find('/');
     if (pos != string::npos) {


### PR DESCRIPTION
Seems like a regression. Tenant prefix was missing in bucket name while linking bucket to a tenanted user. 

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
