### PR TITLE
mds: use set to store to evict client

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3686,15 +3686,15 @@ bool Locker::any_late_revoking_caps(xlist<Capability*> const &revoking,
     }
 }
 
-std::vector<client_t> Locker::get_late_revoking_clients(double timeout) const
+std::set<client_t> Locker::get_late_revoking_clients(double timeout) const
 {
-  std::vector<client_t> result;
+  std::set<client_t> result;
 
   if (any_late_revoking_caps(revoking_caps, timeout)) {
     // Slow path: execute in O(N_clients)
     for (auto &p : revoking_caps_by_client) {
       if (any_late_revoking_caps(p.second, timeout)) {
-        result.push_back(p.first);
+        result.insert(p.first);
       }
     }
   } else {

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -181,7 +181,7 @@ public:
 
   void remove_client_cap(CInode *in, Capability *cap, bool kill=false);
 
-  std::vector<client_t> get_late_revoking_clients(double timeout) const;
+  std::set<client_t> get_late_revoking_clients(double timeout) const;
 
 private:
   bool any_late_revoking_caps(xlist<Capability*> const &revoking, double timeout) const;


### PR DESCRIPTION
client is put to to_evict vector more than once if client does't response more than one caps revoke, it may cause session hang if session opening is aborted by next evict, use set structure to keep to evict client unique.

Fixes: https://tracker.ceph.com/issues/41585
Signed-off-by: Erqi Chen <chenerqi@gmail.com>