### PR TITLE
[doc] Modify client.glance creation command

### DIFF
--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -245,9 +245,10 @@ The following entries describe valid capability profiles:
 :Description: Gives a user permissions to manipulate RBD images. When used
               as a Monitor cap, it provides the minimal privileges required
               by an RBD client application; this includes the ability
-	      to blacklist other client users. When used as an OSD cap, it
-              provides read-write access to the specified pool to an
-	      RBD client application.
+            to blacklist other client users. When used as an OSD cap, it
+              provides read-write and class-read access for rbd_children and
+              rbd_mirroring prefixes to the specified pool to an RBD client
+              application.
 
 ``profile rbd-mirror`` (Monitor only)
 

--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -128,7 +128,7 @@ Setup Ceph Client Authentication
 If you have `cephx authentication`_ enabled, create a new user for Nova/Cinder
 and Glance. Execute the following::
 
-    ceph auth get-or-create client.glance mon 'profile rbd' osd 'profile rbd pool=images'
+    ceph auth get-or-create client.glance mon 'profile rbd' osd 'allow class-read object_prefix rbd_children, profile rbd pool=images'
     ceph auth get-or-create client.cinder mon 'profile rbd' osd 'profile rbd pool=volumes, profile rbd pool=vms, profile rbd-read-only pool=images'
     ceph auth get-or-create client.cinder-backup mon 'profile rbd' osd 'profile rbd pool=backups'
 


### PR DESCRIPTION
As glance require class-read permissions to rbd_children for
verifying locks across pools, this is good thing to mention inside docs.

Also it adds mention, that profile rbd provides class-read access for
object_prefix'es of rbd_children and rbd_mirroring [1] but for specified
pool only.

[1] https://github.com/ceph/ceph/blob/nautilus/src/osd/OSDCap.cc#L335-L338

Signed-off-by: Dmitriy Rabotyagov <drabotyagov@vexxhost.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
