### PR TITLE
rgw: Move get_val out of hot path; Make RGWEnv a config observer

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -381,17 +381,23 @@ class RGWConf {
   friend class RGWEnv;
   int enable_ops_log;
   int enable_usage_log;
+  size_t max_attr_name_len;
+  size_t max_attr_size;
+  uint64_t max_attrs_num_in_req;
   uint8_t defer_to_bucket_acls;
-  void init(CephContext *cct);
+  void update(const ConfigProxy& conf);
 public:
   RGWConf()
     : enable_ops_log(1),
       enable_usage_log(1),
+      max_attr_name_len(0),
+      max_attr_size(0),
+      max_attrs_num_in_req(0),
       defer_to_bucket_acls(0) {
   }
 };
 
-class RGWEnv {
+class RGWEnv : public md_config_obs_t {
   std::map<string, string, ltstr_nocase> env_map;
   RGWConf conf;
 public:
@@ -417,6 +423,22 @@ public:
   int get_defer_to_bucket_acls() const {
     return conf.defer_to_bucket_acls;
   }
+
+  size_t get_max_attr_name_len() const {
+    return conf.max_attr_name_len;
+  }
+
+  size_t get_max_attr_size() const {
+    return conf.max_attr_size;
+  }
+
+  uint64_t get_max_attrs_num_in_req() const {
+    return conf.max_attrs_num_in_req;
+  }
+
+  const char** get_tracked_conf_keys() const override;
+  void handle_conf_change(const ConfigProxy& c,
+                          const std::set<std::string>& changed) override;
 };
 
 // return true if the connection is secure. this either means that the

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1694,7 +1694,7 @@ namespace rgw {
       attrbl.append(val.c_str(), val.size() + 1);
     }
 
-    op_ret = rgw_get_request_metadata(s->cct, s->info, attrs);
+    op_ret = get_request_metadata(attrs);
     if (op_ret < 0) {
       goto done;
     }


### PR DESCRIPTION
During wallclock profiling of RGW I noticed that we were spending approximately 2-3% of the time in each radosgw thread waiting on get_val with 32 radosgw threads. This problem gets worse the more threads you have.  Instead, make GetEnv a config observer, put the relevant config options there, and use the op's pointer to s->info.env to get them.

Before:
```
|   |         | | | | + 3.40% rgw_get_request_metadata
|   |         | | | | | + 2.60% get_val<Option::size_t>
|   |         | | | | | | + 2.40% lock_guard
|   |         | | | | | | | + 2.40% lock
|   |         | | | | | | |   + 2.40% __gthread_recursive_mutex_lock
|   |         | | | | | | |     + 2.40% __gthread_mutex_lock
|   |         | | | | | | |       + 2.40% pthread_mutex_lock
|   |         | | | | | | |         + 2.40% _L_lock_870
|   |         | | | | | | |           + 2.40% __lll_lock_wait
|   |         | | | | | | + 0.20% md_config_t::get_val<Option::size_t>
|   |         | | | | | + 0.80% get_val<unsigned long>
```

After:
```
|   |         | | | | + 0.30% RGWOp::get_request_metadata
```

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
