### PR TITLE
luminous: osd: clear PG_STATE_CLEAN when repair object

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -14524,6 +14524,7 @@ int PrimaryLogPG::rep_repair_primary_object(const hobject_t& soid, OpRequestRef 
   if (!eio_errors_to_process) {
     eio_errors_to_process = true;
     assert(is_clean());
+    state_clear(PG_STATE_CLEAN);
     queue_peering_event(
         CephPeeringEvtRef(
 	  std::make_shared<CephPeeringEvt>(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41733

---

backport of https://github.com/ceph/ceph/pull/29756
parent tracker: https://tracker.ceph.com/issues/41348

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh