### PR TITLE
mgr/volumes: prevent negative subvolume size

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -162,6 +162,17 @@ class TestVolumes(CephFSTestCase):
         else:
             raise
 
+    def test_subvolume_create_with_invalid_size(self):
+        # create subvolume with an invalid size -1
+        subvolume = self._generate_random_subvolume_name()
+        try:
+            self._fs_cmd("subvolume", "create", self.volname, subvolume, "--size", "-1")
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise
+        else:
+            raise RuntimeError("expected the 'fs subvolume create' command to fail")
+
     def test_nonexistent_subvolume_rm(self):
         # remove non-existing subvolume
         subvolume = "non_existent_subvolume"

--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -77,8 +77,10 @@ class SubVolume(object):
 
         try:
             if size is not None:
-                self.fs.setxattr(subvolpath, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
-
+                try:
+                    self.fs.setxattr(subvolpath, 'ceph.quota.max_bytes', str(size).encode('utf-8'), 0)
+                except cephfs.InvalidValue as e:
+                    raise VolumeException(-errno.EINVAL, "Invalid size: '{0}'".format(size))
             if pool:
                 try:
                     self.fs.setxattr(subvolpath, 'ceph.dir.layout.pool', pool.encode('utf-8'), 0)


### PR DESCRIPTION
Fixes: 
```
$ ./bin/ceph fs subvolume create myfs mysubvol --size -10 --group_name mygroup --pool_layout mycephfs_data --mode 777
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2019-09-01T21:42:23.406+0530 7f08ce9f6700 -1 WARNING: all dangerous and experimental features are enabled.
2019-09-01T21:42:23.503+0530 7f08ce9f6700 -1 WARNING: all dangerous and experimental features are enabled.
Error EINVAL: Traceback (most recent call last):
  File "/home/jcollin/workspace/ceph/src/pybind/mgr/mgr_module.py", line 915, in _handle_command
    return self.handle_command(inbuf, cmd)
  File "/home/jcollin/workspace/ceph/src/pybind/mgr/volumes/module.py", line 188, in handle_command
    return handler(inbuf, cmd)
  File "/home/jcollin/workspace/ceph/src/pybind/mgr/volumes/module.py", line 230, in _cmd_fs_subvolume_create
    mode=cmd.get('mode', '755'))
  File "/home/jcollin/workspace/ceph/src/pybind/mgr/volumes/fs/volume.py", line 345, in conn_wrapper
    result = func(self, fs_h, **kwargs)
  File "/home/jcollin/workspace/ceph/src/pybind/mgr/volumes/fs/volume.py", line 372, in create_subvolume
    sv.create_subvolume(spec, size, pool=pool, mode=self.octal_str_to_decimal_int(mode))
  File "/home/jcollin/workspace/ceph/src/pybind/mgr/volumes/fs/subvolume.py", line 111, in create_subvolume
    raise e
InvalidValue: error in setxattr: Invalid argument [Errno 22]
```