### PR TITLE
pybind/ceph_argparse: improve 'ceph -h' syntax

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -704,12 +704,12 @@ class argdesc(object):
         like str(), but omit parameter names (except for CephString,
         which really needs them)
         """
-        if self.t == CephString:
-            chunk = '<{0}>'.format(self.name)
-        elif self.t == CephBool:
+        if self.t == CephBool:
             chunk = "--{0}".format(self.name.replace("_", "-"))
-        else:
+        elif self.t == CephPrefix or self.t == CephChoices:
             chunk = str(self.instance)
+        else:
+            chunk = '<{0}>'.format(self.name)
         s = chunk
         if self.N:
             s += '...'

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -708,6 +708,14 @@ class argdesc(object):
             chunk = "--{0}".format(self.name.replace("_", "-"))
         elif self.t == CephPrefix or self.t == CephChoices:
             chunk = str(self.instance)
+        elif self.t == CephOsdName:
+            # it just so happens all CephOsdName commands are named 'id' anyway,
+            # so <id|osd.id> is perfect.
+            chunk = '<id|osd.id>'
+        elif self.t == CephName:
+            # CephName commands similarly only have one arg of the
+            # type, so <type.id> is good.
+            chunk = '<type.id>'
         else:
             chunk = '<{0}>'.format(self.name)
         s = chunk

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -696,7 +696,7 @@ class argdesc(object):
             if self.N:
                 s += ' [' + str(self.instance) + '...]'
         if not self.req:
-            s = '{' + s + '}'
+            s = '[' + s + ']'
         return s
 
     def helpstr(self):
@@ -714,7 +714,7 @@ class argdesc(object):
         if self.N:
             s += ' [' + chunk + '...]'
         if not self.req:
-            s = '{' + s + '}'
+            s = '[' + s + ']'
         return s
 
     def complete(self, s):

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -716,6 +716,10 @@ class argdesc(object):
             # CephName commands similarly only have one arg of the
             # type, so <type.id> is good.
             chunk = '<type.id>'
+        elif self.t == CephInt:
+            chunk = '<{0}:int>'.format(self.name)
+        elif self.t == CephFloat:
+            chunk = '<{0}:float>'.format(self.name)
         else:
             chunk = '<{0}>'.format(self.name)
         s = chunk

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -694,7 +694,7 @@ class argdesc(object):
         else:
             s = '{0}({1})'.format(self.name, str(self.instance))
             if self.N:
-                s += ' [' + str(self.instance) + '...]'
+                s += '...'
         if not self.req:
             s = '[' + s + ']'
         return s
@@ -712,7 +712,7 @@ class argdesc(object):
             chunk = str(self.instance)
         s = chunk
         if self.N:
-            s += ' [' + chunk + '...]'
+            s += '...'
         if not self.req:
             s = '[' + s + ']'
         return s


### PR DESCRIPTION
Try to align the CLI help with man-style syntax.  

Here's a bit of sample output:

```
osd set-nearfull-ratio <ratio:float>                                                                        set usage ratio at which OSDs are marked near-full
osd set-require-min-compat-client <version> [--yes-i-really-mean-it]                                        set the minimum client version we will maintain compatibility with
osd setcrushmap [<prior_version:int>]                                                                       set crush map from input file
osd setmaxosd <newmax:int>                                                                                  set new maximum osd value
osd stat                                                                                                    print summary of OSD map
osd status [<bucket>]                                                                                       Show the status of OSDs within a bucket, or all
osd stop <ids>...                                                                                           stop the corresponding osd daemons and mark them as down
osd test-reweight-by-pg [<oload:int>] [<max_change:float>] [<max_osds:int>] [<pools>...]                    dry run of reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]
osd test-reweight-by-utilization [<oload:int>] [<max_change:float>] [<max_osds:int>] [--no-increasing]      dry run of reweight OSDs by utilization [overload-percentage-for-consideration, default 120]
osd tier add <pool> <tierpool> [--force-nonempty]                                                           add the tier <tierpool> (the second one) to base pool <pool> (the first one)
osd tier add-cache <pool> <tierpool> <size:int>                                                             add a cache <tierpool> (the second one) of size <size> to existing pool <pool> (the first one)
osd tier cache-mode <pool> none|writeback|forward|readonly|readforward|proxy|readproxy [--yes-i-really-     specify the caching mode for cache tier <pool>
 mean-it]                                                                                                   
osd tier rm <pool> <tierpool>                                                                               remove the tier <tierpool> (the second one) from base pool <pool> (the first one)
osd tier rm-overlay <pool>                                                                                  remove the overlay pool for base pool <pool>
osd tier set-overlay <pool> <overlaypool>                                                                   set the overlay pool for base pool <pool> to be <overlaypool>
osd tree [<epoch:int>] [up|down|in|out|destroyed...]                                                        print OSD tree
osd tree-from [<epoch:int>] <bucket> [up|down|in|out|destroyed...]                                          print OSD tree in bucket
osd unpause                                                                                                 unpause osd
osd unset full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|          unset <key>
 notieragent|nosnaptrim                                                                                     
osd unset-group <flags> <who>...                                                                            unset <flags> for batch osds or crush nodes, <flags> must be a comma-separated subset of {noup,nodown,noin,
```

vs before,

```
osd set-nearfull-ratio <float[0.0-1.0]>                                                                     set usage ratio at which OSDs are marked near-full
osd set-require-min-compat-client <version> {--yes-i-really-mean-it}                                        set the minimum client version we will maintain compatibility with
osd setcrushmap {<int>}                                                                                     set crush map from input file
osd setmaxosd <int[0-]>                                                                                     set new maximum osd value
osd stat                                                                                                    print summary of OSD map
osd status {<bucket>}                                                                                       Show the status of OSDs within a bucket, or all
osd stop <ids> [<ids>...]                                                                                   stop the corresponding osd daemons and mark them as down
osd test-reweight-by-pg {<int>} {<float>} {<int>} {<poolname> [<poolname>...]}                              dry run of reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]
osd test-reweight-by-utilization {<int>} {<float>} {<int>} {--no-increasing}                                dry run of reweight OSDs by utilization [overload-percentage-for-consideration, default 120]
osd tier add <poolname> <poolname> {--force-nonempty}                                                       add the tier <tierpool> (the second one) to base pool <pool> (the first one)
osd tier add-cache <poolname> <poolname> <int[0-]>                                                          add a cache <tierpool> (the second one) of size <size> to existing pool <pool> (the first one)
osd tier cache-mode <poolname> none|writeback|forward|readonly|readforward|proxy|readproxy {--yes-i-really- specify the caching mode for cache tier <pool>
 mean-it}                                                                                                   
osd tier rm <poolname> <poolname>                                                                           remove the tier <tierpool> (the second one) from base pool <pool> (the first one)
osd tier rm-overlay <poolname>                                                                              remove the overlay pool for base pool <pool>
osd tier set-overlay <poolname> <poolname>                                                                  set the overlay pool for base pool <pool> to be <overlaypool>
osd tree {<int[0-]>} {up|down|in|out|destroyed [up|down|in|out|destroyed...]}                               print OSD tree
osd tree-from {<int[0-]>} <bucket> {up|down|in|out|destroyed [up|down|in|out|destroyed...]}                 print OSD tree in bucket
osd unpause                                                                                                 unpause osd
osd unset full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|          unset <key>
 notieragent|nosnaptrim                                                                                     
osd unset-group <flags> <who> [<who>...]                                                                    unset <flags> for batch osds or crush nodes, <flags> must be a comma-separated subset of {noup,nodown,noin,
                                                                                                             noout}
```



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>