### PR TITLE
RBD:clear up all objects when pool is empty

### DIFF
--- a/src/tools/rbd/action/Remove.cc
+++ b/src/tools/rbd/action/Remove.cc
@@ -150,6 +150,44 @@ int execute(const po::variables_map &vm,
     }
     return r;
   }
+  
+  std::vector<string> image_list;
+  r = rbd.list(io_ctx, image_list);
+  if(r == -ENOENT) {
+    std::cerr << "rbd error: list rbd image(ENOENT)" << cpp_strerror(r) << std::endl;
+    return 0;
+  }
+  if(r < 0) {
+    std::cerr << "rbd error list rbd image:" << cpp_strerror(r) << std::endl;
+    return 0;
+  }
+  if(0 == image_list.size()) {
+    std::vector<librbd::trash_image_info_t> trash_entries;
+    r = rbd.trash_list(io_ctx, trash_entries);
+    if (r < 0) {
+      return 0;
+    }
+    if(trash_entries.empty()) {
+      r = io_ctx.remove(RBD_DIRECTORY);
+      if(r < 0) {
+        std::cerr << "rbd error: fail to clear up directory object: " << cpp_strerror(r) << std::endl;
+        return 0;
+      }
+      
+      r = io_ctx.remove(RBD_INFO);
+      if(r < 0) {
+        std::cerr << "rbd error: fail to clear up rbd_info object: " << cpp_strerror(r) << std::endl;
+        return 0;
+      }
+
+      r = io_ctx.remove(RBD_TRASH);
+      if(r < 0) {
+        std::cerr << "rbd error: fail to clear up rbd_trash object: " << cpp_strerror(r) << std::endl;
+        return 0;
+      }
+    }
+  }
+  
   return 0;
 }
 


### PR DESCRIPTION
RBD:clear up all objects when pool is empty

After removing all images in a pool, some objects still exist, eg. rbd_directory、rbd_info、rbd_trash. I think it is illogic, so i try to clear up all these objects when the pool is empty.

Fixs: https://tracker.ceph.com/issues/41591
Signed-off-by: mxdInspur muxiangdong@inspur.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
