### PR TITLE
luminous: rgw: make dns hostnames matching case insensitive

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -289,10 +289,11 @@ static bool str_ends_with_nocase(const string& s, const string& suffix, size_t *
     *pos = p;
   }
 
-  return boost::algorithm::iends_with(suffix, s);
+  return boost::algorithm::iends_with(s, suffix);
 }
 
-static bool rgw_find_host_in_domains(const string& host, string *domain, string *subdomain, set<string> valid_hostnames_set)
+static bool rgw_find_host_in_domains(const string& host, string *domain, string *subdomain,
+                                     const set<string>& valid_hostnames_set)
 {
   set<string>::iterator iter;
   /** TODO, Future optimization

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -277,7 +277,7 @@ void rgw_rest_init(CephContext *cct, RGWRados *store, RGWZoneGroup& zone_group)
    */
 }
 
-static bool str_ends_with(const string& s, const string& suffix, size_t *pos)
+static bool str_ends_with_nocase(const string& s, const string& suffix, size_t *pos)
 {
   size_t len = suffix.size();
   if (len > (size_t)s.size()) {
@@ -289,7 +289,7 @@ static bool str_ends_with(const string& s, const string& suffix, size_t *pos)
     *pos = p;
   }
 
-  return s.compare(p, len, suffix) == 0;
+  return boost::algorithm::iends_with(suffix, s);
 }
 
 static bool rgw_find_host_in_domains(const string& host, string *domain, string *subdomain, set<string> valid_hostnames_set)
@@ -301,7 +301,7 @@ static bool rgw_find_host_in_domains(const string& host, string *domain, string 
    */
   for (iter = valid_hostnames_set.begin(); iter != valid_hostnames_set.end(); ++iter) {
     size_t pos;
-    if (!str_ends_with(host, *iter, &pos))
+    if (!str_ends_with_nocase(host, *iter, &pos))
       continue;
 
     if (pos == 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41480

---

backport of

* https://github.com/ceph/ceph/pull/29380
* https://github.com/ceph/ceph/pull/30221

parent trackers:

* https://tracker.ceph.com/issues/40995
* https://tracker.ceph.com/issues/41692

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh