### PR TITLE
mimic: core: choose async recovery targets by last_complete

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1477,7 +1477,8 @@ protected:
                                         set<pg_shard_t> *async_recovery) const;
 
   bool recoverable_and_ge_min_size(const vector<int> &want) const;
-  bool choose_acting(pg_shard_t &auth_log_shard,
+  bool choose_acting(map<pg_shard_t, pg_info_t> &all_info,
+                     pg_shard_t &auth_log_shard,
 		     bool restrict_to_up_acting,
 		     bool *history_les_bound);
   void build_might_have_unfound();


### PR DESCRIPTION
In the asynchronous recovery feature, 
the asynchronous recovery target OSD is selected by last_updata.version, 
so that after the peering is completed, the asynchronous recovery target OSDs update the last_update.version, and then go down again, when the asynchronous recovery target OSDs is back online, when peering,there is no pglog difference between the asynchronous recovery targets and the authoritative OSD, resulting in no asynchronous recovery. My solution is to use last_complete.version to calculate the pglog difference and update the last_complete of the asynchronous recovery target OSD in the copy of peer_info to the latest after the recovery is complete.