### PR TITLE
nautilus: rpm: always build ceph-test package

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -22,6 +22,7 @@
 # bcond syntax!
 #################################################################################
 %bcond_with make_check
+%bcond_without ceph_test_package
 %ifarch s390 s390x
 %bcond_with tcmalloc
 %else
@@ -29,7 +30,6 @@
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %bcond_without selinux
-%bcond_without ceph_test_package
 %bcond_without cephfs_java
 %bcond_without lttng
 %bcond_without libradosstriper
@@ -39,7 +39,6 @@
 %endif
 %if 0%{?suse_version}
 %bcond_with selinux
-%bcond_with ceph_test_package
 %bcond_with cephfs_java
 %bcond_with amqp_endpoint
 #Compat macro for new _fillupdir macro introduced in Nov 2017


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41333

---

backport of https://github.com/ceph/ceph/pull/29685
parent tracker: https://tracker.ceph.com/issues/41296

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh