### PR TITLE
mgr: set hostname in DeviceState::set_metadata()

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -417,9 +417,6 @@ bool DaemonServer::handle_open(const ref_t<MMgrOpen>& m)
     daemon = std::make_shared<DaemonState>(daemon_state.types);
     daemon->key = key;
     daemon->service_daemon = true;
-    if (m->daemon_metadata.count("hostname")) {
-      daemon->hostname = m->daemon_metadata["hostname"];
-    }
     daemon_state.insert(daemon);
   }
   if (daemon) {
@@ -2745,9 +2742,6 @@ void DaemonServer::got_service_map()
 	auto daemon = std::make_shared<DaemonState>(daemon_state.types);
 	daemon->key = key;
 	daemon->set_metadata(q.second.metadata);
-        if (q.second.metadata.count("hostname")) {
-          daemon->hostname = q.second.metadata["hostname"];
-        }
 	daemon->service_daemon = true;
 	daemon_state.insert(daemon);
 	dout(10) << "added missing " << key << dendl;

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -181,6 +181,10 @@ class DaemonState
 	}
       }
     }
+    p = m.find("hostname");
+    if (p != m.end()) {
+      hostname = p->second;
+    }
   }
 
   const std::map<std::string,std::string>& _get_config_defaults() {


### PR DESCRIPTION
before this change, we don't update daemon's host if the daemon already
exists in the `daemon_state` registry when handling MMgrOpen even if the
hostname is updated and different from the existing one. and we set
daemon's metadata and update daemon's hostname when handling MMgrOpen or
MServiceMap.

after this change, daemon's hostname is always set whenever
`DaemonState::set_metadata()` is called.

Fixes: https://tracker.ceph.com/issues/40871
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
