### PR TITLE
mgr/dashboard: Display the "destroyed" state in OSD list

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -35,7 +35,7 @@
                  let-value="value">
       <span *ngFor="let state of value; last as last">
         <span class="badge"
-              [ngClass]="{'badge-success': ['in', 'up'].includes(state), 'badge-danger': ['down', 'out'].includes(state)}">{{ state }}</span>
+              [ngClass]="{'badge-success': ['in', 'up'].includes(state), 'badge-danger': ['down', 'out', 'destroyed'].includes(state)}">{{ state }}</span>
         <span *ngIf="!last">&nbsp;</span>
       </span>
     </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -4,7 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import _ = require('lodash');
+import * as _ from 'lodash';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { EMPTY, of } from 'rxjs';
@@ -129,7 +129,8 @@ describe('OsdListComponent', () => {
       stats: {
         stat_bytes_used: n * n,
         stat_bytes: n * n * n
-      }
+      },
+      state: []
     });
 
     const expectAttributeOnEveryOsd = (attr: string) =>
@@ -154,6 +155,15 @@ describe('OsdListComponent', () => {
     it('should have custom attribute "collectedStates"', () => {
       expectAttributeOnEveryOsd('collectedStates');
       expect(component.osds[0].collectedStates).toEqual(['in', 'up']);
+    });
+
+    it('should have "destroyed" state in "collectedStates"', () => {
+      osds[0].state.push('destroyed');
+      osds[0].up = 0;
+      component.getOsdList();
+
+      expectAttributeOnEveryOsd('collectedStates');
+      expect(component.osds[0].collectedStates).toEqual(['in', 'destroyed']);
     });
 
     it('should have custom attribute "stats_history.out_bytes"', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -56,7 +56,15 @@ export class OsdListComponent implements OnInit {
   osds = [];
 
   protected static collectStates(osd) {
-    return [osd['in'] ? 'in' : 'out', osd['up'] ? 'up' : 'down'];
+    const states = [osd['in'] ? 'in' : 'out'];
+    if (osd['up']) {
+      states.push('up');
+    } else if (osd.state.includes('destroyed')) {
+      states.push('destroyed');
+    } else {
+      states.push('down');
+    }
+    return states;
   }
 
   constructor(


### PR DESCRIPTION

![FireShot Capture 008 - Ceph - localhost](https://user-images.githubusercontent.com/399326/65428831-9e627980-de04-11e9-9a68-b1de6a426192.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
