### PR TITLE
mimic: mon/AuthMonitor: fix initial creation of rotating keys

### DIFF
--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -78,7 +78,10 @@ struct KeyServerData {
   }
 
   void clear_secrets() {
+    version = 0;
     secrets.clear();
+    rotating_ver = 0;
+    rotating_secrets.clear();
   }
 
   void add_auth(const EntityName& name, EntityAuth& auth) {

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -171,6 +171,7 @@ void AuthMonitor::create_initial()
   dout(10) << "create_initial -- creating initial map" << dendl;
 
   // initialize rotating keys
+  mon->key_server.clear_secrets();
   last_rotating_ver = 0;
   check_rotate();
   assert(pending_auth.size() == 1);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40732

---

backport of https://github.com/ceph/ceph/pull/28850
parent tracker: https://tracker.ceph.com/issues/40634

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh