### PR TITLE
doc: set ceph_perf_msgr_server arguments

### DIFF
--- a/doc/dev/messenger.rst
+++ b/doc/dev/messenger.rst
@@ -12,14 +12,15 @@ ceph_perf_msgr is used to do benchmark for messenger module only and can help
 to find the bottleneck or time consuming within messenger moduleIt just like
 "iperf", we need to start server-side program firstly:
 
-# ./ceph_perf_msgr_server 172.16.30.181:10001 0
+# ./ceph_perf_msgr_server 172.16.30.181:10001 1 0
 
 The first argument is ip:port pair which is telling the destination address the
-client need to specified. The second argument tells the "think time" when
-dispatching messages. After Giant, CEPH_OSD_OP message which is the actual client
-read/write io request is fast dispatched without queueing to Dispatcher, in order
-to achieve better performance. So CEPH_OSD_OP message will be processed inline,
-"think time" is used by mock this "inline process" process.
+client need to specified. The second argument configures the server threads. The
+third argument tells the "think time"(us) when dispatching messages. After Giant,
+CEPH_OSD_OP message which is the actual client read/write io request is fast
+dispatched without queueing to Dispatcher, in order to achieve better performance.
+So CEPH_OSD_OP message will be processed inline, "think time" is used by mock
+this "inline process" process.
 
 # ./ceph_perf_msgr_client 172.16.30.181:10001 1 32 10000 10 4096 
 


### PR DESCRIPTION
align with commit: d6f6ad03
PerfMsgr: Make Server worker threads configurable

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
