### PR TITLE
msg: add some anonymous connection infrastructure

### DIFF
--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -50,6 +50,7 @@ struct Connection : public RefCountedObject {
   int64_t peer_id = -1;  // [msgr2 only] the 0 of osd.0, 4567 or client.4567
   safe_item_history<entity_addrvec_t> peer_addrs;
   utime_t last_keepalive, last_keepalive_ack;
+  bool anon = false;  ///< anonymous outgoing connection
 private:
   uint64_t features;
 public:
@@ -116,6 +117,10 @@ public:
 
   virtual bool is_msgr2() const {
     return false;
+  }
+
+  bool is_anon() const {
+    return anon;
   }
 
   Messenger *get_messenger() {

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -531,18 +531,19 @@ public:
    * @param dest The entity to get a connection for.
    */
   virtual ConnectionRef connect_to(
-    int type, const entity_addrvec_t& dest) = 0;
-  ConnectionRef connect_to_mon(const entity_addrvec_t& dest) {
-    return connect_to(CEPH_ENTITY_TYPE_MON, dest);
+    int type, const entity_addrvec_t& dest,
+    bool anon=false) = 0;
+  ConnectionRef connect_to_mon(const entity_addrvec_t& dest, bool anon=false) {
+    return connect_to(CEPH_ENTITY_TYPE_MON, dest, anon);
   }
-  ConnectionRef connect_to_mds(const entity_addrvec_t& dest) {
-    return connect_to(CEPH_ENTITY_TYPE_MDS, dest);
+  ConnectionRef connect_to_mds(const entity_addrvec_t& dest, bool anon=false) {
+    return connect_to(CEPH_ENTITY_TYPE_MDS, dest, anon);
   }
-  ConnectionRef connect_to_osd(const entity_addrvec_t& dest) {
-    return connect_to(CEPH_ENTITY_TYPE_OSD, dest);
+  ConnectionRef connect_to_osd(const entity_addrvec_t& dest, bool anon=false) {
+    return connect_to(CEPH_ENTITY_TYPE_OSD, dest, anon);
   }
-  ConnectionRef connect_to_mgr(const entity_addrvec_t& dest) {
-    return connect_to(CEPH_ENTITY_TYPE_MGR, dest);
+  ConnectionRef connect_to_mgr(const entity_addrvec_t& dest, bool anon=false) {
+    return connect_to(CEPH_ENTITY_TYPE_MGR, dest, anon);
   }
 
   /**

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -165,7 +165,9 @@ class AsyncConnection : public Connection {
   int state;
   ConnectedSocket cs;
   int port;
+public:
   Messenger::Policy policy;
+private:
 
   DispatchQueue *dispatch_queue;
 

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -861,6 +861,12 @@ int AsyncMessenger::get_proto_version(int peer_type, bool connect) const
 int AsyncMessenger::accept_conn(const AsyncConnectionRef& conn)
 {
   std::lock_guard l{lock};
+  if (conn->policy.server &&
+      conn->policy.lossy) {
+    anon_conns.insert(conn);
+    conn->get_perf_counter()->inc(l_msgr_active_connections);
+    return 0;
+  }
   auto it = conns.find(*conn->peer_addrs);
   if (it != conns.end()) {
     auto& existing = it->second;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -563,7 +563,7 @@ void AsyncMessenger::add_accept(Worker *w, ConnectedSocket cli_socket,
 }
 
 AsyncConnectionRef AsyncMessenger::create_connect(
-  const entity_addrvec_t& addrs, int type)
+  const entity_addrvec_t& addrs, int type, bool anon)
 {
   ceph_assert(ceph_mutex_is_locked(lock));
 
@@ -587,11 +587,16 @@ AsyncConnectionRef AsyncMessenger::create_connect(
   Worker *w = stack->get_worker();
   AsyncConnectionRef conn = new AsyncConnection(cct, this, &dispatch_queue, w,
 						target.is_msgr2(), false);
+  conn->anon = anon;
   conn->connect(addrs, type, target);
-  ceph_assert(!conns.count(addrs));
-  ldout(cct, 10) << __func__ << " " << conn << " " << addrs << " "
-		 << *conn->peer_addrs << dendl;
-  conns[addrs] = conn;
+  if (anon) {
+    anon_conns.insert(conn);
+  } else {
+    ceph_assert(!conns.count(addrs));
+    ldout(cct, 10) << __func__ << " " << conn << " " << addrs << " "
+		   << *conn->peer_addrs << dendl;
+    conns[addrs] = conn;
+  }
   w->get_perf_counter()->inc(l_msgr_active_connections);
 
   return conn;
@@ -663,7 +668,9 @@ int AsyncMessenger::send_to(Message *m, int type, const entity_addrvec_t& addrs)
   return 0;
 }
 
-ConnectionRef AsyncMessenger::connect_to(int type, const entity_addrvec_t& addrs)
+ConnectionRef AsyncMessenger::connect_to(int type,
+					 const entity_addrvec_t& addrs,
+					 bool anon)
 {
   std::lock_guard l{lock};
   if (*my_addrs == addrs ||
@@ -675,11 +682,15 @@ ConnectionRef AsyncMessenger::connect_to(int type, const entity_addrvec_t& addrs
 
   auto av = _filter_addrs(addrs);
 
+  if (anon) {
+    return create_connect(av, type, anon);
+  }
+
   AsyncConnectionRef conn = _lookup_conn(av);
   if (conn) {
     ldout(cct, 10) << __func__ << " " << av << " existing " << conn << dendl;
   } else {
-    conn = create_connect(av, type);
+    conn = create_connect(av, type, false);
     ldout(cct, 10) << __func__ << " " << av << " new " << conn << dendl;
   }
 
@@ -727,7 +738,7 @@ void AsyncMessenger::submit_message(Message *m, const AsyncConnectionRef& con,
   } else {
     ldout(cct,20) << __func__ << " " << *m << " remote, " << dest_addrs
 		  << ", new connection." << dendl;
-    auto&& new_con = create_connect(dest_addrs, dest_type);
+    auto&& new_con = create_connect(dest_addrs, dest_type, false);
     new_con->send_message(m);
   }
 }
@@ -797,6 +808,13 @@ void AsyncMessenger::shutdown_connections(bool queue_reset)
     c->stop(queue_reset);
   }
   conns.clear();
+
+  for (const auto& c : anon_conns) {
+    ldout(cct, 5) << __func__ << " mark down " << c << dendl;
+    c->get_perf_counter()->dec(l_msgr_active_connections);
+    c->stop(queue_reset);
+  }
+  anon_conns.clear();
 
   {
     std::lock_guard l{deleted_lock};
@@ -930,6 +948,7 @@ int AsyncMessenger::reap_dead()
       if (conns_it != conns.end() && conns_it->second == c)
         conns.erase(conns_it);
       accepting_conns.erase(c);
+      anon_conns.erase(c);
       ++num;
     }
     deleted_conns.clear();

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -147,7 +147,8 @@ public:
    * @{
    */
   ConnectionRef connect_to(int type,
-			   const entity_addrvec_t& addrs) override;
+			   const entity_addrvec_t& addrs,
+			   bool anon) override;
   ConnectionRef get_loopback_connection() override;
   void mark_down(const entity_addr_t& addr) override {
     mark_down_addrs(entity_addrvec_t(addr));
@@ -196,7 +197,8 @@ private:
    * @return a pointer to the newly-created connection. Caller does not own a
    * reference; take one if you need it.
    */
-  AsyncConnectionRef create_connect(const entity_addrvec_t& addrs, int type);
+  AsyncConnectionRef create_connect(const entity_addrvec_t& addrs, int type,
+				    bool anon);
 
   /**
    * Queue up a Message for delivery to the entity specified
@@ -281,6 +283,9 @@ private:
    * These are not yet in the conns map.
    */
   set<AsyncConnectionRef> accepting_conns;
+
+  /// anonymous outgoing connections
+  set<AsyncConnectionRef> anon_conns;
 
   /**
    * list of connection are closed which need to be clean up

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -2050,7 +2050,14 @@ CtPtr ProtocolV1::handle_connect_message_2() {
   // session security structure.  PLR
   ldout(cct, 10) << __func__ << " accept setting up session_security." << dendl;
 
-  // existing?
+  if (connection->policy.server &&
+      connection->policy.lossy) {
+    // incoming lossy client, no need to register this connection
+    // new session
+    ldout(cct, 10) << __func__ << " accept new session" << dendl;
+    return open(reply, authorizer_reply);
+  }
+
   AsyncConnectionRef existing = messenger->lookup_conn(*connection->peer_addrs);
 
   connection->inject_delay();


### PR DESCRIPTION
- allow clients to create multiple outgoing lossy connections to the same server
- allow servers to accept multiple incoming lossy connections from the same client

The goal is to allow the same client to open multiple connections to the same server.  From the server's perspective, we are in lossy mode, there is no reason for the server to register/track connections by client, or ensure that there is only one connection per client: each connection is independent and the server is only every sending client messages via a particular connection handle.

From the client's perspective, this can be very useful.  In particular, this enables the MonClient to use an independent Connection for sending 'tell' messages ('ceph tell mon.a') that does not interact with or interfere with the somewhat-complicated connection management that ensures the client is always connected to a mon, that we search for a new mon with multiple parallel connection attempts, etc.  The old/existing mon tell code is a kludge that tries to force the automagic connection to connect to just a single mon, but it is only partially effective because it interferes with the existing mon connection management.
