### PR TITLE
mon.test: improve validation and add a test for "osd pool create"

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1022,8 +1022,8 @@ COMMAND("osd pool create " \
         "name=pool_type,type=CephChoices,strings=replicated|erasure,req=false " \
 	"name=erasure_code_profile,type=CephString,req=false,goodchars=[A-Za-z0-9-_.] " \
 	"name=rule,type=CephString,req=false " \
-        "name=expected_num_objects,type=CephInt,req=false " \
-        "name=size,type=CephInt,req=false " \
+        "name=expected_num_objects,type=CephInt,range=0,req=false " \
+        "name=size,type=CephInt,range=0,req=false " \
 	"name=pg_num_min,type=CephInt,range=0,req=false " \
 	"name=target_size_bytes,type=CephInt,range=0,req=false " \
 	"name=target_size_ratio,type=CephFloat,range=0|1,req=false",\

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1068,6 +1068,15 @@ class TestOSD(TestArgparse):
                                    'erasure', 'A-Za-z0-9-_.', 'ruleset^^'])
         self.assert_valid_command(['osd', 'pool', 'create', 'poolname'])
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create']))
+        # invalid pg_num and pgp_num, like "-1", could spill over to
+        # erasure_code_profile and rule as they are valid profile and rule
+        # names, so validate_commands() cannot identify such cases.
+        # but if they are matched by profile and rule, the "rule" argument
+        # won't get a chance to be matched anymore.
+        assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
+                                                    'poolname',
+                                                    '-1', '-1',
+                                                    'ruleset']))
         assert_equal({}, validate_command(sigdict, ['osd', 'pool', 'create',
                                                     'poolname',
                                                     '128', '128',


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
