### PR TITLE
rgw: move delimiter-based bucket listing/filtering logic to cls

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -152,15 +152,22 @@ static int log_index_operation(cls_method_context_t hctx, cls_rgw_obj_key& obj_k
  * UTF-8 object names can *both* preceed and follow the "ugly
  * namespace".
  */
-static int get_obj_vals(cls_method_context_t hctx, const string& start, const string& filter_prefix,
-                        int num_entries, map<string, bufferlist> *pkeys, bool *pmore)
+static int get_obj_vals(cls_method_context_t hctx,
+			const string& start,
+			const string& filter_prefix,
+                        int num_entries,
+			map<string, bufferlist> *pkeys,
+			bool *pmore)
 {
-  int ret = cls_cxx_map_get_vals(hctx, start, filter_prefix, num_entries, pkeys, pmore);
-  if (ret < 0)
+  int ret = cls_cxx_map_get_vals(hctx, start, filter_prefix,
+				 num_entries, pkeys, pmore);
+  if (ret < 0) {
     return ret;
+  }
 
-  if (pkeys->empty())
+  if (pkeys->empty()) {
     return 0;
+  }
 
   auto last_element = pkeys->rbegin();
   if ((unsigned char)last_element->first[0] < BI_PREFIX_CHAR) {
@@ -195,8 +202,9 @@ static int get_obj_vals(cls_method_context_t hctx, const string& start, const st
   auto upper = std::lower_bound(lower, pkeys->end(), new_start, comp);
   pkeys->erase(lower, upper);
 
-  if (num_entries == (int)pkeys->size() || !(*pmore))
+  if (num_entries == (int)pkeys->size() || !(*pmore)) {
     return 0;
+  }
 
   if (pkeys->size() && new_start < pkeys->rbegin()->first) {
     new_start = pkeys->rbegin()->first;
@@ -205,12 +213,15 @@ static int get_obj_vals(cls_method_context_t hctx, const string& start, const st
   map<string, bufferlist> new_keys;
 
   /* now get some more keys */
-  ret = cls_cxx_map_get_vals(hctx, new_start, filter_prefix, num_entries - pkeys->size(), &new_keys, pmore);
-  if (ret < 0)
+  ret = cls_cxx_map_get_vals(hctx, new_start, filter_prefix,
+			     num_entries - pkeys->size(), &new_keys, pmore);
+  if (ret < 0) {
     return ret;
+  }
 
   pkeys->insert(std::make_move_iterator(new_keys.begin()),
                 std::make_move_iterator(new_keys.end()));
+
   return 0;
 }
 
@@ -1339,11 +1350,15 @@ static int write_version_marker(cls_method_context_t hctx, cls_rgw_obj_key& key)
 }
 
 /*
- * plain entries are the ones who were created when bucket was not versioned,
- * if we override these objects, we need to convert these to versioned entries -- ones that have
- * both data entry, and listing key. Their version is going to be empty though
+ * plain entries are the ones who were created when bucket was not
+ * versioned, if we override these objects, we need to convert these
+ * to versioned entries -- ones that have both data entry, and listing
+ * key. Their version is going to be empty though
  */
-static int convert_plain_entry_to_versioned(cls_method_context_t hctx, cls_rgw_obj_key& key, bool demote_current, bool instance_only)
+static int convert_plain_entry_to_versioned(cls_method_context_t hctx,
+					    cls_rgw_obj_key& key,
+					    bool demote_current,
+					    bool instance_only)
 {
   if (!key.instance.empty()) {
     return -EINVAL;
@@ -1375,7 +1390,8 @@ static int convert_plain_entry_to_versioned(cls_method_context_t hctx, cls_rgw_o
       ret = write_obj_entries(hctx, entry, new_idx);
     }
     if (ret < 0) {
-      CLS_LOG(0, "ERROR: write_obj_entries new_idx=%s returned %d", new_idx.c_str(), ret);
+      CLS_LOG(0, "ERROR: write_obj_entries new_idx=%s returned %d",
+	      new_idx.c_str(), ret);
       return ret;
     }
   }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -429,25 +429,33 @@ int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const string& oid, const str
 class CLSRGWIssueBucketList : public CLSRGWConcurrentIO {
   cls_rgw_obj_key start_obj;
   string filter_prefix;
+  string delimiter;
   uint32_t num_entries;
   bool list_versions;
   map<int, rgw_cls_list_ret>& result;
 protected:
   int issue_op(int shard_id, const string& oid) override;
 public:
-  CLSRGWIssueBucketList(librados::IoCtx& io_ctx, const cls_rgw_obj_key& _start_obj,
-                        const string& _filter_prefix, uint32_t _num_entries,
+  CLSRGWIssueBucketList(librados::IoCtx& io_ctx,
+			const cls_rgw_obj_key& _start_obj,
+                        const string& _filter_prefix,
+			const string& _delimiter,
+			uint32_t _num_entries,
                         bool _list_versions,
                         map<int, string>& oids,
                         map<int, rgw_cls_list_ret>& list_results,
                         uint32_t max_aio) :
   CLSRGWConcurrentIO(io_ctx, oids, max_aio),
-  start_obj(_start_obj), filter_prefix(_filter_prefix), num_entries(_num_entries), list_versions(_list_versions), result(list_results) {}
+    start_obj(_start_obj), filter_prefix(_filter_prefix), delimiter(_delimiter),
+    num_entries(_num_entries), list_versions(_list_versions),
+    result(list_results)
+  {}
 };
 
 void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
                             const cls_rgw_obj_key& start_obj,
                             const std::string& filter_prefix,
+			    const std::string& delimiter,
                             uint32_t num_entries,
                             bool list_versions,
                             rgw_cls_list_ret* result);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -385,30 +385,38 @@ struct rgw_cls_list_op
   cls_rgw_obj_key start_obj;
   uint32_t num_entries;
   string filter_prefix;
+  string delimiter;
   bool list_versions;
 
   rgw_cls_list_op() : num_entries(0), list_versions(false) {}
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(5, 4, bl);
+    ENCODE_START(6, 4, bl);
     encode(num_entries, bl);
     encode(filter_prefix, bl);
     encode(start_obj, bl);
     encode(list_versions, bl);
+    encode(delimiter, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(5, 2, 2, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(6, 2, 2, bl);
     if (struct_v < 4) {
       decode(start_obj.name, bl);
     }
     decode(num_entries, bl);
-    if (struct_v >= 3)
+    if (struct_v >= 3) {
       decode(filter_prefix, bl);
-    if (struct_v >= 4)
+    }
+    if (struct_v >= 4) {
       decode(start_obj, bl);
-    if (struct_v >= 5)
+    }
+    if (struct_v >= 5) {
       decode(list_versions, bl);
+    }
+    if (struct_v >= 6) {
+      decode(delimiter, bl);
+    }
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_RGW_OPS_H
 #define CEPH_CLS_RGW_OPS_H
 

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -339,12 +339,16 @@ struct cls_rgw_obj_key {
 WRITE_CLASS_ENCODER(cls_rgw_obj_key)
 
 
-#define RGW_BUCKET_DIRENT_FLAG_VER           0x1    /* a versioned object instance */
-#define RGW_BUCKET_DIRENT_FLAG_CURRENT       0x2    /* the last object instance of a versioned object */
-#define RGW_BUCKET_DIRENT_FLAG_DELETE_MARKER 0x4    /* delete marker */
-#define RGW_BUCKET_DIRENT_FLAG_VER_MARKER    0x8    /* object is versioned, a placeholder for the plain entry */
-
 struct rgw_bucket_dir_entry {
+  /* a versioned object instance */
+  static constexpr uint16_t FLAG_VER =                0x1;
+  /* the last object instance of a versioned object */
+  static constexpr uint16_t FLAG_CURRENT =            0x2;
+  /* delete marker */
+  static constexpr uint16_t FLAG_DELETE_MARKER =      0x4;
+  /* object is versioned, a placeholder for the plain entry */
+  static constexpr uint16_t FLAG_VER_MARKER =         0x8;
+
   cls_rgw_obj_key key;
   rgw_bucket_entry_ver ver;
   std::string locator;
@@ -406,16 +410,21 @@ struct rgw_bucket_dir_entry {
     DECODE_FINISH(bl);
   }
 
-  bool is_current() {
-    int test_flags = RGW_BUCKET_DIRENT_FLAG_VER | RGW_BUCKET_DIRENT_FLAG_CURRENT;
-    return (flags & RGW_BUCKET_DIRENT_FLAG_VER) == 0 ||
+  bool is_current() const {
+    int test_flags =
+      rgw_bucket_dir_entry::FLAG_VER | rgw_bucket_dir_entry::FLAG_CURRENT;
+    return (flags & rgw_bucket_dir_entry::FLAG_VER) == 0 ||
            (flags & test_flags) == test_flags;
   }
-  bool is_delete_marker() { return (flags & RGW_BUCKET_DIRENT_FLAG_DELETE_MARKER) != 0; }
-  bool is_visible() {
+  bool is_delete_marker() const {
+    return (flags & rgw_bucket_dir_entry::FLAG_DELETE_MARKER) != 0;
+  }
+  bool is_visible() const {
     return is_current() && !is_delete_marker();
   }
-  bool is_valid() { return (flags & RGW_BUCKET_DIRENT_FLAG_VER_MARKER) == 0; }
+  bool is_valid() const {
+    return (flags & rgw_bucket_dir_entry::FLAG_VER_MARKER) == 0;
+  }
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -62,6 +62,19 @@ static inline uint64_t cls_rgw_get_rounded_size(uint64_t size)
   return (size + ROUND_BLOCK_SIZE - 1) & ~(ROUND_BLOCK_SIZE - 1);
 }
 
+/*
+ * This takes a string that either wholly contains a delimiter or is a
+ * path that ends with a delimiter and appends a new character to the
+ * end such that when a we request bucket-index entries *after* this,
+ * we'll get the next object after the "subdirectory". This works
+ * because we append a '\xFF' charater, and no valid UTF-8 character
+ * can contain that byte, so no valid entries can be skipped.
+ */
+static inline std::string cls_rgw_after_delim(const std::string& path) {
+  // assert: ! path.empty()
+  return path + '\xFF';
+}
+
 struct rgw_bucket_pending_info {
   RGWPendingState state;
   ceph::real_time timestamp;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -347,6 +347,12 @@ struct rgw_bucket_dir_entry {
   static constexpr uint16_t FLAG_DELETE_MARKER =      0x4;
   /* object is versioned, a placeholder for the plain entry */
   static constexpr uint16_t FLAG_VER_MARKER =         0x8;
+  /* object is a proxy; it is not listed in the bucket index but is a
+   * prefix ending with a delimiter, perhaps common to multiple
+   * entries; it is only useful when a delimiter is used and
+   * represents a "subdirectory" (again, ending in a delimiter) that
+   * may contain one or more actual entries/objects */
+  static constexpr uint16_t FLAG_COMMON_PREFIX =   0x8000;
 
   cls_rgw_obj_key key;
   rgw_bucket_entry_ver ver;
@@ -423,6 +429,9 @@ struct rgw_bucket_dir_entry {
   }
   bool is_valid() const {
     return (flags & rgw_bucket_dir_entry::FLAG_VER_MARKER) == 0;
+  }
+  bool is_common_prefix() const {
+    return flags & rgw_bucket_dir_entry::FLAG_COMMON_PREFIX;
   }
 
   void dump(Formatter *f) const;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -57,8 +57,7 @@ enum RGWCheckMTimeType {
 
 #define ROUND_BLOCK_SIZE 4096
 
-static inline uint64_t cls_rgw_get_rounded_size(uint64_t size)
-{
+static inline uint64_t cls_rgw_get_rounded_size(uint64_t size) {
   return (size + ROUND_BLOCK_SIZE - 1) & ~(ROUND_BLOCK_SIZE - 1);
 }
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6245,6 +6245,7 @@ next:
     }
 
     bool is_truncated = true;
+    bool cls_filtered = true;
 
     rgw_obj_index_key marker;
     string empty_prefix;
@@ -6259,7 +6260,7 @@ next:
 	bucket_info, RGW_NO_SHARD,
 	marker, empty_prefix, empty_delimiter,
 	1000, true,
-	result, &is_truncated, &marker,
+	result, &is_truncated, &cls_filtered, &marker,
 	null_yield,
 	rgw_bucket_object_check_filter);
       if (r < 0 && r != -ENOENT) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1451,13 +1451,6 @@ int set_user_quota(int opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state, in
   return 0;
 }
 
-static bool bucket_object_check_filter(const string& name)
-{
-  rgw_obj_key k;
-  string ns; /* empty namespace */
-  return rgw_obj_key::oid_to_key_in_ns(name, &k, ns);
-}
-
 int check_min_obj_stripe_size(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_info, rgw_obj& obj, uint64_t min_stripe_size, bool *need_rewrite)
 {
   map<string, bufferlist> attrs;
@@ -6266,8 +6259,7 @@ next:
 				       prefix, 1000, true,
 				       result, &is_truncated, &marker,
                                        null_yield,
-				       bucket_object_check_filter);
-
+				       rgw_bucket_object_check_filter);
       if (r < 0 && r != -ENOENT) {
         cerr << "ERROR: failed operation r=" << r << std::endl;
       }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6247,19 +6247,21 @@ next:
     bool is_truncated = true;
 
     rgw_obj_index_key marker;
-    string prefix;
+    string empty_prefix;
+    string empty_delimiter;
 
     formatter->open_object_section("result");
     formatter->dump_string("bucket", bucket_name);
     formatter->open_array_section("objects");
     while (is_truncated) {
       RGWRados::ent_map_t result;
-      int r =
-	store->getRados()->cls_bucket_list_ordered(bucket_info, RGW_NO_SHARD, marker,
-				       prefix, 1000, true,
-				       result, &is_truncated, &marker,
-                                       null_yield,
-				       rgw_bucket_object_check_filter);
+      int r = store->getRados()->cls_bucket_list_ordered(
+	bucket_info, RGW_NO_SHARD,
+	marker, empty_prefix, empty_delimiter,
+	1000, true,
+	result, &is_truncated, &marker,
+	null_yield,
+	rgw_bucket_object_check_filter);
       if (r < 0 && r != -ENOENT) {
         cerr << "ERROR: failed operation r=" << r << std::endl;
       }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -303,7 +303,8 @@ void check_bad_user_bucket_mapping(rgw::sal::RGWRadosStore *store, const rgw_use
   } while (user_buckets.is_truncated());
 }
 
-static bool bucket_object_check_filter(const string& oid)
+// note: function type conforms to RGWRados::check_filter_t
+bool rgw_bucket_object_check_filter(const string& oid)
 {
   rgw_obj_key key;
   string ns;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1004,6 +1004,7 @@ int RGWBucket::check_object_index(RGWBucketAdminOpState& op_state,
   store->getRados()->cls_obj_set_bucket_tag_timeout(bucket_info, BUCKET_TAG_TIMEOUT);
 
   string prefix;
+  string empty_delimiter;
   rgw_obj_index_key marker;
   bool is_truncated = true;
 
@@ -1014,8 +1015,9 @@ int RGWBucket::check_object_index(RGWBucketAdminOpState& op_state,
     result.reserve(listing_max_entries);
 
     int r = store->getRados()->cls_bucket_list_ordered(
-      bucket_info, RGW_NO_SHARD, marker, prefix, listing_max_entries, true,
-      result, &is_truncated, &marker, y, bucket_object_check_filter);
+      bucket_info, RGW_NO_SHARD, marker, prefix, empty_delimiter,
+      listing_max_entries, true, result, &is_truncated, &marker, y,
+      rgw_bucket_object_check_filter);
     if (r == -ENOENT) {
       break;
     } else if (r < 0 && r != -ENOENT) {

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -345,7 +345,6 @@ static int rgw_remove_bucket(rgw::sal::RGWRadosStore *store, rgw_bucket& bucket,
   RGWRados::Bucket target(store->getRados(), info);
   RGWRados::Bucket::List list_op(&target);
   CephContext *cct = store->ctx();
-  int max = 1000;
 
   list_op.params.list_versions = true;
   list_op.params.allow_unordered = true;
@@ -354,7 +353,8 @@ static int rgw_remove_bucket(rgw::sal::RGWRadosStore *store, rgw_bucket& bucket,
   do {
     objs.clear();
 
-    ret = list_op.list_objects(max, &objs, &common_prefixes, &is_truncated, null_yield);
+    ret = list_op.list_objects(listing_max_entries, &objs, &common_prefixes,
+			       &is_truncated, null_yield);
     if (ret < 0)
       return ret;
 
@@ -463,13 +463,13 @@ int rgw_remove_bucket_bypass_gc(rgw::sal::RGWRadosStore *store, rgw_bucket& buck
 
   std::list<librados::AioCompletion*> handles;
 
-  int max = 1000;
   int max_aio = concurrent_max;
   bool is_truncated = true;
 
   while (is_truncated) {
     objs.clear();
-    ret = list_op.list_objects(max, &objs, &common_prefixes, &is_truncated, null_yield);
+    ret = list_op.list_objects(listing_max_entries, &objs, &common_prefixes,
+			       &is_truncated, null_yield);
     if (ret < 0)
       return ret;
 
@@ -887,8 +887,6 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
   bool fix_index = op_state.will_fix_index();
   rgw_bucket bucket = op_state.get_bucket();
 
-  size_t max = 1000;
-
   map<string, bool> common_prefixes;
 
   bool is_truncated;
@@ -911,7 +909,8 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
 
   do {
     vector<rgw_bucket_dir_entry> result;
-    int r = list_op.list_objects(max, &result, &common_prefixes, &is_truncated, null_yield);
+    int r = list_op.list_objects(listing_max_entries, &result,
+				 &common_prefixes, &is_truncated, null_yield);
     if (r < 0) {
       set_err_msg(err_msg, "failed to list objects in bucket=" + bucket.name +
               " err=" +  cpp_strerror(-r));
@@ -941,7 +940,6 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
         }
       }
     }
-
   } while (is_truncated);
 
   list<rgw_obj_index_key> objs_to_unlink;
@@ -956,7 +954,7 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
       objs_to_unlink.push_back(aiter->first);
     }
 
-    if (objs_to_unlink.size() > max) {
+    if (objs_to_unlink.size() > listing_max_entries) {
       if (fix_index) {
 	int r = store->getRados()->remove_objs_from_index(bucket_info, objs_to_unlink);
 	if (r < 0) {
@@ -1012,12 +1010,11 @@ int RGWBucket::check_object_index(RGWBucketAdminOpState& op_state,
   formatter->open_object_section("objects");
   while (is_truncated) {
     RGWRados::ent_map_t result;
+    result.reserve(listing_max_entries);
 
-    int r = store->getRados()->cls_bucket_list_ordered(bucket_info, RGW_NO_SHARD,
-					   marker, prefix, 1000, true,
-					   result, &is_truncated, &marker,
-                                           y,
-					   bucket_object_check_filter);
+    int r = store->getRados()->cls_bucket_list_ordered(
+      bucket_info, RGW_NO_SHARD, marker, prefix, listing_max_entries, true,
+      result, &is_truncated, &marker, y, bucket_object_check_filter);
     if (r == -ENOENT) {
       break;
     } else if (r < 0 && r != -ENOENT) {
@@ -1955,12 +1952,12 @@ static int fix_bucket_obj_expiry(rgw::sal::RGWRadosStore *store,
   list_op.params.list_versions = bucket_info.versioned();
   list_op.params.allow_unordered = true;
 
-  constexpr auto max_objects = 1000;
   bool is_truncated {false};
   do {
     std::vector<rgw_bucket_dir_entry> objs;
 
-    int ret = list_op.list_objects(max_objects, &objs, nullptr, &is_truncated, null_yield);
+    int ret = list_op.list_objects(listing_max_entries, &objs, nullptr,
+				   &is_truncated, null_yield);
     if (ret < 0) {
       lderr(store->ctx()) << "ERROR failed to list objects in the bucket" << dendl;
       return ret;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1007,6 +1007,7 @@ int RGWBucket::check_object_index(RGWBucketAdminOpState& op_state,
   string empty_delimiter;
   rgw_obj_index_key marker;
   bool is_truncated = true;
+  bool cls_filtered = true;
 
   Formatter *formatter = flusher.get_formatter();
   formatter->open_object_section("objects");
@@ -1016,8 +1017,8 @@ int RGWBucket::check_object_index(RGWBucketAdminOpState& op_state,
 
     int r = store->getRados()->cls_bucket_list_ordered(
       bucket_info, RGW_NO_SHARD, marker, prefix, empty_delimiter,
-      listing_max_entries, true, result, &is_truncated, &marker, y,
-      rgw_bucket_object_check_filter);
+      listing_max_entries, true, result, &is_truncated, &cls_filtered,
+      &marker, y, rgw_bucket_object_check_filter);
     if (r == -ENOENT) {
       break;
     } else if (r < 0 && r != -ENOENT) {

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -22,6 +22,13 @@
 
 #include "services/svc_bucket_types.h"
 
+
+static constexpr size_t listing_max_entries = 1000;
+
+
+// define as static when RGWBucket implementation completes
+extern void rgw_get_buckets_obj(const rgw_user& user_id, string& buckets_obj_id);
+
 class RGWSI_Meta;
 class RGWBucketMetadataHandler;
 class RGWBucketInstanceMetadataHandler;

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -49,6 +49,10 @@ extern void rgw_parse_url_bucket(const string& bucket,
                                  const string& auth_tenant,
                                  string &tenant_name, string &bucket_name);
 
+// this is used as a filter to RGWRados::cls_bucket_list_ordered; it
+// conforms to the type declaration of RGWRados::check_filter_t.
+extern bool rgw_bucket_object_check_filter(const string& oid);
+
 struct RGWBucketCompleteInfo {
   RGWBucketInfo info;
   map<string, bufferlist> attrs;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1707,15 +1707,6 @@ int RGWRados::Bucket::update_bucket_id(const string& new_bucket_id)
 }
 
 
-static inline std::string after_delim(std::string_view delim)
-{
-  // assert: ! delim.empty()
-  std::string result{delim.data(), delim.length()};
-  result += char(255);
-  return result;
-}
-
-
 /**
  * Get ordered listing of the objects in a bucket.
  *
@@ -1767,7 +1758,7 @@ int RGWRados::Bucket::List::list_objects_ordered(int64_t max_p,
   string after_delim_s; /* needed in !params.delim.empty() AND later */
 
   if (!params.delim.empty()) {
-    after_delim_s = after_delim(params.delim);
+    after_delim_s = cls_rgw_after_delim(params.delim);
     /* if marker points at a common prefix, fast forward it into its
      * upper bound string */
     int delim_pos = cur_marker.name.find(params.delim, cur_prefix.size());

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1710,7 +1710,7 @@ int RGWRados::Bucket::update_bucket_id(const string& new_bucket_id)
 /**
  * Get ordered listing of the objects in a bucket.
  *
- * max: maximum number of results to return
+ * max_p: maximum number of results to return
  * bucket: bucket to list contents of
  * prefix: only return results that match this prefix
  * delim: do not include results that match this string.

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1724,11 +1724,12 @@ int RGWRados::Bucket::update_bucket_id(const string& new_bucket_id)
  * is_truncated: if number of objects in the bucket is bigger than
  * max, then truncated.
  */
-int RGWRados::Bucket::List::list_objects_ordered(int64_t max_p,
-						 vector<rgw_bucket_dir_entry> *result,
-						 map<string, bool> *common_prefixes,
-						 bool *is_truncated,
-						 optional_yield y)
+int RGWRados::Bucket::List::list_objects_ordered(
+  int64_t max_p,
+  vector<rgw_bucket_dir_entry> *result,
+  map<string, bool> *common_prefixes,
+  bool *is_truncated,
+  optional_yield y)
 {
   RGWRados *store = target->get_store();
   CephContext *cct = store->ctx();

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1348,10 +1348,13 @@ public:
 
   using check_filter_t = bool (*)(const std::string&);
 
-  int cls_bucket_list_ordered(RGWBucketInfo& bucket_info, int shard_id,
+  int cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
+			      int shard_id,
 			      const rgw_obj_index_key& start_after,
 			      const string& prefix,
-			      uint32_t num_entries, bool list_versions,
+			      const string& delimiter,
+			      uint32_t num_entries,
+			      bool list_versions,
 			      ent_map_t& m,
 			      bool *is_truncated,
 			      rgw_obj_index_key *last_entry,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1356,7 +1356,8 @@ public:
 			      uint32_t num_entries,
 			      bool list_versions,
 			      ent_map_t& m,
-			      bool *is_truncated,
+			      bool* is_truncated,
+			      bool* cls_filtered,
 			      rgw_obj_index_key *last_entry,
                               optional_yield y,
 			      check_filter_t force_check_filter = nullptr);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1346,23 +1346,28 @@ public:
   using ent_map_t =
     boost::container::flat_map<std::string, rgw_bucket_dir_entry>;
 
+  using check_filter_t = bool (*)(const std::string&);
+
   int cls_bucket_list_ordered(RGWBucketInfo& bucket_info, int shard_id,
-			      const rgw_obj_index_key& start,
+			      const rgw_obj_index_key& start_after,
 			      const string& prefix,
 			      uint32_t num_entries, bool list_versions,
 			      ent_map_t& m,
 			      bool *is_truncated,
 			      rgw_obj_index_key *last_entry,
                               optional_yield y,
-			      bool (*force_check_filter)(const string& name) = nullptr);
-  int cls_bucket_list_unordered(RGWBucketInfo& bucket_info, int shard_id,
-				const rgw_obj_index_key& start,
+			      check_filter_t force_check_filter = nullptr);
+  int cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
+				int shard_id,
+				const rgw_obj_index_key& start_after,
 				const string& prefix,
-				uint32_t num_entries, bool list_versions,
+				uint32_t num_entries,
+				bool list_versions,
 				vector<rgw_bucket_dir_entry>& ent_list,
-				bool *is_truncated, rgw_obj_index_key *last_entry,
+				bool *is_truncated,
+				rgw_obj_index_key *last_entry,
                                 optional_yield y,
-				bool (*force_check_filter)(const string& name) = nullptr);
+				check_filter_t = nullptr);
   int cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, vector<rgw_bucket_dir_header>& headers, map<int, string> *bucket_instance_ids = NULL);
   int cls_bucket_head_async(const RGWBucketInfo& bucket_info, int shard_id, RGWGetDirHeader_CB *ctx, int *num_aio);
 

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -421,8 +421,11 @@ TEST_F(cls_rgw, index_list)
   map<int, string> oids = { {0, bucket_oid} };
   map<int, struct rgw_cls_list_ret> list_results;
   cls_rgw_obj_key start_key("", "");
-  int r = CLSRGWIssueBucketList(ioctx, start_key, "", 1000, true, oids, list_results, 1)();
-
+  string empty_prefix;
+  string empty_delimiter;
+  int r = CLSRGWIssueBucketList(ioctx, start_key,
+				empty_prefix, empty_delimiter,
+				1000, true, oids, list_results, 1)();
   ASSERT_EQ(r, 0);
   ASSERT_EQ(1u, list_results.size());
 


### PR DESCRIPTION
Presently, when listing the contents of a bucket using delimiters (i.e., for simulated subdirectories), the cls/osds return many more entries than will ultimately be listed. This uses CPU to encode and decode them along with network traffic to send them. This process would be much more efficient if the logic for this was pushed down to the cls/osd level.

This PR does other clean-ups as well.

Tracker: https://tracker.ceph.com/issues/41051