### PR TITLE
mgr/dashboard: Display legend for CephFS standbys

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
@@ -4,20 +4,19 @@
     <div class="row">
       <div class="col-sm-6">
         <legend i18n>Ranks</legend>
-
         <cd-table [data]="ranks.data"
                   [columns]="ranks.columns"
                   (fetchData)="refresh()"
                   [toolHeader]="false">
         </cd-table>
 
+        <legend i18n>Standbys</legend>
         <cd-table-key-value [data]="standbys">
         </cd-table-key-value>
       </div>
 
       <div class="col-sm-6">
         <legend i18n>Pools</legend>
-
         <cd-table [data]="pools.data"
                   [columns]="pools.columns"
                   [toolHeader]="false">


### PR DESCRIPTION
If there is no data available for standbys, the UI looks strange without a legend.

Before:
![FireShot Capture 050 - Ceph - localhost](https://user-images.githubusercontent.com/1897962/63760312-62003400-c8bf-11e9-8d8f-44117b4bb8de.png)

After:
![FireShot Capture 051 - Ceph - localhost](https://user-images.githubusercontent.com/1897962/63760326-67f61500-c8bf-11e9-8434-a254485d7e98.png)

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
