### PR TITLE
osd: acting set choose stray pg when peered

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -5369,6 +5369,34 @@ boost::statechart::result PeeringState::Active::react(const MNotifyRec& notevt)
     if (ps->have_unfound() || (ps->is_degraded() && ps->might_have_unfound.count(notevt.from))) {
       ps->discover_all_missing(context< PeeringMachine >().get_query_map());
     }
+
+    // find valid stray pg to join acting set iff the pg in peered state
+    if (ps->acting.size() < ps->pool.info.min_size) {
+      if (notevt.notify.info.is_incomplete() ||
+          notevt.notify.info.last_update < ps->info.log_tail) {
+        return discard_event(); 
+      }
+
+      vector<int> newacting(ps->acting);
+      if (ps->pool.info.is_replicated()) {
+        for (vector<int>::const_iterator i = ps->acting.begin();
+             i != ps->acting.end();
+             ++i) {
+          if (notevt.from.osd == *i) {
+            return discard_event();
+          }
+        }
+        newacting.push_back(notevt.from.osd);
+      } else {
+        auto &shard = ps->acting[notevt.from.shard];
+        if (shard != CRUSH_ITEM_NONE || shard == notevt.from.osd) {
+          return discard_event();
+        }
+        newacting[notevt.from.shard] = notevt.from.osd;
+      }
+
+      pl->queue_want_pg_temp(newacting);
+    }
   }
   return discard_event();
 }


### PR DESCRIPTION
current if the pg had stay in peered state, it will ignore any stray
pg, and can't go active.

production steps:

MON=1 OSD=4 MDS=0 RGW=0 MGR=1  ../src/vstart.sh --new -x --localhost --bluestore
bin/ceph osd pool create rep 1 1
bin/ceph osd pool set rep min_size 3
bin/ceph osd set nobackfill

bin/init-ceph stop osd.2
bin/ceph osd out osd.2

bin/ceph tell osd.* injectargs "--osd_min_pg_log_entries=1"
bin/ceph tell osd.* injectargs "--osd_pg_log_trim_min=1"

bin/rados -p put test1 /etc/hosts
bin/rados -p put test2 /etc/hosts
bin/rados -p put test3 /etc/hosts

bin/init-ceph stop osd.3
bin/init-ceph start osd.2
bin/ceph osd in osd.2

\# now the pg will stay in peered state

bin/init-ceph start osd.3
\# all osds up, but pg will keep in peered state

modification:
Active react any stray pg notify, if the pg stay in peered state, we
will find wether the stray pg could move the acting set, if so, we
queue a new pg temp.

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
