### PR TITLE
nautilus: core: osd/PeeringState: recover_got - add special handler for empty log and improvements to standalone tests

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -135,7 +135,7 @@ do
 	    CEPH_ROOT=.. \
 	    CEPH_LIB=lib \
 	    LOCALRUN=yes \
-	    $cmd ; then
+	    time -f "Elapsed %E (%e seconds)" $cmd ; then
           echo "$f .............. FAILED"
           errors=$(expr $errors + 1)
         fi

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -673,6 +673,10 @@ EOF
     echo start osd.$id
     ceph-osd -i $id $ceph_args &
 
+    # If noup is set, then can't wait for this osd
+    if ceph osd dump --format=json | jq '.flags_set[]' | grep -q '"noup"' ; then
+      return 0
+    fi
     wait_for_osd up $id || return 1
 
 }
@@ -722,6 +726,10 @@ EOF
     echo start osd.$id
     ceph-osd -i $id $ceph_args &
 
+    # If noup is set, then can't wait for this osd
+    if ceph osd dump --format=json | jq '.flags_set[]' | grep -q '"noup"' ; then
+      return 0
+    fi
     wait_for_osd up $id || return 1
 
 
@@ -859,6 +867,10 @@ function activate_osd() {
 
     [ "$id" = "$(cat $osd_data/whoami)" ] || return 1
 
+    # If noup is set, then can't wait for this osd
+    if ceph osd dump --format=json | jq '.flags_set[]' | grep -q '"noup"' ; then
+      return 0
+    fi
     wait_for_osd up $id || return 1
 }
 
@@ -2148,6 +2160,24 @@ function multidiff() {
         fi
         diff $DIFFCOLOPTS $@
     fi
+}
+
+function create_ec_pool() {
+    local pool_name=$1
+    shift
+    local allow_overwrites=$1
+    shift
+
+    ceph osd erasure-code-profile set myprofile crush-failure-domain=osd "$@" || return 1
+
+    create_pool "$poolname" 1 1 erasure myprofile || return 1
+
+    if [ "$allow_overwrites" = "true" ]; then
+        ceph osd pool set "$poolname" allow_ec_overwrites true || return 1
+    fi
+
+    wait_for_clean || return 1
+    return 0
 }
 
 # Local Variables:

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -677,7 +677,7 @@ EOF
 
 }
 
-function run_osd_bluestore() {
+function run_osd_filestore() {
     local dir=$1
     shift
     local id=$1
@@ -710,7 +710,7 @@ function run_osd_bluestore() {
     echo "{\"cephx_secret\": \"$OSD_SECRET\"}" > $osd_data/new.json
     ceph osd new $uuid -i $osd_data/new.json
     rm $osd_data/new.json
-    ceph-osd -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid --osd-objectstore=bluestore
+    ceph-osd -i $id $ceph_args --mkfs --key $OSD_SECRET --osd-uuid $uuid --osd-objectstore=filestore
 
     local key_fn=$osd_data/keyring
     cat > $key_fn<<EOF
@@ -1179,13 +1179,8 @@ function _objectstore_tool_nodown() {
     shift
     local osd_data=$dir/$id
 
-    local journal_args
-    if [ "$objectstore_type" == "filestore" ]; then
-	journal_args=" --journal-path $osd_data/journal"
-    fi
     ceph-objectstore-tool \
         --data-path $osd_data \
-        $journal_args \
         "$@" || return 1
 }
 
@@ -2133,7 +2128,8 @@ function inject_eio() {
     if [ "$pooltype" != "ec" ]; then
         shard_id=""
     fi
-    set_config osd $osd_id filestore_debug_inject_read_err true || return 1
+    type=$(cat $dir/$osd_id/type)
+    set_config osd $osd_id ${type}_debug_inject_read_err true || return 1
     local loop=0
     while ( CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.$osd_id) \
              inject${which}err $poolname $objname $shard_id | grep -q Invalid ); do

--- a/qa/standalone/erasure-code/test-erasure-eio.sh
+++ b/qa/standalone/erasure-code/test-erasure-eio.sh
@@ -26,7 +26,6 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--osd-objectstore=filestore "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do

--- a/qa/standalone/mon/mon-osdmap-prune.sh
+++ b/qa/standalone/mon/mon-osdmap-prune.sh
@@ -4,11 +4,6 @@ source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
 
 base_test=$CEPH_ROOT/qa/workunits/mon/test_mon_osdmap_prune.sh
 
-# We are going to open and close a lot of files, and generate a lot of maps
-# that the osds will need to process. If we don't increase the fd ulimit, we
-# risk having the osds asserting when handling filestore transactions.
-ulimit -n 4096
-
 function run() {
 
   local dir=$1

--- a/qa/standalone/mon/osd-pool-create.sh
+++ b/qa/standalone/mon/osd-pool-create.sh
@@ -212,12 +212,11 @@ function TEST_pool_create_rep_expected_num_objects() {
     local dir=$1
     setup $dir || return 1
 
-    # disable pg dir merge
-    CEPH_ARGS+="--osd-objectstore=filestore"
     export CEPH_ARGS
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
-    run_osd $dir 0 || return 1
+    # disable pg dir merge
+    run_osd_filestore $dir 0 || return 1
 
     ceph osd pool create rep_expected_num_objects 64 64 replicated  replicated_rule 100000 || return 1
     # wait for pg dir creating

--- a/qa/standalone/osd/divergent-priors.sh
+++ b/qa/standalone/osd/divergent-priors.sh
@@ -1,0 +1,630 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 Red Hat <contact@redhat.com>
+#
+# Author: David Zafman <dzafman@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    # This should multiple of 6
+    export loglen=12
+    export divisor=3
+    export trim=$(expr $loglen / 2)
+    export DIVERGENT_WRITE=$(expr $trim / $divisor)
+    export DIVERGENT_REMOVE=$(expr $trim / $divisor)
+    export DIVERGENT_CREATE=$(expr $trim / $divisor)
+    export poolname=test
+    export testobjects=100
+    # Fix port????
+    export CEPH_MON="127.0.0.1:7115" # git grep '\<7115\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    # so we will not force auth_log_shard to be acting_primary
+    CEPH_ARGS+="--osd_force_auth_primary_missing_objects=1000000 "
+    CEPH_ARGS+="--osd_debug_pg_log_writeout=true "
+    CEPH_ARGS+="--osd_min_pg_log_entries=$loglen --osd_max_pg_log_entries=$loglen --osd_pg_log_trim_min=$trim "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+
+# Special case divergence test
+#	Test handling of divergent entries with prior_version
+#	prior to log_tail
+# 	based on qa/tasks/divergent_prior.py
+function TEST_divergent() {
+    local dir=$1
+
+    # something that is always there
+    local dummyfile='/etc/fstab'
+    local dummyfile2='/etc/resolv.conf'
+
+    local num_osds=3
+    local osds="$(seq 0 $(expr $num_osds - 1))"
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for i in $osds
+    do
+      run_osd $dir $i || return 1
+    done
+
+    ceph osd set noout
+    ceph osd set noin
+    ceph osd set nodown
+    create_pool $poolname 1 1
+    ceph osd pool set $poolname size 3
+    ceph osd pool set $poolname min_size 2
+
+    flush_pg_stats || return 1
+    wait_for_clean || return 1
+
+    # determine primary
+    local divergent="$(ceph pg dump pgs --format=json | jq '.pg_stats[0].up_primary')"
+    echo "primary and soon to be divergent is $divergent"
+    ceph pg dump pgs
+    local non_divergent=""
+    for i in $osds
+    do
+      if [ "$i" = "$divergent" ]; then
+	  continue
+      fi
+      non_divergent="$non_divergent $i"
+    done
+
+    echo "writing initial objects"
+    # write a bunch of objects
+    for i in $(seq 1 $testobjects)
+    do
+      rados -p $poolname put existing_$i $dummyfile
+    done
+
+    WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    local pgid=$(get_pg $poolname existing_1)
+
+    # blackhole non_divergent
+    echo "blackholing osds $non_divergent"
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${i}) config set objectstore_blackhole 1
+    done
+
+    local case5=$testobjects
+    local case3=$(expr $testobjects - 1)
+    # Write some soon to be divergent
+    echo 'writing divergent object'
+    rados -p $poolname put existing_$case5 $dummyfile &
+    echo 'create missing divergent object'
+    inject_eio rep data $poolname existing_$case3 $dir 0 || return 1
+    rados -p $poolname get existing_$case3 $dir/existing &
+    sleep 10
+    killall -9 rados
+
+    # kill all the osds but leave divergent in
+    echo 'killing all the osds'
+    ceph pg dump pgs
+    kill_daemons $dir KILL osd || return 1
+    for i in $osds
+    do
+      ceph osd down osd.$i
+    done
+    for i in $non_divergent
+    do
+      ceph osd out osd.$i
+    done
+
+    # bring up non-divergent
+    echo "bringing up non_divergent $non_divergent"
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      activate_osd $dir $i || return 1
+    done
+    for i in $non_divergent
+    do
+      ceph osd in osd.$i
+    done
+
+    WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    # write 1 non-divergent object (ensure that old divergent one is divergent)
+    objname="existing_$(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE)"
+    echo "writing non-divergent object $objname"
+    ceph pg dump pgs
+    rados -p $poolname put $objname $dummyfile2
+
+    # ensure no recovery of up osds first
+    echo 'delay recovery'
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${i}) set_recovery_delay 100000
+    done
+
+    # bring in our divergent friend
+    echo "revive divergent $divergent"
+    ceph pg dump pgs
+    ceph osd set noup
+    activate_osd $dir $divergent
+    sleep 5
+
+    echo 'delay recovery divergent'
+    ceph pg dump pgs
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${divergent}) set_recovery_delay 100000
+
+    ceph osd unset noup
+
+    wait_for_osd up 0
+    wait_for_osd up 1
+    wait_for_osd up 2
+
+    ceph pg dump pgs
+    echo 'wait for peering'
+    ceph pg dump pgs
+    rados -p $poolname put foo $dummyfile
+
+    echo "killing divergent $divergent"
+    ceph pg dump pgs
+    kill_daemons $dir KILL osd.$divergent
+    #_objectstore_tool_nodown $dir $divergent --op log --pgid $pgid
+    echo "reviving divergent $divergent"
+    ceph pg dump pgs
+    activate_osd $dir $divergent
+
+    sleep 20
+
+    echo "allowing recovery"
+    ceph pg dump pgs
+    # Set osd_recovery_delay_start back to 0 and kick the queue
+    for i in $osds
+    do
+	 ceph tell osd.$i debug kick_recovery_wq 0
+    done
+
+    echo 'reading divergent objects'
+    ceph pg dump pgs
+    for i in $(seq 1 $(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE))
+    do
+      rados -p $poolname get existing_$i $dir/existing || return 1
+    done
+    rm -f $dir/existing
+
+    grep _merge_object_divergent_entries $(find $dir -name '*osd*log')
+    # Check for _merge_object_divergent_entries for case #5
+    if ! grep -q "_merge_object_divergent_entries.*cannot roll back, removing and adding to missing" $(find $dir -name '*osd*log')
+    then
+	    echo failure
+	    return 1
+    fi
+    echo "success"
+
+    delete_pool $poolname
+    kill_daemons $dir || return 1
+}
+
+function TEST_divergent_ec() {
+    local dir=$1
+
+    # something that is always there
+    local dummyfile='/etc/fstab'
+    local dummyfile2='/etc/resolv.conf'
+
+    local num_osds=3
+    local osds="$(seq 0 $(expr $num_osds - 1))"
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for i in $osds
+    do
+      run_osd $dir $i || return 1
+    done
+
+    ceph osd set noout
+    ceph osd set noin
+    ceph osd set nodown
+    create_ec_pool $poolname true k=2 m=1 || return 1
+
+    flush_pg_stats || return 1
+    wait_for_clean || return 1
+
+    # determine primary
+    local divergent="$(ceph pg dump pgs --format=json | jq '.pg_stats[0].up_primary')"
+    echo "primary and soon to be divergent is $divergent"
+    ceph pg dump pgs
+    local non_divergent=""
+    for i in $osds
+    do
+      if [ "$i" = "$divergent" ]; then
+	  continue
+      fi
+      non_divergent="$non_divergent $i"
+    done
+
+    echo "writing initial objects"
+    # write a bunch of objects
+    for i in $(seq 1 $testobjects)
+    do
+      rados -p $poolname put existing_$i $dummyfile
+    done
+
+    WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    local pgid=$(get_pg $poolname existing_1)
+
+    # blackhole non_divergent
+    echo "blackholing osds $non_divergent"
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${i}) config set objectstore_blackhole 1
+    done
+
+    # Write some soon to be divergent
+    echo 'writing divergent object'
+    rados -p $poolname put existing_$testobjects $dummyfile2 &
+    sleep 1
+    rados -p $poolname put existing_$testobjects $dummyfile &
+    rados -p $poolname mksnap snap1
+    rados -p $poolname put existing_$(expr $testobjects - 1) $dummyfile &
+    sleep 10
+    killall -9 rados
+
+    # kill all the osds but leave divergent in
+    echo 'killing all the osds'
+    ceph pg dump pgs
+    kill_daemons $dir KILL osd || return 1
+    for i in $osds
+    do
+      ceph osd down osd.$i
+    done
+    for i in $non_divergent
+    do
+      ceph osd out osd.$i
+    done
+
+    # bring up non-divergent
+    echo "bringing up non_divergent $non_divergent"
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      activate_osd $dir $i || return 1
+    done
+    for i in $non_divergent
+    do
+      ceph osd in osd.$i
+    done
+
+    sleep 5
+    #WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    # write 1 non-divergent object (ensure that old divergent one is divergent)
+    objname="existing_$(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE)"
+    echo "writing non-divergent object $objname"
+    ceph pg dump pgs
+    rados -p $poolname put $objname $dummyfile2
+
+    WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    # Dump logs
+    for i in $non_divergent
+    do
+      kill_daemons $dir KILL osd.$i || return 1
+      _objectstore_tool_nodown $dir $i --op log --pgid $pgid
+      activate_osd $dir $i || return 1
+    done
+    _objectstore_tool_nodown $dir $divergent --op log --pgid $pgid
+
+    WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    # ensure no recovery of up osds first
+    echo 'delay recovery'
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${i}) set_recovery_delay 100000
+    done
+
+    # bring in our divergent friend
+    echo "revive divergent $divergent"
+    ceph pg dump pgs
+    ceph osd set noup
+    activate_osd $dir $divergent
+    sleep 5
+
+    echo 'delay recovery divergent'
+    ceph pg dump pgs
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${divergent}) set_recovery_delay 100000
+
+    ceph osd unset noup
+
+    wait_for_osd up 0
+    wait_for_osd up 1
+    wait_for_osd up 2
+
+    ceph pg dump pgs
+    echo 'wait for peering'
+    ceph pg dump pgs
+    rados -p $poolname put foo $dummyfile
+
+    echo "killing divergent $divergent"
+    ceph pg dump pgs
+    kill_daemons $dir KILL osd.$divergent
+    #_objectstore_tool_nodown $dir $divergent --op log --pgid $pgid
+    echo "reviving divergent $divergent"
+    ceph pg dump pgs
+    activate_osd $dir $divergent
+
+    sleep 20
+
+    echo "allowing recovery"
+    ceph pg dump pgs
+    # Set osd_recovery_delay_start back to 0 and kick the queue
+    for i in $osds
+    do
+	 ceph tell osd.$i debug kick_recovery_wq 0
+    done
+
+    echo 'reading divergent objects'
+    ceph pg dump pgs
+    for i in $(seq 1 $(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE))
+    do
+      rados -p $poolname get existing_$i $dir/existing || return 1
+    done
+    rm -f $dir/existing
+
+    grep _merge_object_divergent_entries $(find $dir -name '*osd*log')
+    # Check for _merge_object_divergent_entries for case #3
+    # XXX: Not reproducing this case
+#    if ! grep -q "_merge_object_divergent_entries.* missing, .* adjusting" $(find $dir -name '*osd*log')
+#    then
+#	echo failure
+#	return 1
+#    fi
+    # Check for _merge_object_divergent_entries for case #4
+    if ! grep -q "_merge_object_divergent_entries.*rolled back" $(find $dir -name '*osd*log')
+    then
+	echo failure
+	return 1
+    fi
+    echo "success"
+
+    delete_pool $poolname
+    kill_daemons $dir || return 1
+}
+
+# Special case divergence test with ceph-objectstore-tool export/remove/import
+# 	Test handling of divergent entries with prior_version
+# 	prior to log_tail and a ceph-objectstore-tool export/import
+# 	based on qa/tasks/divergent_prior2.py
+function TEST_divergent_2() {
+    local dir=$1
+
+    # something that is always there
+    local dummyfile='/etc/fstab'
+    local dummyfile2='/etc/resolv.conf'
+
+    local num_osds=3
+    local osds="$(seq 0 $(expr $num_osds - 1))"
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for i in $osds
+    do
+      run_osd $dir $i || return 1
+    done
+
+    ceph osd set noout
+    ceph osd set noin
+    ceph osd set nodown
+    create_pool $poolname 1 1
+    ceph osd pool set $poolname size 3
+    ceph osd pool set $poolname min_size 2
+
+    flush_pg_stats || return 1
+    wait_for_clean || return 1
+
+    # determine primary
+    local divergent="$(ceph pg dump pgs --format=json | jq '.pg_stats[0].up_primary')"
+    echo "primary and soon to be divergent is $divergent"
+    ceph pg dump pgs
+    local non_divergent=""
+    for i in $osds
+    do
+      if [ "$i" = "$divergent" ]; then
+	  continue
+      fi
+      non_divergent="$non_divergent $i"
+    done
+
+    echo "writing initial objects"
+    # write a bunch of objects
+    for i in $(seq 1 $testobjects)
+    do
+      rados -p $poolname put existing_$i $dummyfile
+    done
+
+    WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    local pgid=$(get_pg $poolname existing_1)
+
+    # blackhole non_divergent
+    echo "blackholing osds $non_divergent"
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${i}) config set objectstore_blackhole 1
+    done
+
+    # Do some creates to hit case 2
+    echo 'create new divergent objects'
+    for i in $(seq 1 $DIVERGENT_CREATE)
+    do
+      rados -p $poolname create newobject_$i &
+    done
+    # Write some soon to be divergent
+    echo 'writing divergent objects'
+    for i in $(seq 1 $DIVERGENT_WRITE)
+    do
+      rados -p $poolname put existing_$i $dummyfile2 &
+    done
+    # Remove some soon to be divergent
+    echo 'remove divergent objects'
+    for i in $(seq 1 $DIVERGENT_REMOVE)
+    do
+      rmi=$(expr $i + $DIVERGENT_WRITE)
+      rados -p $poolname rm existing_$rmi &
+    done
+    sleep 10
+    killall -9 rados
+
+    # kill all the osds but leave divergent in
+    echo 'killing all the osds'
+    ceph pg dump pgs
+    kill_daemons $dir KILL osd || return 1
+    for i in $osds
+    do
+      ceph osd down osd.$i
+    done
+    for i in $non_divergent
+    do
+      ceph osd out osd.$i
+    done
+
+    # bring up non-divergent
+    echo "bringing up non_divergent $non_divergent"
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      activate_osd $dir $i || return 1
+    done
+    for i in $non_divergent
+    do
+      ceph osd in osd.$i
+    done
+
+    WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    # write 1 non-divergent object (ensure that old divergent one is divergent)
+    objname="existing_$(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE)"
+    echo "writing non-divergent object $objname"
+    ceph pg dump pgs
+    rados -p $poolname put $objname $dummyfile2
+
+    WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
+
+    # ensure no recovery of up osds first
+    echo 'delay recovery'
+    ceph pg dump pgs
+    for i in $non_divergent
+    do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${i}) set_recovery_delay 100000
+    done
+
+    # bring in our divergent friend
+    echo "revive divergent $divergent"
+    ceph pg dump pgs
+    ceph osd set noup
+    activate_osd $dir $divergent
+    sleep 5
+
+    echo 'delay recovery divergent'
+    ceph pg dump pgs
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${divergent}) set_recovery_delay 100000
+
+    ceph osd unset noup
+
+    wait_for_osd up 0
+    wait_for_osd up 1
+    wait_for_osd up 2
+
+    ceph pg dump pgs
+    echo 'wait for peering'
+    ceph pg dump pgs
+    rados -p $poolname put foo $dummyfile
+
+    # At this point the divergent_priors should have been detected
+
+    echo "killing divergent $divergent"
+    ceph pg dump pgs
+    kill_daemons $dir KILL osd.$divergent
+
+    # export a pg
+    expfile=$dir/exp.$$.out
+    _objectstore_tool_nodown $dir $divergent --op export-remove --pgid $pgid --file $expfile
+    _objectstore_tool_nodown $dir $divergent --op import --file $expfile
+
+    echo "reviving divergent $divergent"
+    ceph pg dump pgs
+    activate_osd $dir $divergent
+    wait_for_osd up $divergent
+
+    sleep 20
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${divergent}) dump_ops_in_flight
+
+    echo "allowing recovery"
+    ceph pg dump pgs
+    # Set osd_recovery_delay_start back to 0 and kick the queue
+    for i in $osds
+    do
+	 ceph tell osd.$i debug kick_recovery_wq 0
+    done
+
+    echo 'reading divergent objects'
+    ceph pg dump pgs
+    for i in $(seq 1 $(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE))
+    do
+      rados -p $poolname get existing_$i $dir/existing || return 1
+    done
+    for i in $(seq 1 $DIVERGENT_CREATE)
+    do
+      rados -p $poolname get newobject_$i $dir/existing
+    done
+    rm -f $dir/existing
+
+    grep _merge_object_divergent_entries $(find $dir -name '*osd*log')
+    # Check for _merge_object_divergent_entries for case #1
+    if ! grep -q "_merge_object_divergent_entries: more recent entry found:" $(find $dir -name '*osd*log')
+    then
+	    echo failure
+	    return 1
+    fi
+    # Check for _merge_object_divergent_entries for case #2
+    if ! grep -q "_merge_object_divergent_entries.*prior_version or op type indicates creation" $(find $dir -name '*osd*log')
+    then
+	    echo failure
+	    return 1
+    fi
+    echo "success"
+
+    rm $dir/$expfile
+
+    delete_pool $poolname
+    kill_daemons $dir || return 1
+}
+
+
+main divergent-priors "$@"
+
+# Local Variables:
+# compile-command: "make -j4 && ../qa/run-standalone.sh divergent-priors.sh"
+# End:

