### PR TITLE
test: make ceph-helps.sh ignore unittest cores.

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -177,7 +177,8 @@ function teardown() {
       pattern=""
     fi
     # Local we start with core and teuthology ends with core
-    if ls $(dirname "$pattern") | grep -q '^core\|core$' ; then
+    # unittest cores can be lying around during parallel ctest, and are safe to ignore
+    if ls $(dirname "$pattern") | grep -v unittest | grep -q '^core\|core$' ; then
         cores="yes"
         if [ -n "$LOCALRUN" ]; then
 	    mkdir /tmp/cores.$$ 2> /dev/null || true


### PR DESCRIPTION
When running ctests in parallel it can happen dat there are
unittest cores to be found. They are however not generated
by the tests running with ceph-helpers.
So they can safely be ignore during startup of teardown.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>