### PR TITLE
ceph-volume: pre-install python-apt and its variants before test runs

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -17,6 +17,9 @@
     delegate_facts_host: True
     dashboard_enabled: False
 
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
   pre_tasks:
     # If we can't get python2 installed before any module is used we will fail
     # so just try what we can to get it installed
@@ -31,6 +34,17 @@
       ignore_errors: yes
       when:
         - systempython2.stat is undefined or systempython2.stat.exists == false
+
+    # Ansible will try to auto-install python-apt, in some systems this might be
+    # python3-apt, or python-apt, and it has caused whole runs to fail because
+    # it is trying to do an interactive prompt
+    - name: install python-apt and aptitude in debian based systems
+      raw: sudo apt-get -y install "{{ item }}"
+      ignore_errors: yes
+      with_items:
+        - python3-apt
+        - python-apt
+        - aptitude
 
     - name: install python2 for fedora
       raw: sudo dnf -y install python creates=/usr/bin/python


### PR DESCRIPTION
So that Ansible doesn't fail with a prompt when trying to auto-install. This is a second attempt at fixing this issue as it seems that exporting (or injecting) the `DEBIAN_FRONTEND` environment variable had no effect into the problem.

Fixes: https://tracker.ceph.com/issues/41378