### PR TITLE
mgr/dashboard: Fix OSD's safe_to_destroy method

### DIFF
--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -99,8 +99,11 @@ class OsdTest(DashboardTestCase):
 
     def test_safe_to_destroy(self):
         osd_dump = json.loads(self._ceph_cmd(['osd', 'dump', '-f', 'json']))
-        unused_osd_id = max(map(lambda e: e['osd'], osd_dump['osds'])) + 10
-        self._get('/api/osd/{}/safe_to_destroy'.format(unused_osd_id))
+        max_id = max(map(lambda e: e['osd'], osd_dump['osds']))
+
+        # 1 OSD safe to destroy
+        unused_osd_id = max_id + 10
+        self._get('/api/osd/safe_to_destroy?ids={}'.format(unused_osd_id))
         self.assertStatus(200)
         self.assertJsonBody({
             'is_safe_to_destroy': True,
@@ -110,8 +113,21 @@ class OsdTest(DashboardTestCase):
             'stored_pgs': [],
         })
 
+        # multiple OSDs safe to destroy
+        unused_osd_ids = [max_id + 11, max_id + 12]
+        self._get('/api/osd/safe_to_destroy?ids={}'.format(str(unused_osd_ids)))
+        self.assertStatus(200)
+        self.assertJsonBody({
+            'is_safe_to_destroy': True,
+            'active': [],
+            'missing_stats': [],
+            'safe_to_destroy': unused_osd_ids,
+            'stored_pgs': [],
+        })
+
+        # 1 OSD unsafe to destroy
         def get_destroy_status():
-            self._get('/api/osd/0/safe_to_destroy')
+            self._get('/api/osd/safe_to_destroy?ids=0')
             if 'is_safe_to_destroy' in self.jsonBody():
                 return self.jsonBody()['is_safe_to_destroy']
             return None

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from . import ApiController, RESTController, UpdatePermission
+import json
+from . import ApiController, RESTController, Endpoint, ReadPermission, UpdatePermission
 from .. import mgr, logger
 from ..security import Scope
 from ..services.ceph_service import CephService, SendCommandError
@@ -196,18 +197,23 @@ class Osd(RESTController):
         CephService.send_command(
             'mon', 'osd destroy-actual', id=int(svc_id), yes_i_really_mean_it=True)
 
-    @RESTController.Resource('GET')
-    def safe_to_destroy(self, svc_id):
+    @Endpoint('GET', query_params=['ids'])
+    @ReadPermission
+    def safe_to_destroy(self, ids):
         """
-        :type svc_id: int|[int]
+        :type ids: int|[int]
         """
-        if not isinstance(svc_id, list):
-            svc_id = [svc_id]
-        svc_id = list(map(str, svc_id))
+
+        ids = json.loads(ids)
+        if isinstance(ids, list):
+            ids = list(map(str, ids))
+        else:
+            ids = [str(ids)]
+
         try:
             result = CephService.send_command(
-                'mon', 'osd safe-to-destroy', ids=svc_id, target=('mgr', ''))
-            result['is_safe_to_destroy'] = set(result['safe_to_destroy']) == set(map(int, svc_id))
+                'mon', 'osd safe-to-destroy', ids=ids, target=('mgr', ''))
+            result['is_safe_to_destroy'] = set(result['safe_to_destroy']) == set(map(int, ids))
             return result
 
         except SendCommandError as e:

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -108,7 +108,7 @@ describe('OsdService', () => {
 
   it('should return if it is safe to destroy an OSD', () => {
     service.safeToDestroy('[0,1]').subscribe();
-    const req = httpTesting.expectOne('api/osd/[0,1]/safe_to_destroy');
+    const req = httpTesting.expectOne('api/osd/safe_to_destroy?ids=[0,1]');
     expect(req.request.method).toBe('GET');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -248,6 +248,6 @@ export class OsdService {
       'safe-to-destroy': boolean;
       message?: string;
     }
-    return this.http.get<SafeToDestroyResponse>(`${this.path}/${ids}/safe_to_destroy`);
+    return this.http.get<SafeToDestroyResponse>(`${this.path}/safe_to_destroy?ids=${ids}`);
   }
 }


### PR DESCRIPTION
We were passing the wrong value in "send_command".

Changed the ids path param to a query param.

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
