### PR TITLE
mgr: use new MMgrCommand for CLI commands sent to mgr

### DIFF
--- a/src/common/CommandTable.h
+++ b/src/common/CommandTable.h
@@ -16,6 +16,7 @@
 #define COMMAND_TABLE_H_
 
 #include "messages/MCommand.h"
+#include "messages/MMgrCommand.h"
 
 class CommandOp
 {
@@ -29,14 +30,22 @@ class CommandOp
   ceph::buffer::list   *outbl;
   std::string  *outs;
 
-  ceph::ref_t<MCommand> get_message(const uuid_d &fsid) const
+  MessageRef get_message(const uuid_d &fsid,
+			 bool mgr=false) const
   {
-    auto m = make_message<MCommand>(fsid);
-    m->cmd = cmd;
-    m->set_data(inbl);
-    m->set_tid(tid);
-
-    return m;
+    if (mgr) {
+      auto m = make_message<MMgrCommand>(fsid);
+      m->cmd = cmd;
+      m->set_data(inbl);
+      m->set_tid(tid);
+      return m;
+    } else {
+      auto m = make_message<MCommand>(fsid);
+      m->cmd = cmd;
+      m->set_data(inbl);
+      m->set_tid(tid);
+      return m;
+    }
   }
 
   CommandOp(const ceph_tid_t t) : tid(t), on_finish(nullptr),

--- a/src/messages/MMgrBeacon.h
+++ b/src/messages/MMgrBeacon.h
@@ -24,7 +24,7 @@
 
 class MMgrBeacon : public PaxosServiceMessage {
 private:
-  static constexpr int HEAD_VERSION = 8;
+  static constexpr int HEAD_VERSION = 9;
   static constexpr int COMPAT_VERSION = 8;
 
 protected:
@@ -45,6 +45,8 @@ protected:
 
   map<string,string> metadata; ///< misc metadata about this osd
 
+  uint64_t mgr_features = 0;   ///< reporting mgr's features
+
 public:
   MMgrBeacon()
     : PaxosServiceMessage{MSG_MGR_BEACON, 0, HEAD_VERSION, COMPAT_VERSION},
@@ -54,10 +56,12 @@ public:
   MMgrBeacon(const uuid_d& fsid_, uint64_t gid_, const std::string &name_,
              entity_addrvec_t server_addrs_, bool available_,
 	     std::vector<MgrMap::ModuleInfo>&& modules_,
-	     map<string,string>&& metadata_)
+	     map<string,string>&& metadata_,
+	     uint64_t feat)
     : PaxosServiceMessage{MSG_MGR_BEACON, 0, HEAD_VERSION, COMPAT_VERSION},
       gid(gid_), server_addrs(server_addrs_), available(available_), name(name_),
-      fsid(fsid_), modules(std::move(modules_)), metadata(std::move(metadata_))
+      fsid(fsid_), modules(std::move(modules_)), metadata(std::move(metadata_)),
+      mgr_features(feat)
   {
   }
 
@@ -69,10 +73,10 @@ public:
   const std::map<std::string,std::string>& get_metadata() const {
     return metadata;
   }
-
   const std::map<std::string,std::string>& get_services() const {
     return services;
   }
+  uint64_t get_mgr_features() const { return mgr_features; }
 
   void set_services(const std::map<std::string, std::string> &svcs)
   {
@@ -138,6 +142,7 @@ public:
     encode(services, payload);
 
     encode(modules, payload);
+    encode(mgr_features, payload);
   }
   void decode_payload() override {
     auto p = payload.cbegin();
@@ -173,6 +178,9 @@ public:
     }
     if (header.version >= 7) {
       decode(modules, p);
+    }
+    if (header.version >= 9) {
+      decode(mgr_features, p);
     }
   }
 private:

--- a/src/messages/MMgrCommand.h
+++ b/src/messages/MMgrCommand.h
@@ -1,0 +1,46 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <vector>
+
+#include "msg/Message.h"
+
+class MMgrCommand : public Message {
+public:
+  uuid_d fsid;
+  std::vector<std::string> cmd;
+
+  MMgrCommand()
+    : Message{MSG_MGR_COMMAND} {}
+  MMgrCommand(const uuid_d &f)
+    : Message{MSG_MGR_COMMAND},
+      fsid(f) { }
+
+private:
+  ~MMgrCommand() override {}
+
+public:
+  std::string_view get_type_name() const override { return "mgr_command"; }
+  void print(std::ostream& o) const override {
+    o << "mgr_command(tid " << get_tid() << ": ";
+    for (unsigned i=0; i<cmd.size(); i++) {
+      if (i) o << ' ';
+      o << cmd[i];
+    }
+    o << ")";
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(fsid, payload);
+    encode(cmd, payload);
+  }
+  void decode_payload() override {
+    using ceph::decode;
+    auto p = payload.cbegin();
+    decode(fsid, p);
+    decode(cmd, p);
+  }
+};

--- a/src/messages/MMgrCommandReply.h
+++ b/src/messages/MMgrCommandReply.h
@@ -1,0 +1,45 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <string_view>
+
+#include "msg/Message.h"
+#include "MMgrCommand.h"
+
+class MMgrCommandReply : public Message {
+public:
+  errorcode32_t r;
+  std::string rs;
+
+  MMgrCommandReply()
+    : Message{MSG_MGR_COMMAND_REPLY} {}
+  MMgrCommandReply(MMgrCommand *m, int _r)
+    : Message{MSG_MGR_COMMAND_REPLY}, r(_r) {
+    header.tid = m->get_tid();
+  }
+  MMgrCommandReply(int _r, std::string_view s)
+    : Message{MSG_MGR_COMMAND_REPLY},
+      r(_r), rs(s) { }
+private:
+  ~MMgrCommandReply() override {}
+
+public:
+  std::string_view get_type_name() const override { return "mgr_command_reply"; }
+  void print(std::ostream& o) const override {
+    o << "mgr_command_reply(tid " << get_tid() << ": " << r << " " << rs << ")";
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(r, payload);
+    encode(rs, payload);
+  }
+  void decode_payload() override {
+    using ceph::decode;
+    auto p = payload.cbegin();
+    decode(r, p);
+    decode(rs, p);
+  }
+};

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -36,6 +36,7 @@ class MMgrOpen;
 class MMgrClose;
 class MMonMgrReport;
 class MCommand;
+class MMgrCommand;
 struct MonCommand;
 class CommandContext;
 struct OSDPerfMetricQuery;
@@ -147,8 +148,8 @@ public:
   bool handle_close(const ceph::ref_t<MMgrClose>& m);
   bool handle_report(const ceph::ref_t<MMgrReport>& m);
   bool handle_command(const ceph::ref_t<MCommand>& m);
-  bool _handle_command(const ceph::ref_t<MCommand>& m,
-		       std::shared_ptr<CommandContext>& cmdctx);
+  bool handle_command(const ceph::ref_t<MMgrCommand>& m);
+  bool _handle_command(std::shared_ptr<CommandContext>& cmdctx);
   void send_report();
   void got_service_map();
   void got_mgr_map();

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -120,7 +120,11 @@ public:
   bool handle_mgr_map(ceph::ref_t<MMgrMap> m);
   bool handle_mgr_configure(ceph::ref_t<MMgrConfigure> m);
   bool handle_mgr_close(ceph::ref_t<MMgrClose> m);
-  bool handle_command_reply(ceph::ref_t<MCommandReply> m);
+  bool handle_command_reply(
+    uint64_t tid,
+    bufferlist& data,
+    const std::string& rs,
+    int r);
 
   void set_perf_metric_query_cb(
     std::function<void(const std::map<OSDPerfMetricQuery,

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -224,7 +224,8 @@ void MgrStandby::send_beacon()
                                  addrs,
                                  available,
 				 std::move(module_info),
-				 std::move(metadata));
+				 std::move(metadata),
+				 CEPH_FEATURES_ALL);
 
   if (available) {
     if (!available_in_map) {

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -182,6 +182,8 @@
 #include "messages/MMgrClose.h"
 #include "messages/MMgrConfigure.h"
 #include "messages/MMonMgrReport.h"
+#include "messages/MMgrCommand.h"
+#include "messages/MMgrCommandReply.h"
 #include "messages/MServiceMap.h"
 
 #include "messages/MLock.h"
@@ -820,6 +822,14 @@ Message *decode_message(CephContext *cct, int crcflags,
 
   case MSG_MGR_DIGEST:
     m = make_message<MMgrDigest>();
+    break;
+
+  case MSG_MGR_COMMAND:
+    m = make_message<MMgrCommand>();
+    break;
+
+  case MSG_MGR_COMMAND_REPLY:
+    m = make_message<MMgrCommandReply>();
     break;
 
   case MSG_MGR_OPEN:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -215,6 +215,8 @@
 #define MSG_SERVICE_MAP           0x707
 
 #define MSG_MGR_CLOSE             0x708
+#define MSG_MGR_COMMAND           0x709
+#define MSG_MGR_COMMAND_REPLY     0x70a
 
 // ======================================================
 


### PR DESCRIPTION
Currently we have

- MCommand: sent to osd, mgr, mds daemons (CLI and/or tell commands)
- MMonCommand: sent to mon (CLI commands)

Our goal is to unify the tell and daemon commands, and to keep them distinct from CLI commands (ceph pg ls != ceph tell mgr.x pg ls).  This is the first step in that process.  (Next steps will include using MCommand for mon tell commands, and then actually unifying the daemon and tell command handling for each daemon.)

(I didn't just use MMonCommand for CLI commands to mon because MMonCommand derives from PaxosServiceMessage, and that doesn't seem appropriate for the mgr.)