### PR TITLE
mgr/prometheus: assign a value to osd_dev_node when obj_store is not filestore or bluestore

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -619,6 +619,7 @@ class Module(MgrModule):
                     'osd.{}'.format(id_),
                 ))
 
+            osd_dev_node = None
             if obj_store == "filestore":
                 # collect filestore backend device
                 osd_dev_node = osd_metadata.get(
@@ -634,8 +635,6 @@ class Module(MgrModule):
                 osd_wal_dev_node = osd_metadata.get('bluefs_wal_dev_node', '')
                 # collect bluestore db backend
                 osd_db_dev_node = osd_metadata.get('bluefs_db_dev_node', '')
-            else:
-                osd_dev_node = "unknown"
             if osd_dev_node and osd_dev_node == "unknown":
                 osd_dev_node = None
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -634,6 +634,8 @@ class Module(MgrModule):
                 osd_wal_dev_node = osd_metadata.get('bluefs_wal_dev_node', '')
                 # collect bluestore db backend
                 osd_db_dev_node = osd_metadata.get('bluefs_db_dev_node', '')
+            else:
+                osd_dev_node = "unknown"
             if osd_dev_node and osd_dev_node == "unknown":
                 osd_dev_node = None
 


### PR DESCRIPTION
mgr/prometheus: assign a value to osd_dev_node when obj_store is not filestore or bluestore

Fixes: https://tracker.ceph.com/issues/42017

Signed-off-by: jiahuizeng <jhzeng93@foxmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
