### PR TITLE
rgw: Fix documentation for rgw_ldap_secret

### DIFF
--- a/doc/radosgw/ldap-auth.rst
+++ b/doc/radosgw/ldap-auth.rst
@@ -64,7 +64,7 @@ authentication:
   over the wire.
 - ``rgw_ldap_binddn``: The Distinguished Name (DN) of the service account used
   by the Ceph Object Gateway
-- ``rgw_ldap_secret``: The password for the service account
+- ``rgw_ldap_secret``: Path to file containing credentials for ``rgw_ldap_binddn``
 - ``rgw_ldap_searchdn``: Specifies the base in the directory information tree
   for searching users. This might be your users organizational unit or some
   more specific Organizational Unit (OU).


### PR DESCRIPTION
The value for `rgw_ldap_secrect` has to be a path to the file containing
the secret not the secret itself.

Signed-off-by: Robin Müller <github@mail.coder-hugo.de>

## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
