### PR TITLE
nautilus: mds: evict an unresponsive client only when another client wants its caps

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -166,6 +166,7 @@ class FuseMount(CephFSMount):
     def gather_mount_info(self):
         status = self.admin_socket(['status'])
         self.id = status['id']
+        self.client_pid = status['metadata']['pid']
         try:
             self.inst = status['inst_str']
             self.addr = status['addr_str']

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -502,6 +502,14 @@ class CephFSMount(object):
         self._kill_background(p)
         self.background_procs.remove(p)
 
+    def send_signal(self, signal):
+        signal = signal.lower()
+        if signal.lower() not in ['sigstop', 'sigcont', 'sigterm', 'sigkill']:
+            raise NotImplementedError
+
+        self.client_remote.run(args=['sudo', 'kill', '-{0}'.format(signal),
+                                self.client_pid], omit_sudo=False)
+
     def get_global_id(self):
         raise NotImplementedError()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40900

---

backport of https://github.com/ceph/ceph/pull/22645
parent tracker: https://tracker.ceph.com/issues/17854

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh