### PR TITLE
cls/rbd: sanitize entity instance messenger version type

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -4651,6 +4651,13 @@ int uuid_get(cls_method_context_t hctx, std::string *mirror_uuid) {
   return 0;
 }
 
+void sanitize_entity_inst(entity_inst_t* entity_inst) {
+  // make all addrs of type ANY because the type isn't what uniquely
+  // identifies them and clients and on-disk formats can be encoded
+  // with different backwards compatibility settings.
+  entity_inst->addr.set_type(entity_addr_t::TYPE_ANY);
+}
+
 int list_watchers(cls_method_context_t hctx,
                   std::set<entity_inst_t> *entities) {
   obj_list_watch_response_t watchers;
@@ -4662,7 +4669,10 @@ int list_watchers(cls_method_context_t hctx,
 
   entities->clear();
   for (auto &w : watchers.entries) {
-    entities->emplace(w.name, w.addr);
+    entity_inst_t entity_inst{w.name, w.addr};
+    sanitize_entity_inst(&entity_inst);
+
+    entities->insert(entity_inst);
   }
   return 0;
 }
@@ -4894,6 +4904,7 @@ int image_status_set(cls_method_context_t hctx, const string &global_image_id,
   ondisk_status.last_update = ceph_clock_now();
 
   int r = cls_get_request_origin(hctx, &ondisk_status.origin);
+  sanitize_entity_inst(&ondisk_status.origin);
   ceph_assert(r == 0);
 
   bufferlist bl;


### PR DESCRIPTION
The entity_addr_t::type field does not uniquely identify the connection
and might switch back and forth between LEGACY, V2, and ALL depending on
the client, the OSD, and the OSD map feature bits. Therefore, always
fix the entity address type to ANY prior to any comparisons.

Fixes: https://tracker.ceph.com/issues/41833
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
