### PR TITLE
doc/cephfs: correct a description mistake about mds states

### DIFF
--- a/doc/cephfs/mds-states.rst
+++ b/doc/cephfs/mds-states.rst
@@ -211,7 +211,7 @@ Color
 - Orange: MDS is in transient state trying to become active.
 - Red: MDS is indicating a state that causes the rank to be marked failed.
 - Purple: MDS and rank is stopping.
-- Red: MDS is indicating a state that causes the rank to be marked damaged.
+- Black: MDS is indicating a state that causes the rank to be marked damaged.
 
 Shape
 ~~~~~


### PR DESCRIPTION
Signed-off-by: Xiao Guodong xiaogd@inspur.com