### PR TITLE
mgr/dashboard: A block-manager can not access the pool page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -17,6 +17,7 @@ import { ConfigurationService } from '../../../shared/api/configuration.service'
 import { PoolService } from '../../../shared/api/pool.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
 import { ExecutingTask } from '../../../shared/models/executing-task';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -81,9 +82,14 @@ describe('PoolListComponent', () => {
   });
 
   describe('monAllowPoolDelete', () => {
+    let configOptRead: boolean;
     let configurationService: ConfigurationService;
 
     beforeEach(() => {
+      configOptRead = true;
+      spyOn(TestBed.get(AuthStorageService), 'getPermissions').and.callFake(() => ({
+        configOpt: { read: configOptRead }
+      }));
       configurationService = TestBed.get(ConfigurationService);
     });
 
@@ -124,6 +130,13 @@ describe('PoolListComponent', () => {
         name: 'mon_allow_pool_delete'
       };
       spyOn(configurationService, 'get').and.returnValue(of(configOption));
+      fixture = TestBed.createComponent(PoolListComponent);
+      component = fixture.componentInstance;
+      expect(component.monAllowPoolDelete).toBe(false);
+    });
+
+    it('should set value correctly w/o config-opt read privileges', () => {
+      configOptRead = false;
       fixture = TestBed.createComponent(PoolListComponent);
       component = fixture.componentInstance;
       expect(component.monAllowPoolDelete).toBe(false);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -96,14 +96,18 @@ export class PoolListComponent implements OnInit {
       }
     ];
 
-    this.configurationService.get('mon_allow_pool_delete').subscribe((data: any) => {
-      if (_.has(data, 'value')) {
-        const monSection = _.find(data.value, (v) => {
-          return v.section === 'mon';
-        }) || { value: false };
-        this.monAllowPoolDelete = monSection.value === 'true' ? true : false;
-      }
-    });
+    // Note, we need read permissions to get the 'mon_allow_pool_delete'
+    // configuration option.
+    if (this.permissions.configOpt.read) {
+      this.configurationService.get('mon_allow_pool_delete').subscribe((data: any) => {
+        if (_.has(data, 'value')) {
+          const monSection = _.find(data.value, (v) => {
+            return v.section === 'mon';
+          }) || { value: false };
+          this.monAllowPoolDelete = monSection.value === 'true' ? true : false;
+        }
+      });
+    }
   }
 
   ngOnInit() {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41573

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
