### PR TITLE
nautilus: mgr/prometheus: Cast collect_timeout (scrape_interval) to float

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1072,8 +1072,8 @@ class Module(MgrModule):
                     raise cherrypy.HTTPError(503, 'No MON connection')
 
         # Make the cache timeout for collecting configurable
-        self.collect_timeout = self.get_localized_module_option(
-            'scrape_interval', 5.0)
+        self.collect_timeout = float(self.get_localized_module_option(
+            'scrape_interval', 5.0))
 
         server_addr = self.get_localized_module_option(
             'server_addr', get_default_addr())


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41279

---

backport of https://github.com/ceph/ceph/pull/29382
parent tracker: https://tracker.ceph.com/issues/40997

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh