### PR TITLE
qa/tasks/mon_thrash: sync force requires some force flags

### DIFF
--- a/qa/tasks/mon_thrash.py
+++ b/qa/tasks/mon_thrash.py
@@ -169,7 +169,9 @@ class MonitorThrasher(Thrasher):
         """
         addr = self.ctx.ceph['ceph'].mons['mon.%s' % mon]
         self.log('thrashing mon.{id}@{addr} store'.format(id=mon, addr=addr))
-        out = self.manager.raw_cluster_cmd('-m', addr, 'sync', 'force')
+        out = self.manager.raw_cluster_cmd('-m', addr, 'sync', 'force',
+                                           '--yes-i-really-mean-it',
+                                           '--i-know-what-i-am-doing')
         j = json.loads(out)
         assert j['ret'] == 0, \
             'error forcing store sync on mon.{id}:\n{ret}'.format(


### PR DESCRIPTION
AFAICS this has been the case for basically forever.  Not sure why/how
the mon_thrash task hasn't had a problem with that?

Signed-off-by: Sage Weil <sage@redhat.com>

see /a/sage-2019-09-10_21:11:49-rados-wip-sage3-testing-2019-09-10-1000-distro-basic-smithi/4296834