### PR TITLE
nautilus: mgr/zabbix: encode string for Python 3 compatibility

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -37,7 +37,7 @@ class ZabbixSender(object):
         proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
 
         for key, value in data.items():
-            proc.stdin.write('{0} ceph.{1} {2}\n'.format(hostname, key, value))
+            proc.stdin.write('{0} ceph.{1} {2}\n'.format(hostname, key, value).encode('utf-8'))
 
         stdout, stderr = proc.communicate()
         if proc.returncode != 0:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41509

---

backport of https://github.com/ceph/ceph/pull/28624
parent tracker: https://tracker.ceph.com/issues/36318

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh