### PR TITLE
mgr: add guards to PyInt_Check

### DIFF
--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -305,8 +305,10 @@ ceph_set_health_checks(BaseMgrModule *self, PyObject *args)
       } else if (ks == "count") {
 	if (PyLong_Check(v)) {
 	  count = PyLong_AsLong(v);
+#if PY_MAJOR_VERSION < 3
 	} else if (PyInt_Check(v)) {
 	  count = PyInt_AsLong(v);
+#endif
 	} else {
 	  derr << __func__ << " check " << check_name
 	       << " count value not long or int" << dendl;
@@ -348,7 +350,7 @@ ceph_set_health_checks(BaseMgrModule *self, PyObject *args)
   self->py_modules->set_health_checks(self->this_module->get_name(),
                                       std::move(out_checks));
   PyEval_RestoreThread(tstate);
-  
+
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Introduced by 69a712ad4bf48eb81a503e14d9957b1186ed35f5

Fixes: https://tracker.ceph.com/issues/41432
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
