### PR TITLE
ceph-objectstore-tool: better error message if pgid and object do not match

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -3758,6 +3758,12 @@ int main(int argc, char **argv)
           ret = 1;
           goto out;
         }
+	auto ch = fs->open_collection(coll_t(pgid));
+	if (!ghobj.match(fs->collection_bits(ch), pgid.ps())) {
+	  stringstream ss;
+	  ss << "object " << ghobj << " not contained by pg " << pgid;
+	  throw std::runtime_error(ss.str());
+	}
       }
     } catch (std::runtime_error& e) {
       cerr << e.what() << std::endl;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41913
Signed-off-by: Sage Weil <sage@redhat.com>