### PR TITLE
Make dumping of reservation info congruent between scrub and recovery

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -132,3 +132,6 @@
 
 * New OSD daemon command dump_recovery_reservations which reveals the
   recovery locks held (in_progress) and waiting in priority queues.
+
+* New OSD daemon command dump_scrub_reservations which reveals the
+  scrub reservations that are active and pending.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -134,4 +134,4 @@
   recovery locks held (in_progress) and waiting in priority queues.
 
 * New OSD daemon command dump_scrub_reservations which reveals the
-  scrub reservations that are active and pending.
+  scrub reservations that are held for local (primary) and remote (replica) PGs.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -129,3 +129,6 @@
   for the command `ceph osd erasure-code-profile set xxx`.
   * invalid `m` for "reed_sol_r6_op" erasure technique
   * invalid `m` and invalid `w` for "liber8tion" erasure technique
+
+* New OSD daemon command dump_recovery_reservations which reveals the
+  recovery locks held (in_progress) and waiting in priority queues.

--- a/doc/dev/osd_internals/recovery_reservation.rst
+++ b/doc/dev/osd_internals/recovery_reservation.rst
@@ -48,6 +48,14 @@ necessary), the primary drops the local reservation and enters the
 Recovered state. Once all the PGs have reported they are clean, the
 primary enters the Clean state and marks itself active+clean.
 
+-----------------
+Dump Reservations
+-----------------
+
+An OSD daemon command dumps total local and remote reservations::
+
+  ceph daemon osd.<id> dump_recovery_reservations
+
 
 --------------
 Things to Note

--- a/doc/dev/osd_internals/scrub.rst
+++ b/doc/dev/osd_internals/scrub.rst
@@ -1,6 +1,9 @@
 
+Scrub internals and diagnostics
+===============================
+
 Scrubbing Behavior Table
-========================
+------------------------
 
 +-------------------------------------------------+----------+-----------+---------------+----------------------+
 |                                          Flags  | none     | noscrub   | nodeep_scrub  | noscrub/nodeep_scrub |
@@ -28,3 +31,11 @@ State variables
 - Initiated scrub state is  must_scrub && !must_deep_scrub && !time_for_deep
 - Initiated scrub after osd_deep_scrub_interval state is must scrub && !must_deep_scrub && time_for_deep
 - Initiated deep scrub state is  must_scrub && must_deep_scrub
+
+Scrub Reservations
+------------------
+
+An OSD daemon command dumps total local and remote reservations::
+
+  ceph daemon osd.<id> dump_scrub_reservations
+

--- a/qa/standalone/osd/osd-recovery-prio.sh
+++ b/qa/standalone/osd/osd-recovery-prio.sh
@@ -152,7 +152,7 @@ function TEST_recovery_priority() {
     # to be preempted.
     ceph osd pool set $pool3 size 2
     sleep 2
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations || return 1
 
     # 3. Item is in progress, adjust priority with no higher priority waiting
     for i in $(seq 1 $max_tries)
@@ -167,18 +167,18 @@ function TEST_recovery_priority() {
       sleep 2
     done
     flush_pg_stats || return 1
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations || return 1
 
     ceph osd out osd.$chk_osd1_2
     sleep 2
     flush_pg_stats || return 1
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations || return 1
     ceph pg dump pgs
 
     ceph osd pool set $pool2 size 2
     sleep 2
     flush_pg_stats || return 1
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/out || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/out || return 1
     cat $dir/out
     ceph pg dump pgs
 
@@ -217,7 +217,7 @@ function TEST_recovery_priority() {
       sleep 2
     done
     sleep 2
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/out || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/out || return 1
     cat $dir/out
     PRIO=$(cat $dir/out | jq "(.local_reservations.queues[].items[] | select(.item == \"${PG2}\")).prio")
     if [ "$PRIO" != "$FORCE_PRIO" ];
@@ -232,7 +232,7 @@ function TEST_recovery_priority() {
     ceph pg cancel-force-recovery $PG3 || return 1
     sleep 2
     #ceph osd set norecover
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/out || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/out || return 1
     cat $dir/out
     PRIO=$(cat $dir/out | jq "(.local_reservations.queues[].items[] | select(.item == \"${PG3}\")).prio")
     if [ "$PRIO" != "$NORMAL_PRIO" ];
@@ -257,14 +257,14 @@ function TEST_recovery_priority() {
 
     ceph pg cancel-force-recovery $PG2 || return 1
     sleep 5
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations || return 1
 
     # 2. Item is queued, re-queue and preempt because new priority higher than an in progress item
     flush_pg_stats || return 1
     ceph pg force-recovery $PG3 || return 1
     sleep 2
 
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/out || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/out || return 1
     cat $dir/out
     PRIO=$(cat $dir/out | jq "(.local_reservations.queues[].items[] | select(.item == \"${PG2}\")).prio")
     if [ "$PRIO" != "$NORMAL_PRIO" ];
@@ -290,7 +290,7 @@ function TEST_recovery_priority() {
     ceph osd unset noout
     ceph osd unset norecover
 
-    wait_for_clean "CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations" || return 1
+    wait_for_clean "CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations" || return 1
 
     ceph pg dump pgs
 
@@ -318,7 +318,7 @@ function TEST_recovery_priority() {
 # pool 2 with recovery_priority 2
 #
 # Start recovery by changing the pool sizes from 1 to 2
-# Use dump_reservations to verify priorities
+# Use dump_recovery_reservations to verify priorities
 function TEST_recovery_pool_priority() {
     local dir=$1
     local pools=3 # Don't assume the first 2 pools are exact what we want
@@ -426,10 +426,10 @@ function TEST_recovery_pool_priority() {
     ceph osd pool set $pool1 size 2
     ceph osd pool set $pool2 size 2
     sleep 10
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/dump.${chk_osd1_1}.out
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/dump.${chk_osd1_1}.out
     echo osd.${chk_osd1_1}
     cat $dir/dump.${chk_osd1_1}.out
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_2}) dump_reservations > $dir/dump.${chk_osd1_2}.out
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_2}) dump_recovery_reservations > $dir/dump.${chk_osd1_2}.out
     echo osd.${chk_osd1_2}
     cat $dir/dump.${chk_osd1_2}.out
 

--- a/qa/standalone/scrub/osd-scrub-dump.sh
+++ b/qa/standalone/scrub/osd-scrub-dump.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 Red Hat <contact@redhat.com>
+#
+# Author: David Zafman <dzafman@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+MAX_SCRUBS=4
+SCRUB_SLEEP=2
+POOL_SIZE=3
+
+function run() {
+    local dir=$1
+    shift
+    local SLEEP=0
+    local CHUNK_MAX=5
+
+    export CEPH_MON="127.0.0.1:7184" # git grep '\<7184\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd_max_scrubs=$MAX_SCRUBS "
+    CEPH_ARGS+="--osd_scrub_sleep=$SLEEP "
+    CEPH_ARGS+="--osd_scrub_chunk_max=$CHUNK_MAX "
+    CEPH_ARGS+="--osd_scrub_sleep=$SCRUB_SLEEP "
+    CEPH_ARGS+="--osd_pool_default_size=$POOL_SIZE "
+
+    export -n CEPH_CLI_TEST_DUP_COMMAND
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_recover_unexpected() {
+    local dir=$1
+    shift
+    local OSDS=6
+    local PGS=16
+    local POOLS=3
+    local OBJS=1000
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for o in $(seq 0 $(expr $OSDS - 1))
+    do
+        run_osd $dir $o
+    done
+
+    for i in $(seq 1 $POOLS)
+    do
+        create_pool test$i $PGS $PGS
+    done
+
+    wait_for_clean || return 1
+
+    dd if=/dev/urandom of=datafile bs=4k count=2
+    for i in $(seq 1 $POOLS)
+    do
+       for j in $(seq 1 $OBJS)
+       do
+	       rados -p test$i put obj$j datafile
+       done
+    done
+    rm datafile
+
+    ceph osd set noscrub
+    ceph osd set nodeep-scrub
+
+    for qpg in $(ceph pg dump pgs --format=json-pretty | jq '.pg_stats[].pgid')
+    do
+	primary=$(ceph pg dump pgs --format=json | jq ".pg_stats[] | select(.pgid == $qpg) | .acting_primary")
+	eval pg=$qpg   # strip quotes around qpg
+	CEPH_ARGS='' ceph daemon $(get_asok_path osd.$primary) trigger_scrub $pg
+    done
+
+    ceph pg dump pgs
+
+    max=$(CEPH_ARGS='' ceph daemon $(get_asok_path osd.0) dump_scrub_reservations | jq '.osd_max_scrubs')
+    if [ $max != $MAX_SCRUBS];
+    then
+	echo "ERROR: Incorrect osd_max_scrubs from dump_scrub_reservations"
+	return 1
+    fi
+
+    ceph osd unset noscrub
+
+    ok=false
+    for i in $(seq 0 300)
+    do
+	ceph pg dump pgs
+	if ceph pg dump pgs | grep scrubbing; then
+	    ok=true
+	    break
+	fi
+	sleep 1
+    done
+    if test $ok = "false"; then
+	echo "ERROR: Test set-up failed no scrubbing"
+	return 1
+    fi
+
+    local total=0
+    local zerocount=0
+    local maxzerocount=3
+    while(true)
+    do
+	pass=0
+	for o in $(seq 0 $(expr $OSDS - 1))
+	do
+		CEPH_ARGS='' ceph daemon $(get_asok_path osd.$o) dump_scrub_reservations
+		scrubs=$(CEPH_ARGS='' ceph daemon $(get_asok_path osd.$o) dump_scrub_reservations | jq '.scrubs_local + .scrubs_remote')
+		if [ $scrubs -gt $MAX_SCRUBS ]; then
+		    echo "ERROR: More than $MAX_SCRUBS currently reserved"
+		    return 1
+	        fi
+		pass=$(expr $pass + $scrubs)
+        done
+	if [ $pass = "0" ]; then
+	    zerocount=$(expr $zerocount + 1)
+	fi
+	if [ $zerocount -gt $maxzerocount ]; then
+	    break
+	fi
+	total=$(expr $total + $pass)
+	sleep $(expr $SCRUB_SLEEP \* 2)
+    done
+
+    # Check that there are no more scrubs
+    for i in $(seq 0 5)
+    do
+        if ceph pg dump pgs | grep scrubbing; then
+	    echo "ERROR: Extra scrubs after test completion...not expected"
+	    return 1
+        fi
+	sleep $SCRUB_SLEEP
+    done
+
+    echo $total total reservations seen
+
+    # Sort of arbitraty number based on PGS * POOLS * POOL_SIZE as the number of total scrub
+    # reservations that must occur.  However, the loop above might see the same reservation more
+    # than once.
+    actual_reservations=$(expr $PGS \* $POOLS \* $POOL_SIZE)
+    if [ $total -lt $actual_reservations ]; then
+	echo "ERROR: Unexpectedly low amount of scrub reservations seen during test"
+	return 1
+    fi
+
+    return 0
+}
+
+
+main osd-scrub-dump "$@"
+
+# Local Variables:
+# compile-command: "cd build ; make check && \
+#    ../qa/run-standalone.sh osd-scrub-dump.sh"
+# End:

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2450,7 +2450,7 @@ will start to track new ops received afterwards.";
     }
 
     f->close_section(); //watchers
-  } else if (admin_command == "dump_reservations") {
+  } else if (admin_command == "dump_recovery_reservations") {
     f->open_object_section("reservations");
     f->open_object_section("local_reservations");
     service.local_reserver.dump(f);
@@ -3320,7 +3320,7 @@ void OSD::final_init()
 				     "show clients which have active watches,"
 				     " and on which objects");
   ceph_assert(r == 0);
-  r = admin_socket->register_command("dump_reservations", "dump_reservations",
+  r = admin_socket->register_command("dump_recovery_reservations", "dump_recovery_reservations",
 				     asok_hook,
 				     "show recovery reservations");
   ceph_assert(r == 0);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1263,6 +1263,14 @@ void OSDService::dec_scrubs_active()
   ceph_assert(scrubs_active >= 0);
 }
 
+void OSDService::dump_scrub_reservations(Formatter *f)
+{
+  std::lock_guard l{sched_scrub_lock};
+  f->dump_int("scrubs_active", scrubs_active);
+  f->dump_int("scrubs_pending", scrubs_pending);
+  f->dump_int("osd_max_scrubs", cct->_conf->osd_max_scrubs);
+}
+
 void OSDService::retrieve_epochs(epoch_t *_boot_epoch, epoch_t *_up_epoch,
                                  epoch_t *_bind_epoch) const
 {
@@ -2459,6 +2467,10 @@ will start to track new ops received afterwards.";
     service.remote_reserver.dump(f);
     f->close_section();
     f->close_section();
+  } else if (admin_command == "dump_scrub_reservations") {
+    f->open_object_section("scrub_reservations");
+    service.dump_scrub_reservations(f);
+    f->close_section();
   } else if (admin_command == "get_latest_osdmap") {
     get_latest_osdmap();
   } else if (admin_command == "heap") {
@@ -3323,6 +3335,10 @@ void OSD::final_init()
   r = admin_socket->register_command("dump_recovery_reservations", "dump_recovery_reservations",
 				     asok_hook,
 				     "show recovery reservations");
+  ceph_assert(r == 0);
+  r = admin_socket->register_command("dump_scrub_reservations", "dump_scrub_reservations",
+				     asok_hook,
+				     "show scrub reservations");
   ceph_assert(r == 0);
   r = admin_socket->register_command("get_latest_osdmap", "get_latest_osdmap",
 				     asok_hook,

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -354,6 +354,7 @@ public:
   void inc_scrubs_active(bool reserved);
   void dec_scrubs_pending();
   void dec_scrubs_active();
+  void dump_scrub_reservations(Formatter *f);
 
   void reply_op_error(OpRequestRef op, int err);
   void reply_op_error(OpRequestRef op, int err, eversion_t v, version_t uv);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -273,8 +273,8 @@ public:
 private:
   // -- scrub scheduling --
   ceph::mutex sched_scrub_lock = ceph::make_mutex("OSDService::sched_scrub_lock");
-  int scrubs_pending;
-  int scrubs_active;
+  int scrubs_local;
+  int scrubs_remote;
 
 public:
   struct ScrubJob {
@@ -349,11 +349,11 @@ public:
     f->close_section();
   }
 
-  bool can_inc_scrubs_pending();
-  bool inc_scrubs_pending();
-  void inc_scrubs_active(bool reserved);
-  void dec_scrubs_pending();
-  void dec_scrubs_active();
+  bool can_inc_scrubs();
+  bool inc_scrubs_local();
+  void dec_scrubs_local();
+  bool inc_scrubs_remote();
+  void dec_scrubs_remote();
   void dump_scrub_reservations(Formatter *f);
 
   void reply_op_error(OpRequestRef op, int err);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -352,7 +352,7 @@ void PG::clear_primary_state()
 }
 
 PG::Scrubber::Scrubber()
- : reserved(false), reserve_failed(false),
+ : local_reserved(false), remote_reserved(false), reserve_failed(false),
    epoch_start(0),
    active(false),
    shallow_errors(0), deep_errors(0), fixed(0),
@@ -1323,22 +1323,24 @@ void PG::requeue_map_waiters()
 /*
  * when holding pg and sched_scrub_lock, then the states are:
  *   scheduling:
- *     scrubber.reserved = true
- *     scrub_rserved_peers includes whoami
- *     osd->scrub_pending++
+ *     scrubber.local_reserved = true
+ *     scrubber.active = false
+ *     scrubber.reserved_peers includes whoami
+ *     osd->scrubs_local++
  *   scheduling, replica declined:
- *     scrubber.reserved = true
+ *     scrubber.local_reserved = true
  *     scrubber.reserved_peers includes -1
- *     osd->scrub_pending++
+ *     osd->scrub_local++
  *   pending:
- *     scrubber.reserved = true
+ *     scrubber.local_reserved = true
+ *     scrubber.active = false
  *     scrubber.reserved_peers.size() == acting.size();
  *     pg on scrub_wq
- *     osd->scrub_pending++
+ *     osd->scrub_local++
  *   scrubbing:
- *     scrubber.reserved = false;
+ *     scrubber.local_reserved = true;
+ *     scrubber.active = true
  *     scrubber.reserved_peers empty
- *     osd->scrubber.active++
  */
 
 // returns true if a scrub has been newly kicked off
@@ -1352,7 +1354,7 @@ bool PG::sched_scrub()
 
   // All processing the first time through commits us to whatever
   // choices are made.
-  if (!scrubber.reserved) {
+  if (!scrubber.local_reserved) {
     dout(20) << __func__ << ": Start processing pg " << info.pgid << dendl;
 
     bool allow_deep_scrub = !(get_osdmap()->test_flag(CEPH_OSDMAP_NODEEP_SCRUB) ||
@@ -1442,9 +1444,9 @@ bool PG::sched_scrub()
                           (cct->_conf->osd_repair_during_recovery && scrubber.must_repair) ||
                           !osd->is_recovery_active();
     if (allow_scrubing &&
-         osd->inc_scrubs_pending()) {
+         osd->inc_scrubs_local()) {
       dout(20) << __func__ << ": reserved locally, reserving replicas" << dendl;
-      scrubber.reserved = true;
+      scrubber.local_reserved = true;
       scrubber.reserved_peers.insert(pg_whoami);
       scrub_reserve_replicas();
     } else {
@@ -1453,7 +1455,7 @@ bool PG::sched_scrub()
     }
   }
 
-  if (scrubber.reserved) {
+  if (scrubber.local_reserved) {
     if (scrubber.reserve_failed) {
       dout(20) << __func__ << ": failed, a peer declined" << dendl;
       clear_scrub_reserved();
@@ -1895,23 +1897,23 @@ void PG::handle_scrub_reserve_request(OpRequestRef op)
 {
   dout(7) << __func__ << " " << *op->get_req() << dendl;
   op->mark_started();
-  if (scrubber.reserved) {
+  if (scrubber.remote_reserved) {
     dout(10) << __func__ << " ignoring reserve request: Already reserved"
 	     << dendl;
     return;
   }
   if ((cct->_conf->osd_scrub_during_recovery || !osd->is_recovery_active()) &&
-      osd->inc_scrubs_pending()) {
-    scrubber.reserved = true;
+      osd->inc_scrubs_remote()) {
+    scrubber.remote_reserved = true;
   } else {
     dout(20) << __func__ << ": failed to reserve remotely" << dendl;
-    scrubber.reserved = false;
+    scrubber.remote_reserved = false;
   }
   auto m = op->get_req<MOSDScrubReserve>();
   Message *reply = new MOSDScrubReserve(
     spg_t(info.pgid.pgid, get_primary().shard),
     m->map_epoch,
-    scrubber.reserved ? MOSDScrubReserve::GRANT : MOSDScrubReserve::REJECT,
+    scrubber.remote_reserved ? MOSDScrubReserve::GRANT : MOSDScrubReserve::REJECT,
     pg_whoami);
   osd->send_message_osd_cluster(reply, op->get_req()->get_connection());
 }
@@ -1920,7 +1922,7 @@ void PG::handle_scrub_reserve_grant(OpRequestRef op, pg_shard_t from)
 {
   dout(7) << __func__ << " " << *op->get_req() << dendl;
   op->mark_started();
-  if (!scrubber.reserved) {
+  if (!scrubber.local_reserved) {
     dout(10) << "ignoring obsolete scrub reserve reply" << dendl;
     return;
   }
@@ -1937,7 +1939,7 @@ void PG::handle_scrub_reserve_reject(OpRequestRef op, pg_shard_t from)
 {
   dout(7) << __func__ << " " << *op->get_req() << dendl;
   op->mark_started();
-  if (!scrubber.reserved) {
+  if (!scrubber.local_reserved) {
     dout(10) << "ignoring obsolete scrub reserve reply" << dendl;
     return;
   }
@@ -2053,9 +2055,13 @@ void PG::clear_scrub_reserved()
   scrubber.reserved_peers.clear();
   scrubber.reserve_failed = false;
 
-  if (scrubber.reserved) {
-    scrubber.reserved = false;
-    osd->dec_scrubs_pending();
+  if (scrubber.local_reserved) {
+    scrubber.local_reserved = false;
+    osd->dec_scrubs_local();
+  }
+  if (scrubber.remote_reserved) {
+    scrubber.remote_reserved = false;
+    osd->dec_scrubs_remote();
   }
 }
 
@@ -2621,12 +2627,6 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
         scrubber.epoch_start = info.history.same_interval_since;
         scrubber.active = true;
 
-	osd->inc_scrubs_active(scrubber.reserved);
-	if (scrubber.reserved) {
-	  scrubber.reserved = false;
-	  scrubber.reserved_peers.clear();
-	}
-
 	{
 	  ObjectStore::Transaction t;
 	  scrubber.cleanup_store(&t);
@@ -2989,9 +2989,12 @@ void PG::scrub_clear_state(bool has_error)
   state_clear(PG_STATE_DEEP_SCRUB);
   publish_stats_to_osd();
 
-  // active -> nothing.
-  if (scrubber.active)
-    osd->dec_scrubs_active();
+  // local -> nothing.
+  if (scrubber.local_reserved) {
+    osd->dec_scrubs_local();
+    scrubber.local_reserved = false;
+    scrubber.reserved_peers.clear();
+  }
 
   requeue_ops(waiting_for_scrub);
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1091,7 +1091,7 @@ public:
 
     // metadata
     set<pg_shard_t> reserved_peers;
-    bool reserved, reserve_failed;
+    bool local_reserved, remote_reserved, reserve_failed;
     epoch_t epoch_start;
 
     // common to both scrubs


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
