### PR TITLE
script/run_tox.sh: remove unused code

### DIFF
--- a/src/script/run_tox.sh
+++ b/src/script/run_tox.sh
@@ -101,12 +101,6 @@ function main() {
         esac
     done
 
-    # normalize options
-    [ "$with_python2" = "ON" ] && with_python2=true || with_python2=false
-    # WITH_PYTHON3 might be set to "ON" or to the python3 RPM version number
-    # prevailing on the system - e.g. "3", "36"
-    [[ "$with_python3" =~ (^3|^ON) ]] && with_python3=true || with_python3=false
-
     local test_name
     if [ -z "$tox_path" ]; then
         # try harder


### PR DESCRIPTION
it's a follow-up of 793308f8, where the code to use python2/python3 to
determine env_list was removed already

Signed-off-by: Kefu Chai <tchaikov@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
