### PR TITLE
build/cmake: set HAVE_GETENTROPY to false when function is not implemented

### DIFF
--- a/cmake/modules/CephChecks.cmake
+++ b/cmake/modules/CephChecks.cmake
@@ -70,7 +70,28 @@ check_symbol_exists(res_nquery "resolv.h" HAVE_RES_NQUERY)
 check_symbol_exists(F_SETPIPE_SZ "linux/fcntl.h" CEPH_HAVE_SETPIPE_SZ)
 check_symbol_exists(__func__ "" HAVE_FUNC)
 check_symbol_exists(__PRETTY_FUNCTION__ "" HAVE_PRETTY_FUNC)
-check_symbol_exists(getentropy "unistd.h" HAVE_GETENTROPY)
+
+include(CheckCSourceRuns)
+check_c_source_runs("
+  #include <errno.h>
+  #include <unistd.h>
+
+  int main() {
+    char buf[20];
+    int ret;
+    ret = getentropy(buf, 20);
+    if (ret < 0 && errno == ENOSYS) // Function not implemented
+      return -1;
+    else 
+      return 0;
+  }
+" HAVE_IMPLEMENTED_GETENTROPY)
+if(HAVE_IMPLEMENTED_GETENTROPY)
+  set(HAVE_GETENTROPY 1)
+else()
+  set(HAVE_GETENTROPY 0)
+endif(HAVE_IMPLEMENTED_GETENTROPY)
+
 
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles("


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42018

Signed-off-by: Chang Liu <liuchang0812@gmail.com>

@tchaikov @liewegas mind taking a look? thanks

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
