### PR TITLE
nautilus: core: Improve health status for backfill_toofull and recovery_toofull and fix backfill_toofull seen on cluster where the most full OSD is at 1%

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -489,16 +489,27 @@ The state of specific problematic PGs can be queried with::
   ceph tell <pgid> query
 
 
-PG_DEGRADED_FULL
+PG_RECOVERY_FULL
 ________________
 
 Data redundancy may be reduced or at risk for some data due to a lack
 of free space in the cluster.  Specifically, one or more PGs has the
-*backfill_toofull* or *recovery_toofull* flag set, meaning that the
+*recovery_toofull* flag set, meaning that the
+cluster is unable to migrate or recover data because one or more OSDs
+is above the *full* threshold.
+
+See the discussion for *OSD_FULL* above for steps to resolve this condition.
+
+PG_BACKFILL_FULL
+________________
+
+Data redundancy may be reduced or at risk for some data due to a lack
+of free space in the cluster.  Specifically, one or more PGs has the
+*backfill_toofull* flag set, meaning that the
 cluster is unable to migrate or recover data because one or more OSDs
 is above the *backfillfull* threshold.
 
-See the discussion for *OSD_BACKFILLFULL* or *OSD_FULL* above for
+See the discussion for *OSD_BACKFILLFULL* above for
 steps to resolve this condition.
 
 PG_DAMAGED

--- a/doc/rados/operations/monitoring-osd-pg.rst
+++ b/doc/rados/operations/monitoring-osd-pg.rst
@@ -385,6 +385,11 @@ and, ``backfill_toofull`` indicates that a backfill operation was requested,
 but couldn't be completed due to insufficient storage capacity. When a 
 placement group cannot be backfilled, it may be considered ``incomplete``.
 
+The ``backfill_toofull`` state may be transient.  It is possible that as PGs
+are moved around, space may become available.  The ``backfill_toofull`` is
+similar to ``backfill_wait`` in that as soon as conditions change
+backfill can proceed.
+
 Ceph provides a number of settings to manage the load spike associated with
 reassigning placement groups to an OSD (especially a new OSD). By default,
 ``osd_max_backfills`` sets the maximum number of concurrent backfills to and from

--- a/doc/rados/operations/pg-states.rst
+++ b/doc/rados/operations/pg-states.rst
@@ -69,8 +69,8 @@ map is ``active + clean``.
   The placement group is waiting in line to start backfill.
 
 *backfill_toofull*
-  A backfill operation is waiting because the destination OSD is over its
-  full ratio.
+  A backfill operation is waiting because the destination OSD is over
+  the backfillfull ratio.
 
 *backfill_unfound*
   Backfill stopped due to unfound objects.

