### PR TITLE
doc/releases/schedule.rst: add 14.2.3, 14.2.4, 15.0.0 and drop dumpling

### DIFF
--- a/doc/_ext/ceph_releases.py
+++ b/doc/_ext/ceph_releases.py
@@ -106,7 +106,7 @@ class CephReleases(Directive):
 
 class CephTimeline(Directive):
     has_content = False
-    required_arguments = 13
+    required_arguments = 12
     optional_arguments = 0
     option_spec = {}
 

--- a/doc/releases/releases.yml
+++ b/doc/releases/releases.yml
@@ -361,11 +361,3 @@ development:
       released: 2013-12-01
     - version: '0.73'
       released: 2013-12-01
-    - version: '0.71'
-      released: 2013-10-01
-    - version: '0.70'
-      released: 2013-10-01
-    - version: '0.69'
-      released: 2013-09-01
-    - version: '0.68'
-      released: 2013-09-01

--- a/doc/releases/releases.yml
+++ b/doc/releases/releases.yml
@@ -14,6 +14,10 @@
 releases:
   nautilus:
     releases:
+      - version: 14.2.4
+        released: 2019-09-17
+      - version: 14.2.3
+        released: 2019-09-04
       - version: 14.2.2
         released: 2019-07-17
       - version: 14.2.1
@@ -222,6 +226,9 @@ releases:
 
 development:
   releases:
+    - version: 15.0.0
+      released: 2019-04-03
+      skip_ref: true        
     - version: 14.1.1
       released:  2019-03-11
       skip_ref: true        

--- a/doc/releases/schedule.rst
+++ b/doc/releases/schedule.rst
@@ -10,7 +10,7 @@ Current
 Timeline
 --------
 
-.. ceph_timeline:: releases.yml development nautilus mimic luminous kraken jewel infernalis hammer giant firefly emperor dumpling
+.. ceph_timeline:: releases.yml development nautilus mimic luminous kraken jewel infernalis hammer giant firefly emperor
 
 .. _Nautilus: ../nautilus
 .. _14.2.4: ../nautilus#v14-2-4-nautilus

--- a/doc/releases/schedule.rst
+++ b/doc/releases/schedule.rst
@@ -13,6 +13,8 @@ Timeline
 .. ceph_timeline:: releases.yml development nautilus mimic luminous kraken jewel infernalis hammer giant firefly emperor dumpling
 
 .. _Nautilus: ../nautilus
+.. _14.2.4: ../nautilus#v14-2-4-nautilus
+.. _14.2.3: ../nautilus#v14-2-3-nautilus
 .. _14.2.2: ../nautilus#v14-2-2-nautilus
 .. _14.2.1: ../nautilus#v14-2-1-nautilus
 .. _14.2.0: ../nautilus#v14-2-0-nautilus


### PR DESCRIPTION
Update release schedule:

* add 14.2.3, 14.2.4, 15.0.0
* drop dumpling column

Note: the dumpling column can still be observed in the stable branches, so nothing is lost.