### PR TITLE
nautilus: build/ops: install-deps.sh: install `python*-devel` for python*rpm-macros

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -340,6 +340,7 @@ else
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
                 if test $ID = centos -a $MAJOR_VERSION = 7 ; then
+		    $SUDO $yumdnf install -y python36-devel
 		    case $(uname -m) in
 			x86_64)
 			    $SUDO yum -y install centos-release-scl


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41700

---

backport of https://github.com/ceph/ceph/pull/30190
parent tracker: https://tracker.ceph.com/issues/41603

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh