### PR TITLE
nautilus: build/ops: use gcc-8

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1087,7 +1087,7 @@ This package provides Ceph’s default alerts for Prometheus.
 %define _lto_cflags %{nil}
 
 %if 0%{?rhel} == 7
-. /opt/rh/devtoolset-7/enable
+. /opt/rh/devtoolset-8/enable
 %endif
 
 %if 0%{with cephfs_java}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -149,7 +149,11 @@ BuildRequires:	fuse-devel
 %if 0%{?rhel} == 7
 # devtoolset offers newer make and valgrind-devel, but the old ones are good
 # enough.
+%ifarch x86_64
+BuildRequires:	devtoolset-8-gcc-c++ >= 8.2.1
+%else
 BuildRequires:	devtoolset-7-gcc-c++ >= 7.3.1-5.13
+%endif
 %else
 BuildRequires:	gcc-c++
 %endif

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -183,11 +183,11 @@ function ensure_decent_gcc_on_rh {
 	    cat <<EOF
 Your GCC is too old. Please run following command to add DTS to your environment:
 
-scl enable devtoolset-7 bash
+scl enable devtoolset-8 bash
 
 Or add following line to the end of ~/.bashrc to add it permanently:
 
-source scl_source enable devtoolset-7
+source scl_source enable devtoolset-8
 
 see https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/ for more details.
 EOF
@@ -343,7 +343,7 @@ else
 		    case $(uname -m) in
 			x86_64)
 			    $SUDO yum -y install centos-release-scl
-			    dts_ver=7
+			    dts_ver=8
 			    ;;
 			aarch64)
 			    $SUDO yum -y install centos-release-scl-rh
@@ -353,8 +353,10 @@ else
 			    ;;
 		    esac
                 elif test $ID = rhel -a $MAJOR_VERSION = 7 ; then
-                    $SUDO yum-config-manager --enable rhel-server-rhscl-7-rpms
-                    dts_ver=7
+                    $SUDO yum-config-manager \
+			  --enable rhel-server-rhscl-7-rpms \
+			  --enable rhel-7-server-devtools-rpms
+                    dts_ver=8
                 fi
                 ;;
         esac

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -70,7 +70,7 @@ function ensure_decent_gcc_on_ubuntu {
     local old=$(gcc -dumpfullversion -dumpversion)
     local new=$1
     local codename=$2
-    if dpkg --compare-versions $old ge 7.0; then
+    if dpkg --compare-versions $old ge ${new}.0; then
 	return
     fi
 
@@ -97,7 +97,7 @@ msyaQpNl/m/lNtOLhR64v5ZybofB2EWkMxUzX8D/FQ==
 -----END PGP PUBLIC KEY BLOCK-----
 ENDOFKEY
 	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get update -y || true
-	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y g++-7
+	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y g++-${new}
     fi
 
     case $codename in
@@ -274,10 +274,10 @@ else
         $SUDO apt-get install -y dpkg-dev
         case "$VERSION" in
             *Trusty*)
-                ensure_decent_gcc_on_ubuntu 7 trusty
+                ensure_decent_gcc_on_ubuntu 8 trusty
                 ;;
             *Xenial*)
-                ensure_decent_gcc_on_ubuntu 7 xenial
+                ensure_decent_gcc_on_ubuntu 8 xenial
                 install_boost_on_ubuntu xenial
                 ;;
             *Bionic*)


### PR DESCRIPTION
we are using DTS-7 on CentOS7 and gcc-7 from ubuntu-toolchain-r PPA on xenial already for building nautilus. 

we switched to GCC-8 in master for addressing ICE issues. these issues may or may not impact nautilus. and it's found that some builders are using GCC-8. even though `install-deps.sh` only installs gcc-7 if the installed GCC is lower than 7 on xenial. also, it's found that if we compile nautilus tree using GCC-7. we have
```
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/include/encoding.h:30:0,
                 from /home/jenkins-build/build/workspace/ceph-pull-requests/src/include/uuid.h:8,
                 from /home/jenkins-build/build/workspace/ceph-pull-requests/src/include/types.h:21,
                 from /home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_json.h:4,
                 from /home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/rgw_auth_keystone.cc:13:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/ceph_time.h:504:16: warning: variable templates only available with -std=c++14 or -std=gnu++14
 constexpr bool converts_to_timespec_v = converts_to_timespec<Clock>::value;
                ^~~~~~~~~~~~~~~~~~~~~~
```

so, to ensure that we use the same compiler for building nautilus. let's move to GCC-8. also as a side-effect, the produced binary should be better because of the newer (and better) library, compiler and toolchain.