### PR TITLE
mimic: rgw: data/bilogs are trimmed when no peers are reading them

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -804,7 +804,7 @@ int RGWSyncLogTrimCR::request_complete()
     return r;
   }
   // nothing left to trim, update last_trim_marker
-  if (*last_trim_marker < to_marker) {
+  if (*last_trim_marker < to_marker && to_marker != max_marker) {
     *last_trim_marker = to_marker;
   }
   return 0;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -1136,6 +1136,9 @@ class RGWSyncLogTrimCR : public RGWRadosTimelogTrimCR {
   CephContext *cct;
   std::string *last_trim_marker;
  public:
+  // a marker that compares greater than any timestamp-based index
+  static constexpr const char* max_marker = "99999999";
+
   RGWSyncLogTrimCR(RGWRados *store, const std::string& oid,
                    const std::string& to_marker, std::string *last_trim_marker);
   int request_complete() override;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3563,7 +3563,7 @@ class DataLogTrimCR : public RGWCoroutine {
       num_shards(num_shards),
       zone_id(store->get_zone().id),
       peer_status(store->zone_conn_map.size()),
-      min_shard_markers(num_shards),
+      min_shard_markers(num_shards, "99999999"),
       last_trim(last_trim)
   {}
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3547,6 +3547,7 @@ void take_min_markers(IterIn first, IterIn last, IterOut dest)
 } // anonymous namespace
 
 class DataLogTrimCR : public RGWCoroutine {
+  using TrimCR = RGWSyncLogTrimCR;
   RGWRados *store;
   RGWHTTPManager *http;
   const int num_shards;
@@ -3563,7 +3564,7 @@ class DataLogTrimCR : public RGWCoroutine {
       num_shards(num_shards),
       zone_id(store->get_zone().id),
       peer_status(store->zone_conn_map.size()),
-      min_shard_markers(num_shards, "99999999"),
+      min_shard_markers(num_shards, TrimCR::max_marker),
       last_trim(last_trim)
   {}
 
@@ -3622,7 +3623,6 @@ int DataLogTrimCR::operate()
         ldout(cct, 10) << "trimming log shard " << i
             << " at marker=" << m
             << " last_trim=" << last_trim[i] << dendl;
-        using TrimCR = RGWSyncLogTrimCR;
         spawn(new TrimCR(store, store->data_log->get_oid(i),
                          m, &last_trim[i]),
               true);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3524,14 +3524,6 @@ const std::string& get_stable_marker(const rgw_data_sync_marker& m)
   return m.state == m.FullSync ? m.next_step_marker : m.marker;
 }
 
-/// comparison operator for take_min_markers()
-bool operator<(const rgw_data_sync_marker& lhs,
-               const rgw_data_sync_marker& rhs)
-{
-  // sort by stable marker
-  return get_stable_marker(lhs) < get_stable_marker(rhs);
-}
-
 /// populate the container starting with 'dest' with the minimum stable marker
 /// of each shard for all of the peers in [first, last)
 template <typename IterIn, typename IterOut>
@@ -3540,18 +3532,12 @@ void take_min_markers(IterIn first, IterIn last, IterOut dest)
   if (first == last) {
     return;
   }
-  // initialize markers with the first peer's
-  auto m = dest;
-  for (auto &shard : first->sync_markers) {
-    *m = std::move(shard.second);
-    ++m;
-  }
-  // for remaining peers, replace with smaller markers
-  for (auto p = first + 1; p != last; ++p) {
-    m = dest;
+  for (auto p = first; p != last; ++p) {
+    auto m = dest;
     for (auto &shard : p->sync_markers) {
-      if (shard.second < *m) {
-        *m = std::move(shard.second);
+      const auto& stable = get_stable_marker(shard.second);
+      if (*m > stable) {
+        *m = stable;
       }
       ++m;
     }
@@ -3566,7 +3552,7 @@ class DataLogTrimCR : public RGWCoroutine {
   const int num_shards;
   const std::string& zone_id; //< my zone id
   std::vector<rgw_data_sync_status> peer_status; //< sync status for each peer
-  std::vector<rgw_data_sync_marker> min_shard_markers; //< min marker per shard
+  std::vector<std::string> min_shard_markers; //< min marker per shard
   std::vector<std::string>& last_trim; //< last trimmed marker per shard
   int ret{0};
 
@@ -3630,16 +3616,15 @@ int DataLogTrimCR::operate()
 
       for (int i = 0; i < num_shards; i++) {
         const auto& m = min_shard_markers[i];
-        auto& stable = get_stable_marker(m);
-        if (stable <= last_trim[i]) {
+        if (m <= last_trim[i]) {
           continue;
         }
         ldout(cct, 10) << "trimming log shard " << i
-            << " at marker=" << stable
+            << " at marker=" << m
             << " last_trim=" << last_trim[i] << dendl;
         using TrimCR = RGWSyncLogTrimCR;
         spawn(new TrimCR(store, store->data_log->get_oid(i),
-                         stable, &last_trim[i]),
+                         m, &last_trim[i]),
               true);
       }
     }

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -472,7 +472,9 @@ int BucketTrimInstanceCR::operate()
       }
     }
 
-    min_markers.resize(std::max(1u, bucket_info.num_shards));
+    // initialize each shard with the maximum marker, which is only used when
+    // there are no peers syncing from us
+    min_markers.assign(std::max(1u, bucket_info.num_shards), "99999999");
 
     // determine the minimum marker for each shard
     retcode = take_min_status(cct, peer_status.begin(), peer_status.end(),

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -348,16 +348,8 @@ template <typename Iter>
 int take_min_status(CephContext *cct, Iter first, Iter last,
                     std::vector<std::string> *status)
 {
-  status->clear();
-  // The initialisation below is required to silence a false positive
-  // -Wmaybe-uninitialized warning
-  boost::optional<size_t> num_shards = boost::make_optional(false, 0UL);
   for (auto peer = first; peer != last; ++peer) {
-    const size_t peer_shards = peer->size();
-    if (!num_shards) {
-      num_shards = peer_shards;
-      status->resize(*num_shards);
-    } else if (*num_shards != peer_shards) {
+    if (peer->size() != status->size()) {
       // all peers must agree on the number of shards
       return -EINVAL;
     }
@@ -479,6 +471,8 @@ int BucketTrimInstanceCR::operate()
         return set_cr_error(child_ret);
       }
     }
+
+    min_markers.resize(std::max(1u, bucket_info.num_shards));
 
     // determine the minimum marker for each shard
     retcode = take_min_status(cct, peer_status.begin(), peer_status.end(),

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -660,7 +660,7 @@ int AsyncMetadataList::_send_request()
       assert(keys.size() == 1);
       auto& key = keys.front();
       // stop at original marker
-      if (marker >= start_marker) {
+      if (marker > start_marker) {
         return 0;
       }
       if (!callback(std::move(key), std::move(marker))) {

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -474,7 +474,8 @@ int BucketTrimInstanceCR::operate()
 
     // initialize each shard with the maximum marker, which is only used when
     // there are no peers syncing from us
-    min_markers.assign(std::max(1u, bucket_info.num_shards), "99999999");
+    min_markers.assign(std::max(1u, bucket_info.num_shards),
+                       RGWSyncLogTrimCR::max_marker);
 
     // determine the minimum marker for each shard
     retcode = take_min_status(cct, peer_status.begin(), peer_status.end(),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40629

---

backport of https://github.com/ceph/ceph/pull/27794
parent tracker: https://tracker.ceph.com/issues/39487

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh