### PR TITLE
script/run-make.sh: do not pass cmake options twice

### DIFF
--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -111,9 +111,8 @@ EOM
 }
 
 function configure() {
-    CMAKE_BUILD_OPTS="$@"
-    CMAKE_BUILD_OPTS+=$(detect_ceph_dev_pkgs)
-    $DRY_RUN ./do_cmake.sh $CMAKE_BUILD_OPTS $@ || return 1
+    local cmake_build_opts=$(detect_ceph_dev_pkgs)
+    $DRY_RUN ./do_cmake.sh $cmake_build_opts $@ || return 1
 }
 
 function build() {


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
