### PR TITLE
osd/SnapMapper: remove pre-octopus snapmapper keys after conversion

### DIFF
--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -701,6 +701,17 @@ int SnapMapper::convert_legacy(
 
   dout(1) << __func__ << " converted " << n << " keys in "
 	  << timespan_str(end - start) << dendl;
-#warning fixme remove old keys
+
+  // remove the old keys
+  {
+    ObjectStore::Transaction t;
+    string end = SnapMapper::LEGACY_MAPPING_PREFIX;
+    ++end[end.size()-1]; // turn _ to whatever comes after _
+    t.omap_rmkeyrange(ch->cid, hoid,
+		      SnapMapper::LEGACY_MAPPING_PREFIX,
+		      end);
+    int r = store->queue_transaction(ch, std::move(t));
+    ceph_assert(r == 0);
+  }
   return 0;
 }


### PR DESCRIPTION
We don't need to keep these around (forever) unless we are paranoid the
conversion won't work for some reason, but I don't think we need to
worry about that.

Thanks to rmkeyrange, this is always fast and easy!

Signed-off-by: Sage Weil <sage@redhat.com>