### PR TITLE
nautilus: mgr/dashboard: Empty datatable rendered before data has been fetched

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -320,6 +320,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     if (this.table && this.table.element.clientWidth !== this.currentWidth) {
       this.currentWidth = this.table.element.clientWidth;
       this.table.recalculate();
+      window.dispatchEvent(new Event('resize'));
     }
   }
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/41698