### PR TITLE
ceph-volume: improve inventory subcommand's performance

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1232,14 +1232,14 @@ def get_lv(lv_name=None, vg_name=None, lv_path=None, lv_uuid=None, lv_tags=None,
     )
 
 
-def get_lv_from_argument(argument):
+def get_lv_from_argument(argument, lvs=None):
     """
     Helper proxy function that consumes a possible logical volume passed in from the CLI
     in the form of `vg/lv`, but with some validation so that an argument that is a full
     path to a device can be ignored
     """
     if argument.startswith('/'):
-        lv = get_lv(lv_path=argument)
+        lv = get_lv(lv_path=argument, lvs=lvs)
         return lv
     try:
         vg_name, lv_name = argument.split('/')

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1224,8 +1224,10 @@ def get_lv(lv_name=None, vg_name=None, lv_path=None, lv_uuid=None, lv_tags=None,
     """
     if not any([lv_name, vg_name, lv_path, lv_uuid, lv_tags]):
         return None
-    if lvs is None:
+
+    if lvs is None or len(lvs) == 0:
         lvs = Volumes()
+
     return lvs.get(
         lv_name=lv_name, vg_name=vg_name, lv_path=lv_path, lv_uuid=lv_uuid,
         lv_tags=lv_tags

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1049,18 +1049,12 @@ class Volumes(list):
         """
         if not any([lv_name, vg_name, lv_path, lv_uuid, lv_tags]):
             raise TypeError('.filter() requires lv_name, vg_name, lv_path, lv_uuid, or tags (none given)')
+
+        lvs_copy = Volumes(populate=False)
         # first find the filtered volumes with the values in self
-        filtered_volumes = self._filter(
-            lv_name=lv_name,
-            vg_name=vg_name,
-            lv_path=lv_path,
-            lv_uuid=lv_uuid,
-            lv_tags=lv_tags
-        )
-        # then purge everything
-        self._purge()
-        # and add the filtered items
-        self.extend(filtered_volumes)
+        lvs_copy.extend(self._filter(lv_name, vg_name, lv_path, lv_uuid,
+                                     lv_tags))
+        return lvs_copy if lvs_copy != [] else None
 
     def get(self, lv_name=None, vg_name=None, lv_path=None, lv_uuid=None, lv_tags=None):
         """

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -496,13 +496,16 @@ def remove_pv(pv_name):
     )
 
 
-def is_pv(pv_name):
-    stdout = [i.strip() for i in get_api_pvs(fields='pv_name', unparsed=True)]
-    try:
-        stdout.index(pv_name)
-    except ValueError:
-        return False
-    return True
+def is_pv(pv_name, pvs=None):
+    if pvs:
+        return pvs.get(pv_name) is not None
+    else:
+        stdout = [i.strip() for i in get_api_pvs(fields='pv_name', unparsed=True)]
+        try:
+            stdout.index(pv_name)
+        except ValueError:
+            return False
+        return True
 
 
 def get_pv(pv_name=None, pv_uuid=None, pv_tags=None, pvs=None):
@@ -853,13 +856,16 @@ def remove_vg(vg_name):
     )
 
 
-def is_vg(vg_name):
-    stdout = [i.strip() for i in get_api_vgs(fields='pv_name', unparsed=True)]
-    try:
-        stdout.index(vg_name)
-    except ValueError:
-        return False
-    return True
+def is_vg(vg_name, vgs=None):
+    if vgs:
+        return vgs.get(vg_name) is not None
+    else:
+        stdout = [i.strip() for i in get_api_vgs(fields='pv_name', unparsed=True)]
+        try:
+            stdout.index(vg_name)
+        except ValueError:
+            return False
+        return True
 
 
 def get_vg(vg_name=None, vg_tags=None, vgs=None):

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -990,8 +990,9 @@ class Volumes(list):
     to filter them via keyword arguments.
     """
 
-    def __init__(self):
-        self._populate()
+    def __init__(self, populate=True):
+        if populate:
+            self._populate()
 
     def _populate(self):
         # get all the lvs in the current system

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -274,7 +274,7 @@ def dmsetup_splitname(dev):
 ################################
 
 
-def get_api_pvs():
+def get_api_pvs(fields=None):
     """
     Return the list of physical volumes configured for lvm and available in the
     system using flags to include common metadata associated with them like the uuid
@@ -288,7 +288,8 @@ def get_api_pvs():
           /dev/sdv;;07A4F654-4162-4600-8EB3-88D1E42F368D
 
     """
-    fields = 'pv_name,pv_tags,pv_uuid,vg_name,lv_uuid'
+    if fields is None:
+        fields = 'pv_name,pv_tags,pv_uuid,vg_name,lv_uuid'
 
     stdout, stderr, returncode = process.call(
         ['pvs', '--no-heading', '--readonly', '--separator=";"', '-o', fields],
@@ -517,7 +518,7 @@ def get_pv(pv_name=None, pv_uuid=None, pv_tags=None, pvs=None):
 #############################
 
 
-def get_api_vgs():
+def get_api_vgs(fields=None):
     """
     Return the list of group volumes available in the system using flags to
     include common metadata associated with them
@@ -532,7 +533,8 @@ def get_api_vgs():
     To normalize sizing, the units are forced in 'g' which is equivalent to
     gigabytes, which uses multiples of 1024 (as opposed to 1000)
     """
-    fields = 'vg_name,pv_count,lv_count,snap_count,vg_attr,vg_size,vg_free,vg_free_count'
+    if fields is None:
+        fields = 'vg_name,pv_count,lv_count,snap_count,vg_attr,vg_size,vg_free,vg_free_count'
     stdout, stderr, returncode = process.call(
         ['vgs', '--noheadings', '--readonly', '--units=g', '--separator=";"', '-o', fields],
         verbose_on_failure=False
@@ -866,7 +868,7 @@ def get_vg(vg_name=None, vg_tags=None, vgs=None):
 ###############################
 
 
-def get_api_lvs():
+def get_api_lvs(fields=None):
     """
     Return the list of logical volumes available in the system using flags to include common
     metadata associated with them
@@ -878,7 +880,8 @@ def get_api_lvs():
           ;/dev/ubuntubox-vg/swap_1;swap_1;ubuntubox-vg
 
     """
-    fields = 'lv_tags,lv_path,lv_name,vg_name,lv_uuid,lv_size'
+    if fields is None:
+        fields = 'lv_tags,lv_path,lv_name,vg_name,lv_uuid,lv_size'
     stdout, stderr, returncode = process.call(
         ['lvs', '--noheadings', '--readonly', '--separator=";"', '-a', '-o', fields],
         verbose_on_failure=False

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1100,7 +1100,7 @@ class Volumes(list):
             lv_tags=lv_tags
         )
         if not lvs:
-            return None
+            return []
         if len(lvs) > 1:
             raise MultipleLVsError(lv_name, lv_path)
         return lvs[0]

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -274,7 +274,7 @@ def dmsetup_splitname(dev):
 ################################
 
 
-def get_api_pvs(fields=None, unparsed=False):
+def get_api_pvs(fields=None, unparsed=False, sep='";"'):
     """
     Return the list of physical volumes configured for lvm and available in the
     system using flags to include common metadata associated with them like the uuid
@@ -292,9 +292,8 @@ def get_api_pvs(fields=None, unparsed=False):
         fields = 'pv_name,pv_tags,pv_uuid,vg_name,lv_uuid'
 
     stdout, stderr, returncode = process.call(
-        ['pvs', '--no-heading', '--readonly', '--separator=";"', '-o', fields],
-        verbose_on_failure=False
-    )
+        ['pvs', '--no-heading', '--readonly', '--separator=' + sep,
+         '-o', fields], verbose_on_failure=False)
 
     return stdout if unparsed else _output_parser(stdout, fields)
 
@@ -518,7 +517,7 @@ def get_pv(pv_name=None, pv_uuid=None, pv_tags=None, pvs=None):
 #############################
 
 
-def get_api_vgs(fields=None, unparsed=False):
+def get_api_vgs(fields=None, unparsed=False, sep='";"'):
     """
     Return the list of group volumes available in the system using flags to
     include common metadata associated with them
@@ -536,9 +535,9 @@ def get_api_vgs(fields=None, unparsed=False):
     if fields is None:
         fields = 'vg_name,pv_count,lv_count,snap_count,vg_attr,vg_size,vg_free,vg_free_count'
     stdout, stderr, returncode = process.call(
-        ['vgs', '--noheadings', '--readonly', '--units=g', '--separator=";"', '-o', fields],
-        verbose_on_failure=False
-    )
+        ['vgs', '--noheadings', '--readonly', '--separator=' + sep,
+         '--units=g', '-o', fields], verbose_on_failure=False)
+
     return stdout if unparsed else _output_parser(stdout, fields)
 
 
@@ -868,7 +867,7 @@ def get_vg(vg_name=None, vg_tags=None, vgs=None):
 ###############################
 
 
-def get_api_lvs(fields=None, unparsed=False):
+def get_api_lvs(fields=None, unparsed=False, sep='";"'):
     """
     Return the list of logical volumes available in the system using flags to include common
     metadata associated with them
@@ -883,9 +882,8 @@ def get_api_lvs(fields=None, unparsed=False):
     if fields is None:
         fields = 'lv_tags,lv_path,lv_name,vg_name,lv_uuid,lv_size'
     stdout, stderr, returncode = process.call(
-        ['lvs', '--noheadings', '--readonly', '--separator=";"', '-a', '-o', fields],
-        verbose_on_failure=False
-    )
+        ['lvs', '--noheadings', '--readonly', '--separator=' + sep,
+         '-a', '-o', fields], verbose_on_failure=False)
 
     return stdout if unparsed else _output_parser(stdout, fields)
 

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -853,6 +853,15 @@ def remove_vg(vg_name):
     )
 
 
+def is_vg(vg_name):
+    stdout = [i.strip() for i in get_api_vgs(fields='pv_name', unparsed=True)]
+    try:
+        stdout.index(vg_name)
+    except ValueError:
+        return False
+    return True
+
+
 def get_vg(vg_name=None, vg_tags=None, vgs=None):
     """
     Return a matching vg for the current system, requires ``vg_name`` or

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -274,7 +274,7 @@ def dmsetup_splitname(dev):
 ################################
 
 
-def get_api_pvs(fields=None):
+def get_api_pvs(fields=None, unparsed=False):
     """
     Return the list of physical volumes configured for lvm and available in the
     system using flags to include common metadata associated with them like the uuid
@@ -296,7 +296,7 @@ def get_api_pvs(fields=None):
         verbose_on_failure=False
     )
 
-    return _output_parser(stdout, fields)
+    return stdout if unparsed else _output_parser(stdout, fields)
 
 
 class PVolume(object):
@@ -518,7 +518,7 @@ def get_pv(pv_name=None, pv_uuid=None, pv_tags=None, pvs=None):
 #############################
 
 
-def get_api_vgs(fields=None):
+def get_api_vgs(fields=None, unparsed=False):
     """
     Return the list of group volumes available in the system using flags to
     include common metadata associated with them
@@ -539,7 +539,7 @@ def get_api_vgs(fields=None):
         ['vgs', '--noheadings', '--readonly', '--units=g', '--separator=";"', '-o', fields],
         verbose_on_failure=False
     )
-    return _output_parser(stdout, fields)
+    return stdout if unparsed else _output_parser(stdout, fields)
 
 
 class VolumeGroup(object):
@@ -868,7 +868,7 @@ def get_vg(vg_name=None, vg_tags=None, vgs=None):
 ###############################
 
 
-def get_api_lvs(fields=None):
+def get_api_lvs(fields=None, unparsed=False):
     """
     Return the list of logical volumes available in the system using flags to include common
     metadata associated with them
@@ -886,7 +886,8 @@ def get_api_lvs(fields=None):
         ['lvs', '--noheadings', '--readonly', '--separator=";"', '-a', '-o', fields],
         verbose_on_failure=False
     )
-    return _output_parser(stdout, fields)
+
+    return stdout if unparsed else _output_parser(stdout, fields)
 
 
 class Volume(object):

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -496,6 +496,15 @@ def remove_pv(pv_name):
     )
 
 
+def is_pv(pv_name):
+    stdout = [i.strip() for i in get_api_pvs(fields='pv_name', unparsed=True)]
+    try:
+        stdout.index(pv_name)
+    except ValueError:
+        return False
+    return True
+
+
 def get_pv(pv_name=None, pv_uuid=None, pv_tags=None, pvs=None):
     """
     Return a matching pv (physical volume) for the current system, requiring

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -244,9 +244,9 @@ class Activate(object):
         lvs = api.Volumes()
         # filter them down for the OSD ID and FSID we need to activate
         if osd_id and osd_fsid:
-            lvs.filter(lv_tags={'ceph.osd_id': osd_id, 'ceph.osd_fsid': osd_fsid})
+            lvs = lvs.filter(lv_tags={'ceph.osd_id': osd_id, 'ceph.osd_fsid': osd_fsid})
         elif osd_fsid and not osd_id:
-            lvs.filter(lv_tags={'ceph.osd_fsid': osd_fsid})
+            lvs = lvs.filter(lv_tags={'ceph.osd_fsid': osd_fsid})
         if not lvs:
             raise RuntimeError('could not find osd.%s with fsid %s' % (osd_id, osd_fsid))
         # This argument is only available when passed in directly or via

--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -184,7 +184,7 @@ class List(object):
             try:
                 lv = api.get_lv(vg_name=pv.vg_name)
             except MultipleLVsError:
-                lvs.filter(vg_name=pv.vg_name)
+                lvs = lvs.filter(vg_name=pv.vg_name)
                 return self.full_report(lvs=lvs)
 
         if lv:

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -81,7 +81,7 @@ def find_associated_devices(osd_id=None, osd_fsid=None):
     if osd_fsid:
         lv_tags['ceph.osd_fsid'] = osd_fsid
     lvs = api.Volumes()
-    lvs.filter(lv_tags=lv_tags)
+    lvs = lvs.filter(lv_tags=lv_tags)
     if not lvs:
         raise RuntimeError('Unable to find any LV for zapping OSD: %s' % osd_id or osd_fsid)
 
@@ -175,7 +175,7 @@ class Zap(object):
 
         if self.args.destroy:
             lvs = api.Volumes()
-            lvs.filter(vg_name=device.vg_name)
+            lvs = lvs.filter(vg_name=device.vg_name)
             if len(lvs) <= 1:
                 mlogger.info('Only 1 LV left in VG, will proceed to destroy volume group %s', device.vg_name)
                 api.remove_vg(device.vg_name)

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -219,7 +219,7 @@ class TestVolumes(object):
         assert volumes.get() is None
 
     def test_volume_get_filtered_has_no_volumes(self, volumes):
-        assert volumes.get(lv_name='ceph') is None
+        assert volumes.get(lv_name='ceph') == []
 
     def test_volume_has_multiple_matches(self, volumes):
         volume1 = volume2 = api.Volume(lv_name='foo', lv_path='/dev/vg/lv', lv_tags='')
@@ -525,7 +525,7 @@ class TestGetLVFromArgument(object):
 
     def test_absolute_path_is_not_lv(self, volumes):
         volumes.append(self.foo_volume)
-        assert api.get_lv_from_argument('/path') is None
+        assert api.get_lv_from_argument('/path') == []
 
     def test_absolute_path_is_lv(self, volumes):
         volumes.append(self.foo_volume)

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -139,12 +139,16 @@ def conf_ceph_stub(monkeypatch, tmpfile):
 
 
 @pytest.fixture
+def volumes_empty(monkeypatch):
+    monkeypatch.setattr('ceph_volume.process.call', lambda x, **kw: ('', '', 0))
+    return lvm_api.Volumes(populate=False)
+
+@pytest.fixture
 def volumes(monkeypatch):
     monkeypatch.setattr('ceph_volume.process.call', lambda x, **kw: ('', '', 0))
     volumes = lvm_api.Volumes()
     volumes._purge()
     return volumes
-
 
 @pytest.fixture
 def volume_groups(monkeypatch):

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -208,7 +208,7 @@ def disable_kernel_queries(monkeypatch):
     '''
     This speeds up calls to Device and Disk
     '''
-    monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: {})
+    monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda lvs=None: {})
     monkeypatch.setattr("ceph_volume.util.disk.udevadm_property", lambda *a, **kw: {})
 
 
@@ -217,8 +217,8 @@ def disable_lvm_queries(monkeypatch):
     '''
     This speeds up calls to Device and Disk
     '''
-    monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: None)
-    monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv", lambda vg_name, lv_uuid: None)
+    monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path, lvs=None: None)
+    monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv", lambda vg_name, lv_uuid, lvs=None: None)
 
 
 @pytest.fixture(params=[
@@ -273,12 +273,12 @@ def device_info(monkeypatch):
         udevadm = udevadm if udevadm else {}
         lv = Factory(**lv) if lv else None
         monkeypatch.setattr("ceph_volume.sys_info.devices", {})
-        monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
+        monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda lvs=None: devices)
         if not devices:
-            monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
+            monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path, lvs=None: lv)
         else:
-            monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: None)
-        monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv", lambda vg_name, lv_uuid: lv)
+            monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path, lvs=None: None)
+        monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv", lambda vg_name, lv_uuid, lvs=None: lv)
         monkeypatch.setattr("ceph_volume.util.device.disk.lsblk", lambda path: lsblk)
         monkeypatch.setattr("ceph_volume.util.device.disk.blkid", lambda path: blkid)
         monkeypatch.setattr("ceph_volume.util.disk.udevadm_property", lambda *a, **kw: udevadm)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -22,34 +22,34 @@ class TestActivate(object):
     # test the negative side effect with an actual functional run, so we must
     # setup a perfect scenario for this test to check it can really work
     # with/without osd_id
-    def test_no_osd_id_matches_fsid(self, is_root, volumes, monkeypatch, capture):
+    def test_no_osd_id_matches_fsid(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         FooVolume = api.Volume(lv_name='foo', lv_path='/dev/vg/foo', lv_tags="ceph.osd_fsid=1234")
         volumes.append(FooVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         monkeypatch.setattr(activate, 'activate_filestore', capture)
         args = Args(osd_id=None, osd_fsid='1234', filestore=True)
         activate.Activate([]).activate(args)
         assert capture.calls[0]['args'][0] == [FooVolume]
 
-    def test_no_osd_id_matches_fsid_bluestore(self, is_root, volumes, monkeypatch, capture):
+    def test_no_osd_id_matches_fsid_bluestore(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         FooVolume = api.Volume(lv_name='foo', lv_path='/dev/vg/foo', lv_tags="ceph.osd_fsid=1234")
         volumes.append(FooVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         monkeypatch.setattr(activate, 'activate_bluestore', capture)
         args = Args(osd_id=None, osd_fsid='1234', bluestore=True)
         activate.Activate([]).activate(args)
         assert capture.calls[0]['args'][0] == [FooVolume]
 
-    def test_no_osd_id_no_matching_fsid(self, is_root, volumes, monkeypatch, capture):
+    def test_no_osd_id_no_matching_fsid(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         FooVolume = api.Volume(lv_name='foo', lv_path='/dev/vg/foo', lv_tags="ceph.osd_fsid=11234")
         volumes.append(FooVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         monkeypatch.setattr(activate, 'activate_filestore', capture)
         args = Args(osd_id=None, osd_fsid='1234')
         with pytest.raises(RuntimeError):
             activate.Activate([]).activate(args)
 
-    def test_filestore_no_systemd(self, is_root, volumes, monkeypatch, capture):
+    def test_filestore_no_systemd(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
@@ -73,13 +73,13 @@ class TestActivate(object):
             lv_tags="ceph.cluster_name=ceph,ceph.journal_device=/dev/vg/journal,ceph.journal_uuid=000,ceph.type=data,ceph.osd_id=0,ceph.osd_fsid=1234")
         volumes.append(DataVolume)
         volumes.append(JournalVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=True, filestore=True)
         activate.Activate([]).activate(args)
         assert fake_enable.calls == []
         assert fake_start_osd.calls == []
 
-    def test_filestore_no_systemd_autodetect(self, is_root, volumes, monkeypatch, capture):
+    def test_filestore_no_systemd_autodetect(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
@@ -103,13 +103,13 @@ class TestActivate(object):
             lv_tags="ceph.cluster_name=ceph,ceph.journal_device=/dev/vg/journal,ceph.journal_uuid=000,ceph.type=data,ceph.osd_id=0,ceph.osd_fsid=1234")
         volumes.append(DataVolume)
         volumes.append(JournalVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=True, filestore=True, auto_detect_objectstore=True)
         activate.Activate([]).activate(args)
         assert fake_enable.calls == []
         assert fake_start_osd.calls == []
 
-    def test_filestore_systemd_autodetect(self, is_root, volumes, monkeypatch, capture):
+    def test_filestore_systemd_autodetect(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
@@ -133,13 +133,13 @@ class TestActivate(object):
             lv_tags="ceph.cluster_name=ceph,ceph.journal_device=/dev/vg/journal,ceph.journal_uuid=000,ceph.type=data,ceph.osd_id=0,ceph.osd_fsid=1234")
         volumes.append(DataVolume)
         volumes.append(JournalVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=False, filestore=True, auto_detect_objectstore=False)
         activate.Activate([]).activate(args)
         assert fake_enable.calls != []
         assert fake_start_osd.calls != []
 
-    def test_filestore_systemd(self, is_root, volumes, monkeypatch, capture):
+    def test_filestore_systemd(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
@@ -163,13 +163,13 @@ class TestActivate(object):
             lv_tags="ceph.cluster_name=ceph,ceph.journal_device=/dev/vg/journal,ceph.journal_uuid=000,ceph.type=data,ceph.osd_id=0,ceph.osd_fsid=1234")
         volumes.append(DataVolume)
         volumes.append(JournalVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=False, filestore=True)
         activate.Activate([]).activate(args)
         assert fake_enable.calls != []
         assert fake_start_osd.calls != []
 
-    def test_bluestore_no_systemd(self, is_root, volumes, monkeypatch, capture):
+    def test_bluestore_no_systemd(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
@@ -182,13 +182,13 @@ class TestActivate(object):
             lv_path='/dev/vg/data',
             lv_tags="ceph.cluster_name=ceph,,ceph.journal_uuid=000,ceph.type=block,ceph.osd_id=0,ceph.osd_fsid=1234")
         volumes.append(DataVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=True, bluestore=True)
         activate.Activate([]).activate(args)
         assert fake_enable.calls == []
         assert fake_start_osd.calls == []
 
-    def test_bluestore_systemd(self, is_root, volumes, monkeypatch, capture):
+    def test_bluestore_systemd(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
@@ -201,13 +201,13 @@ class TestActivate(object):
             lv_path='/dev/vg/data',
             lv_tags="ceph.cluster_name=ceph,,ceph.journal_uuid=000,ceph.type=block,ceph.osd_id=0,ceph.osd_fsid=1234")
         volumes.append(DataVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=False, bluestore=True)
         activate.Activate([]).activate(args)
         assert fake_enable.calls != []
         assert fake_start_osd.calls != []
 
-    def test_bluestore_no_systemd_autodetect(self, is_root, volumes, monkeypatch, capture):
+    def test_bluestore_no_systemd_autodetect(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
@@ -220,13 +220,13 @@ class TestActivate(object):
             lv_path='/dev/vg/data',
             lv_tags="ceph.cluster_name=ceph,,ceph.block_uuid=000,ceph.type=block,ceph.osd_id=0,ceph.osd_fsid=1234")
         volumes.append(DataVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=True, bluestore=True, auto_detect_objectstore=True)
         activate.Activate([]).activate(args)
         assert fake_enable.calls == []
         assert fake_start_osd.calls == []
 
-    def test_bluestore_systemd_autodetect(self, is_root, volumes, monkeypatch, capture):
+    def test_bluestore_systemd_autodetect(self, is_root, volumes, volumes_empty, monkeypatch, capture):
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
@@ -239,7 +239,7 @@ class TestActivate(object):
             lv_path='/dev/vg/data',
             lv_tags="ceph.cluster_name=ceph,,ceph.journal_uuid=000,ceph.type=block,ceph.osd_id=0,ceph.osd_fsid=1234")
         volumes.append(DataVolume)
-        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(api, 'Volumes', lambda populate=True: volumes if populate else volumes_empty)
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=False, bluestore=True, auto_detect_objectstore=False)
         activate.Activate([]).activate(args)
         assert fake_enable.calls != []

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -1,6 +1,9 @@
 import pytest
 from ceph_volume.util import device
 from ceph_volume.api import lvm as api
+from sys import version_info as py_version_info
+if py_version_info.major >= 3:
+        from importlib import reload
 
 
 class TestDevice(object):
@@ -191,6 +194,8 @@ class TestDevice(object):
 
     @pytest.mark.parametrize("ceph_type", ["data", "block"])
     def test_used_by_ceph(self, device_info, pvolumes, pvolumes_empty, monkeypatch, ceph_type):
+        reload(device)
+
         FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", lv_uuid="0000", pv_tags={}, vg_name="vg")
         pvolumes.append(FooPVolume)
         monkeypatch.setattr(api, 'PVolumes', lambda populate=True: pvolumes if populate else pvolumes_empty)
@@ -202,6 +207,8 @@ class TestDevice(object):
         assert disk.used_by_ceph
 
     def test_not_used_by_ceph(self, device_info, pvolumes, pvolumes_empty, monkeypatch):
+        reload(device)
+
         FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", lv_uuid="0000", pv_tags={}, vg_name="vg")
         pvolumes.append(FooPVolume)
         monkeypatch.setattr(api, 'PVolumes', lambda populate=True: pvolumes if populate else pvolumes_empty)

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -125,7 +125,8 @@ class Device(object):
                     break
 
         # start with lvm since it can use an absolute or relative path
-        lv = lvm.get_lv_from_argument(self.path)
+        lvs = lvm.Volumes()
+        lv = lvm.get_lv_from_argument(self.path, lvs)
         if lv:
             self.lv_api = lv
             self.lvs = [lv]

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -21,6 +21,8 @@ def encryption_status(abspath):
     return encryption.status(abspath)
 
 # TODO: create global list of LVs (and PVs and VGs) and then get rid of this.
+global_pvs = lvm.PVolumes()
+global_vgs = lvm.VolumeGroups()
 global_lvs = lvm.Volumes()
 
 class Devices(object):
@@ -81,13 +83,15 @@ class Device(object):
     ]
 
     def __init__(self, path, lvs=None):
+        global global_pvs
+        global global_vgs
         global global_lvs
 
         self.path = path
 
-        if lvm.is_pv(path):
+        if lvm.is_pv(path, global_pvs):
             self.lvs = lvs or lvm.get_lv(pv_name=path, lvs=global_lvs)
-        elif lvm.is_vg(os.path.basename(path)):
+        elif lvm.is_vg(os.path.basename(path), global_vgs):
             self.lvs = lvs or lvm.get_lv(vg_name=os.path.basename(path),
                                          lvs=global_lvs)
         elif lvm.is_lv(lv_name=path):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -787,6 +787,7 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
     dev_devs = get_dev_devs(_dev_path)
     mapper_devs = get_mapper_devs(_mapper_path)
 
+    lvs = lvm.Volumes()
     for block in block_devs:
         sysdir = os.path.join(_sys_block_path, block)
         metadata = {}
@@ -799,7 +800,7 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
 
         # If the mapper device is a logical volume it gets excluded
         if is_mapper_device(diskname):
-            if lvm.is_lv(diskname):
+            if lvm.is_lv(diskname, lvs):
                 continue
 
         metadata['removable'] = get_file_contents(os.path.join(sysdir, 'removable'))

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -800,7 +800,7 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
 
         # If the mapper device is a logical volume it gets excluded
         if is_mapper_device(diskname):
-            if lvm.is_lv(diskname, lvs):
+            if lvm.is_lv(diskname, lvs=lvs):
                 continue
 
         metadata['removable'] = get_file_contents(os.path.join(sysdir, 'removable'))

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -761,7 +761,7 @@ def is_locked_raw_device(disk_path):
     return 0
 
 
-def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/dev/mapper'):
+def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/dev/mapper', lvs=None):
     """
     Captures all available devices from /sys/block/, including its partitions,
     along with interesting metadata like sectors, size, vendor,


### PR DESCRIPTION
`Volumes.__init__()` ends up being called 2-3 times per disk/partition. This
PR makes sure that it is called only once irrespective of the number of disks.

Fixes: https://tracker.ceph.com/issues/38175



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>