### PR TITLE
mimic: os/filestore: assure sufficient leaves in pre-split

### DIFF
--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -587,10 +587,11 @@ int HashIndex::pre_split_folder(uint32_t pg_num, uint64_t expected_num_objs)
   const uint32_t subs = (1 << split_bits);
   // Calculate how many levels we create starting from here
   int level  = 0;
-  leavies /= subs;
-  while (leavies > 1) {
+  int level_limit = MAX_HASH_LEVEL - dump_num - 1;
+  uint64_t actual_leaves = subs;
+  while (actual_leaves < leavies && level < level_limit) {
     ++level;
-    leavies = leavies >> 4;
+    actual_leaves <<= 4;
   }
   for (uint32_t i = 0; i < subs; ++i) {
     ceph_assert(split_bits <= 4); // otherwise BAD_SHIFT


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41291

---

backport of https://github.com/ceph/ceph/pull/27689
parent tracker: https://tracker.ceph.com/issues/39390

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh