### PR TITLE
mgr/BaseMgrModule: use PyInt_Check() to compatible with py2

### DIFF
--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -303,13 +303,11 @@ ceph_set_health_checks(BaseMgrModule *self, PyObject *args)
 	  summary = std::move(vs);
 	}
       } else if (ks == "count") {
-	if (PyLong_Check(v)) {
-	  count = PyLong_AsLong(v);
-	} else if (PyInt_Check(v)) {
+	if (PyInt_Check(v)) {
 	  count = PyInt_AsLong(v);
 	} else {
 	  derr << __func__ << " check " << check_name
-	       << " count value not long or int" << dendl;
+	       << " count value not int" << dendl;
 	  continue;
 	}
       } else if (ks == "detail") {
@@ -946,16 +944,12 @@ ceph_add_osd_perf_query(BaseMgrModule *self, PyObject *args)
           }
           limit->order_by = it->second;
         } else if (limit_param_name == NAME_LIMIT_MAX_COUNT) {
-#if PY_MAJOR_VERSION <= 2
-          if (!PyInt_Check(limit_param_val) && !PyLong_Check(limit_param_val)) {
-#else
-          if (!PyLong_Check(limit_param_val)) {
-#endif
+          if (!PyInt_Check(limit_param_val)) {
             derr << __func__ << " " << limit_param_name << " not an int"
                  << dendl;
             Py_RETURN_NONE;
           }
-          limit->max_count = PyLong_AsLong(limit_param_val);
+          limit->max_count = PyInt_AsLong(limit_param_val);
         } else {
           derr << __func__ << " unknown limit param: " << limit_param_name
                << dendl;

--- a/src/mgr/PythonCompat.h
+++ b/src/mgr/PythonCompat.h
@@ -20,6 +20,9 @@ inline PyObject* PyString_FromString(const char *v) {
 inline const char* PyString_AsString(PyObject *string) {
   return PyUnicode_AsUTF8(string);
 }
+inline int PyInt_Check(PyObject *o) {
+  return PyLong_Check(o);
+}
 inline long PyInt_AsLong(PyObject *io) {
   return PyLong_AsLong(io);
 }


### PR DESCRIPTION
in python2, we have both `PyLongObject` and `PyIntObject` for presenting
`long` and `int` types. and in python3, `PyIntObject` is dropped, `int`
is represented using `PyLongObject`. and the related functions like
`PyInt_Check()` and `PyInt_AsLong()` are removed along with
`PyIntObject`.

so we should use different set of functions for converting an `int` python
object to native type in C++. since we don't use `long` for "count" when
calling `MgrModule.set_health_checks()`, in this change, we just define
a macro to unify the difference between python2 and python3.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>
