### PR TITLE
test/librbd: allow parallel runs of run-rbd-unit-tests

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -527,7 +527,14 @@ if(WITH_FIO OR WITH_SYSTEM_FIO)
 endif()
 
 if(WITH_RBD)
-  add_ceph_test(run-rbd-unit-tests.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh)
+  # Run rbd-unit-tests separate so they an run in parallel
+  # For values see: src/include/rbd/features.h
+  add_ceph_test(run-rbd-unit-tests-N.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh N)
+  add_ceph_test(run-rbd-unit-tests-0.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 0)
+  add_ceph_test(run-rbd-unit-tests-1.sh   ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 1)
+  add_ceph_test(run-rbd-unit-tests-61.sh  ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 61)
+  add_ceph_test(run-rbd-unit-tests-109.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 109)
+  add_ceph_test(run-rbd-unit-tests-127.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh 127)
   if(FREEBSD)
     add_ceph_test(rbd-ggate.sh ${CMAKE_CURRENT_SOURCE_DIR}/rbd-ggate.sh)
   endif(FREEBSD)

--- a/src/test/run-rbd-unit-tests.sh
+++ b/src/test/run-rbd-unit-tests.sh
@@ -6,10 +6,18 @@ set -ex
 source $(dirname $0)/detect-build-env-vars.sh
 PATH="$CEPH_BIN:$PATH"
 
-unset RBD_FEATURES
-unittest_librbd
+if [ $# = 0 ]; then
+  # mimic the old behaviour
+  TESTS='0 1 61 109 127'
+  unset RBD_FEATURES; unittest_librbd
+elif [ $# = 1 -a "${1}" = N ] ; then
+  # new style no feature request
+  unset RBD_FEATURES; unittest_librbd
+else 
+  TESTS="$*"
+fi
 
-for i in 0 1 61 109 127
+for i in ${TESTS}
 do
     RBD_FEATURES=$i unittest_librbd
 done


### PR DESCRIPTION
Running all tests sequential makes it the longest test of
`make check`, with each partial test taking around 500 sec.
Running 6 tests thus takes almost an hour.

Cut this down if ctest runs tests in parallel

Default behaviour of src/test/run-rbd-unit-tests.sh is kept:
  Without parameters the tests are run in sequence

To run unitttest_librbd with RBD_FEATURES, use `N` as parameter




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>