### PR TITLE
rgw: change MAX_USAGE_TRIM_ENTRIES value from 128 to 1000.

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3115,7 +3115,7 @@ int rgw_user_usage_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlis
   string iter;
   bool more;
   bool found = false;
-#define MAX_USAGE_TRIM_ENTRIES 128
+#define MAX_USAGE_TRIM_ENTRIES 1000
   ret = usage_iterate_range(hctx, op.start_epoch, op.end_epoch, op.user, op.bucket, iter, MAX_USAGE_TRIM_ENTRIES, &more, usage_log_trim_cb, (void *)&found);
   if (ret < 0)
     return ret;


### PR DESCRIPTION
Keep consistent with other log trim configure. Besides, increasing the value can accelerate the trim operation.
In my vstart environment, I create over 30,000 buckets and upload one file to each bucket.
Trim time is about 20s when MAX_USAGE_TRIM_ENTRIES is 128, and the time is reduced to 14s when   MAX_USAGE_TRIM_ENTRIES is 1000.

Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>

