### PR TITLE
nautilus: rgw: fix drain handles error when deleting bucket with bypass-gc option

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -694,7 +694,7 @@ int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket,
         for (; miter != manifest.obj_end() && max_aio--; ++miter) {
           if (!max_aio) {
             ret = drain_handles(handles);
-            if (ret < 0) {
+            if (ret < 0 && ret != -ENOENT) {
               lderr(store->ctx()) << "ERROR: could not drain handles as aio completion returned with " << ret << dendl;
               return ret;
             }
@@ -723,7 +723,7 @@ int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket,
 
       if (!max_aio) {
         ret = drain_handles(handles);
-        if (ret < 0) {
+        if (ret < 0 && ret != -ENOENT) {
           lderr(store->ctx()) << "ERROR: could not drain handles as aio completion returned with " << ret << dendl;
           return ret;
         }
@@ -733,7 +733,7 @@ int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket,
   }
 
   ret = drain_handles(handles);
-  if (ret < 0) {
+  if (ret < 0 && ret != -ENOENT) {
     lderr(store->ctx()) << "ERROR: could not drain handles as aio completion returned with " << ret << dendl;
     return ret;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41109

---

backport of https://github.com/ceph/ceph/pull/28789
parent tracker: https://tracker.ceph.com/issues/40587

---

Backport automated with https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh