### PR TITLE
nautilus: rgw: Put User Policy is sensitive to whitespace

### DIFF
--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -90,9 +90,9 @@ uint64_t RGWPutUserPolicy::get_op()
 
 int RGWPutUserPolicy::get_params()
 {
-  policy_name = s->info.args.get("PolicyName");
-  user_name = s->info.args.get("UserName");
-  policy = s->info.args.get("PolicyDocument");
+  policy_name = url_decode(s->info.args.get("PolicyName"), true);
+  user_name = url_decode(s->info.args.get("UserName"), true);
+  policy = url_decode(s->info.args.get("PolicyDocument"), true);
 
   if (policy_name.empty() || user_name.empty() || policy.empty()) {
     ldout(s->cct, 20) << "ERROR: one of policy name, user name or policy document is empty"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41459

---

backport of https://github.com/ceph/ceph/pull/29578
parent tracker: https://tracker.ceph.com/issues/41189

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh