### PR TITLE
osd: Change osd op queue cut off default to high

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -400,7 +400,7 @@ Operations
 
 :Type: String
 :Valid Choices: prio, wpq, mclock_opclass, mclock_client
-:Default: ``prio``
+:Default: ``wpq``
 
 
 ``osd op queue cut off``
@@ -417,7 +417,7 @@ Operations
 
 :Type: String
 :Valid Choices: low, high
-:Default: ``low``
+:Default: ``high``
 
 
 ``osd client op priority``

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2792,7 +2792,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("osd_op_queue_cut_off"),
 
     Option("osd_op_queue_cut_off", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("low")
+    .set_default("high")
     .set_enum_allowed( { "low", "high", "debug_random" } )
     .set_description("the threshold between high priority ops and low priority ops")
     .set_long_description("the threshold between high priority ops that use strict priority ordering and low priority ops that use a fairness algorithm that may or may not incorporate priority")


### PR DESCRIPTION
On the ceph-users list last month there was discussion including @emmericp and @rldleblanc regarding changing the default from "low" to "high".  @dvanders invited anyone to submit a PR to effect the change, and today that someone is me.

Setting this value to "high" has the benefit of reducing OSD op starvation by backfill/recovery and thus mitigating high-latency client ops.

Reference: https://www.mail-archive.com/ceph-users@ceph.io/msg00166.html

Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>
