### PR TITLE
luminous: rgw: don't throw when accept errors are happening on frontend

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -480,7 +480,8 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
   } else if (ec == boost::asio::error::operation_aborted) {
     return;
   } else if (ec) {
-    throw ec;
+    ldout(ctx(), 1) << "accept failed: " << ec.message() << dendl;
+    return;
   }
   auto socket = std::move(l.socket);
   tcp::no_delay options(l.use_nodelay);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41266

---

backport of https://github.com/ceph/ceph/pull/29587
parent tracker: https://tracker.ceph.com/issues/41169

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh