### PR TITLE
luminous: mgr/localpool: pg_num is an int arg to 'osd pool create'

### DIFF
--- a/src/pybind/mgr/localpool/module.py
+++ b/src/pybind/mgr/localpool/module.py
@@ -55,7 +55,7 @@ class Module(MgrModule):
                         "pool": pool_name,
                         'rule': pool_name,
                         "pool_type": 'replicated',
-                        'pg_num': str(pg_num),
+                        'pg_num': int(pg_num),
                     }), "")
                     r, outb, outs = result.wait()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41914

---

backport of https://github.com/ceph/ceph/pull/23478
parent tracker: https://tracker.ceph.com/issues/37866
