### PR TITLE
mimic: build/ops: install-deps.sh: Remove CR repo

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -224,7 +224,6 @@ else
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$VERSION_ID
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
                 if test $ID = centos -a $VERSION_ID = 7 ; then
-                    $SUDO yum-config-manager --enable cr
 		    case $(uname -m) in
 			x86_64)
 			    $SUDO yum -y install centos-release-scl
@@ -240,8 +239,6 @@ else
                 elif test $ID = rhel -a $MAJOR_VERSION = 7 ; then
                     $SUDO yum-config-manager --enable rhel-server-rhscl-7-rpms
                     dts_ver=7
-                elif test $ID = virtuozzo -a $MAJOR_VERSION = 7 ; then
-                    $SUDO yum-config-manager --enable cr
                 fi
                 ;;
         esac


### PR DESCRIPTION
This PR fixes the present scourge of "make check" failures in PRs targeting mimic (https://tracker.ceph.com/issues/41603).

backport tracker: https://tracker.ceph.com/issues/41645
  
---

backport of https://github.com/ceph/ceph/pull/25211
parent tracker: https://tracker.ceph.com/issues/37335

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh