### PR TITLE
tools/setup-virtualenv.sh: do not default to python2.7

### DIFF
--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -16,7 +16,6 @@
 #
 
 SCRIPTNAME="$(basename $0)"
-PYTHON_BINARY="python2.7"
 if [ `uname` == FreeBSD ]; then
     GETOPT="/usr/local/bin/getopt"
 else
@@ -31,7 +30,6 @@ function usage {
     echo "Usage:"
     echo "    $SCRIPTNAME [--python=PYTHON_BINARY] TARGET_DIRECTORY"
     echo
-    echo "    PYTHON_BINARY defaults to \"$PYTHON_BINARY\""
     echo "    TARGET_DIRECTORY will be created if it doesn't exist,"
     echo "        and completely destroyed and re-created if it does!"
     echo
@@ -42,10 +40,11 @@ TEMP=$($GETOPT --options "h" --long "help,python:" --name "$SCRIPTNAME" -- "$@")
 test $? != 0 && usage
 eval set -- "$TEMP"
 
+PYTHON_OPTION=""
 while true ; do
     case "$1" in
         -h|--help) usage ;;  # does not return
-        --python) PYTHON_BINARY="$2" ; shift ; shift ;;
+        --python) PYTHON_OPTION="--python=$2" ; shift ; shift ;;
         --) shift ; break ;;
         *) echo "Internal error" ; exit 1 ;;
     esac
@@ -58,7 +57,7 @@ if [ -z "$DIR" ] ; then
 fi
 rm -fr $DIR
 mkdir -p $DIR
-virtualenv --python $PYTHON_BINARY $DIR
+virtualenv $PYTHON_OPTION $DIR
 . $DIR/bin/activate
 
 if pip --help | grep -q disable-pip-version-check; then


### PR DESCRIPTION
This commit changes the script's behavior when run without a --python option. Before, we were running virtualenv with "--python python2.7" in that case.

That is not a reasonable default in September 2019, given that Python 2 EOL is coming on January 1, 2020. Also, it breaks setup-virtualenv.sh in py3-only environments.

With this patch, the script will not pass any "--python" option to virtualenv (i.e., it will let virtualenv do whatever it thinks is best) in this case.

Fixes: https://tracker.ceph.com/issues/41821
Signed-off-by: Nathan Cutler <ncutler@suse.com>
