### PR TITLE
nautilus: cephfs: client: return -eio when sync file which unsafe reqs have been dropped

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2942,8 +2942,21 @@ void Client::kick_requests_closed(MetaSession *session)
       if (req->got_unsafe) {
 	lderr(cct) << __func__ << " removing unsafe request " << req->get_tid() << dendl;
 	req->unsafe_item.remove_myself();
-	req->unsafe_dir_item.remove_myself();
-	req->unsafe_target_item.remove_myself();
+	if (is_dir_operation(req)) {
+	  Inode *dir = req->inode();
+	  assert(dir);
+	  dir->set_async_err(-EIO);
+	  lderr(cct) << "kick_requests_closed drop req of inode(dir) : "
+		     <<  dir->ino  << " " << req->get_tid() << dendl;
+	  req->unsafe_dir_item.remove_myself();
+	}
+	if (req->target) {
+	  InodeRef &in = req->target;
+	  in->set_async_err(-EIO);
+	  lderr(cct) << "kick_requests_closed drop req of inode : "
+		     <<  in->ino  << " " << req->get_tid() << dendl;
+	  req->unsafe_target_item.remove_myself();
+	}
 	signal_cond_list(req->waitfor_safe);
 	unregister_request(req);
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41488

---

backport of https://github.com/ceph/ceph/pull/29167
parent tracker: https://tracker.ceph.com/issues/40877

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh