### PR TITLE
doc: Fix FUSE expansion

### DIFF
--- a/doc/cephfs/fuse.rst
+++ b/doc/cephfs/fuse.rst
@@ -2,7 +2,7 @@
 Mount CephFS using FUSE
 =======================
 
-Before mounting a Ceph File System in User Space (FUSE), ensure that the client
+Before mounting Ceph via "Filesystem in USErspace" (FUSE), ensure that the client
 host has a copy of the Ceph configuration file and a keyring with CAPS for the
 Ceph metadata server.
 

--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -15,7 +15,7 @@ Synopsis
 Description
 ===========
 
-**ceph-fuse** is a FUSE (File system in USErspace) client for Ceph
+**ceph-fuse** is a FUSE ("Filesystem in USErspace") client for Ceph
 distributed file system. It will mount a ceph file system specified
 via the -m option or described by ceph.conf (see below) at the
 specific mount point. See `Mount CephFS using FUSE`_ for detailed

--- a/doc/man/8/rbd-fuse.rst
+++ b/doc/man/8/rbd-fuse.rst
@@ -20,7 +20,7 @@ Note
 Description
 ===========
 
-**rbd-fuse** is a FUSE (File system in USErspace) client for RADOS
+**rbd-fuse** is a FUSE ("Filesystem in USErspace") client for RADOS
 block device (rbd) images.  Given a pool containing rbd images,
 it will mount a userspace file system allowing access to those images
 as regular files at **mountpoint**.


### PR DESCRIPTION
Fixed the FUSE abbreviation expansion in doc.

Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
