### PR TITLE
test/erasure-code: add exception handling to k & m

### DIFF
--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -121,10 +121,15 @@ int ErasureCodeBench::setup(int argc, char** argv) {
     exhaustive_erasures = false;
   if (vm.count("erased") > 0)
     erased = vm["erased"].as<vector<int> >();
-
-  k = stoi(profile["k"]);
-  m = stoi(profile["m"]);
   
+  try {
+    k = stoi(profile["k"]);
+    m = stoi(profile["m"]);
+  } catch (const std::logic_error& e) {
+    cout << "Invalid k and/or m: k=" << profile["k"] << ", m=" << profile["m"] 
+         << " (" << e.what() << ")" << endl;
+    return -EINVAL;
+  }
   if (k <= 0) {
     cout << "parameter k is " << k << ". But k needs to be > 0." << endl;
     return -EINVAL;


### PR DESCRIPTION
There are no exception handling after using stoi to k & m , so when one of them is missing or invalid , the program crashes with core dump info filling the screen. So I try to catch the invalid_argument & out_of_range exception.

Signed-off-by: Hang Li <lihang48@hisilicon.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
