### PR TITLE
mimic: core: mon: C_AckMarkedDown has not handled the Callback Arguments

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2275,15 +2275,22 @@ public:
     MonOpRequestRef op)
     : C_MonOp(op), osdmon(osdmon) {}
 
-  void _finish(int) override {
-    MOSDMarkMeDown *m = static_cast<MOSDMarkMeDown*>(op->get_req());
-    osdmon->mon->send_reply(
-      op,
-      new MOSDMarkMeDown(
-	m->fsid,
-	m->get_target(),
-	m->get_epoch(),
-	false));   // ACK itself does not request an ack
+  void _finish(int r) override {
+    if (r == 0) {
+      MOSDMarkMeDown *m = static_cast<MOSDMarkMeDown*>(op->get_req());
+      osdmon->mon->send_reply(
+        op,
+        new MOSDMarkMeDown(
+          m->fsid,
+          m->get_target(),
+          m->get_epoch(),
+          false));   // ACK itself does not request an ack
+    } else if (r == -EAGAIN) {
+        osdmon->dispatch(op);
+    } else {
+        lgeneric_derr(osdmon->cct) << "C_AckMarkedDown: unknown result" << r << dendl;
+        ceph_abort();
+    }
   }
   ~C_AckMarkedDown() override {
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41449

---

backport of https://github.com/ceph/ceph/pull/29624
parent tracker: https://tracker.ceph.com/issues/41217

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh