### PR TITLE
rgw: iam: use a function to calculate the Action Bit string

### DIFF
--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -103,26 +103,27 @@ static constexpr std::uint64_t s3GetObjectLegalHold = 59;
 static constexpr std::uint64_t s3BypassGovernanceRetention = 60;
 static constexpr std::uint64_t s3All = 61;
 
-static constexpr std::uint64_t iamPutUserPolicy = 62;
-static constexpr std::uint64_t iamGetUserPolicy = 63;
-static constexpr std::uint64_t iamDeleteUserPolicy = 64;
-static constexpr std::uint64_t iamListUserPolicies = 65;
-static constexpr std::uint64_t iamCreateRole = 66;
-static constexpr std::uint64_t iamDeleteRole = 67;
-static constexpr std::uint64_t iamModifyRole = 68;
-static constexpr std::uint64_t iamGetRole = 69;
-static constexpr std::uint64_t iamListRoles = 70;
-static constexpr std::uint64_t iamPutRolePolicy = 71;
-static constexpr std::uint64_t iamGetRolePolicy = 72;
-static constexpr std::uint64_t iamListRolePolicies = 73;
-static constexpr std::uint64_t iamDeleteRolePolicy = 74;
-static constexpr std::uint64_t iamAll = 75;
-static constexpr std::uint64_t stsAssumeRole = 76;
-static constexpr std::uint64_t stsAssumeRoleWithWebIdentity = 77;
-static constexpr std::uint64_t stsGetSessionToken = 78;
-static constexpr std::uint64_t stsAll = 79;
+static constexpr std::uint64_t iamPutUserPolicy = s3All + 1;
+static constexpr std::uint64_t iamGetUserPolicy = s3All + 2;
+static constexpr std::uint64_t iamDeleteUserPolicy = s3All + 3;
+static constexpr std::uint64_t iamListUserPolicies = s3All + 4;
+static constexpr std::uint64_t iamCreateRole = s3All + 5;
+static constexpr std::uint64_t iamDeleteRole = s3All + 6;
+static constexpr std::uint64_t iamModifyRole = s3All + 7;
+static constexpr std::uint64_t iamGetRole = s3All + 8;
+static constexpr std::uint64_t iamListRoles = s3All + 9;
+static constexpr std::uint64_t iamPutRolePolicy = s3All + 10;
+static constexpr std::uint64_t iamGetRolePolicy = s3All + 11;
+static constexpr std::uint64_t iamListRolePolicies = s3All + 12;
+static constexpr std::uint64_t iamDeleteRolePolicy = s3All + 13;
+static constexpr std::uint64_t iamAll = s3All + 14;
 
-static constexpr std::uint64_t s3Count = s3BypassGovernanceRetention + 1;
+static constexpr std::uint64_t stsAssumeRole = iamAll + 1;
+static constexpr std::uint64_t stsAssumeRoleWithWebIdentity = iamAll + 2;
+static constexpr std::uint64_t stsGetSessionToken = iamAll + 3;
+static constexpr std::uint64_t stsAll = iamAll + 4;
+
+static constexpr std::uint64_t s3Count = s3All;
 static constexpr std::uint64_t allCount = stsAll + 1;
 
 using Action_t = bitset<allCount>;

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -129,12 +129,24 @@ static constexpr std::uint64_t allCount = stsAll + 1;
 using Action_t = bitset<allCount>;
 using NotAction_t = Action_t;
 
+template <size_t N>
+constexpr std::bitset<N> make_bitmask(size_t s) {
+  // unfortunately none of the shift/logic operators of std::bitset have a constexpr variation
+  return s < 64 ? std::bitset<N> ((1ULL << s) - 1) :
+    std::bitset<N>((1ULL << 63) - 1) | make_bitmask<N> (s - 63) << 63;
+}
+
+template <size_t N>
+constexpr std::bitset<N> set_cont_bits(size_t start, size_t end)
+{
+  return (make_bitmask<N>(end - start)) << start;
+}
+
 static const Action_t None(0);
-static const Action_t s3AllValue("1111111111111111111111111111111111111111111111111111111111111");
-static const Action_t iamAllValue("111111111111100000000000000000000000000000000000000000000000000000000000000");
-static const Action_t stsAllValue("1110000000000000000000000000000000000000000000000000000000000000000000000000000");
-//Modify allValue if more Actions are added
-static const Action_t allValue("11111111111111111111111111111111111111111111111111111111111111111111111111111111");
+static const Action_t s3AllValue = set_cont_bits<allCount>(0,s3All);
+static const Action_t iamAllValue = set_cont_bits<allCount>(s3All+1,iamAll);
+static const Action_t stsAllValue = set_cont_bits<allCount>(iamAll+1,stsAll);
+static const Action_t allValue = set_cont_bits<allCount>(0,allCount);
 
 namespace {
 // Please update the table in doc/radosgw/s3/authentication.rst if you

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -1202,3 +1202,20 @@ TEST(MatchPolicy, String)
   EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
   EXPECT_TRUE(match_policy("a:*", "a:b:c", flag)); // can span segments
 }
+
+static const Action_t s3AllValuet("1111111111111111111111111111111111111111111111111111111111111");
+static const Action_t iamAllValuet("111111111111100000000000000000000000000000000000000000000000000000000000000");
+static const Action_t stsAllValuet("1110000000000000000000000000000000000000000000000000000000000000000000000000000");
+static const Action_t allValuet("11111111111111111111111111111111111111111111111111111111111111111111111111111111");
+
+using rgw::IAM::s3AllValue;
+using rgw::IAM::stsAllValue;
+using rgw::IAM::allValue;
+using rgw::IAM::iamAllValue;
+TEST(set_cont_bits, iamconsts)
+{
+  EXPECT_EQ(s3AllValue, s3AllValuet);
+  EXPECT_EQ(iamAllValue, iamAllValuet);
+  EXPECT_EQ(stsAllValue, stsAllValuet);
+  EXPECT_EQ(allValue , allValuet);
+}


### PR DESCRIPTION
currently every new action added will change 4 iam Action bitsets which require
the string to be modified by hand and validated by hand. Use a function to do
this instead

(I'm not open to other approaches to solve this as well, right now we can't constexpr evaluate these functions yet (other than ranges fitting within 64) just that hand editing these strings caused some errors while adding a couple of new APIs)