### PR TITLE
backfill_toofull seen on cluster where the most full OSD is at 1%

### DIFF
--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -29,7 +29,7 @@ public:
   enum {
     REQUEST = 0,   // primary->replica: please reserve a slot
     GRANT = 1,     // replica->primary: ok, i reserved it
-    REJECT = 2,    // replica->primary: sorry, try again later (*)
+    REJECT_TOOFULL = 2,    // replica->primary: too full, sorry, try again later (*)
     RELEASE = 3,   // primary->replcia: release the slot i reserved before
     REVOKE_TOOFULL = 4,   // replica->primary: too full, stop backfilling
     REVOKE = 5,    // replica->primary: i'm taking back the slot i gave you
@@ -62,7 +62,7 @@ public:
 	query_epoch,
 	query_epoch,
 	RemoteBackfillReserved());
-    case REJECT:
+    case REJECT_TOOFULL:
       // NOTE: this is replica -> primary "i reject your request"
       //      and also primary -> replica "cancel my previously-granted request"
       //                                  (for older peers)
@@ -71,7 +71,7 @@ public:
       return new PGPeeringEvent(
 	query_epoch,
 	query_epoch,
-	RemoteReservationRejected());
+	RemoteReservationRejectedTooFull());
     case RELEASE:
       return new PGPeeringEvent(
 	query_epoch,
@@ -118,8 +118,8 @@ public:
     case GRANT:
       out << "GRANT";
       break;
-    case REJECT:
-      out << "REJECT ";
+    case REJECT_TOOFULL:
+      out << "REJECT_TOOFULL";
       break;
     case RELEASE:
       out << "RELEASE";
@@ -159,7 +159,7 @@ public:
       encode(pgid.pgid, payload);
       encode(query_epoch, payload);
       encode((type == RELEASE || type == REVOKE_TOOFULL || type == REVOKE) ?
-	       REJECT : type, payload);
+	       REJECT_TOOFULL : type, payload);
       encode(priority, payload);
       encode(pgid.shard, payload);
       return;

--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -31,7 +31,7 @@ public:
     GRANT = 1,     // replica->primary: ok, i reserved it
     REJECT = 2,    // replica->primary: sorry, try again later (*)
     RELEASE = 3,   // primary->replcia: release the slot i reserved before
-    TOOFULL = 4,   // replica->primary: too full, stop backfilling
+    REVOKE_TOOFULL = 4,   // replica->primary: too full, stop backfilling
     REVOKE = 5,    // replica->primary: i'm taking back the slot i gave you
     // (*) NOTE: prior to luminous, REJECT was overloaded to also mean release
   };
@@ -77,7 +77,7 @@ public:
 	query_epoch,
 	query_epoch,
 	RemoteReservationCanceled());
-    case TOOFULL:
+    case REVOKE_TOOFULL:
       return new PGPeeringEvent(
 	query_epoch,
 	query_epoch,
@@ -124,8 +124,8 @@ public:
     case RELEASE:
       out << "RELEASE";
       break;
-    case TOOFULL:
-      out << "TOOFULL";
+    case REVOKE_TOOFULL:
+      out << "REVOKE_TOOFULL";
       break;
     case REVOKE:
       out << "REVOKE";
@@ -158,7 +158,7 @@ public:
       header.compat_version = 3;
       encode(pgid.pgid, payload);
       encode(query_epoch, payload);
-      encode((type == RELEASE || type == TOOFULL || type == REVOKE) ?
+      encode((type == RELEASE || type == REVOKE_TOOFULL || type == REVOKE) ?
 	       REJECT : type, payload);
       encode(priority, payload);
       encode(pgid.shard, payload);

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -162,7 +162,7 @@ struct RequestRecoveryPrio : boost::statechart::event< RequestRecoveryPrio > {
 
 TrivialEvent(NullEvt)
 TrivialEvent(RemoteBackfillReserved)
-TrivialEvent(RemoteReservationRejected)
+TrivialEvent(RemoteReservationRejectedTooFull)
 TrivialEvent(RemoteReservationRevokedTooFull)
 TrivialEvent(RemoteReservationRevoked)
 TrivialEvent(RemoteReservationCanceled)

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4884,7 +4884,7 @@ PeeringState::RepRecovering::react(const BackfillTooFull &)
   pl->send_cluster_message(
     ps->primary.osd,
     new MBackfillReserve(
-      MBackfillReserve::TOOFULL,
+      MBackfillReserve::REVOKE_TOOFULL,
       spg_t(ps->info.pgid.pgid, ps->primary.shard),
       ps->get_osdmap_epoch()),
     ps->get_osdmap_epoch());

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1186,7 +1186,7 @@ void PeeringState::reject_reservation()
   pl->send_cluster_message(
     primary.osd,
     new MBackfillReserve(
-      MBackfillReserve::REJECT,
+      MBackfillReserve::REJECT_TOOFULL,
       spg_t(info.pgid.pgid, primary.shard),
       get_osdmap_epoch()),
     get_osdmap_epoch());
@@ -4564,7 +4564,7 @@ void PeeringState::WaitRemoteBackfillReserved::retry()
 }
 
 boost::statechart::result
-PeeringState::WaitRemoteBackfillReserved::react(const RemoteReservationRejected &evt)
+PeeringState::WaitRemoteBackfillReserved::react(const RemoteReservationRejectedTooFull &evt)
 {
   DECLARE_LOCALS;
   ps->state_set(PG_STATE_BACKFILL_TOOFULL);
@@ -4627,7 +4627,7 @@ PeeringState::NotBackfilling::react(const RemoteBackfillReserved &evt)
 }
 
 boost::statechart::result
-PeeringState::NotBackfilling::react(const RemoteReservationRejected &evt)
+PeeringState::NotBackfilling::react(const RemoteReservationRejectedTooFull &evt)
 {
   return discard_event();
 }
@@ -4671,11 +4671,11 @@ PeeringState::RepNotRecovering::RepNotRecovering(my_context ctx)
 }
 
 boost::statechart::result
-PeeringState::RepNotRecovering::react(const RejectRemoteReservation &evt)
+PeeringState::RepNotRecovering::react(const RejectTooFullRemoteReservation &evt)
 {
   DECLARE_LOCALS;
   ps->reject_reservation();
-  post_event(RemoteReservationRejected());
+  post_event(RemoteReservationRejectedTooFull());
   return discard_event();
 }
 
@@ -4744,7 +4744,7 @@ PeeringState::RepNotRecovering::react(const RequestBackfillPrio &evt)
 
   if (!pl->try_reserve_recovery_space(
 	evt.primary_num_bytes, evt.local_num_bytes)) {
-    post_event(RejectRemoteReservation());
+    post_event(RejectTooFullRemoteReservation());
   } else {
     PGPeeringEventRef preempt;
     if (HAVE_FEATURE(ps->upacting_features, RECOVERY_RESERVATION_2)) {
@@ -4819,17 +4819,17 @@ PeeringState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &evt)
 
 boost::statechart::result
 PeeringState::RepWaitBackfillReserved::react(
-  const RejectRemoteReservation &evt)
+  const RejectTooFullRemoteReservation &evt)
 {
   DECLARE_LOCALS;
   ps->reject_reservation();
-  post_event(RemoteReservationRejected());
+  post_event(RemoteReservationRejectedTooFull());
   return discard_event();
 }
 
 boost::statechart::result
 PeeringState::RepWaitBackfillReserved::react(
-  const RemoteReservationRejected &evt)
+  const RemoteReservationRejectedTooFull &evt)
 {
   DECLARE_LOCALS;
   pl->unreserve_recovery_space();

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4553,7 +4553,6 @@ void PeeringState::WaitRemoteBackfillReserved::retry()
   }
 
   ps->state_clear(PG_STATE_BACKFILL_WAIT);
-  ps->state_set(PG_STATE_BACKFILL_TOOFULL);
   pl->publish_stats_to_osd();
 
   pl->schedule_event_after(
@@ -4567,6 +4566,8 @@ void PeeringState::WaitRemoteBackfillReserved::retry()
 boost::statechart::result
 PeeringState::WaitRemoteBackfillReserved::react(const RemoteReservationRejected &evt)
 {
+  DECLARE_LOCALS;
+  ps->state_set(PG_STATE_BACKFILL_TOOFULL);
   retry();
   return transit<NotBackfilling>();
 }

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -480,7 +480,7 @@ public:
   TrivialEvent(NeedUpThru)
   TrivialEvent(Backfilled)
   TrivialEvent(LocalBackfillReserved)
-  TrivialEvent(RejectRemoteReservation)
+  TrivialEvent(RejectTooFullRemoteReservation)
   TrivialEvent(RequestBackfill)
   TrivialEvent(RemoteRecoveryPreempted)
   TrivialEvent(RemoteBackfillPreempted)
@@ -870,12 +870,12 @@ public:
       boost::statechart::custom_reaction< Backfilled >,
       boost::statechart::custom_reaction< DeferBackfill >,
       boost::statechart::custom_reaction< UnfoundBackfill >,
-      boost::statechart::custom_reaction< RemoteReservationRejected >,
+      boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
       boost::statechart::custom_reaction< RemoteReservationRevokedTooFull>,
       boost::statechart::custom_reaction< RemoteReservationRevoked>
       > reactions;
     explicit Backfilling(my_context ctx);
-    boost::statechart::result react(const RemoteReservationRejected& evt) {
+    boost::statechart::result react(const RemoteReservationRejectedTooFull& evt) {
       // for compat with old peers
       post_event(RemoteReservationRevokedTooFull());
       return discard_event();
@@ -893,7 +893,7 @@ public:
   struct WaitRemoteBackfillReserved : boost::statechart::state< WaitRemoteBackfillReserved, Active >, NamedState {
     typedef boost::mpl::list<
       boost::statechart::custom_reaction< RemoteBackfillReserved >,
-      boost::statechart::custom_reaction< RemoteReservationRejected >,
+      boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
       boost::statechart::custom_reaction< RemoteReservationRevoked >,
       boost::statechart::transition< AllBackfillsReserved, Backfilling >
       > reactions;
@@ -902,7 +902,7 @@ public:
     void retry();
     void exit();
     boost::statechart::result react(const RemoteBackfillReserved& evt);
-    boost::statechart::result react(const RemoteReservationRejected& evt);
+    boost::statechart::result react(const RemoteReservationRejectedTooFull& evt);
     boost::statechart::result react(const RemoteReservationRevoked& evt);
   };
 
@@ -918,12 +918,12 @@ public:
     typedef boost::mpl::list<
       boost::statechart::transition< RequestBackfill, WaitLocalBackfillReserved>,
       boost::statechart::custom_reaction< RemoteBackfillReserved >,
-      boost::statechart::custom_reaction< RemoteReservationRejected >
+      boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >
       > reactions;
     explicit NotBackfilling(my_context ctx);
     void exit();
     boost::statechart::result react(const RemoteBackfillReserved& evt);
-    boost::statechart::result react(const RemoteReservationRejected& evt);
+    boost::statechart::result react(const RemoteReservationRejectedTooFull& evt);
   };
 
   struct NotRecovering : boost::statechart::state< NotRecovering, Active>, NamedState {
@@ -1003,7 +1003,7 @@ public:
     typedef boost::mpl::list<
       boost::statechart::transition< RecoveryDone, RepNotRecovering >,
       // for compat with old peers
-      boost::statechart::transition< RemoteReservationRejected, RepNotRecovering >,
+      boost::statechart::transition< RemoteReservationRejectedTooFull, RepNotRecovering >,
       boost::statechart::transition< RemoteReservationCanceled, RepNotRecovering >,
       boost::statechart::custom_reaction< BackfillTooFull >,
       boost::statechart::custom_reaction< RemoteRecoveryPreempted >,
@@ -1019,15 +1019,15 @@ public:
   struct RepWaitBackfillReserved : boost::statechart::state< RepWaitBackfillReserved, ReplicaActive >, NamedState {
     typedef boost::mpl::list<
       boost::statechart::custom_reaction< RemoteBackfillReserved >,
-      boost::statechart::custom_reaction< RejectRemoteReservation >,
-      boost::statechart::custom_reaction< RemoteReservationRejected >,
+      boost::statechart::custom_reaction< RejectTooFullRemoteReservation >,
+      boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
       boost::statechart::custom_reaction< RemoteReservationCanceled >
       > reactions;
     explicit RepWaitBackfillReserved(my_context ctx);
     void exit();
     boost::statechart::result react(const RemoteBackfillReserved &evt);
-    boost::statechart::result react(const RejectRemoteReservation &evt);
-    boost::statechart::result react(const RemoteReservationRejected &evt);
+    boost::statechart::result react(const RejectTooFullRemoteReservation &evt);
+    boost::statechart::result react(const RemoteReservationRejectedTooFull &evt);
     boost::statechart::result react(const RemoteReservationCanceled &evt);
   };
 
@@ -1035,13 +1035,13 @@ public:
     typedef boost::mpl::list<
       boost::statechart::custom_reaction< RemoteRecoveryReserved >,
       // for compat with old peers
-      boost::statechart::custom_reaction< RemoteReservationRejected >,
+      boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
       boost::statechart::custom_reaction< RemoteReservationCanceled >
       > reactions;
     explicit RepWaitRecoveryReserved(my_context ctx);
     void exit();
     boost::statechart::result react(const RemoteRecoveryReserved &evt);
-    boost::statechart::result react(const RemoteReservationRejected &evt) {
+    boost::statechart::result react(const RemoteReservationRejectedTooFull &evt) {
       // for compat with old peers
       post_event(RemoteReservationCanceled());
       return discard_event();
@@ -1053,8 +1053,8 @@ public:
     typedef boost::mpl::list<
       boost::statechart::custom_reaction< RequestRecoveryPrio >,
       boost::statechart::custom_reaction< RequestBackfillPrio >,
-      boost::statechart::custom_reaction< RejectRemoteReservation >,
-      boost::statechart::transition< RemoteReservationRejected, RepNotRecovering >,
+      boost::statechart::custom_reaction< RejectTooFullRemoteReservation >,
+      boost::statechart::transition< RemoteReservationRejectedTooFull, RepNotRecovering >,
       boost::statechart::transition< RemoteReservationCanceled, RepNotRecovering >,
       boost::statechart::custom_reaction< RemoteRecoveryReserved >,
       boost::statechart::custom_reaction< RemoteBackfillReserved >,
@@ -1071,7 +1071,7 @@ public:
       // my reservation completion raced with a RELEASE from primary
       return discard_event();
     }
-    boost::statechart::result react(const RejectRemoteReservation &evt);
+    boost::statechart::result react(const RejectTooFullRemoteReservation &evt);
     void exit();
   };
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] ~Updates documentation if necessary~
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
