### PR TITLE
qa: avoid hexdump skip and length options

### DIFF
--- a/qa/rbd/krbd_huge_image.t
+++ b/qa/rbd/krbd_huge_image.t
@@ -24,18 +24,18 @@ Write to first and last sectors and make sure we hit the right objects:
 Dump first and last megabytes:
 
   $ DEV=$(sudo rbd map hugeimg/img)
-  $ hexdump -n 1048576 $DEV
+  $ dd if=$DEV bs=1M count=1 status=none | hexdump
   0000000 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
   *
   0000200 0000 0000 0000 0000 0000 0000 0000 0000
   *
   0100000
-  $ hexdump -s 4611686018426339328 $DEV
-  3ffffffffff00000 0000 0000 0000 0000 0000 0000 0000 0000
+  $ dd if=$DEV bs=1M skip=4398046511103 status=none | hexdump
+  0000000 0000 0000 0000 0000 0000 0000 0000 0000
   *
-  3ffffffffffffe00 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
+  00ffe00 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
   *
-  4000000000000000
+  0100000
   $ sudo rbd unmap $DEV
 
   $ ceph osd pool delete hugeimg hugeimg --yes-i-really-really-mean-it >/dev/null 2>&1


### PR DESCRIPTION
On Debian-based distros, hexdump(1) comes from FreeBSD in bsdmainutils
package (other distros ship a Linux version from util-linux).  It turns
out that '-s skip' for anything but a regular file has been broken for
ages in FreeBSD -- instead of calling fseek(), it consumed the input
byte by byte with getchar().  This was fixed in commit 7cd5ae492557
"hexdump(1): Speed up -s flag on devices" last year, but it hasn't made
it to the Debian world yet.

bsdmainutils_9.0.6ubuntu3 in xenial had a custom patch for that, but
it's no longer there in bsdmainutils_11.1.2ubuntu1 in bionic.  hexdump
-s <large offset> is now a fancy infinite loop!

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>