### PR TITLE
qa/vstart_runner.py: add more options

### DIFF
--- a/doc/dev/developer_guide/index.rst
+++ b/doc/dev/developer_guide/index.rst
@@ -1636,6 +1636,8 @@ vstart_runner.py can take 3 options -
 --create-cluster-only       creates the cluster and quits; tests can be issued
                             later
 --interactive               drops a Python shell when a test fails
+--teardown                  tears Ceph cluster down after test(s) has finished
+                            runnng
 
 Internal working of vstart_runner.py -
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/dev/developer_guide/index.rst
+++ b/doc/dev/developer_guide/index.rst
@@ -1632,6 +1632,7 @@ it would execute a single test.
 
 vstart_runner.py can take 3 options -
 
+--clear-old-log             deletes old log file before running the test
 --create                    create Ceph cluster before running a test
 --create-cluster-only       creates the cluster and quits; tests can be issued
                             later

--- a/doc/dev/developer_guide/index.rst
+++ b/doc/dev/developer_guide/index.rst
@@ -1636,6 +1636,7 @@ vstart_runner.py can take 3 options -
 --create-cluster-only       creates the cluster and quits; tests can be issued
                             later
 --interactive               drops a Python shell when a test fails
+--log-ps-output             logs ps output; might be useful while debugging
 --teardown                  tears Ceph cluster down after test(s) has finished
                             runnng
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -390,10 +390,13 @@ class LocalDaemon(object):
             if line.find("ceph-{0} -i {1}".format(self.daemon_type, self.daemon_id)) != -1:
                 log.info("Found ps line for daemon: {0}".format(line))
                 return int(line.split()[0])
-        log.info("No match for {0} {1}: {2}".format(
-            self.daemon_type, self.daemon_id, ps_txt
-            ))
-        return None
+        if log_ps_output:
+            log.info("No match for {0} {1}: {2}".format(
+                self.daemon_type, self.daemon_id, ps_txt))
+        else:
+            log.info("No match for {0} {1}".format(self.daemon_type,
+                     self.daemon_id))
+            return None
 
     def wait(self, timeout):
         waited = 0
@@ -999,6 +1002,8 @@ def exec_test():
     create_cluster_only = False
     ignore_missing_binaries = False
     teardown_cluster = False
+    global log_ps_output
+    log_ps_output = False
 
     args = sys.argv[1:]
     flags = [a for a in args if a.startswith("-")]
@@ -1014,6 +1019,8 @@ def exec_test():
             ignore_missing_binaries = True
         elif f == '--teardown':
             teardown_cluster = True
+        elif f == '--log-ps-output':
+            log_ps_output = True
         else:
             log.error("Unknown option '{0}'".format(f))
             sys.exit(-1)

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -989,7 +989,7 @@ class LocalContext(object):
 
 def _teardown_cluster():
     log.info('\ntearing down the cluster...')
-    remote.run(args = [os.path.join(SRC_PREFIX, "stop.sh")])
+    remote.run(args = [os.path.join(SRC_PREFIX, "stop.sh")], timeout=60)
     remote.run(args = ['rm', '-rf', './dev', './out'])
 
 def exec_test():
@@ -1060,7 +1060,9 @@ def exec_test():
         if require_memstore:
             args.append("--memstore")
 
-        remote.run(args, env=vstart_env)
+        # usually, i get vstart.sh running completely in less than 100
+        # seconds.
+        remote.run(args, env=vstart_env, timeout=(3 * 60))
 
         # Wait for OSD to come up so that subsequent injectargs etc will
         # definitely succeed

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1005,6 +1005,22 @@ def _teardown_cluster():
     remote.run(args = [os.path.join(SRC_PREFIX, "stop.sh")], timeout=60)
     remote.run(args = ['rm', '-rf', './dev', './out'])
 
+def _clear_old_log():
+    from os import stat
+
+    try:
+        stat(logpath)
+    # would need an update when making this py3 compatible. Use FileNotFound
+    # instead.
+    except OSError:
+        return
+    else:
+        os.remove(logpath)
+        with open(logpath, 'w') as logfile:
+            logfile.write('')
+        init_log()
+        log.info('logging in a fresh file now...')
+
 def exec_test():
     # Parse arguments
     interactive_on_error = False
@@ -1014,6 +1030,7 @@ def exec_test():
     teardown_cluster = False
     global log_ps_output
     log_ps_output = False
+    clear_old_log = False
 
     args = sys.argv[1:]
     flags = [a for a in args if a.startswith("-")]
@@ -1031,6 +1048,9 @@ def exec_test():
             teardown_cluster = True
         elif f == '--log-ps-output':
             log_ps_output = True
+        elif f == '--clear-old-log':
+            clear_old_log = True
+            _clear_old_log()
         else:
             log.error("Unknown option '{0}'".format(f))
             sys.exit(-1)

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -53,15 +53,25 @@ from teuthology.config import config as teuth_config
 
 import logging
 
-log = logging.getLogger(__name__)
+def init_log():
+    global log
+    if log is not None:
+        del log
+    log = logging.getLogger(__name__)
 
-handler = logging.FileHandler("./vstart_runner.log")
-formatter = logging.Formatter(
-    fmt=u'%(asctime)s.%(msecs)03d %(levelname)s:%(name)s:%(message)s',
-    datefmt='%Y-%m-%dT%H:%M:%S')
-handler.setFormatter(formatter)
-log.addHandler(handler)
-log.setLevel(logging.INFO)
+    global logpath
+    logpath = './vstart_runner.log'
+
+    handler = logging.FileHandler(logpath)
+    formatter = logging.Formatter(
+        fmt=u'%(asctime)s.%(msecs)03d %(levelname)s:%(name)s:%(message)s',
+        datefmt='%Y-%m-%dT%H:%M:%S')
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+
+log = None
+init_log()
 
 
 def respawn_in_path(lib_path, python_paths):


### PR DESCRIPTION
This PR adds following options to `vstart_runner.py` -

* `--clear-old-log`: option creates fresh log file
* `--teardown`: tears cluster down after tests have completed running option
* `--show-ps-output`: now onwards ps output is suppressed in logs by default
since it makes log harder to read. to prevent that use this option.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>