### PR TITLE
rgw: lifecycle transition won't process small object.

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1303,6 +1303,7 @@ OPTION(rgw_lc_lock_max_time, OPT_INT)  // total run time for a single lc process
 OPTION(rgw_lc_max_objs, OPT_INT)
 OPTION(rgw_lc_max_rules, OPT_U32)  // Max rules set on one bucket
 OPTION(rgw_lc_debug_interval, OPT_INT)  // Debug run interval, in seconds
+OPTION(rgw_lc_transition_min_size, OPT_U64)  // Min size of object for storage class transition
 OPTION(rgw_script_uri, OPT_STR) // alternative value for SCRIPT_URI if not set in request
 OPTION(rgw_request_uri, OPT_STR) // alternative value for REQUEST_URI if not set in request
 OPTION(rgw_ignore_get_invalid_range, OPT_BOOL) // treat invalid (e.g., negative) range requests as full

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5753,6 +5753,10 @@ std::vector<Option> get_rgw_options() {
     .set_default(-1)
     .set_description(""),
 
+    Option("rgw_lc_transition_min_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .set_default(128_K)
+    .set_description("Min size of object that will be processed by lifecycle transition action"),
+
     Option("rgw_mp_lock_max_time", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(600)
     .set_description("Multipart upload max completion time")

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -857,6 +857,10 @@ public:
       return false;
     }
 
+    if (o.meta.accounted_size < oc.cct->_conf->rgw_lc_transition_min_size) {
+      return false;
+    }
+
     auto mtime = get_effective_mtime(oc);
     bool is_expired;
     if (transition.days <= 0) {


### PR DESCRIPTION
Amazon S3 does not transition objects that are smaller than 128K.

https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-transition-general-considerations.html

Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>



</details>
