### PR TITLE
osd: fix possible crash on sending dynamic perf stats report

### DIFF
--- a/src/osd/DynamicPerfStats.h
+++ b/src/osd/DynamicPerfStats.h
@@ -169,10 +169,15 @@ public:
   }
 
   void add_to_reports(
-      const std::map<OSDPerfMetricQuery, OSDPerfMetricLimits> & limits,
+      const std::map<OSDPerfMetricQuery, OSDPerfMetricLimits> &limits,
       std::map<OSDPerfMetricQuery, OSDPerfMetricReport> *reports) {
     for (auto &it : data) {
       auto &query = it.first;
+      auto limit_it = limits.find(query);
+      if (limit_it == limits.end()) {
+        continue;
+      }
+      auto &query_limits = limit_it->second;
       auto &counters = it.second;
       auto &report = (*reports)[query];
 
@@ -182,7 +187,7 @@ public:
       auto &descriptors = report.performance_counter_descriptors;
       ceph_assert(descriptors.size() > 0);
 
-      if (!is_limited(limits.at(query), counters.size())) {
+      if (!is_limited(query_limits, counters.size())) {
         for (auto &it_counters : counters) {
           auto &bl = report.group_packed_performance_counters[it_counters.first];
           query.pack_counters(it_counters.second, &bl);
@@ -190,7 +195,7 @@ public:
         continue;
       }
 
-      for (auto &limit : limits.at(query)) {
+      for (auto &limit : query_limits) {
         size_t index = 0;
         for (; index < descriptors.size(); index++) {
           if (descriptors[index] == limit.order_by) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10285,10 +10285,8 @@ void OSD::set_perf_queries(
   std::vector<PGRef> pgs;
   _get_pgs(&pgs);
   for (auto& pg : pgs) {
-    if (pg->is_primary()) {
-      std::scoped_lock l{*pg};
-      pg->set_dynamic_perf_stats_queries(supported_queries);
-    }
+    std::scoped_lock l{*pg};
+    pg->set_dynamic_perf_stats_queries(supported_queries);
   }
 }
 
@@ -10298,17 +10296,15 @@ void OSD::get_perf_reports(
   _get_pgs(&pgs);
   DynamicPerfStats dps;
   for (auto& pg : pgs) {
-    if (pg->is_primary()) {
-      // m_perf_queries can be modified only in set_perf_queries by mgr client
-      // request, and it is protected by by mgr client's lock, which is held
-      // when set_perf_queries/get_perf_reports are called, so we may not hold
-      // m_perf_queries_lock here.
-      DynamicPerfStats pg_dps(m_perf_queries);
-      pg->lock();
-      pg->get_dynamic_perf_stats(&pg_dps);
-      pg->unlock();
-      dps.merge(pg_dps);
-    }
+    // m_perf_queries can be modified only in set_perf_queries by mgr client
+    // request, and it is protected by by mgr client's lock, which is held
+    // when set_perf_queries/get_perf_reports are called, so we may not hold
+    // m_perf_queries_lock here.
+    DynamicPerfStats pg_dps(m_perf_queries);
+    pg->lock();
+    pg->get_dynamic_perf_stats(&pg_dps);
+    pg->unlock();
+    dps.merge(pg_dps);
   }
   dps.add_to_reports(m_perf_limits, reports);
   dout(20) << "reports for " << reports->size() << " queries" << dendl;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41891
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
