### PR TITLE
nautilus: mgr/zabbix: Adds possibility to send data to multiple zabbix servers.

### DIFF
--- a/doc/mgr/zabbix.rst
+++ b/doc/mgr/zabbix.rst
@@ -100,6 +100,22 @@ A `template <https://raw.githubusercontent.com/ceph/ceph/9c54334b615362e0a60442c
 
 This template contains all items and a few triggers. You can customize the triggers afterwards to fit your needs.
 
+
+Multiple Zabbix servers
+^^^^^^^^^^^^^^^^^^^^^^^
+It is possible to instruct zabbix module to send data to multiple Zabbix servers.
+
+Parameter *zabbix_host* can be set with multiple hostnames separated by commas.
+Hosnames (or IP adderesses) can be followed by colon and port number. If a port
+number is not present module will use the port number defined in *zabbix_port*.
+
+For example:
+
+::
+
+ceph zabbix config-set zabbix_host "zabbix1,zabbix2:2222,zabbix3:3333"
+
+
 Manually sending data
 ---------------------
 If needed the module can be asked to send data immediately instead of waiting for

--- a/doc/mgr/zabbix.rst
+++ b/doc/mgr/zabbix.rst
@@ -113,7 +113,7 @@ For example:
 
 ::
 
-ceph zabbix config-set zabbix_host "zabbix1,zabbix2:2222,zabbix3:3333"
+    ceph zabbix config-set zabbix_host "zabbix1,zabbix2:2222,zabbix3:3333"
 
 
 Manually sending data

--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -6,6 +6,7 @@ server using the zabbix_sender executable.
 """
 import json
 import errno
+import re
 from subprocess import Popen, PIPE
 from threading import Event
 from mgr_module import MgrModule
@@ -51,6 +52,7 @@ class Module(MgrModule):
     run = False
     config = dict()
     ceph_health_mapping = {'HEALTH_OK': 0, 'HEALTH_WARN': 1, 'HEALTH_ERR': 2}
+    _zabbix_hosts = list()
 
     @property
     def config_keys(self):
@@ -112,6 +114,9 @@ class Module(MgrModule):
         for key, default in self.config_keys.items():
             self.set_config_option(key, self.get_module_option(key, default))
 
+        if self.config['zabbix_host']:
+            self._parse_zabbix_hosts()
+
     def set_config_option(self, option, value):
         if option not in self.config_keys.keys():
             raise RuntimeError('{0} is a unknown configuration '
@@ -131,6 +136,20 @@ class Module(MgrModule):
                        value)
         self.config[option] = value
         return True
+
+    def _parse_zabbix_hosts(self):
+        self._zabbix_hosts = list()
+        servers = self.config['zabbix_host'].split(",")
+        for server in servers:
+            uri = re.match("(?:(?:\[?)([a-z0-9-\.]+|[a-f0-9:\.]+)(?:\]?))(?:((?::))([0-9]{1,5}))?$", server)
+            if uri:
+                zabbix_host, sep, zabbix_port = uri.groups()
+                zabbix_port = zabbix_port if sep == ':' else self.config['zabbix_port']
+                self._zabbix_hosts.append({'zabbix_host': zabbix_host, 'zabbix_port': zabbix_port})
+            else:
+                self.log.error('Zabbix host "%s" is not valid', server)
+
+        self.log.error('Parsed Zabbix hosts: %s', self._zabbix_hosts)
 
     def get_pg_stats(self):
         stats = dict()
@@ -257,7 +276,7 @@ class Module(MgrModule):
         if identifier is None or len(identifier) == 0:
             identifier = 'ceph-{0}'.format(self.fsid)
 
-        if not self.config['zabbix_host']:
+        if not self.config['zabbix_host'] or not self._zabbix_hosts:
             self.log.error('Zabbix server not set, please configure using: '
                            'ceph zabbix config-set zabbix_host <zabbix_host>')
             self.set_health_checks({
@@ -269,25 +288,21 @@ class Module(MgrModule):
             })
             return
 
-        servers = self.config['zabbix_host'].split(",")
         result = True
 
-        for server in servers:
-            zabbix_host, sep, zabbix_port = server.partition(':')
-            zabbix_port = zabbix_port if sep == ':' else self.config['zabbix_port']
-
+        for server in self._zabbix_hosts:
             self.log.info(
                 'Sending data to Zabbix server %s, port %s as host/identifier %s',
-                zabbix_host, zabbix_port, identifier)
+                server['zabbix_host'], server['zabbix_port'], identifier)
             self.log.debug(data)
 
             try:
                 zabbix = ZabbixSender(self.config['zabbix_sender'],
-                                      zabbix_host,
-                                      zabbix_port, self.log)
+                                      server['zabbix_host'],
+                                      server['zabbix_port'], self.log)
                 zabbix.send(identifier, data)
             except Exception as exc:
-                self.log.error('Exception when sending: %s', exc)
+                self.log.exception('Failed to send.')
                 self.set_health_checks({
                     'MGR_ZABBIX_SEND_FAILED': {
                         'severity': 'warning',
@@ -295,6 +310,7 @@ class Module(MgrModule):
                         'detail': [str(exc)]
                     }
                 })
+                result = False
 
         self.set_health_checks(dict())
         return result
@@ -311,6 +327,8 @@ class Module(MgrModule):
             self.log.debug('Setting configuration option %s to %s', key, value)
             if self.set_config_option(key, value):
                 self.set_module_option(key, value)
+                if key == 'zabbix_host' or key == 'zabbix_port':
+                    self._parse_zabbix_hosts()
                 return 0, 'Configuration option {0} updated'.format(key), ''
 
             return 1,\


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40126

---

backport of https://github.com/ceph/ceph/pull/26547
parent tracker: https://tracker.ceph.com/issues/38409

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh