### PR TITLE
mgr/dashboard: Check if `num_sessions` is available

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -149,7 +149,8 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
   }
 
   getDeleteDisableDesc(): string | undefined {
-    if (this.selection.first() && this.selection.first()['info']['num_sessions']) {
+    const first = this.selection.first();
+    if (first && first['info'] && first['info']['num_sessions']) {
       return this.i18n('Target has active sessions');
     }
   }


### PR DESCRIPTION
This PR will check if `num_sessions` is available before accessing it to prevent the following error:

![Screenshot from 2019-09-09 19-36-30](https://user-images.githubusercontent.com/14297426/64557302-293d7180-d339-11e9-80a0-bda7238d57d7.png)

Fixes: https://tracker.ceph.com/issues/41727

Signed-off-by: Ricardo Marques <rimarques@suse.com>