### PR TITLE
script/run-cbt.sh: always use python3

### DIFF
--- a/src/script/run-cbt.sh
+++ b/src/script/run-cbt.sh
@@ -93,11 +93,11 @@ fi
 for config_file in $config_files; do
     echo "testing $config_file"
     cbt_config=$(mktemp $config_file.XXXX.yaml)
-    $source_dir/src/test/crimson/cbt/t2c.py \
+    python3 $source_dir/src/test/crimson/cbt/t2c.py \
         --build-dir $build_dir \
         --input $config_file \
         --output $cbt_config
-    $cbt_dir/cbt.py \
+    python3 $cbt_dir/cbt.py \
         --archive $archive_dir \
         --conf $build_dir/ceph.conf \
         $cbt_config

--- a/src/test/crimson/cbt/t2c.py
+++ b/src/test/crimson/cbt/t2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import argparse


### PR DESCRIPTION
run-cbt.sh will be used by the "ceph-perf-pull-requests" jenkins job,
which will prepare the runtime dependencies by installing python3
modules.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
