### PR TITLE
nautilus: core: pool_stat.dump() - value of num_store_stats is wrong

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3007,7 +3007,7 @@ void pool_stat_t::dump(Formatter *f) const
   f->dump_int("ondisk_log_size", ondisk_log_size);
   f->dump_int("up", up);
   f->dump_int("acting", acting);
-  f->dump_int("num_store_stats", acting);
+  f->dump_int("num_store_stats", num_store_stats);
 }
 
 void pool_stat_t::encode(bufferlist &bl, uint64_t features) const


### PR DESCRIPTION
https://tracker.ceph.com/issues/39412