### PR TITLE
mimic: rgw: Fix bucket versioning vs. swift metadata bug.

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -10217,6 +10217,9 @@ int RGWRados::Object::Read::prepare()
   if (r < 0) {
     return r;
   }
+  if (params.target_obj) {
+    *params.target_obj = state.obj;
+  }
   if (params.attrs) {
     *params.attrs = astate->attrset;
     if (cct->_conf->subsys.should_gather<ceph_subsys_rgw, 20>()) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2828,8 +2828,10 @@ public:
         ceph::real_time *lastmod;
         uint64_t *obj_size;
         map<string, bufferlist> *attrs;
+        rgw_obj *target_obj;
 
-        Params() : lastmod(NULL), obj_size(NULL), attrs(NULL) {}
+        Params() : lastmod(nullptr), obj_size(nullptr), attrs(nullptr),
+		 target_obj(nullptr) {}
       } params;
 
       explicit Read(RGWRados::Object *_source) : source(_source) {}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41131

---

backport of https://github.com/ceph/ceph/pull/29240
parent tracker: https://tracker.ceph.com/issues/37531

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh