### PR TITLE
test/bufferlist.cc: encode/decode int64_t instead of long

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -843,7 +843,7 @@ TEST(BufferListIterator, iterate_with_empties) {
   EXPECT_EQ(bl.length(), 0u);
   EXPECT_EQ(bl.get_num_buffers(), 1u);
 
-  encode(42l, bl);
+  encode(int64_t(42), bl);
   EXPECT_EQ(bl.get_num_buffers(), 2u);
 
   bl.push_back(ceph::buffer::create(0));
@@ -859,11 +859,11 @@ TEST(BufferListIterator, iterate_with_empties) {
     bl.append(bl_with_empty_ptr);
   }
 
-  encode(24l, bl);
+  encode(int64_t(24), bl);
   EXPECT_EQ(bl.get_num_buffers(), 5u);
 
   auto i = bl.cbegin();
-  long val;
+  int64_t val;
   decode(val, i);
   EXPECT_EQ(val, 42l);
 
@@ -871,7 +871,7 @@ TEST(BufferListIterator, iterate_with_empties) {
   EXPECT_EQ(val, 24l);
 
   val = 0;
-  i.seek(sizeof(long));
+  i.seek(sizeof(val));
   decode(val, i);
   EXPECT_EQ(val, 24l);
   EXPECT_TRUE(i == bl.end());
@@ -2671,7 +2671,7 @@ TEST(BufferList, InternalCarriage) {
   ceph::bufferlist bl;
   EXPECT_EQ(bl.get_num_buffers(), 0u);
 
-  encode(42l, bl);
+  encode(int64_t(42), bl);
   EXPECT_EQ(bl.get_num_buffers(), 1u);
 
   {
@@ -2684,7 +2684,7 @@ TEST(BufferList, InternalCarriage) {
     EXPECT_EQ(bl.get_num_buffers(), 2u);
   }
 
-  encode(24l, bl);
+  encode(int64_t(24), bl);
   EXPECT_EQ(bl.get_num_buffers(), 3u);
 }
 
@@ -2696,7 +2696,7 @@ TEST(BufferList, ContiguousAppender) {
   {
     auto ap = bl.get_contiguous_appender(100);
 
-    denc(42l, ap);
+    denc(int64_t(42), ap);
     EXPECT_EQ(bl.get_num_buffers(), 1u);
 
     // append bufferlist with single ptr inside. This should
@@ -2713,11 +2713,11 @@ TEST(BufferList, ContiguousAppender) {
       EXPECT_EQ(bl.get_num_buffers(), 3u);
     }
 
-    denc(24l, ap);
+    denc(int64_t(24), ap);
     EXPECT_EQ(bl.get_num_buffers(), 3u);
-    EXPECT_EQ(bl.length(), sizeof(long) + 3u);
+    EXPECT_EQ(bl.length(), sizeof(int64_t) + 3u);
   }
-  EXPECT_EQ(bl.length(), 2u * sizeof(long) + 3u);
+  EXPECT_EQ(bl.length(), 2u * sizeof(int64_t) + 3u);
 }
 
 TEST(BufferList, TestPtrAppend) {


### PR DESCRIPTION
use `int64_t` instead of `long`, as on LP64 systems, `long` are 64bit.
and LP64 is quite popular nowadays.

quote from Alexandre's mail:

> encode/decode don't handle long at all, they deal with u?int{32,64}_t
> and uint64_t.  When int64_t happens to be int or long, this works, but
> when int64_t is long long, then long ends up uncovered

Signed-off-by: Alexandre Oliva <oliva@gnu.org>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
