### PR TITLE
common: fix compat of strerror_r

### DIFF
--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -193,3 +193,14 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize,
 }
 #endif
 
+char *ceph_strerror_r(int errnum, char *buf, size_t buflen)
+{
+#ifdef STRERROR_R_CHAR_P
+  return strerror_r(errnum, buf, buflen);
+#else
+  if (strerror_r(errnum, buf, buflen)) {
+    snprintf(buf, buflen, "Unknown error %d", errnum);
+  }
+  return buf;
+#endif
+}

--- a/src/common/errno.cc
+++ b/src/common/errno.cc
@@ -1,5 +1,6 @@
 #include "common/errno.h"
 #include "acconfig.h"
+#include "include/compat.h"
 
 #include <sstream>
 #include <string.h>
@@ -12,15 +13,8 @@ std::string cpp_strerror(int err)
   if (err < 0)
     err = -err;
   std::ostringstream oss;
-  buf[0] = '\0';
 
-  // strerror_r returns char * on Linux, and does not always fill buf
-#ifdef STRERROR_R_CHAR_P
-  errmsg = strerror_r(err, buf, sizeof(buf));
-#else
-  strerror_r(err, buf, sizeof(buf));
-  errmsg = buf;
-#endif
+  errmsg = ceph_strerror_r(err, buf, sizeof(buf));
 
   oss << "(" << err << ") " << errmsg;
 

--- a/src/common/module.c
+++ b/src/common/module.c
@@ -11,6 +11,7 @@
  */
 
 #include "acconfig.h"
+#include "include/compat.h"
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,14 +43,9 @@ static int run_command(const char *command)
 
 	if (status < 0) {
 		char error_buf[80];
-#ifdef STRERROR_R_CHAR_P
-		char* dummy = strerror_r(errno, error_buf, sizeof(error_buf));
-		(void)dummy;
-#else
-		strerror_r(errno, error_buf, sizeof(error_buf));
-#endif
+		char* errp = ceph_strerror_r(errno, error_buf, sizeof(error_buf));
 		fprintf(stderr, "couldn't run '%s': %s\n", command,
-			error_buf);
+			errp);
 	} else if (WIFSIGNALED(status)) {
 		fprintf(stderr, "'%s' killed by signal %d\n", command,
 			WTERMSIG(status));

--- a/src/common/secret.c
+++ b/src/common/secret.c
@@ -19,6 +19,7 @@
 #include <fcntl.h>
 #include <keyutils.h>
 
+#include "include/compat.h"
 #include "common/armor.h"
 #include "common/safe_io.h"
 
@@ -65,7 +66,7 @@ int set_kernel_secret(const char *secret, const char *key_name)
   if (ret < 0) {
     char error_buf[80];
     fprintf(stderr, "secret is not valid base64: %s.\n",
-	    strerror_r(-ret, error_buf, sizeof(error_buf)));
+	    ceph_strerror_r(-ret, error_buf, sizeof(error_buf)));
     return ret;
   }
 
@@ -113,7 +114,7 @@ int get_secret_option(const char *secret, const char *key_name,
       } else {
         char error_buf[80];
 	fprintf(stderr, "adding ceph secret key to kernel failed: %s.\n",
-		strerror_r(-ret, error_buf, sizeof(error_buf)));
+		ceph_strerror_r(-ret, error_buf, sizeof(error_buf)));
 	return ret;
       }
     }

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -195,4 +195,14 @@ int ceph_posix_fallocate(int fd, off_t offset, off_t len);
 
 int pipe_cloexec(int pipefd[2], int flags);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *ceph_strerror_r(int errnum, char *buf, size_t buflen);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* !CEPH_COMPAT_H */


### PR DESCRIPTION
https://linux.die.net/man/3/strerror_r

under Alpine Linux, there are a few compiling warnings:

```
warning: format specifies type 'char *' but the argument has type 'int' [-Wformat]
```

Signed-off-by: luo.runbing <luo.runbing@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
