### PR TITLE
mimic: qa: use hard_reset to reboot kclient

### DIFF
--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -277,6 +277,9 @@ class TestClientRecovery(CephFSTestCase):
         # Simulate client death
         self.mount_a.kill()
 
+        # wait for it to die so it doesn't voluntarily release buffer cap
+        time.sleep(5)
+
         try:
             # The waiter should get stuck waiting for the capability
             # held on the MDS by the now-dead client A


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41129

---

backport of https://github.com/ceph/ceph/pull/28825
parent tracker: https://tracker.ceph.com/issues/37681

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh