### PR TITLE
crimson: serve basic RBD traffic coming from fio

### DIFF
--- a/src/crimson/os/cyan_store.cc
+++ b/src/crimson/os/cyan_store.cc
@@ -218,7 +218,7 @@ seastar::future<ceph::bufferptr> CyanStore::get_attr(CollectionRef ch,
     return seastar::make_ready_future<ceph::bufferptr>(found->second);
   } else {
     return seastar::make_exception_future<ceph::bufferptr>(
-      EnoentException(fmt::format("attr does not exist: {}/{}", oid, name)));
+      EnodataException(fmt::format("attr does not exist: {}/{}", oid, name)));
   }
 }
 

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -23,6 +23,7 @@ class Transaction;
 class FuturizedStore {
 
 public:
+  // TODO: replace with the ceph::errorator concept
   template <class ConcreteExceptionT>
   class Exception : public std::logic_error {
   public:
@@ -48,6 +49,9 @@ public:
 
   struct EnoentException : public Exception<EnoentException> {
     using Exception<EnoentException>::Exception;
+  };
+  struct EnodataException : public Exception<EnodataException> {
+    using Exception<EnodataException>::Exception;
   };
   static std::unique_ptr<FuturizedStore> create(const std::string& type,
                                                 const std::string& data);

--- a/src/crimson/osd/exceptions.h
+++ b/src/crimson/osd/exceptions.h
@@ -40,6 +40,10 @@ struct invalid_argument : public error {
   invalid_argument() : error(std::errc::invalid_argument) {}
 };
 
+struct no_message_available : public error {
+  no_message_available() : error(std::errc::no_message_available) {}
+};
+
 // FIXME: error handling
 struct operation_not_supported : public error {
   operation_not_supported()

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -142,7 +142,17 @@ int cls_cxx_write2(cls_method_context_t hctx,
                    bufferlist *inbl,
                    uint32_t op_flags)
 {
-  return 0;
+  OSDOp op{ CEPH_OSD_OP_WRITE };
+  op.op.extent.offset = ofs;
+  op.op.extent.length = len;
+  op.op.flags = op_flags;
+  op.indata = *inbl;
+  try {
+    reinterpret_cast<ceph::osd::OpsExecuter*>(hctx)->do_osd_op(op).get();
+    return 0;
+  } catch (ceph::osd::error& e) {
+    return -e.code().value();
+  }
 }
 
 int cls_cxx_write_full(cls_method_context_t hctx, bufferlist * const inbl)

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -68,8 +68,7 @@ int cls_cxx_remove(cls_method_context_t hctx)
 
 int cls_cxx_stat(cls_method_context_t hctx, uint64_t *size, time_t *mtime)
 {
-  OSDOp op;//{CEPH_OSD_OP_STAT};
-  op.op.op = CEPH_OSD_OP_STAT;
+  OSDOp op{CEPH_OSD_OP_STAT};
 
   // we're blocking here which presumes execution in Seastar's thread.
   try {
@@ -109,8 +108,7 @@ int cls_cxx_read2(cls_method_context_t hctx,
                   bufferlist *outbl,
                   uint32_t op_flags)
 {
-  OSDOp op;
-  op.op.op = CEPH_OSD_OP_SYNC_READ;
+  OSDOp op{CEPH_OSD_OP_SYNC_READ};
   op.op.extent.offset = ofs;
   op.op.extent.length = len;
   op.op.flags = op_flags;
@@ -134,8 +132,7 @@ int cls_cxx_write2(cls_method_context_t hctx,
 
 int cls_cxx_write_full(cls_method_context_t hctx, bufferlist * const inbl)
 {
-  OSDOp op;
-  op.op.op = CEPH_OSD_OP_WRITEFULL;
+  OSDOp op{CEPH_OSD_OP_WRITEFULL};
   op.op.extent.offset = 0;
   op.op.extent.length = inbl->length();
   op.indata = *inbl;
@@ -164,8 +161,7 @@ int cls_cxx_getxattr(cls_method_context_t hctx,
                      const char *name,
                      bufferlist *outbl)
 {
-  OSDOp op;
-  op.op.op = CEPH_OSD_OP_GETXATTR;
+  OSDOp op{CEPH_OSD_OP_GETXATTR};
   op.op.xattr.name_len = strlen(name);
   op.indata.append(name, op.op.xattr.name_len);
   try {
@@ -187,8 +183,7 @@ int cls_cxx_setxattr(cls_method_context_t hctx,
                      const char *name,
                      bufferlist *inbl)
 {
-  OSDOp op;
-  op.op.op = CEPH_OSD_OP_SETXATTR;
+  OSDOp op{CEPH_OSD_OP_SETXATTR};
   op.op.xattr.name_len = std::strlen(name);
   op.op.xattr.value_len = inbl->length();
   op.indata.append(name, op.op.xattr.name_len);

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -56,9 +56,16 @@ int cls_get_request_origin(cls_method_context_t hctx, entity_inst_t *origin)
   return 0;
 }
 
-int cls_cxx_create(cls_method_context_t hctx, bool exclusive)
+int cls_cxx_create(cls_method_context_t hctx, const bool exclusive)
 {
-  return 0;
+  OSDOp op{CEPH_OSD_OP_CREATE};
+  op.op.flags = (exclusive ? CEPH_OSD_OP_FLAG_EXCL : 0);
+  try {
+    reinterpret_cast<ceph::osd::OpsExecuter*>(hctx)->do_osd_op(op).get();
+    return 0;
+  } catch (ceph::osd::error& e) {
+    return -e.code().value();
+  }
 }
 
 int cls_cxx_remove(cls_method_context_t hctx)

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -53,6 +53,9 @@ int cls_read(cls_method_context_t hctx,
 
 int cls_get_request_origin(cls_method_context_t hctx, entity_inst_t *origin)
 {
+  assert(origin)
+  *origin =
+    reinterpret_cast<ceph::osd::OpsExecuter*>(hctx)->get_orig_source_inst();
   return 0;
 }
 

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -363,7 +363,19 @@ int cls_cxx_map_set_val(cls_method_context_t hctx,
                         const string &key,
                         bufferlist *inbl)
 {
-  return 0;
+  OSDOp op{ CEPH_OSD_OP_OMAPSETVALS };
+  {
+    std::map<std::string, ceph::bufferlist> m;
+    m[key] = *inbl;
+    encode(m, op.indata);
+  }
+
+  try {
+    reinterpret_cast<ceph::osd::OpsExecuter*>(hctx)->do_osd_op(op).get();
+    return 0;
+  } catch (ceph::osd::error& e) {
+    return -e.code().value();
+  }
 }
 
 int cls_cxx_map_set_vals(cls_method_context_t hctx,

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -323,10 +323,17 @@ int cls_cxx_map_set_val(cls_method_context_t hctx,
 }
 
 int cls_cxx_map_set_vals(cls_method_context_t hctx,
-                         const std::map<string,
-                         bufferlist> *map)
+                         const std::map<string, ceph::bufferlist> *map)
 {
-  return 0;
+  OSDOp op{ CEPH_OSD_OP_OMAPSETVALS };
+  encode(*map, op.indata);
+
+  try {
+    reinterpret_cast<ceph::osd::OpsExecuter*>(hctx)->do_osd_op(op).get();
+    return 0;
+  } catch (ceph::osd::error& e) {
+    return -e.code().value();
+  }
 }
 
 int cls_cxx_map_clear(cls_method_context_t hctx)

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -53,10 +53,16 @@ int cls_read(cls_method_context_t hctx,
 
 int cls_get_request_origin(cls_method_context_t hctx, entity_inst_t *origin)
 {
-  assert(origin)
-  *origin =
-    reinterpret_cast<ceph::osd::OpsExecuter*>(hctx)->get_orig_source_inst();
-  return 0;
+  assert(origin);
+
+  try {
+    const auto& message = \
+      reinterpret_cast<ceph::osd::OpsExecuter*>(hctx)->get_message();
+    *origin = message.get_orig_source_inst();
+    return 0;
+  } catch (ceph::osd::error& e) {
+    return -e.code().value();
+  }
 }
 
 int cls_cxx_create(cls_method_context_t hctx, const bool exclusive)

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -444,7 +444,13 @@ uint64_t cls_get_features(cls_method_context_t hctx)
 
 uint64_t cls_get_client_features(cls_method_context_t hctx)
 {
-  return 0;
+  try {
+    const auto& message = \
+      reinterpret_cast<ceph::osd::OpsExecuter*>(hctx)->get_message();
+    return message.get_features();
+  } catch (ceph::osd::error& e) {
+    return -e.code().value();
+  }
 }
 
 ceph_release_t cls_get_required_osd_release(cls_method_context_t hctx)

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -401,6 +401,11 @@ OpsExecuter::do_osd_op(OSDOp& osd_op)
     return do_const_op([&osd_op] (/* const */auto& backend, const auto& os) {
       return backend.stat(os, osd_op);
     });
+  case CEPH_OSD_OP_TMAPUP:
+    // TODO: there was an effort to kill TMAP in ceph-osd. According to
+    // @dzafman this isn't possible yet. Maybe it could be accomplished
+    // before crimson's readiness and we'd luckily don't need to carry.
+    return dont_do_legacy_op();
   default:
     logger().warn("unknown op {}", ceph_osd_op_name(op.op));
     throw std::runtime_error(

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -432,6 +432,13 @@ OpsExecuter::do_osd_op(OSDOp& osd_op)
       return backend.omap_set_vals(os, osd_op, txn);
     });
 
+  // watch/notify
+  case CEPH_OSD_OP_WATCH:
+    return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      logger().warn("CEPH_OSD_OP_WATCH is not implemented yet; ignoring");
+      return seastar::now();
+    });
+
   default:
     logger().warn("unknown op {}", ceph_osd_op_name(op.op));
     throw std::runtime_error(

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -410,6 +410,12 @@ OpsExecuter::do_osd_op(OSDOp& osd_op)
     // @dzafman this isn't possible yet. Maybe it could be accomplished
     // before crimson's readiness and we'd luckily don't need to carry.
     return dont_do_legacy_op();
+
+  // OMAP
+  case CEPH_OSD_OP_OMAPGETVALSBYKEYS:
+    return do_read_op([&osd_op] (auto& backend, const auto& os) {
+      return backend.omap_get_vals_by_keys(os, osd_op);
+    });
   default:
     logger().warn("unknown op {}", ceph_osd_op_name(op.op));
     throw std::runtime_error(

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -416,6 +416,14 @@ OpsExecuter::do_osd_op(OSDOp& osd_op)
     return do_read_op([&osd_op] (auto& backend, const auto& os) {
       return backend.omap_get_vals_by_keys(os, osd_op);
     });
+  case CEPH_OSD_OP_OMAPSETVALS:
+    if (!pg.get_pool().info.supports_omap()) {
+      throw ceph::osd::operation_not_supported{};
+    }
+    return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      return backend.omap_set_vals(os, osd_op, txn);
+    });
+
   default:
     logger().warn("unknown op {}", ceph_osd_op_name(op.op));
     throw std::runtime_error(

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -416,6 +416,10 @@ OpsExecuter::do_osd_op(OSDOp& osd_op)
     return do_read_op([&osd_op] (auto& backend, const auto& os) {
       return backend.omap_get_keys(os, osd_op);
     });
+  case CEPH_OSD_OP_OMAPGETVALS:
+    return do_read_op([&osd_op] (auto& backend, const auto& os) {
+      return backend.omap_get_vals(os, osd_op);
+    });
   case CEPH_OSD_OP_OMAPGETVALSBYKEYS:
     return do_read_op([&osd_op] (auto& backend, const auto& os) {
       return backend.omap_get_vals_by_keys(os, osd_op);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -368,6 +368,10 @@ OpsExecuter::do_osd_op(OSDOp& osd_op)
     return do_read_op([&osd_op] (auto& backend, const auto& os) {
       return backend.getxattr(os, osd_op);
     });
+  case CEPH_OSD_OP_CREATE:
+    return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      return backend.create(os, osd_op, txn);
+    });
   case CEPH_OSD_OP_WRITE:
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
       return backend.write(os, osd_op, txn);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -412,6 +412,10 @@ OpsExecuter::do_osd_op(OSDOp& osd_op)
     return dont_do_legacy_op();
 
   // OMAP
+  case CEPH_OSD_OP_OMAPGETKEYS:
+    return do_read_op([&osd_op] (auto& backend, const auto& os) {
+      return backend.omap_get_keys(os, osd_op);
+    });
   case CEPH_OSD_OP_OMAPGETVALSBYKEYS:
     return do_read_op([&osd_op] (auto& backend, const auto& os) {
       return backend.omap_get_vals_by_keys(os, osd_op);

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -27,6 +27,7 @@
 
 #include "crimson/osd/pg.h"
 #include "crimson/osd/pg_backend.h"
+#include "crimson/osd/exceptions.h"
 
 class PGLSFilter;
 class OSDOp;
@@ -86,6 +87,10 @@ class OpsExecuter {
   auto do_pg_op(Func&& f) {
     return std::forward<Func>(f)(std::as_const(pg),
                                  std::as_const(os->oi.soid.get_namespace()));
+  }
+
+  seastar::future<> dont_do_legacy_op() {
+    throw ceph::osd::operation_not_supported();
   }
 
 public:

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -109,8 +109,8 @@ public:
   template <typename Func>
   seastar::future<> submit_changes(Func&& f) &&;
 
-  auto get_orig_source_inst() const {
-    return msg->get_orig_source_inst();
+  const auto& get_message() const {
+    return *msg;
   }
 };
 

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -29,6 +29,8 @@
 #include "crimson/osd/pg_backend.h"
 #include "crimson/osd/exceptions.h"
 
+#include "messages/MOSDOp.h"
+
 class PGLSFilter;
 class OSDOp;
 
@@ -48,6 +50,7 @@ class OpsExecuter {
   PGBackend::cached_os_t os;
   PG& pg;
   PGBackend& backend;
+  Ref<MOSDOp> msg;
   ceph::os::Transaction txn;
 
   size_t num_read = 0;    ///< count read ops
@@ -94,14 +97,21 @@ class OpsExecuter {
   }
 
 public:
-  OpsExecuter(PGBackend::cached_os_t os, PG& pg)
-    : os(std::move(os)), pg(pg), backend(pg.get_backend()) {
+  OpsExecuter(PGBackend::cached_os_t os, PG& pg, Ref<MOSDOp> msg)
+    : os(std::move(os)),
+      pg(pg),
+      backend(pg.get_backend()),
+      msg(std::move(msg)) {
   }
 
   seastar::future<> do_osd_op(class OSDOp& osd_op);
 
   template <typename Func>
   seastar::future<> submit_changes(Func&& f) &&;
+
+  auto get_orig_source_inst() const {
+    return msg->get_orig_source_inst();
+  }
 };
 
 template <class Context, class MainFunc, class EffectFunc>

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -358,8 +358,8 @@ seastar::future<Ref<MOSDOpReply>> PG::do_osd_ops(Ref<MOSDOp> m)
   const auto oid = m->get_snapid() == CEPH_SNAPDIR ? m->get_hobj().get_head()
                                                    : m->get_hobj();
   return backend->get_object_state(oid).then([this, m](auto os) mutable {
-    return seastar::do_with(OpsExecuter{std::move(os), *this/* as const& */},
-                            [this, m=std::move(m)] (auto& ox) {
+    return seastar::do_with(OpsExecuter{std::move(os), *this/* as const& */, m},
+                            [this, m] (auto& ox) {
       return seastar::do_for_each(m->ops, [this, &ox](OSDOp& osd_op) {
         logger().debug("will be handling op {}", ceph_osd_op_name(osd_op.op.op));
         return ox.do_osd_op(osd_op);

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -350,6 +350,32 @@ seastar::future<> PGBackend::writefull(
   return seastar::now();
 }
 
+seastar::future<> PGBackend::create(
+  ObjectState& os,
+  const OSDOp& osd_op,
+  ceph::os::Transaction& txn)
+{
+  const int flags = le32_to_cpu(osd_op.op.flags);
+  if (os.exists && !os.oi.is_whiteout() && (flags & CEPH_OSD_OP_FLAG_EXCL)) {
+    // this is an exclusive create
+    throw ceph::osd::make_error(-EEXIST);
+  }
+
+  if (osd_op.indata.length()) {
+    // handle the legacy. `category` is no longer implemented.
+    try {
+      auto p = osd_op.indata.cbegin();
+      std::string category;
+      decode(category, p);
+    } catch (buffer::error&) {
+      throw ceph::osd::invalid_argument();
+    }
+  }
+  maybe_create_new_object(os, txn);
+  txn.nop();
+  return seastar::now();
+}
+
 seastar::future<> PGBackend::remove(ObjectState& os,
                                     ceph::os::Transaction& txn)
 {

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -505,6 +505,62 @@ maybe_get_omap_vals_by_keys(
   }
 }
 
+static seastar::future<bool, ceph::os::FuturizedStore::omap_values_t>
+maybe_get_omap_vals(
+  auto& store,
+  const auto& coll,
+  const auto& oi,
+  const auto& start_after)
+{
+  if (oi.is_omap()) {
+    return store->omap_get_values(coll, ghobject_t{oi.soid}, start_after);
+  } else {
+    return seastar::make_ready_future<bool, ceph::os::FuturizedStore::omap_values_t>(
+      true, ceph::os::FuturizedStore::omap_values_t{});
+  }
+}
+
+seastar::future<> PGBackend::omap_get_keys(
+  const ObjectState& os,
+  OSDOp& osd_op) const
+{
+  std::string start_after;
+  uint64_t max_return;
+  try {
+    auto p = osd_op.indata.cbegin();
+    decode(start_after, p);
+    decode(max_return, p);
+  } catch (buffer::error&) {
+    throw ceph::osd::invalid_argument{};
+  }
+  max_return =
+    std::min(max_return, local_conf()->osd_max_omap_entries_per_request);
+
+  // TODO: truly chunk the reading
+  return maybe_get_omap_vals(store, coll, os.oi, start_after).then(
+    [=, &osd_op] (bool, ceph::os::FuturizedStore::omap_values_t vals) {
+      ceph::bufferlist result;
+      bool truncated = false;
+      uint32_t num = 0;
+      for (auto& [key, val] : vals) {
+        if (num++ >= max_return ||
+            result.length() >= local_conf()->osd_max_omap_bytes_per_request) {
+          truncated = true;
+          break;
+        }
+        encode(key, result);
+      }
+      encode(num, osd_op.outdata);
+      osd_op.outdata.claim_append(result);
+      encode(truncated, osd_op.outdata);
+      return seastar::now();
+    });
+
+  // TODO:
+  //ctx->delta_stats.num_rd_kb += shift_round_up(osd_op.outdata.length(), 10);
+  //ctx->delta_stats.num_rd++;
+}
+
 seastar::future<> PGBackend::omap_get_vals_by_keys(
   const ObjectState& os,
   OSDOp& osd_op) const

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -92,6 +92,10 @@ public:
   seastar::future<> omap_get_vals_by_keys(
     const ObjectState& os,
     OSDOp& osd_op) const;
+  seastar::future<> omap_set_vals(
+    ObjectState& os,
+    const OSDOp& osd_op,
+    ceph::os::Transaction& trans);
 
   virtual void got_rep_op_reply(const MOSDRepOpReply&) {}
 

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -89,6 +89,9 @@ public:
     std::string_view key) const;
 
   // OMAP
+  seastar::future<> omap_get_keys(
+    const ObjectState& os,
+    OSDOp& osd_op) const;
   seastar::future<> omap_get_vals_by_keys(
     const ObjectState& os,
     OSDOp& osd_op) const;

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -88,6 +88,11 @@ public:
     const hobject_t& soid,
     std::string_view key) const;
 
+  // OMAP
+  seastar::future<> omap_get_vals_by_keys(
+    const ObjectState& os,
+    OSDOp& osd_op) const;
+
   virtual void got_rep_op_reply(const MOSDRepOpReply&) {}
 
 protected:

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -50,6 +50,11 @@ public:
   seastar::future<> stat(
     const ObjectState& os,
     OSDOp& osd_op);
+
+  seastar::future<> create(
+    ObjectState& os,
+    const OSDOp& osd_op,
+    ceph::os::Transaction& trans);
   seastar::future<> remove(
     ObjectState& os,
     ceph::os::Transaction& txn);

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -92,6 +92,9 @@ public:
   seastar::future<> omap_get_keys(
     const ObjectState& os,
     OSDOp& osd_op) const;
+  seastar::future<> omap_get_vals(
+    const ObjectState& os,
+    OSDOp& osd_op) const;
   seastar::future<> omap_get_vals_by_keys(
     const ObjectState& os,
     OSDOp& osd_op) const;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5666,10 +5666,15 @@ struct OSDOp {
   sobject_t soid;
 
   ceph::buffer::list indata, outdata;
-  errorcode32_t rval;
+  errorcode32_t rval = 0;
 
-  OSDOp() : rval(0) {
+  OSDOp() {
     memset(&op, 0, sizeof(ceph_osd_op));
+  }
+
+  OSDOp(const int op_code) {
+    memset(&op, 0, sizeof(ceph_osd_op));
+    op.op = op_code;
   }
 
   /**


### PR DESCRIPTION
We don't support the RBD's `exclusive-lock` yet, so an image must be created with restricted features. For instance:
`rbd create fio_test --size 1G --image-format=2 --rbd_default_features=3`.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
