### PR TITLE
mgr/orchestrator: Make Completions composable

### DIFF
--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -114,9 +114,9 @@ Completions and batching
 ------------------------
 
 All methods that read or modify the state of the system can potentially
-be long running.  To handle that, all such methods return a *completion*
-object (a *ReadCompletion* or a *WriteCompletion*).  Orchestrator modules
-must implement the *wait* method: this takes a list of completions, and
+be long running.  To handle that, all such methods return a *Completion*
+object.  Orchestrator modules
+must implement the *process* method: this takes a list of completions, and
 is responsible for checking if they're finished, and advancing the underlying
 operations as needed.
 
@@ -125,24 +125,21 @@ for completions.  This might involve running the underlying operations
 in threads, or batching the operations up before later executing
 in one go in the background.  If implementing such a batching pattern, the
 module would do no work on any operation until it appeared in a list
-of completions passed into *wait*.
+of completions passed into *process*.
 
-*WriteCompletion* objects have a two-stage execution.  First they become
-*persistent*, meaning that the write has made it to the orchestrator
-itself, and been persisted there (e.g. a manifest file has been updated).
-If ceph-mgr crashed at this point, the operation would still eventually take
-effect.  Second, the completion becomes *effective*, meaning that the operation has really happened (e.g. a service has actually been started).
+Some operations need to show a progress. Those operations need to add
+a *ProgressReference* to the completion. At some point, the progress reference
+becomes *effective*, meaning that the operation has really happened
+(e.g. a service has actually been started).
 
-.. automethod:: Orchestrator.wait
+.. automethod:: Orchestrator.process
 
-.. autoclass:: _Completion
+.. autoclass:: Completion
    :members:
 
-.. autoclass:: ReadCompletion
+.. autoclass:: ProgressReference
    :members:
 
-.. autoclass:: WriteCompletion
-   :members:
 
 Placement
 ---------
@@ -196,7 +193,7 @@ In detail, orchestrators need to explicitly deal with different kinds of errors:
 5. Errors when actually executing commands
 
    The resulting Completion should contain an error string that assists in understanding the
-   problem. In addition, :func:`_Completion.is_errored` is set to ``True``
+   problem. In addition, :func:`Completion.is_errored` is set to ``True``
 
 6. Invalid configuration in the orchestrator modules
 
@@ -205,7 +202,7 @@ In detail, orchestrators need to explicitly deal with different kinds of errors:
 
 All other errors are unexpected orchestrator issues and thus should raise an exception that are then
 logged into the mgr log file. If there is a completion object at that point,
-:func:`_Completion.result` may contain an error message.
+:func:`Completion.result` may contain an error message.
 
 
 Excluded functionality

--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -2,6 +2,7 @@ import errno
 import json
 import logging
 from tempfile import NamedTemporaryFile
+from time import sleep
 
 from teuthology.exceptions import CommandFailedError
 
@@ -180,6 +181,7 @@ class TestOrchestratorCli(MgrTestCase):
         evs = json.loads(self._progress_cmd('json'))['completed']
         self.assertEqual(len(evs), 0)
         self._orch_cmd("mgr", "update", "4")
+        sleep(6)  # There is a sleep(5) in the test_orchestrator.module.serve()
         evs = json.loads(self._progress_cmd('json'))['completed']
         self.assertEqual(len(evs), 1)
         self.assertIn('update_mgrs', evs[0]['message'])

--- a/src/pybind/mgr/ansible/ansible_runner_svc.py
+++ b/src/pybind/mgr/ansible/ansible_runner_svc.py
@@ -6,8 +6,13 @@ import json
 import re
 from functools import wraps
 import collections
+import logging
+from typing import Optional
 
 import requests
+from orchestrator import OrchestratorError
+
+logger = logging.getLogger(__name__)
 
 # Ansible Runner service API endpoints
 API_URL = "api"
@@ -17,7 +22,7 @@ EVENT_DATA_URL = "api/v1/jobs/%s/events/%s"
 URL_MANAGE_GROUP = "api/v1/groups/{group_name}"
 URL_ADD_RM_HOSTS = "api/v1/hosts/{host_name}/groups/{inventory_group}"
 
-class AnsibleRunnerServiceError(Exception):
+class AnsibleRunnerServiceError(OrchestratorError):
     """Generic Ansible Runner Service Exception"""
     pass
 
@@ -46,9 +51,12 @@ class PlayBookExecution(object):
     """Object to provide all the results of a Playbook execution
     """
 
-    def __init__(self, rest_client, playbook, logger, result_pattern="",
-                 the_params=None,
-                 querystr_dict=None):
+    def __init__(self, rest_client,  # type: Client
+                 playbook,  # type: str
+                 result_pattern="",  # type: str
+                 the_params=None,  # type: Optional[dict]
+                 querystr_dict=None  # type: Optional[dict]
+                 ):
 
         self.rest_client = rest_client
 
@@ -67,9 +75,6 @@ class PlayBookExecution(object):
         # Query string used in the "launch" request
         self.querystr_dict = querystr_dict
 
-        # Logger
-        self.log = logger
-
     def launch(self):
         """ Launch the playbook execution
         """
@@ -82,7 +87,7 @@ class PlayBookExecution(object):
                                                   self.params,
                                                   self.querystr_dict)
         except AnsibleRunnerServiceError:
-            self.log.exception("Error launching playbook <%s>", self.playbook)
+            logger.exception("Error launching playbook <%s>", self.playbook)
             raise
 
         # Here we have a server response, but an error trying
@@ -91,7 +96,7 @@ class PlayBookExecution(object):
         # to the orchestrator (via completion object)
         if response.ok:
             self.play_uuid = json.loads(response.text)["data"]["play_uuid"]
-            self.log.info("Playbook execution launched succesfuly")
+            logger.info("Playbook execution launched succesfuly")
         else:
             raise AnsibleRunnerServiceError(response.reason)
 
@@ -117,7 +122,7 @@ class PlayBookExecution(object):
             try:
                 response = self.rest_client.http_get(endpoint)
             except AnsibleRunnerServiceError:
-                self.log.exception("Error getting playbook <%s> status",
+                logger.exception("Error getting playbook <%s> status",
                                    self.playbook)
 
             if response:
@@ -131,7 +136,7 @@ class PlayBookExecution(object):
             else:
                 status_value = ExecutionStatusCode.ERROR
 
-        self.log.info("Requested playbook execution status is: %s", status_value)
+        logger.info("Requested playbook execution status is: %s", status_value)
         return status_value
 
     def get_result(self, event_filter):
@@ -148,7 +153,7 @@ class PlayBookExecution(object):
         try:
             response = self.rest_client.http_get(PLAYBOOK_EVENTS % self.play_uuid)
         except AnsibleRunnerServiceError:
-            self.log.exception("Error getting playbook <%s> result", self.playbook)
+            logger.exception("Error getting playbook <%s> result", self.playbook)
 
         if not response:
             result_events = {}
@@ -170,7 +175,7 @@ class PlayBookExecution(object):
                 result_events = {event:data for event, data in result_events.items()
                                  if re.match(type_of_events, data['event'])}
 
-        self.log.info("Requested playbook result is: %s", json.dumps(result_events))
+        logger.info("Requested playbook result is: %s", json.dumps(result_events))
         return result_events
 
 class Client(object):
@@ -178,8 +183,13 @@ class Client(object):
     and execute easily playbooks
     """
 
-    def __init__(self, server_url, verify_server, ca_bundle, client_cert,
-                 client_key, logger):
+    def __init__(self,
+                 server_url,  # type: str
+                 verify_server,  # type: bool
+                 ca_bundle,  # type: str
+                 client_cert, # type: str
+                 client_key  # type: str
+                 ):
         """Provide an https client to make easy interact with the Ansible
         Runner Service"
 
@@ -194,17 +204,15 @@ class Client(object):
                             file
         :param client_key: Path to Ansible Runner Service client certificate key
                            file
-        :param logger: Log file
         """
         self.server_url = server_url
-        self.log = logger
         self.client_cert = (client_cert, client_key)
 
         # used to provide the "verify" parameter in requests
         # a boolean that sometimes contains a string :-(
         self.verify_server = verify_server
         if ca_bundle: # This intentionallly overwrites
-            self.verify_server = ca_bundle
+            self.verify_server = ca_bundle  # type: ignore
 
         self.server_url = "https://{0}".format(self.server_url)
 
@@ -238,11 +246,11 @@ class Client(object):
                                 headers={})
 
         if response.status_code != requests.codes.ok:
-            self.log.error("http GET %s <--> (%s - %s)\n%s",
+            logger.error("http GET %s <--> (%s - %s)\n%s",
                            the_url, response.status_code, response.reason,
                            response.text)
         else:
-            self.log.info("http GET %s <--> (%s - %s)",
+            logger.info("http GET %s <--> (%s - %s)",
                           the_url, response.status_code, response.text)
 
         return response
@@ -267,11 +275,11 @@ class Client(object):
                                  params=params_dict)
 
         if response.status_code != requests.codes.ok:
-            self.log.error("http POST %s [%s] <--> (%s - %s:%s)\n",
+            logger.error("http POST %s [%s] <--> (%s - %s:%s)\n",
                            the_url, payload, response.status_code,
                            response.reason, response.text)
         else:
-            self.log.info("http POST %s <--> (%s - %s)",
+            logger.info("http POST %s <--> (%s - %s)",
                           the_url, response.status_code, response.text)
 
         return response
@@ -292,11 +300,11 @@ class Client(object):
                                    headers={})
 
         if response.status_code != requests.codes.ok:
-            self.log.error("http DELETE %s <--> (%s - %s)\n%s",
+            logger.error("http DELETE %s <--> (%s - %s)\n%s",
                            the_url, response.status_code, response.reason,
                            response.text)
         else:
-            self.log.info("http DELETE %s <--> (%s - %s)",
+            logger.info("http DELETE %s <--> (%s - %s)",
                           the_url, response.status_code, response.text)
 
         return response
@@ -400,6 +408,7 @@ class InventoryGroup(collections.MutableSet):
     """ Manages an Ansible Inventory Group
     """
     def __init__(self, group_name, ars_client):
+        # type: (str, Client) -> None
         """Init the group_name attribute and
            Create the inventory group if it does not exist
 

--- a/src/pybind/mgr/ansible/ansible_runner_svc.py
+++ b/src/pybind/mgr/ansible/ansible_runner_svc.py
@@ -7,7 +7,10 @@ import re
 from functools import wraps
 import collections
 import logging
-from typing import Optional
+try:
+    from typing import Optional
+except ImportError:
+    pass # just for type checking
 
 import requests
 from orchestrator import OrchestratorError

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -10,8 +10,12 @@ import json
 import os
 import errno
 import tempfile
-from typing import List, Any, Optional, Callable, Tuple, TypeVar
-T = TypeVar('T')
+
+try:
+    from typing import List, Optional, Callable
+except ImportError:
+    pass # just for type checking
+
 
 import requests
 
@@ -66,7 +70,7 @@ URL_GET_HOSTS = "api/v1/hosts"
 
 
 def deferred(f):
-    # type: (Callable[..., T]) -> Callable[..., orchestrator.Completion[T]]
+    # type: (Callable) -> Callable[..., orchestrator.Completion]
     """
     Decorator to make RookOrchestrator methods return
     a completion object that executes themselves.

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -475,7 +475,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         return (available, msg)
 
-    def wait(self, completions):
+    def process(self, completions):
         """Given a list of Completion instances, progress any which are
            incomplete.
 
@@ -487,13 +487,6 @@ class Module(MgrModule, orchestrator.Orchestrator):
         # Access completion.status property do the trick
         for operation in completions:
             self.log.info("<%s> status:%s", operation, operation.status)
-
-        completions = filter(lambda x: not x.is_complete, completions)
-
-        ops_pending = len(completions)
-        self.log.info("Operations pending: %s", ops_pending)
-
-        return ops_pending == 0
 
     def serve(self):
         """ Mandatory for standby modules

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -5,11 +5,14 @@ The external Orchestrator is the Ansible runner service (RESTful https service)
 """
 
 # pylint: disable=abstract-method, no-member, bad-continuation
-
+import functools
 import json
 import os
 import errno
 import tempfile
+from typing import List, Any, Optional, Callable, Tuple, TypeVar
+T = TypeVar('T')
+
 import requests
 
 from mgr_module import MgrModule, Option, CLIWriteCommand
@@ -21,7 +24,9 @@ from .ansible_runner_svc import Client, PlayBookExecution, ExecutionStatusCode,\
                                 URL_MANAGE_GROUP, URL_ADD_RM_HOSTS
 
 from .output_wizards import ProcessInventory, ProcessPlaybookResult, \
-                            ProcessHostsList
+                            ProcessHostsList, OutputWizard
+
+
 
 # Time to clean the completions list
 WAIT_PERIOD = 10
@@ -59,366 +64,158 @@ URL_GET_HOST_GROUPS = "api/v1/hosts/{host_name}"
 URL_GET_HOSTS = "api/v1/hosts"
 
 
-class AnsibleReadOperation(orchestrator.ReadCompletion):
-    """ A read operation means to obtain information from the cluster.
+
+def deferred(f):
+    # type: (Callable[..., T]) -> Callable[..., orchestrator.Completion[T]]
     """
-    def __init__(self, client, logger):
-        """
-        :param client        : Ansible Runner Service Client
-        :param logger        : The object used to log messages
-        """
-        super(AnsibleReadOperation, self).__init__()
-
-        # Private attributes
-        self._is_complete = False
-        self._is_errored = False
-        self._result = []
-        self._status = ExecutionStatusCode.NOT_LAUNCHED
-
-        # Object used to process operation result in different ways
-        self.output_wizard = None
-
-        # Error description in operation
-        self.error = ""
-
-        # Ansible Runner Service client
-        self.ar_client = client
-
-        # Logger
-        self.log = logger
-
-    def __str__(self):
-        return "Playbook {playbook_name}".format(playbook_name=self.playbook)
-
-    @property
-    def has_result(self):
-        return self._is_complete
-
-    @property
-    def is_errored(self):
-        return self._is_errored
-
-    @property
-    def result(self):
-        return self._result
-
-    @property
-    def status(self):
-        """Retrieve the current status of the operation and update state
-        attributes
-        """
-        raise NotImplementedError()
-
-class ARSOperation(AnsibleReadOperation):
-    """Execute an Ansible Runner Service Operation
+    Decorator to make RookOrchestrator methods return
+    a completion object that executes themselves.
     """
 
-    def __init__(self, client, logger, url, get_operation=True, payload=None):
-        """
-        :param client        : Ansible Runner Service Client
-        :param logger        : The object used to log messages
-        :param url           : The Ansible Runner Service URL that provides
-                               the operation
-        :param get_operation : True if operation is provided using an http GET
-        :param payload       : http request payload
-        """
-        super(ARSOperation, self).__init__(client, logger)
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return orchestrator.Completion(on_complete=lambda _: f(*args, **kwargs))
 
-        self.url = url
-        self.get_operation = get_operation
-        self.payload = payload
-
-    def __str__(self):
-        return "Ansible Runner Service: {operation} {url}".format(
-                    operation="GET" if self.get_operation else "POST",
-                    url=self.url)
-
-    @property
-    def status(self):
-        """ Execute the Ansible Runner Service operation and update the status
-        and result of the underlying Completion object.
-        """
-
-        # Execute the right kind of http request
-        if self.get_operation:
-            response = self.ar_client.http_get(self.url)
-        else:
-            response = self.ar_client.http_post(self.url, self.payload)
-
-        # If no connection errors, the operation is complete
-        self._is_complete = True
-
-        # Depending of the response, status and result is updated
-        if not response:
-            self._is_errored = True
-            self._status = ExecutionStatusCode.ERROR
-            self._result = "Ansible Runner Service not Available"
-        else:
-            self._is_errored = (response.status_code != requests.codes.ok)
-
-            if not self._is_errored:
-                self._status = ExecutionStatusCode.SUCCESS
-                if self.output_wizard:
-                    self._result = self.output_wizard.process(self.url,
-                                                              response.text)
-                else:
-                    self._result = response.text
-            else:
-                self._status = ExecutionStatusCode.ERROR
-                self._result = response.reason
-
-        return self._status
+    return wrapper
 
 
-class PlaybookOperation(AnsibleReadOperation):
-    """Execute a playbook using the Ansible Runner Service
+def clean_inventory(ar_client, clean_hosts_on_success):
+    # type: (Client, dict) -> None
+    """ Remove hosts from inventory groups
     """
 
-    def __init__(self, client, playbook, logger, result_pattern,
-                 params,
-                 querystr_dict={}):
-        """
-        :param client        : Ansible Runner Service Client
-        :param playbook      : The playbook to execute
-        :param logger        : The object used to log messages
-        :param result_pattern: The "pattern" to discover what execution events
-                               have the information deemed as result
-        :param params        : http request payload for the playbook execution
-        :param querystr_dict : http request querystring for the playbook
-                               execution (DO NOT MODIFY HERE)
+    for group, hosts in clean_hosts_on_success.items():
+        InventoryGroup(group, ar_client).clean(hosts)
 
-        """
-        super(PlaybookOperation, self).__init__(client, logger)
 
-       # Private attributes
-        self.playbook = playbook
+def playbook_operation(client,  # type: Client
+                       playbook,  # type: str
+                       result_pattern,  # type: str
+                       params,  # type: dict
+                       event_filter_list=None,  # type: Optional[List[str]]
+                       querystr_dict=None,  # type: Optional[dict]
+                       output_wizard=None,  # type: Optional[OutputWizard]
+                       clean_hosts_on_success=None  # type: Optional[dict]
+                       ):
+    # type: (...) -> orchestrator.Completion
+    """
+    :param client        : Ansible Runner Service Client
+    :param playbook      : The playbook to execute
+    :param result_pattern: The "pattern" to discover what execution events
+                           have the information deemed as result
+    :param params        : http request payload for the playbook execution
+    :param querystr_dict : http request querystring for the playbook
+                           execution (DO NOT MODIFY HERE)
+    :param event_filter_list: An aditional filter of result events based in the event
+    :param clean_hosts_on_success: A dict with groups and hosts to remove from inventory if operation is
+        succesful. Ex: {"group1": ["host1"], "group2": ["host3", "host4"]}
+    """
 
-        # An aditional filter of result events based in the event
-        self.event_filter_list = [""]
+    querystr_dict = querystr_dict or {}
+    event_filter_list = event_filter_list or [""]
+    clean_hosts_on_success = clean_hosts_on_success or {}
 
-        # A dict with groups and hosts to remove from inventory if operation is
-        # succesful. Ex: {"group1": ["host1"], "group2": ["host3", "host4"]}
-        self.clean_hosts_on_success = {}
-
-        # Playbook execution object
-        self.pb_execution = PlayBookExecution(client,
-                                              playbook,
-                                              logger,
-                                              result_pattern,
-                                              params,
-                                              querystr_dict)
-
-    def __str__(self):
-        return "Playbook {playbook_name}".format(playbook_name=self.playbook)
-
-    @property
-    def status(self):
+    def status(_):
         """Check the status of the playbook execution and update the status
         and result of the underlying Completion object.
         """
 
-        if self._status in [ExecutionStatusCode.ON_GOING,
-                            ExecutionStatusCode.NOT_LAUNCHED]:
-            self._status = self.pb_execution.get_status()
+        status = pb_execution.get_status()
 
-        self._is_complete = (self._status == ExecutionStatusCode.SUCCESS) or \
-                            (self._status == ExecutionStatusCode.ERROR)
+        if status in (ExecutionStatusCode.SUCCESS, ExecutionStatusCode.ERROR):
+            if status == ExecutionStatusCode.ERROR:
+                raw_result = pb_execution.get_result(["runner_on_failed",
+                                                      "runner_on_unreachable",
+                                                      "runner_on_no_hosts",
+                                                      "runner_on_async_failed",
+                                                      "runner_item_on_failed"])
+            else:
+                raw_result = pb_execution.get_result(event_filter_list)
 
-        self._is_errored = (self._status == ExecutionStatusCode.ERROR)
-
-        if self._is_complete:
-            self.update_result()
+            if output_wizard:
+                processed_result = output_wizard.process(pb_execution.play_uuid,
+                                                         raw_result)
+            else:
+                processed_result = raw_result
 
             # Clean hosts if operation is succesful
-            if self._status == ExecutionStatusCode.SUCCESS:
-                self.clean_inventory()
+            if status == ExecutionStatusCode.SUCCESS:
+                clean_inventory(client, clean_hosts_on_success)
 
-        return self._status
-
-    def execute_playbook(self):
-        """Launch the execution of the playbook with the parameters configured
-        """
-        try:
-            self.pb_execution.launch()
-        except AnsibleRunnerServiceError:
-            self._status = ExecutionStatusCode.ERROR
-            raise
-
-    def update_result(self):
-        """Output of the read operation
-
-        The result of the playbook execution can be customized through the
-        function provided as 'process_output' attribute
-
-        :return string: Result of the operation formatted if it is possible
-        """
-
-        processed_result = []
-
-        if self._is_errored:
-            raw_result = self.pb_execution.get_result(["runner_on_failed",
-                                                       "runner_on_unreachable",
-                                                       "runner_on_no_hosts",
-                                                       "runner_on_async_failed",
-                                                       "runner_item_on_failed"])
-        elif self._is_complete:
-            raw_result = self.pb_execution.get_result(self.event_filter_list)
-
-        if self.output_wizard:
-            processed_result = self.output_wizard.process(self.pb_execution.play_uuid,
-                                                          raw_result)
+            return processed_result
         else:
-            processed_result = raw_result
+            return orchestrator.Completion(on_complete=status)
 
-        self._result = processed_result
+    pb_execution = PlayBookExecution(client, playbook, result_pattern, params, querystr_dict)
 
-    def clean_inventory(self):
-        """ Remove hosts from inventory groups
-        """
-
-        for group, hosts in self.clean_hosts_on_success.items():
-            InventoryGroup(group, self.ar_client).clean(hosts)
-            del self.clean_hosts_on_success[group]
+    return orchestrator.Completion(on_complete=lambda _: pb_execution.launch()).then(status)
 
 
+def ars_http_operation(url, http_operation, payload="", params_dict=None):
+    def inner(ar_client):
+        # type: (Client) -> str
+        if http_operation == "post":
+            response = ar_client.http_post(url,
+                                           payload,
+                                           params_dict)
+        elif http_operation == "delete":
+            response = ar_client.http_delete(url)
+        elif http_operation == "get":
+            response = ar_client.http_get(url)
+        else:
+            assert False, http_operation
 
-class AnsibleChangeOperation(orchestrator.WriteCompletion):
-    """Operations that changes the "cluster" state
+        # Any problem executing the secuence of operations will
+        # produce an errored completion object.
+        try:
+            response.raise_for_status()
+        except Exception as e:
+            raise AnsibleRunnerServiceError(str(e))
 
-    Modifications/Changes (writes) are a two-phase thing, firstly execute
-    the playbook that is going to change elements in the Ceph Cluster.
-    When the playbook finishes execution (independently of the result),
-    the modification/change operation has finished.
+        return response.text
+    return inner
+
+
+@deferred
+def ars_change(client, operations, output_wizard=None):
+    # type: (Client, List[Callable[[Client], str]], Optional[OutputWizard]) -> str
     """
-    def __init__(self):
-        super(AnsibleChangeOperation, self).__init__()
-
-        self._status = ExecutionStatusCode.NOT_LAUNCHED
-        self._result = None
-
-        # Object used to process operation result in different ways
-        self.output_wizard = None
-
-    @property
-    def status(self):
-        """Return the status code of the operation
-        """
-        raise NotImplementedError()
-
-    @property
-    def has_result(self):
-        """
-        Has the operation updated the orchestrator's configuration
-        persistently?  Typically this would indicate that an update
-        had been written to a manifest, but that the update
-        had not necessarily been pushed out to the cluster.
-
-        :return Boolean: True if the execution of the Ansible Playbook or the
-                         operation over the Ansible Runner Service has finished
-        """
-
-        return self._status in [ExecutionStatusCode.SUCCESS,
-                                ExecutionStatusCode.ERROR]
-
-    @property
-    def is_effective(self):
-        """Has the operation taken effect on the cluster?
-        For example, if we were adding a service, has it come up and appeared
-        in Ceph's cluster maps?
-
-        In the case of Ansible, this will be True if the playbooks has been
-        executed succesfully.
-
-        :return Boolean: if the playbook/ARS operation has been executed
-                         succesfully
-        """
-
-        return self._status == ExecutionStatusCode.SUCCESS
-
-    @property
-    def is_errored(self):
-        return self._status == ExecutionStatusCode.ERROR
-
-    @property
-    def result(self):
-        return self._result
-
-class HttpOperation(object):
-    """A class to ease the management of http operations
-    """
-
-    def __init__(self, url, http_operation, payload="", query_string="{}"):
-        self.url = url
-        self.http_operation = http_operation
-        self.payload = payload
-        self.query_string = query_string
-        self.response = None
-
-class ARSChangeOperation(AnsibleChangeOperation):
-    """Execute one or more Ansible Runner Service Operations that implies
+    Execute one or more Ansible Runner Service Operations that implies
     a change in the cluster
+
+    :param client         : Ansible Runner Service Client
+    :param operations     : A list of http_operation objects
+
+    Execute the Ansible Runner Service operations and update the status
+    and result of the underlying Completion object.
     """
-    def __init__(self, client, logger, operations):
-        """
-        :param client         : Ansible Runner Service Client
-        :param logger         : The object used to log messages
-        :param operations     : A list of http_operation objects
-        :param payload        : dict with http request payload
-        """
-        super(ARSChangeOperation, self).__init__()
 
-        assert operations, "At least one operation is needed"
-        self.ar_client = client
-        self.log = logger
-        self.operations = operations
-
-    def __str__(self):
-        # Use the last operation as the main
-        return "Ansible Runner Service: {operation} {url}".format(
-                                operation=self.operations[-1].http_operation,
-                                url=self.operations[-1].url)
-
-    @property
-    def status(self):
-        """Execute the Ansible Runner Service operations and update the status
-        and result of the underlying Completion object.
-        """
-
-        for my_request in self.operations:
-            # Execute the right kind of http request
-            try:
-                if my_request.http_operation == "post":
-                    response = self.ar_client.http_post(my_request.url,
-                                                        my_request.payload,
-                                                        my_request.query_string)
-                elif my_request.http_operation == "delete":
-                    response = self.ar_client.http_delete(my_request.url)
-                elif my_request.http_operation == "get":
-                    response = self.ar_client.http_get(my_request.url)
-
-                # Any problem executing the secuence of operations will
-                # produce an errored completion object.
-                if response.status_code != requests.codes.ok:
-                    self._status = ExecutionStatusCode.ERROR
-                    self._result = response.text
-                    return self._status
-
-            # Any kind of error communicating with ARS or preventing
-            # to have a right http response
-            except AnsibleRunnerServiceError as ex:
-                self._status = ExecutionStatusCode.ERROR
-                self._result = str(ex)
-                return self._status
-
+    out = None
+    for my_request in operations:
+        # Execute the right kind of http request
+        out = my_request(client)
         # If this point is reached, all the operations has been succesfuly
         # executed, and the final result is updated
-        self._status = ExecutionStatusCode.SUCCESS
-        if self.output_wizard:
-            self._result = self.output_wizard.process("", response.text)
-        else:
-            self._result = response.text
+    assert out is not None
+    if output_wizard:
+        return output_wizard.process("", out)
+    else:
+        return out
 
-        return self._status
+
+def ars_read(client, url, get_operation=True, payload=None, output_wizard=None):
+    # type: (Client, str, bool, Optional[str], Optional[OutputWizard]) -> orchestrator.Completion[str]
+    """
+    Execute the Ansible Runner Service operation
+
+    :param client        : Ansible Runner Service Client
+    :param url           : The Ansible Runner Service URL that provides
+                           the operation
+    :param get_operation : True if operation is provided using an http GET
+    :param payload       : http request payload
+    """
+    return ars_change(client, [ars_http_operation(url, 'get' if get_operation else 'post', payload)], output_wizard)
+
 
 class Module(MgrModule, orchestrator.Orchestrator):
     """An Orchestrator that uses <Ansible Runner Service> to perform operations
@@ -440,7 +237,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         self.all_completions = []
 
-        self.ar_client = None
+        self.ar_client = None  # type: Client
 
         # TLS certificate and key file names used to connect with the external
         # Ansible Runner Service
@@ -449,6 +246,9 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         # used to provide more verbose explanation of errors in status method
         self.status_message = ""
+
+        self.all_progress_references = list()  # type: List[orchestrator.ProgressReference]
+
 
     def available(self):
         """ Check if Ansible Runner service is working
@@ -486,7 +286,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
         # Check progress and update status in each operation
         # Access completion.status property do the trick
         for operation in completions:
-            self.log.info("<%s> status:%s", operation, operation.status)
+            self.log.info("<%s> is_finished:%s", operation, operation.is_finished)
 
     def serve(self):
         """ Mandatory for standby modules
@@ -503,8 +303,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
                 verify_server=self.get_module_option('verify_server', True),
                 ca_bundle=self.get_module_option('ca_bundle', ''),
                 client_cert=self.client_cert_fname,
-                client_key=self.client_key_fname,
-                logger=self.log)
+                client_key=self.client_key_fname)
 
         except AnsibleRunnerServiceError:
             self.log.exception("Ansible Runner Service not available. "
@@ -530,54 +329,41 @@ class Module(MgrModule, orchestrator.Orchestrator):
         """
 
         # Create a new read completion object for execute the playbook
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=GET_STORAGE_DEVICES_CATALOG_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="list storage inventory",
-                                               params={})
+        op = playbook_operation(client=self.ar_client,
+                                playbook=GET_STORAGE_DEVICES_CATALOG_PLAYBOOK,
+                                result_pattern="list storage inventory",
+                                params={},
+                                output_wizard=ProcessInventory(self.ar_client),
+                                event_filter_list=["runner_on_ok"])
 
+        self._launch_operation(op)
 
-        # Assign the process_output function
-        playbook_operation.output_wizard = ProcessInventory(self.ar_client,
-                                                            self.log)
-        playbook_operation.event_filter_list = ["runner_on_ok"]
+        return op
 
-        # Execute the playbook to obtain data
-        self._launch_operation(playbook_operation)
-
-        return playbook_operation
-
-    def create_osds(self, drive_group, all_hosts):
+    def create_osds(self, drive_group):
         """Create one or more OSDs within a single Drive Group.
         If no host provided the operation affects all the host in the OSDS role
 
 
         :param drive_group: (ceph.deployment.drive_group.DriveGroupSpec),
                             Drive group with the specification of drives to use
-        :param all_hosts  : (List[str]),
-                            List of hosts where the OSD's must be created
         """
 
         # Transform drive group specification to Ansible playbook parameters
         host, osd_spec = dg_2_ansible(drive_group)
 
         # Create a new read completion object for execute the playbook
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=ADD_OSD_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="",
-                                               params=osd_spec,
-                                               querystr_dict={"limit": host})
+        op = playbook_operation(client=self.ar_client,
+                                playbook=ADD_OSD_PLAYBOOK,
+                                result_pattern="",
+                                params=osd_spec,
+                                querystr_dict={"limit": host},
+                                output_wizard=ProcessPlaybookResult(self.ar_client),
+                                event_filter_list=["playbook_on_stats"])
 
-        # Filter to get the result
-        playbook_operation.output_wizard = ProcessPlaybookResult(self.ar_client,
-                                                                  self.log)
-        playbook_operation.event_filter_list = ["playbook_on_stats"]
+        self._launch_operation(op)
 
-        # Execute the playbook
-        self._launch_operation(playbook_operation)
-
-        return playbook_operation
+        return op
 
     def remove_osds(self, osd_ids, destroy=False):
         """Remove osd's.
@@ -591,32 +377,24 @@ class Module(MgrModule, orchestrator.Orchestrator):
                      'ireallymeanit':'yes'}
 
         # Create a new read completion object for execute the playbook
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=REMOVE_OSD_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="",
-                                               params=extravars)
-
-        # Filter to get the result
-        playbook_operation.output_wizard = ProcessPlaybookResult(self.ar_client,
-                                                                 self.log)
-        playbook_operation.event_filter_list = ["playbook_on_stats"]
-
+        op = playbook_operation(client=self.ar_client,
+                                playbook=REMOVE_OSD_PLAYBOOK,
+                                result_pattern="",
+                                params=extravars,
+                                output_wizard=ProcessPlaybookResult(self.ar_client),
+                                event_filter_list=["playbook_on_stats"])
 
         # Execute the playbook
-        self._launch_operation(playbook_operation)
+        self._launch_operation(op)
 
-        return playbook_operation
+        return op
 
     def get_hosts(self):
         """Provides a list Inventory nodes
         """
 
-        host_ls_op = ARSOperation(self.ar_client, self.log, URL_GET_HOSTS)
-
-        host_ls_op.output_wizard = ProcessHostsList(self.ar_client,
-                                                    self.log)
-
+        host_ls_op = ars_read(self.ar_client, url=URL_GET_HOSTS,
+                              output_wizard=ProcessHostsList(self.ar_client))
         return host_ls_op
 
     def add_host(self, host):
@@ -625,7 +403,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
         group
 
         :param host: hostname
-        :returns : orchestrator.WriteCompletion
+        :returns : orchestrator.Completion
         """
 
         url_group = URL_MANAGE_GROUP.format(group_name=ORCHESTRATOR_GROUP)
@@ -640,16 +418,16 @@ class Module(MgrModule, orchestrator.Orchestrator):
             add_url = URL_ADD_RM_HOSTS.format(host_name=host,
                                               inventory_group=ORCHESTRATOR_GROUP)
 
-            operations = [HttpOperation(add_url, "post", "", None)]
+            operations = [ars_http_operation(add_url, "post", "", None)]
 
         except AnsibleRunnerServiceError as ex:
             # Problems with the external orchestrator.
             # Prepare the operation to return the error in a Completion object.
             self.log.exception("Error checking <orchestrator> group: %s",
                                str(ex))
-            operations = [HttpOperation(url_group, "post", "", None)]
+            operations = [ars_http_operation(url_group, "post", "", None)]
 
-        return ARSChangeOperation(self.ar_client, self.log, operations)
+        return ars_change(self.ar_client, operations)
 
     def remove_host(self, host):
         """
@@ -657,10 +435,9 @@ class Module(MgrModule, orchestrator.Orchestrator):
         inventory.
 
         :param host: hostname
-        :returns : orchestrator.WriteCompletion
+        :returns : orchestrator.Completion
         """
 
-        operations = []
         host_groups = []
 
         try:
@@ -673,25 +450,26 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         except AnsibleRunnerServiceError:
             self.log.exception("Error retrieving host groups")
+            raise
 
         if not host_groups:
             # Error retrieving the groups, prepare the completion object to
             # execute the problematic operation just to provide the error
             # to the caller
-            operations = [HttpOperation(groups_url, "get")]
+            operations = [ars_http_operation(groups_url, "get")]
         else:
             # Build the operations list
             operations = list(map(lambda x:
-                                  HttpOperation(URL_ADD_RM_HOSTS.format(
-                                                    host_name=host,
-                                                    inventory_group=x),
-                                                "delete"),
+                                  ars_http_operation(URL_ADD_RM_HOSTS.format(
+                                      host_name=host,
+                                      inventory_group=x),
+                                      "delete"),
                                   host_groups))
 
-        return ARSChangeOperation(self.ar_client, self.log, operations)
+        return ars_change(self.ar_client, operations)
 
     def add_rgw(self, spec):
-        # type: (orchestrator.RGWSpec) -> PlaybookOperation
+        # type: (orchestrator.RGWSpec) -> orchestrator.Completion
         """ Add a RGW service in the cluster
 
         : spec        : an Orchestrator.RGWSpec object
@@ -743,31 +521,26 @@ class Module(MgrModule, orchestrator.Orchestrator):
         resource_group = "rgw_zone_{}".format(spec.name)
         InventoryGroup(resource_group, self.ar_client).update(hosts)
 
-
         # Execute the playbook to create the service
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=SITE_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="",
-                                               params=extravars,
-                                               querystr_dict={"limit": limited})
-
-        # Filter to get the result
-        playbook_operation.output_wizard = ProcessPlaybookResult(self.ar_client,
-                                                                 self.log)
-        playbook_operation.event_filter_list = ["playbook_on_stats"]
+        op = playbook_operation(client=self.ar_client,
+                                playbook=SITE_PLAYBOOK,
+                                result_pattern="",
+                                params=extravars,
+                                querystr_dict={"limit": limited},
+                                output_wizard=ProcessPlaybookResult(self.ar_client),
+                                event_filter_list=["playbook_on_stats"])
 
         # Execute the playbook
-        self._launch_operation(playbook_operation)
+        self._launch_operation(op)
 
-        return playbook_operation
+        return op
 
     def remove_rgw(self, zone):
         """ Remove a RGW service providing <zone>
 
-        :zone : <zone name> of the RGW
+        :param zone: <zone name> of the RGW
                             ...
-        : returns    : Completion object
+        :returns    : Completion object
         """
 
 
@@ -784,30 +557,25 @@ class Module(MgrModule, orchestrator.Orchestrator):
         # Avoid manual confirmation
         extravars = {"ireallymeanit": "yes"}
 
-        # Execute the playbook to remove the service
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=PURGE_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="",
-                                               params=extravars,
-                                               querystr_dict={"limit": limited})
-
-        # Filter to get the result
-        playbook_operation.output_wizard = ProcessPlaybookResult(self.ar_client,
-                                                                 self.log)
-        playbook_operation.event_filter_list = ["playbook_on_stats"]
-
         # Cleaning of inventory after a sucessful operation
         clean_inventory = {}
         clean_inventory[resource_group] = hosts_list
         clean_inventory[group] = hosts_list
-        playbook_operation.clean_hosts_on_success = clean_inventory
+
+        # Execute the playbook to remove the service
+        op = playbook_operation(client=self.ar_client,
+                                               playbook=PURGE_PLAYBOOK,
+                                               result_pattern="",
+                                               params=extravars,
+                                               querystr_dict={"limit": limited},
+                                output_wizard=ProcessPlaybookResult(self.ar_client),
+                                event_filter_list=["playbook_on_stats"],
+                                clean_hosts_on_success=clean_inventory)
 
         # Execute the playbook
-        self.log.info("Removing service rgw for resource %s", zone)
-        self._launch_operation(playbook_operation)
+        self._launch_operation(op)
 
-        return playbook_operation
+        return op
 
     def _launch_operation(self, ansible_operation):
         """Launch the operation and add the operation to the completion objects
@@ -815,9 +583,6 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         :ansible_operation: A read/write ansible operation (completion object)
         """
-
-        # Execute the playbook
-        ansible_operation.execute_playbook()
 
         # Add the operation to the list of things ongoing
         self.all_completions.append(ansible_operation)
@@ -837,7 +602,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
         if the_crt is None or the_key is None:
             # If not possible... try to get generic certificates and key content
             # ex: mgr/ansible/[crt/key]
-            self.log.warning("Specific tls files for this manager not "\
+            self.log.warning("Specific tls files for this manager not "
                              "configured, trying to use generic files")
             the_crt = self.get_store("crt")
             the_key = self.get_store("key")

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -91,7 +91,7 @@ class AnsibleReadOperation(orchestrator.ReadCompletion):
         return "Playbook {playbook_name}".format(playbook_name=self.playbook)
 
     @property
-    def is_complete(self):
+    def has_result(self):
         return self._is_complete
 
     @property
@@ -306,7 +306,7 @@ class AnsibleChangeOperation(orchestrator.WriteCompletion):
         raise NotImplementedError()
 
     @property
-    def is_persistent(self):
+    def has_result(self):
         """
         Has the operation updated the orchestrator's configuration
         persistently?  Typically this would indicate that an update

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -287,10 +287,8 @@ class Module(MgrModule, orchestrator.Orchestrator):
         :Returns          : True if everything is done.
         """
 
-        # Check progress and update status in each operation
-        # Access completion.status property do the trick
-        for operation in completions:
-            self.log.info("<%s> is_finished:%s", operation, operation.is_finished)
+        if completions:
+            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
 
     def serve(self):
         """ Mandatory for standby modules

--- a/src/pybind/mgr/ansible/output_wizards.py
+++ b/src/pybind/mgr/ansible/output_wizards.py
@@ -6,23 +6,24 @@ completion objects
 """
 
 import json
+import logging
 
 from ceph.deployment import inventory
 from orchestrator import InventoryNode
 
 from .ansible_runner_svc import EVENT_DATA_URL
 
+logger = logging.getLogger(__name__)
+
 class OutputWizard(object):
     """Base class for help to process output in completion objects
     """
-    def __init__(self, ar_client, logger):
+    def __init__(self, ar_client):
         """Make easy to work in output wizards using this attributes:
 
         :param ars_client: Ansible Runner Service client
-        :param logger: log object
         """
         self.ar_client = ar_client
-        self.log = logger
 
     def process(self, operation_id, raw_result):
         """Make the magic here
@@ -139,12 +140,12 @@ class ProcessHostsList(OutputWizard):
                 inventory_nodes.append(InventoryNode(host, inventory.Devices([])))
 
         except ValueError:
-            self.log.exception("Malformed json response")
+            logger.exception("Malformed json response")
         except KeyError:
-            self.log.exception("Unexpected content in Ansible Runner Service"
+            logger.exception("Unexpected content in Ansible Runner Service"
                                " response")
         except TypeError:
-            self.log.exception("Hosts data must be iterable in Ansible Runner "
+            logger.exception("Hosts data must be iterable in Ansible Runner "
                                "Service response")
 
         return inventory_nodes

--- a/src/pybind/mgr/ansible/tests/test_client_playbooks.py
+++ b/src/pybind/mgr/ansible/tests/test_client_playbooks.py
@@ -33,8 +33,7 @@ logger.addHandler(handler)
 def mock_get_pb(mock_server, playbook_name, return_code):
 
     ars_client = Client(SERVER_URL, verify_server=False, ca_bundle="",
-                        client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH",
-                        logger = logger)
+                        client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH")
 
     the_pb_url = "https://%s/%s/%s" % (SERVER_URL, PLAYBOOK_EXEC_URL, playbook_name)
 
@@ -53,7 +52,7 @@ def mock_get_pb(mock_server, playbook_name, return_code):
                                "data": { "play_uuid": "1733c3ac" }},
                         status_code=return_code)
 
-    return PlayBookExecution(ars_client, playbook_name, logger,
+    return PlayBookExecution(ars_client, playbook_name,
                              result_pattern = "RESULTS")
 
 class ARSclientTest(unittest.TestCase):
@@ -62,8 +61,7 @@ class ARSclientTest(unittest.TestCase):
 
         with self.assertRaises(AnsibleRunnerServiceError):
             ars_client = Client(SERVER_URL, verify_server=False, ca_bundle="",
-                            client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH",
-                            logger = logger)
+                            client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH")
 
             status = ars_client.is_operative()
 
@@ -73,8 +71,7 @@ class ARSclientTest(unittest.TestCase):
         with requests_mock.Mocker() as mock_server:
 
             ars_client = Client(SERVER_URL, verify_server=False, ca_bundle="",
-                                client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH",
-                                logger = logger)
+                                client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH")
 
             the_api_url = "https://%s/%s" % (SERVER_URL,API_URL)
             mock_server.register_uri("GET",
@@ -90,8 +87,7 @@ class ARSclientTest(unittest.TestCase):
         with requests_mock.Mocker() as mock_server:
 
             ars_client = Client(SERVER_URL, verify_server=False, ca_bundle="",
-                                client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH",
-                                logger = logger)
+                                client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH")
 
             url = "https://%s/test" % (SERVER_URL)
             mock_server.register_uri("DELETE",

--- a/src/pybind/mgr/ansible/tests/test_output_wizards.py
+++ b/src/pybind/mgr/ansible/tests/test_output_wizards.py
@@ -24,8 +24,7 @@ class  OutputWizardProcessHostsList(unittest.TestCase):
                 }
                 """
     ar_client = mock.Mock()
-    logger = mock.Mock()
-    test_wizard = ProcessHostsList(ar_client, logger)
+    test_wizard = ProcessHostsList(ar_client)
 
     def test_process(self):
         """Test a normal call"""
@@ -64,9 +63,7 @@ class OutputWizardProcessPlaybookResult(unittest.TestCase):
     ar_client = mock.Mock()
     ar_client.http_get = mock.MagicMock(return_value=mocked_response)
 
-    logger = mock.Mock()
-
-    test_wizard = ProcessPlaybookResult(ar_client, logger)
+    test_wizard = ProcessPlaybookResult(ar_client)
 
     def test_process(self):
         """Test a normal call
@@ -177,9 +174,7 @@ class OutputWizardProcessInventory(unittest.TestCase):
     ar_client = mock.Mock()
     ar_client.http_get = mock.MagicMock(return_value=mocked_response)
 
-    logger = mock.Mock()
-
-    test_wizard = ProcessInventory(ar_client, logger)
+    test_wizard = ProcessInventory(ar_client)
 
     def test_process(self):
         """Test a normal call

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -272,29 +272,24 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             return c
 
-    def wait(self, completions):
-        incomplete = False
+    def process(self, completions):
+        """
+        Does nothing, as completions are processed in another thread.
+        """
 
-        with self._completion_lock:
-            for c in completions:
-                if c.is_complete:
-                    continue
-                if not c.is_complete:
-                    # TODO: the job is in the bus, it should reach us eventually
-                    # unless something has gone wrong (e.g. salt-api died, etc.),
-                    # in which case it's possible the job finished but we never
-                    # noticed the salt/run/$id/ret event.  Need to add the job ID
-                    # (or possibly the full event tag) to the completion object.
-                    # That way, if we want to double check on a job that hasn't
-                    # been completed yet, we can make a synchronous request to
-                    # salt-api to invoke jobs.lookup_jid, and if it's complete we
-                    # should be able to pass its return value to _process_result()
-                    # Question: do we do this automatically after some timeout?
-                    # Or do we add a function so the admin can check and "unstick"
-                    # a stuck completion?
-                    incomplete = True
-
-        return not incomplete
+        # If the job is still incomplete:
+        # TODO: the job is in the bus, it should reach us eventually
+        # unless something has gone wrong (e.g. salt-api died, etc.),
+        # in which case it's possible the job finished but we never
+        # noticed the salt/run/$id/ret event.  Need to add the job ID
+        # (or possibly the full event tag) to the completion object.
+        # That way, if we want to double check on a job that hasn't
+        # been completed yet, we can make a synchronous request to
+        # salt-api to invoke jobs.lookup_jid, and if it's complete we
+        # should be able to pass its return value to _process_result()
+        # Question: do we do this automatically after some timeout?
+        # Or do we add a function so the admin can check and "unstick"
+        # a stuck completion?
 
 
     def handle_command(self, inbuf, cmd):

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -40,7 +40,7 @@ class DeepSeaReadCompletion(orchestrator.ReadCompletion):
         return self._result
 
     @property
-    def is_complete(self):
+    def has_result(self):
         return self._complete
 
 

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -150,7 +150,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
             return result
 
         with self._completion_lock:
-            c = DeepSeaReadCompletion(process_result)
+            c = DeepSeaReadCompletion(on_complete=process_result)
 
             nodes = []
             roles = []
@@ -249,7 +249,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
             return result
 
         with self._completion_lock:
-            c = DeepSeaReadCompletion(process_result)
+            c = DeepSeaReadCompletion(on_complete=process_result)
 
             # Always request all services, so we always have all services cached.
             resp = self._do_request_with_login("POST", data = {

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -10,7 +10,10 @@ ceph-mgr DeepSea orchestrator module
 
 import json
 import errno
-from typing import Dict
+try:
+    from typing import Dict
+except ImportError:
+    pass  # type checking
 
 import requests
 

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -679,6 +679,14 @@ class Orchestrator(object):
                     }
         return features
 
+    @_hide_in_features
+    def cancel_completions(self):
+        # type: () -> None
+        """
+        Cancels ongoing completions. Unstuck the mgr.
+        """
+        raise NotImplementedError()
+
     def add_host(self, host):
         # type: (str) -> Completion
         """

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -894,7 +894,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def update_rgw(self, spec):
-        # type: (StatelessServiceSpec) -> Completion
+        # type: (RGWSpec) -> Completion
         """
         Update / redeploy existing RGW zone
         Like for example changing the number of service instances.

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -637,7 +637,8 @@ class TrivialReadCompletion(Completion):
     """
     def __init__(self, result):
         super(TrivialReadCompletion, self).__init__()
-        self._result = result
+        if result:
+            self.finalize(result)
 
 
 def _hide_in_features(f):

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -659,6 +659,15 @@ Usage:
 
         return HandleCommandResult(-errno.EINVAL, stderr="Module '{0}' not found".format(module_name))
 
+    @_write_cli('orchestrator cancel',
+                desc='cancels ongoing operations')
+    def _cancel(self):
+        """
+        ProgressReferences might get stuck. Let's unstuck them.
+        """
+        self.cancel_completions()
+        return HandleCommandResult()
+
     @orchestrator._cli_read_command(
         'orchestrator status',
         desc='Report configured backend and its status')

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -339,19 +339,7 @@ Usage:
         else:
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
 
-        # TODO: Remove this and make the orchestrator composable
-        #   Like a future or so.
-        host_completion = self.get_hosts()
-        self._orchestrator_wait([host_completion])
-        orchestrator.raise_if_exception(host_completion)
-        all_hosts = [h.name for h in host_completion.result]
-
-        try:
-            drive_group.validate(all_hosts)
-        except DriveGroupValidationError as e:
-            return HandleCommandResult(-errno.EINVAL, stderr=str(e))
-
-        completion = self.create_osds(drive_group, all_hosts)
+        completion = self.create_osds(drive_group)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         self.log.warning(str(completion.result))

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -659,8 +659,9 @@ Usage:
 
         return HandleCommandResult(-errno.EINVAL, stderr="Module '{0}' not found".format(module_name))
 
-    @_write_cli('orchestrator cancel',
-                desc='cancels ongoing operations')
+    @orchestrator._cli_write_command(
+        'orchestrator cancel',
+        desc='cancels ongoing operations')
     def _cancel(self):
         """
         ProgressReferences might get stuck. Let's unstuck them.
@@ -705,3 +706,6 @@ Usage:
             assert False
         except orchestrator.OrchestratorError as e:
             assert e.args == ('hello', 'world')
+
+        c = orchestrator.TrivialReadCompletion(result=True)
+        assert c.has_result

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -35,7 +35,7 @@ from .rook_cluster import RookCluster
 
 class RookCompletion(orchestrator.Completion):
     def evaluate(self):
-        self._first_promise.finalize(None)
+        self.finalize(None)
 
 
 def deferred_read(f):

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -103,7 +103,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         # type: (List[RookCompletion]) -> None
 
         if completions:
-            self.log.info("wait: promises={0}".format(completions))
+            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
 
             for p in completions:
                 p.evaluate()

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -205,6 +205,11 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             self._shutdown.wait(5)
 
+    def cancel_completions(self):
+        for p in self.all_progress_references:
+            p.fail()
+        self.all_progress_references.clear()
+
     @deferred_read
     def get_inventory(self, node_filter=None, refresh=False):
         node_list = None

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -10,9 +10,6 @@ try:
 except ImportError:
     pass  # just for type checking
 
-T = TypeVar('T')
-
-
 try:
     from kubernetes import client, config
     from kubernetes.client.rest import ApiException
@@ -36,13 +33,13 @@ import orchestrator
 from .rook_cluster import RookCluster
 
 
-class RookCompletion(orchestrator.Completion[T]):
+class RookCompletion(orchestrator.Completion):
     def evaluate(self):
         self._first_promise.finalize(None)
 
 
 def deferred_read(f):
-    # type: (Callable[..., T]) -> Callable[..., RookCompletion[T]]
+    # type: (Callable) -> Callable[..., RookCompletion]
     """
     Decorator to make RookOrchestrator methods return
     a completion object that executes themselves.
@@ -55,12 +52,12 @@ def deferred_read(f):
     return wrapper
 
 
-def write_completion(on_complete,  # type: Callable[[], T]
+def write_completion(on_complete,  # type: Callable
                      message,  # type: str
                      mgr,
-                     calc_percent=None  # type: Optional[Callable[[], RookCompletion[float]]]
+                     calc_percent=None  # type: Optional[Callable[[], RookCompletion]]
                      ):
-    # type: (...) -> RookCompletion[T]
+    # type: (...) -> RookCompletion
     return RookCompletion.with_progress(
         message=message,
         mgr=mgr,

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -448,11 +448,11 @@ class Module(MgrModule):
         import orchestrator
         if what == 'OrchestratorError':
             c = orchestrator.TrivialReadCompletion(result=None)
-            c.exception = orchestrator.OrchestratorError('hello', 'world')
+            c.fail(orchestrator.OrchestratorError('hello', 'world'))
             return c
         elif what == "ZeroDivisionError":
             c = orchestrator.TrivialReadCompletion(result=None)
-            c.exception = ZeroDivisionError('hello', 'world')
+            c.fail(ZeroDivisionError('hello', 'world'))
             return c
         assert False, repr(what)
 

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -79,14 +79,14 @@ class SSHCompletionmMixin(object):
 
 class SSHReadCompletion(SSHCompletionmMixin, orchestrator.ReadCompletion):
     @property
-    def is_complete(self):
+    def has_result(self):
         return all(map(lambda r: r.ready(), self._result))
 
 
 class SSHWriteCompletion(SSHCompletionmMixin, orchestrator.WriteCompletion):
 
     @property
-    def is_persistent(self):
+    def has_result(self):
         return all(map(lambda r: r.ready(), self._result))
 
     @property
@@ -113,7 +113,7 @@ class SSHWriteCompletionReady(SSHWriteCompletion):
         return self._result
 
     @property
-    def is_persistent(self):
+    def has_result(self):
         return True
 
     @property

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -73,7 +73,7 @@ except ImportError:
 class AsyncCompletion(orchestrator.Completion):
     def __init__(self, *args, **kwargs):
         self.__on_complete = None  # type: Callable
-        self.many = kwargs.pop('many')
+        self.many = kwargs.pop('many', False)
         super(AsyncCompletion, self).__init__(*args, **kwargs)
 
     def propagate_to_next(self):

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -9,7 +9,6 @@ try:
 except ImportError:
     pass  # just for type checking
 
-T = TypeVar('T')
 
 import six
 import os
@@ -71,10 +70,10 @@ except ImportError:
 #    multiple bootstrapping / initialization
 
 
-class AsyncCompletion(orchestrator.Completion[T]):
-    def __init__(self, *args, many=False, **kwargs):
-        self.__on_complete = None  # type: Callable[[T], Any]
-        self.many = many
+class AsyncCompletion(orchestrator.Completion):
+    def __init__(self, *args, **kwargs):
+        self.__on_complete = None  # type: Callable
+        self.many = kwargs.pop('many')
         super(AsyncCompletion, self).__init__(*args, **kwargs)
 
     def propagate_to_next(self):
@@ -89,7 +88,7 @@ class AsyncCompletion(orchestrator.Completion[T]):
 
     @property
     def _on_complete(self):
-        # type: () -> Optional[Callable[[T], Any]]
+        # type: () -> Optional[Callable]
         if self.__on_complete is None:
             return None
 
@@ -112,7 +111,7 @@ class AsyncCompletion(orchestrator.Completion[T]):
 
     @_on_complete.setter
     def _on_complete(self, inner):
-        # type: (Callable[[T], Any]) -> None
+        # type: (Callable) -> None
         self.__on_complete = inner
 
 
@@ -131,17 +130,17 @@ def ssh_completion(cls=AsyncCompletion, **c_kwargs):
 
 
 def async_completion(f):
-    # type: (Callable[..., T]) -> Callable[..., AsyncCompletion[T]]
+    # type: (Callable) -> Callable[..., AsyncCompletion]
     return ssh_completion()(f)
 
 
 def async_map_completion(f):
-    # type: (Callable[..., T]) -> Callable[..., AsyncCompletion[T]]
+    # type: (Callable) -> Callable[..., AsyncCompletion]
     return ssh_completion(many=True)(f)
 
 
 def trivial_completion(f):
-    # type: (Callable[..., T]) -> Callable[..., orchestrator.Completion[T]]
+    # type: (Callable) -> Callable[..., orchestrator.Completion]
     return ssh_completion(cls=orchestrator.Completion)(f)
 
 

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -409,7 +409,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         Does nothing, as completions are processed in another thread.
         """
         if completions:
-            self.log.info("wait: promises={0}".format(completions))
+            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
 
             for p in completions:
                 p.finalize()

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -330,21 +330,10 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         """
         return self.can_run()
 
-    def wait(self, completions):
-        self.log.info("wait: completions={}".format(completions))
-
-        complete = True
-        for c in completions:
-            if c.is_complete:
-                continue
-
-            if not isinstance(c, SSHReadCompletion) and \
-                    not isinstance(c, SSHWriteCompletion):
-                raise TypeError("unexpected completion: {}".format(c.__class__))
-
-            complete = False
-
-        return complete
+    def process(self, completions):
+        """
+        Does nothing, as completions are processed in another thread.
+        """
 
     def _require_hosts(self, hosts):
         """

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -639,7 +639,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         """
         return [orchestrator.InventoryNode(host_name) for host_name in self.inventory_cache]
 
-"""
+    """
     def add_host_label(self, host, label):
         if host not in self.inventory:
             raise OrchestratorError('host %s does not exist' % host)
@@ -671,7 +671,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         return SSHWriteCompletion(
             self._worker_pool.apply_async(run, (host, label)))
-"""
+    """
 
     @async_map_completion
     def _refresh_host_services(self, host):

--- a/src/pybind/mgr/ssh/tests/fixtures.py
+++ b/src/pybind/mgr/ssh/tests/fixtures.py
@@ -1,0 +1,40 @@
+from contextlib import contextmanager
+
+import pytest
+
+from ssh import SSHOrchestrator
+from tests import mock
+
+
+def set_store(self, k, v):
+    if v is None:
+        del self._store[k]
+    else:
+        self._store[k] = v
+
+
+def get_store(self, k):
+    return self._store[k]
+
+
+def get_store_prefix(self, prefix):
+    return {
+        k: v for k, v in self._store.items()
+        if k.startswith(prefix)
+    }
+
+
+@pytest.yield_fixture()
+def ssh_module():
+    with mock.patch("ssh.module.SSHOrchestrator.get_ceph_option", lambda _, key: __file__),\
+            mock.patch("ssh.module.SSHOrchestrator.set_store", set_store),\
+            mock.patch("ssh.module.SSHOrchestrator.get_store", get_store),\
+            mock.patch("ssh.module.SSHOrchestrator.get_store_prefix", get_store_prefix):
+        m = SSHOrchestrator.__new__ (SSHOrchestrator)
+        m._store = {
+            'ssh_config': '',
+            'ssh_identity_key': '',
+            'ssh_identity_pub': '',
+        }
+        m.__init__('ssh', 0, 0)
+        yield m

--- a/src/pybind/mgr/ssh/tests/fixtures.py
+++ b/src/pybind/mgr/ssh/tests/fixtures.py
@@ -35,6 +35,7 @@ def ssh_module():
             'ssh_config': '',
             'ssh_identity_key': '',
             'ssh_identity_pub': '',
+            'inventory': {},
         }
         m.__init__('ssh', 0, 0)
         yield m

--- a/src/pybind/mgr/ssh/tests/test_completion.py
+++ b/src/pybind/mgr/ssh/tests/test_completion.py
@@ -1,0 +1,171 @@
+import sys
+import time
+
+
+try:
+    from typing import Any
+except ImportError:
+    pass
+
+import pytest
+
+
+from orchestrator import raise_if_exception, Completion
+from .fixtures import ssh_module
+from ..module import trivial_completion, async_completion, async_map_completion, SSHOrchestrator
+
+
+class TestCompletion(object):
+    def _wait(self, m, c):
+        # type: (SSHOrchestrator, Completion) -> Any
+        m.process([c])
+        m.process([c])
+
+        for _ in range(30):
+            if c.is_finished:
+                raise_if_exception(c)
+                return c.result
+            time.sleep(0.1)
+        assert False, "timeout" + str(c._state)
+
+    def test_trivial(self, ssh_module):
+        @trivial_completion
+        def run(x):
+            return x+1
+        assert self._wait(ssh_module, run(1)) == 2
+
+    @pytest.mark.parametrize("input", [
+        ((1, ), ),
+        ((1, 2), ),
+        (("hallo", ), ),
+        (("hallo", "foo"), ),
+    ])
+    def test_async(self, input, ssh_module):
+        @async_completion
+        def run(*args):
+            return str(args)
+
+        assert self._wait(ssh_module, run(*input)) == str(input)
+
+    @pytest.mark.parametrize("input,expected", [
+        ([], []),
+        ([1], ["(1,)"]),
+        (["hallo"], ["('hallo',)"]),
+        ("hi", ["('h',)", "('i',)"]),
+        (list(range(5)), [str((x, )) for x in range(5)]),
+        ([(1, 2), (3, 4)], ["(1, 2)", "(3, 4)"]),
+    ])
+    def test_async_map(self, input, expected, ssh_module):
+        @async_map_completion
+        def run(*args):
+            return str(args)
+
+        c = run(input)
+        self._wait(ssh_module, c)
+        assert c.result == expected
+
+    def test_async_self(self, ssh_module):
+        class Run(object):
+            def __init__(self):
+                self.attr = 1
+
+            @async_completion
+            def run(self, x):
+                assert self.attr == 1
+                return x + 1
+
+        assert self._wait(ssh_module, Run().run(1)) == 2
+
+    @pytest.mark.parametrize("input,expected", [
+        ([], []),
+        ([1], ["(1,)"]),
+        (["hallo"], ["('hallo',)"]),
+        ("hi", ["('h',)", "('i',)"]),
+        (list(range(5)), [str((x, )) for x in range(5)]),
+        ([(1, 2), (3, 4)], ["(1, 2)", "(3, 4)"]),
+    ])
+    def test_async_map_self(self, input, expected, ssh_module):
+        class Run(object):
+            def __init__(self):
+                self.attr = 1
+
+            @async_map_completion
+            def run(self, *args):
+                assert self.attr == 1
+                return str(args)
+
+        c = Run().run(input)
+        self._wait(ssh_module, c)
+        assert c.result == expected
+
+    def test_then1(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            return x+1
+
+        assert self._wait(ssh_module, run([1,2]).then(str)) == '[2, 3]'
+
+    def test_then2(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            time.sleep(0.1)
+            return x+1
+
+        @async_completion
+        def async_str(results):
+            return str(results)
+
+        c = run([1,2]).then(async_str)
+
+        self._wait(ssh_module, c)
+        assert c.result == '[2, 3]'
+
+    def test_then3(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            time.sleep(0.1)
+            return x+1
+
+        def async_str(results):
+            return async_completion(str)(results)
+
+        c = run([1,2]).then(async_str)
+
+        self._wait(ssh_module, c)
+        assert c.result == '[2, 3]'
+
+    def test_then4(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            time.sleep(0.1)
+            return x+1
+
+        def async_str(results):
+            return async_completion(str)(results).then(lambda x: x + "hello")
+
+        c = run([1,2]).then(async_str)
+
+        self._wait(ssh_module, c)
+        assert c.result == '[2, 3]hello'
+
+    @pytest.mark.skip(reason="see limitation of async_map_completion")
+    def test_then5(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            time.sleep(0.1)
+            return async_completion(str)(x+1)
+
+        c = run([1,2])
+
+        self._wait(ssh_module, c)
+        assert c.result == "['2', '3']"
+
+    @pytest.mark.skipif(sys.version_info < (3,0), reason="requires python3")
+    def test_raise(self, ssh_module):
+        @async_completion
+        def run(x):
+            raise ZeroDivisionError()
+
+        with pytest.raises(ZeroDivisionError):
+            self._wait(ssh_module, run(1))
+

--- a/src/pybind/mgr/ssh/tests/test_ssh.py
+++ b/src/pybind/mgr/ssh/tests/test_ssh.py
@@ -1,15 +1,176 @@
-from orchestrator import ServiceDescription
+import json
+import time
+from contextlib import contextmanager
+
+from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
+
+try:
+    from typing import Any
+except ImportError:
+    pass
+
+from orchestrator import ServiceDescription, raise_if_exception, Completion, InventoryNode, \
+    StatelessServiceSpec, PlacementSpec, RGWSpec, parse_host_specs
 from ..module import SSHOrchestrator
 from tests import mock
+from .fixtures import ssh_module
 
 
-@mock.patch("ssh.module.SSHOrchestrator.get_ceph_option", lambda _,key: __file__)
-def test_get_unique_name():
-    o = SSHOrchestrator('module_name', 0, 0)
-    existing = [
-        ServiceDescription(service_instance='mon.a')
-    ]
-    new_mon = o.get_unique_name(existing, 'mon')
-    assert new_mon.startswith('mon.')
-    assert new_mon != 'mon.a'
+"""
+TODOs:
+    There is really room for improvement here. I just quickly assembled theses tests.
+    I general, everything should be testes in Teuthology as well. Reasons for
+    also testing this here is the development roundtrip time.
+"""
+
+
+
+def _run_ceph_daemon(ret):
+    def foo(*args, **kwargs):
+        return ret, 0
+    return foo
+
+def mon_command(*args, **kwargs):
+    return 0, '', ''
+
+
+class TestSSH(object):
+    def _wait(self, m, c):
+        # type: (SSHOrchestrator, Completion) -> Any
+        m.process([c])
+        m.process([c])
+
+        for _ in range(30):
+            if c.is_finished:
+                raise_if_exception(c)
+                return c.result
+            time.sleep(0.1)
+        assert False, "timeout" + str(c._state)
+
+    @contextmanager
+    def _with_host(self, m, name):
+        self._wait(m, m.add_host(name))
+        yield
+        self._wait(m, m.remove_host(name))
+
+    def test_get_unique_name(self, ssh_module):
+        existing = [
+            ServiceDescription(service_instance='mon.a')
+        ]
+        new_mon = ssh_module.get_unique_name(existing, 'mon')
+        assert new_mon.startswith('mon.')
+        assert new_mon != 'mon.a'
+
+    def test_host(self, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            assert self._wait(ssh_module, ssh_module.get_hosts()) == [InventoryNode('test')]
+        c = ssh_module.get_hosts()
+        assert self._wait(ssh_module, c) == []
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
+    def test_service_ls(self, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.describe_service()
+            assert self._wait(ssh_module, c) == []
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
+    def test_device_ls(self, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.get_inventory()
+            assert self._wait(ssh_module, c) == [InventoryNode('test')]
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_mon_update(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.update_mons(1, [parse_host_specs('test:0.0.0.0')])
+            assert self._wait(ssh_module, c) == ["(Re)deployed mon.test on host 'test'"]
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_mgr_update(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.update_mgrs(1, [parse_host_specs('test:0.0.0.0')])
+            [out] = self._wait(ssh_module, c)
+            assert "(Re)deployed mgr." in out
+            assert " on host 'test'" in out
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_create_osds(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            dg = DriveGroupSpec('test', DeviceSelection(paths=['']))
+            c = ssh_module.create_osds(dg)
+            assert self._wait(ssh_module, c) == "Created osd(s) on host 'test'"
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_mds(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            ps = PlacementSpec(nodes=['test'])
+            c = ssh_module.add_mds(StatelessServiceSpec('name', ps))
+            [out] = self._wait(ssh_module, c)
+            assert "(Re)deployed mds.name." in out
+            assert " on host 'test'" in out
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_rgw(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            ps = PlacementSpec(nodes=['test'])
+            c = ssh_module.add_rgw(RGWSpec('name', ps))
+            [out] = self._wait(ssh_module, c)
+            assert "(Re)deployed rgw.name." in out
+            assert " on host 'test'" in out
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon(
+        json.dumps([
+            dict(
+                name='rgw.myrgw.foobar',
+                style='ceph-daemon',
+                fsid='fsid',
+                container_id='container_id',
+                version='version',
+                state='running',
+            )
+        ])
+    ))
+    def test_remove_rgw(self, ssh_module):
+        ssh_module._cluster_fsid = "fsid"
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.remove_rgw('myrgw')
+            out = self._wait(ssh_module, c)
+            assert out == ["Removed rgw.myrgw.foobar from host 'test'"]
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_rbd_mirror(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            ps = PlacementSpec(nodes=['test'])
+            c = ssh_module.add_rbd_mirror(StatelessServiceSpec('name', ps))
+            [out] = self._wait(ssh_module, c)
+            assert "(Re)deployed rbd-mirror." in out
+            assert " on host 'test'" in out
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_blink_device_light(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.blink_device_light('ident', True, [('test', '')])
+            assert self._wait(ssh_module, c) == ['Set ident light for test: on']
+
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -67,7 +67,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def process(self, completions):
         # type: (List[TestCompletion]) -> None
         if completions:
-            self.log.info("wait: promises={0}".format(completions))
+            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
 
             for p in completions:
                 p.evaluate()

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -19,7 +19,7 @@ import orchestrator
 
 
 class TestCompletionMixin(object):
-    all_completions = []  # Hacky global
+    all_completions = []  # type: orchestrator.Completion
 
     def __init__(self, cb, message, *args, **kwargs):
         super(TestCompletionMixin, self).__init__(*args, **kwargs)
@@ -37,7 +37,7 @@ class TestCompletionMixin(object):
         return self._result
 
     @property
-    def is_complete(self):
+    def has_result(self):
         return self._complete
 
     def execute(self):
@@ -64,7 +64,7 @@ class TestWriteCompletion(TestCompletionMixin, orchestrator.WriteCompletion):
         super(TestWriteCompletion, self).__init__(cb, message)
 
     @property
-    def is_persistent(self):
+    def has_result(self):
         return (not self.is_errored) and self.executed
 
     @property
@@ -114,7 +114,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
                         c.__class__
                     ))
 
-            if not c.has_result:
+            if c.needs_result:
                 c.execute()
 
     @CLICommand('test_orchestrator load_data', '', 'load dummy data into test orchestrator', 'w')
@@ -153,7 +153,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             self.wait(TestCompletionMixin.all_completions)
             TestCompletionMixin.all_completions = [c for c in TestCompletionMixin.all_completions if
-                                                   not c.is_complete]
+                                                   c.is_finished]
 
             self._shutdown.wait(5)
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -15,16 +15,14 @@ from mgr_module import MgrModule
 
 import orchestrator
 
-T = TypeVar('T')
 
-
-class TestCompletion(orchestrator.Completion[T]):
+class TestCompletion(orchestrator.Completion):
     def evaluate(self):
         self._first_promise.finalize(None)
 
 
 def deferred_read(f):
-    # type: (Callable[..., T]) -> Callable[..., TestCompletion[T]]
+    # type: (Callable) -> Callable[..., TestCompletion]
     """
     Decorator to make methods return
     a completion object that executes themselves.
@@ -39,7 +37,7 @@ def deferred_read(f):
 
 def deferred_write(message):
     def inner(f):
-        # type: (Callable[..., T]) -> Callable[..., TestCompletion[T]]
+        # type: (Callable) -> Callable[..., TestCompletion]
 
         @functools.wraps(f)
         def wrapper(self, *args, **kwargs):

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -21,7 +21,7 @@ import orchestrator
 
 class TestCompletion(orchestrator.Completion):
     def evaluate(self):
-        self._first_promise.finalize(None)
+        self.finalize(None)
 
 
 def deferred_read(f):

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -5,7 +5,10 @@ import os
 import threading
 import functools
 from subprocess import check_output, CalledProcessError
-from typing import Callable, TypeVar, List
+try:
+    from typing import Callable, List
+except ImportError:
+    pass  # type checking
 
 import six
 

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -22,7 +22,6 @@ if 'UNITTEST' in os.environ:
             self._ceph_get = mock.MagicMock()
             self._ceph_get_module_option = mock.MagicMock()
             self._ceph_log = mock.MagicMock()
-            self._ceph_get_option = mock.MagicMock()
             self._ceph_get_store = lambda _: ''
             self._ceph_get_store_prefix = lambda _: {}
 

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import
 import json
-from unittest.mock import MagicMock
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    # py2
+    from mock import MagicMock
 
 import pytest
 

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -177,13 +177,13 @@ def test_progress():
                                       completion=lambda: Completion(
                                           on_complete=lambda _: progress_val))
     )
-    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.0, ['orchestrator'])
+    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.0, [('origin', 'orchestrator')])
 
     c.finalize()
-    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.5, ['orchestrator'])
+    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.5, [('origin', 'orchestrator')])
 
     c.progress_reference.update()
-    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', progress_val, ['orchestrator'])
+    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', progress_val, [('origin', 'orchestrator')])
     assert not c.progress_reference.effective
 
     progress_val = 1

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -5,4 +5,4 @@ skipsdist = true
 [testenv]
 setenv = UNITTEST = true
 deps = -rrequirements.txt
-commands = pytest --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ ssh/}
+commands = pytest -v --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ ssh/}


### PR DESCRIPTION
I've tried to look into making Completions composable by being able to
call one completion from another completion. I.e. making them re-usable
using Promises E.g.:

```python
>>> return self.get_hosts().then(self._create_osd)
```

where `get_hosts` returns a Completion of list of hosts and
`_create_osd` takes a list of hosts.

The concept behind this is to store the computation steps explicit and then explicitly evaluate the chain:

```python
p = Completion(on_complete=lambda x: x*2).then(on_complete=lambda x: str(x))
p.finalize(2)
assert p.result = "4"
```

or graphically:

```
+---------------+      +-----------------+
|               | then |                 |
| lambda x: x*x | +--> | lambda x: str(x)|
|               |      |                 |
+---------------+      +-----------------+
```


Each orchestrator has it's way of evaluating them:

* Rook and Ansible make the networks calls in `on_complete`
* DeepSea calls `finalize` when the SSO are finished
* SSH breaks the chain between completions and uses `multiprocessing` callbacks



I'll need this for notifying the dashboard for things that are busy /
locked: I'll need to call self.get_hosts() basically for all write
operations, and I don't want to force users of the orchestrator API to
always fetch the hosts.

Do you think this makes sense at all? Do you have an alternative
implementation in mind? Is it too complex?

The orchestrator API will surely loose some understandability with this.

Some major changes are:

* Remove `ReadCompletion` and `WriteCompletion`
* Add `Completion.then(self, on_complete: Callable) -> Completion`
* Refactored progress references
* Simplified Ansible module
* Simplified `DeepSeaReadCompletion`
* `s/Orchestrator.wait/Orchestrator.process`
* Removed `all_hosts` parameter from `Orchestrator.create_osds()`
* Removed `SSHCompletionmMixin`
* Removed `TestCompletionMixin`
* Simplified `orchestrator_cli.create_osds()`

Overall, this moves some logic from the CLI, and the orchestrator modules into the `Completion` class.

## Checklist
- [x] Updates documentation
- [x] Includes tests for new functionality or reproducer for bug
- [x] Fix remaining issues in the Rook orchestrator
- [ ] Fix remaining issues in the SSH orchestrator
- [x] Fix remaining issues in the test orchestrator
- [x] Rework git history
- [x] Remove Type hinting incompatible to Python 2

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
