### PR TITLE
mimic: cephfs: test_volume_client: declare only one default for python version

### DIFF
--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -19,7 +19,8 @@ class TestVolumeClient(CephFSTestCase):
 
     def setUp(self):
         CephFSTestCase.setUp(self)
-        self.py_version = self.ctx.config.get('overrides', {}).get('python', 'python')
+        self.py_version = self.ctx.config.get('overrides', {}).\
+                          get('python', TestVolumeClient.default_py_version)
         log.info("using python version: {python_version}".format(
             python_version=self.py_version
         ))


### PR DESCRIPTION
NOTE: omitted the cherry-pick of 4870574473d592194ef17c152f304d4e968f3771 because it was already done in https://github.com/ceph/ceph/pull/30236

backport tracker: https://tracker.ceph.com/issues/40494

---

backport of https://github.com/ceph/ceph/pull/28194
parent tracker: https://tracker.ceph.com/issues/40460

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh