### PR TITLE
doc/ceph-kvstore-tool: add description for 'stats' command

### DIFF
--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -80,6 +80,11 @@ which are as follows:
     Note that in the case of rocksdb this may corrupt an otherwise uncorrupted
     database--use this only as a last resort!
 
+:command:`stats`
+    Prints statistics from of underlying key-value database. This is only for informative purposes.
+    Format and information content may vary between releases. For RocksDB information includes
+    compactions stats, performance counters, memory usage and internal RocksDB stats. 
+
 Availability
 ============
 

--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -81,7 +81,7 @@ which are as follows:
     database--use this only as a last resort!
 
 :command:`stats`
-    Prints statistics from of underlying key-value database. This is only for informative purposes.
+    Prints statistics from underlying key-value database. This is only for informative purposes.
     Format and information content may vary between releases. For RocksDB information includes
     compactions stats, performance counters, memory usage and internal RocksDB stats. 
 


### PR DESCRIPTION
Description is true but intentionally vague.