### PR TITLE
mgr/dashboard: Firefox ngx-datatable performance issue

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -92,7 +92,7 @@ describe('TableComponent', () => {
     mouseEvent.stopPropagation = () => {
       wasCalled = true;
     };
-    spyOn(window, 'addEventListener').and.callFake((eventName, fn) => {
+    spyOn(component.table.element, 'addEventListener').and.callFake((eventName, fn) => {
       fn(mouseEvent);
       expect(eventName).toBe('mouseenter');
       expect(wasCalled).toBe(true);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -179,7 +179,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   ngOnInit() {
     // ngx-datatable triggers calculations each time mouse enters a row,
     // this will prevent that.
-    window.addEventListener('mouseenter', (event) => event.stopPropagation(), true);
+    this.table.element.addEventListener('mouseenter', (e) => e.stopPropagation(), true);
     this._addTemplates();
     if (!this.sorts) {
       // Check whether the specified identifier exists.


### PR DESCRIPTION
AFAICT, this issue affects Firefox users, only. I assume this is due Chrome handling the same situation faster and thus not having an issue at this point. 

This PR removes a fix for Chrome (and likely Firefox) users which was supposed to fix a slow down of large data tables. I was not able to reproduce this behavior, though. The fix that is removed by this PR is a workaround. A genuine fix needs to be implemented in the `ngx-datatable` package to disable the unwanted behavior there instead of mitigating it using a workaround.

The "unwanted behavior" is the redrawing (or firing of an event) of the data table each time the mouse is hovered over a row of the data table. It is not prevented that the event is fired with the provided workaround, but it its prevented that the event bubbles up to parent elements. The event handler that is added prevent the bubbling is called very often in a very short time frame. This is what causes Firefox to slow down. Removing that workaround makes Firefox perform again.

For a more detailed description of the issues as well as short recordings, please have a look at the [tracker issue](https://tracker.ceph.com/issues/41667).

Related issues:

- https://github.com/ceph/ceph/pull/28118
- https://github.com/swimlane/ngx-datatable/issues/1513
- https://github.com/swimlane/ngx-datatable/pull/1544

Fixes: https://tracker.ceph.com/issues/41667

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
