### PR TITLE
librbd: clean up unused variable

### DIFF
--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -54,7 +54,6 @@ public:
   }
 
 private:
-  uint64_t m_object_size;
   ::SnapContext m_snapc;
   uint64_t m_object_no;
 


### PR DESCRIPTION
librbd: Delete unused variable: C_MigrateObject::m_object_size

Fixes: https://tracker.ceph.com/issues/41580

Signed-off-by: mxdInspur muxiangdong@inspur.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
