### PR TITLE
mimic: ceph-volume: minor optimizations related to class Volumes's use

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -364,7 +364,7 @@ def get_lv_from_argument(argument):
     return get_lv(lv_name=lv_name, vg_name=vg_name)
 
 
-def get_lv(lv_name=None, vg_name=None, lv_path=None, lv_uuid=None, lv_tags=None):
+def get_lv(lv_name=None, vg_name=None, lv_path=None, lv_uuid=None, lv_tags=None, lvs=None):
     """
     Return a matching lv for the current system, requiring ``lv_name``,
     ``vg_name``, ``lv_path`` or ``tags``. Raises an error if more than one lv
@@ -376,7 +376,8 @@ def get_lv(lv_name=None, vg_name=None, lv_path=None, lv_uuid=None, lv_tags=None)
     """
     if not any([lv_name, vg_name, lv_path, lv_uuid, lv_tags]):
         return None
-    lvs = Volumes()
+    if lvs is None:
+        lvs = Volumes()
     return lvs.get(
         lv_name=lv_name, vg_name=vg_name, lv_path=lv_path, lv_uuid=lv_uuid,
         lv_tags=lv_tags

--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -112,8 +112,8 @@ class List(object):
     def list(self, args):
         # ensure everything is up to date before calling out
         # to list lv's
-        self.update()
-        report = self.generate(args)
+        lvs = self.update()
+        report = self.generate(args, lvs)
         if args.format == 'json':
             # If the report is empty, we don't return a non-zero exit status
             # because it is assumed this is going to be consumed by automated
@@ -153,25 +153,27 @@ class List(object):
                         # this means that the device has changed, so it must be updated
                         # on the API to reflect this
                         lv.set_tags({device_name: disk_device})
+        return lvs
 
-    def generate(self, args):
+    def generate(self, args, lvs=None):
         """
         Generate reports for an individual device or for all Ceph-related
         devices, logical or physical, as long as they have been prepared by
         this tool before and contain enough metadata.
         """
         if args.device:
-            return self.single_report(args.device)
+            return self.single_report(args.device, lvs)
         else:
-            return self.full_report()
+            return self.full_report(lvs)
 
-    def single_report(self, device):
+    def single_report(self, device, lvs=None):
         """
         Generate a report for a single device. This can be either a logical
         volume in the form of vg/lv or a device with an absolute path like
         /dev/sda1 or /dev/sda
         """
-        lvs = api.Volumes()
+        if lvs is None:
+            lvs = api.Volumes()
         report = {}
         lv = api.get_lv_from_argument(device)
 
@@ -228,6 +230,7 @@ class List(object):
         if lvs is None:
             lvs = api.Volumes()
         report = {}
+
         for lv in lvs:
             try:
                 _id = lv.tags['ceph.osd_id']
@@ -247,7 +250,7 @@ class List(object):
                     # bluestore will not have a journal, filestore will not have
                     # a block/wal/db, so we must skip if not present
                     continue
-                if not api.get_lv(lv_uuid=device_uuid):
+                if not api.get_lv(lv_uuid=device_uuid, lvs=lvs):
                     # means we have a regular device, so query blkid
                     disk_device = disk.get_device_from_partuuid(device_uuid)
                     if disk_device:

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
@@ -79,6 +79,23 @@ class TestList(object):
         with pytest.raises(SystemExit):
             lvm.listing.List([]).list(args)
 
+    def test_lvs_list_is_created_just_once(self, monkeypatch, is_root, volumes, factory):
+        api.volumes_obj_create_count = 0
+
+        def monkey_populate(self):
+            api.volumes_obj_create_count += 1
+            for lv_item in api.get_api_lvs():
+                self.append(api.Volume(**lv_item))
+        monkeypatch.setattr(api.Volumes, '_populate', monkey_populate)
+
+        args = factory(format='pretty', device='/dev/sda1')
+        with pytest.raises(SystemExit):
+            lvm.listing.List([]).list(args)
+
+        # XXX: Ideally, the count should be just 1. Volumes._populate() is
+        # being called thrice out of which only twice is moneky_populate.
+        assert api.volumes_obj_create_count == 2
+
 
 class TestFullReport(object):
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41612

---

backport of https://github.com/ceph/ceph/pull/29665
parent tracker: https://tracker.ceph.com/issues/37490

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh