### PR TITLE
mimic: radosgw-admin: bucket sync status not 'caught up' during full sync

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2415,11 +2415,11 @@ static int bucket_source_sync_status(RGWRados *store, const RGWZone& zone,
       shards_behind.insert(shard_id);
     }
   }
-  if (shards_behind.empty()) {
-    out << indented{width} << "bucket is caught up with source\n";
-  } else {
+  if (!shards_behind.empty()) {
     out << indented{width} << "bucket is behind on " << shards_behind.size() << " shards\n";
     out << indented{width} << "behind shards: [" << shards_behind << "]\n" ;
+  } else if (!num_full) {
+    out << indented{width} << "bucket is caught up with source\n";
   }
   return 0;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41494

---

backport of https://github.com/ceph/ceph/pull/29094
parent tracker: https://tracker.ceph.com/issues/40806

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh