### PR TITLE
 nautilus: build/ops: cmake/BuildDPDK: ignore gcc8/9 warnings

### DIFF
--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -71,11 +71,13 @@ function(do_build_dpdk dpdk_dir)
       "\"${target}\" not listed in ${supported_targets}")
   endif()
 
+  set(EXTRA_CFLAGS "-Wno-unknown-warning-option -Wno-stringop-truncation -Wno-address-of-packed-member -fPIC")
+
   include(ExternalProject)
   ExternalProject_Add(dpdk-ext
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/spdk/dpdk
     CONFIGURE_COMMAND $(MAKE) config O=${dpdk_dir} T=${target}
-    BUILD_COMMAND env CC=${CMAKE_C_COMPILER} $(MAKE) O=${dpdk_dir} EXTRA_CFLAGS=-fPIC
+    BUILD_COMMAND env CC=${CMAKE_C_COMPILER} $(MAKE) O=${dpdk_dir} EXTRA_CFLAGS=${EXTRA_CFLAGS}
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND "true")
   ExternalProject_Add_Step(dpdk-ext patch-config


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

In GCC9, the following warning (that exist in the dpdk submodule) are treated as errors when using ``-Werror``:
```
stringop-truncation, address-of-packed-member
```
These errors appear in several places in the code. For example:
```
src/spdk/dpdk/lib/librte_eal/linuxapp/eal/eal_vfio.c: In function ‘rte_vfio_setup_device’:                                                                                                                       
src/spdk/dpdk/lib/librte_eal/linuxapp/eal/eal_vfio.c:566:27: error: taking address of packed member of ‘struct rte_mem_config’ may result in an unaligned pointer value [-Werror=address-of-packed-member]       
  566 |  rte_rwlock_t *mem_lock = &mcfg->memory_hotplug_lock;                                                                                                                                                                                 
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
```
And:
```
In function ‘eal_plugin_add’,                                                                                          
    inlined from ‘eal_plugindir_init’ at src/spdk/dpdk/lib/librte_eal/common/eal_common_options.c:256:7:
src/spdk/dpdk/lib/librte_eal/common/eal_common_options.c:223:2: error: ‘strncpy’ output may be truncated copying 4095 bytes from a string of length 4095 [-Werror=stringop-truncation]
  223 |  strncpy(solib->name, path, PATH_MAX-1);                                                                       
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~              
```

Therefore they are muted in the makefile of dpdk.
> Note that ```-Wno-unknown-warning-option``` is used to make gcc7 (minimum version for compiling nautilus) and clang5 ignore the newly added gcc8/9 flags
