### PR TITLE
rgw: omit prepare/abort entries from mdlog

### DIFF
--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -475,6 +475,11 @@ void decode_json_obj(utime_t& val, JSONObj *obj)
   }
 }
 
+void encode_json(const char *name, std::string_view val, Formatter *f)
+{
+  f->dump_string(name, val);
+}
+
 void encode_json(const char *name, const string& val, Formatter *f)
 {
   f->dump_string(name, val);

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -376,6 +376,7 @@ static void encode_json(const char *name, const T& val, ceph::Formatter *f)
 
 class utime_t;
 
+void encode_json(const char *name, std::string_view val, ceph::Formatter *f);
 void encode_json(const char *name, const std::string& val, ceph::Formatter *f);
 void encode_json(const char *name, const char *val, ceph::Formatter *f);
 void encode_json(const char *name, bool val, ceph::Formatter *f);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7831,7 +7831,7 @@ next:
     int ret = store->ctl()->meta.mgr->mutate(RGWSI_MetaBackend_OTP::get_meta_key(user_id),
 					     mtime, &objv_tracker,
 					     null_yield,
-					     RGWMDLogStatus::Write,
+					     RGWMDLogOp::Write,
 					     [&] {
       return store->svc()->cls->mfa.create_mfa(user_id, config, &objv_tracker, mtime, null_yield);
     });
@@ -7867,7 +7867,7 @@ next:
     int ret = store->ctl()->meta.mgr->mutate(RGWSI_MetaBackend_OTP::get_meta_key(user_id),
 					     mtime, &objv_tracker,
 					     null_yield,
-					     RGWMDLogStatus::Write,
+					     RGWMDLogOp::Write,
 					     [&] {
       return store->svc()->cls->mfa.remove_mfa(user_id, totp_serial, &objv_tracker, mtime, null_yield);
     });
@@ -8011,7 +8011,7 @@ next:
     ret = store->ctl()->meta.mgr->mutate(RGWSI_MetaBackend_OTP::get_meta_key(user_id),
 				         mtime, &objv_tracker,
 				         null_yield,
-				         RGWMDLogStatus::Write,
+				         RGWMDLogOp::Write,
 				         [&] {
       return store->svc()->cls->mfa.create_mfa(user_id, config, &objv_tracker, mtime, null_yield);
     });

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7831,7 +7831,7 @@ next:
     int ret = store->ctl()->meta.mgr->mutate(RGWSI_MetaBackend_OTP::get_meta_key(user_id),
 					     mtime, &objv_tracker,
 					     null_yield,
-					     MDLOG_STATUS_WRITE,
+					     RGWMDLogStatus::Write,
 					     [&] {
       return store->svc()->cls->mfa.create_mfa(user_id, config, &objv_tracker, mtime, null_yield);
     });
@@ -7867,7 +7867,7 @@ next:
     int ret = store->ctl()->meta.mgr->mutate(RGWSI_MetaBackend_OTP::get_meta_key(user_id),
 					     mtime, &objv_tracker,
 					     null_yield,
-					     MDLOG_STATUS_WRITE,
+					     RGWMDLogStatus::Write,
 					     [&] {
       return store->svc()->cls->mfa.remove_mfa(user_id, totp_serial, &objv_tracker, mtime, null_yield);
     });
@@ -8011,7 +8011,7 @@ next:
     ret = store->ctl()->meta.mgr->mutate(RGWSI_MetaBackend_OTP::get_meta_key(user_id),
 				         mtime, &objv_tracker,
 				         null_yield,
-				         MDLOG_STATUS_WRITE,
+				         RGWMDLogStatus::Write,
 				         [&] {
       return store->svc()->cls->mfa.create_mfa(user_id, config, &objv_tracker, mtime, null_yield);
     });

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3314,7 +3314,7 @@ int RGWRunBucketSyncCoroutine::operate()
 
         call(new RGWMetaSyncSingleEntryCR(&meta_sync_env, raw_key,
                                           string() /* no marker */,
-                                          MDLOG_STATUS_COMPLETE,
+                                          RGWMDLogStatus::Complete,
                                           NULL /* no marker tracker */,
                                           tn));
       }

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -147,6 +147,7 @@ struct RGWMetadataLogData {
   obj_version read_version;
   obj_version write_version;
   RGWMDLogStatus status = RGWMDLogStatus::Unknown;
+  RGWMDLogOp op = RGWMDLogOp::Unknown;
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -146,9 +146,7 @@ struct LogStatusDump {
 struct RGWMetadataLogData {
   obj_version read_version;
   obj_version write_version;
-  RGWMDLogStatus status;
-  
-  RGWMetadataLogData() : status(MDLOG_STATUS_UNKNOWN) {}
+  RGWMDLogStatus status = RGWMDLogStatus::Unknown;
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);

--- a/src/rgw/rgw_mdlog_types.h
+++ b/src/rgw/rgw_mdlog_types.h
@@ -24,12 +24,11 @@ enum RGWMDLogSyncType {
   APPLY_EXCLUSIVE
 };
 
-enum RGWMDLogStatus {
-  MDLOG_STATUS_UNKNOWN,
-  MDLOG_STATUS_WRITE,
-  MDLOG_STATUS_SETATTRS,
-  MDLOG_STATUS_REMOVE,
-  MDLOG_STATUS_COMPLETE,
-  MDLOG_STATUS_ABORT,
+enum class RGWMDLogStatus : uint32_t {
+  Unknown,
+  Write,
+  SetAttrs,
+  Remove,
+  Complete,
+  Abort,
 };
-

--- a/src/rgw/rgw_mdlog_types.h
+++ b/src/rgw/rgw_mdlog_types.h
@@ -32,3 +32,9 @@ enum class RGWMDLogStatus : uint32_t {
   Complete,
   Abort,
 };
+
+enum class RGWMDLogOp : uint8_t {
+  Unknown,
+  Write,
+  Remove,
+};

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -31,36 +31,26 @@ using namespace rgw::sal;
 
 const std::string RGWMetadataLogHistory::oid = "meta.history";
 
-void LogStatusDump::dump(Formatter *f) const {
-  string s;
+std::string_view mdlog_status_string(RGWMDLogStatus status) {
   switch (status) {
-    case MDLOG_STATUS_WRITE:
-      s = "write";
-      break;
-    case MDLOG_STATUS_SETATTRS:
-      s = "set_attrs";
-      break;
-    case MDLOG_STATUS_REMOVE:
-      s = "remove";
-      break;
-    case MDLOG_STATUS_COMPLETE:
-      s = "complete";
-      break;
-    case MDLOG_STATUS_ABORT:
-      s = "abort";
-      break;
-    default:
-      s = "unknown";
-      break;
+    case RGWMDLogStatus::Write: return "write";
+    case RGWMDLogStatus::SetAttrs: return "set_attrs";
+    case RGWMDLogStatus::Remove: return "remove";
+    case RGWMDLogStatus::Complete: return "complete";
+    case RGWMDLogStatus::Abort: return "abort";
+    default: return "unknown";
   }
-  encode_json("status", s, f);
+}
+
+void LogStatusDump::dump(Formatter *f) const {
+  encode_json("status", mdlog_status_string(status), f);
 }
 
 void RGWMetadataLogData::encode(bufferlist& bl) const {
   ENCODE_START(1, 1, bl);
   encode(read_version, bl);
   encode(write_version, bl);
-  uint32_t s = (uint32_t)status;
+  uint32_t s = static_cast<uint32_t>(status);
   encode(s, bl);
   ENCODE_FINISH(bl);
 }
@@ -71,7 +61,7 @@ void RGWMetadataLogData::decode(bufferlist::const_iterator& bl) {
    decode(write_version, bl);
    uint32_t s;
    decode(s, bl);
-   status = (RGWMDLogStatus)s;
+   status = static_cast<RGWMDLogStatus>(s);
    DECODE_FINISH(bl);
 }
 
@@ -85,17 +75,17 @@ void decode_json_obj(RGWMDLogStatus& status, JSONObj *obj) {
   string s;
   JSONDecoder::decode_json("status", s, obj);
   if (s == "complete") {
-    status = MDLOG_STATUS_COMPLETE;
+    status = RGWMDLogStatus::Complete;
   } else if (s == "write") {
-    status = MDLOG_STATUS_WRITE;
+    status = RGWMDLogStatus::Write;
   } else if (s == "remove") {
-    status = MDLOG_STATUS_REMOVE;
+    status = RGWMDLogStatus::Remove;
   } else if (s == "set_attrs") {
-    status = MDLOG_STATUS_SETATTRS;
+    status = RGWMDLogStatus::SetAttrs;
   } else if (s == "abort") {
-    status = MDLOG_STATUS_ABORT;
+    status = RGWMDLogStatus::Abort;
   } else {
-    status = MDLOG_STATUS_UNKNOWN;
+    status = RGWMDLogStatus::Unknown;
   }
 }
 

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -77,7 +77,7 @@ public:
 		     const ceph::real_time& mtime,
 		     RGWObjVersionTracker *objv_tracker,
                      optional_yield y,
-		     RGWMDLogStatus op_type,
+		     RGWMDLogOp op,
 		     std::function<int()> f) = 0;
 
   virtual int list_keys_init(const string& marker, void **phandle) = 0;
@@ -166,7 +166,7 @@ public:
 	     const ceph::real_time& mtime,
 	     RGWObjVersionTracker *objv_tracker,
              optional_yield y,
-	     RGWMDLogStatus op_type,
+	     RGWMDLogOp op,
 	     std::function<int()> f) override;
 
   int get_shard_id(const string& entry, int *shard_id) override;
@@ -237,7 +237,7 @@ public:
 	     const ceph::real_time& mtime,
 	     RGWObjVersionTracker *objv_tracker,
              optional_yield y,
-	     RGWMDLogStatus op_type,
+	     RGWMDLogOp op,
 	     std::function<int()> f);
 
   int list_keys_init(const string& section, void **phandle);

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1268,7 +1268,7 @@ int RGWMetaSyncSingleEntryCR::operate() {
       return set_cr_error(-EIO);
     }
 
-    if (op_status != MDLOG_STATUS_COMPLETE) {
+    if (op_status != RGWMDLogStatus::Complete) {
       tn->log(20, "skipping pending operation");
       yield call(marker_tracker->finish(entry_marker));
       if (retcode < 0) {
@@ -1617,7 +1617,7 @@ public:
           } else {
             // fetch remote and write locally
             yield {
-              RGWCoroutinesStack *stack = spawn(new RGWMetaSyncSingleEntryCR(sync_env, marker, marker, MDLOG_STATUS_COMPLETE, marker_tracker, tn), false);
+              RGWCoroutinesStack *stack = spawn(new RGWMetaSyncSingleEntryCR(sync_env, marker, marker, RGWMDLogStatus::Complete, marker_tracker, tn), false);
               // stack_to_pos holds a reference to the stack
               stack_to_pos[stack] = marker;
               pos_to_prev[marker] = marker;

--- a/src/rgw/services/svc_meta_be.cc
+++ b/src/rgw/services/svc_meta_be.cc
@@ -125,7 +125,7 @@ int RGWSI_MetaBackend::put(Context *ctx,
   };
 
   return do_mutate(ctx, key, params.mtime, objv_tracker,
-                MDLOG_STATUS_WRITE,
+                RGWMDLogStatus::Write,
                 y,
                 f,
                 false);
@@ -142,7 +142,7 @@ int RGWSI_MetaBackend::remove(Context *ctx,
   };
 
   return do_mutate(ctx, key, params.mtime, objv_tracker,
-                MDLOG_STATUS_REMOVE,
+                RGWMDLogStatus::Remove,
                 y,
                 f,
                 false);

--- a/src/rgw/services/svc_meta_be.cc
+++ b/src/rgw/services/svc_meta_be.cc
@@ -9,12 +9,6 @@
 #define dout_subsys ceph_subsys_rgw
 
 
-RGWSI_MetaBackend::Context::~Context() {} // needed, even though destructor is pure virtual
-RGWSI_MetaBackend::Module::~Module() {} // ditto
-RGWSI_MetaBackend::PutParams::~PutParams() {} // ...
-RGWSI_MetaBackend::GetParams::~GetParams() {} // ...
-RGWSI_MetaBackend::RemoveParams::~RemoveParams() {} // ...
-
 int RGWSI_MetaBackend::pre_modify(RGWSI_MetaBackend::Context *ctx,
                                   const string& key,
                                   RGWMetadataLogData& log_data,

--- a/src/rgw/services/svc_meta_be.h
+++ b/src/rgw/services/svc_meta_be.h
@@ -51,7 +51,7 @@ protected:
   virtual int do_mutate(Context *ctx,
                      const std::string& key,
                      const ceph::real_time& mtime, RGWObjVersionTracker *objv_tracker,
-                     RGWMDLogStatus op_type,
+                     RGWMDLogOp op,
                      optional_yield y,
                      std::function<int()> f,
                      bool generic_prepare);
@@ -60,12 +60,13 @@ protected:
                          const std::string& key,
                          RGWMetadataLogData& log_data,
                          RGWObjVersionTracker *objv_tracker,
-                         RGWMDLogStatus op_type,
+                         RGWMDLogOp op, RGWMDLogStatus status,
                          optional_yield y);
   virtual int post_modify(Context *ctx,
                           const std::string& key,
                           RGWMetadataLogData& log_data,
-                          RGWObjVersionTracker *objv_tracker, int ret,
+                          RGWObjVersionTracker *objv_tracker,
+                          RGWMDLogOp op, int ret,
                           optional_yield y);
 public:
   class Module {
@@ -110,11 +111,11 @@ public:
 
   struct MutateParams {
     ceph::real_time mtime;
-    RGWMDLogStatus op_type;
+    RGWMDLogOp op;
 
     MutateParams() {}
     MutateParams(const ceph::real_time& _mtime,
-		 RGWMDLogStatus _op_type) : mtime(_mtime), op_type(_op_type) {}
+		 RGWMDLogOp _op) : mtime(_mtime), op(_op) {}
   };
 
   enum Type {

--- a/src/rgw/services/svc_meta_be.h
+++ b/src/rgw/services/svc_meta_be.h
@@ -48,26 +48,15 @@ protected:
                      RGWObjVersionTracker *objv_tracker,
                      optional_yield y);
 
-  virtual int do_mutate(Context *ctx,
-                     const std::string& key,
-                     const ceph::real_time& mtime, RGWObjVersionTracker *objv_tracker,
-                     RGWMDLogOp op,
-                     optional_yield y,
-                     std::function<int()> f,
-                     bool generic_prepare);
+  int do_mutate(Context *ctx, const std::string& key,
+                const ceph::real_time& mtime, RGWObjVersionTracker *objv_tracker,
+                RGWMDLogOp op, optional_yield y,
+                std::function<int()> f, bool generic_prepare);
 
-  virtual int pre_modify(Context *ctx,
-                         const std::string& key,
-                         RGWMetadataLogData& log_data,
-                         RGWObjVersionTracker *objv_tracker,
-                         RGWMDLogOp op, RGWMDLogStatus status,
-                         optional_yield y);
   virtual int post_modify(Context *ctx,
                           const std::string& key,
-                          RGWMetadataLogData& log_data,
                           RGWObjVersionTracker *objv_tracker,
-                          RGWMDLogOp op, int ret,
-                          optional_yield y);
+                          RGWMDLogOp op, optional_yield y) = 0;
 public:
   class Module {
     /*

--- a/src/rgw/services/svc_meta_be.h
+++ b/src/rgw/services/svc_meta_be.h
@@ -73,7 +73,7 @@ public:
      * Backend specialization module
      */
   public:
-    virtual ~Module() = 0;
+    virtual ~Module() {}
   };
 
   using ModuleRef = std::shared_ptr<Module>;
@@ -83,7 +83,7 @@ public:
                     * backend and operation itself; operation might span multiple backend
                     * calls.
                     */
-    virtual ~Context() = 0;
+    virtual ~Context() {}
 
     virtual void init(RGWSI_MetaBackend_Handler *h) = 0;
   };
@@ -95,20 +95,16 @@ public:
 
     PutParams() {}
     PutParams(const ceph::real_time& _mtime) : mtime(_mtime) {}
-    virtual ~PutParams() = 0;
   };
 
   struct GetParams {
     GetParams() {}
     GetParams(ceph::real_time *_pmtime) : pmtime(_pmtime) {}
-    virtual ~GetParams();
 
     ceph::real_time *pmtime{nullptr};
   };
 
   struct RemoveParams {
-    virtual ~RemoveParams() = 0;
-
     ceph::real_time mtime;
   };
 
@@ -119,7 +115,6 @@ public:
     MutateParams() {}
     MutateParams(const ceph::real_time& _mtime,
 		 RGWMDLogStatus _op_type) : mtime(_mtime), op_type(_op_type) {}
-    virtual ~MutateParams() {}
   };
 
   enum Type {

--- a/src/rgw/services/svc_meta_be_sobj.cc
+++ b/src/rgw/services/svc_meta_be_sobj.cc
@@ -32,12 +32,12 @@ int RGWSI_MetaBackend_SObj::pre_modify(RGWSI_MetaBackend::Context *_ctx,
                                        const string& key,
                                        RGWMetadataLogData& log_data,
                                        RGWObjVersionTracker *objv_tracker,
-                                       RGWMDLogStatus op_type,
+                                       RGWMDLogOp op, RGWMDLogStatus status,
                                        optional_yield y)
 {
   auto ctx = static_cast<Context_SObj *>(_ctx);
   int ret = RGWSI_MetaBackend::pre_modify(ctx, key, log_data,
-                                          objv_tracker, op_type,
+                                          objv_tracker, op, status,
                                           y);
   if (ret < 0) {
     return ret;
@@ -51,7 +51,8 @@ int RGWSI_MetaBackend_SObj::pre_modify(RGWSI_MetaBackend::Context *_ctx,
     log_data.write_version = objv_tracker->write_version;
   }
 
-  log_data.status = op_type;
+  log_data.op = op;
+  log_data.status = status;
 
   bufferlist logbl;
   encode(log_data, logbl);
@@ -66,7 +67,8 @@ int RGWSI_MetaBackend_SObj::pre_modify(RGWSI_MetaBackend::Context *_ctx,
 int RGWSI_MetaBackend_SObj::post_modify(RGWSI_MetaBackend::Context *_ctx,
                                         const string& key,
                                         RGWMetadataLogData& log_data,
-                                        RGWObjVersionTracker *objv_tracker, int ret,
+                                        RGWObjVersionTracker *objv_tracker,
+                                        RGWMDLogOp op, int ret,
                                         optional_yield y)
 {
   auto ctx = static_cast<Context_SObj *>(_ctx);
@@ -85,7 +87,7 @@ int RGWSI_MetaBackend_SObj::post_modify(RGWSI_MetaBackend::Context *_ctx,
   if (r < 0)
     return r;
 
-  return RGWSI_MetaBackend::post_modify(ctx, key, log_data, objv_tracker, ret, y);
+  return RGWSI_MetaBackend::post_modify(ctx, key, log_data, objv_tracker, op, ret, y);
 }
 
 int RGWSI_MetaBackend_SObj::get_shard_id(RGWSI_MetaBackend::Context *_ctx,

--- a/src/rgw/services/svc_meta_be_sobj.cc
+++ b/src/rgw/services/svc_meta_be_sobj.cc
@@ -71,9 +71,9 @@ int RGWSI_MetaBackend_SObj::post_modify(RGWSI_MetaBackend::Context *_ctx,
 {
   auto ctx = static_cast<Context_SObj *>(_ctx);
   if (ret >= 0)
-    log_data.status = MDLOG_STATUS_COMPLETE;
+    log_data.status = RGWMDLogStatus::Complete;
   else 
-    log_data.status = MDLOG_STATUS_ABORT;
+    log_data.status = RGWMDLogStatus::Abort;
 
   bufferlist logbl;
   encode(log_data, logbl);

--- a/src/rgw/services/svc_meta_be_sobj.h
+++ b/src/rgw/services/svc_meta_be_sobj.h
@@ -136,12 +136,13 @@ public:
                  const string& key,
                  RGWMetadataLogData& log_data,
                  RGWObjVersionTracker *objv_tracker,
-                 RGWMDLogStatus op_type,
+                 RGWMDLogOp op, RGWMDLogStatus status,
                  optional_yield y);
   int post_modify(RGWSI_MetaBackend::Context *ctx,
                   const string& key,
                   RGWMetadataLogData& log_data,
-                  RGWObjVersionTracker *objv_tracker, int ret,
+                  RGWObjVersionTracker *objv_tracker,
+                  RGWMDLogOp op, int ret,
                   optional_yield y);
 
   int get_entry(RGWSI_MetaBackend::Context *ctx,

--- a/src/rgw/services/svc_meta_be_sobj.h
+++ b/src/rgw/services/svc_meta_be_sobj.h
@@ -132,18 +132,10 @@ public:
 
   int call_with_get_params(ceph::real_time *pmtime, std::function<int(RGWSI_MetaBackend::GetParams&)> cb) override;
 
-  int pre_modify(RGWSI_MetaBackend::Context *ctx,
-                 const string& key,
-                 RGWMetadataLogData& log_data,
-                 RGWObjVersionTracker *objv_tracker,
-                 RGWMDLogOp op, RGWMDLogStatus status,
-                 optional_yield y);
   int post_modify(RGWSI_MetaBackend::Context *ctx,
                   const string& key,
-                  RGWMetadataLogData& log_data,
                   RGWObjVersionTracker *objv_tracker,
-                  RGWMDLogOp op, int ret,
-                  optional_yield y);
+                  RGWMDLogOp op, optional_yield y);
 
   int get_entry(RGWSI_MetaBackend::Context *ctx,
                 const string& key,


### PR DESCRIPTION
metadata sync filters out the mdlog prepare entries generated by pre_modify(), and the abort entries from post_modify() - so we can avoid writing them in the first place

this change also adds a separate RGWMDLogOp which includes whether the operation was a Write or Delete. this information was previously only written to the prepare entries, and metadata sync doesn't have a reliable way to associate the completes with their prepares. this is groundwork for the cleanup of deleted buckets in multisite