### PR TITLE
ceph-backport.sh: cherry-pick individual commits

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -232,6 +232,7 @@ function populate_original_pr {
 }
 
 function prepare {
+    local offset=0
     populate_original_issue
     if [ -z "$original_issue" ] ; then
         error "Could not find original issue"
@@ -265,7 +266,12 @@ function prepare {
 
     debug "Cherry picking $number commits from ${github_endpoint}/pull/${original_pr} into local branch $local_branch"
     debug "If this operation does not succeed, you will need to resolve the conflicts manually"
-    git cherry-pick -x pr-$original_pr~$number..pr-$original_pr
+    let offset=$number-1 || true # don't fail on set -e when result is 0
+    for ((i=$offset; i>=0; i--))
+    do
+        debug "Cherry-picking commit $(git log --oneline --max-count=1 --no-decorate)"
+        git cherry-pick -x "pr-$original_pr~$i"
+    done
     info "Cherry picked $number commits from ${github_endpoint}/pull/${original_pr} into local branch $local_branch"
 
     exit 0


### PR DESCRIPTION
In git 2.23.0 (possibly earlier too) cherry-pick seems to interact with
rev-list and submodules in unexpected ways, where the cherry-pick of a
commit range (<sha1>..<sha1>) fails with "changes would be overwritten"
in a submodule. CP'ing individual commits avoids this.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
