### PR TITLE
mimic: osd/PrimaryLogPG: Avoid accessing destroyed references in finish_degr…

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11418,7 +11418,7 @@ void PrimaryLogPG::remove_missing_object(const hobject_t &soid,
   assert(r == 0);
 }
 
-void PrimaryLogPG::finish_degraded_object(const hobject_t& oid)
+void PrimaryLogPG::finish_degraded_object(const hobject_t oid)
 {
   dout(10) << __func__ << " " << oid << dendl;
   if (callbacks_for_degraded_object.count(oid)) {

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1096,7 +1096,7 @@ protected:
 				  PGBackend::RecoveryHandle *h,
 				  bool *work_started);
 
-  void finish_degraded_object(const hobject_t& oid);
+  void finish_degraded_object(const hobject_t oid);
 
   // Cancels/resets pulls from peer
   void check_recovery_sources(const OSDMapRef& map) override ;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41447

---

backport of https://github.com/ceph/ceph/pull/29663
parent tracker: https://tracker.ceph.com/issues/41250

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh