### PR TITLE
mimic: cephfs: avoid map been inserted by mistake

### DIFF
--- a/src/mds/SnapRealm.h
+++ b/src/mds/SnapRealm.h
@@ -148,9 +148,10 @@ public:
   }
   void remove_cap(client_t client, Capability *cap) {
     cap->item_snaprealm_caps.remove_myself();
-    if (client_caps[client]->empty()) {
-      delete client_caps[client];
-      client_caps.erase(client);
+    auto found = client_caps.find(client);
+    if (found != client_caps.end() && found->second->empty()) {
+      delete found->second;
+      client_caps.erase(found);
     }
   }
 };


### PR DESCRIPTION
https://tracker.ceph.com/issues/41097