--- a/qa/standalone/osd/osd-recovery-space.sh
+++ b/qa/standalone/osd/osd-recovery-space.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2018 Red Hat <contact@redhat.com>
+#
+# Author: David Zafman <dzafman@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7221" # git grep '\<7221\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd_max_backfills=10 "
+    export objects=600
+    export poolprefix=test
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+
+function get_num_in_state() {
+    local state=$1
+    local expression
+    expression+="select(contains(\"${state}\"))"
+    ceph --format json pg dump pgs 2>/dev/null | \
+        jq ".pg_stats | [.[] | .state | $expression] | length"
+}
+
+
+function wait_for_state() {
+    local state=$1
+    local num_in_state=-1
+    local cur_in_state
+    local -a delays=($(get_timeout_delays $2 5))
+    local -i loop=0
+
+    flush_pg_stats || return 1
+    while test $(get_num_pgs) == 0 ; do
+	sleep 1
+    done
+
+    while true ; do
+        cur_in_state=$(get_num_in_state ${state})
+        test $cur_in_state = "0" && break
+        if test $cur_in_state != $num_in_state ; then
+            loop=0
+            num_in_state=$cur_in_state
+        elif (( $loop >= ${#delays[*]} )) ; then
+            ceph pg dump pgs
+            return 1
+        fi
+        sleep ${delays[$loop]}
+        loop+=1
+    done
+    return 0
+}
+
+
+function wait_for_recovery_toofull() {
+    local timeout=$1
+    wait_for_state recovery_toofull $timeout
+}
+
+
+# Create 1 pools with size 1
+# set ful-ratio to 50%
+# Write data 600 5K (3000K)
+# Inject fake_statfs_for_testing to 3600K (83% full)
+# Incresase the pool size to 2
+# The pool shouldn't have room to recovery
+function TEST_recovery_test_simple() {
+    local dir=$1
+    local pools=1
+    local OSDS=2
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    export CEPH_ARGS
+
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd || return 1
+    done
+
+    ceph osd set-nearfull-ratio .40
+    ceph osd set-backfillfull-ratio .45
+    ceph osd set-full-ratio .50
+
+    for p in $(seq 1 $pools)
+    do
+      create_pool "${poolprefix}$p" 1 1
+      ceph osd pool set "${poolprefix}$p" size 1
+    done
+
+    wait_for_clean || return 1
+
+    dd if=/dev/urandom of=$dir/datafile bs=1024 count=5
+    for o in $(seq 1 $objects)
+    do
+      rados -p "${poolprefix}$p" put obj$o $dir/datafile
+    done
+
+    for o in $(seq 0 $(expr $OSDS - 1))
+    do
+      ceph tell osd.$o injectargs '--fake_statfs_for_testing 3686400' || return 1
+    done
+    sleep 5
+
+    ceph pg dump pgs
+
+    for p in $(seq 1 $pools)
+    do
+      ceph osd pool set "${poolprefix}$p" size 2
+    done
+
+    # If this times out, we'll detected errors below
+    wait_for_recovery_toofull 30
+
+    ERRORS=0
+    if [ "$(ceph pg dump pgs | grep +recovery_toofull | wc -l)" != "1" ];
+    then
+      echo "One pool should have been in recovery_toofull"
+      ERRORS="$(expr $ERRORS + 1)"
+    fi
+
+    ceph pg dump pgs
+    ceph status
+    ceph status --format=json-pretty > $dir/stat.json
+
+    eval SEV=$(jq '.health.checks.PG_RECOVERY_FULL.severity' $dir/stat.json)
+    if [ "$SEV" != "HEALTH_ERR" ]; then
+      echo "PG_RECOVERY_FULL severity $SEV not HEALTH_ERR"
+      ERRORS="$(expr $ERRORS + 1)"
+    fi
+    eval MSG=$(jq '.health.checks.PG_RECOVERY_FULL.summary.message' $dir/stat.json)
+    if [ "$MSG" != "Full OSDs blocking recovery: 1 pg recovery_toofull" ]; then
+      echo "PG_RECOVERY_FULL message '$MSG' mismatched"
+      ERRORS="$(expr $ERRORS + 1)"
+    fi
+    rm -f $dir/stat.json
+
+    if [ $ERRORS != "0" ];
+    then
+      return 1
+    fi
+
+    for i in $(seq 1 $pools)
+    do
+      delete_pool "${poolprefix}$i"
+    done
+    kill_daemons $dir || return 1
+}
+
+
+main osd-recovery-space "$@"
+
+# Local Variables:
+# compile-command: "make -j4 && ../qa/run-standalone.sh osd-recovery-space.sh"
+# End:

--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -30,7 +30,7 @@ public:
   enum {
     REQUEST = 0,   // primary->replica: please reserve a slot
     GRANT = 1,     // replica->primary: ok, i reserved it
-    REJECT = 2,    // replica->primary: sorry, try again later (*)
+    REJECT_TOOFULL = 2,    // replica->primary: too full, sorry, try again later (*)
     RELEASE = 3,   // primary->replcia: release the slot i reserved before
     REVOKE_TOOFULL = 4,   // replica->primary: too full, stop backfilling
     REVOKE = 5,    // replica->primary: i'm taking back the slot i gave you
@@ -63,7 +63,7 @@ public:
 	query_epoch,
 	query_epoch,
 	RemoteBackfillReserved());
-    case REJECT:
+    case REJECT_TOOFULL:
       // NOTE: this is replica -> primary "i reject your request"
       //      and also primary -> replica "cancel my previously-granted request"
       //                                  (for older peers)
@@ -72,7 +72,7 @@ public:
       return new PGPeeringEvent(
 	query_epoch,
 	query_epoch,
-	RemoteReservationRejected());
+	RemoteReservationRejectedTooFull());
     case RELEASE:
       return new PGPeeringEvent(
 	query_epoch,
@@ -119,8 +119,8 @@ public:
     case GRANT:
       out << "GRANT";
       break;
-    case REJECT:
-      out << "REJECT ";
+    case REJECT_TOOFULL:
+      out << "REJECT_TOOFULL";
       break;
     case RELEASE:
       out << "RELEASE";
@@ -160,7 +160,7 @@ public:
       encode(pgid.pgid, payload);
       encode(query_epoch, payload);
       encode((type == RELEASE || type == REVOKE_TOOFULL || type == REVOKE) ?
-	       REJECT : type, payload);
+	       REJECT_TOOFULL : type, payload);
       encode(priority, payload);
       encode(pgid.shard, payload);
       return;

--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -32,7 +32,7 @@ public:
     GRANT = 1,     // replica->primary: ok, i reserved it
     REJECT = 2,    // replica->primary: sorry, try again later (*)
     RELEASE = 3,   // primary->replcia: release the slot i reserved before
-    TOOFULL = 4,   // replica->primary: too full, stop backfilling
+    REVOKE_TOOFULL = 4,   // replica->primary: too full, stop backfilling
     REVOKE = 5,    // replica->primary: i'm taking back the slot i gave you
     // (*) NOTE: prior to luminous, REJECT was overloaded to also mean release
   };
@@ -78,7 +78,7 @@ public:
 	query_epoch,
 	query_epoch,
 	RemoteReservationCanceled());
-    case TOOFULL:
+    case REVOKE_TOOFULL:
       return new PGPeeringEvent(
 	query_epoch,
 	query_epoch,
@@ -125,8 +125,8 @@ public:
     case RELEASE:
       out << "RELEASE";
       break;
-    case TOOFULL:
-      out << "TOOFULL";
+    case REVOKE_TOOFULL:
+      out << "REVOKE_TOOFULL";
       break;
     case REVOKE:
       out << "REVOKE";
@@ -159,7 +159,7 @@ public:
       header.compat_version = 3;
       encode(pgid.pgid, payload);
       encode(query_epoch, payload);
-      encode((type == RELEASE || type == TOOFULL || type == REVOKE) ?
+      encode((type == RELEASE || type == REVOKE_TOOFULL || type == REVOKE) ?
 	       REJECT : type, payload);
       encode(priority, payload);
       encode(pgid.shard, payload);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7762,7 +7762,6 @@ void PG::RecoveryState::WaitRemoteBackfillReserved::retry()
   }
 
   pg->state_clear(PG_STATE_BACKFILL_WAIT);
-  pg->state_set(PG_STATE_BACKFILL_TOOFULL);
   pg->publish_stats_to_osd();
 
   pg->schedule_backfill_retry(pg->cct->_conf->osd_backfill_retry_interval);
@@ -7771,6 +7770,8 @@ void PG::RecoveryState::WaitRemoteBackfillReserved::retry()
 boost::statechart::result
 PG::RecoveryState::WaitRemoteBackfillReserved::react(const RemoteReservationRejected &evt)
 {
+  PG *pg = context< RecoveryMachine >().pg;
+  pg->state_set(PG_STATE_BACKFILL_TOOFULL);
   retry();
   return transit<NotBackfilling>();
 }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -8125,7 +8125,7 @@ PG::RecoveryState::RepRecovering::react(const BackfillTooFull &)
   pg->osd->send_message_osd_cluster(
     pg->primary.osd,
     new MBackfillReserve(
-      MBackfillReserve::TOOFULL,
+      MBackfillReserve::REVOKE_TOOFULL,
       spg_t(pg->info.pgid.pgid, pg->primary.shard),
       pg->get_osdmap_epoch()),
     pg->get_osdmap_epoch());

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4703,7 +4703,7 @@ void PG::reject_reservation()
   osd->send_message_osd_cluster(
     primary.osd,
     new MBackfillReserve(
-      MBackfillReserve::REJECT,
+      MBackfillReserve::REJECT_TOOFULL,
       spg_t(info.pgid.pgid, primary.shard),
       get_osdmap_epoch()),
     get_osdmap_epoch());
@@ -7768,7 +7768,7 @@ void PG::RecoveryState::WaitRemoteBackfillReserved::retry()
 }
 
 boost::statechart::result
-PG::RecoveryState::WaitRemoteBackfillReserved::react(const RemoteReservationRejected &evt)
+PG::RecoveryState::WaitRemoteBackfillReserved::react(const RemoteReservationRejectedTooFull &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_set(PG_STATE_BACKFILL_TOOFULL);
@@ -7829,7 +7829,7 @@ PG::RecoveryState::NotBackfilling::react(const RemoteBackfillReserved &evt)
 }
 
 boost::statechart::result
-PG::RecoveryState::NotBackfilling::react(const RemoteReservationRejected &evt)
+PG::RecoveryState::NotBackfilling::react(const RemoteReservationRejectedTooFull &evt)
 {
   return discard_event();
 }
@@ -7871,11 +7871,11 @@ PG::RecoveryState::RepNotRecovering::RepNotRecovering(my_context ctx)
 }
 
 boost::statechart::result
