### PR TITLE
nautilus: build/ops: fix build fail related to PYTHON_EXECUTABLE variable

### DIFF
--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -325,7 +325,7 @@
 /* Define if endian type is little endian */
 #cmakedefine CEPH_LITTLE_ENDIAN
 
-#cmakedefine PYTHON_EXECUTABLE "@MGR_PYTHON_EXECUTABLE@"
+#cmakedefine MGR_PYTHON_EXECUTABLE "@MGR_PYTHON_EXECUTABLE@"
 
 /* Define to 1 if you have the `getprogname' function. */
 #cmakedefine HAVE_GETPROGNAME 1

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -41,10 +41,10 @@ void PyModuleRegistry::init()
   // Set up global python interpreter
 #if PY_MAJOR_VERSION >= 3
 #define WCHAR(s) L ## #s
-  Py_SetProgramName(const_cast<wchar_t*>(WCHAR(PYTHON_EXECUTABLE)));
+  Py_SetProgramName(const_cast<wchar_t*>(WCHAR(MGR_PYTHON_EXECUTABLE)));
 #undef WCHAR
 #else
-  Py_SetProgramName(const_cast<char*>(PYTHON_EXECUTABLE));
+  Py_SetProgramName(const_cast<char*>(MGR_PYTHON_EXECUTABLE));
 #endif
   // Add more modules
   if (g_conf().get_val<bool>("daemonize")) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41724

---

backport of https://github.com/ceph/ceph/pull/30199
parent tracker: https://tracker.ceph.com/issues/41676

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh