### PR TITLE
cephfs-shell: rewrite help text for put and get commands

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -1,3 +1,7 @@
+"""
+Before running this testsuite, add path to cephfs-shell module to $PATH and
+export $PATH.
+"""
 from os import path
 import crypt
 import logging

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -560,7 +560,7 @@ exists.')
     @with_argparser(put_parser)
     def do_put(self, args):
         """
-        Copy a file to Ceph File System from Local Directory.
+        Copy a local file/directory to CephFS.
         """
         root_src_dir = args.local_path
         root_dst_dir = args.remote_path
@@ -661,7 +661,7 @@ exists.')
     @with_argparser(get_parser)
     def do_get(self, args):
         """
-        Copy a file/directory  from Ceph File System to Local Directory.
+        Copy a file/directory from CephFS to given path.
         """
         root_src_dir = args.remote_path
         root_dst_dir = args.local_path


### PR DESCRIPTION
Just a quick fix.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>