### PR TITLE
rgw:[bug] fix data consistency error casued by rgw sent timeout

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -14,15 +14,17 @@
 
 size_t RGWCivetWeb::write_data(const char *buf, const size_t len)
 {
+  size_t off = 0;
   auto to_sent = len;
   while (to_sent) {
-    const int ret = mg_write(conn, buf, len);
+    const int ret = mg_write(conn, buf + off, to_sent);
     if (ret < 0 || ! ret) {
       /* According to the documentation of mg_write() it always returns -1 on
        * error. The details aren't available, so we will just throw EIO. Same
        * goes to 0 that is associated with writing to a closed connection. */
       throw rgw::io::Exception(EIO, std::system_category());
     } else {
+      off += static_cast<size_t>(ret);
       to_sent -= static_cast<size_t>(ret);
     }
   }


### PR DESCRIPTION
Incomplete data transmission and incorrect data re-transmission

Signed-off-by: 李纲彬82225 <82225@sangfor.com>