### PR TITLE
mgr/volumes: uid, gid for subvolume create and subvolumegroup create commands

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -65,14 +65,14 @@ FS Subvolume groups
 
 Create a subvolume group using::
 
-    $ ceph fs subvolumegroup create <vol_name> <group_name> [--mode <octal_mode> --pool_layout <data_pool_name>]
+    $ ceph fs subvolumegroup create <vol_name> <group_name> [--pool_layout <data_pool_name> --uid <uid> --gid <gid> --mode <octal_mode>]
 
 The command succeeds even if the subvolume group already exists.
 
 When creating a subvolume group you can specify its data pool layout (see
-:doc:`/cephfs/file-layouts`), and file mode in octal numerals. By default, the
-subvolume group is created with an octal file mode '755', and data pool layout
-of its parent directory.
+:doc:`/cephfs/file-layouts`), uid, gid, and file mode in octal numerals. By default, the
+subvolume group is created with an octal file mode '755', uid '0', gid '0' and data pool
+layout of its parent directory.
 
 
 Remove a subvolume group using::
@@ -116,17 +116,17 @@ FS Subvolumes
 
 Create a subvolume using::
 
-    $ ceph fs subvolume create <vol_name> <subvol_name> [--group_name <subvol_group_name> --mode <octal_mode> --pool_layout <data_pool_name> --size <size_in_bytes>]
+    $ ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes> --group_name <subvol_group_name> --pool_layout <data_pool_name> --uid <uid> --gid <gid> --mode <octal_mode>]
 
 
 The command succeeds even if the subvolume already exists.
 
 When creating a subvolume you can specify its subvolume group, data pool layout,
-file mode in octal numerals, and size in bytes. The size of the subvolume is
+uid, gid, file mode in octal numerals, and size in bytes. The size of the subvolume is
 specified by setting a quota on it (see :doc:`/cephfs/quota`). By default a
 subvolume is created within the default subvolume group, and with an octal file
-mode '755', data pool layout of its parent directory and no size limit.
-
+mode '755', uid of its subvolume group, gid of its subvolume group, data pool layout of
+its parent directory and no size limit.
 
 Remove a subvolume using::
 

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -396,6 +396,31 @@ class TestVolumes(CephFSTestCase):
         self._fs_cmd("subvolumegroup", "rm", self.volname, group1)
         self._fs_cmd("subvolumegroup", "rm", self.volname, group2)
 
+    def test_subvolume_group_create_with_desired_uid_gid(self):
+        """
+        That the subvolume group can be created with the desired uid and gid and its uid and gid matches the
+        expected values.
+        """
+        uid = 1000
+        gid = 1000
+
+        # create subvolume group
+        subvolgroupname = self._generate_random_group_name()
+        self._fs_cmd("subvolumegroup", "create", self.volname, subvolgroupname, "--uid", str(uid), "--gid", str(gid))
+
+        # make sure it exists
+        subvolgrouppath = self._get_subvolume_group_path(self.volname, subvolgroupname)
+        self.assertNotEqual(subvolgrouppath, None)
+
+        # verify the uid and gid
+        suid = int(self.mount_a.run_shell(['stat', '-c' '%u', subvolgrouppath]).stdout.getvalue().strip())
+        sgid = int(self.mount_a.run_shell(['stat', '-c' '%g', subvolgrouppath]).stdout.getvalue().strip())
+        self.assertEqual(uid, suid)
+        self.assertEqual(gid, sgid)
+
+        # remove group
+        self._fs_cmd("subvolumegroup", "rm", self.volname, subvolgroupname)
+
     def test_subvolume_create_with_desired_mode_in_group(self):
         subvol1 = self._generate_random_subvolume_name()
         subvol2 = self._generate_random_subvolume_name()
@@ -431,6 +456,31 @@ class TestVolumes(CephFSTestCase):
         self._fs_cmd("subvolume", "rm", self.volname, subvol2, group)
         self._fs_cmd("subvolume", "rm", self.volname, subvol3, group)
         self._fs_cmd("subvolumegroup", "rm", self.volname, group)
+
+    def test_subvolume_create_with_desired_uid_gid(self):
+        """
+        That the subvolume can be created with the desired uid and gid and its uid and gid matches the
+        expected values.
+        """
+        uid = 1000
+        gid = 1000
+
+        # create subvolume
+        subvolname = self._generate_random_subvolume_name()
+        self._fs_cmd("subvolume", "create", self.volname, subvolname, "--uid", str(uid), "--gid", str(gid))
+
+        # make sure it exists
+        subvolpath = self._get_subvolume_path(self.volname, subvolname)
+        self.assertNotEqual(subvolpath, None)
+
+        # verify the uid and gid
+        suid = int(self.mount_a.run_shell(['stat', '-c' '%u', subvolpath]).stdout.getvalue().strip())
+        sgid = int(self.mount_a.run_shell(['stat', '-c' '%g', subvolpath]).stdout.getvalue().strip())
+        self.assertEqual(uid, suid)
+        self.assertEqual(gid, sgid)
+
+        # remove subvolume
+        self._fs_cmd("subvolume", "rm", self.volname, subvolname)
 
     def test_nonexistent_subvolme_group_rm(self):
         group = "non_existent_group"

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -175,6 +175,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_fsync(ceph_mount_info *cmount, int fd, int syncdataonly)
     int ceph_conf_parse_argv(ceph_mount_info *cmount, int argc, const char **argv)
     int ceph_chmod(ceph_mount_info *cmount, const char *path, mode_t mode)
+    int ceph_chown(ceph_mount_info *cmount, const char *path, int uid, int gid)
     int64_t ceph_lseek(ceph_mount_info *cmount, int fd, int64_t offset, int whence)
     void ceph_buffer_free(char *buf)
     mode_t ceph_umask(ceph_mount_info *cmount, mode_t mode)
@@ -860,6 +861,29 @@ cdef class LibCephFS(object):
             ret = ceph_chmod(self.cluster, _path, _mode)
         if ret < 0:
             raise make_ex(ret, "error in chmod {}".format(path.decode('utf-8')))
+
+    def chown(self, path, int uid, int gid):
+        """
+        Change directory ownership
+        :param path: the path of the directory to change.
+        :param uid: the uid to set
+        :param gid: the gid to set
+        """
+        self.require_state("mounted")
+        path = cstr(path, 'path')
+        if not isinstance(uid, int):
+            raise TypeError('uid must be an int')
+        elif not isinstance(gid, int):
+            raise TypeError('gid must be an int')
+
+        cdef:
+            char* _path = path
+            int _uid = uid
+            int _gid = gid
+        with nogil:
+            ret = ceph_chown(self.cluster, _path, _uid, _gid)
+        if ret < 0:
+            raise make_ex(ret, "error in chown {}".format(path.decode('utf-8')))
 
     def mkdirs(self, path, mode):
         """

--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -57,7 +57,8 @@ class SubVolume(object):
 
     ### basic subvolume operations
 
-    def create_subvolume(self, spec, size=None, namespace_isolated=True, mode=0o755, pool=None):
+    def create_subvolume(self, spec, size=None,  pool=None, namespace_isolated=True,
+                         uid=None, gid=None, mode=0o755):
         """
         Set up metadata, pools and auth for a subvolume.
 
@@ -66,8 +67,11 @@ class SubVolume(object):
 
         :param spec: subvolume path specification
         :param size: In bytes, or None for no size limit
-        :param namespace_isolated: If true, use separate RADOS namespace for this subvolume
         :param pool: the RADOS pool where the data objects of the subvolumes will be stored
+        :param namespace_isolated: If true, use separate RADOS namespace for this subvolume
+        :param uid: the user identifier
+        :param gid: the group identifier
+        :mode: the user permissions
         :return: None
         """
         subvolpath = spec.subvolume_path
@@ -101,6 +105,23 @@ class SubVolume(object):
                 xattr_val = self._get_ancestor_xattr(subvolpath, "ceph.dir.layout.pool")
             # TODO: handle error...
             self.fs.setxattr(subvolpath, xattr_key, xattr_val.encode('utf-8'), 0)
+
+            groupstat = self.fs.stat(spec.group_path)
+            if uid is None:
+                uid = int(groupstat.st_uid)
+            elif uid < 0:
+                raise VolumeException(-errno.EINVAL, "Provide a valid uid")
+
+            if gid is None:
+                gid = int(groupstat.st_gid)
+            elif gid < 0:
+                raise VolumeException(-errno.EINVAL, "Provide a valid gid")
+
+            try:
+                self.fs.chown(subvolpath, uid, gid)
+            except cephfs.InvalidValue:
+                raise VolumeException(-e.args[0], e.args[1])
+
         except Exception as e:
             try:
                 # cleanup subvol path on best effort basis
@@ -210,7 +231,17 @@ class SubVolume(object):
 
     ### group operations
 
-    def create_group(self, spec, mode=0o755, pool=None):
+    def create_group(self, spec, pool=None, uid=None, gid=None, mode=0o755):
+        """
+        Create a subvolume group.
+
+        :param spec: subvolume path specification
+        :param pool: the RADOS pool where the data objects of the subvolumes will be stored
+        :param uid: the user identifier
+        :param gid: the group identifier
+        :mode: the user permissions
+        :return: None
+        """
         path = spec.group_path
         self.fs.mkdirs(path, mode)
         try:
@@ -221,6 +252,22 @@ class SubVolume(object):
             except cephfs.InvalidValue:
                 raise VolumeException(-errno.EINVAL,
                                       "Invalid pool layout '{0}'. It must be a valid data pool".format(pool))
+
+            if uid is None:
+                uid = 0
+            elif uid < 0:
+                raise VolumeException(-errno.EINVAL, "Provide a valid uid")
+
+            if gid is None:
+                gid = 0
+            elif gid < 0:
+                raise VolumeException(-errno.EINVAL, "Provide a valid gid")
+
+            try:
+                self.fs.chown(path, uid, gid)
+            except cephfs.InvalidValue:
+                raise VolumeException(-e.args[0], e.args[1])
+
         except Exception as e:
             try:
                 # cleanup group path on best effort basis

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -387,6 +387,8 @@ class VolumeClient(object):
         groupname  = kwargs['group_name']
         size       = kwargs['size']
         pool       = kwargs['pool_layout']
+        uid        = kwargs['uid']
+        gid        = kwargs['gid']
         mode       = kwargs['mode']
 
         try:
@@ -396,7 +398,7 @@ class VolumeClient(object):
                     raise VolumeException(
                         -errno.ENOENT, "Subvolume group '{0}' not found, create it with " \
                         "`ceph fs subvolumegroup create` before creating subvolumes".format(groupname))
-                sv.create_subvolume(spec, size, pool=pool, mode=self.octal_str_to_decimal_int(mode))
+                sv.create_subvolume(spec, size, pool=pool, uid=uid, gid=gid, mode=self.octal_str_to_decimal_int(mode))
         except VolumeException as ve:
             ret = self.volume_exception_to_retval(ve)
         return ret
@@ -550,13 +552,15 @@ class VolumeClient(object):
         volname   = kwargs['vol_name']
         groupname = kwargs['group_name']
         pool      = kwargs['pool_layout']
+        uid       = kwargs['uid']
+        gid       = kwargs['gid']
         mode      = kwargs['mode']
 
         try:
             # TODO: validate that subvol size fits in volume size
             with SubVolume(self.mgr, fs_handle) as sv:
                 spec = SubvolumeSpec("", groupname)
-                sv.create_group(spec, pool=pool, mode=self.octal_str_to_decimal_int(mode))
+                sv.create_group(spec, pool=pool, uid=uid, gid=gid, mode=self.octal_str_to_decimal_int(mode))
         except VolumeException as ve:
             ret = self.volume_exception_to_retval(ve)
         return ret

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -37,6 +37,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=vol_name,type=CephString '
                    'name=group_name,type=CephString '
                    'name=pool_layout,type=CephString,req=false '
+                   'name=uid,type=CephInt,req=false '
+                   'name=gid,type=CephInt,req=false '
                    'name=mode,type=CephString,req=false ',
             'desc': "Create a CephFS subvolume group in a volume, and optionally, "
                     "with a specific data pool layout, and a specific numeric mode",
@@ -64,6 +66,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=size,type=CephInt,req=false '
                    'name=group_name,type=CephString,req=false '
                    'name=pool_layout,type=CephString,req=false '
+                   'name=uid,type=CephInt,req=false '
+                   'name=gid,type=CephInt,req=false '
                    'name=mode,type=CephString,req=false ',
             'desc': "Create a CephFS subvolume in a volume, and optionally, "
                     "with a specific size (in bytes), a specific data pool layout, "
@@ -200,7 +204,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """
         return self.vc.create_subvolume_group(
             None, vol_name=cmd['vol_name'], group_name=cmd['group_name'],
-            pool_layout=cmd.get('pool_layout', None), mode=cmd.get('mode', '755'))
+            pool_layout=cmd.get('pool_layout', None), uid=cmd.get('uid', None),
+            gid=cmd.get('gid', None), mode=cmd.get('mode', '755'))
 
     def _cmd_fs_subvolumegroup_rm(self, inbuf, cmd):
         """
@@ -223,6 +228,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                         group_name=cmd.get('group_name', None),
                                         size=cmd.get('size', None),
                                         pool_layout=cmd.get('pool_layout', None),
+                                        uid=cmd.get('uid', None),
+                                        gid=cmd.get('gid', None),
                                         mode=cmd.get('mode', '755'))
 
     def _cmd_fs_subvolume_rm(self, inbuf, cmd):


### PR DESCRIPTION
Allow setting uid, gid for subvolume create and subvolumegroup create commands

Fixes: https://tracker.ceph.com/issues/40959



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>