### PR TITLE
nautilus: core: osd: avoid prep_object_replica_pushes() on clone object when head missing

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1697,6 +1697,11 @@ bool ReplicatedBackend::handle_pull_response(
       a.second.rebuild();
     }
     pi.obc = get_parent()->get_obc(pi.recovery_info.soid, attrset);
+    if (attrset.find(SS_ATTR) != attrset.end()) {
+      bufferlist ssbv = attrset.at(SS_ATTR);
+      SnapSet ss(ssbv);
+      assert(ss.seq  == pi.obc->ssc->snapset.seq);
+    }
     pi.recovery_info.oi = pi.obc->obs.oi;
     pi.recovery_info = recalc_subsets(
       pi.recovery_info,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41506

---

backport of https://github.com/ceph/ceph/pull/27575
parent tracker: https://tracker.ceph.com/issues/39286

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh