### PR TITLE
doc: modify the wrong word "defails" to "details".

### DIFF
--- a/doc/radosgw/layout.rst
+++ b/doc/radosgw/layout.rst
@@ -42,8 +42,7 @@ Some variables have been used in above commands, they are:
 - bucket: Holds a mapping between bucket name and bucket instance id
 - bucket.instance: Holds bucket instance information[2]
 
-Every metadata entry is kept on a single rados object.
-See below for implementation defails.
+Every metadata entry is kept on a single rados object. See below for implementation details.
 
 Note that the metadata is not indexed. When listing a metadata section we do a
 rados pgls operation on the containing pool.


### PR DESCRIPTION
Signed-off-by: ypdai <self19900924@gmail.com>
(cherry picked from commit 8cefe3de7835ce136826faf595122cc210bf90af)

---

Note: this fix was applied, via #26381, to luminous without going into master, first. Hence the forward port in this case.