### PR TITLE
mgr/BaseMgrModule: fix PyInt_Check call for py3

### DIFF
--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -305,8 +305,10 @@ ceph_set_health_checks(BaseMgrModule *self, PyObject *args)
       } else if (ks == "count") {
 	if (PyLong_Check(v)) {
 	  count = PyLong_AsLong(v);
+#if PY_MAJOR_VERSION <= 2
 	} else if (PyInt_Check(v)) {
 	  count = PyInt_AsLong(v);
+#endif
 	} else {
 	  derr << __func__ << " check " << check_name
 	       << " count value not long or int" << dendl;


### PR DESCRIPTION
PyInt_Check doesn't exist for py3.

Fixes 69a712ad4bf48eb81a503e14d9957b1186ed35f5

Signed-off-by: Sage Weil <sage@redhat.com>