### PR TITLE
mimic: osd: Better error message when OSD count is less than osd_pool_default_size

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -385,6 +385,12 @@ so marking "out" OSDs "in" (if there are any) can also help::
 Please refer to :ref:`choosing-number-of-placement-groups` for more
 information.
 
+TOO_FEW_OSDS
+____________
+
+The number of OSDs in the cluster is below the configurable
+threshold of ``osd_pool_default_size``.
+
 SMALLER_PGP_NUM
 _______________
 

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1507,9 +1507,11 @@ function test_wait_for_health_ok() {
     local dir=$1
 
     setup $dir || return 1
-    run_mon $dir a --osd_pool_default_size=1 --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
+    run_mon $dir a --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
     run_mgr $dir x --mon_pg_warn_min_per_osd=0 || return 1
     run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
     ! TIMEOUT=1 wait_for_health_ok || return 1
     activate_osd $dir 0 || return 1

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1513,6 +1513,7 @@ function test_wait_for_health_ok() {
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
+    ceph osd down 0 || return 1
     ! TIMEOUT=1 wait_for_health_ok || return 1
     activate_osd $dir 0 || return 1
     wait_for_health_ok || return 1

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1509,13 +1509,18 @@ function test_wait_for_health_ok() {
     setup $dir || return 1
     run_mon $dir a --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
     run_mgr $dir x --mon_pg_warn_min_per_osd=0 || return 1
+    # start osd_pool_default_size OSDs
     run_osd $dir 0 || return 1
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
     ceph osd down 0 || return 1
+    # expect TOO_FEW_OSDS warning
     ! TIMEOUT=1 wait_for_health_ok || return 1
+    # resurrect all OSDs
     activate_osd $dir 0 || return 1
+    activate_osd $dir 1 || return 1
+    activate_osd $dir 2 || return 1
     wait_for_health_ok || return 1
     teardown $dir || return 1
 }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1463,6 +1463,11 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description("Enable POOL_APP_NOT_ENABLED health check"),
 
+    Option("mon_warn_on_too_few_osds", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .add_service("mgr")
+    .set_description("Issue a health warning if there are fewer OSDs than osd_pool_default_size"),
+
     Option("mon_max_snap_prune_per_epoch", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(100)
     .set_description("Max number of pruned snaps we will process in a single OSDMap epoch"),

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2569,6 +2569,15 @@ void PGMap::get_health_checks(
     }
   }
 
+  // TOO_FEW_OSDS
+  auto osd_pool_default_size = cct->_conf->get_val<uint64_t>("osd_pool_default_size");
+  if (osdmap.get_num_osds() < osd_pool_default_size) {
+    ostringstream ss;
+    ss << "OSD count " << osdmap.get_num_osds()
+	 << " < osd_pool_default_size " << osd_pool_default_size;
+    checks->add("TOO_FEW_OSDS", HEALTH_WARN, ss.str());
+  }
+
   // SMALLER_PGP_NUM
   // MANY_OBJECTS_PER_PG
   if (!pg_stat.empty()) {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2570,8 +2570,9 @@ void PGMap::get_health_checks(
   }
 
   // TOO_FEW_OSDS
+  auto warn_too_few_osds = cct->_conf->get_val<bool>("mon_warn_on_too_few_osds");
   auto osd_pool_default_size = cct->_conf->get_val<uint64_t>("osd_pool_default_size");
-  if (osdmap.get_num_osds() < osd_pool_default_size) {
+  if (warn_too_few_osds && osdmap.get_num_osds() < osd_pool_default_size) {
     ostringstream ss;
     ss << "OSD count " << osdmap.get_num_osds()
 	 << " < osd_pool_default_size " << osd_pool_default_size;


### PR DESCRIPTION
NOTE: I intentionally omitted 0483c1c3e7ffdfa6a6f65c5ef000c45d2f096428 because there is no `qa/tasks/ceph.conf.template` in mimic. As noted below, in mimic the template file in the teuthology repo is used. Therefore, this PR has a companion PR in teuthology.

backport tracker: https://tracker.ceph.com/issues/40083
companion teuthology PR: https://github.com/ceph/teuthology/pull/1308

---

backport of https://github.com/ceph/ceph/pull/27806
parent tracker: https://tracker.ceph.com/issues/38617

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh