### PR TITLE
luminous: osd: Better error message when OSD count is less than osd_pool_default_size

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -408,6 +408,12 @@ Please refer to
 :doc:`placement-groups#Choosing-the-number-of-Placement-Groups` for
 more information.
 
+TOO_FEW_OSDS
+____________
+
+The number of OSDs in the cluster is below the configurable
+threshold of ``osd_pool_default_size``.
+
 SMALLER_PGP_NUM
 _______________
 

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1507,9 +1507,11 @@ function test_wait_for_health_ok() {
     local dir=$1
 
     setup $dir || return 1
-    run_mon $dir a --osd_pool_default_size=1 --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
+    run_mon $dir a --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
     run_mgr $dir x --mon_pg_warn_min_per_osd=0 || return 1
     run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
     ! TIMEOUT=1 wait_for_health_ok || return 1
     activate_osd $dir 0 || return 1

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1513,6 +1513,7 @@ function test_wait_for_health_ok() {
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
+    ceph osd down 0 || return 1
     ! TIMEOUT=1 wait_for_health_ok || return 1
     activate_osd $dir 0 || return 1
     wait_for_health_ok || return 1

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1509,13 +1509,18 @@ function test_wait_for_health_ok() {
     setup $dir || return 1
     run_mon $dir a --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
     run_mgr $dir x --mon_pg_warn_min_per_osd=0 || return 1
+    # start osd_pool_default_size OSDs
     run_osd $dir 0 || return 1
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
     kill_daemons $dir TERM osd || return 1
     ceph osd down 0 || return 1
+    # expect TOO_FEW_OSDS warning
     ! TIMEOUT=1 wait_for_health_ok || return 1
+    # resurrect all OSDs
     activate_osd $dir 0 || return 1
+    activate_osd $dir 1 || return 1
+    activate_osd $dir 2 || return 1
     wait_for_health_ok || return 1
     teardown $dir || return 1
 }

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1464,12 +1464,12 @@ function test_wait_for_clean() {
     local dir=$1
 
     setup $dir || return 1
-    run_mon $dir a --osd_pool_default_size=1 || return 1
+    run_mon $dir a --osd_pool_default_size=2 || return 1
     run_osd $dir 0 || return 1
     run_mgr $dir x || return 1
     create_rbd_pool || return 1
     ! TIMEOUT=1 wait_for_clean || return 1
-    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
     wait_for_clean || return 1
     teardown $dir || return 1
 }

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -490,13 +490,17 @@ function test_run_mon() {
 
     setup $dir || return 1
 
-    run_mon $dir a --mon-initial-members=a || return 1
+    run_mon $dir a --mon-initial-members=a --osd_pool_default_size=1 || return 1
+    run_osd $dir 0 || return 1
     create_rbd_pool || return 1
-    # rbd has not been deleted / created, hence it has pool id 0
+    # rbd has not been deleted / created, hence it has pool id 1
     ceph osd dump | grep "pool 1 'rbd'" || return 1
     kill_daemons $dir || return 1
 
-    run_mon $dir a || return 1
+    run_mon $dir a --osd_pool_default_size=3 || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
     create_rbd_pool || return 1
     # rbd has been deleted / created, hence it does not have pool id 0
     ! ceph osd dump | grep "pool 1 'rbd'" || return 1
@@ -1461,6 +1465,7 @@ function test_wait_for_clean() {
 
     setup $dir || return 1
     run_mon $dir a --osd_pool_default_size=1 || return 1
+    run_osd $dir 0 || return 1
     run_mgr $dir x || return 1
     create_rbd_pool || return 1
     ! TIMEOUT=1 wait_for_clean || return 1

--- a/qa/standalone/erasure-code/test-erasure-eio.sh
+++ b/qa/standalone/erasure-code/test-erasure-eio.sh
@@ -26,6 +26,7 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd-objectstore=filestore "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do

--- a/qa/standalone/erasure-code/test-erasure-eio.sh
+++ b/qa/standalone/erasure-code/test-erasure-eio.sh
@@ -33,7 +33,6 @@ function run() {
         setup $dir || return 1
         run_mon $dir a || return 1
 	run_mgr $dir x || return 1
-	create_rbd_pool || return 1
 
         # check that erasure code plugins are preloaded
         CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1

--- a/qa/standalone/mon/misc.sh
+++ b/qa/standalone/mon/misc.sh
@@ -39,7 +39,6 @@ function TEST_osd_pool_get_set() {
 
     setup $dir || return 1
     run_mon $dir a || return 1
-    create_rbd_pool || return 1
     create_pool $TEST_POOL 8
 
     local flag

--- a/qa/standalone/mon/osd-crush.sh
+++ b/qa/standalone/mon/osd-crush.sh
@@ -210,7 +210,7 @@ function TEST_crush_rename_bucket() {
 
 function TEST_crush_reject_empty() {
     local dir=$1
-    run_mon $dir a || return 1
+    run_mon $dir a --osd_pool_default_size=1 || return 1
     # should have at least one OSD
     run_osd $dir 0 || return 1
     create_rbd_pool || return 1

--- a/qa/standalone/mon/osd-pool-create.sh
+++ b/qa/standalone/mon/osd-pool-create.sh
@@ -213,6 +213,7 @@ function TEST_pool_create_rep_expected_num_objects() {
     setup $dir || return 1
 
     # disable pg dir merge
+    CEPH_ARGS+="--osd-objectstore=filestore"
     export CEPH_ARGS
     run_mon $dir a || return 1
     run_osd $dir 0 || return 1

--- a/qa/standalone/osd/osd-rep-recov-eio.sh
+++ b/qa/standalone/osd/osd-rep-recov-eio.sh
@@ -27,6 +27,7 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd-objectstore=filestore "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do

--- a/qa/standalone/osd/osd-rep-recov-eio.sh
+++ b/qa/standalone/osd/osd-rep-recov-eio.sh
@@ -27,13 +27,14 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--osd-objectstore=filestore "
+    CEPH_ARGS+="--osd-objectstore=filestore --osd_pool_default_size=1 "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
         setup $dir || return 1
         run_mon $dir a || return 1
 	run_mgr $dir x || return 1
+	run_osd $dir 0 || return 1
 	create_rbd_pool || return 1
 
         $func $dir || return 1

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -57,6 +57,7 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
     CEPH_ARGS+="--osd-skip-data-digest=false "
+    CEPH_ARGS+="--osd-objectstore=filestore "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -30,7 +30,7 @@ function run() {
     export CEPH_MON="127.0.0.1:7121" # git grep '\<7121\>' : there must be only one
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
-    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--mon-host=$CEPH_MON --osd-objectstore=filestore"
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do

--- a/qa/standalone/special/ceph_objectstore_tool.py
+++ b/qa/standalone/special/ceph_objectstore_tool.py
@@ -72,6 +72,7 @@ def get_pool_id(name, nullfd):
 
 # return a list of unique PGS given an osd subdirectory
 def get_osd_pgs(SUBDIR, ID):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     PGS = []
     if ID:
         endhead = re.compile("{id}.*_head$".format(id=ID))
@@ -83,6 +84,7 @@ def get_osd_pgs(SUBDIR, ID):
 
 # return a sorted list of unique PGs given a directory
 def get_pgs(DIR, ID):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     OSDS = [f for f in os.listdir(DIR) if os.path.isdir(os.path.join(DIR, f)) and f.find("osd") == 0]
     PGS = []
     for d in OSDS:
@@ -93,6 +95,7 @@ def get_pgs(DIR, ID):
 
 # return a sorted list of PGS a subset of ALLPGS that contain objects with prefix specified
 def get_objs(ALLPGS, prefix, DIR, ID):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     OSDS = [f for f in os.listdir(DIR) if os.path.isdir(os.path.join(DIR, f)) and f.find("osd") == 0]
     PGS = []
     for d in OSDS:
@@ -111,6 +114,7 @@ def get_objs(ALLPGS, prefix, DIR, ID):
 
 # return a sorted list of OSDS which have data from a given PG
 def get_osds(PG, DIR):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     ALLOSDS = [f for f in os.listdir(DIR) if os.path.isdir(os.path.join(DIR, f)) and f.find("osd") == 0]
     OSDS = []
     for d in ALLOSDS:
@@ -407,6 +411,7 @@ def kill_daemons():
 
 
 def check_data(DATADIR, TMPFILE, OSDDIR, SPLIT_NAME):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     repcount = 0
     ERRORS = 0
     for rawnsfile in [f for f in os.listdir(DATADIR) if f.split('-')[1].find(SPLIT_NAME) == 0]:
@@ -598,6 +603,7 @@ def test_get_set_inc_osdmap(CFSD_PREFIX, osd_path):
 
 
 def test_removeall(CFSD_PREFIX, db, OBJREPPGS, REP_POOL, CEPH_BIN, OSDDIR, REP_NAME, NUM_CLONED_REP_OBJECTS):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     # Test removeall
     TMPFILE = r"/tmp/tmp.{pid}".format(pid=os.getpid())
     nullfd = open(os.devnull, "w")
@@ -667,6 +673,7 @@ def test_removeall(CFSD_PREFIX, db, OBJREPPGS, REP_POOL, CEPH_BIN, OSDDIR, REP_N
 
 
 def main(argv):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     if sys.version_info[0] < 3:
         sys.stdout = stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
     else:

--- a/qa/suites/rados/objectstore/alloc-hint.yaml
+++ b/qa/suites/rados/objectstore/alloc-hint.yaml
@@ -11,6 +11,7 @@ overrides:
     conf:
       osd:
         filestore xfs extsize: true
+        osd objectstore: filestore
 
 tasks:
 - install:

--- a/qa/suites/rados/objectstore/ceph_objectstore_tool.yaml
+++ b/qa/suites/rados/objectstore/ceph_objectstore_tool.yaml
@@ -12,6 +12,8 @@ tasks:
       global:
         osd max object name len: 460
         osd max object namespace len: 64
+      osd:
+        osd objectstore: filestore
     log-whitelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/workunits/rados/test_alloc_hint.sh
+++ b/qa/workunits/rados/test_alloc_hint.sh
@@ -51,6 +51,7 @@ function setup_pgid() {
 }
 
 function expect_alloc_hint_eq() {
+    export CEPH_ARGS="--osd-objectstore=filestore"
     local expected_extsize="$1"
 
     for (( i = 0 ; i < "${NUM_OSDS}" ; i++ )); do

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1170,6 +1170,11 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description("Enable POOL_APP_NOT_ENABLED health check"),
 
+    Option("mon_warn_on_too_few_osds", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .add_service("mgr")
+    .set_description("Issue a health warning if there are fewer OSDs than osd_pool_default_size"),
+
     Option("mon_min_osdmap_epochs", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(500)
     .set_description(""),

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3013,6 +3013,15 @@ void PGMap::get_health_checks(
     }
   }
 
+  // TOO_FEW_OSDS
+  auto osd_pool_default_size = cct->_conf->get_val<uint64_t>("osd_pool_default_size");
+  if (osdmap.get_num_osds() < osd_pool_default_size) {
+    ostringstream ss;
+    ss << "OSD count " << osdmap.get_num_osds()
+	 << " < osd_pool_default_size " << osd_pool_default_size;
+    checks->add("TOO_FEW_OSDS", HEALTH_WARN, ss.str());
+  }
+
   // SMALLER_PGP_NUM
   // MANY_OBJECTS_PER_PG
   if (!pg_stat.empty()) {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3014,8 +3014,9 @@ void PGMap::get_health_checks(
   }
 
   // TOO_FEW_OSDS
-  auto osd_pool_default_size = cct->_conf->get_val<uint64_t>("osd_pool_default_size");
-  if (osdmap.get_num_osds() < osd_pool_default_size) {
+  auto warn_too_few_osds = cct->_conf->get_val<bool>("mon_warn_on_too_few_osds");
+  auto osd_pool_default_size = cct->_conf->get_val<int64_t>("osd_pool_default_size");
+  if (warn_too_few_osds && osdmap.get_num_osds() < osd_pool_default_size) {
     ostringstream ss;
     ss << "OSD count " << osdmap.get_num_osds()
 	 << " < osd_pool_default_size " << osd_pool_default_size;


### PR DESCRIPTION
NOTE: I intentionally omitted 0483c1c3e7ffdfa6a6f65c5ef000c45d2f096428 because there is no `qa/tasks/ceph.conf.template` in mimic. As noted below, in mimic the template file in the teuthology repo is used. Therefore, this PR has a companion PR in teuthology.

backport tracker: https://tracker.ceph.com/issues/40082
companion teuthology PR: https://github.com/ceph/teuthology/pull/1308

---

backport of https://github.com/ceph/ceph/pull/27806
parent tracker: https://tracker.ceph.com/issues/38617

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh