### PR TITLE
mgr/dashboard: NFS list should display the "Pseudo Path"

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -101,10 +101,15 @@ export class NfsListComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.columns = [
       {
-        name: this.i18n('Export'),
+        name: this.i18n('Path'),
         prop: 'path',
         flexGrow: 2,
         cellTransformation: CellTemplate.executing
+      },
+      {
+        name: this.i18n('Pseudo'),
+        prop: 'pseudo',
+        flexGrow: 2
       },
       {
         name: this.i18n('Cluster'),
@@ -137,7 +142,7 @@ export class NfsListComponent implements OnInit, OnDestroy {
           .value();
 
         this.isDefaultCluster = clusters.length === 1 && clusters[0] === '_default_';
-        this.columns[1].isHidden = this.isDefaultCluster;
+        this.columns[2].isHidden = this.isDefaultCluster;
         if (this.table) {
           this.table.updateColumns();
         }


### PR DESCRIPTION
Sometimes we have multiple exports with the same "path" and different "pseudo-path", so the NFS export list should also include the "pseudo-path" info.

![Screenshot from 2019-09-13 13-49-56](https://user-images.githubusercontent.com/14297426/64863750-83864d00-d62d-11e9-8ea1-7d407c016503.png)


Fixes: https://tracker.ceph.com/issues/41815

Signed-off-by: Ricardo Marques <rimarques@suse.com>