### PR TITLE
mgr/DaemonHealthMetricCollector: Set "reported" flag only if metrics exist

### DIFF
--- a/src/mgr/DaemonHealthMetricCollector.h
+++ b/src/mgr/DaemonHealthMetricCollector.h
@@ -11,8 +11,9 @@ public:
   using DaemonKey = std::pair<std::string, std::string>;
   static std::unique_ptr<DaemonHealthMetricCollector> create(daemon_metric m);
   void update(const DaemonKey& daemon, const DaemonHealthMetric& metric) {
-    if (_is_relevant(metric.get_type())) {
-      reported = _update(daemon, metric);
+    if (_is_relevant(metric.get_type()) &&
+        _update(daemon, metric)) {
+      reported = true;
     }
   }
   void summarize(health_check_map_t& cm) {


### PR DESCRIPTION
mgr/DaemonHealthMetricCollector: Set  "reported" flag only if metrics exist.

The "reported" flag is now set ONLY if a metric is relevant and if
_update() on the health metric collector indicates metrics are available
for e.g. slow ops or pending create PGs.

The above is necessitated because the DaemonServer in send_report()
iterates through all the daemons (osd and mon) and in case an osd daemon
for e.g. reported any slow ops metric, the corresponding collector along
with the metric type is added to an "accumulated" map and the "reported"
flag for the collector is set. Subsequent iterations over the mon
daemon on the same metric (slow ops for e.g.) has a risk of overwriting the
state of the "reported" flag.

This results in the summary string for the daemon that actually had metrics
to report to not get sent to the monitor and therefore not get reported in
the ceph status.

Fixes: https://tracker.ceph.com/issues/41758

Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
