### PR TITLE
luminous: install-deps.sh: Remove CR repo

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -176,12 +176,6 @@ else
                 $SUDO yum install --nogpgcheck -y epel-release
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
-                if test $(lsb_release -si) = CentOS -a $MAJOR_VERSION = 7 ; then
-                    $SUDO yum-config-manager --enable cr
-                fi
-                if test $(lsb_release -si) = VirtuozzoLinux -a $MAJOR_VERSION = 7 ; then
-                    $SUDO yum-config-manager --enable cr
-                fi
                 ;;
         esac
         munge_ceph_spec_in $DIR/ceph.spec


### PR DESCRIPTION
There is no immediate urgent need for this backport in luminous, but it seems prudent to refrain from adding the CR repo, since it is a potential source of dependency issues - e.g. https://tracker.ceph.com/issues/41603

backport tracker: https://tracker.ceph.com/issues/41644

---

backport of https://github.com/ceph/ceph/pull/25211
parent tracker: https://tracker.ceph.com/issues/37335

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh