### PR TITLE
mimic: rgw/multisite: Don't allow certain radosgw-admin commands to run on non-master zone

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4919,6 +4919,12 @@ int main(int argc, const char **argv)
   case OPT_USER_INFO:
     break;
   case OPT_USER_CREATE:
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "user created here will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
+
     if (!user_op.has_existing_user()) {
       user_op.set_generate_key(); // generate a new key by default
     }
@@ -4939,6 +4945,11 @@ int main(int argc, const char **argv)
     }
     break;
   case OPT_USER_RM:
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "user delete operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     ret = user.remove(user_op, &err_msg);
     if (ret < 0) {
       cerr << "could not remove user: " << err_msg << std::endl;
@@ -4950,6 +4961,11 @@ int main(int argc, const char **argv)
   case OPT_USER_ENABLE:
   case OPT_USER_SUSPEND:
   case OPT_USER_MODIFY:
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "user modify operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     ret = user.modify(user_op, &err_msg);
     if (ret < 0) {
       cerr << "could not modify user: " << err_msg << std::endl;
@@ -5450,6 +5466,11 @@ int main(int argc, const char **argv)
   }
 
   if (opt_cmd == OPT_BUCKET_LINK) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "link operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     bucket_op.set_bucket_id(bucket_id);
     string err;
     int r = RGWBucketAdminOp::link(store, bucket_op, &err);
@@ -5460,6 +5481,11 @@ int main(int argc, const char **argv)
   }
 
   if (opt_cmd == OPT_BUCKET_UNLINK) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "unlink operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     int r = RGWBucketAdminOp::unlink(store, bucket_op);
     if (r < 0) {
       cerr << "failure: " << cpp_strerror(-r) << std::endl;
@@ -6106,6 +6132,11 @@ next:
   }
 
   if (opt_cmd == OPT_BUCKET_RESHARD) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "resharding only applies to the local zone and will not be synced to master" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     rgw_bucket bucket;
     RGWBucketInfo bucket_info;
     map<string, bufferlist> attrs;
@@ -6289,6 +6320,11 @@ next:
   }
 
   if (opt_cmd == OPT_OBJECT_UNLINK) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "unlink operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     RGWBucketInfo bucket_info;
     int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
     if (ret < 0) {
@@ -6380,6 +6416,11 @@ next:
   }
 
   if (opt_cmd == OPT_BUCKET_RM) {
+    if (!store->svc.zone->is_meta_master() && !yes_i_really_mean_it) {
+      cerr << "bucket remove operation will not be synced to master zone" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return EINVAL;
+    }
     if (!inconsistent_index) {
       RGWBucketAdminOp::remove_bucket(store, bucket_op, bypass_gc, true);
     } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40850

---

backport of https://github.com/ceph/ceph/pull/28861
parent tracker: https://tracker.ceph.com/issues/39548

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh