### PR TITLE
mgr: relinguish GIL when performing blocking op

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -608,6 +608,8 @@ PyObject *ActivePyModules::get_store_prefix(const std::string &module_name,
 void ActivePyModules::set_store(const std::string &module_name,
     const std::string &key, const boost::optional<std::string>& val)
 {
+  PyThreadState *tstate = PyEval_SaveThread();
+
   const std::string global_key = PyModule::config_prefix
                                    + module_name + "/" + key;
   
@@ -645,6 +647,7 @@ void ActivePyModules::set_store(const std::string &module_name,
       << cpp_strerror(set_cmd.r) << dendl;
     dout(0) << "mon returned " << set_cmd.r << ": " << set_cmd.outs << dendl;
   }
+  PyEval_RestoreThread(tstate);
 }
 
 void ActivePyModules::set_config(const std::string &module_name,


### PR DESCRIPTION
as a rule of thumb, we should not hold GIL when performing blocking
operations which do not access python internal data, otherwise we could
starve/dead lock other threads that want to acquire the GIL.

see the related section about Py_BEGIN_ALLOW_THREADS and
Py_END_ALLOW_THREADS in following doc:

* https://docs.python.org/3/c-api/init.html
* https://docs.python.org/2.0/api/threads.html

in this case, `ActivePyModules::set_store()` is a blocking call, as it
needs to wait for the completion of mon command.

Fixes: https://tracker.ceph.com/issues/40156
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
