### PR TITLE
nautilus: core: osd: clear PG_STATE_CLEAN when repair object

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15257,6 +15257,7 @@ int PrimaryLogPG::rep_repair_primary_object(const hobject_t& soid, OpContext *ct
     eio_errors_to_process = true;
     ceph_assert(is_clean());
     state_set(PG_STATE_REPAIR);
+    state_clear(PG_STATE_CLEAN);
     queue_peering_event(
         PGPeeringEventRef(
 	  std::make_shared<PGPeeringEvent>(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41443

---

backport of https://github.com/ceph/ceph/pull/29756
parent tracker: https://tracker.ceph.com/issues/41348

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh