### PR TITLE
mon: disable min pg per osd warning

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1565,7 +1565,7 @@ std::vector<Option> get_global_options() {
     .add_service("mgr"),
 
     Option("mon_pg_warn_min_per_osd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(30)
+    .set_default(0)
     .add_service("mgr")
     .set_description("minimal number PGs per (in) osd before we warn the admin"),
 


### PR DESCRIPTION
Now that the pg_autoscaler is on by default, it is "normal" (and okay) to
have a small number of PGs in the cluster if the overall cluster usage is
also low.  This setting just results in a health warning out of the box
when you create a pool and haven't written any data yet.

Signed-off-by: Sage Weil <sage@redhat.com>

https://tracker.ceph.com/issues/41735