### PR TITLE
mgr/volumes: return string type to ceph-manager

### DIFF
--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -419,7 +419,7 @@ class VolumeClient(object):
                 if not path:
                     raise VolumeException(
                         -errno.ENOENT, "Subvolume '{0}' not found".format(subvolname))
-                ret = 0, path, ""
+                ret = 0, path.decode("utf-8"), ""
         except VolumeException as ve:
             ret = self.volume_exception_to_retval(ve)
         return ret
@@ -520,7 +520,7 @@ class VolumeClient(object):
                 if path is None:
                     raise VolumeException(
                         -errno.ENOENT, "Subvolume group '{0}' not found".format(groupname))
-                return 0, path, ""
+                return 0, path.decode("utf-8"), ""
         except VolumeException as ve:
             return self.volume_exception_to_retval(ve)
 


### PR DESCRIPTION
The 'volumes' ceph-mgr module returns a byte type instead of a string type as the stdout result of commands, `fs subvolume getpath` and `fs subvolumegroup getpath` to the ceph-mgr. This causes the commands to hang and the ceph-mgr to utilize 100% CPU. Fix the 'volumes' ceph-mgr module to return string type to ceph-mgr as the stdout result of the commands.

Fixes: https://tracker.ceph.com/issues/41903
Signed-off-by: Venky Shankar <vshankar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
