### PR TITLE
Add days0 to rgw lc

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -863,7 +863,7 @@ public:
 
     auto mtime = get_effective_mtime(oc);
     bool is_expired;
-    if (transition.days <= 0) {
+    if (transition.days < 0) {
       if (transition.date == boost::none) {
         ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": no transition day/date set in rule, skipping" << dendl;
         return false;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -130,7 +130,7 @@ public:
   bool valid() const {
     if (!days.empty() && !date.empty()) {
       return false;
-    } else if (!days.empty() && get_days() <=0) {
+    } else if (!days.empty() && get_days() < 0) {
       return false;
     }
     //We've checked date in xml parsing


### PR DESCRIPTION
Currently lc does not get days 0, but  by aws s3 spec it should
Test fix in: ceph/s3-tests#301

Fixes: https://tracker.ceph.com/issues/38389
Signed-off-by: Or Friedmann <ofriedma@redhat.com>