### PR TITLE
nautilus: librbd: always try to acquire exclusive lock when removing image

### DIFF
--- a/src/librbd/image/PreRemoveRequest.h
+++ b/src/librbd/image/PreRemoveRequest.h
@@ -35,15 +35,12 @@ private:
    * @verbatim
    *
    *       <start>
-   *          |
-   *          v
-   *   CHECK EXCLUSIVE LOCK
-   *          |
-   *          v (skip if not needed)
-   *  ACQUIRE EXCLUSIVE LOCK
-   *          |
-   *          v
-   *   CHECK IMAGE WATCHERS
+   *          |   (skip if
+   *          v    not needed)   (error)
+   *  ACQUIRE EXCLUSIVE LOCK  * * * * * * > SHUT DOWN EXCLUSIVE LOCK
+   *          |                                |
+   *          v                                |
+   *   CHECK IMAGE WATCHERS <------------------/
    *          |
    *          v
    *     CHECK GROUP
@@ -72,7 +69,9 @@ private:
 
   void acquire_exclusive_lock();
   void handle_exclusive_lock(int r);
-  void handle_exclusive_lock_force(int r);
+
+  void shut_down_exclusive_lock();
+  void handle_shut_down_exclusive_lock(int r);
 
   void validate_image_removal();
   void check_image_snaps();


### PR DESCRIPTION
We want it to use object map for fast removal.

Fixes: https://tracker.ceph.com/issues/41229
Signed-off-by: Mykola Golub <mgolub@suse.com>
(cherry picked from commit 48ab30d9b551edbb5270972ea8cdb8caf02769a7)

Backport ticket:  https://tracker.ceph.com/issues/41420
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
