### PR TITLE
cmake: set empty RPATH for some test executables

### DIFF
--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -45,7 +45,8 @@ add_executable(ceph_test_mon_memory_target
   test_mon_memory_target.cc)
 target_link_libraries(ceph_test_mon_memory_target Boost::system Threads::Threads)
 set_target_properties(ceph_test_mon_memory_target PROPERTIES
-  SKIP_RPATH TRUE)
+  SKIP_RPATH TRUE
+  INSTALL_RPATH "")
 install(TARGETS ceph_test_mon_memory_target
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -53,7 +54,8 @@ install(TARGETS ceph_test_mon_memory_target
 add_executable(ceph_test_log_rss_usage
   test_log_rss_usage.cc)
 set_target_properties(ceph_test_log_rss_usage PROPERTIES
-  SKIP_RPATH TRUE)
+  SKIP_RPATH TRUE
+  INSTALL_RPATH "")
 install(TARGETS ceph_test_log_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -61,7 +63,8 @@ install(TARGETS ceph_test_log_rss_usage
 add_executable(ceph_test_mon_rss_usage
   test_mon_rss_usage.cc)
 set_target_properties(ceph_test_mon_rss_usage PROPERTIES
-  SKIP_RPATH TRUE)
+  SKIP_RPATH TRUE
+  INSTALL_RPATH "")
 install(TARGETS ceph_test_mon_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41524
Signed-off-by: Nathan Cutler <ncutler@suse.com>
