### PR TITLE
rgw/rgw_reshard: Don't dump RGWBucketReshard JSON in process_single_logshard

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -993,11 +993,8 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	}
 
 	RGWBucketReshard br(store, bucket_info, attrs, nullptr);
-
-	Formatter* formatter = new JSONFormatter(false);
-	auto formatter_ptr = std::unique_ptr<Formatter>(formatter);
-	ret = br.execute(entry.new_num_shards, max_entries, true, nullptr,
-			 formatter, this);
+	ret = br.execute(entry.new_num_shards, max_entries, false, nullptr,
+			 nullptr, this);
 	if (ret < 0) {
 	  ldout (store->ctx(), 0) <<  __func__ <<
 	    "ERROR in reshard_bucket " << entry.bucket_name << ":" <<


### PR DESCRIPTION
Currently a significant amount of wallclock time is spent in the rgw_reshard thread dumping rgw_bucket_dir_entries to JSON.  While the current code can avoid dumping JSON, we currently always pass true when calling RGWBucketReshard::execute in process_single_logshard.  This PR instead disables dumping JSON when called from process_single_logshard.  During testing of a resharding event of a single bucket from 16->32 shards (ie ~1.6M objects), this appeared to reduce the reshard time (and thus time spent blocking writes) from 65s to 25s on a single NVMe backed OSD instance.  If we determine that we do in fact want to dump to JSON by default, we should consider moving the JSON encoding/formatting out of the hot path as an alternative.

Wallclock profle of the rgw_reshard thread before:
```
Thread: 133 (rgw_reshard) - 1000 samples 

+ 100.00% clone
  + 100.00% start_thread
    + 100.00% RGWReshard::ReshardWorker::entry
      + 99.90% RGWReshard::process_all_logshards
      | + 99.90% RGWReshard::process_single_logshard
      |   + 98.40% RGWBucketReshard::execute
      |   | + 98.10% RGWBucketReshard::do_reshard
      |   | | + 41.20% encode_json<rgw_cls_bi_entry>
      |   | | | + 40.40% rgw_cls_bi_entry::dump
      |   | | | | + 37.40% dump_bi_entry
      |   | | | | | + 35.40% encode_json<rgw_bucket_dir_entry>
      |   | | | | | | + 32.80% rgw_bucket_dir_entry::dump
      |   | | | | | | | + 17.50% encode_json<rgw_bucket_dir_entry_meta>
      |   | | | | | | | + 4.60% encode_json<rgw_bucket_entry_ver>
      |   | | | | | | | + 4.40% ceph::JSONFormatter::print_quoted_string
      |   | | | | | | | + 2.70% ceph::JSONFormatter::add_value<long>
      |   | | | | | | | + 2.10% ceph::JSONFormatter::add_value
      |   | | | | | | | + 0.80% encode_json
      |   | | | | | | | + 0.70% encode_json<std::basic_string<char>, rgw_bucket_pending_info>
      |   | | | | | | + 2.30% ceph::JSONFormatter::add_value<unsigned long>
      |   | | | | | | + 0.20% ceph::JSONFormatter::close_section
      |   | | | | | | + 0.10% ceph::JSONFormatter::open_section
      |   | | | | | + 1.80% decode
      |   | | | | | + 0.20% rgw_bucket_dir_entry::~rgw_bucket_dir_entry
      |   | | | | + 1.50% ceph::JSONFormatter::print_quoted_string
      |   | | | | + 0.70% ceph::JSONFormatter::add_value
      |   | | | | + 0.20% ~list
      |   | | | | + 0.20% list
      |   | | | | + 0.20% encode_json
      |   | | | | + 0.10% ~basic_string
      |   | | | | + 0.10% std::string::operator=
      |   | | | + 0.70% ceph::JSONFormatter::open_section
      |   | | | + 0.10% ceph::JSONFormatter::close_section
      |   | | + 41.20% RGWRados::bi_list
      |   | | | + 41.10% RGWRados::bi_list
      |   | | | | + 41.10% cls_rgw_bi_list
      |   | | | |   + 41.10% librados::v14_2_0::IoCtx::exec
      |   | | | |     + 41.10% librados::IoCtxImpl::exec
      |   | | | |       + 41.10% librados::IoCtxImpl::operate_read
      |   | | | |         + 41.00% wait<librados::IoCtxImpl::operate_read(const object_t&, ObjectOperation*, ceph::bufferlist*, int)::<lambda()> >
      |   | | | |         | + 41.00% std::condition_variable::wait(std::unique_lock<std::mutex>&)
      |   | | | |         |   + 41.00% pthread_cond_wait@@GLIBC_2.3.2
      |   | | | |         + 0.10% Objecter::op_submit
      |   | | | + 0.10% RGWRados::BucketShard::init
      |   | | + 4.80% add_entry
      |   | | + 3.20% rgw_cls_bi_entry::get_info
      |   | | + 3.20% ceph::JSONFormatter::add_value<long>
      |   | | + 2.70% ceph::JSONFormatter::add_value<unsigned long>
      |   | | + 0.70% clear
      |   | | + 0.30% rgw_obj
      |   | | + 0.20% ceph::JSONFormatter::open_section
      |   | | + 0.20% ceph::JSONFormatter::close_section
      |   | | + 0.10% ~rgw_obj
      |   | | + 0.10% rgw_obj_key
      |   | | + 0.10% operator=
      |   | | + 0.10% ceph::JSONFormatter::open_object_section
      |   | + 0.10% set_resharding_status
      |   | + 0.10% RGWReshard::update
      |   | + 0.10% RGWBucketReshard::create_new_bucket_instance
      |   + 0.50% RGWReshard::list
      |   + 0.50% RGWBucketReshardLock::unlock
      |   + 0.50% RGWBucketReshardLock::lock
      + 0.10% wait_for<long, std::ratio<1> >
```

After:
```
Thread: 133 (rgw_reshard) - 1000 samples 

+ 100.00% clone
  + 100.00% start_thread
    + 100.00% RGWReshard::ReshardWorker::entry
      + 100.00% RGWReshard::process_all_logshards
        + 100.00% RGWReshard::process_single_logshard
          + 45.00% RGWBucketReshardLock::lock
          | + 45.00% rados::cls::lock::Lock::lock_exclusive
          |   + 45.00% rados::cls::lock::lock
          |     + 45.00% librados::v14_2_0::IoCtx::operate
          |       + 45.00% librados::IoCtxImpl::operate
          |         + 44.90% wait<librados::IoCtxImpl::operate(const object_t&, ObjectOperation*, ceph::real_time*, int)::<lambda()> >
          |         | + 44.90% std::condition_variable::wait(std::unique_lock<std::mutex>&)
          |         |   + 44.90% pthread_cond_wait@@GLIBC_2.3.2
          |         |     + 0.10% __pthread_mutex_cond_lock
          |         + 0.10% Objecter::op_submit
          + 38.90% RGWBucketReshardLock::unlock
          | + 38.90% rados::cls::lock::Lock::unlock
          |   + 38.90% rados::cls::lock::unlock
          |     + 38.90% librados::v14_2_0::IoCtx::operate
          |       + 38.90% librados::IoCtxImpl::operate
          |         + 38.90% wait<librados::IoCtxImpl::operate(const object_t&, ObjectOperation*, ceph::real_time*, int)::<lambda()> >
          |           + 38.90% std::condition_variable::wait(std::unique_lock<std::mutex>&)
          |             + 38.90% pthread_cond_wait@@GLIBC_2.3.2
          |               + 0.10% __pthread_mutex_cond_lock
          + 16.10% RGWReshard::list
```

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
