### PR TITLE
nautilus: osd/PeeringState: do not complain about past_intervals constrained by oldest epoch

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -912,11 +912,15 @@ bool PG::needs_backfill() const
 
 void PG::check_past_interval_bounds() const
 {
+  auto oldest_epoch = osd->get_superblock().oldest_map;
   auto rpib = get_required_past_interval_bounds(
     info,
-    osd->get_superblock().oldest_map);
+    oldest_epoch);
   if (rpib.first >= rpib.second) {
-    if (!past_intervals.empty()) {
+    // do not warn if the start bound is dictated by oldest_map; the
+    // past intervals are presumably appropriate given the pg info.
+    if (!past_intervals.empty() &&
+        rpib.first > oldest_epoch) {
       osd->clog->error() << info.pgid << " required past_interval bounds are"
 			 << " empty [" << rpib << ") but past_intervals is not: "
 			 << past_intervals;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41503

---

backport of https://github.com/ceph/ceph/pull/29747
parent tracker: https://tracker.ceph.com/issues/39546

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh