### PR TITLE
mon: allow running without a config file

### DIFF
--- a/doc/man/8/ceph-mon.rst
+++ b/doc/man/8/ceph-mon.rst
@@ -77,6 +77,11 @@ Options
 
    Specify a keyring for use with ``--mkfs``.
 
+.. option:: --no-config-file
+
+    Signal that we don't want to rely on a *ceph.conf*, either user provided
+    or the default, to run the daemon.  This will entail providing all
+    necessary options to the daemon as arguments.
 
 Availability
 ============

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -504,6 +504,9 @@ CephInitParameters ceph_argparse_early_args
     else if (ceph_argparse_witharg(args, i, &val, "--conf", "-c", (char*)NULL)) {
       *conf_file_list = val;
     }
+    else if (ceph_argparse_flag(args, i, "--no-config-file", (char*)NULL)) {
+      iparams.no_config_file = true;
+    }
     else if (ceph_argparse_witharg(args, i, &val, "--cluster", (char*)NULL)) {
       *cluster = val;
     }

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -37,6 +37,7 @@ public:
 
   uint32_t module_type;
   EntityName name;
+  bool no_config_file = false;
 };
 
 /////////////////////// Functions ///////////////////////

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -64,6 +64,8 @@ CephContext *common_preinit(const CephInitParameters &iparams,
     conf.set_val_default("log_flush_on_exit", "false");
   }
 
+  conf.set_val("no_config_file", iparams.no_config_file ? "true" : "false");
+
   return cct;
 }
 #endif	// #ifndef WITH_SEASTAR

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -441,6 +441,18 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_STARTUP)
     .set_default("ceph/daemon-base:latest-master-devel"),
 
+    Option("no_config_file", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_flag(Option::FLAG_NO_MON_UPDATE)
+    .set_flag(Option::FLAG_STARTUP)
+    .add_service("common")
+    .add_tag("config")
+    .set_description("signal that we don't require a config file to be present")
+    .set_long_description("When specified, we won't be looking for a "
+			  "configuration file, and will instead expect that "
+			  "whatever options or values are required for us to "
+			  "work will be passed as arguments."),
+
     // lockdep
     Option("lockdep", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_description("enable lockdep lock dependency analyzer")

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -111,6 +111,10 @@ void global_pre_init(
     }
   }
 
+  if (conf.get_val<bool>("no_config_file")) {
+    flags |= CINIT_FLAG_NO_DEFAULT_CONFIG_FILE;
+  }
+
   int ret = conf.parse_config_files(c_str_or_null(conf_file_list),
 				    &cerr, flags);
   if (ret == -EDOM) {
@@ -126,7 +130,8 @@ void global_pre_init(
 	     << conf_file_list << std::endl;
         _exit(1);
       } else {
-	cerr << "did not load config file, using default settings." << std::endl;
+	cerr << "did not load config file, using default settings."
+	     << std::endl;
       }
     }
   }


### PR DESCRIPTION
As long as all required options are provided as arguments to ceph-mon,
we should allow it to run without a config file.

`Signed-off-by: Joao Eduardo Luis <joao@suse.com>`

(note: I'm currently without access to my dev box, so no make checks were run - we'll have to rely on the bot to flush out any issues that may arise from this.)