### PR TITLE
rgw/pubsub: service reordering issue

### DIFF
--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -616,7 +616,6 @@ int RGWUserPubSub::write(const rgw_raw_obj& obj, const T& info, RGWObjVersionTra
   bufferlist bl;
   encode(info, bl);
 
-  auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
   int ret = rgw_put_system_obj(obj_ctx, obj.pool, obj.oid,
                            bl, false, objv_tracker,
                            real_time());

--- a/src/rgw/services/svc_sync_modules.cc
+++ b/src/rgw/services/svc_sync_modules.cc
@@ -7,6 +7,8 @@
 #include "rgw/rgw_sync_module.h"
 #include "rgw/rgw_zone.h"
 
+#define dout_subsys ceph_subsys_rgw
+
 void RGWSI_SyncModules::init(RGWSI_Zone *zone_svc)
 {
   svc.zone = zone_svc;
@@ -29,6 +31,8 @@ int RGWSI_SyncModules::do_start()
     }
     return ret;
   }
+
+  ldout(cct, 20) << "started sync module instance, tier type = " << zone_public_config.tier_type << dendl;
 
   return 0;
 }

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -63,10 +63,7 @@ int RGWSI_Zone::do_start()
   if (ret < 0) {
     return ret;
   }
-  ret = sync_modules_svc->start();
-  if (ret < 0) {
-    return ret;
-  }
+
   ret = realm->init(cct, sysobj_svc);
   if (ret < 0 && ret != -ENOENT) {
     ldout(cct, 0) << "failed reading realm info: ret "<< ret << " " << cpp_strerror(-ret) << dendl;
@@ -146,13 +143,18 @@ int RGWSI_Zone::do_start()
   }
   if (zone_iter != zonegroup->zones.end()) {
     *zone_public_config = zone_iter->second;
-    ldout(cct, 20) << "zone " << zone_params->get_name() << dendl;
+    ldout(cct, 20) << "zone " << zone_params->get_name() << " found"  << dendl;
   } else {
     lderr(cct) << "Cannot find zone id=" << zone_params->get_id() << " (name=" << zone_params->get_name() << ")" << dendl;
     return -EINVAL;
   }
 
   zone_short_id = current_period->get_map().get_zone_short_id(zone_params->get_id());
+
+  ret = sync_modules_svc->start();
+  if (ret < 0) {
+    return ret;
+  }
 
   RGWSyncModuleRef sm;
   if (!sync_modules_svc->get_manager()->get_module(zone_public_config->tier_type, &sm)) {
@@ -173,7 +175,7 @@ int RGWSI_Zone::do_start()
   if (zone_by_id.find(zone_id()) == zone_by_id.end()) {
     ldout(cct, 0) << "WARNING: could not find zone config in zonegroup for local zone (" << zone_id() << "), will use defaults" << dendl;
   }
-  *zone_public_config = zone_by_id[zone_id()];
+
   for (const auto& ziter : zonegroup->zones) {
     const string& id = ziter.first;
     const RGWZone& z = ziter.second;
@@ -199,6 +201,9 @@ int RGWSI_Zone::do_start()
       ldout(cct, 20) << "NOTICE: not syncing to/from zone " << z.name << " id " << z.id << dendl;
     }
   }
+
+  ldout(cct, 20) << "started zone id=" << zone_params->get_id() << " (name=" << zone_params->get_name() << 
+        ") with tier type = " << zone_public_config->tier_type << dendl;
 
   return 0;
 }


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>
this PR is addressing 2 regression issues:

1. Zone service was populating its configuration after sync module start was called.
therefore, tier_type parameter was not taken into account when the REST API filter was created, and pubsub REST commands were not supported on the pubsub zone
2. Local object context variable shadowed the member one, causing the cache invalidation not to be effective. this was causing all tests, where multiple notifications are sent in one JSON, to fail

pubsub tests are passing (other multisite failures are expected):
http://pulpito.front.sepia.ceph.com/yuvalif-2019-08-26_06:21:43-rgw:multisite-pubsub_regression_issue2-distro-basic-smithi/
