### PR TITLE
cephfs-shell: better complain info, when deleting non-empty directory

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -842,10 +842,9 @@ sub-directories, files')
             if not is_pattern and path != os.path.normpath(b''):
                 try:
                     cephfs.rmdir(path)
-                except libcephfs.Error:
-                    self.perror('error: no such directory {} exists'.format(
-                                path.decode('utf-8')), end='\n',
-                                apply_style=True)
+                except libcephfs.Error as e:
+                    self.perror('Error in rmdir {}: {}'.format(
+                                path.decode('utf-8'), os.strerror(e.errno)))
 
     def complete_rm(self, text, line, begidx, endidx):
         """


### PR DESCRIPTION
cephfs-shell: better complain info, when deleting non-empty directory

fixes:http://tracker.ceph.com/issues/40864

Signed-off-by: Shen Hang <harryshen18@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
