### PR TITLE
nautilus: tests: valgrind: UninitCondition in ceph::crypto::onwire::AES128GCM_OnWireRxHandler::authenticated_decrypt_update_final()

### DIFF
--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -588,7 +588,7 @@
 # while using aes-128-gcm with AES-NI enabled. Not observed while running
 # with `OPENSSL_ia32cap="~0x200000200000000"`.
 {
-   <insert_a_suppression_name_here>
+   uninitialised gcm.Xi in aes-128-gcm with AES-NI for msgr, part 1
    Memcheck:Cond
    ...
    fun:EVP_DecryptFinal_ex
@@ -602,7 +602,7 @@
 }
 
 {
-   <insert_a_suppression_name_here>
+   uninitialised gcm.Xi in aes-128-gcm with AES-NI for msgr, part 2
    Memcheck:Cond
    fun:_ZN4ceph6crypto6onwire25AES128GCM_OnWireRxHandler34authenticated_decrypt_update_finalEONS_6buffer7v14_2_04listEj
    fun:_ZN10ProtocolV231handle_read_frame_epilogue_mainEOSt10unique_ptrIN4ceph6buffer7v14_2_08ptr_nodeENS4_8disposerEEi

--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -598,11 +598,7 @@
    ...
    fun:_ZN15AsyncConnection7processEv
    fun:_ZN11EventCenter14process_eventsEjPNSt6chrono8durationImSt5ratioILl1ELl1000000000EEEE
-   fun:operator()
-   fun:_ZNSt17_Function_handlerIFvvEZN12NetworkStack10add_threadEjEUlvE_E9_M_invokeERKSt9_Any_data
-   fun:execute_native_thread_routine
-   fun:start_thread
-   fun:clone
+   ...
 }
 
 {
@@ -613,9 +609,5 @@
    fun:_ZN10ProtocolV216run_continuationER2CtIS_E
    ...
    fun:_ZN11EventCenter14process_eventsEjPNSt6chrono8durationImSt5ratioILl1ELl1000000000EEEE
-   fun:operator()
-   fun:_ZNSt17_Function_handlerIFvvEZN12NetworkStack10add_threadEjEUlvE_E9_M_invokeERKSt9_Any_data
-   fun:execute_native_thread_routine
-   fun:start_thread
-   fun:clone
+   ...
 }


### PR DESCRIPTION
https://tracker.ceph.com/issues/41534

---

Note: this is a backport of #28305. That PR has three commits, while this backport has only two. The third commit is a revert of https://github.com/ceph/ceph/commit/d25d6ee0af0c85715e0ef8ce377f0b78a91f7ad7 (#28155) which was not backported to nautilus.