### PR TITLE
mimic: test/librbd: set nbd timeout due to newer kernels defaulting it on

### DIFF
--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -1230,6 +1230,7 @@ nbd_open(const char *name, struct rbd_ctx *ctx)
 	SubProcess process("rbd-nbd", SubProcess::KEEP, SubProcess::PIPE,
 			   SubProcess::KEEP);
 	process.add_cmd_arg("map");
+	process.add_cmd_arg("--timeout=600");
 	std::string img;
 	img.append(pool);
 	img.append("/");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41543

---

backport of https://github.com/ceph/ceph/pull/29858 (**NOTE**: first commit only. The second commit is only relevant in master)
parent tracker: https://tracker.ceph.com/issues/41409

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh