### PR TITLE
luminous: rgw: RGWCoroutine::call(nullptr) sets retcode=0

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -733,7 +733,12 @@ void RGWCoroutinesManagerRegistry::dump(Formatter *f) const {
 
 void RGWCoroutine::call(RGWCoroutine *op)
 {
-  stack->call(op);
+  if (op) {
+    stack->call(op);
+  } else {
+    // the call()er expects this to set a retcode
+    retcode = 0;
+  }
 }
 
 RGWCoroutinesStack *RGWCoroutine::spawn(RGWCoroutine *op, bool wait)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41626

---

backport of https://github.com/ceph/ceph/pull/29856
parent tracker: https://tracker.ceph.com/issues/41412

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh