### PR TITLE
mgr/dashboard: fix cdEncode decorator is not working on class

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/decorators/cd-encode.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/decorators/cd-encode.ts
@@ -41,11 +41,12 @@ export function cdEncodeNot(target: Object, propertyKey: string, index: number) 
 }
 
 function encodeClass(target: Function) {
-  for (const propertyName of Object.keys(target.prototype)) {
+  for (const propertyName of Object.getOwnPropertyNames(target.prototype)) {
     const descriptor = Object.getOwnPropertyDescriptor(target.prototype, propertyName);
 
     const isMethod = descriptor.value instanceof Function;
-    if (!isMethod) {
+    const isConstructor = propertyName === 'constructor';
+    if (!isMethod || isConstructor) {
       continue;
     }
 


### PR DESCRIPTION
Object.keys does not return all methods of a class.

Fixes: https://tracker.ceph.com/issues/41368

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
