### PR TITLE
nautilus: mgr/volumes: minor fixes

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -162,6 +162,17 @@ class TestVolumes(CephFSTestCase):
         else:
             raise
 
+    def test_subvolume_create_with_invalid_size(self):
+        # create subvolume with an invalid size -1
+        subvolume = self._generate_random_subvolume_name()
+        try:
+            self._fs_cmd("subvolume", "create", self.volname, subvolume, "--size", "-1")
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise
+        else:
+            raise RuntimeError("expected the 'fs subvolume create' command to fail")
+
     def test_nonexistent_subvolume_rm(self):
         # remove non-existing subvolume
         subvolume = "non_existent_subvolume"

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -132,6 +132,20 @@ class TestVolumes(CephFSTestCase):
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
+    def test_subvolume_create_with_invalid_data_pool_layout(self):
+        subvolume = self._generate_random_subvolume_name()
+        data_pool = "invalid_pool"
+        # create subvolume with invalid data pool layout
+        try:
+            self._fs_cmd("subvolume", "create", self.volname, subvolume, "--pool_layout", data_pool)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise
+        else:
+            raise
+        # clean up
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume, "--force")
+
     def test_nonexistent_subvolume_rm(self):
         # remove non-existing subvolume
         subvolume = "non_existent_subvolume"
@@ -220,6 +234,20 @@ class TestVolumes(CephFSTestCase):
 
         self._fs_cmd("subvolumegroup", "rm", self.volname, group1)
         self._fs_cmd("subvolumegroup", "rm", self.volname, group2)
+
+    def test_subvolume_group_create_with_invalid_data_pool_layout(self):
+        group = self._generate_random_group_name()
+        data_pool = "invalid_pool"
+        # create group with invalid data pool layout
+        try:
+            self._fs_cmd("subvolumegroup", "create", self.volname, group, "--pool_layout", data_pool)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise
+        else:
+            raise
+        # clean up
+        self._fs_cmd("subvolumegroup", "rm", self.volname, group, "--force")
 
     def test_subvolume_create_with_desired_data_pool_layout_in_group(self):
         subvol1 = self._generate_random_subvolume_name()

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -146,6 +146,22 @@ class TestVolumes(CephFSTestCase):
         # clean up
         self._fs_cmd("subvolume", "rm", self.volname, subvolume, "--force")
 
+    def test_subvolume_create_with_auto_cleanup_on_fail(self):
+        subvolume = self._generate_random_subvolume_name()
+        data_pool = "invalid_pool"
+        # create subvolume with invalid data pool layout fails
+        with self.assertRaises(CommandFailedError):
+            self._fs_cmd("subvolume", "create", self.volname, subvolume, "--pool_layout", data_pool)
+
+        # check whether subvol path is cleaned up
+        try:
+            self._fs_cmd("subvolume", "getpath", self.volname, subvolume)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise
+        else:
+            raise
+
     def test_nonexistent_subvolume_rm(self):
         # remove non-existing subvolume
         subvolume = "non_existent_subvolume"
@@ -248,6 +264,22 @@ class TestVolumes(CephFSTestCase):
             raise
         # clean up
         self._fs_cmd("subvolumegroup", "rm", self.volname, group, "--force")
+
+    def test_subvolume_group_create_with_auto_cleanup_on_fail(self):
+        group = self._generate_random_group_name()
+        data_pool = "invalid_pool"
+        # create group with invalid data pool layout
+        with self.assertRaises(CommandFailedError):
+            self._fs_cmd("subvolumegroup", "create", self.volname, group, "--pool_layout", data_pool)
+
+        # check whether group path is cleaned up
+        try:
+            self._fs_cmd("subvolumegroup", "getpath", self.volname, group)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.ENOENT:
+                raise
+        else:
+            raise
 
     def test_subvolume_create_with_desired_data_pool_layout_in_group(self):
         subvol1 = self._generate_random_subvolume_name()

--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -77,8 +77,10 @@ class SubVolume(object):
 
         try:
             if size is not None:
-                self.fs.setxattr(subvolpath, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
-
+                try:
+                    self.fs.setxattr(subvolpath, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
+                except cephfs.InvalidValue as e:
+                    raise VolumeException(-errno.EINVAL, "Invalid size: '{0}'".format(size))
             if pool:
                 try:
                     self.fs.setxattr(subvolpath, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)

--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -75,29 +75,40 @@ class SubVolume(object):
 
         self.fs.mkdirs(subvolpath, mode)
 
-        if size is not None:
-            self.fs.setxattr(subvolpath, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
+        try:
+            if size is not None:
+                self.fs.setxattr(subvolpath, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
 
-        if pool:
+            if pool:
+                try:
+                    self.fs.setxattr(subvolpath, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)
+                except cephfs.InvalidValue:
+                    raise VolumeException(-errno.EINVAL,
+                                          "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
+
+            xattr_key = xattr_val = None
+            if namespace_isolated:
+                # enforce security isolation, use separate namespace for this subvolume
+                xattr_key = 'ceph.dir.layout.pool_namespace'
+                xattr_val = spec.fs_namespace
+            elif not pool:
+                # If subvolume's namespace layout is not set, then the subvolume's pool
+                # layout remains unset and will undesirably change with ancestor's
+                # pool layout changes.
+                xattr_key = 'ceph.dir.layout.pool'
+                xattr_val = self._get_ancestor_xattr(subvolpath, "ceph.dir.layout.pool")
+            # TODO: handle error...
+            self.fs.setxattr(subvolpath, xattr_key, xattr_val.encode('utf-8'), 0)
+        except Exception as e:
             try:
-                self.fs.setxattr(subvolpath, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)
-            except cephfs.InvalidValue:
-                raise VolumeException(-errno.EINVAL,
-                                      "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
-
-        xattr_key = xattr_val = None
-        if namespace_isolated:
-            # enforce security isolation, use separate namespace for this subvolume
-            xattr_key = 'ceph.dir.layout.pool_namespace'
-            xattr_val = spec.fs_namespace
-        elif not pool:
-            # If subvolume's namespace layout is not set, then the subvolume's pool
-            # layout remains unset and will undesirably change with ancestor's
-            # pool layout changes.
-            xattr_key = 'ceph.dir.layout.pool'
-            xattr_val = self._get_ancestor_xattr(subvolpath, "ceph.dir.layout.pool")
-        # TODO: handle error...
-        self.fs.setxattr(subvolpath, xattr_key, xattr_val.encode('utf-8'), 0)
+                # cleanup subvol path on best effort basis
+                log.debug("cleaning up subvolume with path: {0}".format(subvolpath))
+                self.fs.rmdir(subvolpath)
+            except Exception:
+                log.debug("failed to clean up subvolume with path: {0}".format(subvolpath))
+                pass
+            finally:
+                raise e
 
     def remove_subvolume(self, spec, force):
         """
@@ -181,13 +192,24 @@ class SubVolume(object):
     def create_group(self, spec, mode=0o755, pool=None):
         path = spec.group_path
         self.fs.mkdirs(path, mode)
-        if not pool:
-            pool = self._get_ancestor_xattr(path, "ceph.dir.layout.pool")
         try:
-            self.fs.setxattr(path, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)
-        except cephfs.InvalidValue:
-            raise VolumeException(-errno.EINVAL,
-                                  "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
+            if not pool:
+                pool = self._get_ancestor_xattr(path, "ceph.dir.layout.pool")
+            try:
+                self.fs.setxattr(path, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)
+            except cephfs.InvalidValue:
+                raise VolumeException(-errno.EINVAL,
+                                      "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
+        except Exception as e:
+            try:
+                # cleanup group path on best effort basis
+                log.debug("cleaning up subvolumegroup with path: {0}".format(path))
+                self.fs.rmdir(path)
+            except Exception:
+                log.debug("failed to clean up subvolumegroup with path: {0}".format(path))
+                pass
+            finally:
+                raise e
 
     def remove_group(self, spec, force):
         path = spec.group_path

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -248,7 +248,7 @@ class VolumeClient(object):
 
     ### volume operations -- create, rm, ls
 
-    def create_volume(self, volname, size=None):
+    def create_volume(self, volname):
         """
         create volume  (pool, filesystem and mds)
         """

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -412,7 +412,7 @@ class VolumeClient(object):
                 if not path:
                     raise VolumeException(
                         -errno.ENOENT, "Subvolume '{0}' not found".format(subvolname))
-                ret = 0, path, ""
+                ret = 0, path.decode("utf-8"), ""
         except VolumeException as ve:
             ret = self.volume_exception_to_retval(ve)
         return ret
@@ -513,7 +513,7 @@ class VolumeClient(object):
                 if path is None:
                     raise VolumeException(
                         -errno.ENOENT, "Subvolume group '{0}' not found".format(groupname))
-                return 0, path, ""
+                return 0, path.decode("utf-8"), ""
         except VolumeException as ve:
             return self.volume_exception_to_retval(ve)
 

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -31,8 +31,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs volume create '
-                   'name=name,type=CephString '
-                   'name=size,type=CephString,req=false ',
+                   'name=name,type=CephString ',
             'desc': "Create a CephFS volume",
             'perm': 'rw'
         },
@@ -191,9 +190,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         # TODO: validate name against any rules for pool/fs names
         # (...are there any?)
         vol_id = cmd['name']
-        size = cmd.get('size', None)
-
-        return self.vc.create_volume(vol_id, size)
+        return self.vc.create_volume(vol_id)
 
     def _cmd_fs_volume_rm(self, inbuf, cmd):
         vol_name = cmd['vol_name']


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41437
mgr/volumes: subvolume and subvolume group path exists even when creation failed

Fixes: https://tracker.ceph.com/issues/41444
mgr/volumes: give useful error message when creating FS subvolume or subvolume group with invalid data pool layout.

Fixes: https://tracker.ceph.com/issues/41850
mgr/volumes: drop unnecessary size

Fixes: https://tracker.ceph.com/issues/41884
mgr/volumes: prevent negative subvolume size

Fixes: https://tracker.ceph.com/issues/41933
return string type to ceph-manager
