### PR TITLE
qa/tasks: drop object inherit

### DIFF
--- a/qa/tasks/mds_thrash.py
+++ b/qa/tasks/mds_thrash.py
@@ -18,7 +18,7 @@ from tasks.thrasher import Thrasher
 
 log = logging.getLogger(__name__)
 
-class MDSThrasher(Greenlet, Thrasher, object):
+class MDSThrasher(Greenlet, Thrasher):
     """
     MDSThrasher::
 

--- a/qa/tasks/rbd_mirror_thrash.py
+++ b/qa/tasks/rbd_mirror_thrash.py
@@ -22,7 +22,7 @@ from tasks.thrasher import Thrasher
 log = logging.getLogger(__name__)
 
 
-class RBDMirrorThrasher(Greenlet, Thrasher, object):
+class RBDMirrorThrasher(Greenlet, Thrasher):
     """
     RBDMirrorThrasher::
 


### PR DESCRIPTION
Dropped unnecessary `object` introduced in https://github.com/ceph/ceph/commit/f31791e35d8eeaba2355cf2af6c2cab8b6149c6b