### PR TITLE
mgr/dashboard: Gracefully handle client/target info not found

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
@@ -78,7 +78,12 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
     this.metadata = { root: this.selectedItem.target_controls };
     const cssClasses = {
       target: {
-        expanded: _.join([Icons.large, Icons.bullseye], ' ')
+        expanded: _.join(
+          this.selectedItem.cdExecuting
+            ? [Icons.large, Icons.spinner, Icons.spin]
+            : [Icons.large, Icons.bullseye],
+          ' '
+        )
       },
       initiators: {
         expanded: _.join([Icons.large, Icons.user], ' '),
@@ -120,11 +125,13 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
     const clients = [];
     _.forEach(this.selectedItem.clients, (client) => {
       const client_metadata = _.cloneDeep(client.auth);
-      _.extend(client_metadata, client.info);
-      delete client_metadata['state'];
-      _.forEach(Object.keys(client.info.state), (state) => {
-        client_metadata[state.toLowerCase()] = client.info.state[state];
-      });
+      if (client.info) {
+        _.extend(client_metadata, client.info);
+        delete client_metadata['state'];
+        _.forEach(Object.keys(client.info.state), (state) => {
+          client_metadata[state.toLowerCase()] = client.info.state[state];
+        });
+      }
       this.metadata['client_' + client.client_iqn] = client_metadata;
 
       const luns = [];
@@ -138,9 +145,13 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
         });
       });
 
+      let status = '';
+      if (client.info) {
+        status = Object.keys(client.info.state).includes('LOGGED_IN') ? 'logged_in' : 'logged_out';
+      }
       clients.push({
         value: client.client_iqn,
-        status: Object.keys(client.info.state).includes('LOGGED_IN') ? 'logged_in' : 'logged_out',
+        status: status,
         id: 'client_' + client.client_iqn,
         children: luns
       });


### PR DESCRIPTION
_After https://github.com/ceph/ceph-iscsi/pull/140 (Merged)_

------

This PR will gracefully handle the case where clients or targets have been removed using an external tool like `gwcli`.

Additionally, client/target additional info like the number of sessions or the "logged-in" status will not be displayed during target edition.

### During target edition:

![Screenshot from 2019-09-12 09-59-11](https://user-images.githubusercontent.com/14297426/64770382-ff589a80-d544-11e9-8061-2911a5f4dd77.png)

### After target edition:

![Screenshot from 2019-09-12 09-59-20](https://user-images.githubusercontent.com/14297426/64770396-054e7b80-d545-11e9-86a9-4a494cea102f.png)


Fixes: https://tracker.ceph.com/issues/41779

Signed-off-by: Ricardo Marques <rimarques@suse.com>
