### PR TITLE
librbd: clear up rbd_trash object in Trash<I>::remove()

### DIFF
--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -541,6 +541,17 @@ int Trash<I>::remove(IoCtx &io_ctx, const std::string &image_id, bool force,
                << dendl;
   }
 
+  std::vector<librbd::trash_image_info_t> trash_entries;
+  r = librbd::api::Trash<I>::list(io_ctx, trash_entries, true);
+  if (r < 0) {
+    return r;
+  }
+  if(trash_entries.empty()) {
+    r = io_ctx.remove(RBD_TRASH);
+    if(r < 0) {
+      lderr(cct) << "error: faile remove rbd_trash:" << cpp_strerror(r) << dendl;
+    }
+  }
   return 0;
 }
 


### PR DESCRIPTION
librbd/api:clear up rbd_trash object when trash list is empty

When removing image a rbd_trash object generates and keep existing, even if nothing in the trash, so i think it is reasonable to remove rbd_trash on that.

Signed-off-by: mxdInspur muxiangdong@inspur.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
