### PR TITLE
nautilus: core: mon: show pool id in pool ls command

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5164,6 +5164,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	if (f) {
 	  if (detail == "detail") {
 	    f->open_object_section("pool");
+	    f->dump_int("pool_id", it->first);
 	    f->dump_string("pool_name", osdmap.get_pool_name(it->first));
 	    it->second.dump(f.get());
 	    f->close_section();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41921

---

backport of https://github.com/ceph/ceph/pull/28488
parent tracker: https://tracker.ceph.com/issues/40287

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh