### PR TITLE
luminou: ceph-volume: set a lvm_size property on the fakedevice fixture

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -68,6 +68,7 @@ def fakedevice(factory):
             is_lvm_member=True,
         )
         params.update(dict(kw))
+        params['lvm_size'] = disk.Size(b=params['sys_api'].get("size", 0))
         return factory(**params)
     return apply
 


### PR DESCRIPTION
Missing backport causing flake8 runs to fail. Seen in #30302 