### PR TITLE
nautilus: core: msg,mon/MonClient: fix auth for clients without CEPHX_V2 feature

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1927,6 +1927,9 @@ CtPtr ProtocolV1::handle_connect_message_2() {
         connection->policy.features_required |= CEPH_FEATURE_MSG_AUTH;
       }
     }
+    if (cct->_conf->cephx_service_require_version >= 2) {
+      connection->policy.features_required |= CEPH_FEATURE_CEPHX_V2;
+    }
   }
 
   uint64_t feat_missing =


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42013

---

Backport of #30523, plus a nautilus-specific fix
parent tracker: https://tracker.ceph.com/issues/40716