### PR TITLE
mgr/dashboard: Missing service metadata is not handled correctly

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -176,6 +176,11 @@ class CephFS(RESTController):
                     activity = 0.0
 
                 metadata = mgr.get_metadata('mds', info['name'])
+                if metadata is None:
+                    raise DashboardException(
+                        "Failed to fetch metadata for service mds.{}".format(info['name']),
+                        http_status_code=500,
+                        component='cephfs')
                 mds_versions[metadata.get('ceph_version', 'unknown')].append(
                     info['name'])
                 rank_table.append(
@@ -245,9 +250,13 @@ class CephFS(RESTController):
         standby_table = []
         for standby in fsmap['standbys']:
             metadata = mgr.get_metadata('mds', standby['name'])
+            if metadata is None:
+                raise DashboardException(
+                    "Failed to fetch metadata for service mds.{}".format(info['name']),
+                    http_status_code=500,
+                    component='cephfs')
             mds_versions[metadata.get('ceph_version', 'unknown')].append(
                 standby['name'])
-
             standby_table.append({
                 'name': standby['name']
             })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
@@ -7,7 +7,7 @@
 
         <cd-table [data]="ranks.data"
                   [columns]="ranks.columns"
-                  (fetchData)="refresh()"
+                  (fetchData)="refresh($event)"
                   [toolHeader]="false">
         </cd-table>
 


### PR DESCRIPTION
The Dashboard REST API throws a Python error when fetching metadata for service mds.X fails. Instead of a Python error an exception should be thrown.

Fixes: https://tracker.ceph.com/issues/41525

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
