### PR TITLE
nautilus: rgw: potential realm watch lost

### DIFF
--- a/src/rgw/rgw_realm_watcher.cc
+++ b/src/rgw/rgw_realm_watcher.cc
@@ -71,13 +71,11 @@ void RGWRealmWatcher::handle_notify(uint64_t notify_id, uint64_t cookie,
 
 void RGWRealmWatcher::handle_error(uint64_t cookie, int err)
 {
+  lderr(cct) << "RGWRealmWatcher::handle_error oid=" << watch_oid << " err=" << err << dendl;
   if (cookie != watch_handle)
     return;
 
-  if (err == -ENOTCONN) {
-    ldout(cct, 4) << "Disconnected watch on " << watch_oid << dendl;
-    watch_restart();
-  }
+  watch_restart();
 }
 
 int RGWRealmWatcher::watch_start(const RGWRealm& realm)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41482

---

backport of https://github.com/ceph/ceph/pull/29369
parent tracker: https://tracker.ceph.com/issues/40991

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh