### PR TITLE
luminous: rbd-mirror: don't overwrite status error returned by replay

### DIFF
--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -982,14 +982,13 @@ void ImageReplayer<I>::handle_replay_complete(int r, const std::string &error_de
   dout(10) << "r=" << r << dendl;
   if (r < 0) {
     derr << "replay encountered an error: " << cpp_strerror(r) << dendl;
-    set_state_description(r, error_desc);
   }
 
   {
     Mutex::Locker locker(m_lock);
     m_stop_requested = true;
   }
-  on_replay_interrupted();
+  on_stop_journal_replay(r, error_desc);
 }
 
 template <typename I>


### PR DESCRIPTION
Backport ticket: https://tracker.ceph.com/issues/41285

---

Fixes: https://tracker.ceph.com/issues/39980
Signed-off-by: Mykola Golub <mgolub@suse.com>
(cherry picked from commit c06ebf0c075e0533149572fde6c203ab22495cf6)
