### PR TITLE
mimic: cephfs: test_volume_client: fix test_put_object_versioned()

### DIFF
--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -15,7 +15,7 @@ class TestVolumeClient(CephFSTestCase):
     # One for looking at the global filesystem, one for being
     # the VolumeClient, two for mounting the created shares
     CLIENTS_REQUIRED = 4
-    py_version = 'python'
+    default_py_version = 'python'
 
     def setUp(self):
         CephFSTestCase.setUp(self)

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -966,7 +966,7 @@ vc.disconnect()
             obj_data = obj_data
         )))
 
-    def test_put_object_versioned(self):
+    def test_version_check_for_put_object_versioned(self):
         vc_mount = self.mounts[1]
         vc_mount.umount_wait()
         self._configure_vc_auth(vc_mount, "manila")

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -33,6 +33,7 @@ class TestVolumeClient(CephFSTestCase):
         return client.run_python("""
 from __future__ import print_function
 from ceph_volume_client import CephFSVolumeClient, VolumePath
+from sys import version_info as sys_version_info
 import logging
 log = logging.getLogger("ceph_volume_client")
 log.addHandler(logging.StreamHandler())
@@ -1000,9 +1001,19 @@ vc.disconnect()
         with self.assertRaises(CommandFailedError):
             self._volume_client_python(vc_mount, dedent("""
                 data, version = vc.get_object_and_version("{pool_name}", "{obj_name}")
-                data += 'm1'
+
+                if sys_version_info.major < 3:
+                    data = data + 'm1'
+                elif sys_version_info.major > 3:
+                    data = str.encode(data.decode('utf-8') + 'm1')
+
                 vc.put_object("{pool_name}", "{obj_name}", data)
-                data += 'm2'
+
+                if sys_version_info.major < 3:
+                    data = data + 'm2'
+                elif sys_version_info.major > 3:
+                    data = str.encode(data.decode('utf-8') + 'm2')
+
                 vc.put_object_versioned("{pool_name}", "{obj_name}", data, version)
             """).format(pool_name=pool_name, obj_name=obj_name))
 

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -15,7 +15,7 @@ class TestVolumeClient(CephFSTestCase):
     # One for looking at the global filesystem, one for being
     # the VolumeClient, two for mounting the created shares
     CLIENTS_REQUIRED = 4
-    default_py_version = 'python'
+    default_py_version = 'python3'
 
     def setUp(self):
         CephFSTestCase.setUp(self)
@@ -965,6 +965,29 @@ vc.disconnect()
             obj_name = obj_name,
             obj_data = obj_data
         )))
+
+    def test_put_object_versioned(self):
+        vc_mount = self.mounts[1]
+        vc_mount.umount_wait()
+        self._configure_vc_auth(vc_mount, "manila")
+
+        obj_data = 'test_data'
+        obj_name = 'test_vc_obj'
+        pool_name = self.fs.get_data_pool_names()[0]
+        self.fs.rados(['put', obj_name, '-'], pool=pool_name, stdin_data=obj_data)
+
+        self._volume_client_python(vc_mount, dedent("""
+            data, version_before = vc.get_object_and_version("{pool_name}", "{obj_name}")
+
+            if sys_version_info.major < 3:
+                data = data + 'modification1'
+            elif sys_version_info.major > 3:
+                data = str.encode(data.decode() + 'modification1')
+
+            vc.put_object_versioned("{pool_name}", "{obj_name}", data, version_before)
+            data, version_after = vc.get_object_and_version("{pool_name}", "{obj_name}")
+            assert version_after == version_before + 1
+        """).format(pool_name=pool_name, obj_name=obj_name))
 
     def test_version_check_for_put_object_versioned(self):
         vc_mount = self.mounts[1]

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from tasks.cephfs.fuse_mount import FuseMount
 from teuthology.exceptions import CommandFailedError
+from teuthology.misc import sudo_write_file
 
 log = logging.getLogger(__name__)
 
@@ -46,27 +47,6 @@ vc.disconnect()
                    vol_prefix=vol_prefix, ns_prefix=ns_prefix),
         self.py_version)
 
-    def _sudo_write_file(self, remote, path, data):
-        """
-        Write data to a remote file as super user
-
-        :param remote: Remote site.
-        :param path: Path on the remote being written to.
-        :param data: Data to be written.
-
-        Both perms and owner are passed directly to chmod.
-        """
-        remote.run(
-            args=[
-                'sudo',
-                'python',
-                '-c',
-                'import shutil, sys; shutil.copyfileobj(sys.stdin, file(sys.argv[1], "wb"))',
-                path,
-            ],
-            stdin=data,
-        )
-
     def _configure_vc_auth(self, mount, id_name):
         """
         Set up auth credentials for the VolumeClient user
@@ -78,7 +58,7 @@ vc.disconnect()
             "mon", "allow *"
         )
         mount.client_id = id_name
-        self._sudo_write_file(mount.client_remote, mount.get_keyring_path(), out)
+        sudo_write_file(mount.client_remote, mount.get_keyring_path(), out)
         self.set_conf("client.{name}".format(name=id_name), "keyring", mount.get_keyring_path())
 
     def _configure_guest_auth(self, volumeclient_mount, guest_mount,
@@ -141,9 +121,8 @@ vc.disconnect()
             key=key
         ))
         guest_mount.client_id = guest_entity
-        self._sudo_write_file(guest_mount.client_remote,
-                              guest_mount.get_keyring_path(),
-                              keyring_txt)
+        sudo_write_file(guest_mount.client_remote,
+                        guest_mount.get_keyring_path(), keyring_txt)
 
         # Add a guest client section to the ceph config file.
         self.set_conf("client.{0}".format(guest_entity), "client quota", "True")

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -35,6 +35,7 @@ class TestVolumeClient(CephFSTestCase):
 from __future__ import print_function
 from ceph_volume_client import CephFSVolumeClient, VolumePath
 from sys import version_info as sys_version_info
+from rados import OSError as rados_OSError
 import logging
 log = logging.getLogger("ceph_volume_client")
 log.addHandler(logging.StreamHandler())
@@ -977,24 +978,30 @@ vc.disconnect()
 
         # Test if put_object_versioned() crosschecks the version of the
         # given object. Being a negative test, an exception is expected.
-        with self.assertRaises(CommandFailedError):
-            self._volume_client_python(vc_mount, dedent("""
-                data, version = vc.get_object_and_version("{pool_name}", "{obj_name}")
+        expected_exception = 'rados_OSError'
+        output = self._volume_client_python(vc_mount, dedent("""
+            data, version = vc.get_object_and_version("{pool_name}", "{obj_name}")
 
-                if sys_version_info.major < 3:
-                    data = data + 'm1'
-                elif sys_version_info.major > 3:
-                    data = str.encode(data.decode('utf-8') + 'm1')
+            if sys_version_info.major < 3:
+                data = data + 'm1'
+            elif sys_version_info.major > 3:
+                data = str.encode(data.decode('utf-8') + 'm1')
 
-                vc.put_object("{pool_name}", "{obj_name}", data)
+            vc.put_object("{pool_name}", "{obj_name}", data)
 
-                if sys_version_info.major < 3:
-                    data = data + 'm2'
-                elif sys_version_info.major > 3:
-                    data = str.encode(data.decode('utf-8') + 'm2')
+            if sys_version_info.major < 3:
+                data = data + 'm2'
+            elif sys_version_info.major > 3:
+                data = str.encode(data.decode('utf-8') + 'm2')
 
+            try:
                 vc.put_object_versioned("{pool_name}", "{obj_name}", data, version)
-            """).format(pool_name=pool_name, obj_name=obj_name))
+            except {expected_exception}:
+                print('{expected_exception} raised')
+        """).format(pool_name=pool_name, obj_name=obj_name,
+                    expected_exception=expected_exception))
+        self.assertEqual(expected_exception + ' raised', output)
+
 
     def test_delete_object(self):
         vc_mount = self.mounts[1]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40853

---

backport of https://github.com/ceph/ceph/pull/28692
parent tracker: https://tracker.ceph.com/issues/39510

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh