### PR TITLE
mgr/pg_autoscaler: fix pool_logical_used

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -273,7 +273,7 @@ class PgAutoscaler(MgrModule):
 
             raw_used_rate = osdmap.pool_raw_used_rate(pool_id)
 
-            pool_logical_used = pool_stats[pool_id]['bytes_used']
+            pool_logical_used = pool_stats[pool_id]['stored']
             bias = p['options'].get('pg_autoscale_bias', 1.0)
             target_bytes = p['options'].get('target_size_bytes', 0)
 


### PR DESCRIPTION
  value should be taken from the 'stored' column otherwise redundancy (pool size) would taken twice into account.