### PR TITLE
doc: Fix a typo in balancer documentation

### DIFF
--- a/doc/rados/operations/balancer.rst
+++ b/doc/rados/operations/balancer.rst
@@ -103,7 +103,7 @@ The balancer operation is broken into a few distinct phases:
 #. evaluating the quality of the data distribution, either for the current PG distribution, or the PG distribution that would result after executing a *plan*
 #. executing the *plan*
 
-To evautate and score the current distribution,::
+To evaluate and score the current distribution::
 
   ceph balancer eval
 


### PR DESCRIPTION
Signed-off-by: Francois Deppierraz <francois@ctrlaltdel.ch>