### PR TITLE
osd/PeeringState: proc_master_log: fix last_epoch_started assertion

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -2477,7 +2477,7 @@ void PeeringState::proc_master_log(
   }
   update_history(oinfo.history);
   ceph_assert(cct->_conf->osd_find_best_info_ignore_history_les ||
-	 info.last_epoch_started >= info.history.last_epoch_started);
+	      oinfo.last_epoch_started >= info.history.last_epoch_started);
 
   peer_missing[from].claim(omissing);
 }


### PR DESCRIPTION
This assertion is usually, but not always true.  In particular,
    find_best_info is careful to exclude candidates for the master log with
    older last_epoch_started.  However, those OSDs are not excluded from
    acting, and there is no particular constraint on who is primary, which
    means that it is perfectly possibly (and valid) for an OSD with an older
    last_epoch_started to be chosen as the new primary and to get the master
    log from another OSD.

The fix is to assert that the *other* *oinfo* master info has a
last_epoch_started that is >= the history bound.

Fixes: https://tracker.ceph.com/issues/41657