### PR TITLE
script/run_tox.sh: use WITH_PYTHON{2,3} to ensure python is installed

### DIFF
--- a/src/script/run_tox.sh
+++ b/src/script/run_tox.sh
@@ -121,7 +121,15 @@ function main() {
     fi
 
     if [ ! -f ${venv_path}/bin/activate ]; then
-        $source_dir/src/tools/setup-virtualenv.sh ${venv_path}
+        if $with_python3; then
+            python=python3
+        elif $with_python2; then
+            python=python2
+        else
+            # cmake should have rejected this
+            exit 1
+        fi
+        $source_dir/src/tools/setup-virtualenv.sh --python=${python} ${venv_path}
     fi
     source ${venv_path}/bin/activate
     pip install tox


### PR DESCRIPTION
before this change, run_tox.sh is hardwired to python2.7,
`setup-virtualenv.sh` use it as the default python version. after this
change, we use python3 if WITH_PYTHON3 is enabled, and fallback to
python2 otherwise.

this is not quite right, as WITH_PYTHON2 and WITH_PYTHON3 are used to
specify what python version our python binding should be built. it's not
directly related to what python we should use for creating venv which is
in turn used for running tox based test.

but we can use these settings to ensure that the python interpreter is
available for creating the venv environment. normally, the venv is
prepared by `${name}-venv` target if one runs "make tests" for preparing
the dependencies for running "ctest" or "make check". but we should
allow user to use `run_tox.sh` directly for performing tox tests without
running "make tests" first.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
