### PR TITLE
mimic: osd/OSDCap: Check for empty namespace

### DIFF
--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -118,7 +118,7 @@ bool OSDCapPoolNamespace::is_match(const std::string& pn,
     }
   }
   if (nspace) {
-    if ((*nspace)[nspace->length() - 1] == '*' &&
+    if (!nspace->empty() && nspace->back() == '*' &&
 	boost::starts_with(ns, nspace->substr(0, nspace->length() - 1))) {
       return true;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41490

---

backport of https://github.com/ceph/ceph/pull/29146
parent tracker: https://tracker.ceph.com/issues/40835

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh