### PR TITLE
nautilus: mgr/zabbix: Fix typo in key name for PGs in backfill_wait state

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,4 +1,13 @@
->=14.2.2
+14.2.4
+------
+
+* In the Zabbix Mgr Module there was a typo in the key being send
+  to Zabbix for PGs in backfill_wait state. The key that was sent
+  was 'wait_backfill' and the correct name is 'backfill_wait'.
+  Update your Zabbix template accordingly so that it accepts the
+  new key being send to Zabbix.
+
+14.2.3
 --------
 
 * Nautilus-based librbd clients can now open images on Jewel clusters.

--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -137,7 +137,7 @@ class Module(MgrModule):
 
         pg_states = ['active', 'peering', 'clean', 'scrubbing', 'undersized',
                      'backfilling', 'recovering', 'degraded', 'inconsistent',
-                     'remapped', 'backfill_toofull', 'wait_backfill',
+                     'remapped', 'backfill_toofull', 'backfill_wait',
                      'recovery_wait']
 
         for state in pg_states:

--- a/src/pybind/mgr/zabbix/zabbix_template.xml
+++ b/src/pybind/mgr/zabbix/zabbix_template.xml
@@ -755,12 +755,12 @@
                     <logtimefmt/>
                 </item>
                 <item>
-                    <name>Number of Placement Groups in wait_backfill state</name>
+                    <name>Number of Placement Groups in backfill_wait state</name>
                     <type>2</type>
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>ceph.num_pg_wait_backfill</key>
+                    <key>ceph.num_pg_backfill_wait</key>
                     <delay>0</delay>
                     <history>90</history>
                     <trends>365</trends>
@@ -787,7 +787,7 @@
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <description>Total number of Placement Groups in wait_backfill state</description>
+                    <description>Total number of Placement Groups in backfill_wait state</description>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40043

---

backport of https://github.com/ceph/ceph/pull/28057
parent tracker: https://tracker.ceph.com/issues/39666

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh