### PR TITLE
mimic: rgw: perfcounters: add gc retire counter

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -164,6 +164,8 @@ int rgw_perf_start(CephContext *cct)
   plb.add_u64_counter(l_rgw_keystone_token_cache_hit, "keystone_token_cache_hit", "Keystone token cache hits");
   plb.add_u64_counter(l_rgw_keystone_token_cache_miss, "keystone_token_cache_miss", "Keystone token cache miss");
 
+  plb.add_u64_counter(l_rgw_gc_retire, "gc_retire_object", "GC object retires");
+
   perfcounter = plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(perfcounter);
   return 0;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -262,11 +262,13 @@ enum {
   l_rgw_keystone_token_cache_hit,
   l_rgw_keystone_token_cache_miss,
 
+  l_rgw_gc_retire,
+
   l_rgw_last,
 };
 
 
- /* size should be the required string size + 1 */
+/* size should be the required string size + 1 */
 int gen_rand_base64(CephContext *cct, char *dest, int size);
 void gen_rand_alphanumeric(CephContext *cct, char *dest, int size);
 void gen_rand_alphanumeric_lower(CephContext *cct, char *dest, int size);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40517

---

backport of https://github.com/ceph/ceph/pull/26351
parent tracker: https://tracker.ceph.com/issues/38251

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh