### PR TITLE
mimic: cephfs: client: set snapdir's link count to 1

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10328,6 +10328,7 @@ Inode *Client::open_snapdir(Inode *diri)
     in->mode = diri->mode;
     in->uid = diri->uid;
     in->gid = diri->gid;
+    in->nlink = 1;
     in->mtime = diri->mtime;
     in->ctime = diri->ctime;
     in->btime = diri->btime;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40442

---

backport of https://github.com/ceph/ceph/pull/28545
parent tracker: https://tracker.ceph.com/issues/40101

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh