### PR TITLE
mds: Reorganize class members in LogSegment header

### DIFF
--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -48,8 +48,7 @@ class LogSegment {
     dirty_parent_inodes(member_offset(CInode, item_dirty_parent)),
     dirty_dirfrag_dir(member_offset(CInode, item_dirty_dirfrag_dir)),
     dirty_dirfrag_nest(member_offset(CInode, item_dirty_dirfrag_nest)),
-    dirty_dirfrag_dirfragtree(member_offset(CInode, item_dirty_dirfrag_dirfragtree)),
-    slave_updates(0) // passed to begin() manually
+    dirty_dirfrag_dirfragtree(member_offset(CInode, item_dirty_dirfrag_dirfragtree))
   {}
 
   void try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int op_prio);
@@ -75,7 +74,7 @@ class LogSegment {
   elist<CInode*>  dirty_dirfrag_nest;
   elist<CInode*>  dirty_dirfrag_dirfragtree;
 
-  elist<MDSlaveUpdate*> slave_updates;
+  elist<MDSlaveUpdate*> slave_updates{0}; // passed to begin() manually
 
   set<CInode*> truncating_inodes;
 

--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -26,8 +26,6 @@
 
 #include "include/unordered_set.h"
 
-typedef uint64_t log_segment_seq_t;
-
 using ceph::unordered_set;
 
 class CDir;
@@ -38,6 +36,8 @@ struct MDSlaveUpdate;
 
 class LogSegment {
  public:
+  using seq_t = uint64_t;
+
   LogSegment(uint64_t _seq, loff_t off=-1) :
     seq(_seq), offset(off), end(off),
     dirty_dirfrags(member_offset(CDir, item_dirty)),
@@ -60,7 +60,7 @@ class LogSegment {
     expiry_waiters.push_back(c);
   }
 
-  const log_segment_seq_t seq;
+  const seq_t seq;
   uint64_t offset, end;
   int num_events = 0;
 

--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -25,6 +25,9 @@
 #include "CDir.h"
 
 #include "include/unordered_set.h"
+
+typedef uint64_t log_segment_seq_t;
+
 using ceph::unordered_set;
 
 class CDir;
@@ -33,13 +36,33 @@ class CDentry;
 class MDSRank;
 struct MDSlaveUpdate;
 
-typedef uint64_t log_segment_seq_t;
-
 class LogSegment {
  public:
+  LogSegment(uint64_t _seq, loff_t off=-1) :
+    seq(_seq), offset(off), end(off),
+    dirty_dirfrags(member_offset(CDir, item_dirty)),
+    new_dirfrags(member_offset(CDir, item_new)),
+    dirty_inodes(member_offset(CInode, item_dirty)),
+    dirty_dentries(member_offset(CDentry, item_dirty)),
+    open_files(member_offset(CInode, item_open_file)),
+    dirty_parent_inodes(member_offset(CInode, item_dirty_parent)),
+    dirty_dirfrag_dir(member_offset(CInode, item_dirty_dirfrag_dir)),
+    dirty_dirfrag_nest(member_offset(CInode, item_dirty_dirfrag_nest)),
+    dirty_dirfrag_dirfragtree(member_offset(CInode, item_dirty_dirfrag_dirfragtree)),
+    slave_updates(0) // passed to begin() manually
+  {}
+
+  void try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int op_prio);
+
+  void wait_for_expiry(MDSContext *c)
+  {
+    ceph_assert(c != NULL);
+    expiry_waiters.push_back(c);
+  }
+
   const log_segment_seq_t seq;
   uint64_t offset, end;
-  int num_events;
+  int num_events = 0;
 
   // dirty items
   elist<CDir*>    dirty_dirfrags, new_dirfrags;
@@ -53,7 +76,7 @@ class LogSegment {
   elist<CInode*>  dirty_dirfrag_dirfragtree;
 
   elist<MDSlaveUpdate*> slave_updates;
-  
+
   set<CInode*> truncating_inodes;
 
   map<int, ceph::unordered_set<version_t> > pending_commit_tids;  // mdstable
@@ -67,36 +90,11 @@ class LogSegment {
   std::set<entity_name_t> touched_sessions;
 
   // table version
-  version_t inotablev;
-  version_t sessionmapv;
+  version_t inotablev = 0;
+  version_t sessionmapv = 0;
   map<int,version_t> tablev;
 
-  // try to expire
-  void try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int op_prio);
-
   MDSContext::vec expiry_waiters;
-
-  void wait_for_expiry(MDSContext *c)
-  {
-    ceph_assert(c != NULL);
-    expiry_waiters.push_back(c);
-  }
-
-  // cons
-  LogSegment(uint64_t _seq, loff_t off=-1) :
-    seq(_seq), offset(off), end(off), num_events(0),
-    dirty_dirfrags(member_offset(CDir, item_dirty)),
-    new_dirfrags(member_offset(CDir, item_new)),
-    dirty_inodes(member_offset(CInode, item_dirty)),
-    dirty_dentries(member_offset(CDentry, item_dirty)),
-    open_files(member_offset(CInode, item_open_file)),
-    dirty_parent_inodes(member_offset(CInode, item_dirty_parent)),
-    dirty_dirfrag_dir(member_offset(CInode, item_dirty_dirfrag_dir)),
-    dirty_dirfrag_nest(member_offset(CInode, item_dirty_dirfrag_nest)),
-    dirty_dirfrag_dirfragtree(member_offset(CInode, item_dirty_dirfrag_dirfragtree)),
-    slave_updates(0), // passed to begin() manually
-    inotablev(0), sessionmapv(0)
-  { }
 };
 
 #endif

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1150,7 +1150,7 @@ void MDLog::_reformat_journal(JournalPointer const &jp_in, Journaler *old_journa
   // a log segment.  Because we change serialization, this will end up changing
   // for us, so we have to explicitly update the fields that point back to that
   // log segment.
-  std::map<log_segment_seq_t, log_segment_seq_t> segment_pos_rewrite;
+  std::map<LogSegment::seq_t, LogSegment::seq_t> segment_pos_rewrite;
 
   // The logic in here borrowed from replay_thread expects mds_lock to be held,
   // e.g. between checking readable and doing wait_for_readable so that journaler

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -243,7 +243,7 @@ public:
     return segments.rbegin()->second;
   }
 
-  LogSegment *get_segment(log_segment_seq_t seq) {
+  LogSegment *get_segment(LogSegment::seq_t seq) {
     if (segments.count(seq))
       return segments[seq];
     return NULL;

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -322,7 +322,7 @@ private:
 
   // inodes i've truncated
   vector<inodeno_t> truncate_start;        // start truncate
-  map<inodeno_t, log_segment_seq_t> truncate_finish;  // finished truncate (started in segment blah)
+  map<inodeno_t, LogSegment::seq_t> truncate_finish;  // finished truncate (started in segment blah)
 
 public:
   vector<inodeno_t> destroyed_inodes;

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -3116,10 +3116,10 @@ void ENoOp::replay(MDSRank *mds)
  * True if the event was modified.
  */
 bool EMetaBlob::rewrite_truncate_finish(MDSRank const *mds,
-    std::map<log_segment_seq_t, log_segment_seq_t> const &old_to_new)
+    std::map<LogSegment::seq_t, LogSegment::seq_t> const &old_to_new)
 {
   bool modified = false;
-  map<inodeno_t, log_segment_seq_t> new_trunc_finish;
+  map<inodeno_t, LogSegment::seq_t> new_trunc_finish;
   for (const auto& p : truncate_finish) {
     auto q = old_to_new.find(p.second);
     if (q != old_to_new.end()) {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41678
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst



---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
