### PR TITLE
nautilus: rgw: fix cls_bucket_list_unordered() partial results

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9136,6 +9136,8 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
       if (r < 0 && r != -ENOENT) {
           return r;
       }
+    } else {
+        r = 0;
     }
     if (r >= 0) {
       ldout(cct, 10) << "RGWRados::cls_bucket_list_ordered: got " <<
@@ -9276,6 +9278,8 @@ int RGWRados::cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
 	if (r < 0 && r != -ENOENT) {
 	  return r;
 	}
+      } else {
+        r = 0;
       }
 
       // at this point either r >=0 or r == -ENOENT


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41707

---

backport of https://github.com/ceph/ceph/pull/29692
parent tracker: https://tracker.ceph.com/issues/41297

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh