### PR TITLE
nautilus: osd/PrimaryLogPG: Avoid accessing destroyed references in finish_degr…

### DIFF
--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -108,7 +108,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
      virtual void failed_push(const list<pg_shard_t> &from,
                               const hobject_t &soid,
                               const eversion_t &need = eversion_t()) = 0;
-     virtual void finish_degraded_object(const hobject_t& oid) = 0;
+     virtual void finish_degraded_object(const hobject_t oid) = 0;
      virtual void primary_failed(const hobject_t &soid) = 0;
      virtual bool primary_error(const hobject_t& soid, eversion_t v) = 0;
      virtual void cancel_pull(const hobject_t &soid) = 0;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11590,7 +11590,7 @@ void PrimaryLogPG::remove_missing_object(const hobject_t &soid,
   ceph_assert(r == 0);
 }
 
-void PrimaryLogPG::finish_degraded_object(const hobject_t& oid)
+void PrimaryLogPG::finish_degraded_object(const hobject_t oid)
 {
   dout(10) << __func__ << " " << oid << dendl;
   if (callbacks_for_degraded_object.count(oid)) {

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1126,7 +1126,7 @@ protected:
 				  PGBackend::RecoveryHandle *h,
 				  bool *work_started);
 
-  void finish_degraded_object(const hobject_t& oid) override;
+  void finish_degraded_object(const hobject_t oid) override;
 
   // Cancels/resets pulls from peer
   void check_recovery_sources(const OSDMapRef& map) override ;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41448

---

backport of https://github.com/ceph/ceph/pull/29663
parent tracker: https://tracker.ceph.com/issues/41250

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh