### PR TITLE
mon/OSDMonitor: clean up removed_snap keys

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1970,23 +1970,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   pending_metadata.clear();
   pending_metadata_rm.clear();
 
-  // removed_snaps
-  for (auto& i : pending_inc.new_removed_snaps) {
-    {
-      // all snaps removed this epoch
-      string k = make_removed_snap_epoch_key(i.first, pending_inc.epoch);
-      bufferlist v;
-      encode(i.second, v);
-      t->put(OSD_SNAP_PREFIX, k, v);
-    }
-    for (auto q = i.second.begin();
-	 q != i.second.end();
-	 ++q) {
-      insert_snap_update(false, i.first, q.get_start(), q.get_end(),
-			 pending_inc.epoch,
-			 t);
-    }
-  }
+  // purged_snaps
   if (tmp.require_osd_release >= ceph_release_t::octopus &&
       !pending_inc.new_purged_snaps.empty()) {
     // all snaps purged this epoch (across all pools)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -101,13 +101,16 @@ static const string OSD_SNAP_PREFIX("osd_snap");
   OSD snapshot metadata
   ---------------------
 
-  -- starting with mimic --
+  -- starting with mimic, removed in octopus --
 
   "removed_epoch_%llu_%08lx" % (pool, epoch)
    -> interval_set<snapid_t>
 
   "removed_snap_%llu_%016llx" % (pool, last_snap)
    -> { first_snap, end_snap, epoch }   (last_snap = end_snap - 1)
+
+
+  -- starting with mimic --
 
   "purged_snap_%llu_%016llx" % (pool, last_snap)
    -> { first_snap, end_snap, epoch }   (last_snap = end_snap - 1)
@@ -1887,6 +1890,11 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 	dout(10) << __func__ << " there were no pre-octopus purged snaps"
 		 << dendl;
       }
+
+      // clean out the old removed_snap_ and removed_epoch keys
+      // ('`' is ASCII '_' + 1)
+      t->erase_range(OSD_SNAP_PREFIX, "removed_snap_", "removed_snap`");
+      t->erase_range(OSD_SNAP_PREFIX, "removed_epoch_", "removed_epoch`");
     }
   }
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6797,14 +6797,6 @@ void OSDMonitor::clear_pool_flags(int64_t pool_id, uint64_t flags)
   pool->unset_flag(flags);
 }
 
-string OSDMonitor::make_removed_snap_epoch_key(int64_t pool, epoch_t epoch)
-{
-  char k[80];
-  snprintf(k, sizeof(k), "removed_epoch_%llu_%08lx",
-	   (unsigned long long)pool, (unsigned long)epoch);
-  return k;
-}
-
 string OSDMonitor::make_purged_snap_epoch_key(epoch_t epoch)
 {
   char k[80];
@@ -6812,17 +6804,16 @@ string OSDMonitor::make_purged_snap_epoch_key(epoch_t epoch)
   return k;
 }
 
-string OSDMonitor::_make_snap_key(bool purged, int64_t pool, snapid_t snap)
+string OSDMonitor::make_purged_snap_key(int64_t pool, snapid_t snap)
 {
   char k[80];
-  snprintf(k, sizeof(k), "%s_snap_%llu_%016llx",
-	   purged ? "purged" : "removed",
+  snprintf(k, sizeof(k), "purged_snap_%llu_%016llx",
 	   (unsigned long long)pool, (unsigned long long)snap);
   return k;
 }
 
-string OSDMonitor::_make_snap_key_value(
-  bool purged, int64_t pool, snapid_t snap, snapid_t num,
+string OSDMonitor::make_purged_snap_key_value(
+  int64_t pool, snapid_t snap, snapid_t num,
   epoch_t epoch, bufferlist *v)
 {
   // encode the *last* epoch in the key so that we can use forward
@@ -6830,7 +6821,7 @@ string OSDMonitor::_make_snap_key_value(
   encode(snap, *v);
   encode(snap + num, *v);
   encode(epoch, *v);
-  return _make_snap_key(purged, pool, snap + num - 1);
+  return make_purged_snap_key(pool, snap + num - 1);
 }
 
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -566,10 +566,6 @@ private:
   bool try_prune_purged_snaps();
   int _lookup_snap(bool purged, int64_t pool, snapid_t snap,
 		   snapid_t *begin, snapid_t *end);
-  int lookup_removed_snap(int64_t pool, snapid_t snap,
-			  snapid_t *begin, snapid_t *end) {
-    return _lookup_snap(false, pool, snap, begin,end);
-  }
   int lookup_purged_snap(int64_t pool, snapid_t snap,
 			 snapid_t *begin, snapid_t *end) {
     return _lookup_snap(true, pool, snap, begin,end);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -564,12 +564,8 @@ private:
   }
 
   bool try_prune_purged_snaps();
-  int _lookup_snap(bool purged, int64_t pool, snapid_t snap,
-		   snapid_t *begin, snapid_t *end);
   int lookup_purged_snap(int64_t pool, snapid_t snap,
-			 snapid_t *begin, snapid_t *end) {
-    return _lookup_snap(true, pool, snap, begin,end);
-  }
+			 snapid_t *begin, snapid_t *end);
 
   void insert_snap_update(
     bool purged,

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -541,27 +541,10 @@ private:
   bool _is_removed_snap(int64_t pool_id, snapid_t snapid);
   bool _is_pending_removed_snap(int64_t pool_id, snapid_t snapid);
 
-  string make_removed_snap_epoch_key(int64_t pool, epoch_t epoch);
   string make_purged_snap_epoch_key(epoch_t epoch);
-
-  string _make_snap_key(bool purged, int64_t pool, snapid_t snap);
-  string _make_snap_key_value(bool purged,
-			      int64_t pool, snapid_t snap, snapid_t num,
-			      epoch_t epoch, bufferlist *v);
-  string make_removed_snap_key(int64_t pool, snapid_t snap) {
-    return _make_snap_key(false, pool, snap);
-  }
-  string make_removed_snap_key_value(int64_t pool, snapid_t snap, snapid_t num,
-				     epoch_t epoch, bufferlist *v) {
-    return _make_snap_key_value(false, pool, snap, num, epoch, v);
-  }
-  string make_purged_snap_key(int64_t pool, snapid_t snap) {
-    return _make_snap_key(true, pool, snap);
-  }
+  string make_purged_snap_key(int64_t pool, snapid_t snap);
   string make_purged_snap_key_value(int64_t pool, snapid_t snap, snapid_t num,
-				    epoch_t epoch, bufferlist *v) {
-    return _make_snap_key_value(true, pool, snap, num, epoch, v);
-  }
+				    epoch_t epoch, bufferlist *v);
 
   bool try_prune_purged_snaps();
   int lookup_purged_snap(int64_t pool, snapid_t snap,

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -567,8 +567,7 @@ private:
   int lookup_purged_snap(int64_t pool, snapid_t snap,
 			 snapid_t *begin, snapid_t *end);
 
-  void insert_snap_update(
-    bool purged,
+  void insert_purged_snap_update(
     int64_t pool,
     snapid_t start, snapid_t end,
     epoch_t epoch,


### PR DESCRIPTION
In mimic, we started recording when snaps were deleted in removed_snap_ and removed_epoch_ keys.  This was a partial solution to the problem of the unbounded removed_snaps field in the OSDMap, but it was only an initial step.  Notably the removed_snap_ records weren't being merged when contiguous snaps were removed -- unlike the interval_set in teh OSDMap.

Starting in octopus, merged in #28330, this work was completed.  Now the mon records *purged* snaps in addition to removed snaps.  However, it turns out that the removed_snaps were recorded but never looked at in the final version of that PR.

So,

- stop recording keys for removed_snaps and removed_epoch at all, since we never look at them
- simplify a bunch of code that was generalized so that either purged or removed snaps could be looked up
- add a final step to the octopus upgrade completion that removes old removed_* keys.

The net of this is that the big keys that were building up in mimic and nautilus will get removed.

There is one unbounded key set that remains: purged_epoch_*.  This is a record of which snaps were purged in each epoch, and it's used/mirrored to the OSDs so they can do their OSDMap pruning scrubbing thing.