### PR TITLE
mgr/BaseMgrModule: Conditionalize python27 PyInt_Check

### DIFF
--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -305,8 +305,10 @@ ceph_set_health_checks(BaseMgrModule *self, PyObject *args)
       } else if (ks == "count") {
 	if (PyLong_Check(v)) {
 	  count = PyLong_AsLong(v);
+#if PY_MAJOR_VERSION < 3
 	} else if (PyInt_Check(v)) {
 	  count = PyInt_AsLong(v);
+#endif
 	} else {
 	  derr << __func__ << " check " << check_name
 	       << " count value not long or int" << dendl;


### PR DESCRIPTION
Building in a 3.6 only environment gives:
/home/jenkins/workspace/ceph-master36/src/mgr/BaseMgrModule.cc:308:13: error: use of undeclared identifier 'PyInt_Check'
        } else if (PyInt_Check(v)) {
                   ^
1 error generated.

But looks like PyLong_Check would also work for ints on 3.6:
  https://docs.python.org/3.6/c-api/long.html?highlight=pylong_check

int PyLong_Check(PyObject *p)
    Return true if its argument is a PyLongObject or a subtype of PyLongObject.

Introduced by: https://github.com/ceph/ceph/pull/29806




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>