### PR TITLE
common/condition_variable_debug: do not assert() if sloppy

### DIFF
--- a/src/common/condition_variable_debug.cc
+++ b/src/common/condition_variable_debug.cc
@@ -44,9 +44,11 @@ void condition_variable_debug::notify_one()
 
 void condition_variable_debug::notify_all(bool sloppy)
 {
-  // make sure signaler is holding the waiter's lock.
-  ceph_assert(waiter_mutex == NULL ||
-         waiter_mutex->is_locked());
+  if (!sloppy) {
+    // make sure signaler is holding the waiter's lock.
+    ceph_assert(waiter_mutex == NULL ||
+                waiter_mutex->is_locked());
+  }
   if (int r = pthread_cond_broadcast(&cond); r != 0 && !sloppy) {
     throw std::system_error(r, std::generic_category());
   }


### PR DESCRIPTION
replicate the behavior of `Cond::SloppySignal()` to avoid crash like

 ceph version Development (no_version) octopus (dev)
  1: <ceph::__ceph_assert_fail(char const*, char const, int, char const)+0x1e0> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  2: <ceph::__ceph_assert_fail(ceph::assert_data const&)+0x2f> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  3: <ceph::condition_variable_debug::notify_all(bool)+0x59> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  4: <FileJournal::check_for_full(unsigned long, long, long)+0x4e2> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  5: <FileJournal::prepare_single_write(FileJournal::write_item&, ceph::buffer::v14_2_0::list&, long&, unsigned long&, long&)+0x71> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  6: <FileJournal::prepare_multi_write(ceph::buffer::v14_2_0::list&, unsigned long&, ceph::buffer::v14_2_0::list&)+0x19d> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  7: <FileJournal::write_thread_entry(void)+0x561> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  8: <FileJournal::Writer::entry(void)+0x19> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  9: <Thread::entry_wrapper(void)+0x84> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd
  10: <Thread::_entry_func(void*)+0x15> at /home/jenkins/workspace/ceph-master36/build/bin/ceph-osd

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
