### PR TITLE
rgw: move bucket reshard checks out of write path

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6952,7 +6952,7 @@ std::vector<Option> get_rgw_options() {
 
     Option("rgw_reshard_thread_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(10_min)
-    .set_min(10_min)
+    .set_min(10)
     .set_description("Number of seconds between processing of reshard log entries"),
 
     Option("rgw_cache_expiry_interval", Option::TYPE_UINT,

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -3576,16 +3576,21 @@ int RGWBucketCtl::read_buckets_stats(map<string, RGWBucketEnt>& m,
   });
 }
 
-int RGWBucketCtl::sync_user_stats(const rgw_user& user_id, const RGWBucketInfo& bucket_info)
+int RGWBucketCtl::sync_user_stats(const rgw_user& user_id,
+                                  const RGWBucketInfo& bucket_info,
+                                  RGWBucketEnt* pent)
 {
   RGWBucketEnt ent;
-  int r = svc.bi->read_stats(bucket_info, &ent, null_yield);
+  if (!pent) {
+    pent = &ent;
+  }
+  int r = svc.bi->read_stats(bucket_info, pent, null_yield);
   if (r < 0) {
     ldout(cct, 20) << __func__ << "(): failed to read bucket stats (r=" << r << ")" << dendl;
     return r;
   }
 
-  return ctl.user->flush_bucket_stats(user_id, ent);
+  return ctl.user->flush_bucket_stats(user_id, *pent);
 }
 
 RGWBucketMetadataHandlerBase *RGWBucketMetaHandlerAllocator::alloc()

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -844,7 +844,8 @@ public:
                         optional_yield y);
 
   /* quota related */
-  int sync_user_stats(const rgw_user& user_id, const RGWBucketInfo& bucket_info);
+  int sync_user_stats(const rgw_user& user_id, const RGWBucketInfo& bucket_info,
+                      RGWBucketEnt* pent = nullptr);
 
 private:
   int convert_old_bucket_info(RGWSI_Bucket_X_Ctx& ctx,

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1647,12 +1647,6 @@ namespace rgw {
       goto done;
     }
 
-    op_ret = get_store()->getRados()->check_bucket_shards(s->bucket_info, s->bucket,
-					      bucket_quota);
-    if (op_ret < 0) {
-      goto done;
-    }
-
     hash.Final(m);
 
     if (compressor && compressor->is_compressed()) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3750,11 +3750,6 @@ void RGWPutObj::execute()
       ldpp_dout(this, 20) << "check_quota() returned ret=" << op_ret << dendl;
       return;
     }
-    op_ret = store->getRados()->check_bucket_shards(s->bucket_info, s->bucket, bucket_quota);
-    if (op_ret < 0) {
-      ldpp_dout(this, 20) << "check_bucket_shards() returned ret=" << op_ret << dendl;
-      return;
-    }
   }
 
   if (supplied_etag) {
@@ -3956,12 +3951,6 @@ void RGWPutObj::execute()
     return;
   }
 
-  op_ret = store->getRados()->check_bucket_shards(s->bucket_info, s->bucket, bucket_quota);
-  if (op_ret < 0) {
-    ldpp_dout(this, 20) << "check_bucket_shards() returned ret=" << op_ret << dendl;
-    return;
-  }
-
   hash.Final(m);
 
   if (compressor && compressor->is_compressed()) {
@@ -4133,11 +4122,6 @@ void RGWPostObj::execute()
       return;
     }
 
-    op_ret = store->getRados()->check_bucket_shards(s->bucket_info, s->bucket, bucket_quota);
-    if (op_ret < 0) {
-      return;
-    }
-
     if (supplied_md5_b64) {
       char supplied_md5_bin[CEPH_CRYPTO_MD5_DIGESTSIZE + 1];
       ldpp_dout(this, 15) << "supplied_md5_b64=" << supplied_md5_b64 << dendl;
@@ -4238,11 +4222,6 @@ void RGWPostObj::execute()
 
     op_ret = store->getRados()->check_quota(s->bucket_owner.get_id(), s->bucket,
                                 user_quota, bucket_quota, s->obj_size);
-    if (op_ret < 0) {
-      return;
-    }
-
-    op_ret = store->getRados()->check_bucket_shards(s->bucket_info, s->bucket, bucket_quota);
     if (op_ret < 0) {
       return;
     }
@@ -7005,11 +6984,6 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
     return op_ret;
   }
 
-  op_ret = store->getRados()->check_bucket_shards(s->bucket_info, s->bucket, bucket_quota);
-  if (op_ret < 0) {
-    return op_ret;
-  }
-
   rgw_obj obj(binfo.bucket, object);
   if (s->bucket_info.versioning_enabled()) {
     store->getRados()->gen_rand_obj_instance_name(&obj);
@@ -7090,11 +7064,6 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
 			      user_quota, bucket_quota, size);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "quota exceeded for path=" << path << dendl;
-    return op_ret;
-  }
-
-  op_ret = store->getRados()->check_bucket_shards(s->bucket_info, s->bucket, bucket_quota);
-  if (op_ret < 0) {
     return op_ret;
   }
 

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -635,13 +635,14 @@ int RGWUserStatsCache::sync_bucket(const rgw_user& user, rgw_bucket& bucket)
     return r;
   }
 
-  r = store->ctl()->bucket->sync_user_stats(user, bucket_info);
+  RGWBucketEnt ent;
+  r = store->ctl()->bucket->sync_user_stats(user, bucket_info, &ent);
   if (r < 0) {
     ldout(store->ctx(), 0) << "ERROR: sync_user_stats() for user=" << user << ", bucket=" << bucket << " returned " << r << dendl;
     return r;
   }
 
-  return 0;
+  return store->getRados()->check_bucket_shards(bucket_info, bucket, ent.count);
 }
 
 int RGWUserStatsCache::sync_user(const rgw_user& user)
@@ -971,31 +972,21 @@ public:
     user_stats_cache.adjust_stats(user, bucket, obj_delta, added_bytes, removed_bytes);
   }
 
-  int check_bucket_shards(uint64_t max_objs_per_shard, uint64_t num_shards,
-			  const rgw_user& user, const rgw_bucket& bucket, RGWQuotaInfo& bucket_quota,
-			  uint64_t num_objs, bool& need_resharding, uint32_t *suggested_num_shards) override
+  void check_bucket_shards(uint64_t max_objs_per_shard, uint64_t num_shards,
+			   const rgw_bucket& bucket, uint64_t num_objs,
+			   bool& need_resharding, uint32_t *suggested_num_shards) override
   {
-    RGWStorageStats bucket_stats;
-    int ret = bucket_stats_cache.get_stats(user, bucket, bucket_stats,
-                                           bucket_quota);
-    if (ret < 0) {
-      return ret;
-    }
-
-    if (bucket_stats.num_objects  + num_objs > num_shards * max_objs_per_shard) {
-      ldout(store->ctx(), 0) << __func__ << ": resharding needed: stats.num_objects=" << bucket_stats.num_objects
+    if (num_objs > num_shards * max_objs_per_shard) {
+      ldout(store->ctx(), 0) << __func__ << ": resharding needed: stats.num_objects=" << num_objs
              << " shard max_objects=" <<  max_objs_per_shard * num_shards << dendl;
       need_resharding = true;
       if (suggested_num_shards) {
-        *suggested_num_shards = (bucket_stats.num_objects  + num_objs) * 2 / max_objs_per_shard;
+        *suggested_num_shards = num_objs * 2 / max_objs_per_shard;
       }
     } else {
       need_resharding = false;
     }
-
-    return 0;
   }
-
 };
 
 

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -107,10 +107,9 @@ public:
                           RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota,
 			  uint64_t num_objs, uint64_t size) = 0;
 
