### PR TITLE
mgr/dashboard: Increase the global value of jasmine timeout

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
@@ -69,13 +69,6 @@ describe('Logs page', () => {
   });
 
   describe('audit logs respond to editing configuration setting test', () => {
-    let originalTimeout;
-
-    beforeEach(() => {
-      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
-    });
-
     it('should change config settings and check audit logs reacted', async () => {
       await configuration.navigateTo();
       await configuration.edit(configname, ['global', '5']);
@@ -85,10 +78,6 @@ describe('Logs page', () => {
 
       await configuration.navigateTo();
       await configuration.configClear(configname);
-    });
-
-    afterEach(function() {
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.e2e-spec.ts
@@ -43,12 +43,7 @@ describe('RGW users page', () => {
   });
 
   describe('Invalid input test', () => {
-    let originalTimeout;
-
     beforeAll(async () => {
-      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
-
       await users.navigateTo();
     });
 
@@ -58,10 +53,6 @@ describe('RGW users page', () => {
 
     it('should put invalid input into user edit form and check fields are marked invalid', async () => {
       await users.invalidEdit();
-    });
-
-    afterAll(function() {
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/ui/dashboard.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/ui/dashboard.e2e-spec.ts
@@ -94,60 +94,47 @@ describe('Dashboard Main Page', () => {
     });
   });
 
-  describe('Correct information', () => {
-    let originalTimeout;
+  it('Should check that dashboard cards have correct information', async () => {
+    interface TestSpec {
+      cardName: string;
+      regexMatcher?: RegExp;
+      pageObject: PageHelper;
+    }
 
-    beforeEach(async () => {
-      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
-    });
+    const testSpecs: TestSpec[] = [
+      { cardName: 'Object Gateways', regexMatcher: /(\d+)\s+total/, pageObject: daemons },
+      { cardName: 'Monitors', regexMatcher: /(\d+)\s+\(quorum/, pageObject: monitors },
+      { cardName: 'Hosts', regexMatcher: /(\d+)\s+total/, pageObject: hosts },
+      { cardName: 'OSDs', regexMatcher: /(\d+)\s+total/, pageObject: osds },
+      { cardName: 'Pools', pageObject: pools },
+      { cardName: 'iSCSI Gateways', regexMatcher: /(\d+)\s+total/, pageObject: iscsi }
+    ];
 
-    it('Should check that dashboard cards have correct information', async () => {
-      interface TestSpec {
-        cardName: string;
-        regexMatcher?: RegExp;
-        pageObject: PageHelper;
-      }
-
-      const testSpecs: TestSpec[] = [
-        { cardName: 'Object Gateways', regexMatcher: /(\d+)\s+total/, pageObject: daemons },
-        { cardName: 'Monitors', regexMatcher: /(\d+)\s+\(quorum/, pageObject: monitors },
-        { cardName: 'Hosts', regexMatcher: /(\d+)\s+total/, pageObject: hosts },
-        { cardName: 'OSDs', regexMatcher: /(\d+)\s+total/, pageObject: osds },
-        { cardName: 'Pools', pageObject: pools },
-        { cardName: 'iSCSI Gateways', regexMatcher: /(\d+)\s+total/, pageObject: iscsi }
-      ];
-
-      for (let i = 0; i < testSpecs.length; i++) {
-        const spec = testSpecs[i];
-        await dashboard.navigateTo();
-        const infoCardBodyText = await dashboard.infoCardBodyText(spec.cardName);
-        let dashCount = 0;
-        if (spec.regexMatcher) {
-          const match = infoCardBodyText.match(new RegExp(spec.regexMatcher));
-          if (match && match.length > 1) {
-            dashCount = Number(match[1]);
-          } else {
-            return Promise.reject(
-              `Regex ${spec.regexMatcher} did not find a match for card with name ` +
-                `${spec.cardName}`
-            );
-          }
+    for (let i = 0; i < testSpecs.length; i++) {
+      const spec = testSpecs[i];
+      await dashboard.navigateTo();
+      const infoCardBodyText = await dashboard.infoCardBodyText(spec.cardName);
+      let dashCount = 0;
+      if (spec.regexMatcher) {
+        const match = infoCardBodyText.match(new RegExp(spec.regexMatcher));
+        if (match && match.length > 1) {
+          dashCount = Number(match[1]);
         } else {
-          dashCount = Number(infoCardBodyText);
+          return Promise.reject(
+            `Regex ${spec.regexMatcher} did not find a match for card with name ` +
+              `${spec.cardName}`
+          );
         }
-        await spec.pageObject.navigateTo();
-        const tableCount = await spec.pageObject.getTableTotalCount();
-        await expect(dashCount).toBe(
-          tableCount,
-          `Text of card "${spec.cardName}" and regex "${spec.regexMatcher}" resulted in ${dashCount} ` +
-            `but did not match table count ${tableCount}`
-        );
+      } else {
+        dashCount = Number(infoCardBodyText);
       }
-    });
-
-    afterEach(function() {
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-    });
+      await spec.pageObject.navigateTo();
+      const tableCount = await spec.pageObject.getTableTotalCount();
+      await expect(dashCount).toBe(
+        tableCount,
+        `Text of card "${spec.cardName}" and regex "${spec.regexMatcher}" resulted in ${dashCount} ` +
+          `but did not match table count ${tableCount}`
+      );
+    }
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/protractor.conf.js
+++ b/src/pybind/mgr/dashboard/frontend/protractor.conf.js
@@ -28,7 +28,7 @@ const config = {
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,
-    defaultTimeoutInterval: 30000,
+    defaultTimeoutInterval: 300000,
     print: function() {}
   },
   params: {

--- a/src/pybind/mgr/dashboard/frontend/protractor.conf.js
+++ b/src/pybind/mgr/dashboard/frontend/protractor.conf.js
@@ -62,7 +62,7 @@ config.onPrepare = async () => {
   require('ts-node').register({
     project: 'e2e/tsconfig.e2e.json'
   });
-  jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
+  jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true, displayDuration: true } }));
 
   await browser.get('/#/login');
 


### PR DESCRIPTION
Some tests are taking longer than the default jasmine timeout to finish
and are causing a failure.

This commit will increase the timeout to 5 minutes,
removing the need to increase it for each failing test.

Now we are able to see which tests are taking
too much time and may need improvements.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
