### PR TITLE
test/{fs,cephfs}: Get libcephfs and cephfs to compile with FreeBSD

### DIFF
--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -99,6 +99,9 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize,
 #ifndef EKEYREJECTED
 #define EKEYREJECTED 129
 #endif
+#ifndef XATTR_CREATE
+#define XATTR_CREATE 1
+#endif
 
 #ifndef HOST_NAME_MAX
 #ifdef MAXHOSTNAMELEN 

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -51,13 +51,21 @@ cdef extern from "sys/statvfs.h":
         unsigned long int f_padding[32]
 
 
-cdef extern from "dirent.h":
-    cdef struct dirent:
-        long int d_ino
-        unsigned long int d_off
-        unsigned short int d_reclen
-        unsigned char d_type
-        char d_name[256]
+IF UNAME_SYSNAME == "FreeBSD":
+    cdef extern from "dirent.h":
+        cdef struct dirent:
+            long int d_ino
+            unsigned short int d_reclen
+            unsigned char d_type
+            char d_name[256]
+ELSE:
+    cdef extern from "dirent.h":
+        cdef struct dirent:
+            long int d_ino
+            unsigned long int d_off
+            unsigned short int d_reclen
+            unsigned char d_type
+            char d_name[256]
 
 
 cdef extern from "time.h":
@@ -318,11 +326,18 @@ cdef class DirResult(object):
         if not dirent:
             return None
 
-        return DirEntry(d_ino=dirent.d_ino,
-                        d_off=dirent.d_off,
-                        d_reclen=dirent.d_reclen,
-                        d_type=dirent.d_type,
-                        d_name=dirent.d_name)
+        IF UNAME_SYSNAME == "FreeBSD":
+            return DirEntry(d_ino=dirent.d_ino,
+                            d_off=0,
+                            d_reclen=dirent.d_reclen,
+                            d_type=dirent.d_type,
+                            d_name=dirent.d_name)
+        ELSE:
+             return DirEntry(d_ino=dirent.d_ino,
+                            d_off=dirent.d_off,
+                            d_reclen=dirent.d_reclen,
+                            d_type=dirent.d_type,
+                            d_name=dirent.d_name)
 
     def close(self):
         if self.handle:

--- a/src/test/fs/test_trim_caps.cc
+++ b/src/test/fs/test_trim_caps.cc
@@ -1,5 +1,7 @@
 #define _FILE_OFFSET_BITS 64
+#if defined(__linux__)
 #include <features.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>

--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
-#include <sys/xattr.h>
 #include <sys/uio.h>
 #include <iostream>
 #include <vector>
@@ -32,6 +31,7 @@
 
 #ifdef __linux__
 #include <limits.h>
+#include <sys/xattr.h>
 #endif
 
 

--- a/src/test/libcephfs/acl.cc
+++ b/src/test/libcephfs/acl.cc
@@ -21,7 +21,9 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef __linux__
 #include <sys/xattr.h>
+#endif
 
 static size_t acl_ea_size(int count)
 {

--- a/src/test/libcephfs/caps.cc
+++ b/src/test/libcephfs/caps.cc
@@ -22,7 +22,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#ifdef __linux__
 #include <sys/xattr.h>
+#endif
 #include <signal.h>
 
 TEST(Caps, ReadZero) {

--- a/src/test/libcephfs/ceph_pthread_self.h
+++ b/src/test/libcephfs/ceph_pthread_self.h
@@ -1,0 +1,31 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_LIBCEPHFS_PTHREAD_SELF
+#define CEPH_TEST_LIBCEPHFS_PTHREAD_SELF
+
+#include <pthread.h>
+
+#include <type_traits>
+
+/*
+ * There is a  difference between libc shipped with FreeBSD and
+ * glibc shipped with GNU/Linux for the return type of pthread_self().
+ *
+ * Introduced a conversion function in include/compat.h
+ *     (uint64_t)ceph_pthread_self()
+ *
+ * libc returns an opague pthread_t that is not default convertable
+ * to a uint64_t, which is what gtest expects.
+ * And tests using gtest will not compile because of this difference.
+ * 
+ */
+static uint64_t ceph_pthread_self() {
+  auto me = pthread_self();
+  static_assert(std::is_convertible_v<decltype(me), uint64_t> ||
+                std::is_pointer_v<decltype(me)>,
+                "we need to use pthread_self() for the owner parameter");
+  return reinterpret_cast<uint64_t>(me);
+}
+
+#endif

--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -15,11 +15,11 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
-#include <sys/xattr.h>
 #include <sys/uio.h>
 
 #ifdef __linux__
 #include <limits.h>
+#include <sys/xattr.h>
 #endif
 
 #include <map>

--- a/src/test/libcephfs/lazyio.cc
+++ b/src/test/libcephfs/lazyio.cc
@@ -21,7 +21,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#if defined(__linux__)
 #include <sys/xattr.h>
+#endif
 
 rados_t cluster;
 

--- a/src/test/libcephfs/multiclient.cc
+++ b/src/test/libcephfs/multiclient.cc
@@ -20,7 +20,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#ifdef __linux__
 #include <sys/xattr.h>
+#endif
 
 TEST(LibCephFS, MulticlientSimple) {
   struct ceph_mount_info *ca, *cb;

--- a/src/test/libcephfs/reclaim.cc
+++ b/src/test/libcephfs/reclaim.cc
@@ -15,13 +15,17 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
-#include <sys/xattr.h>
 #include <sys/uio.h>
 #include <libgen.h>
 #include <stdlib.h>
 
 #ifdef __linux__
+#include <sys/xattr.h>
 #include <limits.h>
+#endif
+
+#ifdef __FreeBSD__
+#include <sys/wait.h>
 #endif
 
 

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "gtest/gtest.h"
 #include "include/cephfs/libcephfs.h"
 #include "include/stat.h"
@@ -21,7 +22,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
-#include <sys/xattr.h>
 #include <sys/uio.h>
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -30,6 +30,7 @@
 
 #ifdef __linux__
 #include <limits.h>
+#include <sys/xattr.h>
 #endif
 
 #include <map>


### PR DESCRIPTION
FreeBSD does not have features.h
FreeBSD dirent{} does not have d_off, so set the offset pointer to 0
FreeBSD does not have sys/xattr.h
    But only the XATTR_CREATE define looks to be missing

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>