### PR TITLE
mgr/dashboard: Add smartctl data as an details tab of an OSD

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -63,6 +63,32 @@ class Osd(RESTController):
         }
         return resp if svc_id is None else resp[int(svc_id)]
 
+    @staticmethod
+    def _get_smart_data(svc_id):
+        # type: (str) -> dict
+        """
+        Returns S.M.A.R.T data for the given OSD ID.
+        :type svc_id: Numeric ID of the OSD
+        """
+        devices = CephService.send_command(
+            'mon', 'device ls-by-daemon', who='osd.{}'.format(svc_id))
+        smart_data = {}
+        for dev_id in [d['devid'] for d in devices]:
+            if dev_id not in smart_data:
+                dev_smart_data = mgr.remote('devicehealth', 'do_scrape_daemon', 'osd', svc_id,
+                                            dev_id)
+                for _, dev_data in dev_smart_data.items():
+                    if 'error' in dev_data:
+                        logger.warning('[OSD] Error retrieving smartctl data for device ID %s: %s',
+                                       dev_id, dev_smart_data)
+                smart_data.update(dev_smart_data)
+        return smart_data
+
+    @RESTController.Resource('GET')
+    def get_smart_data(self, svc_id):
+        # type: (str) -> dict
+        return self._get_smart_data(svc_id)
+
     @handle_send_command_error('osd')
     def get(self, svc_id):
         """

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -94,12 +94,12 @@ class Osd(RESTController):
         """
         Returns collected data about an OSD.
 
-        :return: Returns the requested data. The `histogram` key man contain a
-                 string with an error that occurred when the OSD is down.
+        :return: Returns the requested data. The `histogram` key may contain a
+                 string with an error that occurred if the OSD is down.
         """
         try:
-            histogram = CephService.send_command('osd', srv_spec=svc_id,
-                                                 prefix='perf histogram dump')
+            histogram = CephService.send_command(
+                'osd', srv_spec=svc_id, prefix='perf histogram dump')
         except SendCommandError as e:
             if 'osd down' in str(e):
                 histogram = str(e)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -35,6 +35,7 @@ import { OsdPgScrubModalComponent } from './osd/osd-pg-scrub-modal/osd-pg-scrub-
 import { OsdRecvSpeedModalComponent } from './osd/osd-recv-speed-modal/osd-recv-speed-modal.component';
 import { OsdReweightModalComponent } from './osd/osd-reweight-modal/osd-reweight-modal.component';
 import { OsdScrubModalComponent } from './osd/osd-scrub-modal/osd-scrub-modal.component';
+import { OsdSmartListComponent } from './osd/osd-smart-list/osd-smart-list.component';
 import { AlertListComponent } from './prometheus/alert-list/alert-list.component';
 import { PrometheusTabsComponent } from './prometheus/prometheus-tabs/prometheus-tabs.component';
 import { SilenceFormComponent } from './prometheus/silence-form/silence-form.component';
@@ -98,7 +99,8 @@ import { ServicesComponent } from './services/services.component';
     SilenceMatcherModalComponent,
     ServicesComponent,
     InventoryComponent,
-    HostFormComponent
+    HostFormComponent,
+    OsdSmartListComponent
   ]
 })
 export class ClusterModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -1,10 +1,12 @@
 <tabset *ngIf="selection.hasSingleSelection">
+
   <tab heading="Attributes (OSD map)"
        i18n-heading>
     <cd-table-key-value *ngIf="osd.loaded"
                         [data]="osd.details.osd_map">
     </cd-table-key-value>
   </tab>
+
   <tab heading="Metadata"
        i18n-heading>
     <cd-table-key-value *ngIf="osd.loaded && osd.details.osd_metadata; else noMetaData"
@@ -15,6 +17,12 @@
       <cd-warning-panel i18n>Metadata not available</cd-warning-panel>
     </ng-template>
   </tab>
+
+  <tab heading="Device health"
+       i18n-heading>
+    <cd-osd-smart-list [osdId]="osd.id"></cd-osd-smart-list>
+  </tab>
+
   <tab heading="Performance counter"
        i18n-heading>
     <cd-table-performance-counter *ngIf="osd.loaded"
@@ -22,6 +30,7 @@
                                   [serviceId]="osd.id">
     </cd-table-performance-counter>
   </tab>
+
   <tab heading="Histogram"
        i18n-heading>
     <cd-warning-panel *ngIf="osd.loaded && osd.histogram_failed"
@@ -41,6 +50,7 @@
       </div>
     </div>
   </tab>
+
   <tab i18n-heading
        *ngIf="grafanaPermission.read"
        heading="Performance Details">
@@ -49,4 +59,5 @@
                 grafanaStyle="GrafanaStyles.two">
     </cd-grafana>
   </tab>
+
 </tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
@@ -12,6 +12,7 @@ import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../../shared/shared.module';
 import { PerformanceCounterModule } from '../../../performance-counter/performance-counter.module';
 import { OsdPerformanceHistogramComponent } from '../osd-performance-histogram/osd-performance-histogram.component';
+import { OsdSmartListComponent } from '../osd-smart-list/osd-smart-list.component';
 import { OsdDetailsComponent } from './osd-details.component';
 
 describe('OsdDetailsComponent', () => {
@@ -28,7 +29,7 @@ describe('OsdDetailsComponent', () => {
       PerformanceCounterModule,
       SharedModule
     ],
-    declarations: [OsdDetailsComponent, OsdPerformanceHistogramComponent],
+    declarations: [OsdDetailsComponent, OsdPerformanceHistogramComponent, OsdSmartListComponent],
     providers: i18nProviders
   });
 
@@ -65,7 +66,7 @@ describe('OsdDetailsComponent', () => {
   it('should succeed creating a histogram', () => {
     const detailDataWithHistogram = {
       osd_map: {},
-      osd_metdata: {},
+      osd_metadata: {},
       histogram: {}
     };
     getDetailsSpy.and.returnValue(of(detailDataWithHistogram));

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.ts
@@ -16,7 +16,13 @@ export class OsdDetailsComponent implements OnChanges {
   @Input()
   selection: CdTableSelection;
 
-  osd: any;
+  osd: {
+    id?: number;
+    loaded?: boolean;
+    details?: any;
+    histogram_failed?: string;
+    tree?: any;
+  };
   grafanaPermission: Permission;
 
   constructor(private osdService: OsdService, private authStorageService: AuthStorageService) {
@@ -34,7 +40,7 @@ export class OsdDetailsComponent implements OnChanges {
   }
 
   refresh() {
-    this.osdService.getDetails(this.osd.id).subscribe((data: any) => {
+    this.osdService.getDetails(this.osd.id).subscribe((data) => {
       this.osd.details = data;
       this.osd.histogram_failed = '';
       if (!_.isObject(data.histogram)) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -27,6 +27,7 @@ import { PerformanceCounterModule } from '../../../performance-counter/performan
 import { OsdDetailsComponent } from '../osd-details/osd-details.component';
 import { OsdPerformanceHistogramComponent } from '../osd-performance-histogram/osd-performance-histogram.component';
 import { OsdReweightModalComponent } from '../osd-reweight-modal/osd-reweight-modal.component';
+import { OsdSmartListComponent } from '../osd-smart-list/osd-smart-list.component';
 import { OsdListComponent } from './osd-list.component';
 
 describe('OsdListComponent', () => {
@@ -84,7 +85,12 @@ describe('OsdListComponent', () => {
       ReactiveFormsModule,
       RouterTestingModule
     ],
-    declarations: [OsdListComponent, OsdDetailsComponent, OsdPerformanceHistogramComponent],
+    declarations: [
+      OsdListComponent,
+      OsdDetailsComponent,
+      OsdPerformanceHistogramComponent,
+      OsdSmartListComponent
+    ],
     providers: [
       { provide: AuthStorageService, useValue: fakeAuthStorageService },
       TableActionsComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/fixtures/smart_data_version_1_0_response.json
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/fixtures/smart_data_version_1_0_response.json
@@ -1,0 +1,570 @@
+{
+  "WDC_WD1003FBYX-01Y7B1_WD-WCAW11111111": {
+    "ata_sct_capabilities": {
+      "data_table_supported": true,
+      "error_recovery_control_supported": true,
+      "feature_control_supported": true,
+      "value": 12351
+    },
+    "ata_smart_attributes": {
+      "revision": 16,
+      "table": [
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": true,
+            "event_count": false,
+            "performance": true,
+            "prefailure": true,
+            "string": "POSR-K ",
+            "updated_online": true,
+            "value": 47
+          },
+          "id": 1,
+          "name": "Raw_Read_Error_Rate",
+          "raw": {
+            "string": "1",
+            "value": 1
+          },
+          "thresh": 51,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": false,
+            "performance": true,
+            "prefailure": true,
+            "string": "POS--K ",
+            "updated_online": true,
+            "value": 39
+          },
+          "id": 3,
+          "name": "Spin_Up_Time",
+          "raw": {
+            "string": "4250",
+            "value": 4250
+          },
+          "thresh": 21,
+          "value": 175,
+          "when_failed": "",
+          "worst": 172
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 4,
+          "name": "Start_Stop_Count",
+          "raw": {
+            "string": "1657",
+            "value": 1657
+          },
+          "thresh": 0,
+          "value": 99,
+          "when_failed": "",
+          "worst": 99
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": true,
+            "string": "PO--CK ",
+            "updated_online": true,
+            "value": 51
+          },
+          "id": 5,
+          "name": "Reallocated_Sector_Ct",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 140,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": true,
+            "event_count": false,
+            "performance": true,
+            "prefailure": false,
+            "string": "-OSR-K ",
+            "updated_online": true,
+            "value": 46
+          },
+          "id": 7,
+          "name": "Seek_Error_Rate",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 0,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 9,
+          "name": "Power_On_Hours",
+          "raw": {
+            "string": "15807",
+            "value": 15807
+          },
+          "thresh": 0,
+          "value": 79,
+          "when_failed": "",
+          "worst": 79
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 10,
+          "name": "Spin_Retry_Count",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 0,
+          "value": 100,
+          "when_failed": "",
+          "worst": 100
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 11,
+          "name": "Calibration_Retry_Count",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 0,
+          "value": 100,
+          "when_failed": "",
+          "worst": 100
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 12,
+          "name": "Power_Cycle_Count",
+          "raw": {
+            "string": "1370",
+            "value": 1370
+          },
+          "thresh": 0,
+          "value": 99,
+          "when_failed": "",
+          "worst": 99
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 192,
+          "name": "Power-Off_Retract_Count",
+          "raw": {
+            "string": "111",
+            "value": 111
+          },
+          "thresh": 0,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 193,
+          "name": "Load_Cycle_Count",
+          "raw": {
+            "string": "1545",
+            "value": 1545
+          },
+          "thresh": 0,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": false,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O---K ",
+            "updated_online": true,
+            "value": 34
+          },
+          "id": 194,
+          "name": "Temperature_Celsius",
+          "raw": {
+            "string": "47",
+            "value": 47
+          },
+          "thresh": 0,
+          "value": 100,
+          "when_failed": "",
+          "worst": 89
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 196,
+          "name": "Reallocated_Event_Count",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 0,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 197,
+          "name": "Current_Pending_Sector",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 0,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "----CK ",
+            "updated_online": false,
+            "value": 48
+          },
+          "id": 198,
+          "name": "Offline_Uncorrectable",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 0,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": true,
+            "error_rate": false,
+            "event_count": true,
+            "performance": false,
+            "prefailure": false,
+            "string": "-O--CK ",
+            "updated_online": true,
+            "value": 50
+          },
+          "id": 199,
+          "name": "UDMA_CRC_Error_Count",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 0,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        },
+        {
+          "flags": {
+            "auto_keep": false,
+            "error_rate": true,
+            "event_count": false,
+            "performance": false,
+            "prefailure": false,
+            "string": "---R-- ",
+            "updated_online": false,
+            "value": 8
+          },
+          "id": 200,
+          "name": "Multi_Zone_Error_Rate",
+          "raw": {
+            "string": "0",
+            "value": 0
+          },
+          "thresh": 0,
+          "value": 200,
+          "when_failed": "",
+          "worst": 200
+        }
+      ]
+    },
+    "ata_smart_data": {
+      "capabilities": {
+        "attribute_autosave_enabled": true,
+        "conveyance_self_test_supported": true,
+        "error_logging_supported": true,
+        "exec_offline_immediate_supported": true,
+        "gp_logging_supported": true,
+        "offline_is_aborted_upon_new_cmd": false,
+        "offline_surface_scan_supported": true,
+        "selective_self_test_supported": true,
+        "self_tests_supported": true,
+        "values": [
+          123,
+          3
+        ]
+      },
+      "offline_data_collection": {
+        "completion_seconds": 16500,
+        "status": {
+          "string": "was suspended by an interrupting command from host",
+          "value": 132
+        }
+      },
+      "self_test": {
+        "polling_minutes": {
+          "conveyance": 5,
+          "extended": 162,
+          "short": 2
+        },
+        "status": {
+          "passed": true,
+          "string": "completed without error",
+          "value": 0
+        }
+      }
+    },
+    "ata_smart_error_log": {
+      "summary": {
+        "count": 0,
+        "revision": 1
+      }
+    },
+    "ata_smart_selective_self_test_log": {
+      "flags": {
+        "remainder_scan_enabled": false,
+        "value": 0
+      },
+      "power_up_scan_resume_minutes": 0,
+      "revision": 1,
+      "table": [
+        {
+          "lba_max": 0,
+          "lba_min": 0,
+          "status": {
+            "string": "Not_testing",
+            "value": 0
+          }
+        },
+        {
+          "lba_max": 0,
+          "lba_min": 0,
+          "status": {
+            "string": "Not_testing",
+            "value": 0
+          }
+        },
+        {
+          "lba_max": 0,
+          "lba_min": 0,
+          "status": {
+            "string": "Not_testing",
+            "value": 0
+          }
+        },
+        {
+          "lba_max": 0,
+          "lba_min": 0,
+          "status": {
+            "string": "Not_testing",
+            "value": 0
+          }
+        },
+        {
+          "lba_max": 0,
+          "lba_min": 0,
+          "status": {
+            "string": "Not_testing",
+            "value": 0
+          }
+        }
+      ]
+    },
+    "ata_smart_self_test_log": {
+      "standard": {
+        "count": 0,
+        "revision": 1
+      }
+    },
+    "ata_version": {
+      "major_value": 510,
+      "minor_value": 0,
+      "string": "ATA8-ACS (minor revision not indicated)"
+    },
+    "device": {
+      "info_name": "/dev/sde [SAT]",
+      "name": "/dev/sde",
+      "protocol": "ATA",
+      "type": "sat"
+    },
+    "firmware_version": "01.01V02",
+    "in_smartctl_database": true,
+    "interface_speed": {
+      "current": {
+        "bits_per_unit": 100000000,
+        "sata_value": 2,
+        "string": "3.0 Gb/s",
+        "units_per_second": 30
+      },
+      "max": {
+        "bits_per_unit": 100000000,
+        "sata_value": 6,
+        "string": "3.0 Gb/s",
+        "units_per_second": 30
+      }
+    },
+    "json_format_version": [
+      1,
+      0
+    ],
+    "local_time": {
+      "asctime": "Mon Sep  2 12:39:01 2019 UTC",
+      "time_t": 1567427941
+    },
+    "logical_block_size": 512,
+    "model_family": "Western Digital RE4",
+    "model_name": "WDC WD1003FBYX-01Y7B1",
+    "nvme_smart_health_information_add_log_error": "nvme returned an error: sudo: exit status: 1",
+    "nvme_smart_health_information_add_log_error_code": -22,
+    "nvme_vendor": "wdc_wd1003fbyx-01y7b1",
+    "physical_block_size": 512,
+    "power_cycle_count": 1370,
+    "power_on_time": {
+      "hours": 15807
+    },
+    "rotation_rate": 7200,
+    "sata_version": {
+      "string": "SATA 3.0",
+      "value": 63
+    },
+    "serial_number": "WD-WCAW11111111",
+    "smart_status": {
+      "passed": true
+    },
+    "smartctl": {
+      "argv": [
+        "smartctl",
+        "-a",
+        "/dev/sde",
+        "--json"
+      ],
+      "build_info": "(SUSE RPM)",
+      "exit_status": 0,
+      "platform_info": "x86_64-linux-5.0.0-25-generic",
+      "svn_revision": "4917",
+      "version": [
+        7,
+        0
+      ]
+    },
+    "temperature": {
+      "current": 47
+    },
+    "user_capacity": {
+      "blocks": 1953525168,
+      "bytes": 1000204886016
+    },
+    "wwn": {
+      "id": 11601695629,
+      "naa": 5,
+      "oui": 5358
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/osd-smart-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/osd-smart-list.component.html
@@ -1,0 +1,33 @@
+<ng-container *ngIf="!loading; else isLoading">
+  <ng-container *ngIf="incompatible; else isCompatible">
+    <cd-warning-panel i18n>The data received has the JSON format version 2.x and is currently incompatible with the dashboard.</cd-warning-panel>
+  </ng-container>
+  <ng-template #isCompatible>
+    <tabset *ngFor="let device of data | keyvalue">
+      <tab [heading]="device.value.device + ' (' + device.value.identifier + ')'">
+        <ng-container *ngIf="device.value.error; else noError">
+          <cd-warning-panel>{{ device.value.userMessage }}</cd-warning-panel>
+        </ng-container>
+        <ng-template #noError>
+          <tabset>
+            <tab i18n-heading
+                 heading="Device Information">
+              <cd-table-key-value [renderObjects]="true"
+                                  [data]="device.value.info"></cd-table-key-value>
+            </tab>
+
+            <tab i18n-heading
+                 heading="S.M.A.R.T">
+              <cd-table [data]="device.value.smart.table"
+                        updateSelectionOnRefresh="never"
+                        [columns]="columns"></cd-table>
+            </tab>
+          </tabset>
+        </ng-template>
+      </tab>
+    </tabset>
+  </ng-template>
+</ng-container>
+<ng-template #isLoading>
+  <cd-loading-panel i18n>S.M.A.R.T data is loading.</cd-loading-panel>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/osd-smart-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/osd-smart-list.component.spec.ts
@@ -1,0 +1,106 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { SimpleChange, SimpleChanges } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+
+import _ = require('lodash');
+import { of } from 'rxjs';
+
+import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
+import { OsdService } from '../../../../shared/api/osd.service';
+import { SharedModule } from '../../../../shared/shared.module';
+import { OsdSmartListComponent } from './osd-smart-list.component';
+
+describe('OsdSmartListComponent', () => {
+  let component: OsdSmartListComponent;
+  let fixture: ComponentFixture<OsdSmartListComponent>;
+  let osdService: OsdService;
+
+  const SMART_DATA_VERSION_1_0 = require('./fixtures/smart_data_version_1_0_response.json');
+
+  const spyOnGetSmartData = (fn: (id: number) => any) =>
+    spyOn(osdService, 'getSmartData').and.callFake(fn);
+
+  /**
+   * Initializes the component after it spied upon the `getSmartData()` method of `OsdService`.
+   * @param data The data to be used to return when `getSmartData()` is called.
+   * @param simpleChanges (optional) The changes to be used for `ngOnChanges()` method.
+   */
+  const initializeComponentWithData = (data?: any, simpleChanges?: SimpleChanges) => {
+    spyOnGetSmartData(() => of(data || SMART_DATA_VERSION_1_0));
+    component.ngOnInit();
+    const changes: SimpleChanges = simpleChanges || {
+      osdId: new SimpleChange(null, 0, true)
+    };
+    component.ngOnChanges(changes);
+  };
+
+  /**
+   * Sets attributes for _all_ returned devices according to the given path. The syntax is the same
+   * as used in lodash.set().
+   *
+   * @example
+   * patchData('json_format_version', [2, 0])  // sets the value of `json_format_version` to [2, 0]
+   *                                           // for all devices
+   *
+   * patchData('json_format_version[0]', 2)    // same result
+   *
+   * @param path The path to the attribute
+   * @param newValue The new value
+   */
+  const patchData = (path: string, newValue: any): any => {
+    return _.reduce(
+      _.cloneDeep(SMART_DATA_VERSION_1_0),
+      (result, dataObj, deviceId) => {
+        result[deviceId] = _.set(dataObj, path, newValue);
+        return result;
+      },
+      {}
+    );
+  };
+
+  configureTestBed({
+    declarations: [OsdSmartListComponent],
+    imports: [TabsModule, SharedModule, HttpClientTestingModule],
+    providers: [i18nProviders]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OsdSmartListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    osdService = TestBed.get(OsdService);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('tests version 1.x', () => {
+    beforeEach(() => initializeComponentWithData());
+
+    it('should return with proper keys', () => {
+      _.each(component.data, (smartData, _deviceId) => {
+        expect(_.keys(smartData)).toEqual(['info', 'smart', 'device', 'identifier']);
+      });
+    });
+
+    it('should not contain excluded keys in `info`', () => {
+      const excludes = [
+        'ata_smart_attributes',
+        'ata_smart_selective_self_test_log',
+        'ata_smart_data'
+      ];
+      _.each(component.data, (smartData, _deviceId) => {
+        _.each(excludes, (exclude) => expect(smartData.info[exclude]).toBeUndefined());
+      });
+    });
+  });
+
+  it('should not work for version 2.x', () => {
+    initializeComponentWithData(patchData('json_format_version', [2, 0]));
+    expect(component.data).toEqual({});
+    expect(component.incompatible).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/osd-smart-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/osd-smart-list.component.ts
@@ -1,0 +1,111 @@
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { I18n } from '@ngx-translate/i18n-polyfill';
+import * as _ from 'lodash';
+import {
+  OsdService,
+  SmartAttribute,
+  SmartDataV1,
+  SmartError
+} from '../../../../shared/api/osd.service';
+import { CdTableColumn } from '../../../../shared/models/cd-table-column';
+
+@Component({
+  selector: 'cd-osd-smart-list',
+  templateUrl: './osd-smart-list.component.html',
+  styleUrls: ['./osd-smart-list.component.scss']
+})
+export class OsdSmartListComponent implements OnInit, OnChanges {
+  @Input()
+  osdId: number;
+  loading = false;
+  incompatible = false;
+
+  data: {
+    [deviceId: string]: {
+      info: { [key: string]: number | string | boolean };
+      smart: {
+        revision: number;
+        table: SmartAttribute[];
+      };
+    };
+  } = {};
+
+  columns: CdTableColumn[];
+
+  constructor(private i18n: I18n, private osdService: OsdService) {}
+
+  private isSmartError(data: SmartDataV1 | SmartError): data is SmartError {
+    return (data as SmartError).error !== undefined;
+  }
+
+  private updateData(osdId: number) {
+    this.loading = true;
+    this.osdService.getSmartData(osdId).subscribe((data) => {
+      const result = {};
+      _.each(data, (smartData, deviceId) => {
+        if (this.isSmartError(smartData)) {
+          let userMessage = '';
+          if (smartData.smartctl_error_code === -22) {
+            const msg =
+              `Smartctl has received an unknown argument (error code ` +
+              `${smartData.smartctl_error_code}). You may be using an incompatible version of ` +
+              `smartmontools.  Version >= 7.0 of smartmontools is required to ` +
+              `succesfully retrieve data.`;
+            userMessage = this.i18n(msg);
+          } else {
+            const msg = `An error with error code ${smartData.smartctl_error_code} occurred.`;
+            userMessage = this.i18n(msg);
+          }
+          result[deviceId] = {
+            error: smartData.error,
+            smartctl_error_code: smartData.smartctl_error_code,
+            smartctl_output: smartData.smartctl_output,
+            userMessage: userMessage,
+            device: smartData.dev,
+            identifier: smartData.nvme_vendor
+          };
+          return;
+        }
+
+        // Prepare S.M.A.R.T data
+        if (smartData.json_format_version[0] === 1) {
+          // Version 1.x
+          const excludes = [
+            'ata_smart_attributes',
+            'ata_smart_selective_self_test_log',
+            'ata_smart_data'
+          ];
+          const info = _.pickBy(smartData, (_value, key) => !excludes.includes(key));
+          // Build result
+          result[deviceId] = {
+            info: info,
+            smart: smartData.ata_smart_attributes,
+            device: info.device.name,
+            identifier: info.serial_number
+          };
+        } else {
+          this.incompatible = true;
+        }
+      });
+      this.data = result;
+      this.loading = false;
+    });
+  }
+
+  ngOnInit() {
+    this.columns = [
+      { prop: 'id', name: this.i18n('ID') },
+      { prop: 'name', name: this.i18n('Name') },
+      { prop: 'raw.value', name: this.i18n('Raw') },
+      { prop: 'thresh', name: this.i18n('Threshold') },
+      { prop: 'value', name: this.i18n('Value') },
+      { prop: 'when_failed', name: this.i18n('When Failed') },
+      { prop: 'worst', name: this.i18n('Worst') }
+    ];
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.data = {}; // Clear previous data
+    this.updateData(changes.osdId.currentValue);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -5,6 +5,100 @@ import { I18n } from '@ngx-translate/i18n-polyfill';
 
 import { ApiModule } from './api.module';
 
+export interface SmartAttribute {
+  flags: object;
+  id: number;
+  name: string;
+  raw: { string: string; value: number };
+  thresh: number;
+  value: number;
+  when_failed: string;
+  worst: number;
+}
+
+export interface SmartError {
+  dev: string;
+  error: string;
+  nvme_smart_health_information_add_log_error: string;
+  nvme_smart_health_information_add_log_error_code: number;
+  nvme_vendor: string;
+  smartctl_error_code: number;
+  smartctl_output: string;
+}
+
+export interface SmartDataV1 {
+  ata_sct_capabilities: object;
+  ata_smart_attributes: {
+    revision: number;
+    table: SmartAttribute[];
+  };
+  ata_smart_data: {
+    capabilities: {
+      attribute_autosave_enabled: boolean;
+      conveyance_self_test_supported: boolean;
+      error_logging_supported: boolean;
+      exec_offline_immediate_supported: boolean;
+      gp_logging_supported: boolean;
+      offline_is_aborted_upon_new_cmd: boolean;
+      offline_surface_scan_supported: boolean;
+      selective_self_test_supported: boolean;
+      self_tests_supported: boolean;
+      values: boolean;
+    };
+    offline_data_collection: {
+      completion_seconds: number;
+      status: {
+        string: string;
+        value: number;
+      };
+    };
+    self_test: {
+      polling_minutes: {
+        conveyance: number;
+        extended: number;
+        short: number;
+      };
+      status: {
+        passed: boolean;
+        string: string;
+        value: number;
+      };
+    };
+  };
+  ata_smart_error_log: object;
+  ata_smart_selective_self_test_log: object;
+  ata_smart_self_test_log: object;
+  ata_version: object;
+  device: {
+    name: string;
+    info_name: string;
+    type: string;
+    protocol: string;
+  };
+  firmware_version: string;
+  in_smartctl_database: boolean;
+  interface_speed: object;
+  json_format_version: number[];
+  local_time: object;
+  logical_block_size: number;
+  model_family: string;
+  model_name: string;
+  nvme_smart_health_information_add_log_error: string;
+  nvme_smart_health_information_add_log_error_code: number;
+  nvme_vendor: string;
+  physical_block_size: number;
+  power_cycle_count: number;
+  power_on_time: object;
+  rotation_rate: number;
+  sata_version: object;
+  serial_number: string;
+  smart_status: object;
+  smartctl: object;
+  temperature: object;
+  user_capacity: object;
+  wwn: object;
+}
+
 @Injectable({
   providedIn: ApiModule
 })
@@ -63,7 +157,22 @@ export class OsdService {
   }
 
   getDetails(id: number) {
-    return this.http.get(`${this.path}/${id}`);
+    interface OsdData {
+      osd_map: { [key: string]: any };
+      osd_metadata: { [key: string]: any };
+      histogram: { [key: string]: object };
+      smart: { [device_identifier: string]: any };
+    }
+    return this.http.get<OsdData>(`${this.path}/${id}`);
+  }
+
+  /**
+   * @param id OSD ID
+   */
+  getSmartData(id: number) {
+    return this.http.get<{ [deviceId: string]: SmartDataV1 | SmartError }>(
+      `${this.path}/${id}/get_smart_data`
+    );
   }
 
   scrub(id, deep) {


### PR DESCRIPTION
This PR adds data retrieved by smartctl (from the smartmontools package) to the details of OSDs on the OSD page. When clicking on any OSD, a new tab `Device health` should appear.

For each device that's used for the selected OSD, there will be a tab shown, named by the path of the device (e.g. `/dev/sde`) and followed by the serial number or vendor of the device.

For each of these devices, there are two tabs shown, `Device Information` and `S.M.A.R.T`. `Device Information` contains all data that is received by smartctl, except for the S.M.A.R.T data, that's displayed in a table on the `S.M.A.R.T` tab.

If you experience performance issue with Firefox, that's most likely due to another [issue](https://github.com/ceph/ceph/pull/30316) I also stumbled upon.

You may notice that some data in `Device Information` is missing to be displayed. This is due to a [bug](https://github.com/ceph/ceph/pull/30203) in the `KeyValueComponent` we use in the frontend.

Please also note that I, due to my setup, was not able to directly receive data from `smartctl`. If udev is not able to get device information like vendor and serial number, the data cannot be returned (e.g. due to a raid-0 configuration). Virtual environments are also likely to fail, as no S.M.A.R.T data can be requested from virtual drives. Last but not least, smartmontools version >= 7 are required to request data as JSON, which is how the data is requested by from smartctl by the mons.

To circumvent this problem for development, I wrote a script that just prints the JSON that smartctl would return and replaced it with smartctl. It might be necessary to do something similar to be able to test this PR. The[ data required to do so](https://github.com/ceph/ceph/pull/30324/files#diff-1ac297bf56ccbb0f5dfba5040dcf7410) is part of part of this PR and resides in the frontend unit test folder `fixture` of the `SmartListComponent`. If you need to mock the data returned by smartctl, you might want to check out the shell script in the `Testing` section below.

## Screenshots

***

![screen](https://user-images.githubusercontent.com/9606095/64692224-d8429000-d494-11e9-9ea6-0d6599e1762b.png)

***

![screen2](https://user-images.githubusercontent.com/9606095/64692753-24420480-d496-11e9-931d-24738f3e6140.png)

***

![screen3](https://user-images.githubusercontent.com/9606095/64693342-543dd780-d497-11e9-9b8f-98d0cf5b6e48.png)


## Testing

In case retrieving data from smartctl does not work for you, you can still test this implementation by a simple shell script that prints out the JSON data:

```bash
#!/bin/bash

# Copy this file to your PATH. Ensure it takes precedence and does not
# overwrite the original `smartctl` binary. Then make it executable.

URL="https://raw.githubusercontent.com/ceph/ceph/da1fbecfcfcc16917d6f3999b243bf7d553149c8/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/fixtures/smart_data_version_1_0_response.json"

#curl -s $URL | jq '.["WDC_WD1003FBYX-01Y7B1_WD-WCAW11111111"]'
# or
if [ ! -f /tmp/smartctl.json ] ; then
  wget $URL --quiet -O /tmp/smartctl.json
fi
cat /tmp/smartctl.json | jq '.["WDC_WD1003FBYX-01Y7B1_WD-WCAW11111111"]'
```

If you are using a vstart cluster in a Docker container, then you need to start the container with ``-v /run/udev:/run/udev:ro`` to mount the UDEV database into the container, otherwise a ``ceph device ls``will not show any devices and you won't be able to test this PR.

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
