### PR TITLE
osd: dispatch peering messages as messages, inside the PG lock

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8971,7 +8971,6 @@ void OSD::dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
   } else if (!is_active()) {
     dout(20) << __func__ << " not active" << dendl;
   } else {
-    do_queries(ctx.query_map, curmap);
     do_infos(ctx.info_map, curmap);
 
     for (auto& [osd, ls] : ctx.message_map) {
@@ -9000,36 +8999,6 @@ void OSD::dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
     ceph_assert(tr == 0);
   }
 }
-
-/** do_queries
- * send out pending queries for info | summaries
- */
-void OSD::do_queries(map<int, map<spg_t,pg_query_t> >& query_map,
-		     OSDMapRef curmap)
-{
-  for (map<int, map<spg_t,pg_query_t> >::iterator pit = query_map.begin();
-       pit != query_map.end();
-       ++pit) {
-    if (!curmap->is_up(pit->first)) {
-      dout(20) << __func__ << " skipping down osd." << pit->first << dendl;
-      continue;
-    }
-    int who = pit->first;
-    ConnectionRef con = service.get_con_osd_cluster(who, curmap->get_epoch());
-    if (!con) {
-      dout(20) << __func__ << " skipping osd." << who
-	       << " (NULL con)" << dendl;
-      continue;
-    }
-    service.maybe_share_map(con.get(), curmap);
-    dout(7) << __func__ << " querying osd." << who
-	    << " on " << pit->second.size() << " PGs" << dendl;
-    MOSDPGQuery *m = new MOSDPGQuery(curmap->get_epoch(),
-				     std::move(pit->second));
-    con->send_message(m);
-  }
-}
-
 
 void OSD::do_infos(map<int,vector<pg_notify_t>>& info_map,
 		   OSDMapRef curmap)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8971,7 +8971,6 @@ void OSD::dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
   } else if (!is_active()) {
     dout(20) << __func__ << " not active" << dendl;
   } else {
-    do_notifies(ctx.notify_list, curmap);
     do_queries(ctx.query_map, curmap);
     do_infos(ctx.info_map, curmap);
 
@@ -9001,36 +9000,6 @@ void OSD::dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
     ceph_assert(tr == 0);
   }
 }
-
-/** do_notifies
- * Send an MOSDPGNotify to a primary, with a list of PGs that I have
- * content for, and they are primary for.
- */
-
-void OSD::do_notifies(
-  map<int,vector<pg_notify_t>>& notify_list,
-  OSDMapRef curmap)
-{
-  for (auto& [osd, notifies] : notify_list) {
-    if (!curmap->is_up(osd)) {
-      dout(20) << __func__ << " skipping down osd." << osd << dendl;
-      continue;
-    }
-    ConnectionRef con = service.get_con_osd_cluster(
-      osd, curmap->get_epoch());
-    if (!con) {
-      dout(20) << __func__ << " skipping osd." << osd << " (NULL con)" << dendl;
-      continue;
-    }
-    service.maybe_share_map(con.get(), curmap);
-    dout(7) << __func__ << " osd." << osd
-	    << " on " << notifies.size() << " PGs" << dendl;
-    MOSDPGNotify *m = new MOSDPGNotify(curmap->get_epoch(),
-				       std::move(notifies));
-    con->send_message(m);
-  }
-}
-
 
 /** do_queries
  * send out pending queries for info | summaries

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8971,8 +8971,6 @@ void OSD::dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
   } else if (!is_active()) {
     dout(20) << __func__ << " not active" << dendl;
   } else {
-    do_infos(ctx.info_map, curmap);
-
     for (auto& [osd, ls] : ctx.message_map) {
       if (!curmap->is_up(osd)) {
 	dout(20) << __func__ << " skipping down osd." << osd << dendl;
@@ -8998,32 +8996,6 @@ void OSD::dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
       handle);
     ceph_assert(tr == 0);
   }
-}
-
-void OSD::do_infos(map<int,vector<pg_notify_t>>& info_map,
-		   OSDMapRef curmap)
-{
-  for (auto& [osd, notifies] : info_map) {
-    if (!curmap->is_up(osd)) {
-      dout(20) << __func__ << " skipping down osd." << osd << dendl;
-      continue;
-    }
-    for (auto& i : notifies) {
-      dout(20) << __func__ << " sending info " << i.info
-	       << " to osd " << osd << dendl;
-    }
-    ConnectionRef con = service.get_con_osd_cluster(
-      osd, curmap->get_epoch());
-    if (!con) {
-      dout(20) << __func__ << " skipping osd." << osd << " (NULL con)" << dendl;
-      continue;
-    }
-    service.maybe_share_map(con.get(), curmap);
-    MOSDPGInfo *m = new MOSDPGInfo(curmap->get_epoch());
-    m->pg_list = std::move(notifies);
-    con->send_message(m);
-  }
-  info_map.clear();
 }
 
 void OSD::handle_fast_pg_create(MOSDPGCreate2 *m)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8974,6 +8974,24 @@ void OSD::dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
     do_notifies(ctx.notify_list, curmap);
     do_queries(ctx.query_map, curmap);
     do_infos(ctx.info_map, curmap);
+
+    for (auto& [osd, ls] : ctx.message_map) {
+      if (!curmap->is_up(osd)) {
+	dout(20) << __func__ << " skipping down osd." << osd << dendl;
+	continue;
+      }
+      ConnectionRef con = service.get_con_osd_cluster(
+	osd, curmap->get_epoch());
+      if (!con) {
+	dout(20) << __func__ << " skipping osd." << osd << " (NULL con)"
+		 << dendl;
+	continue;
+      }
+      service.maybe_share_map(con.get(), curmap);
+      for (auto m : ls) {
+	con->send_message(m.detach());
+      }
+    }
   }
   if ((!ctx.transaction.empty() || ctx.transaction.has_contexts()) && pg) {
     int tr = store->queue_transaction(

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8312,25 +8312,23 @@ void OSD::_finish_splits(set<PGRef>& pgs)
   dout(10) << __func__ << " " << pgs << dendl;
   if (is_stopping())
     return;
-  PeeringCtx rctx = create_context();
   for (set<PGRef>::iterator i = pgs.begin();
        i != pgs.end();
        ++i) {
     PG *pg = i->get();
 
+    PeeringCtx rctx = create_context();
     pg->lock();
     dout(10) << __func__ << " " << *pg << dendl;
     epoch_t e = pg->get_osdmap_epoch();
     pg->handle_initialize(rctx);
     pg->queue_null(e, e);
-    dispatch_context_transaction(rctx, pg);
+    dispatch_context(rctx, pg, service.get_osdmap());
     pg->unlock();
 
     unsigned shard_index = pg->pg_id.hash_to_shard(num_shards);
     shards[shard_index]->register_and_wake_split_child(pg);
   }
-
-  dispatch_context(rctx, 0, service.get_osdmap());
 };
 
 bool OSD::add_merge_waiter(OSDMapRef nextmap, spg_t target, PGRef src,
@@ -8388,7 +8386,7 @@ bool OSD::advance_pg(
 		  << " is merge source, target is " << parent
 		   << dendl;
 	  pg->write_if_dirty(rctx);
-	  dispatch_context_transaction(rctx, pg, &handle);
+	  dispatch_context(rctx, pg, pg->get_osdmap(), &handle);
 	  pg->ch->flush();
 	  pg->on_shutdown();
 	  OSDShard *sdata = pg->osd_shard;
@@ -8963,18 +8961,6 @@ void OSD::handle_pg_create(OpRequestRef op)
 PeeringCtx OSD::create_context()
 {
   return PeeringCtx();
-}
-
-void OSD::dispatch_context_transaction(PeeringCtx &ctx, PG *pg,
-                                       ThreadPool::TPHandle *handle)
-{
-  if (!ctx.transaction.empty() || ctx.transaction.has_contexts()) {
-    int tr = store->queue_transaction(
-      pg->ch,
-      std::move(ctx.transaction), TrackedOpRef(), handle);
-    ceph_assert(tr == 0);
-    ctx.reset_transaction();
-  }
 }
 
 void OSD::dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
@@ -9647,7 +9633,7 @@ void OSD::dequeue_peering_evt(
       pg->unlock();
       return;
     }
-    dispatch_context_transaction(rctx, pg, &handle);
+    dispatch_context(rctx, pg, curmap, &handle);
     need_up_thru = pg->get_need_up_thru();
     same_interval_since = pg->get_same_interval_since();
     pg->unlock();
@@ -9656,7 +9642,6 @@ void OSD::dequeue_peering_evt(
   if (need_up_thru) {
     queue_want_up_thru(same_interval_since);
   }
-  dispatch_context(rctx, pg, curmap, &handle);
 
   service.send_pg_temp();
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1897,8 +1897,6 @@ protected:
   void dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
                         ThreadPool::TPHandle *handle = NULL);
   void discard_context(PeeringCtx &ctx);
-  void do_queries(map<int, map<spg_t,pg_query_t> >& query_map,
-		  OSDMapRef map);
   void do_infos(map<int,vector<pg_notify_t>>& info_map,
 		OSDMapRef map);
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1897,8 +1897,6 @@ protected:
   void dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
                         ThreadPool::TPHandle *handle = NULL);
   void discard_context(PeeringCtx &ctx);
-  void do_notifies(map<int,vector<pg_notify_t>>& notify_list,
-		   OSDMapRef map);
   void do_queries(map<int, map<spg_t,pg_query_t> >& query_map,
 		  OSDMapRef map);
   void do_infos(map<int,vector<pg_notify_t>>& info_map,

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1897,8 +1897,6 @@ protected:
   void dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
                         ThreadPool::TPHandle *handle = NULL);
   void discard_context(PeeringCtx &ctx);
-  void do_infos(map<int,vector<pg_notify_t>>& info_map,
-		OSDMapRef map);
 
   bool require_mon_peer(const Message *m);
   bool require_mon_or_mgr_peer(const Message *m);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1896,8 +1896,6 @@ protected:
   PeeringCtx create_context();
   void dispatch_context(PeeringCtx &ctx, PG *pg, OSDMapRef curmap,
                         ThreadPool::TPHandle *handle = NULL);
-  void dispatch_context_transaction(PeeringCtx &ctx, PG *pg,
-                                    ThreadPool::TPHandle *handle = NULL);
   void discard_context(PeeringCtx &ctx);
   void do_notifies(map<int,vector<pg_notify_t>>& notify_list,
 		   OSDMapRef map);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3617,8 +3617,7 @@ void PG::find_unfound(epoch_t queued, PeeringCtx &rctx)
     * It may be that our initial locations were bad and we errored
     * out while trying to pull.
     */
-  recovery_state.discover_all_missing(rctx.query_map);
-  if (rctx.query_map.empty()) {
+  if (!recovery_state.discover_all_missing(rctx.query_map)) {
     string action;
     if (state_test(PG_STATE_BACKFILLING)) {
       auto evt = PGPeeringEventRef(

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3617,7 +3617,7 @@ void PG::find_unfound(epoch_t queued, PeeringCtx &rctx)
     * It may be that our initial locations were bad and we errored
     * out while trying to pull.
     */
-  if (!recovery_state.discover_all_missing(rctx.query_map)) {
+  if (!recovery_state.discover_all_missing(rctx)) {
     string action;
     if (state_test(PG_STATE_BACKFILLING)) {
       auto evt = PGPeeringEventRef(

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1975,11 +1975,12 @@ bool PeeringState::search_for_missing(
   return found_missing;
 }
 
-void PeeringState::discover_all_missing(
+bool PeeringState::discover_all_missing(
   map<int, map<spg_t,pg_query_t> > &query_map)
 {
   auto &missing = pg_log.get_missing();
   uint64_t unfound = get_num_unfound();
+  bool any = false;  // did we start any queries
 
   psdout(10) << __func__ << " "
 	     << missing.num_missing() << " missing, "
@@ -2031,7 +2032,9 @@ void PeeringState::discover_all_missing(
 	pg_query_t::FULLLOG,
 	peer.shard, pg_whoami.shard,
 	info.history, get_osdmap_epoch());
+    any = true;
   }
+  return any;
 }
 
 /* Build the might_have_unfound set.

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -13,6 +13,7 @@
 #include "messages/MOSDPGInfo.h"
 #include "messages/MOSDPGTrim.h"
 #include "messages/MOSDPGLog.h"
+#include "messages/MOSDPGNotify.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
@@ -20,13 +21,20 @@
 BufferedRecoveryMessages::BufferedRecoveryMessages(PeeringCtx &ctx)
   : query_map(std::move(ctx.query_map)),
     info_map(std::move(ctx.info_map)),
-    notify_list(std::move(ctx.notify_list)),
     message_map(std::move(ctx.message_map))
 {
   ctx.query_map.clear();
   ctx.info_map.clear();
-  ctx.notify_list.clear();
   ctx.message_map.clear();
+}
+
+void PeeringCtxWrapper::send_notify(int to, const pg_notify_t &n)
+{
+  vector<pg_notify_t> notifies;
+  notifies.push_back(n);
+  message_map[to].push_back(
+    new MOSDPGNotify(n.epoch_sent, std::move(notifies))
+    );
 }
 
 void PGPool::update(CephContext *cct, OSDMapRef map)
@@ -2561,7 +2569,7 @@ void PeeringState::fulfill_query(const MQuery& query, PeeringCtxWrapper &rctx)
     update_history(query.query.history);
     fulfill_info(query.from, query.query, notify_info);
     rctx.send_notify(
-      notify_info.first,
+      notify_info.first.osd,
       pg_notify_t(
 	notify_info.first.shard, pg_whoami.shard,
 	query.query_epoch,
@@ -4099,7 +4107,7 @@ boost::statechart::result PeeringState::Reset::react(const ActMap&)
   DECLARE_LOCALS
   if (ps->should_send_notify() && ps->get_primary().osd >= 0) {
     context< PeeringMachine >().send_notify(
-      ps->get_primary(),
+      ps->get_primary().osd,
       pg_notify_t(
 	ps->get_primary().shard, ps->pg_whoami.shard,
 	ps->get_osdmap_epoch(),
@@ -5684,7 +5692,7 @@ boost::statechart::result PeeringState::ReplicaActive::react(const ActMap&)
   DECLARE_LOCALS
   if (ps->should_send_notify() && ps->get_primary().osd >= 0) {
     context< PeeringMachine >().send_notify(
-      ps->get_primary(),
+      ps->get_primary().osd,
       pg_notify_t(
 	ps->get_primary().shard, ps->pg_whoami.shard,
 	ps->get_osdmap_epoch(),
@@ -5804,7 +5812,7 @@ boost::statechart::result PeeringState::Stray::react(const ActMap&)
   DECLARE_LOCALS
   if (ps->should_send_notify() && ps->get_primary().osd >= 0) {
     context< PeeringMachine >().send_notify(
-      ps->get_primary(),
+      ps->get_primary().osd,
       pg_notify_t(
 	ps->get_primary().shard, ps->pg_whoami.shard,
 	ps->get_osdmap_epoch(),

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -48,6 +48,23 @@ void BufferedRecoveryMessages::send_query(
     );
 }
 
+void BufferedRecoveryMessages::send_info(
+  int to,
+  spg_t from_spgid,
+  spg_t to_spgid,
+  epoch_t min_epoch,
+  epoch_t cur_epoch,
+  const pg_info_t &info)
+{
+  MOSDPGInfo *m = new MOSDPGInfo(cur_epoch);
+  m->pg_list.push_back(
+    pg_notify_t(
+      to_spgid.shard, from_spgid.shard,
+      min_epoch, cur_epoch,
+      info, PastIntervals()));
+  message_map[to].push_back(m);
+}
+
 void PGPool::update(CephContext *cct, OSDMapRef map)
 {
   const pg_pool_t *pi = map->get_pg_pool(id);
@@ -1969,12 +1986,13 @@ bool PeeringState::search_for_missing(
       oinfo.last_update != eversion_t()) {
     pg_info_t tinfo(oinfo);
     tinfo.pgid.shard = pg_whoami.shard;
-    ctx.info_map[from.osd].emplace_back(
-      pg_notify_t(
-	from.shard, pg_whoami.shard,
-	get_osdmap_epoch(),
-	get_osdmap_epoch(),
-	tinfo, past_intervals));
+    ctx.send_info(
+      from.osd,
+      info.pgid,
+      spg_t(info.pgid.pgid, from.shard),
+      get_osdmap_epoch(),  // fixme: use lower epoch?
+      get_osdmap_epoch(),
+      tinfo);
   }
   return found_missing;
 }
@@ -2076,7 +2094,6 @@ void PeeringState::build_might_have_unfound()
 void PeeringState::activate(
   ObjectStore::Transaction& t,
   epoch_t activation_epoch,
-  map<int,vector<pg_notify_t>> *activator_map,
   PeeringCtxWrapper &ctx)
 {
   ceph_assert(!is_peered());
@@ -2193,16 +2210,16 @@ void PeeringState::activate(
 				<< " from (" << pi.log_tail << "," << pi.last_update
 				<< "] " << pi.last_backfill
 				<< " to " << info.last_update;
-	if (!pi.is_empty() && activator_map) {
+	if (!pi.is_empty()) {
 	  psdout(10) << "activate peer osd." << peer
 		     << " is up to date, queueing in pending_activators" << dendl;
-	  (*activator_map)[peer.osd].emplace_back(
-	    pg_notify_t(
-	      peer.shard, pg_whoami.shard,
-	      get_osdmap_epoch(),
-	      get_osdmap_epoch(),
-	      info,
-	      past_intervals));
+	  ctx.send_info(
+	    peer.osd,
+	    info.pgid,
+	    spg_t(info.pgid.pgid, peer.shard),
+	    get_osdmap_epoch(), // fixme: use lower epoch?
+	    get_osdmap_epoch(),
+	    info);
 	} else {
 	  psdout(10) << "activate peer osd." << peer
 		     << " is up to date, but sending pg_log anyway" << dendl;
@@ -5258,7 +5275,6 @@ PeeringState::Active::Active(my_context ctx)
   ps->start_flush(context< PeeringMachine >().get_cur_transaction());
   ps->activate(context< PeeringMachine >().get_cur_transaction(),
 	       ps->get_osdmap_epoch(),
-	       &context< PeeringMachine >().get_info_map(),
 	       context< PeeringMachine >().get_recovery_ctx());
 
   // everyone has to commit/ack before we are truly active
@@ -5627,7 +5643,6 @@ boost::statechart::result PeeringState::ReplicaActive::react(
   ps->activate(
     context< PeeringMachine >().get_cur_transaction(),
     actevt.activation_epoch,
-    NULL,
     context< PeeringMachine >().get_recovery_ctx());
   psdout(10) << "Activate Finished" << dendl;
   return discard_event();

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -20,11 +20,9 @@
 #define dout_subsys ceph_subsys_osd
 
 BufferedRecoveryMessages::BufferedRecoveryMessages(PeeringCtx &ctx)
-  : query_map(std::move(ctx.query_map)),
-    info_map(std::move(ctx.info_map)),
+  : info_map(std::move(ctx.info_map)),
     message_map(std::move(ctx.message_map))
 {
-  ctx.query_map.clear();
   ctx.info_map.clear();
   ctx.message_map.clear();
 }
@@ -2078,7 +2076,6 @@ void PeeringState::build_might_have_unfound()
 void PeeringState::activate(
   ObjectStore::Transaction& t,
   epoch_t activation_epoch,
-  map<int, map<spg_t,pg_query_t> >& query_map,
   map<int,vector<pg_notify_t>> *activator_map,
   PeeringCtxWrapper &ctx)
 {
@@ -5261,7 +5258,6 @@ PeeringState::Active::Active(my_context ctx)
   ps->start_flush(context< PeeringMachine >().get_cur_transaction());
   ps->activate(context< PeeringMachine >().get_cur_transaction(),
 	       ps->get_osdmap_epoch(),
-	       context< PeeringMachine >().get_query_map(),
 	       &context< PeeringMachine >().get_info_map(),
 	       context< PeeringMachine >().get_recovery_ctx());
 
@@ -5628,11 +5624,9 @@ boost::statechart::result PeeringState::ReplicaActive::react(
   const Activate& actevt) {
   DECLARE_LOCALS
   psdout(10) << "In ReplicaActive, about to call activate" << dendl;
-  map<int, map<spg_t, pg_query_t> > query_map;
   ps->activate(
     context< PeeringMachine >().get_cur_transaction(),
     actevt.activation_epoch,
-    query_map,
     NULL,
     context< PeeringMachine >().get_recovery_ctx());
   psdout(10) << "Activate Finished" << dendl;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -14,6 +14,7 @@
 #include "messages/MOSDPGTrim.h"
 #include "messages/MOSDPGLog.h"
 #include "messages/MOSDPGNotify.h"
+#include "messages/MOSDPGQuery.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
@@ -37,6 +38,18 @@ void BufferedRecoveryMessages::send_notify(int to, const pg_notify_t &n)
     );
 }
 
+void BufferedRecoveryMessages::send_query(
+  int to,
+  spg_t to_spgid,
+  const pg_query_t &q)
+{
+  map<spg_t,pg_query_t> queries;
+  queries[to_spgid] = q;
+  message_map[to].push_back(
+    new MOSDPGQuery(q.epoch_sent, std::move(queries))
+    );
+}
+
 void PGPool::update(CephContext *cct, OSDMapRef map)
 {
   const pg_pool_t *pi = map->get_pg_pool(id);
@@ -57,13 +70,6 @@ void PGPool::update(CephContext *cct, OSDMapRef map)
     snapc = pi->get_snap_context();
   }
   cached_epoch = map->get_epoch();
-}
-
-void PeeringState::PeeringMachine::send_query(
-  pg_shard_t to, const pg_query_t &query) {
-  ceph_assert(state->rctx);
-  state->rctx->query_map[to.osd][
-    spg_t(context< PeeringMachine >().spgid.pgid, to.shard)] = query;
 }
 
 /*-------------Peering State Helpers----------------*/
@@ -1976,7 +1982,7 @@ bool PeeringState::search_for_missing(
 }
 
 bool PeeringState::discover_all_missing(
-  map<int, map<spg_t,pg_query_t> > &query_map)
+  BufferedRecoveryMessages &rctx)
 {
   auto &missing = pg_log.get_missing();
   uint64_t unfound = get_num_unfound();
@@ -2027,11 +2033,13 @@ bool PeeringState::discover_all_missing(
     psdout(10) << __func__ << ": osd." << peer << ": requesting pg_missing_t"
 	       << dendl;
     peer_missing_requested.insert(peer);
-    query_map[peer.osd][spg_t(info.pgid.pgid, peer.shard)] =
+    rctx.send_query(
+      peer.osd,
+      spg_t(info.pgid.pgid, peer.shard),
       pg_query_t(
 	pg_query_t::FULLLOG,
 	peer.shard, pg_whoami.shard,
-	info.history, get_osdmap_epoch());
+	info.history, get_osdmap_epoch()));
     any = true;
   }
   return any;
@@ -2367,7 +2375,7 @@ void PeeringState::activate(
       build_might_have_unfound();
 
       // Always call now so update_calc_stats() will be accurate
-      discover_all_missing(query_map);
+      discover_all_missing(ctx.msgs);
 
     }
 
@@ -5341,7 +5349,7 @@ boost::statechart::result PeeringState::Active::react(const ActMap&)
 
   if (ps->have_unfound()) {
     // object may have become unfound
-    ps->discover_all_missing(context< PeeringMachine >().get_query_map());
+    ps->discover_all_missing(context<PeeringMachine>().get_recovery_ctx().msgs);
   }
 
   uint64_t unfound = ps->missing_loc.num_unfound();
@@ -5380,7 +5388,8 @@ boost::statechart::result PeeringState::Active::react(const MNotifyRec& notevt)
     ps->proc_replica_info(
       notevt.from, notevt.notify.info, notevt.notify.epoch_sent);
     if (ps->have_unfound() || (ps->is_degraded() && ps->might_have_unfound.count(notevt.from))) {
-      ps->discover_all_missing(context< PeeringMachine >().get_query_map());
+      ps->discover_all_missing(
+	context<PeeringMachine>().get_recovery_ctx().msgs);
     }
   }
   return discard_event();
@@ -5984,10 +5993,11 @@ void PeeringState::GetInfo::get_infos()
     } else {
       psdout(10) << " querying info from osd." << peer << dendl;
       context< PeeringMachine >().send_query(
-	peer, pg_query_t(pg_query_t::INFO,
-			 it->shard, ps->pg_whoami.shard,
-			 ps->info.history,
-			 ps->get_osdmap_epoch()));
+	peer.osd,
+	pg_query_t(pg_query_t::INFO,
+		   it->shard, ps->pg_whoami.shard,
+		   ps->info.history,
+		   ps->get_osdmap_epoch()));
       peer_info_requested.insert(peer);
       ps->blocked_by.insert(peer.osd);
     }
@@ -6135,7 +6145,7 @@ PeeringState::GetLog::GetLog(my_context ctx)
   // how much?
   psdout(10) << " requesting log from osd." << auth_log_shard << dendl;
   context<PeeringMachine>().send_query(
-    auth_log_shard,
+    auth_log_shard.osd,
     pg_query_t(
       pg_query_t::LOG,
       auth_log_shard.shard, ps->pg_whoami.shard,
@@ -6457,7 +6467,7 @@ PeeringState::GetMissing::GetMissing(my_context ctx)
     if (pi.log_tail <= since) {
       psdout(10) << " requesting log+missing since " << since << " from osd." << *i << dendl;
       context< PeeringMachine >().send_query(
-	*i,
+	i->osd,
 	pg_query_t(
 	  pg_query_t::LOG,
 	  i->shard, ps->pg_whoami.shard,
@@ -6468,7 +6478,7 @@ PeeringState::GetMissing::GetMissing(my_context ctx)
 			 << " (want since " << since << " < log.tail "
 			 << pi.log_tail << ")" << dendl;
       context< PeeringMachine >().send_query(
-	*i, pg_query_t(
+	i->osd, pg_query_t(
 	  pg_query_t::FULLLOG,
 	  i->shard, ps->pg_whoami.shard,
 	  ps->info.history, ps->get_osdmap_epoch()));

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -20,10 +20,8 @@
 #define dout_subsys ceph_subsys_osd
 
 BufferedRecoveryMessages::BufferedRecoveryMessages(PeeringCtx &ctx)
-  : info_map(std::move(ctx.info_map)),
-    message_map(std::move(ctx.message_map))
+  : message_map(std::move(ctx.message_map))
 {
-  ctx.info_map.clear();
   ctx.message_map.clear();
 }
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -20,11 +20,13 @@
 BufferedRecoveryMessages::BufferedRecoveryMessages(PeeringCtx &ctx)
   : query_map(std::move(ctx.query_map)),
     info_map(std::move(ctx.info_map)),
-    notify_list(std::move(ctx.notify_list))
+    notify_list(std::move(ctx.notify_list)),
+    message_map(std::move(ctx.message_map))
 {
   ctx.query_map.clear();
   ctx.info_map.clear();
   ctx.notify_list.clear();
+  ctx.message_map.clear();
 }
 
 void PGPool::update(CephContext *cct, OSDMapRef map)

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -28,7 +28,7 @@ BufferedRecoveryMessages::BufferedRecoveryMessages(PeeringCtx &ctx)
   ctx.message_map.clear();
 }
 
-void PeeringCtxWrapper::send_notify(int to, const pg_notify_t &n)
+void BufferedRecoveryMessages::send_notify(int to, const pg_notify_t &n)
 {
   vector<pg_notify_t> notifies;
   notifies.push_back(n);

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -51,7 +51,6 @@ class PeeringCtx;
 
 // [primary only] content recovery state
 struct BufferedRecoveryMessages {
-  map<int, map<spg_t, pg_query_t> > query_map;
   map<int, vector<pg_notify_t>> info_map;
   map<int, vector<MessageRef>> message_map;
 
@@ -59,12 +58,6 @@ struct BufferedRecoveryMessages {
   BufferedRecoveryMessages(PeeringCtx &);
 
   void accept_buffered_messages(BufferedRecoveryMessages &m) {
-    for (auto &[target, qmap] : m.query_map) {
-      auto &omap = query_map[target];
-      for (auto &[pg, query] : qmap) {
-	omap[pg] = query;
-      }
-    }
     for (auto &[target, ivec] : m.info_map) {
       auto &ovec = info_map[target];
       ovec.reserve(ovec.size() + ivec.size());
@@ -204,21 +197,18 @@ struct PeeringCtx : BufferedRecoveryMessages {
 struct PeeringCtxWrapper {
   utime_t start_time;
   BufferedRecoveryMessages &msgs;
-  map<int, map<spg_t, pg_query_t> > &query_map;
   map<int, vector<pg_notify_t>> &info_map;
   ObjectStore::Transaction &transaction;
   HBHandle * const handle = nullptr;
 
   PeeringCtxWrapper(PeeringCtx &wrapped) :
     msgs(wrapped),
-    query_map(wrapped.query_map),
     info_map(wrapped.info_map),
     transaction(wrapped.transaction),
     handle(wrapped.handle) {}
 
   PeeringCtxWrapper(BufferedRecoveryMessages &buf, PeeringCtx &wrapped)
     : msgs(buf),
-      query_map(buf.query_map),
       info_map(buf.info_map),
       transaction(wrapped.transaction),
       handle(wrapped.handle) {}
@@ -573,12 +563,6 @@ public:
     ObjectStore::Transaction& get_cur_transaction() {
       ceph_assert(state->rctx);
       return state->rctx->transaction;
-    }
-
-
-    map<int, map<spg_t, pg_query_t> > &get_query_map() {
-      ceph_assert(state->rctx);
-      return state->rctx->query_map;
     }
 
     map<int, vector<pg_notify_t>> &get_info_map() {
@@ -1524,7 +1508,6 @@ public:
   void activate(
     ObjectStore::Transaction& t,
     epoch_t activation_epoch,
-    map<int, map<spg_t,pg_query_t> >& query_map,
     map<int, vector<pg_notify_t>> *activator_map,
     PeeringCtxWrapper &ctx);
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -78,6 +78,9 @@ struct BufferedRecoveryMessages {
   }
   void send_notify(int to, const pg_notify_t &n);
   void send_query(int to, spg_t spgid, const pg_query_t &q);
+  void send_info(int to, spg_t from_spgid, spg_t to_spgid,
+		 epoch_t min_epoch, epoch_t cur_epoch,
+		 const pg_info_t &info);
 };
 
 struct HeartbeatStamps : public RefCountedObject {
@@ -223,6 +226,11 @@ struct PeeringCtxWrapper {
   }
   void send_query(int to, spg_t spgid, const pg_query_t &q) {
     msgs.send_query(to, spgid, q);
+  }
+  void send_info(int to, spg_t from_spgid, spg_t to_spgid,
+		 epoch_t min_epoch, epoch_t cur_epoch,
+		 const pg_info_t &info) {
+    msgs.send_info(to, from_spgid, to_spgid, min_epoch, cur_epoch, info);
   }
 };
 
@@ -1508,7 +1516,6 @@ public:
   void activate(
     ObjectStore::Transaction& t,
     epoch_t activation_epoch,
-    map<int, vector<pg_notify_t>> *activator_map,
     PeeringCtxWrapper &ctx);
 
   void rewind_divergent_log(ObjectStore::Transaction& t, eversion_t newhead);

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -84,6 +84,7 @@ struct BufferedRecoveryMessages {
     message_map[target].push_back(m);
   }
   void send_notify(int to, const pg_notify_t &n);
+  void send_query(int to, spg_t spgid, const pg_query_t &q);
 };
 
 struct HeartbeatStamps : public RefCountedObject {
@@ -229,6 +230,9 @@ struct PeeringCtxWrapper {
   }
   void send_notify(int to, const pg_notify_t &n) {
     msgs.send_notify(to, n);
+  }
+  void send_query(int to, spg_t spgid, const pg_query_t &q) {
+    msgs.send_query(to, spgid, q);
   }
 };
 
@@ -571,7 +575,6 @@ public:
       return state->rctx->transaction;
     }
 
-    void send_query(pg_shard_t to, const pg_query_t &query);
 
     map<int, map<spg_t, pg_query_t> > &get_query_map() {
       ceph_assert(state->rctx);
@@ -591,6 +594,9 @@ public:
     void send_notify(int to, const pg_notify_t &n) {
       ceph_assert(state->rctx);
       state->rctx->send_notify(to, n);
+    }
+    void send_query(int to, const pg_query_t &query) {
+      state->rctx->send_query(to, spgid, query);
     }
   };
   friend class PeeringMachine;
@@ -1777,7 +1783,7 @@ public:
 
   /// Pull missing sets from all candidate peers
   bool discover_all_missing(
-    map<int, map<spg_t,pg_query_t> > &query_map);
+    BufferedRecoveryMessages &rctx);
 
   /// Notify that hoid has been fully recocovered
   void object_recovered(

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1776,7 +1776,8 @@ public:
     const hobject_t soid);
 
   /// Pull missing sets from all candidate peers
-  void discover_all_missing(std::map<int, map<spg_t,pg_query_t> > &query_map);
+  bool discover_all_missing(
+    map<int, map<spg_t,pg_query_t> > &query_map);
 
   /// Notify that hoid has been fully recocovered
   void object_recovered(


### PR DESCRIPTION
- Get rid of the query/info/notify batching, and instead queue up individual messages
- Send them inside the PG lock to avoid races that change the ordering on the wire