### PR TITLE
nautilus: osd: Better error message when OSD count is less than osd_pool_default_size

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -678,6 +678,12 @@ the pool is too large and should be reduced or set to zero with::
 
 For more information, see :ref:`specifying_pool_target_size`.
 
+TOO_FEW_OSDS
+____________
+
+The number of OSDs in the cluster is below the configurable
+threshold of ``osd_pool_default_size``.
+
 SMALLER_PGP_NUM
 _______________
 

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1619,9 +1619,11 @@ function test_wait_for_health_ok() {
     local dir=$1
 
     setup $dir || return 1
-    run_mon $dir a --osd_pool_default_size=1 --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
+    run_mon $dir a --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
     run_mgr $dir x --mon_pg_warn_min_per_osd=0 || return 1
     run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
     ceph osd down 0 || return 1
     ! TIMEOUT=1 wait_for_health_ok || return 1

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1621,13 +1621,18 @@ function test_wait_for_health_ok() {
     setup $dir || return 1
     run_mon $dir a --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
     run_mgr $dir x --mon_pg_warn_min_per_osd=0 || return 1
+    # start osd_pool_default_size OSDs
     run_osd $dir 0 || return 1
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
     ceph osd down 0 || return 1
+    # expect TOO_FEW_OSDS warning
     ! TIMEOUT=1 wait_for_health_ok || return 1
+    # resurrect all OSDs
     activate_osd $dir 0 || return 1
+    activate_osd $dir 1 || return 1
+    activate_osd $dir 2 || return 1
     wait_for_health_ok || return 1
     teardown $dir || return 1
 }

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -26,6 +26,7 @@
 	mon warn on crush straw calc version zero = false
 	mon warn on no sortbitwise = false
 	mon warn on osd down out interval zero = false
+	mon warn on too few osds = false
 
         osd pool default erasure code profile = "plugin=jerasure technique=reed_sol_van k=2 m=1 ruleset-failure-domain=osd crush-failure-domain=osd"
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1727,6 +1727,11 @@ std::vector<Option> get_global_options() {
     .add_service("mgr")
     .set_description("Issue a health warning if there are misplaced objects"),
 
+    Option("mon_warn_on_too_few_osds", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .add_service("mgr")
+    .set_description("Issue a health warning if there are fewer OSDs than osd_pool_default_size"),
+
     Option("mon_max_snap_prune_per_epoch", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(100)
     .add_service("mon")

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2694,6 +2694,15 @@ void PGMap::get_health_checks(
     }
   }
 
+  // TOO_FEW_OSDS
+  auto osd_pool_default_size = cct->_conf.get_val<uint64_t>("osd_pool_default_size");
+  if (osdmap.get_num_osds() < osd_pool_default_size) {
+    ostringstream ss;
+    ss << "OSD count " << osdmap.get_num_osds()
+	 << " < osd_pool_default_size " << osd_pool_default_size;
+    checks->add("TOO_FEW_OSDS", HEALTH_WARN, ss.str());
+  }
+
   // SMALLER_PGP_NUM
   // MANY_OBJECTS_PER_PG
   if (!pg_stat.empty()) {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2695,8 +2695,9 @@ void PGMap::get_health_checks(
   }
 
   // TOO_FEW_OSDS
+  auto warn_too_few_osds = cct->_conf.get_val<bool>("mon_warn_on_too_few_osds");
   auto osd_pool_default_size = cct->_conf.get_val<uint64_t>("osd_pool_default_size");
-  if (osdmap.get_num_osds() < osd_pool_default_size) {
+  if (warn_too_few_osds && osdmap.get_num_osds() < osd_pool_default_size) {
     ostringstream ss;
     ss << "OSD count " << osdmap.get_num_osds()
 	 << " < osd_pool_default_size " << osd_pool_default_size;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40084

---

backport of https://github.com/ceph/ceph/pull/27806
parent tracker: https://tracker.ceph.com/issues/38617

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh