### PR TITLE
osd: add common smartctl output to JSON output

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -681,7 +681,7 @@ static int block_device_run_smartctl(const string& devname, int timeout,
     "smartctl",
     "-a",
     //"-x",
-    "--json",
+    "--json=o",
     device.c_str(),
     NULL);
 

--- a/sudoers.d/ceph-osd-smartctl
+++ b/sudoers.d/ceph-osd-smartctl
@@ -1,4 +1,4 @@
 ## allow ceph-osd (which runs as user ceph) to collect device health metrics
 
-ceph ALL=NOPASSWD: /usr/sbin/smartctl -a --json /dev/*
+ceph ALL=NOPASSWD: /usr/sbin/smartctl -a --json=o /dev/*
 ceph ALL=NOPASSWD: /usr/sbin/nvme * smart-log-add --json /dev/*


### PR DESCRIPTION
Enables consumers like the dashboard to provide the regular smartctl
output to users.

The previous JSON output stays the same, there is just a field added that contains the regular formatted text output: `smartctl.output`.

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
