### PR TITLE
mgr/dashboard: add debug mode

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -968,7 +968,8 @@ Web UI will automatically allow to choose to which cluster an export belongs.
 Plug-ins
 --------
 
-Dashboard Plug-ins allow to extend the functionality of the dashboard in a modular
-and loosely coupled approach.
+Dashboard Plug-ins extend the functionality of the dashboard in a modular
+and loosely coupled fashion.
 
 .. include:: dashboard_plugins/feature_toggles.inc.rst
+.. include:: dashboard_plugins/debug.inc.rst

--- a/doc/mgr/dashboard_plugins/debug.inc.rst
+++ b/doc/mgr/dashboard_plugins/debug.inc.rst
@@ -1,0 +1,26 @@
+.. _dashboard-debug:
+
+Debug
+^^^^^
+
+This plugin allows to customize the behaviour of the dashboard according to the
+debug mode. It can be enabled, disabled or checked with the following command::
+
+  $ ceph dashboard debug status
+  Debug: 'disabled'
+  $ ceph dashboard debug enable
+  Debug: 'enabled'
+  $ ceph dashboard debug disable
+  Debug: 'disabled'
+
+By default, it's disabled. This is the recommended setting for production
+deployments. If required, debug mode can be enabled without need of restarting.
+Currently, disabled debug mode equals to CherryPy ``production`` environment,
+while when enabled, it uses ``test_suite`` defaults (please refer to
+`CherryPy Environments
+<https://docs.cherrypy.org/en/latest/config.html#environments>`_ for more
+details).
+
+It also adds request uuid (``unique_id``) to Cherrypy on versions that don't
+support this. It additionally prints the ``unique_id`` to error responses and
+log messages.

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -1844,19 +1844,40 @@ In order to create a new plugin, the following steps are required:
 
 #. Add a new file under ``src/pybind/mgr/dashboard/plugins``.
 #. Import the ``PLUGIN_MANAGER`` instance and the ``Interfaces``.
-#. Create a class extending the desired interfaces. The plug-in library will check if all the methods of the interfaces have been properly overridden.
+#. Create a class extending the desired interfaces. The plug-in library will
+   check if all the methods of the interfaces have been properly overridden.
 #. Register the plugin in the ``PLUGIN_MANAGER`` instance.
-#. Import the plug-in from within the Ceph Dashboard ``module.py`` (currently no dynamic loading is implemented).
+#. Import the plug-in from within the Ceph Dashboard ``module.py`` (currently no
+   dynamic loading is implemented).
 
-The available interfaces are the following:
+The available Mixins (helpers) are:
 
 - ``CanMgr``: provides the plug-in with access to the ``mgr`` instance under ``self.mgr``.
 - ``CanLog``: provides the plug-in with access to the Ceph Dashboard logger under ``self.log``.
-- ``Setupable``: requires overriding ``setup()`` hook. This method is run in the Ceph Dashboard ``serve()`` method, right after CherryPy has been configured, but before it is started. It's a placeholder for the plug-in initialization logic.
-- ``HasOptions``: requires overriding ``get_options()`` hook by returning a list of ``Options()``. The options returned here are added to the ``MODULE_OPTIONS``.
-- ``HasCommands``: requires overriding ``register_commands()`` hook by defining the commands the plug-in can handle and decorating them with ``@CLICommand``. The commands can be optionally returned, so that they can be invoked externally (which makes unit testing easier).
-- ``HasControllers``: requires overriding ``get_controllers()`` hook by defining and returning the controllers as usual.
-- ``FilterRequest.BeforeHandler``: requires overriding ``filter_request_before_handler()`` hook. This method receives a ``cherrypy.request`` object for processing. A usual implementation of this method will allow some requests to pass or will raise a ``cherrypy.HTTPError` based on the ``request`` metadata and other conditions.
+
+The available Interfaces are:
+
+- ``Initializable``: requires overriding ``init()`` hook. This method is run at
+  the very beginning of the dashboard module, right after all imports have been
+  performed.
+- ``Setupable``: requires overriding ``setup()`` hook. This method is run in the
+  Ceph Dashboard ``serve()`` method, right after CherryPy has been configured,
+  but before it is started. It's a placeholder for the plug-in initialization
+  logic.
+- ``HasOptions``: requires overriding ``get_options()`` hook by returning a list
+  of ``Options()``. The options returned here are added to the
+  ``MODULE_OPTIONS``.
+- ``HasCommands``: requires overriding ``register_commands()`` hook by defining
+  the commands the plug-in can handle and decorating them with ``@CLICommand``.
+  The commands can be optionally returned, so that they can be invoked
+  externally (which makes unit testing easier).
+- ``HasControllers``: requires overriding ``get_controllers()`` hook by defining
+  and returning the controllers as usual.
+- ``FilterRequest.BeforeHandler``: requires overriding
+  ``filter_request_before_handler()`` hook. This method receives a
+  ``cherrypy.request`` object for processing. A usual implementation of this
+  method will allow some requests to pass or will raise a ``cherrypy.HTTPError`
+  based on the ``request`` metadata and other conditions.
 
 New interfaces and hooks should be added as soon as they are required to
 implement new functionality. The above list only comprises the hooks needed for
@@ -1884,14 +1905,14 @@ A sample plugin implementation would look like this:
 
     @PM.add_hook
     def setup(self):
-      self.mute = self.mgr.get_module_options('mute')
+      self.mute = self.mgr.get_module_option('mute')
 
     @PM.add_hook
     def register_commands(self):
       @CLICommand("dashboard mute")
       def _(mgr):
         self.mute = True
-        self.mgr.set_module_options('mute', True)
+        self.mgr.set_module_option('mute', True)
         return 0
 
     @PM.add_hook
@@ -1908,4 +1929,54 @@ A sample plugin implementation would look like this:
         def get(_):
           return self.mute
 
-      return [FeatureTogglesEndpoint]
+      return [MuteController]
+
+
+Additionally, a helper for creating plugins ``SimplePlugin`` is provided. It
+facilitates the basic tasks (Options, Commands, and common Mixins). The previous
+plugin could be rewritten like this:
+
+.. code-block:: python
+  
+  from . import PLUGIN_MANAGER as PM
+  from . import interfaces as I
+  from .plugin import SimplePlugin as SP
+
+  import cherrypy
+
+  @PM.add_plugin
+  class Mute(SP, I.Setupable, I.FilterRequest.BeforeHandler, I.HasControllers):
+    OPTIONS = [
+        SP.Option('mute', default=False, type='bool')
+    ]
+
+    def shut_up(self):
+      self.set_option('mute', True)
+      self.mute = True
+      return 0
+
+    COMMANDS = [
+        SP.Command("dashboard mute", handler=shut_up)
+    ]
+
+    @PM.add_hook
+    def setup(self):
+      self.mute = self.get_option('mute')
+
+    @PM.add_hook
+    def filter_request_before_handler(self, request):
+      if self.mute:
+        raise cherrypy.HTTPError(500, "I'm muted :-x")
+
+    @PM.add_hook
+    def get_controllers(self):
+      from ..controllers import ApiController, RESTController
+
+      @ApiController('/mute')
+      class MuteController(RESTController):
+        def get(_):
+          return self.mute
+
+      return [MuteController]
+
+

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -1876,7 +1876,7 @@ The available Interfaces are:
 - ``FilterRequest.BeforeHandler``: requires overriding
   ``filter_request_before_handler()`` hook. This method receives a
   ``cherrypy.request`` object for processing. A usual implementation of this
-  method will allow some requests to pass or will raise a ``cherrypy.HTTPError`
+  method will allow some requests to pass or will raise a ``cherrypy.HTTPError``
   based on the ``request`` metadata and other conditions.
 
 New interfaces and hooks should be added as soon as they are required to

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -83,7 +83,10 @@ from .settings import options_command_list, options_schema_list, \
                       handle_option_command
 
 from .plugins import PLUGIN_MANAGER
-from .plugins import feature_toggles  # noqa # pylint: disable=unused-import
+from .plugins import feature_toggles, debug  # noqa # pylint: disable=unused-import
+
+
+PLUGIN_MANAGER.hook.init()
 
 
 # cherrypy likes to sys.exit on error.  don't let it take us down too!
@@ -116,6 +119,11 @@ class CherryPyConfig(object):
     def url_prefix(self):
         return self._url_prefix
 
+    @staticmethod
+    def update_cherrypy_config(config):
+        PLUGIN_MANAGER.hook.configure_cherrypy(config=config)
+        cherrypy.config.update(config)
+
     # pylint: disable=too-many-branches
     def _configure(self):
         """
@@ -141,10 +149,10 @@ class CherryPyConfig(object):
 
         # Initialize custom handlers.
         cherrypy.tools.authenticate = AuthManagerTool()
-        cherrypy.tools.plugin_hooks = cherrypy.Tool(
+        cherrypy.tools.plugin_hooks_filter_request = cherrypy.Tool(
             'before_handler',
             lambda: PLUGIN_MANAGER.hook.filter_request_before_handler(request=cherrypy.request),
-            priority=10)
+            priority=1)
         cherrypy.tools.request_logging = RequestLoggingTool()
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
                                                                         priority=31)
@@ -166,7 +174,7 @@ class CherryPyConfig(object):
             ],
             'tools.json_in.on': True,
             'tools.json_in.force': False,
-            'tools.plugin_hooks.on': True,
+            'tools.plugin_hooks_filter_request.on': True,
         }
 
         if ssl:
@@ -195,7 +203,7 @@ class CherryPyConfig(object):
             config['server.ssl_certificate'] = cert_fname
             config['server.ssl_private_key'] = pkey_fname
 
-        cherrypy.config.update(config)
+        self.update_cherrypy_config(config)
 
         self._url_prefix = prepare_url_prefix(self.get_module_option('url_prefix',
                                                                      default=''))
@@ -338,6 +346,7 @@ class Module(MgrModule, CherryPyConfig):
             config[purl] = {
                 'request.dispatch': mapper
             }
+
         cherrypy.tree.mount(None, config=config)
 
         PLUGIN_MANAGER.hook.setup()

--- a/src/pybind/mgr/dashboard/plugins/__init__.py
+++ b/src/pybind/mgr/dashboard/plugins/__init__.py
@@ -12,6 +12,10 @@ class Interface(object):
     pass
 
 
+class Mixin(object):
+    pass
+
+
 class DashboardPluginManager(object):
     def __init__(self, project_name):
         self.__pm = PluginManager(project_name)
@@ -32,6 +36,11 @@ class DashboardPluginManager(object):
         self.pm.add_hookspecs(cls)
         return cls
 
+    @staticmethod
+    def final(func):
+        setattr(func, '__final__', True)
+        return func
+
     def add_plugin(self, plugin):
         """ Provides decorator interface for PluginManager.register():
             @PLUGIN_MANAGER.add_plugin
@@ -45,6 +54,9 @@ class DashboardPluginManager(object):
         from inspect import getmembers, ismethod
         for interface in plugin.__bases__:
             for method_name, _ in getmembers(interface, predicate=ismethod):
+                if hasattr(getattr(interface, method_name), '__final__'):
+                    continue
+
                 if self.pm.parse_hookimpl_opts(plugin, method_name) is None:
                     raise NotImplementedError(
                         "Plugin '{}' implements interface '{}' but existing"

--- a/src/pybind/mgr/dashboard/plugins/debug.py
+++ b/src/pybind/mgr/dashboard/plugins/debug.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from enum import Enum
+import json
+import uuid
+
+from . import PLUGIN_MANAGER as PM
+from . import interfaces as I  # noqa: E741,N812
+from .plugin import SimplePlugin as SP
+
+
+class Actions(Enum):
+    ENABLE = 'enable'
+    DISABLE = 'disable'
+    STATUS = 'status'
+
+
+@PM.add_plugin  # pylint: disable=too-many-ancestors
+class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy, I.FilterRequest.BeforeHandler):
+    NAME = 'debug'
+
+    OPTIONS = [
+        SP.Option(
+            name=NAME,
+            default=False,
+            type='bool',
+            desc="Enable/disable debug options"
+        )
+    ]
+
+    def handler(self, action):
+        ret = 0
+        msg = ''
+        if action in [Actions.ENABLE.value, Actions.DISABLE.value]:
+            self.set_option(self.NAME, action == Actions.ENABLE.value)
+            self.mgr.update_cherrypy_config({})
+        else:
+            debug = self.get_option(self.NAME)
+            msg = "Debug: '{}'".format('enabled' if debug else 'disabled')
+        return (ret, msg, None)
+
+    COMMANDS = [
+        SP.Command(
+            prefix="dashboard {name}".format(name=NAME),
+            args="name=action,type=CephChoices,strings={states}".format(
+                states="|".join(a.value for a in Actions)),
+            desc="Control and report debug status in Ceph-Dashboard",
+            handler=handler
+        )
+    ]
+
+    def custom_error_response(self, status, message, traceback, version):
+        self.response.headers['Content-Type'] = 'application/json'
+        error_response = dict(status=status, detail=message, request_id=self.request.unique_id)
+
+        if self.get_option(self.NAME):
+            error_response.update(dict(traceback=traceback, version=version))
+
+        return json.dumps(error_response)
+
+    @PM.add_hook
+    def configure_cherrypy(self, config):
+        config.update({
+            'environment': 'test_suite' if self.get_option(self.NAME) else 'production',
+            'error_page.default': self.custom_error_response,
+        })
+
+    @PM.add_hook
+    def filter_request_before_handler(self, request):
+        if not hasattr(request, 'unique_id'):
+            # Cherrypy v8.9.1 doesn't have this property
+            request.unique_id = str(uuid.uuid4())

--- a/src/pybind/mgr/dashboard/plugins/interfaces.py
+++ b/src/pybind/mgr/dashboard/plugins/interfaces.py
@@ -1,17 +1,32 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import PLUGIN_MANAGER as PM, Interface  # pylint: disable=cyclic-import
+from . import PLUGIN_MANAGER as PM, Interface, Mixin  # pylint: disable=cyclic-import
 
 
-class CanMgr(Interface):
+class CanMgr(Mixin):
     from .. import mgr
     mgr = mgr
 
 
-class CanLog(Interface):
+class CanLog(Mixin):
     from .. import logger
     log = logger
+
+
+class CanCherrypy(Mixin):
+    import cherrypy
+    request = cherrypy.request
+    response = cherrypy.response
+
+
+@PM.add_interface
+class Initializable(Interface):
+    @PM.add_abcspec
+    def init(self):
+        """
+        Placeholder for module scope initialization
+        """
 
 
 @PM.add_interface
@@ -42,6 +57,13 @@ class HasCommands(Interface):
 class HasControllers(Interface):
     @PM.add_abcspec
     def get_controllers(self):
+        pass
+
+
+@PM.add_interface
+class ConfiguresCherryPy(Interface):
+    @PM.add_abcspec
+    def configure_cherrypy(self, config):
         pass
 
 

--- a/src/pybind/mgr/dashboard/plugins/plugin.py
+++ b/src/pybind/mgr/dashboard/plugins/plugin.py
@@ -1,0 +1,33 @@
+from mgr_module import Option, Command
+
+from . import PLUGIN_MANAGER as PM
+from . import interfaces as I  # noqa: E741,N812
+
+
+class SimplePlugin(I.CanMgr, I.CanLog, I.HasOptions, I.HasCommands):
+    """
+    Helper class that provides simplified creation of plugins:
+        - Default Mixins/Interfaces: CanMgr, CanLog, HasOptions & HasCommands
+    - Options are defined by OPTIONS class variable, instead from get_options hook
+    - Commands are created with by COMMANDS list of Commands() and handlers
+    (less compact than CLICommand, but allows using method instances)
+    """
+    Option = Option
+    Command = Command
+
+    @PM.add_hook
+    def get_options(self):
+        return self.OPTIONS
+
+    @PM.final
+    def get_option(self, option):
+        return self.mgr.get_module_option(option)
+
+    @PM.final
+    def set_option(self, option, value):
+        self.mgr.set_module_option(option, value)
+
+    @PM.add_hook
+    def register_commands(self):
+        for cmd in self.COMMANDS:
+            cmd.register(instance=self)

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -123,9 +123,9 @@ class RequestLoggingTool(cherrypy.Tool):
                       req.remote.port, req.method, status,
                       "{0:.3f}s".format(lat), user, length, req.path_info)
         else:
-            logger_fn("[%s:%s] [%s] [%s] [%s] [%s] %s", req.remote.ip,
+            logger_fn("[%s:%s] [%s] [%s] [%s] [%s] [%s] %s", req.remote.ip,
                       req.remote.port, req.method, status,
-                      "{0:.3f}s".format(lat), length, req.path_info)
+                      "{0:.3f}s".format(lat), length, getattr(req, 'unique_id', '-'), req.path_info)
 
 
 # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
New command `dashboard debug <status|enable|disable>` added. By default, debug is disabled. This now hides Python tracebacks in HTTP responses (which could reveal sensitive details of the underlying environment, like python version, filesystem locations, etc.):

```diff
{"status": "500 Internal Server Error",
"detail": "The server encountered an unexpected condition which prevented it from fulfilling the request.",
- "traceback": "Traceback (most recent call last):
-  File "/usr/lib/python3.7/site-packages/cherrypy/_cprequest.py", line 670, in respond response.body = self.handler()
-  File "/usr/lib/python3.7/site-packages/cherrypy/lib/encoding.py", line 220, in __call__↵    self.body = self.oldhandler(*args, **kwargs)↵
-  File "/usr/lib/python3.7/site-packages/cherrypy/_cptools.py", line 237, in wrap↵    return self.newhandler(innerfunc, *args, **kwargs)↵
-  File "/ceph/src/pybind/mgr/dashboard/services/exception.py", line 88, in dashboard_exception_handler↵    return handler(*args, **kwargs)↵
-  File "/usr/lib/python3.7/site-packages/cherrypy/_cpdispatch.py", line 60, in __call__↵    return self.callable(*self.args, **self.kwargs)↵  
-  File "/ceph/src/pybind/mgr/dashboard/controllers/__init__.py", line 645, in inner↵    ret = func(*args, **kwargs)↵ 
-  File "/ceph/src/pybind/mgr/dashboard/controllers/__init__.py", line 838, in wrapper↵    return func(*vpath, **params)↵  
-  File "/ceph/src/pybind/mgr/dashboard/controllers/mgr_modules.py", line 24, in list↵    always_on_modules = mgr_map['always_on_modules'][mgr.release_name]↵  
-  File "/ceph/src/pybind/mgr/dashboard/__init__.py", line 33, in __getattr__↵    return getattr(self._mgr, item)↵  
-  File "/ceph/src/pybind/mgr/mgr_module.py", line 594, in release_name↵    return self._ceph_get_release_name()↵AttributeError: 'Module' object has no attribute '_ceph_get_release_name'↵"
+ "traceback": "",
"version": "8.9.1"}   
```
Fixes: https://tracker.ceph.com/issues/41990
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
