### PR TITLE
qa/suites/rados/perf: test min recommended osd_memory_target

### DIFF
--- a/qa/suites/rados/perf/objectstore/bluestore-basic-min-osd-mem-target.yaml
+++ b/qa/suites/rados/perf/objectstore/bluestore-basic-min-osd-mem-target.yaml
@@ -1,0 +1,25 @@
+overrides:
+  thrashosds:
+    bdev_inject_crash: 2
+    bdev_inject_crash_probability: .5
+  ceph:
+    fs: xfs
+    conf:
+      osd:
+        osd objectstore: bluestore
+        osd memory target: 2147483648 # min recommended is 2_G
+        bluestore block size: 96636764160
+        debug bluestore: 20
+        debug bluefs: 20
+        debug rocksdb: 10
+        bluestore fsck on mount: true
+        # lower the full ratios since we can fill up a 100gb osd so quickly
+        mon osd full ratio: .9
+        mon osd backfillfull_ratio: .85
+        mon osd nearfull ratio: .8
+        osd failsafe full ratio: .95
+# this doesn't work with failures bc the log writes are not atomic across the two backends
+#        bluestore bluefs env mirror: true
+        bdev enable discard: true
+        bdev async discard: true
+


### PR DESCRIPTION
Add bluestore-basic-min-osd-mem-target.yaml to objecstore.

Signed-off-by: Neha Ojha <nojha@redhat.com>