### PR TITLE
crimson/osd: extend OpsExecuter to carry about op effects.

### DIFF
--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -5,9 +5,11 @@
 
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include <boost/smart_ptr/local_shared_ptr.hpp>
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_future.hh>
 
@@ -31,6 +33,17 @@ class OSDOp;
 
 namespace ceph::osd {
 class OpsExecuter {
+  // an operation can be divided into two stages: main and effect-exposing
+  // one. The former is performed immediately on call to `do_osd_op()` while
+  // the later on `submit_changes()` – after successfully processing main
+  // stages of all involved operations. When any stage fails, none of all
+  // scheduled effect-exposing stages will be executed.
+  // when operation requires this division, `with_effect()` should be used.
+  struct effect_t {
+    virtual seastar::future<> execute() = 0;
+    virtual ~effect_t() = default;
+  };
+
   PGBackend::cached_os_t os;
   PG& pg;
   PGBackend& backend;
@@ -38,6 +51,14 @@ class OpsExecuter {
 
   size_t num_read = 0;    ///< count read ops
   size_t num_write = 0;   ///< count update ops
+
+  // this gizmo could be wrapped in std::optional for the sake of lazy
+  // initialization. we don't need it for ops that doesn't have effect
+  // TODO: verify the init overhead of chunked_fifo
+  seastar::chunked_fifo<std::unique_ptr<effect_t>> op_effects;
+
+  template <class Context, class MainFunc, class EffectFunc>
+  auto with_effect(Context&& ctx, MainFunc&& main_func, EffectFunc&& effect_func);
 
   seastar::future<> do_op_call(class OSDOp& osd_op);
 
@@ -74,9 +95,52 @@ public:
 
   seastar::future<> do_osd_op(class OSDOp& osd_op);
 
-  template <typename Func> seastar::future<> submit_changes(Func&& f) && {
-    return std::forward<Func>(f)(std::move(txn), std::move(os));
-  }
+  template <typename Func>
+  seastar::future<> submit_changes(Func&& f) &&;
 };
+
+template <class Context, class MainFunc, class EffectFunc>
+auto OpsExecuter::with_effect(
+  Context&& ctx,
+  MainFunc&& main_func,
+  EffectFunc&& effect_func)
+{
+  using context_t = std::decay_t<Context>;
+  // the language offers implicit conversion to pointer-to-function for
+  // lambda only when it's closureless
+  static_assert(std::is_convertible_v<EffectFunc,
+                                      seastar::future<> (*)(context_t&&)>,
+                "with_effect function is not allowed to capture");
+  struct task_t final : effect_t {
+    context_t ctx;
+    EffectFunc effect_func;
+
+    task_t(Context&& ctx, EffectFunc&& effect_func)
+       : ctx(std::move(ctx)), effect_func(std::move(effect_func)) {}
+    seastar::future<> execute() final {
+      return std::move(effect_func)(std::move(ctx));
+    }
+  };
+  auto task =
+    std::make_unique<task_t>(std::move(ctx), std::move(effect_func));
+  auto& ctx_ref = task->ctx;
+  op_effects.emplace_back(std::move(task));
+  return std::forward<MainFunc>(main_func)(ctx_ref);
+}
+
+template <typename Func>
+seastar::future<> OpsExecuter::submit_changes(Func&& f) && {
+  return std::forward<Func>(f)(std::move(txn), std::move(os)).then(
+    // NOTE: this lambda could be scheduled conditionally (if_then?)
+    [this] {
+      return seastar::do_until(
+        [this] { return op_effects.empty(); },
+        [this] {
+          auto fut = op_effects.front()->execute();
+          op_effects.pop_front();
+          return fut;
+        });
+    });
+}
 
 } // namespace ceph::osd


### PR DESCRIPTION
This commit brings a new infrastructural piece that will be needed by e.g. the watch/notify mechanism.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
