### PR TITLE
mimic: rgw: fix CreateBucket with BucketLocation parameter failed under default zonegroup

### DIFF
--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -396,6 +396,7 @@ def task(ctx, config):
                     {
                     'port'      : endpoint.port,
                     'is_secure' : 'yes' if endpoint.cert else 'no',
+                    'api_name'  : 'default',
                     },
                 'fixtures' : {},
                 's3 main'  : {},

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -266,6 +266,7 @@ rgw_pool RGWZoneGroup::get_pool(CephContext *cct_)
 int RGWZoneGroup::create_default(bool old_format)
 {
   name = default_zonegroup_name;
+  api_name = default_zonegroup_name;
   is_master = true;
 
   RGWZoneGroupPlacementTarget placement_target;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2528,6 +2528,8 @@ public:
       const auto& zonegroups_by_api = current_period.get_map().zonegroups_by_api;
       if (zonegroups_by_api.find(api) != zonegroups_by_api.end())
         return true;
+    } else if (zonegroup.api_name == api) {
+        return true;
     }
     return false;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41578

---

backport of https://github.com/ceph/ceph/pull/22312
parent tracker: https://tracker.ceph.com/issues/41401

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh