### PR TITLE
luminous: rbd-mirror: ignore errors relating to parsing the cluster config file

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -184,21 +184,30 @@ global_init(std::vector < const char * > *alt_def_args,
     gid_t gid = 0;
     std::string uid_string;
     std::string gid_string;
+    std::string home_directory;
     if (g_conf->setuser.length()) {
+      char buf[4096];
+      struct passwd pa;
+      struct passwd *p = 0;
+
       uid = atoi(g_conf->setuser.c_str());
-      if (!uid) {
-	char buf[4096];
-	struct passwd pa;
-	struct passwd *p = 0;
+      if (uid) {
+        getpwuid_r(uid, &pa, buf, sizeof(buf), &p);
+      } else {
 	getpwnam_r(g_conf->setuser.c_str(), &pa, buf, sizeof(buf), &p);
-	if (!p) {
+        if (!p) {
 	  cerr << "unable to look up user '" << g_conf->setuser << "'"
 	       << std::endl;
 	  exit(1);
 	}
-	uid = p->pw_uid;
-	gid = p->pw_gid;
-	uid_string = g_conf->setuser;
+
+        uid = p->pw_uid;
+        gid = p->pw_gid;
+        uid_string = g_conf->setuser;
+      }
+
+      if (p && p->pw_dir != nullptr) {
+        home_directory = std::string(p->pw_dir);
       }
     }
     if (g_conf->setgroup.length() > 0) {
@@ -258,6 +267,10 @@ global_init(std::vector < const char * > *alt_def_args,
 	cerr << "unable to setuid " << uid << ": " << cpp_strerror(errno)
 	     << std::endl;
 	exit(1);
+      }
+      if (setenv("HOME", home_directory.c_str(), 1) != 0) {
+	cerr << "warning: unable to set HOME to " << home_directory << ": "
+             << cpp_strerror(errno) << std::endl;
       }
       priv_ss << "set uid:gid to " << uid << ":" << gid << " (" << uid_string << ":" << gid_string << ")";
     } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41439

---

backport of https://github.com/ceph/ceph/pull/29808 (NOTE: omitted 57e684911b1948f780cd9d7409050aedf2bc6dd8, since we don't expect b1289290247fcd724c9f794716176089342f1110 to be backported, and also omitted 1e8c41e5f72b4f42bc87f2a8b6f45a853cc19faf because it's not strictly needed to fix the bug)
parent tracker: https://tracker.ceph.com/issues/41356

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh