### PR TITLE
mimic: client: support the fallocate() when fuse version >= 2.9

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -657,7 +657,7 @@ static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino, int cmd, void *arg, st
 }
 #endif
 
-#if FUSE_VERSION > FUSE_MAKE_VERSION(2, 9)
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 9)
 
 static void fuse_ll_fallocate(fuse_req_t req, fuse_ino_t ino, int mode,
                               off_t offset, off_t length,
@@ -1036,7 +1036,7 @@ const static struct fuse_lowlevel_ops fuse_ll_oper = {
  forget_multi: 0,
  flock: fuse_ll_flock,
 #endif
-#if FUSE_VERSION > FUSE_MAKE_VERSION(2, 9)
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 9)
  fallocate: fuse_ll_fallocate
 #endif
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40841

---

backport of https://github.com/ceph/ceph/pull/28831
parent tracker: https://tracker.ceph.com/issues/40615

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh