### PR TITLE
osd/PeeringState: fix get_num_missing()

### DIFF
--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -2126,8 +2126,8 @@ public:
   bool have_missing() const {
     return pg_log.get_missing().num_missing() > 0;
   }
-  bool get_num_missing() const {
-    return pg_log.get_missing().num_missing() > 0;
+  int get_num_missing() const {
+    return pg_log.get_missing().num_missing();
   }
 
   const MissingLoc &get_missing_loc() const {


### PR DESCRIPTION
This fixes the "m=NNN" output in the debug log so that it's a real
number instead of always 1.

Signed-off-by: Sage Weil <sage@redhat.com>