### PR TITLE
rgw: fix REQUEST_URI setting in the rgw_asio_client.cc

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -70,15 +70,16 @@ int ClientIO::init_env(CephContext *cct)
   env.set("REQUEST_METHOD", request.method_string().to_string());
 
   // split uri from query
-  auto url = request.target();
-  auto pos = url.find('?');
-  if (pos != url.npos) {
-    auto query = url.substr(pos + 1);
+  auto uri = request.target();
+  auto pos = uri.find('?');
+  if (pos != uri.npos) {
+    auto query = uri.substr(pos + 1);
     env.set("QUERY_STRING", query.to_string());
-    url = url.substr(0, pos);
+    uri = uri.substr(0, pos);
   }
-  env.set("REQUEST_URI", url.to_string());
-  env.set("SCRIPT_URI", url.to_string()); /* FIXME */
+  env.set("SCRIPT_URI", uri.to_string());
+
+  env.set("REQUEST_URI", request.target().to_string());
 
   char port_buf[16];
   snprintf(port_buf, sizeof(port_buf), "%d", local_endpoint.port());


### PR DESCRIPTION
rebased https://github.com/ceph/ceph/pull/16935 to the master,
the Civetweb part has been addressed,the Beast part is still
missing.

As Civetweb has set REQUEST_URI with full uri by:

env.set("REQUEST_URI", info->request_uri); // get the full uri, we anyway handle abs uris later

Beast frontend should match this too.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
