### PR TITLE
build-doc: allow building docs on fedora 30

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -20,7 +20,8 @@ if command -v dpkg >/dev/null; then
         exit 1
     fi
 elif command -v yum >/dev/null; then
-    for package in python36-devel python36-pip python36-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel python36-Cython graphviz; do
+    python_package="python$(rpm --eval '%{python3_pkgversion}')"
+    for package in "$python_package"-devel "$python_package"-pip "$python_package"-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel "$python_package"-Cython graphviz; do
 	if ! rpm -q --whatprovides $package >/dev/null ; then
 		missing="${missing:+$missing }$package"
 	fi


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

package names were wrong on fedora30.
