### PR TITLE
mimic: os/bluestore: apply shared_alloc_size to shared device with log level change

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -937,6 +937,7 @@ OPTION(bdev_async_discard, OPT_BOOL)
 OPTION(objectstore_blackhole, OPT_BOOL)
 
 OPTION(bluefs_alloc_size, OPT_U64)
+OPTION(bluefs_shared_alloc_size, OPT_U64)
 OPTION(bluefs_max_prefetch, OPT_U64)
 OPTION(bluefs_min_log_runway, OPT_U64)  // alloc when we get this low
 OPTION(bluefs_max_log_runway, OPT_U64)  // alloc this much at a time

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3782,7 +3782,11 @@ std::vector<Option> get_global_options() {
 
     Option("bluefs_alloc_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1_M)
-    .set_description(""),
+    .set_description("Allocation unit size for DB and WAL devices"),
+
+    Option("bluefs_shared_alloc_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .set_default(64_K)
+    .set_description("Allocation unit size for primary/shared device"),
 
     Option("bluefs_max_prefetch", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1_M)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -430,7 +430,7 @@ void BlueFS::_init_alloc()
     }
     ceph_assert(bdev[id]->get_size());
     ceph_assert(alloc_size[id]);
-    dout(20) << __func__ << " id " << id
+    dout(1) << __func__ << " id " << id
 	     << " alloc_size 0x" << std::hex << alloc_size[id]
 	     << " size 0x" << bdev[id]->get_size() << std::dec << dendl;
     alloc[id] = Allocator::create(cct, cct->_conf->bluefs_allocator,

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2002,8 +2002,8 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
     extents.reserve(4);  // 4 should be (more than) enough for most allocations
     alloc_len = alloc[id]->allocate(left, min_alloc_size, hint, &extents);
   }
-  if (alloc_len < (int64_t)left) {
-    if (alloc_len != 0) {
+  if (alloc_len < 0 || alloc_len < (int64_t)left) {
+    if (alloc_len > 0) {
       alloc[id]->release(extents);
     }
     if (id != BDEV_SLOW) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -216,9 +216,8 @@ int BlueFS::reclaim_blocks(unsigned id, uint64_t want,
   ceph_assert(id < alloc.size());
   ceph_assert(alloc[id]);
 
-  int64_t got = alloc[id]->allocate(want, cct->_conf->bluefs_alloc_size, 0,
-				    extents);
-  assert(got != 0);
+  int64_t got = alloc[id]->allocate(want, alloc_size[id], 0, extents);
+  ceph_assert(got != 0);
   if (got < 0) {
     derr << __func__ << " failed to allocate space to return to bluestore"
       << dendl;
@@ -412,15 +411,31 @@ void BlueFS::_init_alloc()
 {
   dout(20) << __func__ << dendl;
   alloc.resize(MAX_BDEV);
+  alloc_size.resize(MAX_BDEV, 0);
   pending_release.resize(MAX_BDEV);
+
+  if (bdev[BDEV_WAL]) {
+    alloc_size[BDEV_WAL] = cct->_conf->bluefs_alloc_size;
+  }
+  if (bdev[BDEV_SLOW]) {
+    alloc_size[BDEV_DB] = cct->_conf->bluefs_alloc_size;
+    alloc_size[BDEV_SLOW] = cct->_conf->bluefs_shared_alloc_size;
+  } else {
+    alloc_size[BDEV_DB] = cct->_conf->bluefs_shared_alloc_size;
+  }
+
   for (unsigned id = 0; id < bdev.size(); ++id) {
     if (!bdev[id]) {
       continue;
     }
     ceph_assert(bdev[id]->get_size());
+    ceph_assert(alloc_size[id]);
+    dout(20) << __func__ << " id " << id
+	     << " alloc_size 0x" << std::hex << alloc_size[id]
+	     << " size 0x" << bdev[id]->get_size() << std::dec << dendl;
     alloc[id] = Allocator::create(cct, cct->_conf->bluefs_allocator,
 				  bdev[id]->get_size(),
-				  cct->_conf->bluefs_alloc_size);
+				  alloc_size[id]);
     interval_set<uint64_t>& p = block_all[id];
     for (interval_set<uint64_t>::iterator q = p.begin(); q != p.end(); ++q) {
       alloc[id]->init_add_free(q.get_start(), q.get_len());
@@ -1384,9 +1399,13 @@ void BlueFS::_compact_log_async(std::unique_lock<std::mutex>& l)
   log_t.clear();
   _compact_log_dump_metadata(&t);
 
+  uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
+				     std::max(alloc_size[BDEV_DB],
+					      alloc_size[BDEV_SLOW]));
+
   // conservative estimate for final encoded size
   new_log_jump_to = round_up_to(t.op_bl.length() + super.block_size * 2,
-                                cct->_conf->bluefs_alloc_size);
+                                max_alloc_size);
   t.op_jump(log_seq, new_log_jump_to);
 
   bufferlist bl;
@@ -1988,27 +2007,26 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   dout(10) << __func__ << " len 0x" << std::hex << len << std::dec
            << " from " << (int)id << dendl;
   ceph_assert(id < alloc.size());
-  uint64_t min_alloc_size = cct->_conf->bluefs_alloc_size;
-
-  uint64_t left = round_up_to(len, min_alloc_size);
   int64_t alloc_len = 0;
   PExtentVector extents;
-  
   if (alloc[id]) {
     uint64_t hint = 0;
     if (!node->extents.empty() && node->extents.back().bdev == id) {
       hint = node->extents.back().end();
     }   
     extents.reserve(4);  // 4 should be (more than) enough for most allocations
-    alloc_len = alloc[id]->allocate(left, min_alloc_size, hint, &extents);
+    alloc_len = alloc[id]->allocate(round_up_to(len, alloc_size[id]),
+				    alloc_size[id], hint, &extents);
   }
-  if (alloc_len < 0 || alloc_len < (int64_t)left) {
+  if (!alloc[id] ||
+      alloc_len < 0 ||
+      alloc_len < (int64_t)round_up_to(len, alloc_size[id])) {
     if (alloc_len > 0) {
       alloc[id]->release(extents);
     }
     if (id != BDEV_SLOW) {
       if (bdev[id]) {
-	dout(1) << __func__ << " failed to allocate 0x" << std::hex << left
+	dout(1) << __func__ << " failed to allocate 0x" << std::hex << len
 		<< " on bdev " << (int)id
 		<< ", free 0x" << alloc[id]->get_free()
 		<< "; fallback to bdev " << (int)id + 1

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -252,6 +252,7 @@ private:
   vector<IOContext*> ioc;                     ///< IOContexts for bdevs
   vector<interval_set<uint64_t> > block_all;  ///< extents in bdev we own
   vector<Allocator*> alloc;                   ///< allocators for bdevs
+  vector<uint64_t> alloc_size;                ///< alloc size for each device
   vector<interval_set<uint64_t>> pending_release; ///< extents to release
 
   BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
@@ -343,6 +344,9 @@ public:
 
   void collect_metadata(map<string,string> *pm, unsigned skip_bdev_id);
   void get_devices(set<string> *ls);
+  uint64_t get_alloc_size(int id) {
+    return alloc_size[id];
+  }
   int fsck();
 
   uint64_t get_used();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5422,21 +5422,40 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
   }
 
   if (gift) {
-    // round up to alloc size
-    gift = p2roundup(gift, cct->_conf->bluefs_alloc_size);
-
     // hard cap to fit into 32 bits
     gift = std::min<uint64_t>(gift, 1ull << 31);
     dout(10) << __func__ << " gifting " << gift
 	     << " (" << byte_u_t(gift) << ")" << dendl;
 
-    int64_t alloc_len = alloc->allocate(gift,
-					cct->_conf->bluefs_shared_alloc_size,
+    // first try to allocate larger chunks (usually the bluefs alloc
+    // size is larger, but behave regardless)
+    auto max_alloc_size = std::max<uint64_t>(
+      cct->_conf->bluefs_alloc_size,
+      cct->_conf->bluefs_shared_alloc_size);
+    int64_t first_attempt = std::min<int64_t>(p2roundup(gift, max_alloc_size),
+					      1ull<<31);
+    int64_t alloc_len = alloc->allocate(first_attempt, max_alloc_size,
 					0, 0, extents);
-
     if (alloc_len <= 0) {
-      dout(0) << __func__ << " no allocate on 0x" << std::hex << gift
-              << " min_alloc_size 0x" << min_alloc_size << std::dec << dendl;
+      // if that fails, then try the shared size...
+      int64_t second_attempt =
+	std::min<int64_t>(p2roundup(gift, cct->_conf->bluefs_shared_alloc_size),
+			  1ull<<31);
+      dout(10) << __func__ << " failed to alloc 0x " << std::hex << first_attempt
+	       << " with larger chunks (0x"
+	       << max_alloc_size
+	       << "), fall back to 0x" << second_attempt
+	       << " shared_alloc_size (0x"
+	       << cct->_conf->bluefs_shared_alloc_size
+	       << std::dec << ")" << dendl;
+      alloc_len = alloc->allocate(
+	second_attempt,
+	cct->_conf->bluefs_shared_alloc_size,
+	0, 0, extents);
+    }
+    if (alloc_len <= 0 || alloc_len < (int64_t)gift) {
+      dout(0) << __func__ << " no allocate on 0x" << std::hex << gift << std::dec
+	      << dendl;
       _dump_alloc_on_rebalance_failure();
       return 0;
     } else if (alloc_len < (int64_t)gift) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5430,7 +5430,8 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
     dout(10) << __func__ << " gifting " << gift
 	     << " (" << byte_u_t(gift) << ")" << dendl;
 
-    int64_t alloc_len = alloc->allocate(gift, cct->_conf->bluefs_alloc_size,
+    int64_t alloc_len = alloc->allocate(gift,
+					cct->_conf->bluefs_shared_alloc_size,
 					0, 0, extents);
 
     if (alloc_len <= 0) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5453,7 +5453,7 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
 	cct->_conf->bluefs_shared_alloc_size,
 	0, 0, extents);
     }
-    if (alloc_len <= 0 || alloc_len < (int64_t)gift) {
+    if (alloc_len <= 0) {
       dout(0) << __func__ << " no allocate on 0x" << std::hex << gift << std::dec
 	      << dendl;
       _dump_alloc_on_rebalance_failure();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10899,9 +10899,12 @@ int BlueStore::_do_alloc_write(
   prealloc_left = alloc->allocate(
     need, min_alloc_size, need,
     0, &prealloc);
-  if (prealloc_left  < 0) {
+  if (prealloc_left < 0 || prealloc_left < (int64_t)need) {
     derr << __func__ << " failed to allocate 0x" << std::hex << need << std::dec
 	 << dendl;
+    if (prealloc_left > 0) {
+      alloc->release(prealloc);
+    }
     return -ENOSPC;
   }
   ceph_assert(prealloc_left == (int64_t)need);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5454,7 +5454,8 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
   // reclaim from bluefs?
   if (reclaim) {
     // round up to alloc size
-    reclaim = p2roundup(reclaim, cct->_conf->bluefs_alloc_size);
+    uint64_t alloc_size = bluefs->get_alloc_size(bluefs_shared_bdev);
+    reclaim = p2roundup(reclaim, alloc_size);
 
     // hard cap to fit into 32 bits
     reclaim = std::min<uint64_t>(reclaim, 1ull << 31);


### PR DESCRIPTION
backport tracker https://tracker.ceph.com/issues/41339

Backport of #29537

---

originally opened by @liewegas at https://github.com/ceph/ceph/pull/29746

#29746 was superseded by @jdurgin 's PR #29861

this PR supersedes #29861 adding log level change 