### PR TITLE
qa: have kclient tests use new mount.ceph functionality

### DIFF
--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -72,13 +72,6 @@ def task(ctx, config):
 
     test_dir = misc.get_testdir(ctx)
 
-    # Assemble mon addresses
-    remotes_and_roles = ctx.cluster.remotes.items()
-    roles = [roles for (remote_, roles) in remotes_and_roles]
-    ips = [remote_.ssh.get_transport().getpeername()[0]
-           for (remote_, _) in remotes_and_roles]
-    mons = misc.get_mons(roles, ips).values()
-
     mounts = {}
     for id_, remote in clients:
         client_config = config.get("client.%s" % id_)
@@ -90,7 +83,6 @@ def task(ctx, config):
 
         kernel_mount = KernelMount(
             ctx,
-            mons,
             test_dir,
             id_,
             remote,


### PR DESCRIPTION
Now that the mount helper has the ability to discover mon addrs and
can scrape secrets from the keyring, take advantage of it and simplify
the KernelMount class.

Fixes: https://tracker.ceph.com/issues/41892
Signed-off-by: Jeff Layton <jlayton@redhat.com>
