### PR TITLE
mgr/dashboard: Set RO as the default access_type for RGW NFS exports

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -402,7 +402,8 @@
             <select class="form-control custom-select"
                     formControlName="access_type"
                     name="access_type"
-                    id="access_type">
+                    id="access_type"
+                    (change)="accessTypeChangeHandler()">
               <option *ngIf="nfsAccessType === null"
                       value=""
                       i18n>Loading...</option>
@@ -419,6 +420,13 @@
                   *ngIf="nfsForm.getValue('access_type')">
               {{ getAccessTypeHelp(nfsForm.getValue('access_type')) }}
             </span>
+            <span class="form-text text-warning"
+                  *ngIf="nfsForm.getValue('access_type') === 'RW' && nfsForm.getValue('name') === 'RGW'"
+                  i18n>The Object Gateway NFS backend has a number of
+              limitations which will seriously affect applications writing to
+              the share. Please consult the
+              <a href="{{docsUrl}}"
+                 target="_blank"> documentation</a> for details before enabling write access.</span>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('access_type', formDir, 'required')"
                   i18n>Required field</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -9,6 +9,7 @@ import { ToastrModule } from 'ngx-toastr';
 
 import { ActivatedRouteStub } from '../../../../testing/activated-route-stub';
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { NfsFormClientComponent } from '../nfs-form-client/nfs-form-client.component';
@@ -36,7 +37,9 @@ describe('NfsFormComponent', () => {
           provide: ActivatedRoute,
           useValue: new ActivatedRouteStub({ cluster_id: undefined, export_id: undefined })
         },
-        i18nProviders
+        i18nProviders,
+        SummaryService,
+        CephReleaseNamePipe
       ]
     },
     true
@@ -45,6 +48,11 @@ describe('NfsFormComponent', () => {
   beforeEach(() => {
     const summaryService = TestBed.get(SummaryService);
     spyOn(summaryService, 'refresh').and.callFake(() => true);
+    spyOn(summaryService, 'getCurrentSummary').and.callFake(() => {
+      return {
+        version: 'master'
+      };
+    });
 
     fixture = TestBed.createComponent(NfsFormComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -18,7 +18,9 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { FinishedTask } from '../../../shared/models/finished-task';
 import { Permission } from '../../../shared/models/permissions';
+import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
+import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 import { NfsFormClientComponent } from '../nfs-form-client/nfs-form-client.component';
 
@@ -51,11 +53,13 @@ export class NfsFormComponent implements OnInit {
   allCephxClients: any[] = null;
   allFsNames: any[] = null;
 
+  defaultAccessType = { RGW: 'RO' };
   nfsAccessType: any[] = this.nfsService.nfsAccessType;
   nfsSquash: any[] = this.nfsService.nfsSquash;
 
   action: string;
   resource: string;
+  docsUrl: string;
 
   daemonsSelections: SelectOption[] = [];
   daemonsMessages = new SelectMessages(
@@ -81,6 +85,8 @@ export class NfsFormComponent implements OnInit {
     private router: Router,
     private rgwUserService: RgwUserService,
     private formBuilder: CdFormBuilder,
+    private summaryservice: SummaryService,
+    private cephReleaseNamePipe: CephReleaseNamePipe,
     private taskWrapper: TaskWrapperService,
     private cdRef: ChangeDetectorRef,
     private i18n: I18n,
@@ -116,6 +122,10 @@ export class NfsFormComponent implements OnInit {
       this.action = this.actionLabels.CREATE;
       this.getData(promises);
     }
+
+    const summary = this.summaryservice.getCurrentSummary();
+    const releaseName = this.cephReleaseNamePipe.transform(summary.version);
+    this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/radosgw/nfs/`;
   }
 
   getData(promises) {
@@ -319,12 +329,19 @@ export class NfsFormComponent implements OnInit {
   fsalChangeHandler() {
     this.nfsForm.patchValue({
       tag: this._generateTag(),
-      pseudo: this._generatePseudo()
+      pseudo: this._generatePseudo(),
+      access_type: this._updateAccessType()
     });
 
     this.setPathValidation();
 
     this.cdRef.detectChanges();
+  }
+
+  accessTypeChangeHandler() {
+    const name = this.nfsForm.getValue('name');
+    const accessType = this.nfsForm.getValue('access_type');
+    this.defaultAccessType[name] = accessType;
   }
 
   setPathValidation() {
@@ -435,6 +452,17 @@ export class NfsFormComponent implements OnInit {
       }
     }
     return newPseudo;
+  }
+
+  _updateAccessType() {
+    const name = this.nfsForm.getValue('name');
+    let accessType = this.defaultAccessType[name];
+
+    if (!accessType) {
+      accessType = 'RW';
+    }
+
+    return accessType;
   }
 
   onClusterChange() {


### PR DESCRIPTION
It will also show an warning if the user selects RW access_type.

Fixes: https://tracker.ceph.com/issues/40186

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
