### PR TITLE
osd/PeeringState.h: get_num_missing() should report num_missing()

### DIFF
--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -2126,8 +2126,8 @@ public:
   bool have_missing() const {
     return pg_log.get_missing().num_missing() > 0;
   }
-  bool get_num_missing() const {
-    return pg_log.get_missing().num_missing() > 0;
+  unsigned int get_num_missing() const {
+    return pg_log.get_missing().num_missing();
   }
 
   const MissingLoc &get_missing_loc() const {


### PR DESCRIPTION
Introduced in 2e06118f4936c8cd6495e77da0576f03cfc251d5

Signed-off-by: Neha Ojha <nojha@redhat.com>
