### PR TITLE
mgr: change perf-counter precision to float

### DIFF
--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -37,7 +37,7 @@ class OsdTest(DashboardTestCase):
                                                     'op_r', 'op_w'])
         self.assert_in_and_not_none(data['stats_history'], ['op_out_bytes', 'op_in_bytes'])
         self.assertSchema(data['stats_history']['op_out_bytes'],
-                          JList(JTuple([JLeaf(int), JLeaf(float)])))
+                          JList(JTuple([JLeaf(float), JLeaf(float)])))
 
     def test_details(self):
         data = self._get('/api/osd/0')

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -34,7 +34,7 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
 #undef dout_prefix
-#define dout_prefix *_dout << "mgr " << __func__ << " "    
+#define dout_prefix *_dout << "mgr " << __func__ << " "
 
 ActivePyModules::ActivePyModules(PyModuleConfig &module_config_,
           std::map<std::string, std::string> store_data,
@@ -535,7 +535,7 @@ bool ActivePyModules::get_config(const std::string &module_name,
   dout(20) << " key: " << global_key << dendl;
 
   std::lock_guard lock(module_config.lock);
-  
+
   auto i = module_config.config.find(global_key);
   if (i != module_config.config.end()) {
     *val = i->second;
@@ -596,7 +596,7 @@ PyObject *ActivePyModules::get_store_prefix(const std::string &module_name,
   dout(4) << __func__ << " prefix: " << global_prefix << dendl;
 
   PyFormatter f;
-  
+
   for (auto p = store_cache.lower_bound(global_prefix);
        p != store_cache.end() && p->first.find(global_prefix) == 0;
        ++p) {
@@ -610,7 +610,7 @@ void ActivePyModules::set_store(const std::string &module_name,
 {
   const std::string global_key = PyModule::config_prefix
                                    + module_name + "/" + key;
-  
+
   Command set_cmd;
   {
     std::lock_guard l(lock);
@@ -718,7 +718,7 @@ PyObject* ActivePyModules::get_counter_python(
       const auto &avg_data = counter_instance.get_data_avg();
       for (const auto &datapoint : avg_data) {
         f.open_array_section("datapoint");
-        f.dump_unsigned("t", datapoint.t.to_nsec());
+        f.dump_float("t", datapoint.t);
         f.dump_unsigned("s", datapoint.s);
         f.dump_unsigned("c", datapoint.c);
         f.close_section();
@@ -727,7 +727,7 @@ PyObject* ActivePyModules::get_counter_python(
       const auto &data = counter_instance.get_data();
       for (const auto &datapoint : data) {
         f.open_array_section("datapoint");
-        f.dump_unsigned("t", datapoint.t.to_nsec());
+        f.dump_float("t", datapoint.t);
         f.dump_unsigned("v", datapoint.v);
         f.close_section();
       }
@@ -748,12 +748,12 @@ PyObject* ActivePyModules::get_latest_counter_python(
   {
     if (counter_type.type & PERFCOUNTER_LONGRUNAVG) {
       const auto &datapoint = counter_instance.get_latest_data_avg();
-      f.dump_unsigned("t", datapoint.t.to_nsec());
+      f.dump_float("t", datapoint.t);
       f.dump_unsigned("s", datapoint.s);
       f.dump_unsigned("c", datapoint.c);
     } else {
       const auto &datapoint = counter_instance.get_latest_data();
-      f.dump_unsigned("t", datapoint.t.to_nsec());
+      f.dump_float("t", datapoint.t);
       f.dump_unsigned("v", datapoint.v);
     }
   };


### PR DESCRIPTION
Instead of integer nsecs, as added in
https://github.com/ceph/ceph/pull/28882, this recovers second units, but
with double (potentially nsec precision). This will fix some issues
caused by the mixing of second-based and nsec-based timestamps
(https://github.com/ceph/ceph/pull/28603).

Fixes: https://tracker.ceph.com/issues/41867
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
