### PR TITLE
nautilus: mgr: do not reset reported if a new metric is not collected

### DIFF
--- a/src/mgr/DaemonHealthMetricCollector.h
+++ b/src/mgr/DaemonHealthMetricCollector.h
@@ -12,7 +12,7 @@ public:
   static std::unique_ptr<DaemonHealthMetricCollector> create(daemon_metric m);
   void update(const DaemonKey& daemon, const DaemonHealthMetric& metric) {
     if (_is_relevant(metric.get_type())) {
-      reported = _update(daemon, metric);
+      reported |= _update(daemon, metric);
     }
   }
   void summarize(health_check_map_t& cm) {


### PR DESCRIPTION
https://tracker.ceph.com/issues/41804