### PR TITLE
nautilus: mgr/dashboard: Set RO as the default access_type for RGW NFS exports 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -412,7 +412,8 @@
             <select class="form-control"
                     formControlName="access_type"
                     name="access_type"
-                    id="access_type">
+                    id="access_type"
+                    (change)="accessTypeChangeHandler()">
               <option *ngIf="nfsAccessType === null"
                       value=""
                       i18n>Loading...</option>
@@ -429,6 +430,13 @@
                   *ngIf="nfsForm.getValue('access_type')">
               {{ getAccessTypeHelp(nfsForm.getValue('access_type')) }}
             </span>
+            <span class="text-warning"
+                  *ngIf="nfsForm.getValue('access_type') === 'RW' && nfsForm.getValue('name') === 'RGW'"
+                  i18n>The Object Gateway NFS backend has a number of
+              limitations which will seriously affect applications writing to
+              the share. Please consult the
+              <a href="{{docsUrl}}"
+                 target="_blank"> documentation</a> for details before enabling write access.</span>
             <span class="help-block"
                   *ngIf="nfsForm.showError('access_type', formDir, 'required')"
                   i18n>Required field</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -9,6 +9,7 @@ import { ToastrModule } from 'ngx-toastr';
 
 import { ActivatedRouteStub } from '../../../../testing/activated-route-stub';
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { NfsFormClientComponent } from '../nfs-form-client/nfs-form-client.component';
@@ -36,7 +37,9 @@ describe('NfsFormComponent', () => {
           provide: ActivatedRoute,
           useValue: new ActivatedRouteStub({ cluster_id: undefined, export_id: undefined })
         },
-        i18nProviders
+        i18nProviders,
+        SummaryService,
+        CephReleaseNamePipe
       ]
     },
     true
@@ -45,6 +48,11 @@ describe('NfsFormComponent', () => {
   beforeEach(() => {
     const summaryService = TestBed.get(SummaryService);
     spyOn(summaryService, 'refresh').and.callFake(() => true);
+    spyOn(summaryService, 'getCurrentSummary').and.callFake(() => {
+      return {
+        version: 'master'
+      };
+    });
 
     fixture = TestBed.createComponent(NfsFormComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -17,7 +17,9 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { FinishedTask } from '../../../shared/models/finished-task';
 import { Permission } from '../../../shared/models/permissions';
+import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
+import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 import { NfsFormClientComponent } from '../nfs-form-client/nfs-form-client.component';
 
@@ -49,11 +51,13 @@ export class NfsFormComponent implements OnInit {
   allCephxClients: any[] = null;
   allFsNames: any[] = null;
 
+  defaultAccessType = { RGW: 'RO' };
   nfsAccessType: any[] = this.nfsService.nfsAccessType;
   nfsSquash: any[] = this.nfsService.nfsSquash;
 
   action: string;
   resource: string;
+  docsUrl: string;
 
   daemonsSelections: SelectOption[] = [];
   daemonsMessages = new SelectMessages(
@@ -79,6 +83,8 @@ export class NfsFormComponent implements OnInit {
     private router: Router,
     private rgwUserService: RgwUserService,
     private formBuilder: CdFormBuilder,
+    private summaryservice: SummaryService,
+    private cephReleaseNamePipe: CephReleaseNamePipe,
     private taskWrapper: TaskWrapperService,
     private cdRef: ChangeDetectorRef,
     private i18n: I18n,
@@ -114,6 +120,10 @@ export class NfsFormComponent implements OnInit {
       this.action = this.actionLabels.CREATE;
       this.getData(promises);
     }
+
+    const summary = this.summaryservice.getCurrentSummary();
+    const releaseName = this.cephReleaseNamePipe.transform(summary.version);
+    this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/radosgw/nfs/`;
   }
 
   getData(promises) {
@@ -317,12 +327,19 @@ export class NfsFormComponent implements OnInit {
   fsalChangeHandler() {
     this.nfsForm.patchValue({
       tag: this._generateTag(),
-      pseudo: this._generatePseudo()
+      pseudo: this._generatePseudo(),
+      access_type: this._updateAccessType()
     });
 
     this.setPathValidation();
 
     this.cdRef.detectChanges();
+  }
+
+  accessTypeChangeHandler() {
+    const name = this.nfsForm.getValue('name');
+    const accessType = this.nfsForm.getValue('access_type');
+    this.defaultAccessType[name] = accessType;
   }
 
   setPathValidation() {
@@ -433,6 +450,17 @@ export class NfsFormComponent implements OnInit {
       }
     }
     return newPseudo;
+  }
+
+  _updateAccessType() {
+    const name = this.nfsForm.getValue('name');
+    let accessType = this.defaultAccessType[name];
+
+    if (!accessType) {
+      accessType = 'RW';
+    }
+
+    return accessType;
   }
 
   onClusterChange() {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41773

---

backport of https://github.com/ceph/ceph/pull/30111
parent tracker: https://tracker.ceph.com/issues/40186

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh