### PR TITLE
Fix big-endian handling

### DIFF
--- a/src/auth/cephx/CephxProtocol.cc
+++ b/src/auth/cephx/CephxProtocol.cc
@@ -37,9 +37,9 @@ void cephx_calc_client_server_challenge(CephContext *cct, CryptoKey& secret, uin
     return;
 
   uint64_t k = 0;
-  const uint64_t *p = (const uint64_t *)enc.c_str();
+  const ceph_le64 *p = (const ceph_le64 *)enc.c_str();
   for (int pos = 0; pos + sizeof(k) <= enc.length(); pos+=sizeof(k), p++)
-    k ^= mswab(*p);
+    k ^= *p;
   *key = k;
 }
 

--- a/src/auth/cephx/CephxSessionHandler.cc
+++ b/src/auth/cephx/CephxSessionHandler.cc
@@ -49,16 +49,16 @@ int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
     // - skip the leading 4 byte wrapper from encode_encrypt
     struct {
       __u8 v;
-      __le64 magic;
-      __le32 len;
-      __le32 header_crc;
-      __le32 front_crc;
-      __le32 middle_crc;
-      __le32 data_crc;
+      ceph_le64 magic;
+      ceph_le32 len;
+      ceph_le32 header_crc;
+      ceph_le32 front_crc;
+      ceph_le32 middle_crc;
+      ceph_le32 data_crc;
     } __attribute__ ((packed)) sigblock = {
-      1, mswab(AUTH_ENC_MAGIC), mswab<uint32_t>(4*4),
-      mswab<uint32_t>(header.crc), mswab<uint32_t>(footer.front_crc),
-      mswab<uint32_t>(footer.middle_crc), mswab<uint32_t>(footer.data_crc)
+      1, init_le64(AUTH_ENC_MAGIC), init_le32(4*4),
+      init_le32(header.crc), init_le32(footer.front_crc),
+      init_le32(footer.middle_crc), init_le32(footer.data_crc)
     };
 
     char exp_buf[CryptoKey::get_max_outbuf_size(sizeof(sigblock))];
@@ -78,27 +78,27 @@ int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
       return -1;
     }
 
-    *psig = *reinterpret_cast<__le64*>(exp_buf);
+    *psig = *reinterpret_cast<ceph_le64*>(exp_buf);
   } else {
     // newer mimic+ signatures
     struct {
-      __le32 header_crc;
-      __le32 front_crc;
-      __le32 front_len;
-      __le32 middle_crc;
-      __le32 middle_len;
-      __le32 data_crc;
-      __le32 data_len;
-      __le32 seq_lower_word;
+      ceph_le32 header_crc;
+      ceph_le32 front_crc;
+      ceph_le32 front_len;
+      ceph_le32 middle_crc;
+      ceph_le32 middle_len;
+      ceph_le32 data_crc;
+      ceph_le32 data_len;
+      ceph_le32 seq_lower_word;
     } __attribute__ ((packed)) sigblock = {
-      mswab<uint32_t>(header.crc),
-      mswab<uint32_t>(footer.front_crc),
-      mswab<uint32_t>(header.front_len),
-      mswab<uint32_t>(footer.middle_crc),
-      mswab<uint32_t>(header.middle_len),
-      mswab<uint32_t>(footer.data_crc),
-      mswab<uint32_t>(header.data_len),
-      mswab<uint32_t>(header.seq)
+      init_le32(header.crc),
+      init_le32(footer.front_crc),
+      init_le32(header.front_len),
+      init_le32(footer.middle_crc),
+      init_le32(header.middle_len),
+      init_le32(footer.data_crc),
+      init_le32(header.data_len),
+      init_le32(header.seq)
     };
 
     char exp_buf[CryptoKey::get_max_outbuf_size(sizeof(sigblock))];
@@ -119,7 +119,7 @@ int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
     }
 
     struct enc {
-      __le64 a, b, c, d;
+      ceph_le64 a, b, c, d;
     } *penc = reinterpret_cast<enc*>(exp_buf);
     *psig = penc->a ^ penc->b ^ penc->c ^ penc->d;
   }

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -481,7 +481,7 @@ void rgw_bi_log_entry::generate_test_instances(list<rgw_bi_log_entry*>& ls)
   ls.push_back(new rgw_bi_log_entry);
   ls.back()->id = "midf";
   ls.back()->object = "obj";
-  ls.back()->timestamp = ceph::real_clock::from_ceph_timespec({{2}, {3}});
+  ls.back()->timestamp = ceph::real_clock::from_ceph_timespec({init_le32(2), init_le32(3)});
   ls.back()->index_ver = 4323;
   ls.back()->tag = "tagasdfds";
   ls.back()->op = CLS_RGW_OP_DEL;
@@ -663,7 +663,7 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
 {
   ls.push_back(new cls_rgw_reshard_entry);
   ls.push_back(new cls_rgw_reshard_entry);
-  ls.back()->time = ceph::real_clock::from_ceph_timespec({{2}, {3}});
+  ls.back()->time = ceph::real_clock::from_ceph_timespec({init_le32(2), init_le32(3)});
   ls.back()->tenant = "tenant";
   ls.back()->bucket_name = "bucket1""";
   ls.back()->bucket_id = "bucket_id";

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1094,7 +1094,7 @@ struct cls_rgw_gc_obj_info
     ls.push_back(new cls_rgw_gc_obj_info);
     ls.push_back(new cls_rgw_gc_obj_info);
     ls.back()->tag = "footag";
-    ceph_timespec ts{21, 32};
+    ceph_timespec ts{init_le32(21), init_le32(32)};
     ls.back()->time = ceph::real_clock::from_ceph_timespec(ts);
   }
 };

--- a/src/common/Checksummer.h
+++ b/src/common/Checksummer.h
@@ -5,6 +5,7 @@
 #define CEPH_OS_BLUESTORE_CHECKSUMMER
 
 #include "xxHash/xxhash.h"
+#include "include/byteorder.h"
 
 class Checksummer {
 public:
@@ -69,7 +70,7 @@ public:
 
   struct crc32c {
     typedef uint32_t init_value_t;
-    typedef __le32 value_t;
+    typedef ceph_le32 value_t;
 
     // we have no execution context/state.
     typedef int state_t;
@@ -78,7 +79,7 @@ public:
     static void fini(state_t *state) {
     }
 
-    static value_t calc(
+    static init_value_t calc(
       state_t state,
       init_value_t init_value,
       size_t len,
@@ -90,7 +91,7 @@ public:
 
   struct crc32c_16 {
     typedef uint32_t init_value_t;
-    typedef __le16 value_t;
+    typedef ceph_le16 value_t;
 
     // we have no execution context/state.
     typedef int state_t;
@@ -99,7 +100,7 @@ public:
     static void fini(state_t *state) {
     }
 
-    static value_t calc(
+    static init_value_t calc(
       state_t state,
       init_value_t init_value,
       size_t len,
@@ -120,7 +121,7 @@ public:
     static void fini(state_t *state) {
     }
 
-    static value_t calc(
+    static init_value_t calc(
       state_t state,
       init_value_t init_value,
       size_t len,
@@ -132,7 +133,7 @@ public:
 
   struct xxhash32 {
     typedef uint32_t init_value_t;
-    typedef __le32 value_t;
+    typedef ceph_le32 value_t;
 
     typedef XXH32_state_t *state_t;
     static void init(state_t *s) {
@@ -142,7 +143,7 @@ public:
       XXH32_freeState(*s);
     }
 
-    static value_t calc(
+    static init_value_t calc(
       state_t state,
       init_value_t init_value,
       size_t len,
@@ -161,7 +162,7 @@ public:
 
   struct xxhash64 {
     typedef uint64_t init_value_t;
-    typedef __le64 value_t;
+    typedef ceph_le64 value_t;
 
     typedef XXH64_state_t *state_t;
     static void init(state_t *s) {
@@ -171,7 +172,7 @@ public:
       XXH64_freeState(*s);
     }
 
-    static value_t calc(
+    static init_value_t calc(
       state_t state,
       init_value_t init_value,
       size_t len,
@@ -250,7 +251,7 @@ public:
     pv += offset / csum_block_size;
     size_t pos = offset;
     while (length > 0) {
-      typename Alg::value_t v = Alg::calc(state, -1, csum_block_size, p);
+      typename Alg::init_value_t v = Alg::calc(state, -1, csum_block_size, p);
       if (*pv != v) {
 	if (bad_csum) {
 	  *bad_csum = v;

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1756,8 +1756,8 @@ ceph::bufferlist ProtocolV2::do_sweep_messages(
     ceph_msg_header2 header2{header.seq,        header.tid,
                              header.type,       header.priority,
                              header.version,
-                             0,                 header.data_off,
-                             conn.in_seq,
+                             init_le32(0),      header.data_off,
+                             init_le64(conn.in_seq),
                              footer.flags,      header.compat_version,
                              header.reserved};
 
@@ -1794,15 +1794,16 @@ seastar::future<> ProtocolV2::read_message(utime_t throttle_stamp)
                            current_header.type,
                            current_header.priority,
                            current_header.version,
-                           msg_frame.front_len(),
-                           msg_frame.middle_len(),
-                           msg_frame.data_len(),
+                           init_le32(msg_frame.front_len()),
+                           init_le32(msg_frame.middle_len()),
+                           init_le32(msg_frame.data_len()),
                            current_header.data_off,
                            conn.get_peer_name(),
                            current_header.compat_version,
                            current_header.reserved,
-                           0};
-    ceph_msg_footer footer{0, 0, 0, 0, current_header.flags};
+                           init_le32(0)};
+    ceph_msg_footer footer{init_le32(0), init_le32(0),
+                           init_le32(0), init_le64(0), current_header.flags};
 
     Message *message = decode_message(nullptr, 0, header, footer,
         msg_frame.front(), msg_frame.middle(), msg_frame.data(), nullptr);

--- a/src/include/byteorder.h
+++ b/src/include/byteorder.h
@@ -83,14 +83,20 @@ using ceph_le64 = ceph_le<__u64>;
 using ceph_le32 = ceph_le<__u32>;
 using ceph_le16 = ceph_le<__u16>;
 
-inline __u64 init_le64(__u64 x) {
-  return mswab<__u64>(x);
+inline ceph_le64 init_le64(__u64 x) {
+  ceph_le64 v;
+  v = x;
+  return v;
 }
-inline __u32 init_le32(__u32 x) {
-  return mswab<__u32>(x);
+inline ceph_le32 init_le32(__u32 x) {
+  ceph_le32 v;
+  v = x;
+  return v;
 }
-inline __u16 init_le16(__u16 x) {
-  return mswab<__u16>(x);
+inline ceph_le16 init_le16(__u16 x) {
+  ceph_le16 v;
+  v = x;
+  return v;
 }
 
   /*

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -360,19 +360,19 @@ template<typename T, typename=void> struct ExtType {
 template<typename T>
 struct ExtType<T, std::enable_if_t<std::is_same_v<T, int16_t> ||
 				   std::is_same_v<T, uint16_t>>> {
-  using type = __le16;
+  using type = ceph_le16;
 };
 
 template<typename T>
 struct ExtType<T, std::enable_if_t<std::is_same_v<T, int32_t> ||
 				   std::is_same_v<T, uint32_t>>> {
-  using type = __le32;
+  using type = ceph_le32;
 };
 
 template<typename T>
 struct ExtType<T, std::enable_if_t<std::is_same_v<T, int64_t> ||
 				   std::is_same_v<T, uint64_t>>> {
-  using type = __le64;
+  using type = ceph_le64;
 };
 
 template<>
@@ -588,11 +588,11 @@ denc_lba(uint64_t v, It& p) {
   word |= (v << pos) & 0x7fffffff;
   v >>= 31 - pos;
   if (!v) {
-    *(__le32*)p.get_pos_add(sizeof(uint32_t)) = word;
+    *(ceph_le32*)p.get_pos_add(sizeof(uint32_t)) = word;
     return;
   }
   word |= 0x80000000;
-  *(__le32*)p.get_pos_add(sizeof(uint32_t)) = word;
+  *(ceph_le32*)p.get_pos_add(sizeof(uint32_t)) = word;
   uint8_t byte = v & 0x7f;
   v >>= 7;
   while (v) {
@@ -607,7 +607,7 @@ denc_lba(uint64_t v, It& p) {
 template<class It>
 inline std::enable_if_t<is_const_iterator_v<It>>
 denc_lba(uint64_t& v, It& p) {
-  uint32_t word = *(__le32*)p.get_pos_add(sizeof(uint32_t));
+  uint32_t word = *(ceph_le32*)p.get_pos_add(sizeof(uint32_t));
   int shift;
   switch (word & 7) {
   case 0:
@@ -1693,7 +1693,7 @@ inline std::enable_if_t<traits::supported && !traits::featured> decode_nohead(
 			   __u8 *struct_compat,				\
 			   char **len_pos,				\
 			   uint32_t *start_oob_off) {			\
-    *(__le32*)*len_pos = p.get_pos() - *len_pos - sizeof(uint32_t) +	\
+    *(ceph_le32*)*len_pos = p.get_pos() - *len_pos - sizeof(uint32_t) +	\
       p.get_out_of_band_offset() - *start_oob_off;			\
   }									\
   /* decode */								\

--- a/src/include/msgr.h
+++ b/src/include/msgr.h
@@ -7,6 +7,14 @@
 
 #include "include/int_types.h"
 
+/* See comment in ceph_fs.h.  */
+#ifndef __KERNEL__
+#include "byteorder.h"
+#define __le16 ceph_le16
+#define __le32 ceph_le32
+#define __le64 ceph_le64
+#endif
+
 /*
  * Data types for message passing layer used by Ceph.
  */
@@ -236,5 +244,10 @@ struct ceph_msg_footer {
 #define CEPH_MSG_FOOTER_NOCRC     (1<<1)   /* no data crc */
 #define CEPH_MSG_FOOTER_SIGNED	  (1<<2)   /* msg was signed */
 
+#ifndef __KERNEL__
+#undef __le16
+#undef __le32
+#undef __le64
+#endif
 
 #endif

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -10,6 +10,14 @@
 #include <stdbool.h>
 #include "msgr.h"
 
+/* See comment in ceph_fs.h.  */
+#ifndef __KERNEL__
+#include "byteorder.h"
+#define __le16 ceph_le16
+#define __le32 ceph_le32
+#define __le64 ceph_le64
+#endif
+
 /*
  * fs id
  */
@@ -663,5 +671,10 @@ struct ceph_osd_reply_head {
 	struct ceph_osd_op ops[0];  /* ops[], object */
 } __attribute__ ((packed));
 
+#ifndef __KERNEL__
+#undef __le16
+#undef __le32
+#undef __le64
+#endif
 
 #endif

--- a/src/include/rbd_types.h
+++ b/src/include/rbd_types.h
@@ -119,12 +119,12 @@
 #define RBD_MIRROR_PEER_CONFIG_KEY_PREFIX "rbd/mirror/peer/"
 
 struct rbd_info {
-	__le64 max_id;
+	ceph_le64 max_id;
 } __attribute__ ((packed));
 
 struct rbd_obj_snap_ondisk {
-	__le64 id;
-	__le64 image_size;
+	ceph_le64 id;
+	ceph_le64 image_size;
 } __attribute__((packed));
 
 struct rbd_obj_header_ondisk {
@@ -138,11 +138,11 @@ struct rbd_obj_header_ondisk {
 		__u8 comp_type;
 		__u8 unused;
 	} __attribute__((packed)) options;
-	__le64 image_size;
-	__le64 snap_seq;
-	__le32 snap_count;
-	__le32 reserved;
-	__le64 snap_names_len;
+	ceph_le64 image_size;
+	ceph_le64 snap_seq;
+	ceph_le32 snap_count;
+	ceph_le32 reserved;
+	ceph_le64 snap_names_len;
 	struct rbd_obj_snap_ondisk snaps[0];
 } __attribute__((packed));
 

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -24,19 +24,9 @@
 #include <fcntl.h>
 #include <string.h>
 
-// <macro hackery>
-// temporarily remap __le* to ceph_le* for benefit of shared kernel/userland headers
-#define __le16 ceph_le16
-#define __le32 ceph_le32
-#define __le64 ceph_le64
 #include "ceph_fs.h"
 #include "ceph_frag.h"
 #include "rbd_types.h"
-#undef __le16
-#undef __le32
-#undef __le64
-// </macro hackery>
-
 
 #ifdef __cplusplus
 #ifndef _BACKWARD_BACKWARD_WARNING_H

--- a/src/librbd/operation/ResizeRequest.cc
+++ b/src/librbd/operation/ResizeRequest.cc
@@ -401,9 +401,9 @@ void ResizeRequest<I>::send_update_header() {
   librados::ObjectWriteOperation op;
   if (image_ctx.old_format) {
     // rewrite only the size field of the header
-    // NOTE: format 1 image headers are not stored in fixed endian format
+    ceph_le64 new_size = init_le64(m_new_size);
     bufferlist bl;
-    bl.append(reinterpret_cast<const char*>(&m_new_size), sizeof(m_new_size));
+    bl.append(reinterpret_cast<const char*>(&new_size), sizeof(new_size));
     op.write(offsetof(rbd_obj_header_ondisk, image_size), bl);
   } else {
     cls_client::set_size(&op, m_new_size);

--- a/src/mds/locks.c
+++ b/src/mds/locks.c
@@ -3,8 +3,17 @@
 #include <string.h>
 #include <fcntl.h>
 
-#include "include/ceph_fs.h"
 #include "locks.h"
+
+/* Duplicated from ceph_fs.h, which we cannot include into a C file.  */
+#define CEPH_CAP_GSHARED     1  /* client can reads */
+#define CEPH_CAP_GEXCL       2  /* client can read and update */
+#define CEPH_CAP_GCACHE      4  /* (file) client can cache reads */
+#define CEPH_CAP_GRD         8  /* (file) client can read */
+#define CEPH_CAP_GWR        16  /* (file) client can write */
+#define CEPH_CAP_GBUFFER    32  /* (file) client can buffer writes */
+#define CEPH_CAP_GWREXTEND  64  /* (file) client can extend EOF */
+#define CEPH_CAP_GLAZYIO   128  /* (file) client can perform lazy io */
 
 static const struct sm_state_t simplelock[LOCK_MAX] = {
                       // stable     loner  rep state  r     rp   rd   wr   fwr  l    x    caps,other

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1423,13 +1423,13 @@ WRITE_CLASS_ENCODER(snaprealm_reconnect_t)
 
 // compat for pre-FLOCK feature
 struct old_ceph_mds_cap_reconnect {
-	__le64 cap_id;
-	__le32 wanted;
-	__le32 issued;
-  __le64 old_size;
+	ceph_le64 cap_id;
+	ceph_le32 wanted;
+	ceph_le32 issued;
+  ceph_le64 old_size;
   struct ceph_timespec old_mtime, old_atime;
-	__le64 snaprealm;
-	__le64 pathbase;        /* base ino for our path to this ino */
+	ceph_le64 snaprealm;
+	ceph_le64 pathbase;        /* base ino for our path to this ino */
 } __attribute__ ((packed));
 WRITE_RAW_ENCODER(old_ceph_mds_cap_reconnect)
 

--- a/src/messages/MMonSubscribe.h
+++ b/src/messages/MMonSubscribe.h
@@ -22,8 +22,8 @@
  * compatibility with old crap
  */
 struct ceph_mon_subscribe_item_old {
-	__le64 unused;
-	__le64 have;
+	ceph_le64 unused;
+	ceph_le64 have;
 	__u8 onetime;
 } __attribute__ ((packed));
 WRITE_RAW_ENCODER(ceph_mon_subscribe_item_old)

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -498,8 +498,8 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
   ceph_msg_header2 header2{header.seq,        header.tid,
                            header.type,       header.priority,
                            header.version,
-                           0,                 header.data_off,
-                           ack_seq,
+                           init_le32(0),      header.data_off,
+                           init_le64(ack_seq),
                            footer.flags,      header.compat_version,
                            header.reserved};
 
@@ -1393,15 +1393,16 @@ CtPtr ProtocolV2::handle_message() {
                          current_header.type,
                          current_header.priority,
                          current_header.version,
-                         msg_frame.front_len(),
-                         msg_frame.middle_len(),
-                         msg_frame.data_len(),
+                         init_le32(msg_frame.front_len()),
+                         init_le32(msg_frame.middle_len()),
+                         init_le32(msg_frame.data_len()),
                          current_header.data_off,
                          peer_name,
                          current_header.compat_version,
                          current_header.reserved,
-                         0};
-  ceph_msg_footer footer{0, 0, 0, 0, current_header.flags};
+                         init_le32(0)};
+  ceph_msg_footer footer{init_le32(0), init_le32(0),
+	                 init_le32(0), init_le64(0), current_header.flags};
 
   Message *message = decode_message(cct, 0, header, footer,
       msg_frame.front(),

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -62,8 +62,8 @@ struct segment_t {
 
   static constexpr __le16 DEFAULT_ALIGNMENT = sizeof(void *);
 
-  __le32 length;
-  __le16 alignment;
+  ceph_le32 length;
+  ceph_le16 alignment;
 } __attribute__((packed));
 
 struct SegmentIndex {
@@ -102,7 +102,7 @@ struct preamble_block_t {
   __u8 _reserved[2];
 
   // CRC32 for this single preamble block.
-  __le32 crc;
+  ceph_le32 crc;
 } __attribute__((packed));
 static_assert(sizeof(preamble_block_t) % CRYPTO_BLOCK_SIZE == 0);
 static_assert(std::is_standard_layout<preamble_block_t>::value);
@@ -128,7 +128,7 @@ static_assert(std::is_standard_layout<preamble_block_t>::value);
 // frame abortion facility.
 struct epilogue_plain_block_t {
   __u8 late_flags;
-  std::array<__le32, MAX_NUM_SEGMENTS> crc_values;
+  std::array<ceph_le32, MAX_NUM_SEGMENTS> crc_values;
 } __attribute__((packed));
 static_assert(std::is_standard_layout<epilogue_plain_block_t>::value);
 

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -154,8 +154,8 @@ namespace std {
 
 // define a wire format for sockaddr that matches Linux's.
 struct ceph_sockaddr_storage {
-  __le16 ss_family;
-  __u8 __ss_padding[128 - sizeof(__le16)];
+  ceph_le16 ss_family;
+  __u8 __ss_padding[128 - sizeof(ceph_le16)];
 
   void encode(ceph::buffer::list& bl) const {
     struct ceph_sockaddr_storage ss = *this;

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -77,7 +77,7 @@ public:
   bool is_mgr() const { return type() == TYPE_MGR; }
 
   operator ceph_entity_name() const {
-    ceph_entity_name n = { _type, {init_le64(_num)} };
+    ceph_entity_name n = { _type, init_le64(_num) };
     return n;
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -610,9 +610,9 @@ struct Int64ArrayMergeOperator : public KeyValueDB::MergeOperator {
     ceph_assert(llen == rlen);
     ceph_assert((rlen % 8) == 0);
     new_value->resize(rlen);
-    const __le64* lv = (const __le64*)ldata;
-    const __le64* rv = (const __le64*)rdata;
-    __le64* nv = &(__le64&)new_value->at(0);
+    const ceph_le64* lv = (const ceph_le64*)ldata;
+    const ceph_le64* rv = (const ceph_le64*)rdata;
+    ceph_le64* nv = &(ceph_le64&)new_value->at(0);
     for (size_t i = 0; i < rlen >> 3; ++i) {
       nv[i] = lv[i] + rv[i];
     }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -758,11 +758,11 @@ public:
     case 1:
       return reinterpret_cast<const uint8_t*>(p)[i];
     case 2:
-      return reinterpret_cast<const __le16*>(p)[i];
+      return reinterpret_cast<const ceph_le16*>(p)[i];
     case 4:
-      return reinterpret_cast<const __le32*>(p)[i];
+      return reinterpret_cast<const ceph_le32*>(p)[i];
     case 8:
-      return reinterpret_cast<const __le64*>(p)[i];
+      return reinterpret_cast<const ceph_le64*>(p)[i];
     default:
       ceph_abort_msg("unrecognized csum word size");
     }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -111,7 +111,7 @@ std::ostream& operator<<(std::ostream& out, const osd_xinfo_t& xi);
 struct PGTempMap {
 #if 1
   ceph::buffer::list data;
-  typedef btree::btree_map<pg_t,int32_t*> map_t;
+  typedef btree::btree_map<pg_t,ceph_le32*> map_t;
   map_t map;
 
   void encode(ceph::buffer::list& bl) const {
@@ -120,7 +120,7 @@ struct PGTempMap {
     encode(n, bl);
     for (auto &p : map) {
       encode(p.first, bl);
-      bl.append((char*)p.second, (*p.second + 1) * sizeof(int32_t));
+      bl.append((char*)p.second, (*p.second + 1) * sizeof(ceph_le32));
     }
   }
   void decode(ceph::buffer::list::const_iterator& p) {
@@ -152,7 +152,7 @@ struct PGTempMap {
     //map.reserve(n);
     char *start = data.c_str();
     for (auto i : offsets) {
-      map.insert(map.end(), std::make_pair(i.first, (int32_t*)(start + i.second)));
+      map.insert(map.end(), std::make_pair(i.first, (ceph_le32*)(start + i.second)));
     }
   }
   void rebuild() {
@@ -176,8 +176,8 @@ struct PGTempMap {
 	current.first = it->first;
 	ceph_assert(it->second);
 	current.second.resize(*it->second);
-	int32_t *p = it->second + 1;
-	for (int n = 0; n < *it->second; ++n, ++p) {
+	ceph_le32 *p = it->second + 1;
+	for (uint32_t n = 0; n < *it->second; ++n, ++p) {
 	  current.second[n] = *p;
 	}
       }
@@ -239,18 +239,18 @@ struct PGTempMap {
   }
   void set(pg_t pgid, const mempool::osdmap::vector<int32_t>& v) {
     using ceph::encode;
-    size_t need = sizeof(int32_t) * (1 + v.size());
+    size_t need = sizeof(ceph_le32) * (1 + v.size());
     if (need < data.get_append_buffer_unused_tail_length()) {
       ceph::buffer::ptr z(data.get_append_buffer_unused_tail_length());
       z.zero();
       data.append(z.c_str(), z.length());
     }
     encode(v, data);
-    map[pgid] = (int32_t*)(data.back().end_c_str()) - (1 + v.size());
+    map[pgid] = (ceph_le32*)(data.back().end_c_str()) - (1 + v.size());
   }
   mempool::osdmap::vector<int32_t> get(pg_t pgid) {
     mempool::osdmap::vector<int32_t> v;
-    int32_t *p = map[pgid];
+    ceph_le32 *p = map[pgid];
     size_t n = *p++;
     v.resize(n);
     for (size_t i = 0; i < n; ++i, ++p) {

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -585,7 +585,7 @@ void RGWBucketEntryPoint::generate_test_instances(list<RGWBucketEntryPoint*>& o)
   RGWBucketEntryPoint *bp = new RGWBucketEntryPoint();
   init_bucket(&bp->bucket, "tenant", "bucket", "pool", ".index.pool", "marker", "10");
   bp->owner = "owner";
-  bp->creation_time = ceph::real_clock::from_ceph_timespec({{2}, {3}});
+  bp->creation_time = ceph::real_clock::from_ceph_timespec({init_le32(2), init_le32(3)});
 
   o.push_back(bp);
   o.push_back(new RGWBucketEntryPoint);

--- a/src/test/common/test_time.cc
+++ b/src/test/common/test_time.cc
@@ -51,7 +51,7 @@ static constexpr uint32_t bns = 123456789;
 static constexpr uint32_t bus = 123456;
 static constexpr time_t btt = bs;
 static constexpr struct timespec bts = { bs, bns };
-static constexpr struct ceph_timespec bcts = { bs, bns };
+static struct ceph_timespec bcts = { init_le32(bs), init_le32(bns) };
 static constexpr struct timeval btv = { bs, bus };
 static constexpr double bd = bs + ((double)bns / 1000000000.);
 

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -226,8 +226,8 @@ TEST(LibRadosAio, RoundTrip3) {
   rados_read_op_read(op2, 0, sizeof(buf2), buf2, NULL, NULL);
   rados_read_op_set_flags(op2, LIBRADOS_OP_FLAG_FADVISE_NOCACHE |
 			       LIBRADOS_OP_FLAG_FADVISE_RANDOM);
-  __le32 init_value = -1;
-  __le32 checksum[2];
+  ceph_le32 init_value = init_le32(-1);
+  ceph_le32 checksum[2];
   rados_read_op_checksum(op2, LIBRADOS_CHECKSUM_TYPE_CRC32C,
 			 reinterpret_cast<char *>(&init_value),
 			 sizeof(init_value), 0, 0, 0,

--- a/src/tools/immutable_object_cache/Types.h
+++ b/src/tools/immutable_object_cache/Types.h
@@ -15,7 +15,7 @@ namespace {
 struct HeaderHelper {
   uint8_t v;
   uint8_t c_v;
-  uint32_t len;
+  ceph_le32 len;
 }__attribute__((packed));
 
 inline uint8_t get_header_size() {


### PR DESCRIPTION
While attempting to get Ceph to build on IBM Z, a big-endian system, we've been running into various bugs due to incorrect endian handling.

Most of the issues can be traced back to use of the __le16/__le32/__le64 types in Ceph user-space code. While those data types are generally (and correctly) used in Linux kernel code to indicate fixed-format little-endian fields, this does not work in Ceph user space, which is supposed to be using the ceph_le16/ceph_le32/ceph_le64 C++ classes instead.

This pull request contains a series of commits that fixes all endian problems in the Ceph sources I found, to the point that I can now run the ctest test suite on IBM Z without failures.

(Once this is in, I'll post a second PR with further cleanups that are not strictly necessary to fix current bugs, but may help avoid endian issues creeping back in in the future.)

Note: This PR contains changes across many parts of the tree, so it is not tagged with a component.  However, I've tried to break the changes up into small logical pieces implemented as seperate commits, which are so tagged.