### PR TITLE
nautilus: rgw: rgw-log issues the wrong message when decompression fails

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -98,7 +98,7 @@ int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len
     in_bl.copy(ofs_in_bl, first_block->len, tmp);
     int cr = compressor->decompress(tmp, out_bl);
     if (cr < 0) {
-      lderr(cct) << "Compression failed with exit code " << cr << dendl;
+      lderr(cct) << "Decompression failed with exit code " << cr << dendl;
       return cr;
     }
     ++first_block;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41272

---

backport of https://github.com/ceph/ceph/pull/29633
parent tracker: https://tracker.ceph.com/issues/41146

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh