### PR TITLE
osd/MissingLoc, PeeringState: remove osd from missing loc in purge_strays()

### DIFF
--- a/src/osd/MissingLoc.h
+++ b/src/osd/MissingLoc.h
@@ -270,6 +270,9 @@ class MissingLoc {
   /// Uses osdmap to update structures for now down sources
   void check_recovery_sources(const OSDMapRef& osdmap);
 
+  /// Remove stray from recovery sources
+  void remove_stray_recovery_sources(pg_shard_t stray);
+
   /// Call when hoid is no longer missing in acting set
   void recovered(const hobject_t &hoid) {
     needs_recovery_map.erase(hoid);

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -212,6 +212,7 @@ void PeeringState::purge_strays()
     }
     peer_missing.erase(*p);
     peer_info.erase(*p);
+    missing_loc.remove_stray_recovery_sources(*p);
     peer_purged.insert(*p);
     removed = true;
   }


### PR DESCRIPTION

We should always try to keep osds in missing_loc consistent with peer_missing
and peer_info. When we remove an osd from peer_missing and peer_info, we
should also remove it from missing_loc during purging strays.

Signed-off-by: Neha Ojha <nojha@redhat.com>