### PR TITLE
osd: make osd recover more smoothly by avoiding failure peer info to resent

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4482,6 +4482,16 @@ void OSD::maybe_update_heartbeat_peers()
   }
 
   dout(10) << "maybe_update_heartbeat_peers " << heartbeat_peers.size() << " peers, extras " << extras << dendl;
+
+  // clean up stale failure pending
+  for (auto it = failure_pending.begin(); it != failure_pending.end();) {
+    if (heartbeat_peers.count(it->first) == 0) {
+      send_still_alive(osdmap->get_epoch(), it->first, it->second.second);
+      failure_pending.erase(it++);
+    } else {
+      it++;
+    }
+  }
 }
 
 void OSD::reset_heartbeat_peers(bool all)


### PR DESCRIPTION
  maybe_update_heartbeat_peers may remove one peer and never add in.
  if that peer is in failure_pending but that peer is not really has problem,
  failure_pending will hold that failure info until it really down or add in again.

  once ms_handle_connect called, these pending failure will be resent again, which may increase recover time after switch shutdown and then boot.

  2019-09-12 09:44:47.080933 7f1fad781700 10 osd.13 6175 ms_handle_connect on mon
  2019-09-12 09:44:47.080937 7f1fad781700 10 osd.13 6175 send_alive up_thru currently 6159 want 6155
  2019-09-12 09:44:47.080945 7f1fad781700 10 osd.13 6175 requeue_failures 0 + 1 -> 1

Signed-off-by: 宋顺10180185 <song.shun3@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
