### PR TITLE
cmake: selectively rewrite install rpath

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -410,7 +410,7 @@ target_link_libraries(ceph-common ${ceph_common_deps})
 # appease dpkg-shlibdeps
 set_target_properties(ceph-common PROPERTIES
   SOVERSION 0
-  INSTALL_RPATH "")
+  SKIP_RPATH TRUE)
 if(NOT APPLE AND NOT FREEBSD)
   # Apple uses Mach-O, not ELF. so this option does not apply to APPLE.
   #

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -42,25 +42,20 @@ target_link_libraries(unittest_mon_montypes mon global)
 
 # ceph_test_mon_memory_target
 add_executable(ceph_test_mon_memory_target
-  test_mon_memory_target.cc
-  )
-target_link_libraries(ceph_test_mon_memory_target ${UNITTEST_LIBS} Boost::system)
+  test_mon_memory_target.cc)
+target_link_libraries(ceph_test_mon_memory_target Boost::system Threads::Threads)
 install(TARGETS ceph_test_mon_memory_target
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_mon_log_rss_usage
 add_executable(ceph_test_log_rss_usage
-  test_log_rss_usage.cc
-  )
-target_link_libraries(ceph_test_log_rss_usage ${UNITTEST_LIBS})
+  test_log_rss_usage.cc)
 install(TARGETS ceph_test_log_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_mon_rss_usage
 add_executable(ceph_test_mon_rss_usage
-  test_mon_rss_usage.cc
-  )
-target_link_libraries(ceph_test_mon_rss_usage ${UNITTEST_LIBS})
+  test_mon_rss_usage.cc)
 install(TARGETS ceph_test_mon_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -44,18 +44,24 @@ target_link_libraries(unittest_mon_montypes mon global)
 add_executable(ceph_test_mon_memory_target
   test_mon_memory_target.cc)
 target_link_libraries(ceph_test_mon_memory_target Boost::system Threads::Threads)
+set_target_properties(ceph_test_mon_memory_target PROPERTIES
+  SKIP_RPATH TRUE)
 install(TARGETS ceph_test_mon_memory_target
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_mon_log_rss_usage
 add_executable(ceph_test_log_rss_usage
   test_log_rss_usage.cc)
+set_target_properties(ceph_test_log_rss_usage PROPERTIES
+  SKIP_RPATH TRUE)
 install(TARGETS ceph_test_log_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_mon_rss_usage
 add_executable(ceph_test_mon_rss_usage
   test_mon_rss_usage.cc)
+set_target_properties(ceph_test_mon_rss_usage PROPERTIES
+  SKIP_RPATH TRUE)
 install(TARGETS ceph_test_mon_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 


### PR DESCRIPTION
we use rpath for finding libceph-common, which is an internal library
not supposed to be used by 3rd party applications.

before this change, `CMAKE_INSTALL_RPATH` is set globally. so cmake is
asked to rewrite the RPATH for all installed targets. but this is not
needed. as some executables do not link against libceph-common. hence,
cmake complains when installing them, like:

CMake Error at src/test/mon/cmake_install.cmake:90 (file):
  file RPATH_CHANGE could not write new RPATH:
    /usr/lib64/ceph
   to the file:
    /home/abuild/rpmbuild/BUILDROOT/ceph-15.0.0-4347.g85a07b9.x86_64/usr/bin/ceph_test_log_rss_usage
   No valid ELF RPATH or RUNPATH entry exists in the file;

so, in this change, we only apply `INSTALL_RPATH` to libceph-common.

Fixes: https://tracker.ceph.com/issues/41524
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
