### PR TITLE
mds,mon: deprecate CephFS inline_data support

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -131,6 +131,12 @@
   New admin command ``ceph daemon osd.# dump_osd_network [threshold]`` will
   do the same but only including heartbeats initiated by the specified OSD.
 
+* Inline data support for CephFS has been deprecated. When setting the flag,
+  users will see a warning to that effect, and enabling it now requires the
+  ``--yes-i-really-really-mean-it`` flag. If the MDS is started on a
+  filesystem that has it enabled, a health warning is generated. Support for
+  this feature will be removed in a future release.
+
 * Following invalid settings now are not tolerated anymore
   for the command `ceph osd erasure-code-profile set xxx`.
   * invalid `m` for "reed_sol_r6_op" erasure technique

--- a/doc/cephfs/experimental-features.rst
+++ b/doc/cephfs/experimental-features.rst
@@ -23,6 +23,9 @@ failures within it are unlikely to make non-inlined data inaccessible
 Inline data has always been off by default and requires setting
 the ``inline_data`` flag.
 
+Inline data has been declared deprecated for the Octopus release, and will
+likely be removed altogether in the Q release.
+
 Mantle: Programmable Metadata Load Balancer
 -------------------------------------------
 

--- a/qa/cephfs/overrides/whitelist_health.yaml
+++ b/qa/cephfs/overrides/whitelist_health.yaml
@@ -9,3 +9,4 @@ overrides:
       - \(MDS_DAMAGE\)
       - \(MDS_ALL_DOWN\)
       - \(MDS_UP_LESS_THAN_MAX\)
+      - \(FS_INLINE_DATA_DEPRECATED\)

--- a/qa/suites/fs/basic_workload/inline/yes.yaml
+++ b/qa/suites/fs/basic_workload/inline/yes.yaml
@@ -1,4 +1,4 @@
 tasks:
 - exec:
     client.0:
-      - sudo ceph fs set cephfs inline_data true --yes-i-really-mean-it
+      - sudo ceph fs set cephfs inline_data true --yes-i-really-really-mean-it

--- a/qa/suites/kcephfs/cephfs/inline/yes.yaml
+++ b/qa/suites/kcephfs/cephfs/inline/yes.yaml
@@ -1,4 +1,4 @@
 tasks:
 - exec:
     client.0:
-      - sudo ceph fs set cephfs inline_data true --yes-i-really-mean-it
+      - sudo ceph fs set cephfs inline_data true --yes-i-really-really-mean-it

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -966,10 +966,10 @@ function test_mon_mds()
   expect_false ceph fs set cephfs max_mds 257
   expect_false ceph fs set cephfs max_mds asdf
   expect_false ceph fs set cephfs inline_data true
-  ceph fs set cephfs inline_data true --yes-i-really-mean-it
-  ceph fs set cephfs inline_data yes --yes-i-really-mean-it
-  ceph fs set cephfs inline_data 1 --yes-i-really-mean-it
-  expect_false ceph fs set cephfs inline_data --yes-i-really-mean-it
+  ceph fs set cephfs inline_data true --yes-i-really-really-mean-it
+  ceph fs set cephfs inline_data yes --yes-i-really-really-mean-it
+  ceph fs set cephfs inline_data 1 --yes-i-really-really-mean-it
+  expect_false ceph fs set cephfs inline_data --yes-i-really-really-mean-it
   ceph fs set cephfs inline_data false
   ceph fs set cephfs inline_data no
   ceph fs set cephfs inline_data 0

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -505,6 +505,15 @@ void MDSMap::get_health_checks(health_check_map_t *checks) const
     ss << "multi-active mds while there are snapshots possibly created by pre-mimic MDS";
     check.detail.push_back(ss.str());
   }
+
+  if (get_inline_data_enabled()) {
+    health_check_t &check = checks->add(
+      "FS_INLINE_DATA_DEPRECATED", HEALTH_WARN,
+      "%num% filesystem%plurals% with deprecated feature inline_data", 1);
+    stringstream ss;
+    ss << "fs " << fs_name << " has deprecated feature inline_data enabled.";
+    check.detail.push_back(ss.str());
+  }
 }
 
 void MDSMap::mds_info_t::encode_versioned(bufferlist& bl, uint64_t features) const

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2401,6 +2401,9 @@ void MDSRankDispatcher::handle_mds_map(
     purge_queue.update_op_limit(*mdsmap);
   }
 
+  if (mdsmap->get_inline_data_enabled() && !oldmap.get_inline_data_enabled())
+    dout(0) << "WARNING: inline_data support has been deprecated and will be removed in a future release" << dendl;
+
   mdcache->handle_mdsmap(*mdsmap);
 }
 

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -367,9 +367,10 @@ public:
 
       if (enable_inline) {
         bool confirm = false;
-        cmd_getval(g_ceph_context, cmdmap, "yes_i_really_mean_it", confirm);
+        cmd_getval(g_ceph_context, cmdmap, "yes_i_really_really_mean_it", confirm);
 	if (!confirm) {
-	  ss << EXPERIMENTAL_WARNING;
+	  ss << "Inline data support is deprecated and will be removed in a future release. "
+	     << "Add --yes-i-really-really-mean-it if you are certain you want this enabled.";
 	  return -EPERM;
 	}
 	ss << "inline data enabled";

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -424,7 +424,8 @@ COMMAND("fs set " \
         "|standby_count_wanted|session_timeout|session_autoclose" \
         "|allow_standby_replay|down|joinable|min_compat_client " \
 	"name=val,type=CephString "					\
-	"name=yes_i_really_mean_it,type=CephBool,req=false",			\
+	"name=yes_i_really_mean_it,type=CephBool,req=false "		\
+	"name=yes_i_really_really_mean_it,type=CephBool,req=false",	\
 	"set fs parameter <var> to <val>", "mds", "rw")
 COMMAND("fs flag set name=flag_name,type=CephChoices,strings=enable_multiple "
         "name=val,type=CephString " \


### PR DESCRIPTION
I recently sent a proposal to the mailing lists to start deprecating inline_data support:

https://www.spinics.net/lists/ceph-users/msg54688.html

TL;DR: I have some concerns about its safety with the kernel client (i.e., I think there are races where it can corrupt data). The kernel doesn't have write support for it yet. We could try to add it, but that's a large task. Given all that, and the fact that it's not widely used, I'm going to propose that we drop support for this.

This PR just adds a hurdle for someone trying to enable it on a new filesystem. At a minimum, I'd like to see this go in for Octopus, with an eye toward ripping it out completely in Q or R release. 

Other things we should to consider:

- a health warning or something when we encounter an existing filesystem that has inline_data enabled
- a conversion utility that can crawl the filesystem, looking for files that are inlined and uninlining them. Not sure there are enough people using it to warrant this, but we could do it if we thought it would be needed

Anything else?