-PG::RecoveryState::RepNotRecovering::react(const RejectRemoteReservation &evt)
+PG::RecoveryState::RepNotRecovering::react(const RejectTooFullRemoteReservation &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->reject_reservation();
-  post_event(RemoteReservationRejected());
+  post_event(RemoteReservationRejectedTooFull());
   return discard_event();
 }
 
@@ -7979,12 +7979,12 @@ PG::RecoveryState::RepNotRecovering::react(const RequestBackfillPrio &evt)
       (rand()%1000 < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
     ldout(pg->cct, 10) << "backfill reservation rejected: failure injection"
 		       << dendl;
-    post_event(RejectRemoteReservation());
+    post_event(RejectTooFullRemoteReservation());
   } else if (!pg->cct->_conf->osd_debug_skip_full_check_in_backfill_reservation &&
       pg->osd->tentative_backfill_full(pg, pending_adjustment, cur_stat)) {
     ldout(pg->cct, 10) << "backfill reservation rejected: backfill full"
 		       << dendl;
-    post_event(RejectRemoteReservation());
+    post_event(RejectTooFullRemoteReservation());
   } else {
     Context *preempt = nullptr;
     // Don't reserve space if skipped reservation check, this is used
@@ -8066,17 +8066,17 @@ PG::RecoveryState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &
 
 boost::statechart::result
 PG::RecoveryState::RepWaitBackfillReserved::react(
-  const RejectRemoteReservation &evt)
+  const RejectTooFullRemoteReservation &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->reject_reservation();
-  post_event(RemoteReservationRejected());
+  post_event(RemoteReservationRejectedTooFull());
   return discard_event();
 }
 
 boost::statechart::result
 PG::RecoveryState::RepWaitBackfillReserved::react(
-  const RemoteReservationRejected &evt)
+  const RemoteReservationRejectedTooFull &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->clear_reserved_num_bytes();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2043,7 +2043,7 @@ protected:
   TrivialEvent(NeedUpThru)
   TrivialEvent(Backfilled)
   TrivialEvent(LocalBackfillReserved)
-  TrivialEvent(RejectRemoteReservation)
+  TrivialEvent(RejectTooFullRemoteReservation)
   public:
   TrivialEvent(RequestBackfill)
   protected:
@@ -2431,12 +2431,12 @@ protected:
         boost::statechart::custom_reaction< Backfilled >,
 	boost::statechart::custom_reaction< DeferBackfill >,
 	boost::statechart::custom_reaction< UnfoundBackfill >,
-	boost::statechart::custom_reaction< RemoteReservationRejected >,
+	boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
 	boost::statechart::custom_reaction< RemoteReservationRevokedTooFull>,
 	boost::statechart::custom_reaction< RemoteReservationRevoked>
 	> reactions;
       explicit Backfilling(my_context ctx);
-      boost::statechart::result react(const RemoteReservationRejected& evt) {
+      boost::statechart::result react(const RemoteReservationRejectedTooFull& evt) {
 	// for compat with old peers
 	post_event(RemoteReservationRevokedTooFull());
 	return discard_event();
@@ -2454,7 +2454,7 @@ protected:
     struct WaitRemoteBackfillReserved : boost::statechart::state< WaitRemoteBackfillReserved, Active >, NamedState {
       typedef boost::mpl::list<
 	boost::statechart::custom_reaction< RemoteBackfillReserved >,
-	boost::statechart::custom_reaction< RemoteReservationRejected >,
+	boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
 	boost::statechart::custom_reaction< RemoteReservationRevoked >,
 	boost::statechart::transition< AllBackfillsReserved, Backfilling >
 	> reactions;
@@ -2463,7 +2463,7 @@ protected:
       void retry();
       void exit();
       boost::statechart::result react(const RemoteBackfillReserved& evt);
-      boost::statechart::result react(const RemoteReservationRejected& evt);
+      boost::statechart::result react(const RemoteReservationRejectedTooFull& evt);
       boost::statechart::result react(const RemoteReservationRevoked& evt);
     };
 
@@ -2479,12 +2479,12 @@ protected:
       typedef boost::mpl::list<
 	boost::statechart::transition< RequestBackfill, WaitLocalBackfillReserved>,
 	boost::statechart::custom_reaction< RemoteBackfillReserved >,
-	boost::statechart::custom_reaction< RemoteReservationRejected >
+	boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >
 	> reactions;
       explicit NotBackfilling(my_context ctx);
       void exit();
       boost::statechart::result react(const RemoteBackfillReserved& evt);
-      boost::statechart::result react(const RemoteReservationRejected& evt);
+      boost::statechart::result react(const RemoteReservationRejectedTooFull& evt);
     };
 
     struct NotRecovering : boost::statechart::state< NotRecovering, Active>, NamedState {
@@ -2562,7 +2562,7 @@ protected:
       typedef boost::mpl::list<
 	boost::statechart::transition< RecoveryDone, RepNotRecovering >,
 	// for compat with old peers
-	boost::statechart::transition< RemoteReservationRejected, RepNotRecovering >,
+	boost::statechart::transition< RemoteReservationRejectedTooFull, RepNotRecovering >,
 	boost::statechart::transition< RemoteReservationCanceled, RepNotRecovering >,
 	boost::statechart::custom_reaction< BackfillTooFull >,
 	boost::statechart::custom_reaction< RemoteRecoveryPreempted >,
@@ -2578,15 +2578,15 @@ protected:
     struct RepWaitBackfillReserved : boost::statechart::state< RepWaitBackfillReserved, ReplicaActive >, NamedState {
       typedef boost::mpl::list<
 	boost::statechart::custom_reaction< RemoteBackfillReserved >,
-	boost::statechart::custom_reaction< RejectRemoteReservation >,
-	boost::statechart::custom_reaction< RemoteReservationRejected >,
+	boost::statechart::custom_reaction< RejectTooFullRemoteReservation >,
+	boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
 	boost::statechart::custom_reaction< RemoteReservationCanceled >
 	> reactions;
       explicit RepWaitBackfillReserved(my_context ctx);
       void exit();
       boost::statechart::result react(const RemoteBackfillReserved &evt);
-      boost::statechart::result react(const RejectRemoteReservation &evt);
-      boost::statechart::result react(const RemoteReservationRejected &evt);
+      boost::statechart::result react(const RejectTooFullRemoteReservation &evt);
+      boost::statechart::result react(const RemoteReservationRejectedTooFull &evt);
       boost::statechart::result react(const RemoteReservationCanceled &evt);
     };
 
@@ -2594,13 +2594,13 @@ protected:
       typedef boost::mpl::list<
 	boost::statechart::custom_reaction< RemoteRecoveryReserved >,
 	// for compat with old peers
-	boost::statechart::custom_reaction< RemoteReservationRejected >,
+	boost::statechart::custom_reaction< RemoteReservationRejectedTooFull >,
 	boost::statechart::custom_reaction< RemoteReservationCanceled >
 	> reactions;
       explicit RepWaitRecoveryReserved(my_context ctx);
       void exit();
       boost::statechart::result react(const RemoteRecoveryReserved &evt);
-      boost::statechart::result react(const RemoteReservationRejected &evt) {
+      boost::statechart::result react(const RemoteReservationRejectedTooFull &evt) {
 	// for compat with old peers
 	post_event(RemoteReservationCanceled());
 	return discard_event();
@@ -2612,8 +2612,8 @@ protected:
       typedef boost::mpl::list<
 	boost::statechart::custom_reaction< RequestRecoveryPrio >,
 	boost::statechart::custom_reaction< RequestBackfillPrio >,
-	boost::statechart::custom_reaction< RejectRemoteReservation >,
-	boost::statechart::transition< RemoteReservationRejected, RepNotRecovering >,
+	boost::statechart::custom_reaction< RejectTooFullRemoteReservation >,
+	boost::statechart::transition< RemoteReservationRejectedTooFull, RepNotRecovering >,
 	boost::statechart::transition< RemoteReservationCanceled, RepNotRecovering >,
 	boost::statechart::custom_reaction< RemoteRecoveryReserved >,
 	boost::statechart::custom_reaction< RemoteBackfillReserved >,
@@ -2630,7 +2630,7 @@ protected:
 	// my reservation completion raced with a RELEASE from primary
 	return discard_event();
       }
-      boost::statechart::result react(const RejectRemoteReservation &evt);
+      boost::statechart::result react(const RejectTooFullRemoteReservation &evt);
       void exit();
     };
 

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -165,7 +165,7 @@ struct RequestRecoveryPrio : boost::statechart::event< RequestRecoveryPrio > {
 
 TrivialEvent(NullEvt)
 TrivialEvent(RemoteBackfillReserved)
-TrivialEvent(RemoteReservationRejected)
+TrivialEvent(RemoteReservationRejectedTooFull)
 TrivialEvent(RemoteReservationRevokedTooFull)
 TrivialEvent(RemoteReservationRevoked)
 TrivialEvent(RemoteReservationCanceled)


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/41501
* https://tracker.ceph.com/issues/41583

---

backport of

* https://github.com/ceph/ceph/pull/28204
* https://github.com/ceph/ceph/pull/29857

parent trackers:

* https://tracker.ceph.com/issues/39555
* https://tracker.ceph.com/issues/41255

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh