### PR TITLE
mgr/dashboard: Support iSCSI target-level CHAP auth

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -25,7 +25,8 @@ from ..tools import TaskManager
 @UiApiController('/iscsi', Scope.ISCSI)
 class IscsiUi(BaseController):
 
-    REQUIRED_CEPH_ISCSI_CONFIG_VERSION = 10
+    REQUIRED_CEPH_ISCSI_CONFIG_MIN_VERSION = 10
+    REQUIRED_CEPH_ISCSI_CONFIG_MAX_VERSION = 11
 
     @Endpoint()
     @ReadPermission
@@ -43,10 +44,13 @@ class IscsiUi(BaseController):
                     status['message'] = 'Gateway {} is inaccessible'.format(gateway)
                     return status
             config = IscsiClient.instance().get_config()
-            if config['version'] != IscsiUi.REQUIRED_CEPH_ISCSI_CONFIG_VERSION:
-                status['message'] = 'Unsupported `ceph-iscsi` config version. Expected {} but ' \
-                                    'found {}.'.format(IscsiUi.REQUIRED_CEPH_ISCSI_CONFIG_VERSION,
-                                                       config['version'])
+            if config['version'] < IscsiUi.REQUIRED_CEPH_ISCSI_CONFIG_MIN_VERSION or \
+                    config['version'] > IscsiUi.REQUIRED_CEPH_ISCSI_CONFIG_MAX_VERSION:
+                status['message'] = 'Unsupported `ceph-iscsi` config version. ' \
+                                    'Expected >= {} and <= {} but found' \
+                                    ' {}.'.format(IscsiUi.REQUIRED_CEPH_ISCSI_CONFIG_MIN_VERSION,
+                                                  IscsiUi.REQUIRED_CEPH_ISCSI_CONFIG_MAX_VERSION,
+                                                  config['version'])
                 return status
             status['available'] = True
         except RequestException as e:
@@ -60,6 +64,13 @@ class IscsiUi(BaseController):
                     status['message'] = content_message
 
         return status
+
+    @Endpoint()
+    @ReadPermission
+    def version(self):
+        return {
+            'ceph_iscsi_config_version': IscsiClient.instance().get_config()['version']
+        }
 
     @Endpoint()
     @ReadPermission
@@ -216,7 +227,7 @@ class IscsiTarget(RESTController):
 
     @iscsi_target_task('create', {'target_iqn': '{target_iqn}'})
     def create(self, target_iqn=None, target_controls=None, acl_enabled=None,
-               portals=None, disks=None, clients=None, groups=None):
+               auth=None, portals=None, disks=None, clients=None, groups=None):
         target_controls = target_controls or {}
         portals = portals or []
         disks = disks or []
@@ -230,12 +241,13 @@ class IscsiTarget(RESTController):
                                      component='iscsi')
         settings = IscsiClient.instance().get_settings()
         IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups, settings)
-        IscsiTarget._create(target_iqn, target_controls, acl_enabled, portals, disks, clients,
-                            groups, 0, 100, config, settings)
+
+        IscsiTarget._create(target_iqn, target_controls, acl_enabled, auth, portals, disks,
+                            clients, groups, 0, 100, config, settings)
 
     @iscsi_target_task('edit', {'target_iqn': '{target_iqn}'})
     def set(self, target_iqn, new_target_iqn=None, target_controls=None, acl_enabled=None,
-            portals=None, disks=None, clients=None, groups=None):
+            auth=None, portals=None, disks=None, clients=None, groups=None):
         target_controls = target_controls or {}
         portals = IscsiTarget._sorted_portals(portals)
         disks = IscsiTarget._sorted_disks(disks)
@@ -255,8 +267,8 @@ class IscsiTarget(RESTController):
         IscsiTarget._validate(new_target_iqn, target_controls, portals, disks, groups, settings)
         config = IscsiTarget._delete(target_iqn, config, 0, 50, new_target_iqn, target_controls,
                                      portals, disks, clients, groups)
-        IscsiTarget._create(new_target_iqn, target_controls, acl_enabled, portals, disks, clients,
-                            groups, 50, 100, config, settings)
+        IscsiTarget._create(new_target_iqn, target_controls, acl_enabled, auth, portals, disks,
+                            clients, groups, 50, 100, config, settings)
 
     @staticmethod
     def _delete(target_iqn, config, task_progress_begin, task_progress_end, new_target_iqn=None,
@@ -544,8 +556,29 @@ class IscsiTarget(RESTController):
                                      component='iscsi')
 
     @staticmethod
+    def _update_targetauth(config, target_iqn, auth, gateway_name):
+        # Target level authentication was introduced in ceph-iscsi config v11
+        if config['version'] > 10:
+            user = auth['user']
+            password = auth['password']
+            mutual_user = auth['mutual_user']
+            mutual_password = auth['mutual_password']
+            IscsiClient.instance(gateway_name=gateway_name).update_targetauth(target_iqn,
+                                                                              user,
+                                                                              password,
+                                                                              mutual_user,
+                                                                              mutual_password)
+
+    @staticmethod
+    def _update_targetacl(target_config, target_iqn, acl_enabled, gateway_name):
+        if not target_config or target_config['acl_enabled'] != acl_enabled:
+            targetauth_action = ('enable_acl' if acl_enabled else 'disable_acl')
+            IscsiClient.instance(gateway_name=gateway_name).update_targetacl(target_iqn,
+                                                                             targetauth_action)
+
+    @staticmethod
     def _create(target_iqn, target_controls, acl_enabled,
-                portals, disks, clients, groups,
+                auth, portals, disks, clients, groups,
                 task_progress_begin, task_progress_end, config, settings):
         target_config = config['targets'].get(target_iqn, None)
         TaskManager.current_task().set_progress(task_progress_begin)
@@ -569,9 +602,15 @@ class IscsiTarget(RESTController):
                                                                                    host,
                                                                                    ip_list)
                 TaskManager.current_task().inc_progress(task_progress_inc)
-            targetauth_action = ('enable_acl' if acl_enabled else 'disable_acl')
-            IscsiClient.instance(gateway_name=gateway_name).update_targetauth(target_iqn,
-                                                                              targetauth_action)
+
+            if acl_enabled:
+                IscsiTarget._update_targetauth(config, target_iqn, auth, gateway_name)
+                IscsiTarget._update_targetacl(target_config, target_iqn, acl_enabled, gateway_name)
+
+            else:
+                IscsiTarget._update_targetacl(target_config, target_iqn, acl_enabled, gateway_name)
+                IscsiTarget._update_targetauth(config, target_iqn, auth, gateway_name)
+
             for disk in disks:
                 pool = disk['pool']
                 image = disk['image']
@@ -721,6 +760,18 @@ class IscsiTarget(RESTController):
             'target_controls': target_controls,
             'acl_enabled': acl_enabled
         }
+        # Target level authentication was introduced in ceph-iscsi config v11
+        if config['version'] > 10:
+            target_user = target_config['auth']['username']
+            target_password = target_config['auth']['password']
+            target_mutual_user = target_config['auth']['mutual_username']
+            target_mutual_password = target_config['auth']['mutual_password']
+            target['auth'] = {
+                'user': target_user,
+                'password': target_password,
+                'mutual_user': target_mutual_user,
+                'mutual_password': target_mutual_password
+            }
         return target
 
     @staticmethod

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -185,6 +185,135 @@
           </div>
         </div>
 
+        <!-- Target level authentication was introduced in ceph-iscsi config v11 -->
+        <div formGroupName="auth" *ngIf="cephIscsiConfigVersion > 10 && !targetForm.getValue('acl_enabled')">
+
+          <!-- Target user -->
+          <div class="form-group row">
+            <label class="col-form-label col-sm-3"
+                   for="target_user">
+              <ng-container i18n>User</ng-container>
+            </label>
+            <div class="col-sm-9">
+              <input class="form-control"
+                     type="text"
+                     id="target_user"
+                     name="target_user"
+                     formControlName="user" />
+
+              <span class="invalid-feedback"
+                    *ngIf="targetForm.showError('user', formDir, 'required')"
+                    i18n>This field is required.</span>
+
+              <span class="invalid-feedback"
+                    *ngIf="targetForm.showError('user', formDir, 'pattern')"
+                    i18n>Usernames must have a length of 8 to 64 characters and
+                can only contain letters, '.', '@', '-', '_' or ':'.</span>
+            </div>
+          </div>
+
+          <!-- Target password -->
+          <div class="form-group row">
+            <label class="col-form-label col-sm-3"
+                   for="target_password">
+              <ng-container i18n>Password</ng-container>
+            </label>
+            <div class="col-sm-9">
+              <div class="input-group">
+                <input class="form-control"
+                       type="password"
+                       autocomplete="new-password"
+                       id="target_password"
+                       name="target_password"
+                       formControlName="password" />
+
+                <span class="input-group-append">
+                  <button type="button"
+                          class="btn btn-light"
+                          cdPasswordButton="target_password">
+                  </button>
+                  <button type="button"
+                          class="btn btn-light"
+                          cdCopy2ClipboardButton="target_password">
+                  </button>
+                </span>
+              </div>
+
+              <span class="invalid-feedback"
+                    *ngIf="targetForm.showError('password', formDir, 'required')"
+                    i18n>This field is required.</span>
+
+              <span class="invalid-feedback"
+                    *ngIf="targetForm.showError('password', formDir, 'pattern')"
+                    i18n>Passwords must have a length of 12 to 16 characters
+                and can only contain letters, '@', '-', '_' or '/'.</span>
+            </div>
+          </div>
+
+          <!-- Target mutual_user -->
+          <div class="form-group row">
+            <label class="col-form-label col-sm-3"
+                   for="target_mutual_user">
+              <ng-container i18n>Mutual User</ng-container>
+            </label>
+            <div class="col-sm-9">
+              <input class="form-control"
+                     type="text"
+                     id="target_mutual_user"
+                     name="target_mutual_user"
+                     formControlName="mutual_user" />
+
+              <span class="invalid-feedback"
+                    *ngIf="targetForm.showError('mutual_user', formDir, 'required')"
+                    i18n>This field is required.</span>
+
+              <span class="invalid-feedback"
+                    *ngIf="targetForm.showError('mutual_user', formDir, 'pattern')"
+                    i18n>Usernames must have a length of 8 to 64 characters and
+                can only contain letters, '.', '@', '-', '_' or ':'.</span>
+            </div>
+          </div>
+
+          <!-- Target mutual_password -->
+          <div class="form-group row">
+            <label class="col-form-label col-sm-3"
+                   for="target_mutual_password">
+              <ng-container i18n>Mutual Password</ng-container>
+            </label>
+            <div class="col-sm-9">
+              <div class="input-group">
+                <input class="form-control"
+                       type="password"
+                       autocomplete="new-password"
+                       id="target_mutual_password"
+                       name="target_mutual_password"
+                       formControlName="mutual_password" />
+
+                <span class="input-group-append">
+                  <button type="button"
+                          class="btn btn-light"
+                          cdPasswordButton="target_mutual_password">
+                  </button>
+                  <button type="button"
+                          class="btn btn-light"
+                          cdCopy2ClipboardButton="target_mutual_password">
+                  </button>
+                </span>
+              </div>
+
+              <span class="invalid-feedback"
+                    *ngIf="targetForm.showError('mutual_password', formDir, 'required')"
+                    i18n>This field is required.</span>
+
+              <span class="invalid-feedback"
+                    *ngIf="targetForm.showError('mutual_password', formDir, 'pattern')"
+                    i18n>Passwords must have a length of 12 to 16 characters
+                and can only contain letters, '@', '-', '_' or '/'.</span>
+            </div>
+          </div>
+
+        </div>
+
         <!-- Initiators -->
         <div class="form-group row"
              *ngIf="targetForm.getValue('acl_enabled')">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
@@ -72,6 +72,10 @@ describe('IscsiTargetFormComponent', () => {
     { name: 'node2', ip_addresses: ['192.168.100.202'] }
   ];
 
+  const VERSION = {
+    ceph_iscsi_config_version: 11
+  };
+
   const RBD_LIST = [
     { status: 0, value: [], pool_name: 'ganesha' },
     {
@@ -152,6 +156,7 @@ describe('IscsiTargetFormComponent', () => {
 
     httpTesting.expectOne('ui-api/iscsi/settings').flush(SETTINGS);
     httpTesting.expectOne('ui-api/iscsi/portals').flush(PORTALS);
+    httpTesting.expectOne('ui-api/iscsi/version').flush(VERSION);
     httpTesting.expectOne('api/summary').flush({});
     httpTesting.expectOne('api/block/image').flush(RBD_LIST);
     httpTesting.expectOne('api/iscsi/target').flush(LIST_TARGET);
@@ -183,6 +188,12 @@ describe('IscsiTargetFormComponent', () => {
       groups: [],
       initiators: [],
       acl_enabled: false,
+      auth: {
+        password: '',
+        user: '',
+        mutual_password: '',
+        mutual_user: ''
+      },
       portals: [],
       target_controls: {},
       target_iqn: component.targetForm.value.target_iqn
@@ -386,7 +397,13 @@ describe('IscsiTargetFormComponent', () => {
         ],
         target_controls: {},
         target_iqn: component.target_iqn,
-        acl_enabled: true
+        acl_enabled: true,
+        auth: {
+          password: '',
+          user: '',
+          mutual_password: '',
+          mutual_user: ''
+        }
       });
     });
 
@@ -417,7 +434,13 @@ describe('IscsiTargetFormComponent', () => {
         ],
         target_controls: {},
         target_iqn: component.targetForm.value.target_iqn,
-        acl_enabled: true
+        acl_enabled: true,
+        auth: {
+          password: '',
+          user: '',
+          mutual_password: '',
+          mutual_user: ''
+        }
       });
     });
 
@@ -432,6 +455,12 @@ describe('IscsiTargetFormComponent', () => {
         disks: [{ backstore: 'backstore:1', controls: {}, image: 'disk_2', pool: 'rbd' }],
         groups: [],
         acl_enabled: false,
+        auth: {
+          password: '',
+          user: '',
+          mutual_password: '',
+          mutual_user: ''
+        },
         portals: [
           { host: 'node1', ip: '192.168.100.201' },
           { host: 'node2', ip: '192.168.100.202' }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.html
@@ -42,6 +42,7 @@
 
   <cd-iscsi-target-details cdTableDetail
                            *ngIf="selection.hasSingleSelection"
+                           [cephIscsiConfigVersion]="cephIscsiConfigVersion"
                            [selection]="selection"
                            [settings]="settings"></cd-iscsi-target-details>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
@@ -57,6 +57,7 @@ describe('IscsiTargetListComponent', () => {
     summaryService['summaryData$'] = summaryService['summaryDataSource'].asObservable();
 
     spyOn(iscsiService, 'status').and.returnValue(of({ available: true }));
+    spyOn(iscsiService, 'version').and.returnValue(of({ ceph_iscsi_config_version: 11 }));
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -39,6 +39,7 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
   modalRef: BsModalRef;
   permission: Permission;
   selection = new CdTableSelection();
+  cephIscsiConfigVersion: number;
   settings: any;
   status: string;
   summaryDataSubscription: Subscription;
@@ -120,15 +121,18 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
       this.available = result.available;
 
       if (result.available) {
-        this.taskListService.init(
-          () => this.iscsiService.listTargets(),
-          (resp) => this.prepareResponse(resp),
-          (targets) => (this.targets = targets),
-          () => this.onFetchError(),
-          this.taskFilter,
-          this.itemFilter,
-          this.builders
-        );
+        this.iscsiService.version().subscribe((res: any) => {
+          this.cephIscsiConfigVersion = res['ceph_iscsi_config_version'];
+          this.taskListService.init(
+            () => this.iscsiService.listTargets(),
+            (resp) => this.prepareResponse(resp),
+            (targets) => (this.targets = targets),
+            () => this.onFetchError(),
+            this.taskFilter,
+            this.itemFilter,
+            this.builders
+          );
+        });
 
         this.iscsiService.settings().subscribe((settings: any) => {
           this.settings = settings;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/iscsi.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/iscsi.service.ts
@@ -82,6 +82,10 @@ export class IscsiService {
     return this.http.get(`ui-api/iscsi/settings`);
   }
 
+  version() {
+    return this.http.get(`ui-api/iscsi/version`);
+  }
+
   portals() {
     return this.http.get(`ui-api/iscsi/portals`);
   }

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -209,10 +209,22 @@ class IscsiClient(RestClient):
         })
 
     @RestClient.api_put('/api/targetauth/{target_iqn}')
-    def update_targetauth(self, target_iqn, action, request=None):
-        logger.debug("iSCSI[%s] Updating targetauth: %s/%s", self.gateway_name, target_iqn, action)
+    def update_targetacl(self, target_iqn, action, request=None):
+        logger.debug("iSCSI[%s] Updating targetacl: %s/%s", self.gateway_name, target_iqn, action)
         return request({
             'action': action
+        })
+
+    @RestClient.api_put('/api/targetauth/{target_iqn}')
+    def update_targetauth(self, target_iqn, user, password, mutual_user, mutual_password,
+                          request=None):
+        logger.debug("iSCSI[%s] Updating targetauth: %s/%s/%s/%s/%s", self.gateway_name,
+                     target_iqn, user, password, mutual_user, mutual_password)
+        return request({
+            'username': user,
+            'password': password,
+            'mutual_username': mutual_user,
+            'mutual_password': mutual_password
         })
 
     @RestClient.api_get('/api/targetinfo/{target_iqn}')

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -407,6 +407,11 @@ iscsi_target_request = {
         }
     ],
     "acl_enabled": True,
+    "auth": {
+        "password": "",
+        "user": "",
+        "mutual_password": "",
+        "mutual_user": ""},
     "target_controls": {},
     "groups": [
         {
@@ -463,6 +468,11 @@ iscsi_target_response = {
         }
     ],
     "acl_enabled": True,
+    "auth": {
+        "password": "",
+        "user": "",
+        "mutual_password": "",
+        "mutual_user": ""},
     'groups': [
         {
             'group_id': 'mygroup',
@@ -499,7 +509,7 @@ class IscsiClientMock(object):
             "gateways": {},
             "targets": {},
             "updated": "",
-            "version": 9
+            "version": 11
         }
 
     @classmethod
@@ -561,6 +571,14 @@ class IscsiClientMock(object):
         self.config['targets'][target_iqn] = {
             "clients": {},
             "acl_enabled": True,
+            "auth": {
+                "username": "",
+                "password": "",
+                "password_encryption_enabled": False,
+                "mutual_username": "",
+                "mutual_password": "",
+                "mutual_password_encryption_enabled": False
+            },
             "controls": target_controls,
             "created": "2019/01/17 09:22:34",
             "disks": [],
@@ -689,8 +707,15 @@ class IscsiClientMock(object):
         self.config['discovery_auth']['mutual_username'] = mutual_user
         self.config['discovery_auth']['mutual_password'] = mutual_password
 
-    def update_targetauth(self, target_iqn, action):
+    def update_targetacl(self, target_iqn, action):
         self.config['targets'][target_iqn]['acl_enabled'] = (action == 'enable_acl')
+
+    def update_targetauth(self, target_iqn, user, password, mutual_user, mutual_password):
+        target_config = self.config['targets'][target_iqn]
+        target_config['auth']['username'] = user
+        target_config['auth']['password'] = password
+        target_config['auth']['mutual_username'] = mutual_user
+        target_config['auth']['mutual_password'] = mutual_password
 
     def get_targetinfo(self, target_iqn):
         # pylint: disable=unused-argument


### PR DESCRIPTION
This PR adds support for iSCSI target-level CHAP authentication.

Requires `ceph-iscsi` config v11 introduced on PR https://github.com/ceph/ceph-iscsi/pull/133 (Merged).

Fixes: https://tracker.ceph.com/issues/41576

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
