### PR TITLE
librbd: adjust the else-if conditions in validate_striping()

### DIFF
--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -71,11 +71,9 @@ int validate_striping(CephContext *cct, uint8_t order, uint64_t stripe_unit,
     lderr(cct) << "must specify both (or neither) of stripe-unit and "
                << "stripe-count" << dendl;
     return -EINVAL;
-  } else if (stripe_unit || stripe_count) {
-    if ((1ull << order) % stripe_unit || stripe_unit > (1ull << order)) {
-      lderr(cct) << "stripe unit is not a factor of the object size" << dendl;
-      return -EINVAL;
-    }
+  } else if (stripe_unit && ((1ull << order) % stripe_unit || stripe_unit > (1ull << order))) {
+    lderr(cct) << "stripe unit is not a factor of the object size" << dendl;
+    return -EINVAL;
   }
   return 0;
 }


### PR DESCRIPTION
librbd:adjust the else-if conditions in validate_striping()

I think it is illogical to taking "stripe_unit || stripe_count" as the onditions of the else-if, because the statement of the branch will go right only on the premise that the stripe_unit is not equal to 0.
 
Signed-off-by: mxdInspur muxiangdong@inspur.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
