### PR TITLE
ceph-volume: api/lvm: check if list of LVs is empty

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -274,7 +274,9 @@ def is_lv(dev, lvs=None):
     splitname = dmsetup_splitname(dev)
     # Allowing to optionally pass `lvs` can help reduce repetitive checks for
     # multiple devices at once.
-    lvs = lvs if lvs is not None else Volumes()
+    if lvs is None or len(lvs) == 0:
+        lvs = Volumes()
+
     if splitname.get('LV_NAME'):
         lvs.filter(lv_name=splitname['LV_NAME'], vg_name=splitname['VG_NAME'])
         return len(lvs) > 0


### PR DESCRIPTION
Create the list of logical volumes if the list passed in arguments is
empty and rewrite the condition to make it more readable.

Fixes: https://tracker.ceph.com/issues/41649


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>