### PR TITLE
mon/MonClient: skip CEPHX_V2 challenge if client doesn't support it

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1461,6 +1461,18 @@ int MonClient::handle_auth_request(
 	       << auth_method << dendl;
     return -EOPNOTSUPP;
   }
+
+  auto ac = &auth_meta->authorizer_challenge;
+  if (!HAVE_FEATURE(con->get_features(), CEPHX_V2)) {
+    if (cct->_conf->cephx_service_require_version >= 2) {
+      ldout(cct,10) << __func__ << " client missing CEPHX_V2 ("
+		    << "cephx_service_requre_version = "
+		    << cct->_conf->cephx_service_require_version << ")" << dendl;
+      return -EACCES;
+    }
+    ac = nullptr;
+  }
+
   bool was_challenge = (bool)auth_meta->authorizer_challenge;
   bool isvalid = ah->verify_authorizer(
     cct,
@@ -1473,7 +1485,7 @@ int MonClient::handle_auth_request(
     &con->peer_caps_info,
     &auth_meta->session_key,
     &auth_meta->connection_secret,
-    &auth_meta->authorizer_challenge);
+    ac);
   if (isvalid) {
     handle_authentication_dispatcher->ms_handle_authentication(con);
     return 1;


### PR DESCRIPTION
If the client doesn't support the CEPHX_V2 challenge, and we don't require
it, skip it.  This allows the client to authenticate without getting an
error like

  cephx: verify_reply couldn't decrypt with error: error decoding block for decryption

Note that we don't have this problem in the monitor exchange in
Monitor::handle_auth_request() because that verify_authorizer() caller is
only used for msgrv2, and all such clients support CEPHX_V2.  Instead,
those client authenticate via the MAuth messages, a path that does not use
authorizers at all.

Fixes: https://tracker.ceph.com/issues/40716
Signed-off-by: Sage Weil <sage@redhat.com>