### PR TITLE
tools/rados: call pool_lookup() after rados is connected.

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2109,13 +2109,6 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     with_reference = true;
   }
 
-  i = opts.find("pgid");
-  boost::optional<pg_t> pgid(i != opts.end(), pg_t());
-  if (pgid && (!pgid->parse(i->second.c_str()) || (pool_name && rados.pool_lookup(pool_name) != pgid->pool()))) {
-    cerr << "invalid pgid" << std::endl;
-    return 1;
-  }
-
   // open rados
   ret = rados.init_with_context(g_ceph_context);
   if (ret < 0) {
@@ -2142,6 +2135,13 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 	   << cpp_strerror(ret) << std::endl;
       return 1;
     }
+  }
+
+  i = opts.find("pgid");
+  boost::optional<pg_t> pgid(i != opts.end(), pg_t());
+  if (pgid && (!pgid->parse(i->second.c_str()) || (pool_name && rados.pool_lookup(pool_name) != pgid->pool()))) {
+    cerr << "invalid pgid" << std::endl;
+    return 1;
   }
 
   // open io context.


### PR DESCRIPTION
tools/rados: call pool_lookup() after rados is connected

This commit fixes a segmentation fault when using --pgid
option in rados ls command in combination with --pool/-p option.
The reason for the crash was that we can not use the rados object
before connecting it with the cluster using rados.init_with_context().
 
Fixes: https://tracker.ceph.com/issues/41875
 
Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>
