### PR TITLE
mimic: doc: default values for mon_health_to_clog_* were flipped

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -424,8 +424,8 @@ by setting it in the ``[mon]`` section of the configuration file.
               log (a non-positive number disables it). If current health summary
               is empty or identical to the last time, monitor will not send it
               to cluster log.
-:Type: Integer
-:Default: 3600
+:Type: Float
+:Default: 60.000000
 
 
 ``mon health to clog interval``
@@ -435,7 +435,7 @@ by setting it in the ``[mon]`` section of the configuration file.
               send the summary to cluster log no matter if the summary changes
               or not.
 :Type: Integer
-:Default: 60
+:Default: 3600
 
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41530

---

backport of https://github.com/ceph/ceph/pull/29867
parent tracker: https://tracker.ceph.com/issues/41403

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh