### PR TITLE
debian/control: fix Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,10 +57,10 @@ Build-Depends: cmake (>= 3.5),
                libxml2-dev,
 # Crimson      libyaml-cpp-dev,
                librabbitmq-dev,
-# Make-Check   libxmlsec1
-# Make-Check   libxmlsec1-nss
-# Make-Check   libxmlsec1-openssl
-# Make-Check   libxmlsec1-dev
+# Make-Check   libxmlsec1,
+# Make-Check   libxmlsec1-nss,
+# Make-Check   libxmlsec1-openssl,
+# Make-Check   libxmlsec1-dev,
                lsb-release,
                parted,
                patch,


### PR DESCRIPTION
it's a regression introduced by 5d6d770e

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
