### PR TITLE
nautilus: bluestore: Don't forget sub kv_submitted_waiters

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1815,6 +1815,7 @@ public:
 	  auto it = q.rbegin();
 	  it++;
 	  if (it->state >= TransContext::STATE_KV_SUBMITTED) {
+	    --kv_submitted_waiters;
 	    return;
           }
 	}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41258

---

parent tracker: https://tracker.ceph.com/issues/41216

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh