### PR TITLE
auth: also catch end_of_buffer while parsing text input

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -211,6 +211,14 @@ void KeyRing::decode(bufferlist::const_iterator& bl) {
   } catch (ceph::buffer::error& err) {
     keys.clear();
     decode_plaintext(start_pos);
+#if defined(__FreeBSD__)
+  } catch (buffer::end_of_buffer& err) {
+    keys.clear();
+    decode_plaintext(start_pos);
+  } catch (exception& e) {
+    keys.clear();
+    decode_plaintext(start_pos);
+#endif
   }
 }
 


### PR DESCRIPTION
[On FreeBSD]
in KeyRing::decode() text parsing in only executed if decode throws.
This results in an ABORT signal in bin/ceph when running vstart.sh
```
12: Populating config ...
12: /usr/home/Ceph/master/ceph/src/vstart.sh: line 1154: 70347 Done                    cat <<EOF
12: [global]
12: osd_pool_default_size = $OSD_POOL_DEFAULT_SIZE
12: osd_pool_default_min_size = 1
12: mon_pg_warn_min_per_osd = 3
...
...
12: [mgr]
12: mgr/telemetry/nag = false
12: mgr/telemetry/enable = false
12:
12: EOF
12:
12:      70348 Abort trap              (core dumped) | $CEPH_BIN/ceph -c $conf_fn config assimilate-conf -i -
```

Only buffer::error is caught in `KeyRing.cc`, but reading config text sometimes
lets the buffer_length run into absurd numbers. This results in a `copy()` call with too large length.
And this generates `end_of_buffer`.

So we need to catch that as well.

However adding buffer::end_of_buffer as exception in another case
does not seem to work, because it is not matched????
So catching all exceptions, and continue to perhaps trap in  decode_plaintext()

fixes: https://tracker.ceph.com/issues/41717



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>