### PR TITLE
luminous ceph-volume lvm.zap fix cleanup for db partitions

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -77,7 +77,7 @@ def ensure_associated_lvs(lvs):
     wal_lvs = lvs._filter(lv_tags={'ceph.type': 'wal'})
     backing_devices = [
         (journal_lvs, 'journal'),
-        (db_lvs, 'block'),
+        (db_lvs, 'db'),
         (wal_lvs, 'wal')
     ]
 


### PR DESCRIPTION
this uses the correct type 'db' for db type partitions, else
a block.db parition does not get cleaned up by ceph-volume zap

Signed-off-by: Dominik Csapak <d.csapak@proxmox.com>
Fixes: http://tracker.ceph.com/issues/40664
Backport of: https://github.com/ceph/ceph/pull/28267