### PR TITLE
doc: Fixes typo for ceph dashboard command.

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -732,7 +732,7 @@ commands to manage roles are the following:
 
 - *Delete Scope Permission from Role*::
 
-  $ ceph dashboard ac-role-del-perms <rolename> <scopename>
+  $ ceph dashboard ac-role-del-scope-perms <rolename> <scopename>
 
 To associate roles to users, the following CLI commands are available:
 


### PR DESCRIPTION
`ceph dashboard ac-role-del-scope-perms` was mistakenly written as `ceph dashboard ac-role-del-perms` in the documentation. Every other mention of this command uses the former spelling which leads me to believe that it is the correct one.

Signed-off-by: Fabian Bonk <fabian.bonk@croit.io>

- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
