### PR TITLE
qa: krbd_parent_overlap.t: fix read test

### DIFF
--- a/qa/rbd/krbd_parent_overlap.t
+++ b/qa/rbd/krbd_parent_overlap.t
@@ -1,22 +1,27 @@
 
 For reads, only the object extent needs to be reverse mapped:
 
-  $ rbd create --size 20M img
+  $ rbd create --size 5M img
   $ DEV=$(sudo rbd map img)
-  $ xfs_io -c 'pwrite 0 20M' $DEV >/dev/null
+  $ xfs_io -c 'pwrite 0 5M' $DEV >/dev/null
   $ sudo rbd unmap $DEV
   $ rbd snap create img@snap
   $ rbd snap protect img@snap
   $ rbd clone img@snap cloneimg
-  $ rbd resize --no-progress --size 5M --allow-shrink cloneimg
-  $ rbd resize --no-progress --size 20M cloneimg
+  $ rbd resize --no-progress --size 12M cloneimg
   $ DEV=$(sudo rbd map cloneimg)
   $ hexdump $DEV
   0000000 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
   *
   0500000 0000 0000 0000 0000 0000 0000 0000 0000
   *
-  1400000
+  0c00000
+  $ dd if=$DEV iflag=direct bs=4M status=none | hexdump
+  0000000 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
+  *
+  0500000 0000 0000 0000 0000 0000 0000 0000 0000
+  *
+  0c00000
   $ sudo rbd unmap $DEV
   $ rbd rm --no-progress cloneimg
   $ rbd snap unprotect img@snap


### PR DESCRIPTION
It turns out this test has not been triggering the right code path for
a while now (krbd_parent_overlap.t was added just over a year ago, but
the original test goes back a few years).

To do its job it needs an empty clone with the overlap set to somewhere
in the middle of an object.  The test relied on shrinking for this, but
shrinking no longer fits the bill because a copyup is now performed for
the object with the overlap -- we never go to the parent after that.

Let's size the parent so that it ends in the middle of an object and
then grow an empty clone instead.  Also, while reading from page cache
does seem to trigger a read that straddles the overlap, it's not very
reliable, so supplement it with a direct read.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>
