### PR TITLE
cmake: Fix unaligned check on big-endian systems

### DIFF
--- a/cmake/modules/CephChecks.cmake
+++ b/cmake/modules/CephChecks.cmake
@@ -104,23 +104,18 @@ uint32_t load(char* p, size_t offset)
   return *reinterpret_cast<uint32_t*>(p + offset);
 }
 
-bool good(uint32_t lhs, uint32_t small_endian)
+bool good(uint32_t lhs, uint32_t big_endian)
 {
-  uint32_t rhs;
-  if (ntohl(0xdeadbeaf) == 0xdeadbeaf) {
-    return lhs == ntohl(small_endian);
-  } else {
-    return lhs == small_endian;
-  }
+  return lhs == ntohl(big_endian);
 }
 
 int main(int argc, char **argv)
 {
   char a1[] = \"ABCDEFG\";
-  uint32_t a2[] = {0x44434241,
-                   0x45444342,
-                   0x46454443,
-                   0x47464544};
+  uint32_t a2[] = {0x41424344,
+                   0x42434445,
+                   0x43444546,
+                   0x44454647};
   for (size_t i = 0; i < std::size(a2); i++) {
     if (!good(load(a1, i), a2[i])) {
       return 1;


### PR DESCRIPTION
On big-endian systems, ntohl is a no-op, so "good" never does
any conversion.  Fix this by keeping the test constants in
big-endian (network) order and using ntohl to convert them
to native (host) byte order.

Signed-off-by: Ulrich Weigand <ulrich.weigand@de.ibm.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
