### PR TITLE
rgw/services: silence -Wunused-variable warning

### DIFF
--- a/src/rgw/services/svc_user_rados.cc
+++ b/src/rgw/services/svc_user_rados.cc
@@ -315,7 +315,7 @@ public:
       }
     }
 
-    for (const auto& [name, access_key] : old_info.access_keys) {
+    for ([[maybe_unused]] const auto& [name, access_key] : old_info.access_keys) {
       if (!new_info.access_keys.count(access_key.id)) {
         ret = svc.user->remove_key_index(ctx, access_key, y);
         if (ret < 0 && ret != -ENOENT) {


### PR DESCRIPTION
Signed-off-by: Lan Liu <liulan@umcloud.com>

silence compile warning:

```
/root/github/ceph/src/rgw/services/svc_user_rados.cc: In member function ‘int PutOperation::remove_old_indexes(const RGWUserInfo&, const RGWUserInfo&, optional_yield)’:
/root/github/ceph/src/rgw/services/svc_user_rados.cc:318:39: warning: unused variable ‘name’ [-Wunused-variable]
     for (const auto& [name, access_key] : old_info.access_keys) {
                                       ^
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
