### PR TITLE
cephfs-shell: changes to stderr and stdout messages

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -233,6 +233,8 @@ class OutOfRange(OSError):
 class ObjectNotEmpty(OSError):
     pass
 
+class NotDirectory(OSError):
+    pass
 
 IF UNAME_SYSNAME == "FreeBSD":
     cdef errno_to_exception =  {
@@ -261,6 +263,7 @@ ELSE:
         errno.ERANGE     : OutOfRange,
         errno.EWOULDBLOCK: WouldBlock,
         errno.ENOTEMPTY  : ObjectNotEmpty,
+        errno.ENOTDIR    : NotDirectory
     }
 
 

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -180,10 +180,10 @@ class OSError(Error):
     def __init__(self, errno, strerror):
         super(OSError, self).__init__(errno, strerror)
         self.errno = errno
-        self.strerror = strerror
+        self.strerror = "%s: %s" % (strerror, os.strerror(errno))
 
     def __str__(self):
-        return '{0}: {1} [Errno {2}]'.format(self.strerror, os.strerror(self.errno), self.errno)
+        return '{} [Errno {}]'.format(self.strerror, self.errno)
 
 
 class PermissionError(OSError):

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -133,8 +133,8 @@ def ls(path, opts=''):
                 elif almost_all and dent.d_name in (b'.', b'..'):
                     continue
                 yield dent
-    except libcephfs.ObjectNotFound:
-        perror('{}: no such directory exists'.format(path))
+    except libcephfs.ObjectNotFound as e:
+        perror(e)
 
 
 def glob(path, pattern):
@@ -268,9 +268,8 @@ def copy_from_local(local_path, remote_path):
         stdin = 1
     try:
         fd = cephfs.open(remote_path, 'w', 0o666)
-    except libcephfs.Error:
-        perror('error: no permission to write remote file {}'.format(
-               remote_path.decode('utf-8')))
+    except libcephfs.Error as e:
+        perror(e)
         return
     progress = 0
     while True:
@@ -536,9 +535,8 @@ exists.')
             else:
                 try:
                     cephfs.mkdir(path, permission)
-                except libcephfs.Error:
-                    perror('directory missing in the path; you may want to '
-                           'pass the -p argument')
+                except libcephfs.Error as e:
+                    perror(e)
                     return
 
     def complete_put(self, text, line, begidx, endidx):
@@ -862,9 +860,8 @@ sub-directories, files')
             if not is_pattern and path != os.path.normpath(b''):
                 try:
                     cephfs.rmdir(path)
-                except libcephfs.Error:
-                    perror('error: no such directory {} exists'.format(
-                            path.decode('utf-8')))
+                except libcephfs.Error as e:
+                    perror(e)
 
     def complete_rm(self, text, line, begidx, endidx):
         """
@@ -889,8 +886,9 @@ sub-directories, files')
             else:
                 try:
                     cephfs.unlink(path)
-                except libcephfs.Error:
-                    perror('{}: no such file'.format(path.decode('utf-8')))
+                except libcephfs.Error as e:
+                    # perhaps we need a better msg here
+                    perror(e)
 
     def complete_mv(self, text, line, begidx, endidx):
         """
@@ -911,8 +909,8 @@ sub-directories, files')
         """
         try:
             cephfs.rename(args.src_path, args.dest_path)
-        except libcephfs.Error:
-            perror('error: invalid file name')
+        except libcephfs.Error as e:
+            perror(e)
 
     def complete_cd(self, text, line, begidx, endidx):
         """
@@ -933,8 +931,8 @@ sub-directories, files')
             cephfs.chdir(args.path)
             self.working_dir = cephfs.getcwd().decode('utf-8')
             self.set_prompt()
-        except libcephfs.Error:
-            perror('{}: no such directory'.format(args.path.decode('utf-8')))
+        except libcephfs.Error as e:
+            perror(e)
 
     def do_cwd(self, arglist):
         """
@@ -962,9 +960,8 @@ sub-directories, files')
             mode = int(args.mode, base=8)
             try:
                 cephfs.chmod(path, mode)
-            except libcephfs.Error:
-                perror('{}: no such file or directory'.format(
-                            path.decode('utf-8')))
+            except libcephfs.Error as e:
+                perror(e)
 
     def complete_cat(self, text, line, begidx, endidx):
         """
@@ -1167,9 +1164,8 @@ sub-directories, files')
                         f = b'.' + f
                     poutput('{:10s} {}'.format(humansize(dusage),
                         f.decode('utf-8')))
-                except (libcephfs.Error, OSError):
-                    perror('{} : no such directory exists'.format(f.\
-                        decode('utf-8')))
+                except (libcephfs.Error, OSError) as e:
+                    perror(e)
                     continue
 
         for path in args.paths:
@@ -1298,8 +1294,8 @@ Access: {}\nModify: {}\nChange: {}".format(path.decode('utf-8'), stat.st_size,
                              stat.st_ino, stat.st_nlink, stat.st_mode,
                              mode_notation(stat.st_mode), stat.st_uid,
                              stat.st_gid, atime, mtime, ctime))
-            except libcephfs.Error:
-                perror('{}: no such file or directory'.format(path.decode('utf-8')))
+            except libcephfs.Error as e:
+                perror(e)
 
 
 if __name__ == '__main__':

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -62,8 +62,8 @@ def poutput(s, end='\n'):
     shell.poutput(s, end=end)
 
 
-def perror(msg):
-    shell.perror(msg, end='\n', apply_style=True)
+def perror(msg, **kwargs):
+    shell.perror(msg, **kwargs)
 
 
 def setup_cephfs(config_file):

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -341,7 +341,7 @@ class CephFSShell(Cmd):
         self.umask = '2'
 
     def default(self, line):
-        self.perror('Unrecognized command')
+        perror('Unrecognized command')
 
     def set_prompt(self):
         self.prompt = ('\033[01;33mCephFS:~' + colorama.Fore.LIGHTCYAN_EX
@@ -407,11 +407,11 @@ class CephFSShell(Cmd):
                 self.set_prompt()
             return res
         except ConnectionError as e:
-            self.perror('***\n{}'.format(e))
+            perror('***\n{}'.format(e))
         except KeyboardInterrupt:
-            self.perror('Command aborted')
+            perror('Command aborted')
         except Exception as e:
-            self.perror(e)
+            perror(e)
             traceback.print_exc(file=sys.stdout)
 
     class path_to_bytes(argparse.Action):
@@ -537,8 +537,8 @@ exists.')
                 try:
                     cephfs.mkdir(path, permission)
                 except libcephfs.Error:
-                    self.perror('directory missing in the path; '
-                                'you may want to pass the -p argument')
+                    perror('directory missing in the path; you may want to '
+                           'pass the -p argument')
                     return
 
     def complete_put(self, text, line, begidx, endidx):
@@ -588,7 +588,7 @@ exists.')
                     else:
                         root_dst_dir = a[0]
             else:
-                self.perror('error: no filename specified for destination')
+                perror('error: no filename specified for destination')
                 return
 
         if root_dst_dir[-1] != b'/':
@@ -599,8 +599,8 @@ exists.')
                 if os.path.isfile(root_src_dir):
                     dst_file = root_dst_dir
                     if is_file_exists(dst_file):
-                        self.perror('{}: file exists! use --force to overwrite'.format(
-                                    dst_file.decode('utf-8')))
+                        perror('{}: file exists! use --force to overwrite'.format(
+                               dst_file.decode('utf-8')))
                         return
             if args.local_path == b'-':
                 root_src_dir = b'-'
@@ -671,7 +671,7 @@ exists.')
             root_src_dir = cephfs.getcwd()
         if args.local_path == b'-':
             if args.remote_path == b'.' or args.remote_path == b'./':
-                self.perror('error: no remote file name specified')
+                perror('error: no remote file name specified')
                 return
             copy_to_local(root_src_dir, b'-')
         elif is_file_exists(args.remote_path):
@@ -688,8 +688,8 @@ exists.')
                     if args.force:
                         pass
                     else:
-                        self.perror('{}: already exists! use --force to overwrite'.format(
-                                    root_src_dir.decode('utf-8')))
+                        perror('{}: already exists! use --force to overwrite'.format(
+                               root_src_dir.decode('utf-8')))
                         return
 
             for file_ in files:
@@ -707,8 +707,8 @@ exists.')
                     if not args.force:
                         try:
                             os.stat(dst_path)
-                            self.perror('{}: file already exists! use --force to override'.format(
-                                        file_.decode('utf-8')))
+                            perror('{}: file already exists! use --force to override'.format(
+                                   file_.decode('utf-8')))
                             return
                         except OSError:
                             copy_to_local(file_, dst_path)
@@ -863,8 +863,8 @@ sub-directories, files')
                 try:
                     cephfs.rmdir(path)
                 except libcephfs.Error:
-                    self.perror('error: no such directory {} exists'.format(
-                                path.decode('utf-8')))
+                    perror('error: no such directory {} exists'.format(
+                            path.decode('utf-8')))
 
     def complete_rm(self, text, line, begidx, endidx):
         """
@@ -890,7 +890,7 @@ sub-directories, files')
                 try:
                     cephfs.unlink(path)
                 except libcephfs.Error:
-                    self.perror('{}: no such file'.format(path.decode('utf-8')))
+                    perror('{}: no such file'.format(path.decode('utf-8')))
 
     def complete_mv(self, text, line, begidx, endidx):
         """
@@ -912,7 +912,7 @@ sub-directories, files')
         try:
             cephfs.rename(args.src_path, args.dest_path)
         except libcephfs.Error:
-            self.perror('error: invalid file name')
+            perror('error: invalid file name')
 
     def complete_cd(self, text, line, begidx, endidx):
         """
@@ -934,7 +934,7 @@ sub-directories, files')
             self.working_dir = cephfs.getcwd().decode('utf-8')
             self.set_prompt()
         except libcephfs.Error:
-            self.perror('{}: no such directory'.format(args.path.decode('utf-8')))
+            perror('{}: no such directory'.format(args.path.decode('utf-8')))
 
     def do_cwd(self, arglist):
         """
@@ -963,7 +963,7 @@ sub-directories, files')
             try:
                 cephfs.chmod(path, mode)
             except libcephfs.Error:
-                self.perror('{}: no such file or directory'.format(
+                perror('{}: no such file or directory'.format(
                             path.decode('utf-8')))
 
     def complete_cat(self, text, line, begidx, endidx):
@@ -985,7 +985,7 @@ sub-directories, files')
             if is_file_exists(path):
                 copy_to_local(path, b'-')
             else:
-                self.perror('{}: no such file'.format(path.decode('utf-8')))
+                perror('{}: no such file'.format(path.decode('utf-8')))
 
     umask_parser = argparse.ArgumentParser(description='Set umask value.')
     umask_parser.add_argument('mode', help='Mode', type=str, action=ModeAction,
@@ -1038,8 +1038,7 @@ sub-directories, files')
         try:
             os.chdir(os.path.expanduser(args.path))
         except OSError as e:
-            self.perror("Cannot change to {}: {}".format(e.filename,
-                        e.strerror))
+            perror("Cannot change to {}: {}".format(e.filename, e.strerror))
 
     def complete_lls(self, text, line, begidx, endidx):
         """
@@ -1067,7 +1066,7 @@ sub-directories, files')
                     self.poutput("{}:".format(path.decode('utf-8')))
                     print_list(items)
                 except OSError as e:
-                    self.perror("'{}': {}".format(e.filename, e.strerror))
+                    perror("'{}': {}".format(e.filename, e.strerror))
         # Arguments to the with_argpaser decorator function are sticky.
         # The items in args.path do not get overwritten in subsequent calls.
         # The arguments remain in args.paths after the function exits and we
@@ -1169,7 +1168,7 @@ sub-directories, files')
                     self.poutput('{:10s} {}'.format(humansize(dusage),
                         f.decode('utf-8')))
                 except (libcephfs.Error, OSError):
-                    self.perror('{} : no such directory exists'.format(f.\
+                    perror('{} : no such directory exists'.format(f.\
                         decode('utf-8')))
                     continue
 
@@ -1198,13 +1197,13 @@ sub-directories, files')
         Quota management.
         """
         if not is_dir_exists(args.path):
-            self.perror('error: no such directory {}'.format(args.path.decode('utf-8')))
+            perror('error: no such directory {}'.format(args.path.decode('utf-8')))
             return
 
         if args.op == 'set':
             if (args.max_bytes == -1) and (args.max_files == -1):
-                self.perror('please specify either --max_bytes or '
-                            '--max_files or both')
+                perror('please specify either --max_bytes or --max_files or '
+                       'both')
                 return
 
             if args.max_bytes >= 0:
@@ -1218,7 +1217,7 @@ sub-directories, files')
                     cephfs.setxattr(args.path, 'ceph.quota.max_bytes',
                                     max_bytes, len(max_bytes),
                                     os.XATTR_REPLACE)
-                    self.perror('max_bytes reset to %d' % args.max_bytes)
+                    perror('max_bytes reset to %d' % args.max_bytes)
 
             if args.max_files >= 0:
                 max_files = to_bytes(str(args.max_files))
@@ -1231,7 +1230,7 @@ sub-directories, files')
                     cephfs.setxattr(args.path, 'ceph.quota.max_files',
                                     max_files, len(max_files),
                                     os.XATTR_REPLACE)
-                    self.perror('max_files reset to %d' % args.max_files)
+                    perror('max_files reset to %d' % args.max_files)
         elif args.op == 'get':
             max_bytes = '0'
             max_files = '0'
@@ -1240,7 +1239,7 @@ sub-directories, files')
                                             'ceph.quota.max_bytes')
                 self.poutput('max_bytes: %s' % max_bytes)
             except libcephfs.Error:
-                self.perror('max_bytes is not set')
+                perror('max_bytes is not set')
                 pass
 
             try:
@@ -1248,7 +1247,7 @@ sub-directories, files')
                                             'ceph.quota.max_files')
                 self.poutput('max_files: %s' % max_files)
             except libcephfs.Error:
-                self.perror('max_files is not set')
+                perror('max_files is not set')
                 pass
 
     def do_help(self, line):
@@ -1300,7 +1299,7 @@ Access: {}\nModify: {}\nChange: {}".format(path.decode('utf-8'), stat.st_size,
                              mode_notation(stat.st_mode), stat.st_uid,
                              stat.st_gid, atime, mtime, ctime))
             except libcephfs.Error:
-                self.perror('{}: no such file or directory'.format(path.decode('utf-8')))
+                perror('{}: no such file or directory'.format(path.decode('utf-8')))
 
 
 if __name__ == '__main__':

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -134,8 +134,7 @@ def ls(path, opts=''):
                     continue
                 yield dent
     except libcephfs.ObjectNotFound:
-        perror('{}: no such directory exists'.format(path), end='\n',
-               apply_style=True)
+        perror('{}: no such directory exists'.format(path))
 
 
 def glob(path, pattern):
@@ -264,14 +263,14 @@ def copy_from_local(local_path, remote_path):
             file_ = open(local_path, 'rb')
         except PermissionError:
             perror('error: no permission to read local file {}'.format(
-                   local_path.decode('utf-8')), end='\n', apply_style=True)
+                   local_path.decode('utf-8')))
             return
         stdin = 1
     try:
         fd = cephfs.open(remote_path, 'w', 0o666)
     except libcephfs.Error:
         perror('error: no permission to write remote file {}'.format(
-               remote_path.decode('utf-8')), end='\n', apply_style=True)
+               remote_path.decode('utf-8')))
         return
     progress = 0
     while True:
@@ -342,7 +341,7 @@ class CephFSShell(Cmd):
         self.umask = '2'
 
     def default(self, line):
-        self.perror('Unrecognized command', end='\n', apply_style=True)
+        self.perror('Unrecognized command')
 
     def set_prompt(self):
         self.prompt = ('\033[01;33mCephFS:~' + colorama.Fore.LIGHTCYAN_EX
@@ -408,11 +407,11 @@ class CephFSShell(Cmd):
                 self.set_prompt()
             return res
         except ConnectionError as e:
-            self.perror('***\n{}'.format(e), end='\n', apply_style=True)
+            self.perror('***\n{}'.format(e))
         except KeyboardInterrupt:
-            self.perror('Command aborted', end='\n', apply_style=True)
+            self.perror('Command aborted')
         except Exception as e:
-            self.perror(e, end='\n', apply_style=True)
+            self.perror(e)
             traceback.print_exc(file=sys.stdout)
 
     class path_to_bytes(argparse.Action):
@@ -539,8 +538,7 @@ exists.')
                     cephfs.mkdir(path, permission)
                 except libcephfs.Error:
                     self.perror('directory missing in the path; '
-                                'you may want to pass the -p argument',
-                                end='\n', apply_style=True)
+                                'you may want to pass the -p argument')
                     return
 
     def complete_put(self, text, line, begidx, endidx):
@@ -590,8 +588,7 @@ exists.')
                     else:
                         root_dst_dir = a[0]
             else:
-                self.perror('error: no filename specified for destination',
-                            end='\n', apply_style=True)
+                self.perror('error: no filename specified for destination')
                 return
 
         if root_dst_dir[-1] != b'/':
@@ -603,8 +600,7 @@ exists.')
                     dst_file = root_dst_dir
                     if is_file_exists(dst_file):
                         self.perror('{}: file exists! use --force to overwrite'.format(
-                                    dst_file.decode('utf-8')), end='\n',
-                                    apply_style=True)
+                                    dst_file.decode('utf-8')))
                         return
             if args.local_path == b'-':
                 root_src_dir = b'-'
@@ -675,8 +671,7 @@ exists.')
             root_src_dir = cephfs.getcwd()
         if args.local_path == b'-':
             if args.remote_path == b'.' or args.remote_path == b'./':
-                self.perror('error: no remote file name specified', end='\n',
-                            apply_style=True)
+                self.perror('error: no remote file name specified')
                 return
             copy_to_local(root_src_dir, b'-')
         elif is_file_exists(args.remote_path):
@@ -694,8 +689,7 @@ exists.')
                         pass
                     else:
                         self.perror('{}: already exists! use --force to overwrite'.format(
-                                    root_src_dir.decode('utf-8')), end='\n',
-                                    apply_style=True)
+                                    root_src_dir.decode('utf-8')))
                         return
 
             for file_ in files:
@@ -714,8 +708,7 @@ exists.')
                         try:
                             os.stat(dst_path)
                             self.perror('{}: file already exists! use --force to override'.format(
-                                        file_.decode('utf-8')), end='\n',
-                                        apply_style=True)
+                                        file_.decode('utf-8')))
                             return
                         except OSError:
                             copy_to_local(file_, dst_path)
@@ -869,9 +862,9 @@ sub-directories, files')
             if not is_pattern and path != os.path.normpath(b''):
                 try:
                     cephfs.rmdir(path)
-                except libcephfs.Error as e:
-                    self.perror('Error in rmdir {}: {}'.format(
-                                path.decode('utf-8'), os.strerror(e.errno)))
+                except libcephfs.Error:
+                    self.perror('error: no such directory {} exists'.format(
+                                path.decode('utf-8')))
 
     def complete_rm(self, text, line, begidx, endidx):
         """
@@ -897,8 +890,7 @@ sub-directories, files')
                 try:
                     cephfs.unlink(path)
                 except libcephfs.Error:
-                    self.perror('{}: no such file'.format(path.decode('utf-8')),
-                                end='\n', apply_style=True)
+                    self.perror('{}: no such file'.format(path.decode('utf-8')))
 
     def complete_mv(self, text, line, begidx, endidx):
         """
@@ -920,7 +912,7 @@ sub-directories, files')
         try:
             cephfs.rename(args.src_path, args.dest_path)
         except libcephfs.Error:
-            self.perror('error: invalid file name', end='\n', apply_style=True)
+            self.perror('error: invalid file name')
 
     def complete_cd(self, text, line, begidx, endidx):
         """
@@ -942,8 +934,7 @@ sub-directories, files')
             self.working_dir = cephfs.getcwd().decode('utf-8')
             self.set_prompt()
         except libcephfs.Error:
-            self.perror('{}: no such directory'.format(args.path.decode('utf-8')),
-                        end='\n', apply_style=True)
+            self.perror('{}: no such directory'.format(args.path.decode('utf-8')))
 
     def do_cwd(self, arglist):
         """
@@ -973,7 +964,7 @@ sub-directories, files')
                 cephfs.chmod(path, mode)
             except libcephfs.Error:
                 self.perror('{}: no such file or directory'.format(
-                            path.decode('utf-8')), end='\n', apply_style=True)
+                            path.decode('utf-8')))
 
     def complete_cat(self, text, line, begidx, endidx):
         """
@@ -994,8 +985,7 @@ sub-directories, files')
             if is_file_exists(path):
                 copy_to_local(path, b'-')
             else:
-                self.perror('{}: no such file'.format(path.decode('utf-8')),
-                            end='\n', apply_style=True)
+                self.perror('{}: no such file'.format(path.decode('utf-8')))
 
     umask_parser = argparse.ArgumentParser(description='Set umask value.')
     umask_parser.add_argument('mode', help='Mode', type=str, action=ModeAction,
@@ -1049,7 +1039,7 @@ sub-directories, files')
             os.chdir(os.path.expanduser(args.path))
         except OSError as e:
             self.perror("Cannot change to {}: {}".format(e.filename,
-                        e.strerror), end='\n', apply_style=True)
+                        e.strerror))
 
     def complete_lls(self, text, line, begidx, endidx):
         """
@@ -1077,8 +1067,7 @@ sub-directories, files')
                     self.poutput("{}:".format(path.decode('utf-8')))
                     print_list(items)
                 except OSError as e:
-                    self.perror("'{}': {}".format(e.filename, e.strerror),
-                                end='\n', apply_style=True)
+                    self.perror("'{}': {}".format(e.filename, e.strerror))
         # Arguments to the with_argpaser decorator function are sticky.
         # The items in args.path do not get overwritten in subsequent calls.
         # The arguments remain in args.paths after the function exits and we
@@ -1181,7 +1170,7 @@ sub-directories, files')
                         f.decode('utf-8')))
                 except (libcephfs.Error, OSError):
                     self.perror('{} : no such directory exists'.format(f.\
-                        decode('utf-8')), apply_style=True)
+                        decode('utf-8')))
                     continue
 
         for path in args.paths:
@@ -1209,14 +1198,13 @@ sub-directories, files')
         Quota management.
         """
         if not is_dir_exists(args.path):
-            self.perror('error: no such directory {}'.format(args.path.decode('utf-8')),
-                        end='\n', apply_style=True)
+            self.perror('error: no such directory {}'.format(args.path.decode('utf-8')))
             return
 
         if args.op == 'set':
             if (args.max_bytes == -1) and (args.max_files == -1):
                 self.perror('please specify either --max_bytes or '
-                            '--max_files or both', end='\n', apply_style=True)
+                            '--max_files or both')
                 return
 
             if args.max_bytes >= 0:
@@ -1230,8 +1218,7 @@ sub-directories, files')
                     cephfs.setxattr(args.path, 'ceph.quota.max_bytes',
                                     max_bytes, len(max_bytes),
                                     os.XATTR_REPLACE)
-                    self.perror('max_bytes reset to %d' % args.max_bytes,
-                                end='\n', apply_style=True)
+                    self.perror('max_bytes reset to %d' % args.max_bytes)
 
             if args.max_files >= 0:
                 max_files = to_bytes(str(args.max_files))
@@ -1244,8 +1231,7 @@ sub-directories, files')
                     cephfs.setxattr(args.path, 'ceph.quota.max_files',
                                     max_files, len(max_files),
                                     os.XATTR_REPLACE)
-                    self.perror('max_files reset to %d' % args.max_files,
-                                end='\n', apply_style=True)
+                    self.perror('max_files reset to %d' % args.max_files)
         elif args.op == 'get':
             max_bytes = '0'
             max_files = '0'
@@ -1254,7 +1240,7 @@ sub-directories, files')
                                             'ceph.quota.max_bytes')
                 self.poutput('max_bytes: %s' % max_bytes)
             except libcephfs.Error:
-                self.perror('max_bytes is not set', end='\n', apply_style=True)
+                self.perror('max_bytes is not set')
                 pass
 
             try:
@@ -1262,7 +1248,7 @@ sub-directories, files')
                                             'ceph.quota.max_files')
                 self.poutput('max_files: %s' % max_files)
             except libcephfs.Error:
-                self.perror('max_files is not set', end='\n', apply_style=True)
+                self.perror('max_files is not set')
                 pass
 
     def do_help(self, line):
@@ -1314,8 +1300,7 @@ Access: {}\nModify: {}\nChange: {}".format(path.decode('utf-8'), stat.st_size,
                              mode_notation(stat.st_mode), stat.st_uid,
                              stat.st_gid, atime, mtime, ctime))
             except libcephfs.Error:
-                self.perror('{}: no such file or directory'.format(path.decode('utf-8')),
-                            end='\n', apply_style=True)
+                self.perror('{}: no such file or directory'.format(path.decode('utf-8')))
 
 
 if __name__ == '__main__':

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1164,7 +1164,7 @@ sub-directories, files')
                         f = b'.' + f
                     poutput('{:10s} {}'.format(humansize(dusage),
                         f.decode('utf-8')))
-                except (libcephfs.Error, OSError) as e:
+                except libcephfs.Error as e:
                     perror(e)
                     continue
 

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -537,7 +537,6 @@ exists.')
                     cephfs.mkdir(path, permission)
                 except libcephfs.Error as e:
                     perror(e)
-                    return
 
     def complete_put(self, text, line, begidx, endidx):
         """

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -764,11 +764,11 @@ exists.')
                 if dirs:
                     paths.extend(dirs)
                 else:
-                    self.poutput(path.decode('utf-8'), end=':\n')
+                    poutput(path.decode('utf-8'), end=':\n')
                 items = sorted(items, key=lambda item: item.d_name)
             else:
                 if path != b'' and path != cephfs.getcwd() and len(paths) > 1:
-                    self.poutput(path.decode('utf-8'), end=':\n')
+                    poutput(path.decode('utf-8'), end=':\n')
                 items = sorted(ls(path),
                                key=lambda item: item.d_name)
             if not args.all:
@@ -807,7 +807,7 @@ exists.')
             if not args.long:
                 print_list(values, shutil.get_terminal_size().columns)
                 if path != paths[-1]:
-                    self.poutput('')
+                    poutput('')
 
     def complete_rmdir(self, text, line, begidx, endidx):
         """
@@ -940,7 +940,7 @@ sub-directories, files')
         """
         Get current working directory.
         """
-        self.poutput(cephfs.getcwd().decode('utf-8'))
+        poutput(cephfs.getcwd().decode('utf-8'))
 
     def complete_chmod(self, text, line, begidx, endidx):
         """
@@ -997,7 +997,7 @@ sub-directories, files')
         Set Umask value.
         """
         if args.mode == '':
-            self.poutput(self.umask.zfill(4))
+            poutput(self.umask.zfill(4))
         else:
             mode = int(args.mode, 8)
             self.umask = str(oct(cephfs.umask(mode))[2:])
@@ -1063,7 +1063,7 @@ sub-directories, files')
             for path in args.paths:
                 try:
                     items = os.listdir(path)
-                    self.poutput("{}:".format(path.decode('utf-8')))
+                    poutput("{}:".format(path.decode('utf-8')))
                     print_list(items)
                 except OSError as e:
                     perror("'{}': {}".format(e.filename, e.strerror))
@@ -1077,7 +1077,7 @@ sub-directories, files')
         """
         Prints the absolute path of the current local directory
         """
-        self.poutput(os.getcwd())
+        poutput(os.getcwd())
 
     def do_df(self, arglist):
         """
@@ -1085,7 +1085,7 @@ sub-directories, files')
         """
         for index, i in enumerate(ls(b".", opts='A')):
             if index == 0:
-                self.poutput('{:25s}\t{:5s}\t{:15s}{:10s}{}'.format(
+                poutput('{:25s}\t{:5s}\t{:15s}{:10s}{}'.format(
                     "1K-blocks", "Used", "Available", "Use%", "Stored on"))
             if not is_dir_exists(i.d_name):
                 statfs = cephfs.statfs(i.d_name)
@@ -1095,7 +1095,7 @@ sub-directories, files')
                 use = 0
                 if block_size > 0:
                     use = (stat.st_size * 100 // block_size)
-                self.poutput('{:25d}\t{:5d}\t{:10d}\t{:5s} {}'.format(
+                poutput('{:25d}\t{:5d}\t{:10d}\t{:5s} {}'.format(
                     statfs['f_fsid'], stat.st_size, available,
                     str(int(use)) + '%', i.d_name.decode('utf-8')))
 
@@ -1124,9 +1124,9 @@ sub-directories, files')
         else:
             locations = locate_file(args.name)
         if args.count:
-            self.poutput(len(locations))
+            poutput(len(locations))
         else:
-            self.poutput((b'\n'.join(locations)).decode('utf-8'))
+            poutput((b'\n'.join(locations)).decode('utf-8'))
 
     def complete_du(self, text, line, begidx, endidx):
         """
@@ -1165,7 +1165,7 @@ sub-directories, files')
                     f = os.path.normpath(f)
                     if f[0] is ord('/'):
                         f = b'.' + f
-                    self.poutput('{:10s} {}'.format(humansize(dusage),
+                    poutput('{:10s} {}'.format(humansize(dusage),
                         f.decode('utf-8')))
                 except (libcephfs.Error, OSError):
                     perror('{} : no such directory exists'.format(f.\
@@ -1212,7 +1212,7 @@ sub-directories, files')
                     cephfs.setxattr(args.path, 'ceph.quota.max_bytes',
                                     max_bytes, len(max_bytes),
                                     os.XATTR_CREATE)
-                    self.poutput('max_bytes set to %d' % args.max_bytes)
+                    poutput('max_bytes set to %d' % args.max_bytes)
                 except libcephfs.Error:
                     cephfs.setxattr(args.path, 'ceph.quota.max_bytes',
                                     max_bytes, len(max_bytes),
@@ -1225,7 +1225,7 @@ sub-directories, files')
                     cephfs.setxattr(args.path, 'ceph.quota.max_files',
                                     max_files, len(max_files),
                                     os.XATTR_CREATE)
-                    self.poutput('max_files set to %d' % args.max_files)
+                    poutput('max_files set to %d' % args.max_files)
                 except libcephfs.Error:
                     cephfs.setxattr(args.path, 'ceph.quota.max_files',
                                     max_files, len(max_files),
@@ -1237,7 +1237,7 @@ sub-directories, files')
             try:
                 max_bytes = cephfs.getxattr(args.path,
                                             'ceph.quota.max_bytes')
-                self.poutput('max_bytes: %s' % max_bytes)
+                poutput('max_bytes: %s' % max_bytes)
             except libcephfs.Error:
                 perror('max_bytes is not set')
                 pass
@@ -1245,7 +1245,7 @@ sub-directories, files')
             try:
                 max_files = cephfs.getxattr(args.path,
                                             'ceph.quota.max_files')
-                self.poutput('max_files: %s' % max_files)
+                poutput('max_files: %s' % max_files)
             except libcephfs.Error:
                 perror('max_files is not set')
                 pass
@@ -1259,7 +1259,7 @@ sub-directories, files')
         if line == 'all':
             for k in dir(self):
                 if k.startswith('do_'):
-                    self.poutput('-' * 80)
+                    poutput('-' * 80)
                     super().do_help(k[3:])
             return
         parser = self.create_argparser(line)
@@ -1291,7 +1291,7 @@ sub-directories, files')
                 mtime = stat.st_mtime.isoformat(' ')
                 ctime = stat.st_mtime.isoformat(' ')
 
-                self.poutput("File: {}\nSize: {:d}\nBlocks: {:d}\nIO Block: {:d}\n\
+                poutput("File: {}\nSize: {:d}\nBlocks: {:d}\nIO Block: {:d}\n\
 Device: {:d}\tInode: {:d}\tLinks: {:d}\nPermission: {:o}/{}\tUid: {:d}\tGid: {:d}\n\
 Access: {}\nModify: {}\nChange: {}".format(path.decode('utf-8'), stat.st_size,
                              stat.st_blocks, stat.st_blksize, stat.st_dev,


### PR DESCRIPTION
* strerror in OSError in cephfs.pyx should also contain the actual error messages
* align perror signature with cmd2.Cmd.perror
* stop passing default values to perror args
* use perror within module instead of cmd2.Cmd.perror
* use poutput within module instead of cmd2.Cmd.poutput
* print exception's error messages instead of printing custom messages everywhere




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>