### PR TITLE
mimic: ceph-volume: ensure device lists are disjoint

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -254,7 +254,7 @@ class Batch(object):
         self.args = parser.parse_args(argv)
         self.parser = parser
         for dev_list in ['', 'db_', 'wal_', 'journal_']:
-            setattr(self, '{}usable'.format(dev_list), [])
+            setattr(self, '{}usable'.format(dev_list), set())
 
     def get_devices(self):
         # remove devices with partitions
@@ -327,6 +327,7 @@ class Batch(object):
     def _get_explicit_strategy(self):
         # TODO assert that none of the device lists overlap?
         self._filter_devices()
+        self._ensure_disjoint_device_lists()
         if self.args.bluestore:
             if self.db_usable or self.wal_usable:
                 self.strategy = strategies.bluestore.MixedType(
@@ -360,8 +361,17 @@ class Batch(object):
             dev_list_prop = '{}devices'.format(dev_list)
             if hasattr(self.args, dev_list_prop):
                 usable_dev_list_prop = '{}usable'.format(dev_list)
-                usable = [d for d in getattr(self.args, dev_list_prop) if d.available]
+                usable = set([d for d in getattr(self.args, dev_list_prop) if
+                              d.available])
                 setattr(self, usable_dev_list_prop, usable)
                 self.filtered_devices.update({d: used_reason for d in
                                               getattr(self.args, dev_list_prop)
                                               if d.used_by_ceph})
+
+    def _ensure_disjoint_device_lists(self):
+        # check that all device lists are disjoint with each other
+        if not(self.usable.isdisjoint(self.db_usable) and
+               self.usable.isdisjoint(self.wal_usable) and
+               self.usable.isdisjoint(self.journal_usable) and
+               self.db_usable.isdisjoint(self.wal_usable)):
+            raise Exception('Device lists are not disjoint')

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -254,7 +254,7 @@ class Batch(object):
         self.args = parser.parse_args(argv)
         self.parser = parser
         for dev_list in ['', 'db_', 'wal_', 'journal_']:
-            setattr(self, '{}usable'.format(dev_list), set())
+            setattr(self, '{}usable'.format(dev_list), [])
 
     def get_devices(self):
         # remove devices with partitions
@@ -361,8 +361,8 @@ class Batch(object):
             dev_list_prop = '{}devices'.format(dev_list)
             if hasattr(self.args, dev_list_prop):
                 usable_dev_list_prop = '{}usable'.format(dev_list)
-                usable = set([d for d in getattr(self.args, dev_list_prop) if
-                              d.available])
+                usable = [d for d in getattr(self.args, dev_list_prop) if
+                          d.available]
                 setattr(self, usable_dev_list_prop, usable)
                 self.filtered_devices.update({d: used_reason for d in
                                               getattr(self.args, dev_list_prop)
@@ -370,8 +370,8 @@ class Batch(object):
 
     def _ensure_disjoint_device_lists(self):
         # check that all device lists are disjoint with each other
-        if not(self.usable.isdisjoint(self.db_usable) and
-               self.usable.isdisjoint(self.wal_usable) and
-               self.usable.isdisjoint(self.journal_usable) and
-               self.db_usable.isdisjoint(self.wal_usable)):
+        if not(set(self.usable).isdisjoint(set(self.db_usable)) and
+               set(self.usable).isdisjoint(set(self.wal_usable)) and
+               set(self.usable).isdisjoint(set(self.journal_usable)) and
+               set(self.db_usable).isdisjoint(set(self.wal_usable))):
             raise Exception('Device lists are not disjoint')

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
@@ -223,12 +223,3 @@ class TestMixedType(object):
             filestore.MixedType.with_auto_devices(args, devices)
         msg = "Not enough space in fast devices (14.97 GB) to create 2 x 14.77 GB journal LV"
         assert msg in str(error.value)
-
-    def test_filter_all_data_devs(self, fakedevice, factory):
-        # in this scenario the user passed a already used device to be used for
-        # data and an unused device to be used as db device.
-        db_dev = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
-        data_dev = fakedevice(used_by_ceph=True, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
-        args = factory(filtered_devices=[data_dev], osds_per_device=1,
-                       journal_size=None, osd_ids=[])
-        filestore.MixedType(args, [], [db_dev])

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -1,3 +1,4 @@
+import pytest
 from ceph_volume.devices.lvm import batch
 
 
@@ -54,6 +55,16 @@ class TestBatch(object):
         b = batch.Batch([])
         result = b.get_devices().strip()
         assert result == '* /dev/vdf                  20.00 GB   rotational'
+
+    def test_disjoint_device_lists(self, factory):
+        device1 = factory(used_by_ceph=False, available=True, abspath="/dev/sda")
+        device2 = factory(used_by_ceph=False, available=True, abspath="/dev/sdb")
+        b = batch.Batch([])
+        b.args.devices = [device1, device2]
+        b.args.db_devices = [device2]
+        b._filter_devices()
+        with pytest.raises(Exception):
+            b._ensure_disjoint_device_lists()
 
 
 class TestFilterDevices(object):

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -63,8 +63,9 @@ class TestBatch(object):
         b.args.devices = [device1, device2]
         b.args.db_devices = [device2]
         b._filter_devices()
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as disjoint_ex:
             b._ensure_disjoint_device_lists()
+        assert 'Device lists are not disjoint' in str(disjoint_ex.value)
 
 
 class TestFilterDevices(object):


### PR DESCRIPTION
https://tracker.ceph.com/issues/41083
https://tracker.ceph.com/issues/41307

---

Fixes: https://tracker.ceph.com/issues/41018
Fixes: https://tracker.ceph.com/issues/41292

Two missing backports for mimic.

Backport for https://github.com/ceph/ceph/pull/27754
Backport for https://github.com/ceph/ceph/pull/29683