### PR TITLE
nautilus: mgr/pg_autoscaler: fix race with pool deletion

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -254,6 +254,9 @@ class PgAutoscaler(MgrModule):
         # iterate over all pools to determine how they should be sized
         for pool_name, p in iteritems(pools):
             pool_id = p['pool']
+            if pool_id not in pool_stats:
+                # race with pool deletion; skip
+                continue
 
             # FIXME: we assume there is only one take per pool, but that
             # may not be true.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41436

---

backport of https://github.com/ceph/ceph/pull/29807
parent tracker: https://tracker.ceph.com/issues/41386

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh