### PR TITLE
osd/PrimaryLogPG: fix the oi size mismatch with the real object size

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6351,12 +6351,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	maybe_create_new_object(ctx);
 
 	if (op.extent.length == 0) {
-	  if (op.extent.offset > oi.size) {
-	    t->truncate(
-	      soid, op.extent.offset);
-	  } else {
-	    t->nop(soid);
-	  }
+    t->nop(soid);
 	} else {
 	  t->write(
 	    soid, op.extent.offset, op.extent.length, osd_op.indata, op.flags);


### PR DESCRIPTION
Signed-off-by: houbin0504 houbinbj@inspur.com

fix the bug that cluster occured pg inconsistent due to oi size mismatch with the real object size.

Fix bug41601:https://tracker.ceph.com/issues/41601
Signed-off-by: houbin0504 <houbinbj@inspur.com>