-  virtual int check_bucket_shards(uint64_t max_objs_per_shard, uint64_t num_shards,
-				  const rgw_user& bucket_owner, const rgw_bucket& bucket,
-				  RGWQuotaInfo& bucket_quota, uint64_t num_objs, bool& need_resharding,
-                                  uint32_t *suggested_num_shards) = 0;
+  virtual void check_bucket_shards(uint64_t max_objs_per_shard, uint64_t num_shards,
+				   const rgw_bucket& bucket, uint64_t num_objs,
+				   bool& need_resharding, uint32_t *suggested_num_shards) = 0;
 
   virtual void update_stats(const rgw_user& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8432,7 +8432,7 @@ int RGWRados::cls_bucket_head_async(const RGWBucketInfo& bucket_info, int shard_
 }
 
 int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info, const rgw_bucket& bucket,
-				  RGWQuotaInfo& bucket_quota)
+				  uint64_t num_objs)
 {
   if (! cct->_conf.get_val<bool>("rgw_dynamic_resharding")) {
       return 0;
@@ -8444,14 +8444,9 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info, const rgw_bu
 
   const uint64_t max_objs_per_shard =
     cct->_conf.get_val<uint64_t>("rgw_max_objs_per_shard");
-  int ret =
-    quota_handler->check_bucket_shards(max_objs_per_shard, num_source_shards,
-				       bucket_info.owner, bucket, bucket_quota,
-				       1, need_resharding, &suggested_num_shards);
-  if (ret < 0) {
-    return ret;
-  }
-
+  quota_handler->check_bucket_shards(max_objs_per_shard, num_source_shards,
+				     bucket, num_objs, need_resharding,
+				     &suggested_num_shards);
   if (need_resharding) {
     ldout(cct, 20) << __func__ << " bucket " << bucket.name << " need resharding " <<
       " old num shards " << bucket_info.num_shards << " new num shards " << suggested_num_shards <<
@@ -8459,7 +8454,7 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info, const rgw_bu
     return add_bucket_to_reshard(bucket_info, suggested_num_shards);
   }
 
-  return ret;
+  return 0;
 }
 
 int RGWRados::add_bucket_to_reshard(const RGWBucketInfo& bucket_info, uint32_t new_num_shards)

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1420,7 +1420,7 @@ public:
                   RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size, bool check_size_only = false);
 
   int check_bucket_shards(const RGWBucketInfo& bucket_info, const rgw_bucket& bucket,
-			  RGWQuotaInfo& bucket_quota);
+			  uint64_t num_objs);
 
   int add_bucket_to_reshard(const RGWBucketInfo& bucket_info, uint32_t new_num_shards);
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -87,13 +87,13 @@ int rgw_user_sync_all_stats(rgw::sal::RGWRadosStore *store, const rgw_user& user
         ldout(cct, 0) << "ERROR: could not read bucket info: bucket=" << bucket_ent.bucket << " ret=" << ret << dendl;
         continue;
       }
-      ret = store->ctl()->bucket->sync_user_stats(user_id, bucket_info);
+      RGWBucketEnt ent;
+      ret = store->ctl()->bucket->sync_user_stats(user_id, bucket_info, &ent);
       if (ret < 0) {
         ldout(cct, 0) << "ERROR: could not sync bucket stats: ret=" << ret << dendl;
         return ret;
       }
-      RGWQuotaInfo bucket_quota;
-      ret = store->getRados()->check_bucket_shards(bucket_info, bucket_info.bucket, bucket_quota);
+      ret = store->getRados()->check_bucket_shards(bucket_info, bucket_info.bucket, ent.count);
       if (ret < 0) {
 	ldout(cct, 0) << "ERROR in check_bucket_shards: " << cpp_strerror(-ret)<< dendl;
       }


### PR DESCRIPTION
we shouldn't pay for the latency of check_bucket_shards() or add_bucket_to_reshard() on write ops. move them into the quota's bucket sync thread, which tracks modified buckets and syncs their stats every rgw_user_quota_bucket_sync_interval=180 seconds