### PR TITLE
nautilus: mds: fix InoTable::force_consume_to()

### DIFF
--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -226,15 +226,10 @@ bool InoTable::repair(inodeno_t id)
 
 bool InoTable::force_consume_to(inodeno_t ino)
 {
-  auto it = free.begin();
-  if (it != free.end() && it.get_start() <= ino) {
-    inodeno_t min = it.get_start();
-    derr << "erasing " << min << " to " << ino << dendl;
-    free.erase(min, ino - min + 1);
-    projected_free = free;
-    projected_version = ++version;
-    return true;
-  } else {
+  inodeno_t first = free.range_start();
+  if (first > ino)
     return false;
-  }
+
+  skip_inos(inodeno_t(ino + 1 - first));
+  return true;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41477

---

backport of https://github.com/ceph/ceph/pull/29411
parent tracker: https://tracker.ceph.com/issues/41006

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh