### PR TITLE
luminous: ceph-volume: tests set the noninteractive flag for Debian

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -17,6 +17,7 @@ setenv=
   ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
+  DEBIAN_FRONTEND=noninteractive
 changedir=
   centos7-filestore-single_type: {toxinidir}/centos7/filestore/single-type
   centos7-filestore-single_type_dmcrypt: {toxinidir}/centos7/filestore/single-type-dmcrypt

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -18,6 +18,7 @@ setenv=
   ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
+  DEBIAN_FRONTEND=noninteractive
 changedir=
   # plain/unencrypted
   centos7-filestore-create: {toxinidir}/centos7/filestore/create

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -18,6 +18,7 @@ setenv=
   ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
+  DEBIAN_FRONTEND=noninteractive
 changedir=
   centos7-filestore-activate: {toxinidir}/centos7/filestore/activate
   centos7-bluestore-activate: {toxinidir}/centos7/bluestore/activate


### PR DESCRIPTION
We haven't been able to reproduce this issue, but it causes tests to randomly fail. Ensuring that the `noninteractive` flag is set we are at least trying to disable this situation, *hopefully* this means we will get more information if a failure happens, instead of: `Error was: 'debconf: unable to initialize frontend: Dialog`

Fixes: https://tracker.ceph.com/issues/41378
Backport of: https://github.com/ceph/ceph/pull/29804