### PR TITLE
tools/rbd-ggate: close log before running postfork

### DIFF
--- a/src/tools/rbd_ggate/main.cc
+++ b/src/tools/rbd_ggate/main.cc
@@ -102,14 +102,13 @@ static int do_map(int argc, const char *argv[])
       std::cerr << err << std::endl;
       return r;
     }
-
     if (forker.is_parent()) {
-      global_init_postfork_start(g_ceph_context);
       if (forker.parent_wait(err) != 0) {
         return -ENXIO;
       }
       return 0;
     }
+    global_init_postfork_start(g_ceph_context);
   }
 
   common_init_finish(g_ceph_context);
@@ -204,9 +203,8 @@ static int do_map(int argc, const char *argv[])
   std::cout << "/dev/" << drv->get_devname() << std::endl;
 
   if (g_conf()->daemonize) {
-    forker.daemonize();
-    global_init_postfork_start(g_ceph_context);
     global_init_postfork_finish(g_ceph_context);
+    forker.daemonize();
   }
 
   init_async_signal_handler();


### PR DESCRIPTION
Otherwise the assert in Log:open() will trigger since
all data is kept during the fork and also the `is_started` flag

Fixes: https://tracker.ceph.com/issues/41592


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>