### PR TITLE
ceph-conf: added --show-config-value to usage

### DIFF
--- a/src/test/cli/ceph-conf/help.t
+++ b/src/test/cli/ceph-conf/help.t
@@ -18,6 +18,9 @@
                                     can be opened in the resulted comma
                                     delimited search list.
     -D|--dump-all                   dump all variables.
+    --show-config-value <key>       Print the corresponding ceph.conf value
+                                    that matches the specified key. Also searches
+                                    global defaults.
   
   FLAGS
     --name name                     Set type.id

--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -45,6 +45,9 @@ ACTIONS
                                   can be opened in the resulted comma
                                   delimited search list.
   -D|--dump-all                   dump all variables.
+  --show-config-value <key>       Print the corresponding ceph.conf value
+                                  that matches the specified key. Also searches
+                                  global defaults.
 
 FLAGS
   --name name                     Set type.id


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

`--show-config-value` is another way to lookup `ceph.conf`
values. Users may want to utilize `--show-config-value` instead of
`--lookup` because `--show-config-value` also shows global defaults.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>