### PR TITLE
mimic: mds: cleanup truncating inodes when standby replay mds trim log segments

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7376,6 +7376,13 @@ void MDCache::standby_trim_segment(LogSegment *ls)
     CInode *in = ls->dirty_dirfrag_dirfragtree.front();
     in->dirfragtreelock.remove_dirty();
   }
+  while (!ls->truncating_inodes.empty()) {
+    auto it = ls->truncating_inodes.begin();
+    CInode *in = *it;
+    ls->truncating_inodes.erase(it);
+    in->put(CInode::PIN_TRUNCATING);
+    try_trim_inode(in);
+  }
 }
 
 /* This function DOES put the passed message before returning */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40893

---

backport of https://github.com/ceph/ceph/pull/28686
parent tracker: https://tracker.ceph.com/issues/40477

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh