### PR TITLE
mgr/dashboard: REST API: OpenAPI docs require internet connection

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/docs.py
+++ b/src/pybind/mgr/dashboard/controllers/docs.py
@@ -393,11 +393,8 @@ class Docs(BaseController):
         <head>
             <meta charset="UTF-8">
             <meta name="referrer" content="no-referrer" />
-            <link href="https://fonts.googleapis.com/css?family=Open+Sans:400, \
-                        700|Source+Code+Pro:300,600|Titillium+Web:400,600,700"
-                  rel="stylesheet">
             <link rel="stylesheet" type="text/css"
-                  href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css" >
+                  href="/swagger-ui.css" >
             <style>
                 html
                 {{
@@ -419,7 +416,7 @@ class Docs(BaseController):
         </head>
         <body>
         <div id="swagger-ui"></div>
-        <script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js">
+        <script src="/swagger-ui-bundle.js">
         </script>
         <script>
             window.onload = function() {{

--- a/src/pybind/mgr/dashboard/frontend/angular.json
+++ b/src/pybind/mgr/dashboard/frontend/angular.json
@@ -18,7 +18,17 @@
             "polyfills": "src/polyfills.ts",
             "assets": [
               "src/assets",
-              "src/favicon.ico"
+              "src/favicon.ico",
+              {
+                "glob": "**/swagger-ui.css",
+                "input": "node_modules/swagger-ui-dist",
+                "output": "."
+              },
+              {
+                "glob": "**/swagger-ui-bundle.js",
+                "input": "node_modules/swagger-ui-dist",
+                "output": "."
+              }
             ],
             "styles": [
               "node_modules/ngx-toastr/toastr.css",

--- a/src/pybind/mgr/dashboard/frontend/package-lock.json
+++ b/src/pybind/mgr/dashboard/frontend/package-lock.json
@@ -14358,6 +14358,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swagger-ui-dist": {
+      "version": "3.23.10",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.23.10.tgz",
+      "integrity": "sha512-lK9oNNb9HAz2HJIg6+cYZszbYC/0CTm0nWi0XX2AjEbVgu43smbW2/h5zn7yAjYstPJBaYXkt5g6ABRpO/Ncfg=="
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -86,6 +86,7 @@
     "ngx-toastr": "10.0.4",
     "rxjs": "6.5.2",
     "rxjs-compat": "6.5.2",
+    "swagger-ui-dist": "3.23.10",
     "tslib": "1.9.3",
     "zone.js": "0.9.1"
   },


### PR DESCRIPTION
Adds the `swagger-ui-dist` package to `package.json` and loads resources locally instead from the internet.

Fixes: https://tracker.ceph.com/issues/40027

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
