### PR TITLE
test/cls_rbd/test_cls_rbd: update TestClsRbd.sparsify

### DIFF
--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -3141,13 +3141,20 @@ TEST_F(TestClsRbd, sparsify)
   ASSERT_EQ(0, sparsify(&ioctx, oid, 16, false));
   std::map<uint64_t, uint64_t> m;
   bufferlist outbl;
-  std::map<uint64_t, uint64_t> expected_m = {{0, 0}};
+  std::map<uint64_t, uint64_t> expected_m;
   bufferlist expected_outbl;
-  if (sparse_read_supported) {
+  switch (int r = ioctx.sparse_read(oid, m, outbl, inbl.length(), 0); r) {
+  case 0:
     expected_m = {};
+    ASSERT_EQ(expected_m, m);
+    break;
+  case 1:
+    expected_m = {{0, 0}};
+    ASSERT_EQ(expected_m, m);
+    break;
+  default:
+    FAIL() << r << " is odd";
   }
-  ASSERT_EQ((int)expected_m.size(),
-            ioctx.sparse_read(oid, m, outbl, inbl.length(), 0));
   ASSERT_EQ(m, expected_m);
   ASSERT_EQ(0, sparsify(&ioctx, oid, 16, true));
   ASSERT_EQ(-ENOENT, sparsify(&ioctx, oid, 16, true));


### PR DESCRIPTION
after #30061, extents returned by sparse read will always be
an empty map as long as the extents to be read is empty or the extent(s)
in it are empty, even of the objectstorage does not support sparse read.

Fixes: https://tracker.ceph.com/issues/41721
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
