### PR TITLE
nautilus: ceph-volume: systemd fix typo in log message

### DIFF
--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -99,7 +99,7 @@ def main(args=None):
             # don't log any output to the terminal, just rely on stderr/stdout
             # going to logging
             process.run(command, terminal_logging=False)
-            logger.info('successfully trggered activation for: %s', extra_data)
+            logger.info('successfully triggered activation for: %s', extra_data)
             break
         except RuntimeError as error:
             logger.warning(error)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41956

---

backport of https://github.com/ceph/ceph/pull/30497
parent tracker: https://tracker.ceph.com/issues/41942

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh