### PR TITLE
rgw/rgw_op: Remove get_val from hotpath via legacy options

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1265,6 +1265,10 @@ OPTION(rados_osd_op_timeout, OPT_DOUBLE) // how many seconds to wait for a respo
 OPTION(rados_tracing, OPT_BOOL) // true if LTTng-UST tracepoints should be enabled
 
 
+OPTION(rgw_max_attr_name_len, OPT_SIZE)
+OPTION(rgw_max_attr_size, OPT_SIZE)
+OPTION(rgw_max_attrs_num_in_req, OPT_U64)
+
 OPTION(rgw_max_chunk_size, OPT_INT)
 OPTION(rgw_put_obj_min_window_size, OPT_INT)
 OPTION(rgw_put_obj_max_window_size, OPT_INT)

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2014,26 +2014,23 @@ static inline int rgw_get_request_metadata(CephContext* const cct,
        * name. Passing here doesn't guarantee that an OSD will accept that
        * as ObjectStore::get_max_attr_name_length() can set the limit even
        * lower than the "osd_max_attr_name_len" configurable.  */
-      const size_t max_attr_name_len = \
-        cct->_conf.get_val<Option::size_t>("rgw_max_attr_name_len");
+      const auto max_attr_name_len = cct->_conf->rgw_max_attr_name_len;
       if (max_attr_name_len && attr_name.length() > max_attr_name_len) {
         return -ENAMETOOLONG;
       }
 
       /* Similar remarks apply to the check for value size. We're veryfing
        * it early at the RGW's side as it's being claimed in /info. */
-      const size_t max_attr_size = \
-        cct->_conf.get_val<Option::size_t>("rgw_max_attr_size");
+      const auto max_attr_size = cct->_conf->rgw_max_attr_size;
       if (max_attr_size && xattr.length() > max_attr_size) {
         return -EFBIG;
       }
 
       /* Swift allows administrators to limit the number of metadats items
        * send _in a single request_. */
-      const auto rgw_max_attrs_num_in_req = \
-        cct->_conf.get_val<uint64_t>("rgw_max_attrs_num_in_req");
-      if (rgw_max_attrs_num_in_req &&
-          ++valid_meta_count > rgw_max_attrs_num_in_req) {
+      const auto max_attrs_num_in_req = cct->_conf->rgw_max_attrs_num_in_req;
+      if (max_attrs_num_in_req &&
+          ++valid_meta_count > max_attrs_num_in_req) {
         return -E2BIG;
       }
 


### PR DESCRIPTION
This is an alternate PR to #29933.  It replaces the calls to get_val in the hotpath with older legacy settings per request by the radosgw team.  This is a far simpler change vs making rgw_op read these settings from RGWEnv and setting up a config observer but results in similar performance benefits:

Before:

```
|   |         | | | | + 3.40% rgw_get_request_metadata
|   |         | | | | | + 2.60% get_val<Option::size_t>
|   |         | | | | | | + 2.40% lock_guard
|   |         | | | | | | | + 2.40% lock
|   |         | | | | | | |   + 2.40% __gthread_recursive_mutex_lock
|   |         | | | | | | |     + 2.40% __gthread_mutex_lock
|   |         | | | | | | |       + 2.40% pthread_mutex_lock
|   |         | | | | | | |         + 2.40% _L_lock_870
|   |         | | | | | | |           + 2.40% __lll_lock_wait
|   |         | | | | | | + 0.20% md_config_t::get_val<Option::size_t>
|   |         | | | | | + 0.80% get_val<unsigned long>
```

After:
```
|   |         | | | | + 0.30% rgw_get_request_metadata
```

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
