### PR TITLE
mgr/dashboard: Display WWN and LUN number in iSCSI target details

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -721,8 +721,12 @@ class IscsiTarget(RESTController):
                 'pool': disk_config['pool'],
                 'image': disk_config['image'],
                 'controls': disk_config['controls'],
-                'backstore': disk_config['backstore']
+                'backstore': disk_config['backstore'],
+                'wwn': disk_config['wwn']
             }
+            # lun_id was introduced in ceph-iscsi config v11
+            if config['version'] > 10:
+                disk['lun'] = target_config['disks'][target_disk]['lun_id']
             disks.append(disk)
         disks = IscsiTarget._sorted_disks(disks)
         clients = []

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
@@ -54,7 +54,7 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
       {
         prop: 'displayName',
         name: this.i18n('Name'),
-        flexGrow: 2,
+        flexGrow: 1,
         cellTemplate: this.highlightTpl
       },
       {
@@ -122,7 +122,11 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
         controls: disk.controls,
         backstore: disk.backstore
       };
-
+      ['wwn', 'lun'].forEach((k) => {
+        if (k in disk) {
+          this.metadata[id][k] = disk[k];
+        }
+      });
       disks.push({
         value: `${disk.pool}/${disk.image}`,
         id: id
@@ -302,6 +306,15 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
           displayName: 'backstore',
           default: this.iscsiBackstorePipe.transform(this.settings.default_backstore),
           current: this.iscsiBackstorePipe.transform(tempData.backstore)
+        });
+        ['wwn', 'lun'].forEach((k) => {
+          if (k in tempData) {
+            this.data.push({
+              displayName: k,
+              default: undefined,
+              current: tempData[k]
+            });
+          }
         });
       } else {
         this.columns[2].isHidden = true;

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -225,7 +225,10 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
                 "image": "lun3",
                 "pool": "rbd",
                 "controls": {},
-                "backstore": "user:rbd"
+                "backstore": "user:rbd",
+                "wwn": "64af6678-9694-4367-bacc-f8eb0baa2",
+                "lun": 2
+
             })
         response['clients'][0]['luns'].append({"image": "lun3", "pool": "rbd"})
         self._update_iscsi_target(create_request, update_request, response)
@@ -431,8 +434,10 @@ iscsi_target_response = {
     ],
     'disks': [
         {'pool': 'rbd', 'image': 'lun1', 'backstore': 'user:rbd',
+         'wwn': '64af6678-9694-4367-bacc-f8eb0baa0', 'lun': 0,
          'controls': {'max_data_area_mb': 128}},
         {'pool': 'rbd', 'image': 'lun2', 'backstore': 'user:rbd',
+         'wwn': '64af6678-9694-4367-bacc-f8eb0baa1', 'lun': 1,
          'controls': {'max_data_area_mb': 128}}
     ],
     'clients': [
@@ -565,7 +570,7 @@ class IscsiClientMock(object):
         }
 
     def get_config(self):
-        return self.config
+        return copy.deepcopy(self.config)
 
     def create_target(self, target_iqn, target_controls):
         self.config['targets'][target_iqn] = {
@@ -581,7 +586,7 @@ class IscsiClientMock(object):
             },
             "controls": target_controls,
             "created": "2019/01/17 09:22:34",
-            "disks": [],
+            "disks": {},
             "groups": {},
             "portals": {}
         }
@@ -608,12 +613,15 @@ class IscsiClientMock(object):
             "pool": pool,
             "image": image,
             "backstore": backstore,
-            "controls": {}
+            "controls": {},
+            "wwn": '64af6678-9694-4367-bacc-f8eb0baa' + str(len(self.config['disks']))
         }
 
     def create_target_lun(self, target_iqn, image_id):
         target_config = self.config['targets'][target_iqn]
-        target_config['disks'].append(image_id)
+        target_config['disks'][image_id] = {
+            "lun_id": len(target_config['disks'])
+        }
         self.config['disks'][image_id]['owner'] = list(target_config['portals'].keys())[0]
 
     def reconfigure_disk(self, pool, image, controls):
@@ -673,7 +681,7 @@ class IscsiClientMock(object):
 
     def delete_target_lun(self, target_iqn, image_id):
         target_config = self.config['targets'][target_iqn]
-        target_config['disks'].remove(image_id)
+        target_config['disks'].pop(image_id)
         del self.config['disks'][image_id]['owner']
 
     def delete_disk(self, pool, image):


### PR DESCRIPTION
Requires ceph-iscsi config v11 introduced on PR ceph/ceph-iscsi#133 (Merged)

This PR will display the WWN and LUN number in iSCSI target disk details:

![Screenshot from 2019-09-10 17-22-15](https://user-images.githubusercontent.com/14297426/64631840-decafc00-d3ef-11e9-89ed-b2b458b6cc9d.png)


Fixes: https://tracker.ceph.com/issues/41742

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
