### PR TITLE
doc/radosgw/admin:fix how to modify subuser info

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -148,9 +148,9 @@ email addresses, display names and access levels. For example::
 
 	radosgw-admin user modify --uid=johndoe --display-name="John E. Doe"
 
-To modify subuser values, specify ``subuser modify`` and the subuser ID. For example::
+To modify subuser values, specify ``subuser modify``, user ID and the subuser ID. For example::
 
-	radosgw-admin subuser modify --subuser=johndoe:swift --access=full
+	radosgw-admin subuser modify --uid=johndoe --subuser=johndoe:swift --access=full
 
 
 User Enable/Suspend


### PR DESCRIPTION
Signed-off-by: Feng Hualong <hualong.feng@intel.com>

I use it but not work when I modify subuser info.
`radosgw-admin subuser modify --uid=fhl:swift --access=read`
```
root@fenghl-X299-AORUS-Gaming-3-Pro:~/ceph/build# radosgw-admin subuser create --uid="fhl" --subuser=fhl:swift --access=full
{
    "user_id": "fhl",
    "display_name": "First FHL",
    "email": "",
    "suspended": 0,
    "max_buckets": 1000,
    "subusers": [
        {
            "id": "fhl:swift",
            "permissions": "full-control"
        }
    ],
    "keys": [
        {
            "user": "fhl",
            "access_key": "91XCZJCFUL3WBJKWW6I6",
            "secret_key": "Z6QYD1PxzcSXkdRT0IvRvuI3uEpdB7VXjqD24Sxm"
        }
    ],
    "swift_keys": [
        {
            "user": "fhl:swift",
            "secret_key": "ynDjZ5OclsrzsUliyBdk1m1qWSWR3p8Ccxv1szDg"
        }
    ],
    "caps": [],
    "op_mask": "read, write, delete",
    "default_placement": "",
    "default_storage_class": "",
    "placement_tags": [],
    "bucket_quota": {
        "enabled": false,
        "check_on_raw": false,
        "max_size": -1,
        "max_size_kb": 0,
        "max_objects": -1
    },
    "user_quota": {
        "enabled": false,
        "check_on_raw": false,
        "max_size": -1,
        "max_size_kb": 0,
        "max_objects": -1
    },
    "temp_url_keys": [],
    "type": "rgw",
    "mfa_ids": []
}

root@fenghl-X299-AORUS-Gaming-3-Pro:~/ceph/build# radosgw-admin subuser modify --uid=fhl:swift --access=read
could not modify subuser: unable to parse request, user info was not populated
```
