### PR TITLE
os/bluestore: fix broken unused calculation

### DIFF
--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -630,7 +630,7 @@ string bluestore_blob_t::get_flags_string(unsigned flags)
       s += '+';
     s += "csum";
   }
-  if (flags & FLAG_HAS_UNUSED) {
+  if (flags & (FLAG_HAS_UNUSED | LEGACY_FLAG_HAS_UNUSED)) {
     if (s.length())
       s += '+';
     s += "has_unused";
@@ -678,8 +678,7 @@ void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& ls)
   ls.push_back(new bluestore_blob_t);
   ls.back()->init_csum(Checksummer::CSUM_XXHASH32, 16, 65536);
   ls.back()->csum_data = buffer::claim_malloc(4, strdup("abcd"));
-  ls.back()->add_unused(0, 3);
-  ls.back()->add_unused(8, 8);
+  ls.back()->mark_all_unused();
   ls.back()->allocated_test(bluestore_pextent_t(0x40100000, 0x10000));
   ls.back()->allocated_test(
     bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x1000));


### PR DESCRIPTION
The original implementation will take any placeholder pextents into
account when calculating unused bits, which is wrong.
E.g., considering a write sequence like (64kB min_alloc_size):

- _do_write_small 0x11000~1000

- _do_write_small 0x15000~3000

the second write [0x15000~3000] would fail to fill in the unused slot
and trigger a chunk-aligned deferred overwrite instead.

Check the tracker below for a detailed description of the symptom.

Fixes: https://tracker.ceph.com/issues/41901
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
