### PR TITLE
pybind/mgr/balancer/module.py: add max/min info in stats_by_root

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -141,6 +141,8 @@ class Eval:
         for t in ('pgs', 'objects', 'bytes'):
             if total[t] == 0:
                 r[t] = {
+                    'max': 0,
+                    'min': 0,
                     'avg': 0,
                     'stddev': 0,
                     'sum_weight': 0,
@@ -189,6 +191,8 @@ class Eval:
             stddev = math.sqrt(dev / float(max(num - 1, 1)))
             score = score / max(sum_weight, 1)
             r[t] = {
+                'max': max(count[t].values()),
+                'min': min(count[t].values()),
                 'avg': avg,
                 'stddev': stddev,
                 'sum_weight': sum_weight,


### PR DESCRIPTION
$ ceph balancer eval-verbose hahapool
...
count_by_pool {'hahapool': {'objects': {0: 1L, 1: 1L, 2: 0L, 3: 0L, 4: 1L}, 'bytes': {0: 0L, 1: 0L, 2: 0L, 3: 0L, 4: 0L}, 'pgs': {0: 35, 1: 42, 2: 23, 3: 30, 4: 26}}}
...
stats_by_root {'default': {'objects': {'min': 0.0, 'max': 1.0, 'score': 0.2970089549436925, 'stddev': 0.5477225575051662, 'avg': 0.6, 'sum_weight': 0.6000000000000001}, 'bytes': {'min': 0, 'max': 0, 'score': 0, 'stddev': 0, 'avg': 0, 'sum_weight': 0}, 'pgs': {'min': 23.0, 'max': 42.0, 'score': 0.07354228523075643, 'stddev': 7.52994023880668, 'avg': 31.2, 'sum_weight': 0.4}}}

max/min can give us an intuitive feel of the pg/bytes/object's distribution.
In addition, sometimes we really want to know which osd hold the most
number of pgs/bytes/objects for specified pool.

Signed-off-by: Yang Honggang <yanghonggang@umcloud.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
