### PR TITLE
cephfs-shell: read options from ceph.conf

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -173,6 +173,12 @@ class CephCluster(object):
         self._ctx = ctx
         self.mon_manager = ceph_manager.CephManager(self.admin_remote, ctx=ctx, logger=log.getChild('ceph_manager'))
 
+    def set_config_opt(self, section, opt, val):
+        self.mon_manager.raw_cluster_cmd('config', 'set', section, opt, val)
+
+    def rm_config_opt(self, section, opt):
+        self.mon_manager.raw_cluster_cmd('config', 'rm', section)
+
     def get_config(self, key, service_type=None):
         """
         Get config from mon by default, or a specific service if caller asks for it

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -671,11 +671,8 @@ class TestMisc(TestCephFSShell):
         dirname = 'somedirectory'
         self.run_cephfs_shell_cmd(['mkdir', dirname])
 
-        # TODO: Once cephfs-shell can pickup its config variables from
-        # ceph.conf, set colors Never there and get rid of the same in
-        # following comamnd.
         output = self.mount_a.client_remote.run(args=['cephfs-shell', '-c',
-            self.mount_a.config_path, 'set colors Never, ls'],
+            self.mount_a.config_path, 'ls'],
             stdout=StringIO()).stdout.getvalue().strip()
 
         if sys_version_info.major >= 3:

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -31,14 +31,17 @@ def humansize(nbytes):
 class TestCephFSShell(CephFSTestCase):
     CLIENTS_REQUIRED = 1
 
-    def run_cephfs_shell_cmd(self, cmd, mount_x=None, opts=None, stdin=None):
+    def run_cephfs_shell_cmd(self, cmd, mount_x=None, opts=None, stdin=None, config_path=None):
         if mount_x is None:
             mount_x = self.mount_a
+        if config_path is None:
+            config_path = self.mount_a.config_path
 
         if isinstance(cmd, list):
             cmd = " ".join(cmd)
 
-        args = ["cephfs-shell", "-c", mount_x.config_path]
+        args = ["cephfs-shell", "-c", config_path]
+
         if opts is not None:
             args.extend(opts)
 
@@ -54,9 +57,10 @@ class TestCephFSShell(CephFSTestCase):
             getvalue().strip()
 
     def get_cephfs_shell_cmd_output(self, cmd, mount_x=None, opts=None,
-                                    stdin=None):
-        return self.run_cephfs_shell_cmd(cmd, mount_x, opts, stdin).stdout.\
-            getvalue().strip()
+                                    stdin=None, config_path=None):
+        return self.run_cephfs_shell_cmd(cmd, mount_x, opts, stdin,
+                                         config_path).\
+            stdout.getvalue().strip()
 
     def get_cephfs_shell_script_output(self, script, mount_x=None, stdin=None):
         return self.run_cephfs_shell_script(script, mount_x, stdin).stdout.\

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -28,6 +28,11 @@ def humansize(nbytes):
     f = ('%d' % nbytes).rstrip('.')
     return '%s%s' % (f, suffixes[i])
 
+def str_to_bool(val):
+    val = val.strip()
+    trueval = ['true', 'yes', 'y', '1']
+    return True if val == 1 or val.lower() in trueval else False
+
 class TestCephFSShell(CephFSTestCase):
     CLIENTS_REQUIRED = 1
 
@@ -692,3 +697,52 @@ class TestMisc(TestCephFSShell):
         """
         o = self.get_cephfs_shell_cmd_output("help all")
         log.info("output:\n{}".format(o))
+
+class TestConfReading(TestCephFSShell):
+
+    def test_reading_conf_opt(self):
+        """
+        Read conf without duplicate sections/options.
+        """
+        debugval = self.fs.mon_manager.raw_cluster_cmd('config', 'get',
+                                                       'client','debug_shell')
+        debugval = str_to_bool(debugval)
+        self.fs.mon_manager.raw_cluster_cmd('config', 'set', 'client',
+                                            'debug_shell', str(not debugval))
+        output = self.get_cephfs_shell_cmd_output('set debug')
+        new_debug_val = \
+            str_to_bool(output[output.find('debug: ') + len('debug: ') : ])
+        assert not debugval == new_debug_val
+
+    def test_reading_conf_after_setting_opt_twice(self):
+        """
+        Read conf without duplicate sections/options.
+        """
+        debugval = self.fs.mon_manager.raw_cluster_cmd('config', 'get',
+                                                       'client','debug_shell')
+        debugval = str_to_bool(debugval)
+
+        self.fs.mon_manager.raw_cluster_cmd('config', 'set', 'client',
+                                            'debug_shell', str(not debugval))
+        self.fs.mon_manager.raw_cluster_cmd('config', 'set', 'client',
+                                            'debug_shell', str(not debugval))
+        output = self.get_cephfs_shell_cmd_output('set debug')
+        new_debug_val = \
+            str_to_bool(output[output.find('debug: ') + len('debug: ') : ])
+        assert not debugval == new_debug_val
+
+    def test_reading_conf_after_resetting_opt(self):
+        debugval = self.fs.mon_manager.raw_cluster_cmd('config', 'get',
+                                                       'client','debug_shell')
+        debugval = str_to_bool(debugval)
+
+        self.fs.mon_manager.raw_cluster_cmd('config', 'set', 'client',
+                                            'debug_shell', str(not debugval))
+        self.fs.mon_manager.raw_cluster_cmd('config', 'rm', 'client',
+                                            'debug_shell')
+        self.fs.mon_manager.raw_cluster_cmd('config', 'set', 'client',
+                                            'debug_shell', str(not debugval))
+        output = self.get_cephfs_shell_cmd_output('set debug')
+        new_debug_val = \
+            str_to_bool(output[output.find('debug: ') + len('debug: ') : ])
+        assert not debugval == new_debug_val

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1002,6 +1002,12 @@ class LocalCephCluster(CephCluster):
     def admin_remote(self):
         return LocalRemote()
 
+    def set_config_opt(self, section, opt, val):
+        self.mon_manager.raw_cluster_cmd('config', 'set', section, opt, val)
+
+    def rm_config_opt(self, section, opt):
+        self.mon_manager.raw_cluster_cmd('config', 'rm', section, opt)
+
     def get_config(self, key, service_type=None):
         if service_type is None:
             service_type = 'mon'

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -272,6 +272,15 @@ class LocalRemote(object):
         # None
         return mkdtemp(suffix=suffix, prefix='', dir=parentdir)
 
+    def mktemp(self, suffix=None, parentdir=None):
+        """
+        Make a remote temporary file
+
+        Returns: the path of the temp file created.
+        """
+        from tempfile import mktemp
+        return mktemp(suffix=suffix, dir=parentdir)
+
     def _perform_checks_and_return_list_of_args(self, args, omit_sudo):
         # Since Python's shell simulation can only work when commands are
         # provided as a list of argumensts...

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8281,6 +8281,57 @@ std::vector<Option> get_mds_client_options() {
 }
 
 
+std::vector<Option> get_cephfs_shell_options() {
+  return std::vector<Option>({
+    Option("allow_ansi", Option::TYPE_STR, Option::LEVEL_BASIC)
+    .set_default("Terminal")
+    .set_description("Allow ANSI escape sequences in output. Values: "
+		     "Terminal, Always, Never"),
+
+    Option("colors", Option::TYPE_STR, Option::LEVEL_BASIC)
+    .set_default("Terminal")
+    .set_description("Colouring CephFS shell input and output. Values: "
+		     "Terminal, Always, Never"),
+
+    Option("continuation_prompt", Option::TYPE_STR, Option::LEVEL_BASIC)
+    .set_default(">")
+    .set_description("Prompt string when a command continue to second line"),
+
+    Option("debug_shell", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .set_description("Allow tracebacks on error for CephFS Shell"),
+
+    Option("echo", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .set_description("Allow tracebacks on error for CephFS Shell"),
+
+    Option("editor", Option::TYPE_STR, Option::LEVEL_BASIC)
+    .set_default("vim")
+    .set_description("Default text editor for shell"),
+
+    Option("feedback_to_output", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .set_description("include '|' and '>' in result"),
+
+    Option("max_completion_items", Option::TYPE_INT, Option::LEVEL_BASIC)
+    .set_default(50)
+    .set_description("Maximum number of items to be displayed by tab "
+		     "completion"),
+
+    Option("prompt", Option::TYPE_STR, Option::LEVEL_BASIC)
+    .set_default("\x1b[01;33mCephFS:~\x1b[96m/\x1b[0m\x1b[01;33m>>>\x1b[00m ")
+    .set_description("Whether non-essential feedback should be printed."),
+
+    Option("quiet", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .set_description("Whether non-essential feedback should be printed."),
+
+    Option("timing", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .set_description("Whether execution time should be reported"),
+  });
+}
+
 static std::vector<Option> build_options()
 {
   std::vector<Option> result = get_global_options();
@@ -8298,6 +8349,7 @@ static std::vector<Option> build_options()
   ingest(get_immutable_object_cache_options(), "immutable-objet-cache");
   ingest(get_mds_options(), "mds");
   ingest(get_mds_client_options(), "mds_client");
+  ingest(get_cephfs_shell_options(), "cephfs-shell");
 
   return result;
 }

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1379,6 +1379,42 @@ Access: {}\nModify: {}\nChange: {}".format(path.decode('utf-8'), stat.st_size,
             except libcephfs.Error as e:
                 perror(e)
 
+def get_bool_vals_for_boolopts(val):
+    if val.lower() in ['true', 'yes']:
+        return True
+    elif val.lower() in ['false', 'no']:
+        return False
+    else:
+        return val
+
+def read_ceph_conf(shell, config_file):
+    try:
+        shell.debug = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('debug_shell').strip('\n'))
+        shell.allow_ansi = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('allow_ansi').strip('\n'))
+        shell.echo = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('echo').strip('\n'))
+        shell.continuation_prompt = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('continuation_prompt').strip('\n'))
+        shell.colors = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('colors').strip('\n'))
+        shell.editor = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('editor').strip('\n'))
+        shell.feedback_to_output = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('feedback_to_output').strip('\n'))
+        shell.max_completion_items = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('max_completion_items').strip('\n'))
+        shell.prompt = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('prompt').strip('\n'))
+        shell.quiet = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('quiet').strip('\n'))
+        shell.timing = get_bool_vals_for_boolopts(cephfs.\
+            conf_get('timing').strip('\n'))
+    except OSError as e:
+        perror(e)
+    except cephfs.Error as e:
+        perror(e)
 
 if __name__ == '__main__':
     config_file = ''
@@ -1406,6 +1442,8 @@ if __name__ == '__main__':
     sys.argv.clear()
     sys.argv.append(exe)
     sys.argv.extend([i.strip() for i in ' '.join(args.commands).split(',')])
+
     setup_cephfs(config_file)
     shell = CephFSShell()
+    read_ceph_conf(shell, config_file)
     sys.exit(shell.cmdloop())

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -694,6 +694,12 @@ EOF
 
 $extra_conf
 EOF
+wconf <<EOF
+[cephfs-shell]
+        debug shell = true
+
+$extra_conf
+EOF
 
 	do_rgw_conf
 	wconf << EOF


### PR DESCRIPTION
* ~use Python's `configparser` module to read options set under cephfs-shell
section in ceph.conf~
* read ceph conf
* update ceph.conf template in vstart.sh
* update `test_cephfs_shell.TestMisc.test_issue_cephfs_shell_cmd_at_invocation`


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test docs`
- `jenkins render docs`

</details>