### PR TITLE
osd/PeeringState: remove bad recovery_got() assert

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -78,7 +78,11 @@ public:
     mutable ceph::unordered_multimap<osd_reqid_t,pg_log_entry_t*> extra_caller_ops;
     mutable ceph::unordered_map<osd_reqid_t,pg_log_dup_t*> dup_index;
 
-    // recovery pointers
+    // recovery pointers.  the *complete_to* pointer is used for updating
+    // last_complete incrementally during the course of recovery.  It is not
+    // strictly required to be correct, as the last_complete value will also
+    // get reset to last_update when recovery finally finishes and there are no
+    // more missing objects.
     list<pg_log_entry_t>::iterator complete_to; // not inclusive of referenced item
     version_t last_requested = 0;               // last object requested by primary
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3666,9 +3666,6 @@ void PeeringState::recover_got(
   } else {
     psdout(10) << "last_complete now " << info.last_complete
 	       << " log.complete_to at end" << dendl;
-    //below is not true in the repair case.
-    //assert(missing.num_missing() == 0);  // otherwise, complete_to was wrong.
-    ceph_assert(info.last_complete == info.last_update);
   }
 
   if (is_primary()) {


### PR DESCRIPTION
The complete_to pointer's sole purpose is to allow the last_complete value
to advance incrementally as recovery progresses.  However, it is cleared
in certain cases, notably during split, and reset to point to end().

If it is ignored or not set, then the last_complete value will still get
set to last_update when recovery finally finishes--you just won't get the
incremental updates.

Fix a bad assertion caused by recovery following a PG split by removing
this assert.  Add some better code comments to this effect.

Fixes: https://tracker.ceph.com/issues/41816
Signed-off-by: Sage Weil <sage@redhat.com>