### PR TITLE
rgw: use observer api

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -230,7 +230,7 @@ bool ObjectCache::remove(const string& name)
 void ObjectCache::touch_lru(const string& name, ObjectCacheEntry& entry,
 			    std::list<string>::iterator& lru_iter)
 {
-  while (lru_size > (size_t)cct->_conf->rgw_cache_lru_size) {
+  while (lru_size > lru_max_size) {
     auto iter = lru.begin();
     if ((*iter).compare(name) == 0) {
       /*
@@ -338,9 +338,32 @@ void ObjectCache::unchain_cache(RGWChainedCache *cache) {
 }
 
 ObjectCache::~ObjectCache()
-{
+{ 
+  cct->_conf.remove_observer(this);
   for (auto cache : chained_cache) {
     cache->unregistered();
+  }
+}
+
+const char** ObjectCache::get_tracked_conf_keys() const
+{
+  static const char* keys[] = {
+    "rgw_cache_lru_size",
+    "rgw_cache_expiry_interval",
+    nullptr
+  };
+  return keys;
+}
+
+ void ObjectCache::handle_conf_change(const ConfigProxy& conf,
+           const std::set<std::string>& changed)
+{
+  if (changed.find("rgw_cache_lru_size") != changed.end()) {
+    lru_max_size = cct->_conf.get_val<int64_t>("rgw_cache_lru_size");
+    lru_window = lru_max_size / 2;
+      }
+  if (changed.find("rgw_cache_expiry_interval") != changed.end()) {
+    expiry = std::chrono::seconds(cct->_conf.get_val<uint64_t>("rgw_cache_expiry_interval"));
   }
 }
 

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -154,18 +154,19 @@ struct ObjectCacheEntry {
   ObjectCacheEntry() : lru_promotion_ts(0), gen(0) {}
 };
 
-class ObjectCache {
+class ObjectCache: public md_config_obs_t {
   std::unordered_map<string, ObjectCacheEntry> cache_map;
   std::list<string> lru;
+  unsigned long lru_max_size;
   unsigned long lru_size;
   unsigned long lru_counter;
   unsigned long lru_window;
   ceph::shared_mutex lock = ceph::make_shared_mutex("ObjectCache");
   CephContext *cct;
-
+  
   vector<RGWChainedCache *> chained_cache;
 
-  bool enabled;
+  bool enabled = false;
   ceph::timespan expiry;
 
   void touch_lru(const string& name, ObjectCacheEntry& entry,
@@ -202,10 +203,11 @@ public:
   bool remove(const std::string& name);
   void set_ctx(CephContext *_cct) {
     cct = _cct;
-    lru_window = cct->_conf->rgw_cache_lru_size / 2;
-    expiry = std::chrono::seconds(cct->_conf.get_val<uint64_t>(
-						"rgw_cache_expiry_interval"));
-  }
+    lru_max_size = cct->_conf.get_val<int64_t>("rgw_cache_lru_size");
+    lru_window = lru_max_size / 2;
+    expiry = std::chrono::seconds(cct->_conf.get_val<uint64_t>("rgw_cache_expiry_interval")); 
+    cct->_conf.add_observer(this);
+}
   bool chain_cache_entry(std::initializer_list<rgw_cache_entry_info*> cache_info_entries,
 			 RGWChainedCache::Entry *chained_entry);
 
@@ -214,6 +216,8 @@ public:
   void chain_cache(RGWChainedCache *cache);
   void unchain_cache(RGWChainedCache *cache);
   void invalidate_all();
+  const char** get_tracked_conf_keys() const override;
+  void handle_conf_change(const ConfigProxy& conf, const std::set<std::string>& changed) override;
 };
 
 #endif


### PR DESCRIPTION
Use config observer api to dynamically convert rgw_cache_lru_size
and rgw_cache_expiry interval

Signed-off-by: Albin Antony <aantony@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
