### PR TITLE
nautilus: os/bluestore: apply garbage collection against excessive blob count growth

### DIFF
--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -126,7 +126,7 @@ void PerfCountersCollectionImpl::dump_formatted_generic(
     bool schema,
     bool histograms,
     const std::string &logger,
-    const std::string &counter)
+    const std::string &counter) const
 {
   f->open_object_section("perfcounter_collection");
   
@@ -350,7 +350,7 @@ void PerfCounters::reset()
 }
 
 void PerfCounters::dump_formatted_generic(Formatter *f, bool schema,
-    bool histograms, const std::string &counter)
+    bool histograms, const std::string &counter) const
 {
   f->open_object_section(m_name.c_str());
   

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -243,11 +243,11 @@ public:
 
   void reset();
   void dump_formatted(ceph::Formatter *f, bool schema,
-                      const std::string &counter = "") {
+                      const std::string &counter = "") const {
     dump_formatted_generic(f, schema, false, counter);
   }
   void dump_formatted_histograms(ceph::Formatter *f, bool schema,
-                                 const std::string &counter = "") {
+                                 const std::string &counter = "") const {
     dump_formatted_generic(f, schema, true, counter);
   }
   pair<uint64_t, uint64_t> get_tavg_ns(int idx) const;
@@ -274,7 +274,7 @@ private:
   PerfCounters(const PerfCounters &rhs);
   PerfCounters& operator=(const PerfCounters &rhs);
   void dump_formatted_generic(ceph::Formatter *f, bool schema, bool histograms,
-                              const std::string &counter = "");
+                              const std::string &counter = "") const;
 
   typedef std::vector<perf_counter_data_any_d> perf_counter_data_vec_t;
 
@@ -321,13 +321,13 @@ public:
 
   void dump_formatted(ceph::Formatter *f, bool schema,
                       const std::string &logger = "",
-                      const std::string &counter = "") {
+                      const std::string &counter = "") const {
     dump_formatted_generic(f, schema, false, logger, counter);
   }
 
   void dump_formatted_histograms(ceph::Formatter *f, bool schema,
                                  const std::string &logger = "",
-                                 const std::string &counter = "") {
+                                 const std::string &counter = "") const {
     dump_formatted_generic(f, schema, true, logger, counter);
   }
 
@@ -348,7 +348,7 @@ public:
 private:
   void dump_formatted_generic(ceph::Formatter *f, bool schema, bool histograms,
                               const std::string &logger = "",
-                              const std::string &counter = "");
+                              const std::string &counter = "") const;
 
   perf_counters_set_t m_loggers;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -810,8 +810,8 @@ int64_t BlueStore::GarbageCollector::estimate(
   used_alloc_unit = boost::optional<uint64_t >();
   blob_info_counted = nullptr;
 
-  gc_start_offset = start_offset;
-  gc_end_offset = start_offset + length;
+  uint64_t gc_start_offset = start_offset;
+  uint64_t gc_end_offset = start_offset + length;
 
   uint64_t end_offset = start_offset + length;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1016,8 +1016,6 @@ public:
     int64_t expected_for_release = 0;      ///< alloc units currently used by
                                            ///< compressed blobs that might
                                            ///< gone after GC
-    uint64_t gc_start_offset = 0;              ///starting offset for GC
-    uint64_t gc_end_offset = 0;                ///ending offset for GC
 
   protected:
     void process_protrusive_extents(const BlueStore::ExtentMap& extent_map, 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -963,7 +963,7 @@ public:
       uint64_t min_alloc_size);
 
     /// return a collection of extents to perform GC on
-    const vector<bluestore_pextent_t>& get_extents_to_collect() const {
+    const interval_set<uint64_t>& get_extents_to_collect() const {
       return extents_to_collect;
     }
     GarbageCollector(CephContext* _cct) : cct(_cct) {}
@@ -994,7 +994,7 @@ public:
                                          ///< specific write
 
     ///< protrusive extents that should be collected if GC takes place
-    vector<bluestore_pextent_t> extents_to_collect;
+    interval_set<uint64_t> extents_to_collect;
 
     boost::optional<uint64_t > used_alloc_unit; ///< last processed allocation
                                                 ///<  unit when traversing 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2764,6 +2764,7 @@ private:
     unsigned csum_order = 0;        ///< target checksum chunk order
 
     old_extent_map_t old_extents;   ///< must deref these blobs
+    interval_set<uint64_t> extents_to_gc; ///< extents for garbage collection
 
     struct write_item {
       uint64_t logical_offset;      ///< write logical offset
@@ -2882,7 +2883,6 @@ private:
   int _do_gc(TransContext *txc,
              CollectionRef& c,
              OnodeRef o,
-             const GarbageCollector& gc,
              const WriteContext& wctx,
              uint64_t *dirty_start,
              uint64_t *dirty_end);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1320,6 +1320,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     return;
   StartDeferred(65536);
   SetVal(g_conf(), "bluestore_compression_mode", "force");
+  SetVal(g_conf(), "bluestore_max_blob_size", "524288");
   // just a big number to disble gc
   SetVal(g_conf(), "bluestore_gc_enable_total_threshold", "100000");
   SetVal(g_conf(), "bluestore_fsck_on_umount", "true");

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -7731,6 +7731,82 @@ TEST_P(StoreTest, mergeRegionTest) {
     ASSERT_EQ(final_len, static_cast<uint64_t>(r));
   }
 }
+  
+TEST_P(StoreTestSpecificAUSize, ReproNoBlobMultiTest) {
+
+  if(string(GetParam()) != "bluestore")
+    return;
+
+  SetVal(g_conf(), "bluestore_block_db_create", "true");
+  SetVal(g_conf(), "bluestore_block_db_size", "4294967296");
+  SetVal(g_conf(), "bluestore_block_size", "12884901888");
+  SetVal(g_conf(), "bluestore_max_blob_size", "524288");
+
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(65536);
+
+  int r;
+  coll_t cid;
+  ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t hoid2 = hoid;
+  hoid2.hobj.snap = 1;
+
+  auto ch = store->create_new_collection(cid);
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    cerr << "Creating collection " << cid << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bool exists = store->exists(ch, hoid);
+    ASSERT_TRUE(!exists);
+
+    ObjectStore::Transaction t;
+    t.touch(cid, hoid);
+    cerr << "Creating object " << hoid << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+
+    exists = store->exists(ch, hoid);
+    ASSERT_EQ(true, exists);
+  }
+  {
+    uint64_t offs = 0;
+    bufferlist bl;
+    const int size = 0x100;
+    bufferptr ap(size);
+    memset(ap.c_str(), 'a', size);
+    bl.append(ap);
+    int i = 0;
+    uint64_t  blob_size = 524288;
+    uint64_t total = 0;
+    for (i = 0; i <= 512; i++) {
+      offs = 0 + i * size;
+      ObjectStore::Transaction t;
+      ghobject_t hoid2 = hoid;
+      hoid2.hobj.snap = i + 1;
+      while (offs < 128 * 1024 * 1024) {
+
+        t.write(cid, hoid, offs, ap.length(), bl);
+       offs += blob_size;
+       total += ap.length();
+      }
+      t.clone(cid, hoid, hoid2);
+      r = queue_transaction(store, ch, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    cerr << "Total written = " << total << std::endl;
+  }
+  {
+    cerr << "Finalizing" << std::endl;
+    const PerfCounters* logger = store->get_perf_counters();
+    ASSERT_GE(logger->get(l_bluestore_gc_merged), 1024*1024*1024);
+  }
+}
+
 #endif  // WITH_BLUESTORE
 
 int main(int argc, char **argv) {

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1241,8 +1241,8 @@ TEST(GarbageCollector, BasicTest)
     saving = gc.estimate(300, 100, em, old_extents, 4096);
     ASSERT_EQ(saving, 1);
     auto& to_collect = gc.get_extents_to_collect();
-    ASSERT_EQ(to_collect.size(), 1u);
-    ASSERT_EQ(to_collect[0], bluestore_pextent_t(100,10) );
+    ASSERT_EQ(to_collect.num_intervals(), 1u);
+    ASSERT_EQ(*to_collect.begin(), std::make_pair(100ul, 10ul));
 
     em.clear();
     old_extents.clear();
@@ -1311,11 +1311,11 @@ TEST(GarbageCollector, BasicTest)
     saving = gc.estimate(0x30000, 0xf000, em, old_extents, 0x10000);
     ASSERT_EQ(saving, 2);
     auto& to_collect = gc.get_extents_to_collect();
-    ASSERT_EQ(to_collect.size(), 2u);
-    ASSERT_TRUE(to_collect[0] == bluestore_pextent_t(0x0,0x8000) ||
-		  to_collect[1] == bluestore_pextent_t(0x0,0x8000));
-    ASSERT_TRUE(to_collect[0] == bluestore_pextent_t(0x3f000,0x1000) ||
-		  to_collect[1] == bluestore_pextent_t(0x3f000,0x1000));
+    ASSERT_EQ(to_collect.num_intervals(), 2u);
+    ASSERT_TRUE((*to_collect.begin()) == std::make_pair(0x0ul ,0x8000ul) ||
+		  *(++to_collect.begin()) == std::make_pair(0x0ul, 0x8000ul));
+    ASSERT_TRUE((*to_collect.begin()) == std::make_pair(0x3f000ul, 0x1000ul) ||
+		  *(++to_collect.begin()) == std::make_pair(0x3f000ul, 0x1000ul));
 
     em.clear();
     old_extents.clear();
@@ -1357,7 +1357,7 @@ TEST(GarbageCollector, BasicTest)
     saving = gc.estimate(0x3000, 0x4000, em, old_extents, 0x1000);
     ASSERT_EQ(saving, 0);
     auto& to_collect = gc.get_extents_to_collect();
-    ASSERT_EQ(to_collect.size(), 0u);
+    ASSERT_EQ(to_collect.num_intervals(), 0u);
     em.clear();
     old_extents.clear();
   }
@@ -1432,11 +1432,11 @@ TEST(GarbageCollector, BasicTest)
     saving = gc.estimate(0x30000, 0xf000, em, old_extents, 0x10000);
     ASSERT_EQ(saving, 2);
     auto& to_collect = gc.get_extents_to_collect();
-    ASSERT_EQ(to_collect.size(), 2u);
-    ASSERT_TRUE(to_collect[0] == bluestore_pextent_t(0x0,0x8000) ||
-		  to_collect[1] == bluestore_pextent_t(0x0,0x8000));
-    ASSERT_TRUE(to_collect[0] == bluestore_pextent_t(0x3f000,0x1000) ||
-		  to_collect[1] == bluestore_pextent_t(0x3f000,0x1000));
+    ASSERT_EQ(to_collect.num_intervals(), 2u);
+    ASSERT_TRUE(*to_collect.begin() == std::make_pair(0x0ul, 0x8000ul) ||
+		  *(++to_collect.begin()) == std::make_pair(0x0ul, 0x8000ul));
+    ASSERT_TRUE(*to_collect.begin() == std::make_pair(0x3f000ul, 0x1000ul) ||
+		  *(++to_collect.begin()) == std::make_pair(0x3f000ul, 0x1000ul));
 
     em.clear();
     old_extents.clear();


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/40449
Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
