### PR TITLE
mount.ceph: Free saw_name on error

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -167,6 +167,7 @@ static char *parse_options(const char *data, int *filesys_flags)
 
 			if (read_secret_from_file(value, secret, sizeof(secret)) < 0) {
 				printf("error reading secret file\n");
+				free(saw_name);
 				return NULL;
 			}
 
@@ -193,6 +194,7 @@ static char *parse_options(const char *data, int *filesys_flags)
 		} else if (strncmp(data, "name", 4) == 0) {
 			if (!value || !*value) {
 				printf("mount option name requires a value.\n");
+				free(saw_name);
 				return NULL;
 			}
 


### PR DESCRIPTION
When erroring out of the argument parse loop, saw_name
may have already been allocated. Make sure to free it
to match the other early returns in the loop.

Signed-off-by: Kristoffer Grönlund <kgronlund@suse.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