--- a/qa/standalone/osd/ec-error-rollforward.sh
+++ b/qa/standalone/osd/ec-error-rollforward.sh
@@ -10,7 +10,7 @@ function run() {
     export CEPH_MON="127.0.0.1:7132" # git grep '\<7132\>' : there must be only one
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
-    CEPH_ARGS+="--mon-host=$CEPH_MON --osd-objectstore filestore"
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
     export margin=10
     export objects=200
     export poolname=test

--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -38,13 +38,13 @@ function TEST_bluestore() {
 
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
-    run_osd_bluestore $dir 0 || return 1
+    run_osd $dir 0 || return 1
     osd_pid0=$(cat $dir/osd.0.pid)
-    run_osd_bluestore $dir 1 || return 1
+    run_osd $dir 1 || return 1
     osd_pid1=$(cat $dir/osd.1.pid)
-    run_osd_bluestore $dir 2 || return 1
+    run_osd $dir 2 || return 1
     osd_pid2=$(cat $dir/osd.2.pid)
-    run_osd_bluestore $dir 3 || return 1
+    run_osd $dir 3 || return 1
     osd_pid3=$(cat $dir/osd.3.pid)
 
     sleep 5
@@ -140,13 +140,13 @@ function TEST_bluestore() {
 
     ceph-bluestore-tool --path $dir/3 fsck || return 1
 
-    run_osd_bluestore $dir 0 || return 1
+    run_osd $dir 0 || return 1
     osd_pid0=$(cat $dir/osd.0.pid)
-    run_osd_bluestore $dir 1 || return 1
+    run_osd $dir 1 || return 1
     osd_pid1=$(cat $dir/osd.1.pid)
-    run_osd_bluestore $dir 2 || return 1
+    run_osd $dir 2 || return 1
     osd_pid2=$(cat $dir/osd.2.pid)
-    run_osd_bluestore $dir 3 || return 1
+    run_osd $dir 3 || return 1
     osd_pid3=$(cat $dir/osd.3.pid)
 
     wait_for_clean || return 1
@@ -218,13 +218,13 @@ function TEST_bluestore() {
 
     ceph-bluestore-tool --path $dir/3 fsck || return 1
 
-    run_osd_bluestore $dir 0 || return 1
+    run_osd $dir 0 || return 1
     osd_pid0=$(cat $dir/osd.0.pid)
-    run_osd_bluestore $dir 1 || return 1
+    run_osd $dir 1 || return 1
     osd_pid1=$(cat $dir/osd.1.pid)
-    run_osd_bluestore $dir 2 || return 1
+    run_osd $dir 2 || return 1
     osd_pid2=$(cat $dir/osd.2.pid)
-    run_osd_bluestore $dir 3 || return 1
+    run_osd $dir 3 || return 1
     osd_pid3=$(cat $dir/osd.3.pid)
 
     # write some objects
@@ -324,13 +324,13 @@ function TEST_bluestore() {
 
     ceph-bluestore-tool --path $dir/3 fsck || return 1
 
-    run_osd_bluestore $dir 0 || return 1
+    run_osd $dir 0 || return 1
     osd_pid0=$(cat $dir/osd.0.pid)
-    run_osd_bluestore $dir 1 || return 1
+    run_osd $dir 1 || return 1
     osd_pid1=$(cat $dir/osd.1.pid)
-    run_osd_bluestore $dir 2 || return 1
+    run_osd $dir 2 || return 1
     osd_pid2=$(cat $dir/osd.2.pid)
-    run_osd_bluestore $dir 3 || return 1
+    run_osd $dir 3 || return 1
     osd_pid3=$(cat $dir/osd.3.pid)
 
     # write some objects

--- a/qa/standalone/osd/osd-dup.sh
+++ b/qa/standalone/osd/osd-dup.sh
@@ -33,10 +33,10 @@ function TEST_filestore_to_bluestore() {
 
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
-    run_osd $dir 0 || return 1
+    run_osd_filestore $dir 0 || return 1
     osd_pid=$(cat $dir/osd.0.pid)
-    run_osd $dir 1 || return 1
-    run_osd $dir 2 || return 1
+    run_osd_filestore $dir 1 || return 1
+    run_osd_filestore $dir 2 || return 1
 
     sleep 5
 
@@ -61,7 +61,7 @@ function TEST_filestore_to_bluestore() {
 			  --op dup || return 1
     CEPH_ARGS=$O
 
-    run_osd_bluestore $dir 0 || return 1
+    run_osd $dir 0 || return 1
 
     while ! ceph osd stat | grep '3 up' ; do sleep 1 ; done
     ceph osd metadata 0 | grep bluestore || return 1

--- a/qa/standalone/osd/osd-rep-recov-eio.sh
+++ b/qa/standalone/osd/osd-rep-recov-eio.sh
@@ -27,7 +27,7 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
-    CEPH_ARGS+="--osd-objectstore=filestore "
+
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
@@ -44,9 +44,10 @@ function run() {
 function setup_osds() {
     local count=$1
     shift
+    local type=$1
 
     for id in $(seq 0 $(expr $count - 1)) ; do
-        run_osd $dir $id || return 1
+        run_osd${type} $dir $id || return 1
     done
     wait_for_clean || return 1
 }
@@ -331,7 +332,7 @@ function TEST_rep_read_unfound() {
     local dir=$1
     local objname=myobject
 
-    setup_osds 3 || return 1
+    setup_osds 3 _filestore || return 1
 
     ceph osd pool delete foo foo --yes-i-really-really-mean-it || return 1
     local poolname=test-pool

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -190,24 +190,6 @@ function corrupt_and_repair_erasure_coded() {
 
 }
 
-function create_ec_pool() {
-    local pool_name=$1
-    shift
-    local allow_overwrites=$1
-    shift
-
-    ceph osd erasure-code-profile set myprofile crush-failure-domain=osd "$@" || return 1
-
-    create_pool "$poolname" 1 1 erasure myprofile || return 1
-
-    if [ "$allow_overwrites" = "true" ]; then
-        ceph osd pool set "$poolname" allow_ec_overwrites true || return 1
-    fi
-
-    wait_for_clean || return 1
-    return 0
-}
-
 function auto_repair_erasure_coded() {
     local dir=$1
     local allow_overwrites=$2

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -56,7 +56,6 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
     CEPH_ARGS+="--osd-skip-data-digest=false "
-    CEPH_ARGS+="--osd-objectstore=filestore "
 
     export -n CEPH_CLI_TEST_DUP_COMMAND
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
@@ -225,9 +224,9 @@ function auto_repair_erasure_coded() {
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
 	if [ "$allow_overwrites" = "true" ]; then
-            run_osd_bluestore $dir $id $ceph_osd_args || return 1
-	else
             run_osd $dir $id $ceph_osd_args || return 1
+	else
+            run_osd_filestore $dir $id $ceph_osd_args || return 1
 	fi
     done
     create_rbd_pool || return 1
@@ -280,7 +279,7 @@ function TEST_auto_repair_bluestore_basic() {
 	    --osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
-        run_osd_bluestore $dir $id $ceph_osd_args || return 1
+        run_osd $dir $id $ceph_osd_args || return 1
     done
 
     create_pool $poolname 1 1 || return 1
@@ -329,7 +328,7 @@ function TEST_auto_repair_bluestore_scrub() {
 	    --osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
-        run_osd_bluestore $dir $id $ceph_osd_args || return 1
+        run_osd $dir $id $ceph_osd_args || return 1
     done
 
     create_pool $poolname 1 1 || return 1
@@ -384,7 +383,7 @@ function TEST_auto_repair_bluestore_failed() {
 	    --osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
-        run_osd_bluestore $dir $id $ceph_osd_args || return 1
+        run_osd $dir $id $ceph_osd_args || return 1
     done
 
     create_pool $poolname 1 1 || return 1
@@ -453,7 +452,7 @@ function TEST_auto_repair_bluestore_failed_norecov() {
 	    --osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
-        run_osd_bluestore $dir $id $ceph_osd_args || return 1
+        run_osd $dir $id $ceph_osd_args || return 1
     done
 
     create_pool $poolname 1 1 || return 1
@@ -510,7 +509,7 @@ function TEST_repair_stats() {
     local ceph_osd_args="--osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 $(expr $OSDS - 1)) ; do
-        run_osd_bluestore $dir $id $ceph_osd_args || return 1
+        run_osd $dir $id $ceph_osd_args || return 1
     done
 
     create_pool $poolname 1 1 || return 1
@@ -539,8 +538,8 @@ function TEST_repair_stats() {
       OSD=$(expr $i % 2)
       _objectstore_tool_nodown $dir $OSD obj$i remove || return 1
     done
-    run_osd_bluestore $dir $primary $ceph_osd_args || return 1
-    run_osd_bluestore $dir $other $ceph_osd_args || return 1
+    run_osd $dir $primary $ceph_osd_args || return 1
+    run_osd $dir $other $ceph_osd_args || return 1
     wait_for_clean || return 1
 
     repair $pgid
@@ -584,7 +583,7 @@ function TEST_repair_stats_ec() {
     local ceph_osd_args="--osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 $(expr $OSDS - 1)) ; do
-        run_osd_bluestore $dir $id $ceph_osd_args || return 1
+        run_osd $dir $id $ceph_osd_args || return 1
     done
 
     # Create an EC pool
@@ -612,8 +611,8 @@ function TEST_repair_stats_ec() {
       OSD=$(expr $i % 2)
       _objectstore_tool_nodown $dir $OSD obj$i remove || return 1
     done
-    run_osd_bluestore $dir $primary $ceph_osd_args || return 1
-    run_osd_bluestore $dir $other $ceph_osd_args || return 1
+    run_osd $dir $primary $ceph_osd_args || return 1
+    run_osd $dir $other $ceph_osd_args || return 1
     wait_for_clean || return 1
 
     repair $pgid
@@ -655,9 +654,9 @@ function corrupt_and_repair_jerasure() {
     run_mgr $dir x || return 1
     for id in $(seq 0 3) ; do
 	if [ "$allow_overwrites" = "true" ]; then
-            run_osd_bluestore $dir $id || return 1
-	else
             run_osd $dir $id || return 1
+	else
+            run_osd_filestore $dir $id || return 1
 	fi
     done
     create_rbd_pool || return 1
@@ -689,9 +688,9 @@ function corrupt_and_repair_lrc() {
     run_mgr $dir x || return 1
     for id in $(seq 0 9) ; do
 	if [ "$allow_overwrites" = "true" ]; then
-            run_osd_bluestore $dir $id || return 1
-	else
             run_osd $dir $id || return 1
+	else
+            run_osd_filestore $dir $id || return 1
 	fi
     done
     create_rbd_pool || return 1
@@ -724,9 +723,9 @@ function unfound_erasure_coded() {
     run_mgr $dir x || return 1
     for id in $(seq 0 3) ; do
 	if [ "$allow_overwrites" = "true" ]; then
-            run_osd_bluestore $dir $id || return 1
-	else
             run_osd $dir $id || return 1
+	else
+            run_osd_filestore $dir $id || return 1
 	fi
     done
 
@@ -794,9 +793,9 @@ function list_missing_erasure_coded() {
     run_mgr $dir x || return 1
     for id in $(seq 0 2) ; do
 	if [ "$allow_overwrites" = "true" ]; then
-            run_osd_bluestore $dir $id || return 1
-	else
             run_osd $dir $id || return 1
+	else
+            run_osd_filestore $dir $id || return 1
 	fi
     done
     create_rbd_pool || return 1
@@ -3405,9 +3404,9 @@ function corrupt_scrub_erasure() {
     run_mgr $dir x || return 1
     for id in $(seq 0 2) ; do
 	if [ "$allow_overwrites" = "true" ]; then
-            run_osd_bluestore $dir $id || return 1
-	else
             run_osd $dir $id || return 1
+	else
+            run_osd_filestore $dir $id || return 1
 	fi
     done
     create_rbd_pool || return 1

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11684,7 +11684,10 @@ void PrimaryLogPG::recover_got(hobject_t oid, eversion_t v)
 {
   dout(10) << "got missing " << oid << " v " << v << dendl;
   pg_log.recover_got(oid, v, info);
-  if (pg_log.get_log().complete_to != pg_log.get_log().log.end()) {
+  if (pg_log.get_log().log.empty()) {
+    dout(10) << "last_complete now " << info.last_complete
+             << " while log is empty" << dendl;
+  } else if (pg_log.get_log().complete_to != pg_log.get_log().log.end()) {
     dout(10) << "last_complete now " << info.last_complete
 	     << " log.complete_to " << pg_log.get_log().complete_to->version
 	     << dendl;


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/42014
* https://tracker.ceph.com/issues/39517

---

backport of:

* https://github.com/ceph/ceph/pull/30503
* https://github.com/ceph/ceph/pull/27279
* https://github.com/ceph/ceph/pull/30506

parent trackers:

* https://tracker.ceph.com/issues/41816
* https://tracker.ceph.com/issues/39162

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh