### PR TITLE
mgr/dashboard: disable pylint's --py3k flag

### DIFF
--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -9,10 +9,13 @@ import threading
 import warnings
 
 import six
-if six.PY2:
-    FileNotFoundError = IOError
-
 from six.moves.urllib import parse
+
+from .. import mgr, logger
+from ..tools import prepare_url_prefix
+
+if six.PY2:
+    FileNotFoundError = IOError  # pylint: disable=redefined-builtin
 
 try:
     from onelogin.saml2.settings import OneLogin_Saml2_Settings as Saml2Settings
@@ -22,10 +25,6 @@ try:
     python_saml_imported = True
 except ImportError:
     python_saml_imported = False
-
-
-from .. import mgr, logger
-from ..tools import prepare_url_prefix
 
 
 class Saml2(object):

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -61,8 +61,6 @@ addopts =
     -rn
     --rcfile=.pylintrc
     --jobs={[pylint]jobs}
-# Detect Python 2-3 migration issues
-    --py3k
 
 [rstlint]
 dirs =
@@ -72,6 +70,8 @@ dirs =
 [testenv:lint]
 basepython=python3
 deps =
+    -rrequirements.txt
+    -cconstraints.txt
     -rrequirements-lint.txt
 commands =
     lint: flake8 {posargs}


### PR DESCRIPTION
This flag, instead of just improving Python 2 to 3 compatibility checks,
disables a few other checks.

Fixes: https://tracker.ceph.com/issues/41602
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
