### PR TITLE
mimic: core: osd: clear PG_STATE_CLEAN when repair object

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15080,6 +15080,7 @@ int PrimaryLogPG::rep_repair_primary_object(const hobject_t& soid, OpRequestRef 
   if (!eio_errors_to_process) {
     eio_errors_to_process = true;
     assert(is_clean());
+    state_clear(PG_STATE_CLEAN);
     queue_peering_event(
         PGPeeringEventRef(
 	  std::make_shared<PGPeeringEvent>(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41442

---

backport of https://github.com/ceph/ceph/pull/29756
parent tracker: https://tracker.ceph.com/issues/41348

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh