### PR TITLE
os/bluestore: silence StupidAllocator reorder warning

### DIFF
--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -14,9 +14,8 @@ StupidAllocator::StupidAllocator(CephContext* cct,
                                  const std::string& name,
                                  int64_t _block_size)
   : Allocator(name), cct(cct), num_free(0),
-    free(10),
-    last_alloc(0),
-    block_size(_block_size)
+    block_size(_block_size),
+    free(10)
 {
 }
 

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -26,7 +26,7 @@ class StupidAllocator : public Allocator {
   typedef interval_set<uint64_t,interval_set_map_t> interval_set_t;
   std::vector<interval_set_t> free;  ///< leading-edge copy
 
-  uint64_t last_alloc;
+  uint64_t last_alloc = 0;
 
   unsigned _choose_bin(uint64_t len);
   void _insert_free(uint64_t offset, uint64_t len);


### PR DESCRIPTION
warning: ‘StupidAllocator::last_alloc’ will be initialized after [-Wreorder]

Found this while testing https://github.com/ceph/ceph/pull/29730