### PR TITLE
mimic: mon/MDSMonitor: use stringstream instead of dout for mds repaired

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1424,9 +1424,9 @@ int MDSMonitor::filesystem_command(
 
     bool modified = fsmap.undamaged(role.fscid, role.rank);
     if (modified) {
-      dout(1) << "repaired: restoring rank " << role << dendl;
+      ss << "repaired: restoring rank " << role;
     } else {
-      dout(1) << "repaired: no-op on rank " << role << dendl;
+      ss << "nothing to do: rank is not damaged";
     }
 
     r = 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40844

---

backport of https://github.com/ceph/ceph/pull/28683
parent tracker: https://tracker.ceph.com/issues/40472

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh