### PR TITLE
mgr: respawn with a potentially new binary

### DIFF
--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -322,7 +322,13 @@ void MgrStandby::respawn()
    * unlinked.
    */
   char exe_path[PATH_MAX] = "";
-  if (readlink(PROCPREFIX "/proc/self/exe", exe_path, PATH_MAX-1) == -1) {
+  struct stat statbuf;
+  if (stat(orig_argv[0], &statbuf) == 0) {
+    /* if original path still exists, use that since it may be
+       necessary to use an updated binary with updated libraries like
+       libceph-common */
+    strncpy(exe_path, orig_argv[0], PATH_MAX-1);
+  } else if (readlink(PROCPREFIX "/proc/self/exe", exe_path, PATH_MAX-1) == -1) {
     /* Print CWD for the user's interest */
     char buf[PATH_MAX];
     char *cwd = getcwd(buf, sizeof(buf));


### PR DESCRIPTION
This avoids incompatibilities with libraries that have been replaced
during upgrade.

Fixes: https://tracker.ceph.com/issues/41513
Signed-off-by: Josh Durgin <jdurgin@redhat.com>
