### PR TITLE
mimic: ceph-volume: implement __format__ in Size to format sizes in py3

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -602,6 +602,9 @@ class Size(object):
     def __str__(self):
         return "%s" % self._get_best_format()
 
+    def __format__(self, spec):
+        return str(self._get_best_format()).__format__(spec)
+
     def __lt__(self, other):
         return self._b < other._b
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41762

---

backport of https://github.com/ceph/ceph/pull/26401
parent tracker: https://tracker.ceph.com/issues/38291

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh