### PR TITLE
ceph-volume: systemd fix typo in log message

### DIFF
--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -99,7 +99,7 @@ def main(args=None):
             # don't log any output to the terminal, just rely on stderr/stdout
             # going to logging
             process.run(command, terminal_logging=False)
-            logger.info('successfully trggered activation for: %s', extra_data)
+            logger.info('successfully triggered activation for: %s', extra_data)
             break
         except RuntimeError as error:
             logger.warning(error)


### PR DESCRIPTION
ceph-volume systemd logging to `/var/log/ceph/ceph-volume-systemd.log` has a typo in the log message

Fixes: https://tracker.ceph.com/issues/41942
Signed-off-by: Manu Zurmühl <m.zurmuehl@heinlein-support.de>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
