### PR TITLE
fix rgw lc does not delete objects that do not have exactly the same tags as the rule

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -452,20 +452,21 @@ static bool is_valid_op(const lc_op& op)
 static inline bool has_all_tags(const lc_op& rule_action,
 				const RGWObjTags& object_tags)
 {
+  if(! rule_action.obj_tags)
+    return false;
+  if(object_tags.count() < rule_action.obj_tags->count())
+    return false;
+  size_t tag_count = 0;
   for (const auto& tag : object_tags.get_tags()) {
-
-    if (! rule_action.obj_tags)
-      return false;
-
     const auto& rule_tags = rule_action.obj_tags->get_tags();
     const auto& iter = rule_tags.find(tag.first);
-
-    if ((iter == rule_tags.end()) ||
-	(iter->second != tag.second))
-      return false;
+    if(iter->second == tag.second)
+    {
+      tag_count++;
+    }
+  /* all tags in the rule appear in obj tags */
   }
-  /* all tags matched */
-  return true;
+  return tag_count == rule_action.obj_tags->count();
 }
 
 class LCObjsLister {
@@ -696,7 +697,7 @@ static int check_tags(lc_op_ctx& oc, bool *skip)
     }
 
     if (! has_all_tags(op, dest_obj_tags)) {
-      ldout(oc.cct, 20) << __func__ << "() skipping obj " << oc.obj << " as tags do not match" << dendl;
+      ldout(oc.cct, 20) << __func__ << "() skipping obj " << oc.obj << " as tags do not match in rule: " << op.id << dendl;
       return 0;
     }
   }


### PR DESCRIPTION
It is possible that object will have multiple tags more than the rule that applied on.
Object is not being deleted if not all tags exactly the same as in the rule.

S3-tests: https://github.com/ceph/s3-tests/pull/303
Fixes: https://tracker.ceph.com/issues/41652
Signed-off-by: Or Friedmann <ofriedma@redhat.com>
