### PR TITLE
crimson/os: Object::read() returns bufferlist instead of never used errcode

### DIFF
--- a/src/crimson/os/cyan_object.cc
+++ b/src/crimson/os/cyan_object.cc
@@ -7,10 +7,11 @@ size_t Object::get_size() const {
   return data.length();
 }
 
-int Object::read(uint64_t offset, uint64_t len, bufferlist &bl)
+ceph::bufferlist Object::read(uint64_t offset, uint64_t len)
 {
-  bl.substr_of(data, offset, len);
-  return bl.length();
+  bufferlist ret;
+  ret.substr_of(data, offset, len);
+  return ret;
 }
 
 int Object::write(uint64_t offset, const bufferlist &src)

--- a/src/crimson/os/cyan_object.h
+++ b/src/crimson/os/cyan_object.h
@@ -28,7 +28,7 @@ struct Object : public boost::intrusive_ref_counter<
 
   // interface for object data
   size_t get_size() const;
-  int read(uint64_t offset, uint64_t len, bufferlist &bl);
+  ceph::bufferlist read(uint64_t offset, uint64_t len);
   int write(uint64_t offset, const bufferlist &bl);
   int clone(Object *src, uint64_t srcoff, uint64_t len,
 	     uint64_t dstoff);

--- a/src/crimson/os/cyan_store.cc
+++ b/src/crimson/os/cyan_store.cc
@@ -195,11 +195,7 @@ seastar::future<ceph::bufferlist> CyanStore::read(CollectionRef ch,
     l = o->get_size();
   else if (offset + l > o->get_size())
     l = o->get_size() - offset;
-  ceph::bufferlist bl;
-  if (int r = o->read(offset, l, bl); r < 0) {
-    throw std::runtime_error("read");
-  }
-  return seastar::make_ready_future<ceph::bufferlist>(std::move(bl));
+  return seastar::make_ready_future<ceph::bufferlist>(o->read(offset, l));
 }
 
 seastar::future<ceph::bufferptr> CyanStore::get_attr(CollectionRef ch,


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
