### PR TITLE
nautilus: mgr/dashboard: Validate iSCSI controls min/max value…

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -223,7 +223,7 @@ class IscsiTarget(RESTController):
             raise DashboardException(msg='Target already exists',
                                      code='target_already_exists',
                                      component='iscsi')
-        IscsiTarget._validate(target_iqn, portals, disks, groups)
+        IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups)
         IscsiTarget._create(target_iqn, target_controls, acl_enabled, portals, disks, clients,
                             groups, 0, 100, config)
 
@@ -245,7 +245,7 @@ class IscsiTarget(RESTController):
             raise DashboardException(msg='Target IQN already in use',
                                      code='target_iqn_already_in_use',
                                      component='iscsi')
-        IscsiTarget._validate(new_target_iqn, portals, disks, groups)
+        IscsiTarget._validate(new_target_iqn, target_controls, portals, disks, groups)
         config = IscsiTarget._delete(target_iqn, config, 0, 50, new_target_iqn, target_controls,
                                      portals, disks, clients, groups)
         IscsiTarget._create(new_target_iqn, target_controls, acl_enabled, portals, disks, clients,
@@ -412,7 +412,7 @@ class IscsiTarget(RESTController):
         return False
 
     @staticmethod
-    def _validate(target_iqn, portals, disks, groups):
+    def _validate(target_iqn, target_controls, portals, disks, groups):
         if not target_iqn:
             raise DashboardException(msg='Target IQN is required',
                                      code='target_iqn_required',
@@ -429,6 +429,26 @@ class IscsiTarget(RESTController):
             raise DashboardException(msg=msg,
                                      code='portals_required',
                                      component='iscsi')
+
+        # 'target_controls_limits' was introduced in ceph-iscsi > 3.2
+        # When using an older `ceph-iscsi` version these validations will
+        # NOT be executed beforehand
+        if 'target_controls_limits' in settings:
+            for target_control_name, target_control_value in target_controls.items():
+                limits = settings['target_controls_limits'].get(target_control_name)
+                if limits is not None:
+                    min_value = limits.get('min')
+                    if min_value is not None and target_control_value < min_value:
+                        raise DashboardException(msg='Target control {} must be >= '
+                                                     '{}'.format(target_control_name, min_value),
+                                                 code='target_control_invalid_min',
+                                                 component='iscsi')
+                    max_value = limits.get('max')
+                    if max_value is not None and target_control_value > max_value:
+                        raise DashboardException(msg='Target control {} must be <= '
+                                                     '{}'.format(target_control_name, max_value),
+                                                 code='target_control_invalid_max',
+                                                 component='iscsi')
 
         for portal in portals:
             gateway_name = portal['host']
@@ -448,6 +468,26 @@ class IscsiTarget(RESTController):
             unsupported_rbd_features = settings['unsupported_rbd_features'][backstore]
             IscsiTarget._validate_image(pool, image, backstore, required_rbd_features,
                                         unsupported_rbd_features)
+
+            # 'disk_controls_limits' was introduced in ceph-iscsi > 3.2
+            # When using an older `ceph-iscsi` version these validations will
+            # NOT be executed beforehand
+            if 'disk_controls_limits' in settings:
+                for disk_control_name, disk_control_value in disk['controls'].items():
+                    limits = settings['disk_controls_limits'][backstore].get(disk_control_name)
+                    if limits is not None:
+                        min_value = limits.get('min')
+                        if min_value is not None and disk_control_value < min_value:
+                            raise DashboardException(msg='Disk control {} must be >= '
+                                                         '{}'.format(disk_control_name, min_value),
+                                                     code='disk_control_invalid_min',
+                                                     component='iscsi')
+                        max_value = limits.get('max')
+                        if max_value is not None and disk_control_value > max_value:
+                            raise DashboardException(msg='Disk control {} must be <= '
+                                                         '{}'.format(disk_control_name, max_value),
+                                                     code='disk_control_invalid_max',
+                                                     component='iscsi')
 
         initiators = []
         for group in groups:

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -223,9 +223,10 @@ class IscsiTarget(RESTController):
             raise DashboardException(msg='Target already exists',
                                      code='target_already_exists',
                                      component='iscsi')
-        IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups)
+        settings = IscsiClient.instance().get_settings()
+        IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups, settings)
         IscsiTarget._create(target_iqn, target_controls, acl_enabled, portals, disks, clients,
-                            groups, 0, 100, config)
+                            groups, 0, 100, config, settings)
 
     @iscsi_target_task('edit', {'target_iqn': '{target_iqn}'})
     def set(self, target_iqn, new_target_iqn=None, target_controls=None, acl_enabled=None,
@@ -245,11 +246,12 @@ class IscsiTarget(RESTController):
             raise DashboardException(msg='Target IQN already in use',
                                      code='target_iqn_already_in_use',
                                      component='iscsi')
-        IscsiTarget._validate(new_target_iqn, target_controls, portals, disks, groups)
+        settings = IscsiClient.instance().get_settings()
+        IscsiTarget._validate(new_target_iqn, target_controls, portals, disks, groups, settings)
         config = IscsiTarget._delete(target_iqn, config, 0, 50, new_target_iqn, target_controls,
                                      portals, disks, clients, groups)
         IscsiTarget._create(new_target_iqn, target_controls, acl_enabled, portals, disks, clients,
-                            groups, 50, 100, config)
+                            groups, 50, 100, config, settings)
 
     @staticmethod
     def _delete(target_iqn, config, task_progress_begin, task_progress_end, new_target_iqn=None,
@@ -391,7 +393,11 @@ class IscsiTarget(RESTController):
         if not new_disk:
             return True
         old_disk = IscsiTarget._get_disk(target['disks'], image_id)
-        if new_disk != old_disk:
+        new_disk_without_controls = deepcopy(new_disk)
+        new_disk_without_controls.pop('controls')
+        old_disk_without_controls = deepcopy(old_disk)
+        old_disk_without_controls.pop('controls')
+        if new_disk_without_controls != old_disk_without_controls:
             return True
         return False
 
@@ -412,13 +418,12 @@ class IscsiTarget(RESTController):
         return False
 
     @staticmethod
-    def _validate(target_iqn, target_controls, portals, disks, groups):
+    def _validate(target_iqn, target_controls, portals, disks, groups, settings):
         if not target_iqn:
             raise DashboardException(msg='Target IQN is required',
                                      code='target_iqn_required',
                                      component='iscsi')
 
-        settings = IscsiClient.instance().get_settings()
         minimum_gateways = max(1, settings['config']['minimum_gateways'])
         portals_by_host = IscsiTarget._get_portals_by_host(portals)
         if len(portals_by_host.keys()) < minimum_gateways:
@@ -536,7 +541,7 @@ class IscsiTarget(RESTController):
     @staticmethod
     def _create(target_iqn, target_controls, acl_enabled,
                 portals, disks, clients, groups,
-                task_progress_begin, task_progress_end, config):
+                task_progress_begin, task_progress_end, config, settings):
         target_config = config['targets'].get(target_iqn, None)
         TaskManager.current_task().set_progress(task_progress_begin)
         portals_by_host = IscsiTarget._get_portals_by_host(portals)
@@ -566,19 +571,29 @@ class IscsiTarget(RESTController):
                 pool = disk['pool']
                 image = disk['image']
                 image_id = '{}/{}'.format(pool, image)
+                backstore = disk['backstore']
                 if image_id not in config['disks']:
-                    backstore = disk['backstore']
                     IscsiClient.instance(gateway_name=gateway_name).create_disk(pool,
                                                                                 image,
                                                                                 backstore)
                 if not target_config or image_id not in target_config['disks']:
                     IscsiClient.instance(gateway_name=gateway_name).create_target_lun(target_iqn,
                                                                                       image_id)
-                    controls = disk['controls']
-                    if controls:
-                        IscsiClient.instance(gateway_name=gateway_name).reconfigure_disk(pool,
-                                                                                         image,
-                                                                                         controls)
+
+                controls = disk['controls']
+                d_conf_controls = {}
+                if image_id in config['disks']:
+                    d_conf_controls = config['disks'][image_id]['controls']
+                    disk_default_controls = settings['disk_default_controls'][backstore]
+                    for old_control in d_conf_controls.keys():
+                        # If control was removed, restore the default value
+                        if old_control not in controls:
+                            controls[old_control] = disk_default_controls[old_control]
+
+                if (image_id not in config['disks'] or d_conf_controls != controls) and controls:
+                    IscsiClient.instance(gateway_name=gateway_name).reconfigure_disk(pool,
+                                                                                     image,
+                                                                                     controls)
                 TaskManager.current_task().inc_progress(task_progress_inc)
             for client in clients:
                 client_iqn = client['client_iqn']

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -719,18 +719,35 @@ class IscsiTarget(RESTController):
         return target
 
     @staticmethod
+    def _is_executing(target_iqn):
+        executing_tasks, _ = TaskManager.list()
+        for t in executing_tasks:
+            if t.name.startswith('iscsi/target') and t.metadata.get('target_iqn') == target_iqn:
+                return True
+        return False
+
+    @staticmethod
     def _set_info(target):
         if not target['portals']:
             return
         target_iqn = target['target_iqn']
+        # During task execution, additional info is not available
+        if IscsiTarget._is_executing(target_iqn):
+            return
         gateway_name = target['portals'][0]['host']
-        target_info = IscsiClient.instance(gateway_name=gateway_name).get_targetinfo(target_iqn)
-        target['info'] = target_info
-        for client in target['clients']:
-            client_iqn = client['client_iqn']
-            client_info = IscsiClient.instance(gateway_name=gateway_name).get_clientinfo(
-                target_iqn, client_iqn)
-            client['info'] = client_info
+        try:
+            target_info = IscsiClient.instance(gateway_name=gateway_name).get_targetinfo(
+                target_iqn)
+            target['info'] = target_info
+            for client in target['clients']:
+                client_iqn = client['client_iqn']
+                client_info = IscsiClient.instance(gateway_name=gateway_name).get_clientinfo(
+                    target_iqn, client_iqn)
+                client['info'] = client_info
+        except RequestException as e:
+            # Target/Client has been removed in the meanwhile (e.g. using gwcli)
+            if e.status_code != 404:
+                raise e
 
     @staticmethod
     def _sorted_portals(portals):

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -716,8 +716,12 @@ class IscsiTarget(RESTController):
                 'pool': disk_config['pool'],
                 'image': disk_config['image'],
                 'controls': disk_config['controls'],
-                'backstore': disk_config['backstore']
+                'backstore': disk_config['backstore'],
+                'wwn': disk_config['wwn']
             }
+            # lun_id was introduced in ceph-iscsi config v11
+            if config['version'] > 10:
+                disk['lun'] = target_config['disks'][target_disk]['lun_id']
             disks.append(disk)
         disks = IscsiTarget._sorted_disks(disks)
         clients = []

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -321,10 +321,12 @@ class IscsiTarget(RESTController):
                 IscsiClient.instance(gateway_name=gateway_name).delete_group(target_iqn,
                                                                              group_id)
             TaskManager.current_task().inc_progress(task_progress_inc)
+        deleted_clients = []
         for client_iqn in list(target_config['clients'].keys()):
             if IscsiTarget._client_deletion_required(target, new_target_iqn, new_target_controls,
                                                      new_clients, client_iqn,
                                                      new_groups, deleted_groups):
+                deleted_clients.append(client_iqn)
                 IscsiClient.instance(gateway_name=gateway_name).delete_client(target_iqn,
                                                                               client_iqn)
             TaskManager.current_task().inc_progress(task_progress_inc)
@@ -332,6 +334,14 @@ class IscsiTarget(RESTController):
             if IscsiTarget._target_lun_deletion_required(target, new_target_iqn,
                                                          new_target_controls,
                                                          new_disks, image_id):
+                all_clients = target_config['clients'].keys()
+                not_deleted_clients = [c for c in all_clients if c not in deleted_clients]
+                for client_iqn in not_deleted_clients:
+                    client_image_ids = target_config['clients'][client_iqn]['luns'].keys()
+                    for client_image_id in client_image_ids:
+                        if image_id == client_image_id:
+                            IscsiClient.instance(gateway_name=gateway_name).delete_client_lun(
+                                target_iqn, client_iqn, client_image_id)
                 IscsiClient.instance(gateway_name=gateway_name).delete_target_lun(target_iqn,
                                                                                   image_id)
                 pool, image = image_id.split('/', 1)
@@ -633,13 +643,17 @@ class IscsiTarget(RESTController):
                 image = disk['image']
                 image_id = '{}/{}'.format(pool, image)
                 backstore = disk['backstore']
+                wwn = disk.get('wwn')
+                lun = disk.get('lun')
                 if image_id not in config['disks']:
                     IscsiClient.instance(gateway_name=gateway_name).create_disk(pool,
                                                                                 image,
-                                                                                backstore)
+                                                                                backstore,
+                                                                                wwn)
                 if not target_config or image_id not in target_config['disks']:
                     IscsiClient.instance(gateway_name=gateway_name).create_target_lun(target_iqn,
-                                                                                      image_id)
+                                                                                      image_id,
+                                                                                      lun)
 
                 controls = disk['controls']
                 d_conf_controls = {}
@@ -661,18 +675,20 @@ class IscsiTarget(RESTController):
                 if not target_config or client_iqn not in target_config['clients']:
                     IscsiClient.instance(gateway_name=gateway_name).create_client(target_iqn,
                                                                                   client_iqn)
-                    for lun in client['luns']:
-                        pool = lun['pool']
-                        image = lun['image']
-                        image_id = '{}/{}'.format(pool, image)
-                        IscsiClient.instance(gateway_name=gateway_name).create_client_lun(
-                            target_iqn, client_iqn, image_id)
                     user = client['auth']['user']
                     password = client['auth']['password']
                     m_user = client['auth']['mutual_user']
                     m_password = client['auth']['mutual_password']
                     IscsiClient.instance(gateway_name=gateway_name).create_client_auth(
                         target_iqn, client_iqn, user, password, m_user, m_password)
+                for lun in client['luns']:
+                    pool = lun['pool']
+                    image = lun['image']
+                    image_id = '{}/{}'.format(pool, image)
+                    if not target_config or client_iqn not in target_config['clients'] or \
+                            image_id not in target_config['clients'][client_iqn]['luns']:
+                        IscsiClient.instance(gateway_name=gateway_name).create_client_lun(
+                            target_iqn, client_iqn, image_id)
                 TaskManager.current_task().inc_progress(task_progress_inc)
             for group in groups:
                 group_id = group['group_id']

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -14,6 +14,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
 import { FeatureTogglesGuardService } from '../../shared/services/feature-toggles-guard.service';
 import { SharedModule } from '../../shared/shared.module';
+import { IscsiSettingComponent } from './iscsi-setting/iscsi-setting.component';
 import { IscsiTabsComponent } from './iscsi-tabs/iscsi-tabs.component';
 import { IscsiTargetDetailsComponent } from './iscsi-target-details/iscsi-target-details.component';
 import { IscsiTargetDiscoveryModalComponent } from './iscsi-target-discovery-modal/iscsi-target-discovery-modal.component';
@@ -67,6 +68,7 @@ import { RbdTrashRestoreModalComponent } from './rbd-trash-restore-modal/rbd-tra
   declarations: [
     RbdListComponent,
     IscsiComponent,
+    IscsiSettingComponent,
     IscsiTabsComponent,
     IscsiTargetListComponent,
     RbdDetailsComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-setting/iscsi-setting.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-setting/iscsi-setting.component.html
@@ -1,0 +1,58 @@
+<div class="form-group"
+     [ngClass]="{'has-error': settingsForm.showError(setting, formDir)}"
+     [formGroup]="settingsForm">
+  <label class="col-form-label"
+         for="{{ setting }}">{{ setting }}</label>
+  <select id="{{ setting }}"
+          name="{{ setting }}"
+          *ngIf="limits['type'] === 'enum'"
+          class="form-control custom-select"
+          [formControlName]="setting">
+    <option [ngValue]="null"></option>
+    <option *ngFor="let opt of limits['values']"
+            [ngValue]="opt">{{ opt }}</option>
+  </select>
+
+  <span *ngIf="limits['type'] !== 'enum'">
+    <input type="number"
+           *ngIf="limits['type'] === 'int'"
+           class="form-control"
+           [formControlName]="setting">
+
+    <input type="text"
+           *ngIf="limits['type'] === 'str'"
+           class="form-control"
+           [formControlName]="setting">
+
+    <ng-container *ngIf="limits['type'] === 'bool'">
+      <br>
+      <div class="radio radio-inline">
+        <input type="radio"
+               [id]="setting + 'True'"
+               [value]="true"
+               [formControlName]="setting"
+               class="custom-control-input">
+        <label class="custom-control-label"
+               [for]="setting + 'True'">Yes</label>
+      </div>
+      <div class="radio radio-inline">
+        <input type="radio"
+               [id]="setting + 'False'"
+               [value]="false"
+               class="custom-control-input"
+               [formControlName]="setting">
+        <label class="custom-control-label"
+               [for]="setting + 'False'">No</label>
+      </div>
+    </ng-container>
+  </span>
+
+  <span class="help-block"
+        *ngIf="settingsForm.showError(setting, formDir, 'min')">
+    <ng-container i18n>Must be greater than or equal to {{ limits['min'] }}.</ng-container>
+  </span>
+  <span class="help-block"
+        *ngIf="settingsForm.showError(setting, formDir, 'max')">
+    <ng-container i18n>Must be less than or equal to {{ limits['max'] }}.</ng-container>
+  </span>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-setting/iscsi-setting.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-setting/iscsi-setting.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, NgForm, ReactiveFormsModule } from '@angular/forms';
+
+import { configureTestBed } from '../../../../testing/unit-test-helper';
+import { CdFormGroup } from '../../../shared/forms/cd-form-group';
+import { SharedModule } from '../../../shared/shared.module';
+import { IscsiSettingComponent } from './iscsi-setting.component';
+
+describe('IscsiSettingComponent', () => {
+  let component: IscsiSettingComponent;
+  let fixture: ComponentFixture<IscsiSettingComponent>;
+
+  configureTestBed({
+    imports: [SharedModule, ReactiveFormsModule],
+    declarations: [IscsiSettingComponent]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IscsiSettingComponent);
+    component = fixture.componentInstance;
+    component.settingsForm = new CdFormGroup({
+      max_data_area_mb: new FormControl()
+    });
+    component.formDir = new NgForm([], []);
+    component.setting = 'max_data_area_mb';
+    component.limits = {
+      type: 'int',
+      min: 1,
+      max: 2048
+    };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-setting/iscsi-setting.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-setting/iscsi-setting.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { NgForm, Validators } from '@angular/forms';
+
+import { CdFormGroup } from '../../../shared/forms/cd-form-group';
+
+@Component({
+  selector: 'cd-iscsi-setting',
+  templateUrl: './iscsi-setting.component.html',
+  styleUrls: ['./iscsi-setting.component.scss']
+})
+export class IscsiSettingComponent implements OnInit {
+  @Input()
+  settingsForm: CdFormGroup;
+  @Input()
+  formDir: NgForm;
+  @Input()
+  setting: string;
+  @Input()
+  limits: object;
+
+  ngOnInit() {
+    const validators = [];
+    if ('min' in this.limits) {
+      validators.push(Validators.min(this.limits['min']));
+    }
+    if ('max' in this.limits) {
+      validators.push(Validators.max(this.limits['max']));
+    }
+    this.settingsForm.get(this.setting).setValidators(validators);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
@@ -78,7 +78,9 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
 
     const cssClasses = {
       target: {
-        expanded: 'fa fa-fw fa-bullseye fa-lg'
+        expanded: this.selectedItem.cdExecuting
+          ? 'fa fa-fw fa-spinner fa-spin fa-lg'
+          : 'fa fa-fw fa-bullseye fa-lg'
       },
       initiators: {
         expanded: 'fa fa-fw fa-user fa-lg',
@@ -120,11 +122,13 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
     const clients = [];
     _.forEach(this.selectedItem.clients, (client) => {
       const client_metadata = _.cloneDeep(client.auth);
-      _.extend(client_metadata, client.info);
-      delete client_metadata['state'];
-      _.forEach(Object.keys(client.info.state), (state) => {
-        client_metadata[state.toLowerCase()] = client.info.state[state];
-      });
+      if (client.info) {
+        _.extend(client_metadata, client.info);
+        delete client_metadata['state'];
+        _.forEach(Object.keys(client.info.state), (state) => {
+          client_metadata[state.toLowerCase()] = client.info.state[state];
+        });
+      }
       this.metadata['client_' + client.client_iqn] = client_metadata;
 
       const luns = [];
@@ -138,9 +142,13 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
         });
       });
 
+      let status = '';
+      if (client.info) {
+        status = Object.keys(client.info.state).includes('LOGGED_IN') ? 'logged_in' : 'logged_out';
+      }
       clients.push({
         value: client.client_iqn,
-        status: Object.keys(client.info.state).includes('LOGGED_IN') ? 'logged_in' : 'logged_out',
+        status: status,
         id: 'client_' + client.client_iqn,
         children: luns
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
@@ -7,6 +7,7 @@ import { NodeEvent, TreeModel } from 'ng2-tree';
 import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
+import { BooleanTextPipe } from '../../../shared/pipes/boolean-text.pipe';
 import { IscsiBackstorePipe } from '../../../shared/pipes/iscsi-backstore.pipe';
 
 @Component({
@@ -41,7 +42,11 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
   title: string;
   tree: TreeModel;
 
-  constructor(private i18n: I18n, private iscsiBackstorePipe: IscsiBackstorePipe) {}
+  constructor(
+    private i18n: I18n,
+    private iscsiBackstorePipe: IscsiBackstorePipe,
+    private booleanTextPipe: BooleanTextPipe
+  ) {}
 
   ngOnInit() {
     this.columns = [
@@ -245,6 +250,13 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
     };
   }
 
+  private format(value) {
+    if (typeof value === 'boolean') {
+      return this.booleanTextPipe.transform(value);
+    }
+    return value;
+  }
+
   onNodeSelected(e: NodeEvent) {
     if (e.node.id) {
       this.title = e.node.value;
@@ -253,10 +265,11 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
       if (e.node.id === 'root') {
         this.columns[2].isHidden = false;
         this.data = _.map(this.settings.target_default_controls, (value, key) => {
+          value = this.format(value);
           return {
             displayName: key,
             default: value,
-            current: tempData[key] || value
+            current: !_.isUndefined(tempData[key]) ? this.format(tempData[key]) : value
           };
         });
         // Target level authentication was introduced in ceph-iscsi config v11
@@ -272,10 +285,13 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
       } else if (e.node.id.toString().startsWith('disk_')) {
         this.columns[2].isHidden = false;
         this.data = _.map(this.settings.disk_default_controls[tempData.backstore], (value, key) => {
+          value = this.format(value);
           return {
             displayName: key,
             default: value,
-            current: !_.isUndefined(tempData.controls[key]) ? tempData.controls[key] : value
+            current: !_.isUndefined(tempData.controls[key])
+              ? this.format(tempData.controls[key])
+              : value
           };
         });
         this.data.push({
@@ -289,7 +305,7 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
           return {
             displayName: key,
             default: undefined,
-            current: value
+            current: this.format(value)
           };
         });
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
@@ -53,7 +53,7 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
       {
         prop: 'displayName',
         name: this.i18n('Name'),
-        flexGrow: 2,
+        flexGrow: 1,
         cellTemplate: this.highlightTpl
       },
       {
@@ -118,7 +118,11 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
         controls: disk.controls,
         backstore: disk.backstore
       };
-
+      ['wwn', 'lun'].forEach((k) => {
+        if (k in disk) {
+          this.metadata[id][k] = disk[k];
+        }
+      });
       disks.push({
         value: `${disk.pool}/${disk.image}`,
         id: id
@@ -298,6 +302,15 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
           displayName: 'backstore',
           default: this.iscsiBackstorePipe.transform(this.settings.default_backstore),
           current: this.iscsiBackstorePipe.transform(tempData.backstore)
+        });
+        ['wwn', 'lun'].forEach((k) => {
+          if (k in tempData) {
+            this.data.push({
+              displayName: k,
+              default: undefined,
+              current: tempData[k]
+            });
+          }
         });
       } else {
         this.columns[2].isHidden = true;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
@@ -19,6 +19,8 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
   selection: CdTableSelection;
   @Input()
   settings: any;
+  @Input()
+  cephIscsiConfigVersion: number;
 
   @ViewChild('highlightTpl')
   highlightTpl: TemplateRef<any>;
@@ -74,8 +76,12 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
   }
 
   private generateTree() {
-    this.metadata = { root: this.selectedItem.target_controls };
-
+    const target_meta = _.cloneDeep(this.selectedItem.target_controls);
+    // Target level authentication was introduced in ceph-iscsi config v11
+    if (this.cephIscsiConfigVersion > 10) {
+      _.extend(target_meta, _.cloneDeep(this.selectedItem.auth));
+    }
+    this.metadata = { root: target_meta };
     const cssClasses = {
       target: {
         expanded: this.selectedItem.cdExecuting
@@ -253,6 +259,16 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
             current: tempData[key] || value
           };
         });
+        // Target level authentication was introduced in ceph-iscsi config v11
+        if (this.cephIscsiConfigVersion > 10) {
+          ['user', 'password', 'mutual_user', 'mutual_password'].forEach((key) => {
+            this.data.push({
+              displayName: key,
+              default: null,
+              current: tempData[key]
+            });
+          });
+        }
       } else if (e.node.id.toString().startsWith('disk_')) {
         this.columns[2].isHidden = false;
         this.data = _.map(this.settings.disk_default_controls[tempData.backstore], (value, key) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -125,6 +125,8 @@
                        type="text"
                        [value]="image"
                        disabled />
+                <div class="input-group-addon"
+                     *ngIf="api_version >= 1">lun: {{ imagesSettings[image]['lun'] }}</div>
                 <span class="input-group-btn">
                   <button class="btn btn-default"
                           type="button"
@@ -151,9 +153,19 @@
               </span>
             </ng-container>
 
+            <input class="form-control"
+                   type="hidden"
+                   id="disks"
+                   name="disks"
+                   formControlName="disks" />
+
             <span class="help-block"
-                  *ngIf="targetForm.showError('disks', formDir, 'required')"
-                  i18n>At least 1 image is required.</span>
+                  *ngIf="targetForm.showError('disks', formDir, 'dupLunId')"
+                  i18n>Duplicated LUN numbers.</span>
+
+            <span class="help-block"
+                  *ngIf="targetForm.showError('disks', formDir, 'dupWwn')"
+                  i18n>Duplicated WWN.</span>
 
             <div class="row">
               <div class="col-md-12">
@@ -231,7 +243,6 @@
                        id="target_password"
                        name="target_password"
                        formControlName="password" />
-
                 <span class="input-group-btn">
                   <button type="button"
                           class="btn btn-default"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -188,6 +188,139 @@
           </div>
         </div>
 
+        <!-- Target level authentication was introduced in ceph-iscsi config v11 -->
+        <div formGroupName="auth" *ngIf="cephIscsiConfigVersion > 10 && !targetForm.getValue('acl_enabled')">
+
+          <!-- Target user -->
+          <div class="form-group"
+               [ngClass]="{'has-error': targetForm.showError('user', formDir)}">
+            <label class="control-label col-sm-3"
+                   for="target_user">
+              <ng-container i18n>User</ng-container>
+            </label>
+            <div class="col-sm-9">
+              <input class="form-control"
+                     type="text"
+                     id="target_user"
+                     name="target_user"
+                     formControlName="user" />
+
+              <span class="help-block"
+                    *ngIf="targetForm.showError('user', formDir, 'required')"
+                    i18n>This field is required.</span>
+
+              <span class="help-block"
+                    *ngIf="targetForm.showError('user', formDir, 'pattern')"
+                    i18n>Usernames must have a length of 8 to 64 characters and
+                can only contain letters, '.', '@', '-', '_' or ':'.</span>
+            </div>
+          </div>
+
+          <!-- Target password -->
+          <div class="form-group"
+               [ngClass]="{'has-error': targetForm.showError('password', formDir)}">
+            <label class="control-label col-sm-3"
+                   for="target_password">
+              <ng-container i18n>Password</ng-container>
+            </label>
+            <div class="col-sm-9">
+              <div class="input-group">
+                <input class="form-control"
+                       type="password"
+                       autocomplete="new-password"
+                       id="target_password"
+                       name="target_password"
+                       formControlName="password" />
+
+                <span class="input-group-btn">
+                  <button type="button"
+                          class="btn btn-default"
+                          cdPasswordButton="target_password">
+                  </button>
+                  <button type="button"
+                          class="btn btn-default"
+                          cdCopy2ClipboardButton="target_password">
+                  </button>
+                </span>
+              </div>
+
+              <span class="help-block"
+                    *ngIf="targetForm.showError('password', formDir, 'required')"
+                    i18n>This field is required.</span>
+
+              <span class="help-block"
+                    *ngIf="targetForm.showError('password', formDir, 'pattern')"
+                    i18n>Passwords must have a length of 12 to 16 characters
+                and can only contain letters, '@', '-', '_' or '/'.</span>
+            </div>
+          </div>
+
+          <!-- Target mutual_user -->
+          <div class="form-group"
+               [ngClass]="{'has-error': targetForm.showError('mutual_user', formDir)}">
+            <label class="control-label col-sm-3"
+                   for="target_mutual_user">
+              <ng-container i18n>Mutual User</ng-container>
+            </label>
+            <div class="col-sm-9">
+              <input class="form-control"
+                     type="text"
+                     id="target_mutual_user"
+                     name="target_mutual_user"
+                     formControlName="mutual_user" />
+
+              <span class="help-block"
+                    *ngIf="targetForm.showError('mutual_user', formDir, 'required')"
+                    i18n>This field is required.</span>
+
+              <span class="help-block"
+                    *ngIf="targetForm.showError('mutual_user', formDir, 'pattern')"
+                    i18n>Usernames must have a length of 8 to 64 characters and
+                can only contain letters, '.', '@', '-', '_' or ':'.</span>
+            </div>
+          </div>
+
+          <!-- Target mutual_password -->
+          <div class="form-group"
+               [ngClass]="{'has-error': targetForm.showError('mutual_password', formDir)}">
+            <label class="control-label col-sm-3"
+                   for="target_mutual_password">
+              <ng-container i18n>Mutual Password</ng-container>
+            </label>
+            <div class="col-sm-9">
+              <div class="input-group">
+                <input class="form-control"
+                       type="password"
+                       autocomplete="new-password"
+                       id="target_mutual_password"
+                       name="target_mutual_password"
+                       formControlName="mutual_password" />
+
+                <span class="input-group-btn">
+                  <button type="button"
+                          class="btn btn-default"
+                          cdPasswordButton="target_mutual_password">
+                  </button>
+                  <button type="button"
+                          class="btn btn-default"
+                          cdCopy2ClipboardButton="target_mutual_password">
+                  </button>
+                </span>
+              </div>
+
+              <span class="help-block"
+                    *ngIf="targetForm.showError('mutual_password', formDir, 'required')"
+                    i18n>This field is required.</span>
+
+              <span class="help-block"
+                    *ngIf="targetForm.showError('mutual_password', formDir, 'pattern')"
+                    i18n>Passwords must have a length of 12 to 16 characters
+                and can only contain letters, '@', '-', '_' or '/'.</span>
+            </div>
+          </div>
+
+        </div>
+
         <!-- Initiators -->
         <div class="form-group"
              *ngIf="targetForm.getValue('acl_enabled')">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
@@ -42,18 +42,27 @@ describe('IscsiTargetFormComponent', () => {
       'backstore:2': 0
     },
     backstores: ['backstore:1', 'backstore:2'],
-    default_backstore: 'backstore:1'
+    default_backstore: 'backstore:1',
+    api_version: 1
   };
 
   const LIST_TARGET = [
     {
       target_iqn: 'iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw',
       portals: [{ host: 'node1', ip: '192.168.100.201' }],
-      disks: [{ pool: 'rbd', image: 'disk_1', controls: {}, backstore: 'backstore:1' }],
+      disks: [
+        {
+          pool: 'rbd',
+          image: 'disk_1',
+          controls: {},
+          backstore: 'backstore:1',
+          wwn: '64af6678-9694-4367-bacc-f8eb0baa'
+        }
+      ],
       clients: [
         {
           client_iqn: 'iqn.1994-05.com.redhat:rh7-client',
-          luns: [{ pool: 'rbd', image: 'disk_1' }],
+          luns: [{ pool: 'rbd', image: 'disk_1', lun: 0 }],
           auth: {
             user: 'myiscsiusername',
             password: 'myiscsipassword',
@@ -205,6 +214,7 @@ describe('IscsiTargetFormComponent', () => {
     component.onImageSelection({ option: { name: 'rbd/disk_2', selected: true } });
     expect(component.imagesSettings).toEqual({
       'rbd/disk_2': {
+        lun: 0,
         backstore: 'backstore:1',
         'backstore:1': {}
       }
@@ -230,6 +240,7 @@ describe('IscsiTargetFormComponent', () => {
     expect(component.groups.controls[0].value).toEqual({ disks: [], group_id: 'foo', members: [] });
     expect(component.imagesSettings).toEqual({
       'rbd/disk_2': {
+        lun: 0,
         backstore: 'backstore:1',
         'backstore:1': {}
       }
@@ -238,10 +249,10 @@ describe('IscsiTargetFormComponent', () => {
 
   describe('should test initiators', () => {
     beforeEach(() => {
+      component.onImageSelection({ option: { name: 'rbd/disk_2', selected: true } });
       component.targetForm.patchValue({ disks: ['rbd/disk_2'], acl_enabled: true });
       component.addGroup().patchValue({ name: 'group_1' });
       component.addGroup().patchValue({ name: 'group_2' });
-      component.onImageSelection({ option: { name: 'rbd/disk_2', selected: true } });
 
       component.addInitiator();
       component.initiators.controls[0].patchValue({
@@ -356,8 +367,8 @@ describe('IscsiTargetFormComponent', () => {
 
   describe('should submit request', () => {
     beforeEach(() => {
-      component.targetForm.patchValue({ disks: ['rbd/disk_2'], acl_enabled: true });
       component.onImageSelection({ option: { name: 'rbd/disk_2', selected: true } });
+      component.targetForm.patchValue({ disks: ['rbd/disk_2'], acl_enabled: true });
       component.portals.setValue(['node1:192.168.100.201', 'node2:192.168.100.202']);
       component.addInitiator().patchValue({
         client_iqn: 'iqn.initiator'
@@ -386,7 +397,16 @@ describe('IscsiTargetFormComponent', () => {
             luns: []
           }
         ],
-        disks: [{ backstore: 'backstore:1', controls: {}, image: 'disk_2', pool: 'rbd' }],
+        disks: [
+          {
+            backstore: 'backstore:1',
+            controls: {},
+            image: 'disk_2',
+            pool: 'rbd',
+            lun: 0,
+            wwn: undefined
+          }
+        ],
         groups: [
           { disks: [{ image: 'disk_2', pool: 'rbd' }], group_id: 'foo', members: ['iqn.initiator'] }
         ],
@@ -420,7 +440,16 @@ describe('IscsiTargetFormComponent', () => {
             luns: []
           }
         ],
-        disks: [{ backstore: 'backstore:1', controls: {}, image: 'disk_2', pool: 'rbd' }],
+        disks: [
+          {
+            backstore: 'backstore:1',
+            controls: {},
+            image: 'disk_2',
+            pool: 'rbd',
+            lun: 0,
+            wwn: undefined
+          }
+        ],
         groups: [
           {
             disks: [{ image: 'disk_2', pool: 'rbd' }],
@@ -452,7 +481,16 @@ describe('IscsiTargetFormComponent', () => {
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual({
         clients: [],
-        disks: [{ backstore: 'backstore:1', controls: {}, image: 'disk_2', pool: 'rbd' }],
+        disks: [
+          {
+            backstore: 'backstore:1',
+            controls: {},
+            image: 'disk_2',
+            pool: 'rbd',
+            lun: 0,
+            wwn: undefined
+          }
+        ],
         groups: [],
         acl_enabled: false,
         auth: {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
@@ -72,6 +72,10 @@ describe('IscsiTargetFormComponent', () => {
     { name: 'node2', ip_addresses: ['192.168.100.202'] }
   ];
 
+  const VERSION = {
+    ceph_iscsi_config_version: 11
+  };
+
   const RBD_LIST = [
     { status: 0, value: [], pool_name: 'ganesha' },
     {
@@ -152,6 +156,7 @@ describe('IscsiTargetFormComponent', () => {
 
     httpTesting.expectOne('ui-api/iscsi/settings').flush(SETTINGS);
     httpTesting.expectOne('ui-api/iscsi/portals').flush(PORTALS);
+    httpTesting.expectOne('ui-api/iscsi/version').flush(VERSION);
     httpTesting.expectOne('api/summary').flush({});
     httpTesting.expectOne('api/block/image').flush(RBD_LIST);
     httpTesting.expectOne('api/iscsi/target').flush(LIST_TARGET);
@@ -183,6 +188,12 @@ describe('IscsiTargetFormComponent', () => {
       groups: [],
       initiators: [],
       acl_enabled: false,
+      auth: {
+        password: '',
+        user: '',
+        mutual_password: '',
+        mutual_user: ''
+      },
       portals: [],
       target_controls: {},
       target_iqn: component.targetForm.value.target_iqn
@@ -386,7 +397,13 @@ describe('IscsiTargetFormComponent', () => {
         ],
         target_controls: {},
         target_iqn: component.target_iqn,
-        acl_enabled: true
+        acl_enabled: true,
+        auth: {
+          password: '',
+          user: '',
+          mutual_password: '',
+          mutual_user: ''
+        }
       });
     });
 
@@ -417,7 +434,13 @@ describe('IscsiTargetFormComponent', () => {
         ],
         target_controls: {},
         target_iqn: component.targetForm.value.target_iqn,
-        acl_enabled: true
+        acl_enabled: true,
+        auth: {
+          password: '',
+          user: '',
+          mutual_password: '',
+          mutual_user: ''
+        }
       });
     });
 
@@ -432,6 +455,12 @@ describe('IscsiTargetFormComponent', () => {
         disks: [{ backstore: 'backstore:1', controls: {}, image: 'disk_2', pool: 'rbd' }],
         groups: [],
         acl_enabled: false,
+        auth: {
+          password: '',
+          user: '',
+          mutual_password: '',
+          mutual_user: ''
+        },
         portals: [
           { host: 'node1', ip: '192.168.100.201' },
           { host: 'node2', ip: '192.168.100.202' }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
@@ -31,7 +31,7 @@ describe('IscsiTargetFormComponent', () => {
     target_default_controls: {
       cmdsn_depth: 128,
       dataout_timeout: 20,
-      immediate_data: 'Yes'
+      immediate_data: true
     },
     required_rbd_features: {
       'backstore:1': 0,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -28,6 +28,7 @@ export class IscsiTargetFormComponent implements OnInit {
   cephIscsiConfigVersion: number;
   targetForm: CdFormGroup;
   modalRef: BsModalRef;
+  api_version = 0;
   minimum_gateways = 1;
   target_default_controls: any;
   target_controls_limits: any;
@@ -123,6 +124,9 @@ export class IscsiTargetFormComponent implements OnInit {
         .value();
 
       // iscsiService.settings()
+      if ('api_version' in data[3]) {
+        this.api_version = data[3].api_version;
+      }
       this.minimum_gateways = data[3].config.minimum_gateways;
       this.target_default_controls = data[3].target_default_controls;
       this.target_controls_limits = data[3].target_controls_limits;
@@ -188,7 +192,18 @@ export class IscsiTargetFormComponent implements OnInit {
           })
         ]
       }),
-      disks: new FormControl([]),
+      disks: new FormControl([], {
+        validators: [
+          CdValidators.custom('dupLunId', (value) => {
+            const lunIds = this.getLunIds(value);
+            return lunIds.length !== _.uniq(lunIds).length;
+          }),
+          CdValidators.custom('dupWwn', (value) => {
+            const wwns = this.getWwns(value);
+            return wwns.length !== _.uniq(wwns).length;
+          })
+        ]
+      }),
       initiators: new FormArray([]),
       groups: new FormArray([]),
       acl_enabled: new FormControl(false)
@@ -235,6 +250,12 @@ export class IscsiTargetFormComponent implements OnInit {
         backstore: disk.backstore
       };
       this.imagesSettings[id][disk.backstore] = disk.controls;
+      if ('lun' in disk) {
+        this.imagesSettings[id]['lun'] = disk.lun;
+      }
+      if ('wwn' in disk) {
+        this.imagesSettings[id]['wwn'] = disk.wwn;
+      }
 
       this.onImageSelection({ option: { name: id, selected: true } });
     });
@@ -297,6 +318,7 @@ export class IscsiTargetFormComponent implements OnInit {
     });
     this.disks.value.splice(index, 1);
     this.removeImageRefs(image);
+    this.targetForm.get('disks').updateValueAndValidity({ emitEvent: false });
     return false;
   }
 
@@ -334,6 +356,30 @@ export class IscsiTargetFormComponent implements OnInit {
     return result;
   }
 
+  isLunIdInUse(lunId, imageId) {
+    const images = this.disks.value.filter((currentImageId) => currentImageId !== imageId);
+    return this.getLunIds(images).includes(lunId);
+  }
+
+  getLunIds(images) {
+    return _.map(images, (image) => this.imagesSettings[image]['lun']);
+  }
+
+  nextLunId(imageId) {
+    const images = this.disks.value.filter((currentImageId) => currentImageId !== imageId);
+    const lunIdsInUse = this.getLunIds(images);
+    let lunIdCandidate = 0;
+    while (lunIdsInUse.includes(lunIdCandidate)) {
+      lunIdCandidate++;
+    }
+    return lunIdCandidate;
+  }
+
+  getWwns(images) {
+    const wwns = _.map(images, (image) => this.imagesSettings[image]['wwn']);
+    return wwns.filter((wwn) => _.isString(wwn) && wwn !== '');
+  }
+
   onImageSelection($event) {
     const option = $event.option;
 
@@ -341,9 +387,13 @@ export class IscsiTargetFormComponent implements OnInit {
       if (!this.imagesSettings[option.name]) {
         const defaultBackstore = this.getDefaultBackstore(option.name);
         this.imagesSettings[option.name] = {
-          backstore: defaultBackstore
+          backstore: defaultBackstore,
+          lun: this.nextLunId(option.name)
         };
         this.imagesSettings[option.name][defaultBackstore] = {};
+      } else if (this.isLunIdInUse(this.imagesSettings[option.name]['lun'], option.name)) {
+        // If the lun id is now in use, we have to generate a new one
+        this.imagesSettings[option.name]['lun'] = this.nextLunId(option.name);
       }
 
       _.forEach(this.imagesInitiatorSelections, (selections, i) => {
@@ -358,6 +408,7 @@ export class IscsiTargetFormComponent implements OnInit {
     } else {
       this.removeImageRefs(option.name);
     }
+    this.targetForm.get('disks').updateValueAndValidity({ emitEvent: false });
   }
 
   // Initiators
@@ -624,7 +675,9 @@ export class IscsiTargetFormComponent implements OnInit {
         pool: imageSplit[0],
         image: imageSplit[1],
         backstore: backstore,
-        controls: this.imagesSettings[disk][backstore]
+        controls: this.imagesSettings[disk][backstore],
+        lun: this.imagesSettings[disk]['lun'],
+        wwn: this.imagesSettings[disk]['wwn']
       });
     });
 
@@ -727,9 +780,11 @@ export class IscsiTargetFormComponent implements OnInit {
     const initialState = {
       imagesSettings: this.imagesSettings,
       image: image,
+      api_version: this.api_version,
       disk_default_controls: this.disk_default_controls,
       disk_controls_limits: this.disk_controls_limits,
-      backstores: this.getValidBackstores(this.getImageById(image))
+      backstores: this.getValidBackstores(this.getImageById(image)),
+      control: this.targetForm.get('disks')
     };
 
     this.modalRef = this.modalService.show(IscsiTargetImageSettingsModalComponent, {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -29,7 +29,9 @@ export class IscsiTargetFormComponent implements OnInit {
   modalRef: BsModalRef;
   minimum_gateways = 1;
   target_default_controls: any;
+  target_controls_limits: any;
   disk_default_controls: any;
+  disk_controls_limits: any;
   backstores: string[];
   default_backstore: string;
   unsupported_rbd_features: any;
@@ -121,7 +123,9 @@ export class IscsiTargetFormComponent implements OnInit {
       // iscsiService.settings()
       this.minimum_gateways = data[3].config.minimum_gateways;
       this.target_default_controls = data[3].target_default_controls;
+      this.target_controls_limits = data[3].target_controls_limits;
       this.disk_default_controls = data[3].disk_default_controls;
+      this.disk_controls_limits = data[3].disk_controls_limits;
       this.backstores = data[3].backstores;
       this.default_backstore = data[3].default_backstore;
       this.unsupported_rbd_features = data[3].unsupported_rbd_features;
@@ -663,7 +667,8 @@ export class IscsiTargetFormComponent implements OnInit {
   targetSettingsModal() {
     const initialState = {
       target_controls: this.targetForm.get('target_controls'),
-      target_default_controls: this.target_default_controls
+      target_default_controls: this.target_default_controls,
+      target_controls_limits: this.target_controls_limits
     };
 
     this.modalRef = this.modalService.show(IscsiTargetIqnSettingsModalComponent, { initialState });
@@ -674,6 +679,7 @@ export class IscsiTargetFormComponent implements OnInit {
       imagesSettings: this.imagesSettings,
       image: image,
       disk_default_controls: this.disk_default_controls,
+      disk_controls_limits: this.disk_controls_limits,
       backstores: this.getValidBackstores(this.getImageById(image))
     };
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -25,6 +25,7 @@ import { IscsiTargetIqnSettingsModalComponent } from '../iscsi-target-iqn-settin
   styleUrls: ['./iscsi-target-form.component.scss']
 })
 export class IscsiTargetFormComponent implements OnInit {
+  cephIscsiConfigVersion: number;
   targetForm: CdFormGroup;
   modalRef: BsModalRef;
   minimum_gateways = 1;
@@ -100,7 +101,8 @@ export class IscsiTargetFormComponent implements OnInit {
       this.iscsiService.listTargets(),
       this.rbdService.list(),
       this.iscsiService.portals(),
-      this.iscsiService.settings()
+      this.iscsiService.settings(),
+      this.iscsiService.version()
     ];
 
     if (this.router.url.startsWith('/block/iscsi/targets/edit')) {
@@ -160,11 +162,14 @@ export class IscsiTargetFormComponent implements OnInit {
       });
       this.portalsSelections = [...portals];
 
+      // iscsiService.version()
+      this.cephIscsiConfigVersion = data[4]['ceph_iscsi_config_version'];
+
       this.createForm();
 
       // iscsiService.getTarget()
-      if (data[4]) {
-        this.resolveModel(data[4]);
+      if (data[5]) {
+        this.resolveModel(data[5]);
       }
     });
   }
@@ -188,6 +193,17 @@ export class IscsiTargetFormComponent implements OnInit {
       groups: new FormArray([]),
       acl_enabled: new FormControl(false)
     });
+    // Target level authentication was introduced in ceph-iscsi config v11
+    if (this.cephIscsiConfigVersion > 10) {
+      const authFormGroup = new CdFormGroup({
+        user: new FormControl(''),
+        password: new FormControl(''),
+        mutual_user: new FormControl(''),
+        mutual_password: new FormControl('')
+      });
+      this.setAuthValidator(authFormGroup);
+      this.targetForm.addControl('auth', authFormGroup);
+    }
   }
 
   resolveModel(res) {
@@ -196,7 +212,12 @@ export class IscsiTargetFormComponent implements OnInit {
       target_controls: res.target_controls,
       acl_enabled: res.acl_enabled
     });
-
+    // Target level authentication was introduced in ceph-iscsi config v11
+    if (this.cephIscsiConfigVersion > 10) {
+      this.targetForm.patchValue({
+        auth: res.auth
+      });
+    }
     const portals = [];
     _.forEach(res.portals, (portal) => {
       const id = `${portal.host}:${portal.ip}`;
@@ -369,6 +390,25 @@ export class IscsiTargetFormComponent implements OnInit {
       cdIsInGroup: new FormControl(false)
     });
 
+    this.setAuthValidator(fg);
+
+    this.initiators.push(fg);
+
+    _.forEach(this.groupMembersSelections, (selections, i) => {
+      selections.push(new SelectOption(false, '', ''));
+      this.groupMembersSelections[i] = [...selections];
+    });
+
+    const disks = _.map(
+      this.targetForm.getValue('disks'),
+      (disk) => new SelectOption(false, disk, '')
+    );
+    this.imagesInitiatorSelections.push(disks);
+
+    return fg;
+  }
+
+  setAuthValidator(fg: CdFormGroup) {
     CdValidators.validateIf(
       fg.get('user'),
       () => fg.getValue('password') || fg.getValue('mutual_user') || fg.getValue('mutual_password'),
@@ -400,21 +440,6 @@ export class IscsiTargetFormComponent implements OnInit {
       [Validators.pattern(this.PASSWORD_REGEX)],
       [fg.get('user'), fg.get('password'), fg.get('mutual_user')]
     );
-
-    this.initiators.push(fg);
-
-    _.forEach(this.groupMembersSelections, (selections, i) => {
-      selections.push(new SelectOption(false, '', ''));
-      this.groupMembersSelections[i] = [...selections];
-    });
-
-    const disks = _.map(
-      this.targetForm.getValue('disks'),
-      (disk) => new SelectOption(false, disk, '')
-    );
-    this.imagesInitiatorSelections.push(disks);
-
-    return fg;
   }
 
   removeInitiator(index) {
@@ -566,6 +591,30 @@ export class IscsiTargetFormComponent implements OnInit {
       clients: [],
       groups: []
     };
+
+    // Target level authentication was introduced in ceph-iscsi config v11
+    if (this.cephIscsiConfigVersion > 10) {
+      const targetAuth: CdFormGroup = this.targetForm.get('auth') as CdFormGroup;
+      if (!targetAuth.getValue('user')) {
+        targetAuth.get('user').setValue('');
+      }
+      if (!targetAuth.getValue('password')) {
+        targetAuth.get('password').setValue('');
+      }
+      if (!targetAuth.getValue('mutual_user')) {
+        targetAuth.get('mutual_user').setValue('');
+      }
+      if (!targetAuth.getValue('mutual_password')) {
+        targetAuth.get('mutual_password').setValue('');
+      }
+      const acl_enabled = this.targetForm.getValue('acl_enabled');
+      request['auth'] = {
+        user: acl_enabled ? '' : targetAuth.getValue('user'),
+        password: acl_enabled ? '' : targetAuth.getValue('password'),
+        mutual_user: acl_enabled ? '' : targetAuth.getValue('mutual_user'),
+        mutual_password: acl_enabled ? '' : targetAuth.getValue('mutual_password')
+      };
+    }
 
     // Disks
     formValue.disks.forEach((disk) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
@@ -1,6 +1,6 @@
 <cd-modal>
   <ng-container class="modal-title">
-    <ng-container i18n>Settings</ng-container>&nbsp;
+    <ng-container i18n>Configure</ng-container>&nbsp;
     <small>{{ image }}</small>
   </ng-container>
 
@@ -13,6 +13,45 @@
       <div class="modal-body">
         <p class="alert-warning"
            i18n>Changing these parameters from their default values is usually not necessary.</p>
+
+        <span *ngIf="api_version >= 1">
+          <legend class="cd-header"
+                  i18n>Identifier</legend>
+          <!-- LUN -->
+          <div class="form-group row">
+            <div class="col-sm-12">
+              <label class="col-form-label"
+                     for="lun">
+                <ng-container i18n>lun</ng-container>
+                <span class="required"></span>
+              </label>
+              <input type="number"
+                     class="form-control"
+                     id="lun"
+                     name="lun"
+                     formControlName="lun">
+              <span class="invalid-feedback"
+                    *ngIf="settingsForm.showError('lun', formDir, 'required')"
+                    i18n>This field is required.</span>
+            </div>
+          </div>
+          <!-- WWN -->
+          <div class="form-group row">
+            <div class="col-sm-12">
+              <label class="col-form-label"
+                     for="wwn"
+                     i18n>wwn</label>
+              <input type="text"
+                     class="form-control"
+                     id="wwn"
+                     name="wwn"
+                     formControlName="wwn">
+            </div>
+          </div>
+        </span>
+
+        <legend class="cd-header"
+                i18n>Settings</legend>
 
         <!-- BACKSTORE -->
         <div class="form-group row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
@@ -36,20 +36,10 @@
                  *ngFor="let setting of disk_default_controls[bs] | keyvalue"
                  [ngClass]="{'has-error': settingsForm.showError(setting.key, formDir)}">
               <div class="col-sm-12">
-                <label class="control-label"
-                       for="{{ setting.key }}">{{ setting.key }}</label>
-                <input type="number"
-                       class="form-control"
-                       [formControlName]="setting.key">
-                <span class="help-block"
-                      *ngIf="settingsForm.showError(setting.key, formDir, 'min')">
-                  <ng-container i18n>Must be greater than or equal to {{ disk_controls_limits[bs][setting.key]['min'] }}.</ng-container>
-                </span>
-                <span class="help-block"
-                      *ngIf="settingsForm.showError(setting.key, formDir, 'max')">
-                  <ng-container i18n>Must be less than or equal to {{ disk_controls_limits[bs][setting.key]['max'] }}.</ng-container>
-                </span>
-                <span class="help-block">{{ helpText[setting.key]?.help }}</span>
+                <cd-iscsi-setting [settingsForm]="settingsForm"
+                                  [formDir]="formDir"
+                                  [setting]="setting.key"
+                                  [limits]="getDiskControlLimits(bs, setting.key)"></cd-iscsi-setting>
               </div>
             </div>
           </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
@@ -5,54 +5,69 @@
   </ng-container>
 
   <ng-container class="modal-content">
-    <div class="modal-body">
-      <p class="alert-warning"
-         i18n>Changing these parameters from their default values is usually not necessary.</p>
+    <form name="settingsForm"
+          class="form"
+          #formDir="ngForm"
+          [formGroup]="settingsForm"
+          novalidate>
+      <div class="modal-body">
+        <p class="alert-warning"
+           i18n>Changing these parameters from their default values is usually not necessary.</p>
 
-      <!-- BACKSTORE -->
-      <div class="form-group row">
-        <div class="col-sm-12">
-          <label class="control-label"
-                 i18n>Backstore</label>
-          <select id="backstore"
-                  name="backstore"
-                  class="form-control"
-                  [(ngModel)]="model.backstore"
-                  [disabled]="backstores.length == 1">
-            <option *ngFor="let bs of backstores"
-                    [value]="bs">{{ bs | iscsiBackstore }}</option>
-          </select>
+        <!-- BACKSTORE -->
+        <div class="form-group row">
+          <div class="col-sm-12">
+            <label class="control-label"
+                   i18n>Backstore</label>
+            <select id="backstore"
+                    name="backstore"
+                    class="form-control"
+                    formControlName="backstore">
+              <option *ngFor="let bs of backstores"
+                      [value]="bs">{{ bs | iscsiBackstore }}</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- CONTROLS -->
+        <ng-container *ngFor="let bs of backstores">
+          <ng-container *ngIf="settingsForm.value['backstore'] === bs">
+            <div class="form-group row"
+                 *ngFor="let setting of disk_default_controls[bs] | keyvalue"
+                 [ngClass]="{'has-error': settingsForm.showError(setting.key, formDir)}">
+              <div class="col-sm-12">
+                <label class="control-label"
+                       for="{{ setting.key }}">{{ setting.key }}</label>
+                <input type="number"
+                       class="form-control"
+                       [formControlName]="setting.key">
+                <span class="help-block"
+                      *ngIf="settingsForm.showError(setting.key, formDir, 'min')">
+                  <ng-container i18n>Must be greater than or equal to {{ disk_controls_limits[bs][setting.key]['min'] }}.</ng-container>
+                </span>
+                <span class="help-block"
+                      *ngIf="settingsForm.showError(setting.key, formDir, 'max')">
+                  <ng-container i18n>Must be less than or equal to {{ disk_controls_limits[bs][setting.key]['max'] }}.</ng-container>
+                </span>
+                <span class="help-block">{{ helpText[setting.key]?.help }}</span>
+              </div>
+            </div>
+          </ng-container>
+        </ng-container>
+      </div>
+
+      <div class="modal-footer">
+        <div class="button-group text-right">
+          <cd-submit-button i18n
+                            [form]="settingsForm"
+                            (submitAction)="save()">Confirm</cd-submit-button>
+          <cd-back-button [back]="modalRef.hide"
+                          name="Cancel"
+                          i18n-name>
+          </cd-back-button>
         </div>
       </div>
 
-      <!-- CONTROLS -->
-      <ng-container *ngFor="let bs of backstores">
-        <ng-container *ngIf="model.backstore === bs">
-          <div class="form-group row"
-               *ngFor="let setting of disk_default_controls[bs] | keyvalue">
-            <div class="col-sm-12">
-              <label class="control-label"
-                     for="{{ setting.key }}">{{ setting.key }}</label>
-              <input type="number"
-                     class="form-control"
-                     [(ngModel)]="model[bs][setting.key]">
-              <span class="help-block">{{ helpText[setting.key]?.help }}</span>
-            </div>
-          </div>
-        </ng-container>
-      </ng-container>
-    </div>
-
-    <div class="modal-footer">
-      <div class="button-group text-right">
-        <button class="btn btn-sm btn-primary"
-                (click)="save()"
-                i18n>Confirm</button>
-        <cd-back-button [back]="modalRef.hide"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
-      </div>
-    </div>
+    </form>
   </ng-container>
 </cd-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.spec.ts
@@ -7,6 +7,7 @@ import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
+import { IscsiSettingComponent } from '../iscsi-setting/iscsi-setting.component';
 import { IscsiTargetImageSettingsModalComponent } from './iscsi-target-image-settings-modal.component';
 
 describe('IscsiTargetImageSettingsModalComponent', () => {
@@ -14,7 +15,7 @@ describe('IscsiTargetImageSettingsModalComponent', () => {
   let fixture: ComponentFixture<IscsiTargetImageSettingsModalComponent>;
 
   configureTestBed({
-    declarations: [IscsiTargetImageSettingsModalComponent],
+    declarations: [IscsiTargetImageSettingsModalComponent, IscsiSettingComponent],
     imports: [SharedModule, ReactiveFormsModule, HttpClientTestingModule, RouterTestingModule],
     providers: [BsModalRef, i18nProviders]
   });
@@ -32,6 +33,27 @@ describe('IscsiTargetImageSettingsModalComponent', () => {
       },
       'backstore:2': {
         baz: 3
+      }
+    };
+    component.disk_controls_limits = {
+      'backstore:1': {
+        foo: {
+          min: 1,
+          max: 512,
+          type: 'int'
+        },
+        bar: {
+          min: 1,
+          max: 512,
+          type: 'int'
+        }
+      },
+      'backstore:2': {
+        baz: {
+          min: 1,
+          max: 512,
+          type: 'int'
+        }
       }
     };
     component.backstores = ['backstore:1', 'backstore:2'];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
@@ -57,6 +57,7 @@ describe('IscsiTargetImageSettingsModalComponent', () => {
       }
     };
     component.backstores = ['backstore:1', 'backstore:2'];
+    component.control = new FormControl();
 
     component.ngOnInit();
     fixture.detectChanges();
@@ -68,6 +69,8 @@ describe('IscsiTargetImageSettingsModalComponent', () => {
 
   it('should fill the form', () => {
     expect(component.settingsForm.value).toEqual({
+      lun: null,
+      wwn: null,
       backstore: 'backstore:1',
       foo: null,
       bar: null,
@@ -83,6 +86,8 @@ describe('IscsiTargetImageSettingsModalComponent', () => {
     component.save();
     expect(component.imagesSettings).toEqual({
       'rbd/disk_1': {
+        lun: null,
+        wwn: null,
         backstore: 'backstore:1',
         'backstore:1': {
           foo: 1234

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
@@ -15,7 +15,7 @@ describe('IscsiTargetImageSettingsModalComponent', () => {
 
   configureTestBed({
     declarations: [IscsiTargetImageSettingsModalComponent],
-    imports: [SharedModule, FormsModule, HttpClientTestingModule, RouterTestingModule],
+    imports: [SharedModule, ReactiveFormsModule, HttpClientTestingModule, RouterTestingModule],
     providers: [BsModalRef, i18nProviders]
   });
 
@@ -44,16 +44,17 @@ describe('IscsiTargetImageSettingsModalComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should fill the model', () => {
-    expect(component.model).toEqual({
+  it('should fill the form', () => {
+    expect(component.settingsForm.value).toEqual({
       backstore: 'backstore:1',
-      'backstore:1': {},
-      'backstore:2': {}
+      foo: null,
+      bar: null,
+      baz: null
     });
   });
 
   it('should save changes to imagesSettings', () => {
-    component.model['backstore:1'] = { foo: 1234 };
+    component.settingsForm.controls['foo'].setValue(1234);
     expect(component.imagesSettings).toEqual({
       'rbd/disk_1': { backstore: 'backstore:1', 'backstore:1': {} }
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormControl, Validators } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
@@ -20,35 +20,25 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
   backstores: any;
 
   settingsForm: CdFormGroup;
-  helpText: any;
 
   constructor(public modalRef: BsModalRef, public iscsiService: IscsiService) {}
 
   ngOnInit() {
-    this.helpText = this.iscsiService.imageAdvancedSettings;
-
     const fg = {
       backstore: new FormControl(this.imagesSettings[this.image]['backstore'])
     };
     _.forEach(this.backstores, (backstore) => {
       const model = this.imagesSettings[this.image][backstore] || {};
       _.forIn(this.disk_default_controls[backstore], (_value, key) => {
-        const validators = [];
-        if (this.disk_controls_limits && key in this.disk_controls_limits[backstore]) {
-          if ('min' in this.disk_controls_limits[backstore][key]) {
-            validators.push(Validators.min(this.disk_controls_limits[backstore][key]['min']));
-          }
-          if ('max' in this.disk_controls_limits[backstore][key]) {
-            validators.push(Validators.max(this.disk_controls_limits[backstore][key]['max']));
-          }
-        }
-        fg[key] = new FormControl(model[key], {
-          validators: validators
-        });
+        fg[key] = new FormControl(model[key]);
       });
     });
 
     this.settingsForm = new CdFormGroup(fg);
+  }
+
+  getDiskControlLimits(backstore, setting) {
+    return this.disk_controls_limits[backstore][setting];
   }
 
   save() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
 
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { IscsiService } from '../../../shared/api/iscsi.service';
+import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 
 @Component({
   selector: 'cd-iscsi-target-image-settings-modal',
@@ -14,9 +16,10 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
   image: string;
   imagesSettings: any;
   disk_default_controls: any;
+  disk_controls_limits: any;
   backstores: any;
 
-  model: any;
+  settingsForm: CdFormGroup;
   helpText: any;
 
   constructor(public modalRef: BsModalRef, public iscsiService: IscsiService) {}
@@ -24,18 +27,48 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
   ngOnInit() {
     this.helpText = this.iscsiService.imageAdvancedSettings;
 
-    this.model = _.cloneDeep(this.imagesSettings[this.image]);
+    const fg = {
+      backstore: new FormControl(this.imagesSettings[this.image]['backstore'])
+    };
     _.forEach(this.backstores, (backstore) => {
-      this.model[backstore] = this.model[backstore] || {};
+      const model = this.imagesSettings[this.image][backstore] || {};
+      _.forIn(this.disk_default_controls[backstore], (_value, key) => {
+        const validators = [];
+        if (this.disk_controls_limits && key in this.disk_controls_limits[backstore]) {
+          if ('min' in this.disk_controls_limits[backstore][key]) {
+            validators.push(Validators.min(this.disk_controls_limits[backstore][key]['min']));
+          }
+          if ('max' in this.disk_controls_limits[backstore][key]) {
+            validators.push(Validators.max(this.disk_controls_limits[backstore][key]['max']));
+          }
+        }
+        fg[key] = new FormControl(model[key], {
+          validators: validators
+        });
+      });
     });
+
+    this.settingsForm = new CdFormGroup(fg);
   }
 
   save() {
-    const backstore = this.model.backstore;
+    const backstore = this.settingsForm.controls['backstore'].value;
     const settings = {};
-    _.forIn(this.model[backstore], (value, key) => {
-      if (!(value === '' || value === null)) {
-        settings[key] = value;
+    _.forIn(this.settingsForm.controls, (control, key) => {
+      if (
+        !(control.value === '' || control.value === null) &&
+        key in this.disk_default_controls[this.settingsForm.value['backstore']]
+      ) {
+        settings[key] = control.value;
+        // If one setting belongs to multiple backstores, we have to update it in all backstores
+        _.forEach(this.backstores, (currentBackstore) => {
+          if (currentBackstore !== backstore) {
+            const model = this.imagesSettings[this.image][currentBackstore] || {};
+            if (key in model) {
+              this.imagesSettings[this.image][currentBackstore][key] = control.value;
+            }
+          }
+        });
       }
     });
     this.imagesSettings[this.image]['backstore'] = backstore;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
@@ -42,7 +42,11 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
   }
 
   getDiskControlLimits(backstore, setting) {
-    return this.disk_controls_limits[backstore][setting];
+    if (this.disk_controls_limits) {
+      return this.disk_controls_limits[backstore][setting];
+    }
+    // backward compatibility
+    return { type: 'int' };
   }
 
   save() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { AbstractControl, FormControl } from '@angular/forms';
 
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
@@ -15,9 +15,11 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 export class IscsiTargetImageSettingsModalComponent implements OnInit {
   image: string;
   imagesSettings: any;
+  api_version: number;
   disk_default_controls: any;
   disk_controls_limits: any;
   backstores: any;
+  control: AbstractControl;
 
   settingsForm: CdFormGroup;
 
@@ -25,7 +27,9 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
 
   ngOnInit() {
     const fg = {
-      backstore: new FormControl(this.imagesSettings[this.image]['backstore'])
+      backstore: new FormControl(this.imagesSettings[this.image]['backstore']),
+      lun: new FormControl(this.imagesSettings[this.image]['lun']),
+      wwn: new FormControl(this.imagesSettings[this.image]['wwn'])
     };
     _.forEach(this.backstores, (backstore) => {
       const model = this.imagesSettings[this.image][backstore] || {};
@@ -43,6 +47,8 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
 
   save() {
     const backstore = this.settingsForm.controls['backstore'].value;
+    const lun = this.settingsForm.controls['lun'].value;
+    const wwn = this.settingsForm.controls['wwn'].value;
     const settings = {};
     _.forIn(this.settingsForm.controls, (control, key) => {
       if (
@@ -62,8 +68,11 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
       }
     });
     this.imagesSettings[this.image]['backstore'] = backstore;
+    this.imagesSettings[this.image]['lun'] = lun;
+    this.imagesSettings[this.image]['wwn'] = wwn;
     this.imagesSettings[this.image][backstore] = settings;
     this.imagesSettings = { ...this.imagesSettings };
+    this.control.updateValueAndValidity({ emitEvent: false });
     this.modalRef.hide();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html
@@ -22,6 +22,14 @@
                    *ngIf="!isRadio(setting.key)"
                    type="number"
                    [formControlName]="setting.key">
+            <span class="help-block"
+                  *ngIf="settingsForm.showError(setting.key, formDir, 'min')">
+              <ng-container i18n>Must be greater than or equal to {{ target_controls_limits[setting.key]['min'] }}.</ng-container>
+            </span>
+            <span class="help-block"
+                  *ngIf="settingsForm.showError(setting.key, formDir, 'max')">
+              <ng-container i18n>Must be less than or equal to {{ target_controls_limits[setting.key]['max'] }}.</ng-container>
+            </span>
 
             <ng-container *ngIf="isRadio(setting.key)">
               <br>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html
@@ -16,40 +16,10 @@
              *ngFor="let setting of settingsForm.controls | keyvalue"
              [ngClass]="{'has-error': settingsForm.showError(setting.key, formDir)}">
           <div class="col-sm-12">
-            <label class="control-label"
-                   for="{{ setting.key }}">{{ setting.key }}</label>
-            <input class="form-control"
-                   *ngIf="!isRadio(setting.key)"
-                   type="number"
-                   [formControlName]="setting.key">
-            <span class="help-block"
-                  *ngIf="settingsForm.showError(setting.key, formDir, 'min')">
-              <ng-container i18n>Must be greater than or equal to {{ target_controls_limits[setting.key]['min'] }}.</ng-container>
-            </span>
-            <span class="help-block"
-                  *ngIf="settingsForm.showError(setting.key, formDir, 'max')">
-              <ng-container i18n>Must be less than or equal to {{ target_controls_limits[setting.key]['max'] }}.</ng-container>
-            </span>
-
-            <ng-container *ngIf="isRadio(setting.key)">
-              <br>
-              <div class="radio radio-inline">
-                <input type="radio"
-                       [id]="setting.key + 'Yes'"
-                       value="Yes"
-                       [formControlName]="setting.key">
-                <label [for]="setting.key + 'Yes'">Yes</label>
-              </div>
-              <div class="radio radio-inline">
-                <input type="radio"
-                       [id]="setting.key + 'No'"
-                       value="No"
-                       [formControlName]="setting.key">
-                <label [for]="setting.key + 'No'">No</label>
-              </div>
-            </ng-container>
-
-            <span class="help-block">{{ helpText[setting.key]?.help }}</span>
+            <cd-iscsi-setting [settingsForm]="settingsForm"
+                              [formDir]="formDir"
+                              [setting]="setting.key"
+                              [limits]="getTargetControlLimits(setting.key)"></cd-iscsi-setting>
           </div>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.spec.ts
@@ -7,6 +7,7 @@ import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
+import { IscsiSettingComponent } from '../iscsi-setting/iscsi-setting.component';
 import { IscsiTargetIqnSettingsModalComponent } from './iscsi-target-iqn-settings-modal.component';
 
 describe('IscsiTargetIqnSettingsModalComponent', () => {
@@ -14,7 +15,7 @@ describe('IscsiTargetIqnSettingsModalComponent', () => {
   let fixture: ComponentFixture<IscsiTargetIqnSettingsModalComponent>;
 
   configureTestBed({
-    declarations: [IscsiTargetIqnSettingsModalComponent],
+    declarations: [IscsiTargetIqnSettingsModalComponent, IscsiSettingComponent],
     imports: [SharedModule, ReactiveFormsModule, HttpClientTestingModule, RouterTestingModule],
     providers: [BsModalRef, i18nProviders]
   });
@@ -26,7 +27,24 @@ describe('IscsiTargetIqnSettingsModalComponent', () => {
     component.target_default_controls = {
       cmdsn_depth: 1,
       dataout_timeout: 2,
-      first_burst_length: 'Yes'
+      first_burst_length: true
+    };
+    component.target_controls_limits = {
+      cmdsn_depth: {
+        min: 1,
+        max: 512,
+        type: 'int'
+      },
+      dataout_timeout: {
+        min: 2,
+        max: 60,
+        type: 'int'
+      },
+      first_burst_length: {
+        max: 16777215,
+        min: 512,
+        type: 'int'
+      }
     };
     component.ngOnInit();
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormControl, Validators } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
@@ -18,25 +18,13 @@ export class IscsiTargetIqnSettingsModalComponent implements OnInit {
   target_controls_limits: any;
 
   settingsForm: CdFormGroup;
-  helpText: any;
 
   constructor(public modalRef: BsModalRef, public iscsiService: IscsiService) {}
 
   ngOnInit() {
     const fg = {};
-    this.helpText = this.iscsiService.targetAdvancedSettings;
-
     _.forIn(this.target_default_controls, (_value, key) => {
-      const validators = [];
-      if (this.target_controls_limits && key in this.target_controls_limits) {
-        if ('min' in this.target_controls_limits[key]) {
-          validators.push(Validators.min(this.target_controls_limits[key]['min']));
-        }
-        if ('max' in this.target_controls_limits[key]) {
-          validators.push(Validators.max(this.target_controls_limits[key]['max']));
-        }
-      }
-      fg[key] = new FormControl(this.target_controls.value[key], { validators: validators });
+      fg[key] = new FormControl(this.target_controls.value[key]);
     });
 
     this.settingsForm = new CdFormGroup(fg);
@@ -54,7 +42,7 @@ export class IscsiTargetIqnSettingsModalComponent implements OnInit {
     this.modalRef.hide();
   }
 
-  isRadio(control) {
-    return ['Yes', 'No'].indexOf(this.target_default_controls[control]) !== -1;
+  getTargetControlLimits(setting) {
+    return this.target_controls_limits[setting];
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
@@ -43,6 +43,13 @@ export class IscsiTargetIqnSettingsModalComponent implements OnInit {
   }
 
   getTargetControlLimits(setting) {
-    return this.target_controls_limits[setting];
+    if (this.target_controls_limits) {
+      return this.target_controls_limits[setting];
+    }
+    // backward compatibility
+    if (['Yes', 'No'].includes(this.target_default_controls[setting])) {
+      return { type: 'bool' };
+    }
+    return { type: 'int' };
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
@@ -15,6 +15,7 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 export class IscsiTargetIqnSettingsModalComponent implements OnInit {
   target_controls: FormControl;
   target_default_controls: any;
+  target_controls_limits: any;
 
   settingsForm: CdFormGroup;
   helpText: any;
@@ -26,7 +27,16 @@ export class IscsiTargetIqnSettingsModalComponent implements OnInit {
     this.helpText = this.iscsiService.targetAdvancedSettings;
 
     _.forIn(this.target_default_controls, (_value, key) => {
-      fg[key] = new FormControl(this.target_controls.value[key]);
+      const validators = [];
+      if (this.target_controls_limits && key in this.target_controls_limits) {
+        if ('min' in this.target_controls_limits[key]) {
+          validators.push(Validators.min(this.target_controls_limits[key]['min']));
+        }
+        if ('max' in this.target_controls_limits[key]) {
+          validators.push(Validators.max(this.target_controls_limits[key]['max']));
+        }
+      }
+      fg[key] = new FormControl(this.target_controls.value[key], { validators: validators });
     });
 
     this.settingsForm = new CdFormGroup(fg);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.html
@@ -42,6 +42,7 @@
 
   <cd-iscsi-target-details cdTableDetail
                            *ngIf="selection.hasSingleSelection"
+                           [cephIscsiConfigVersion]="cephIscsiConfigVersion"
                            [selection]="selection"
                            [settings]="settings"></cd-iscsi-target-details>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
@@ -57,6 +57,7 @@ describe('IscsiTargetListComponent', () => {
     summaryService['summaryData$'] = summaryService['summaryDataSource'].asObservable();
 
     spyOn(iscsiService, 'status').and.returnValue(of({ available: true }));
+    spyOn(iscsiService, 'version').and.returnValue(of({ ceph_iscsi_config_version: 11 }));
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -36,6 +36,7 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
   modalRef: BsModalRef;
   permissions: Permissions;
   selection = new CdTableSelection();
+  cephIscsiConfigVersion: number;
   settings: any;
   status: string;
   summaryDataSubscription: Subscription;
@@ -113,15 +114,18 @@ export class IscsiTargetListComponent implements OnInit, OnDestroy {
       this.available = result.available;
 
       if (result.available) {
-        this.taskListService.init(
-          () => this.iscsiService.listTargets(),
-          (resp) => this.prepareResponse(resp),
-          (targets) => (this.targets = targets),
-          () => this.onFetchError(),
-          this.taskFilter,
-          this.itemFilter,
-          this.builders
-        );
+        this.iscsiService.version().subscribe((res: any) => {
+          this.cephIscsiConfigVersion = res['ceph_iscsi_config_version'];
+          this.taskListService.init(
+            () => this.iscsiService.listTargets(),
+            (resp) => this.prepareResponse(resp),
+            (targets) => (this.targets = targets),
+            () => this.onFetchError(),
+            this.taskFilter,
+            this.itemFilter,
+            this.builders
+          );
+        });
 
         this.iscsiService.settings().subscribe((settings: any) => {
           this.settings = settings;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/iscsi.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/iscsi.service.ts
@@ -82,6 +82,10 @@ export class IscsiService {
     return this.http.get(`ui-api/iscsi/settings`);
   }
 
+  version() {
+    return this.http.get(`ui-api/iscsi/version`);
+  }
+
   portals() {
     return this.http.get(`ui-api/iscsi/portals`);
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/iscsi.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/iscsi.service.ts
@@ -11,57 +11,6 @@ import { ApiModule } from './api.module';
 export class IscsiService {
   constructor(private http: HttpClient) {}
 
-  targetAdvancedSettings = {
-    cmdsn_depth: {
-      help: ''
-    },
-    dataout_timeout: {
-      help: ''
-    },
-    first_burst_length: {
-      help: ''
-    },
-    immediate_data: {
-      help: ''
-    },
-    initial_r2t: {
-      help: ''
-    },
-    max_burst_length: {
-      help: ''
-    },
-    max_outstanding_r2t: {
-      help: ''
-    },
-    max_recv_data_segment_length: {
-      help: ''
-    },
-    max_xmit_data_segment_length: {
-      help: ''
-    },
-    nopin_response_timeout: {
-      help: ''
-    },
-    nopin_timeout: {
-      help: ''
-    }
-  };
-
-  imageAdvancedSettings = {
-    hw_max_sectors: {
-      help: ''
-    },
-    max_data_area_mb: {
-      help: ''
-    },
-    osd_op_timeout: {
-      help: ''
-    },
-    qfull_timeout: {
-      help: ''
-    }
-  };
-
   listTargets() {
     return this.http.get(`api/iscsi/target`);
   }

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -309,7 +309,8 @@ uib-accordion .panel-title,
   color: $color-required-text;
 }
 /* Forms */
-.form-group > .control-label > span.required {
+.form-group > .control-label > span.required,
+.form-group > .col-sm-12 > .control-label > span.required {
   @extend .fa;
   @extend .fa-asterisk;
   @extend .required;

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -209,10 +209,22 @@ class IscsiClient(RestClient):
         })
 
     @RestClient.api_put('/api/targetauth/{target_iqn}')
-    def update_targetauth(self, target_iqn, action, request=None):
-        logger.debug("iSCSI[%s] Updating targetauth: %s/%s", self.gateway_name, target_iqn, action)
+    def update_targetacl(self, target_iqn, action, request=None):
+        logger.debug("iSCSI[%s] Updating targetacl: %s/%s", self.gateway_name, target_iqn, action)
         return request({
             'action': action
+        })
+
+    @RestClient.api_put('/api/targetauth/{target_iqn}')
+    def update_targetauth(self, target_iqn, user, password, mutual_user, mutual_password,
+                          request=None):
+        logger.debug("iSCSI[%s] Updating targetauth: %s/%s/%s/%s/%s", self.gateway_name,
+                     target_iqn, user, password, mutual_user, mutual_password)
+        return request({
+            'username': user,
+            'password': password,
+            'mutual_username': mutual_user,
+            'mutual_password': mutual_password
         })
 
     @RestClient.api_get('/api/targetinfo/{target_iqn}')

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -115,11 +115,12 @@ class IscsiClient(RestClient):
         return request()
 
     @RestClient.api_put('/api/disk/{pool}/{image}')
-    def create_disk(self, pool, image, backstore, request=None):
+    def create_disk(self, pool, image, backstore, wwn, request=None):
         logger.debug("iSCSI[%s] Creating disk: %s/%s", self.gateway_name, pool, image)
         return request({
             'mode': 'create',
-            'backstore': backstore
+            'backstore': backstore,
+            'wwn': wwn
         })
 
     @RestClient.api_delete('/api/disk/{pool}/{image}')
@@ -138,11 +139,12 @@ class IscsiClient(RestClient):
         })
 
     @RestClient.api_put('/api/targetlun/{target_iqn}')
-    def create_target_lun(self, target_iqn, image_id, request=None):
+    def create_target_lun(self, target_iqn, image_id, lun, request=None):
         logger.debug("iSCSI[%s] Creating target lun: %s/%s", self.gateway_name, target_iqn,
                      image_id)
         return request({
-            'disk': image_id
+            'disk': image_id,
+            'lun_id': lun
         })
 
     @RestClient.api_delete('/api/targetlun/{target_iqn}')
@@ -166,6 +168,14 @@ class IscsiClient(RestClient):
     @RestClient.api_put('/api/clientlun/{target_iqn}/{client_iqn}')
     def create_client_lun(self, target_iqn, client_iqn, image_id, request=None):
         logger.debug("iSCSI[%s] Creating client lun: %s/%s", self.gateway_name, target_iqn,
+                     client_iqn)
+        return request({
+            'disk': image_id
+        })
+
+    @RestClient.api_delete('/api/clientlun/{target_iqn}/{client_iqn}')
+    def delete_client_lun(self, target_iqn, client_iqn, image_id, request=None):
+        logger.debug("iSCSI[%s] Deleting client lun: %s/%s", self.gateway_name, target_iqn,
                      client_iqn)
         return request({
             'disk': image_id

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -131,7 +131,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         request['target_iqn'] = target_iqn
         self._task_post('/api/iscsi/target', request)
         self.assertStatus(201)
-        self._delete('/api/iscsi/target/{}'.format(request['target_iqn']))
+        self._task_delete('/api/iscsi/target/{}'.format(request['target_iqn']))
         self.assertStatus(204)
         self._get('/api/iscsi/target')
         self.assertStatus(200)
@@ -361,7 +361,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
     def _update_iscsi_target(self, create_request, update_request, response):
         self._task_post('/api/iscsi/target', create_request)
         self.assertStatus(201)
-        self._put('/api/iscsi/target/{}'.format(create_request['target_iqn']), update_request)
+        self._task_put('/api/iscsi/target/{}'.format(create_request['target_iqn']), update_request)
         self.assertStatus(200)
         self._get('/api/iscsi/target/{}'.format(update_request['new_target_iqn']))
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -103,7 +103,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw1"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
-        self._post('/api/iscsi/target', request)
+        self._task_post('/api/iscsi/target', request)
         self.assertStatus(201)
         self._get('/api/iscsi/target')
         self.assertStatus(200)
@@ -116,7 +116,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw2"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
-        self._post('/api/iscsi/target', request)
+        self._task_post('/api/iscsi/target', request)
         self.assertStatus(201)
         self._get('/api/iscsi/target/{}'.format(request['target_iqn']))
         self.assertStatus(200)
@@ -129,7 +129,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw3"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
-        self._post('/api/iscsi/target', request)
+        self._task_post('/api/iscsi/target', request)
         self.assertStatus(201)
         self._delete('/api/iscsi/target/{}'.format(request['target_iqn']))
         self.assertStatus(204)
@@ -350,7 +350,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         create_request['target_iqn'] = target_iqn
         create_request['groups'].append(copy.deepcopy(create_request['groups'][0]))
         create_request['groups'][1]['group_id'] = 'mygroup2'
-        self._post('/api/iscsi/target', create_request)
+        self._task_post('/api/iscsi/target', create_request)
         self.assertStatus(400)
         self.assertJsonBody({
             'detail': 'Each initiator can only be part of 1 group at a time',
@@ -359,7 +359,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         })
 
     def _update_iscsi_target(self, create_request, update_request, response):
-        self._post('/api/iscsi/target', create_request)
+        self._task_post('/api/iscsi/target', create_request)
         self.assertStatus(201)
         self._put('/api/iscsi/target/{}'.format(create_request['target_iqn']), update_request)
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -603,20 +603,24 @@ class IscsiClientMock(object):
             target_config['ip_list'].remove(ip)
         target_config['portals'].pop(gateway_name)
 
-    def create_disk(self, pool, image, backstore):
+    def create_disk(self, pool, image, backstore, wwn):
+        if wwn is None:
+            wwn = '64af6678-9694-4367-bacc-f8eb0baa' + str(len(self.config['disks']))
         image_id = '{}/{}'.format(pool, image)
         self.config['disks'][image_id] = {
             "pool": pool,
             "image": image,
             "backstore": backstore,
             "controls": {},
-            "wwn": '64af6678-9694-4367-bacc-f8eb0baa' + str(len(self.config['disks']))
+            "wwn": wwn
         }
 
-    def create_target_lun(self, target_iqn, image_id):
+    def create_target_lun(self, target_iqn, image_id, lun):
         target_config = self.config['targets'][target_iqn]
+        if lun is None:
+            lun = len(target_config['disks'])
         target_config['disks'][image_id] = {
-            "lun_id": len(target_config['disks'])
+            "lun_id": lun
         }
         self.config['disks'][image_id]['owner'] = list(target_config['portals'].keys())[0]
 
@@ -649,6 +653,10 @@ class IscsiClientMock(object):
     def create_client_lun(self, target_iqn, client_iqn, image_id):
         target_config = self.config['targets'][target_iqn]
         target_config['clients'][client_iqn]['luns'][image_id] = {}
+
+    def delete_client_lun(self, target_iqn, client_iqn, image_id):
+        target_config = self.config['targets'][target_iqn]
+        del target_config['clients'][client_iqn]['luns'][image_id]
 
     def create_client_auth(self, target_iqn, client_iqn, user, password, m_user, m_password):
         target_config = self.config['targets'][target_iqn]

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -596,7 +596,14 @@ class IscsiClientMock(object):
 
     def reconfigure_disk(self, pool, image, controls):
         image_id = '{}/{}'.format(pool, image)
-        self.config['disks'][image_id]['controls'] = controls
+        settings = self.get_settings()
+        backstore = self.config['disks'][image_id]['backstore']
+        disk_default_controls = settings['disk_default_controls'][backstore]
+        new_controls = {}
+        for control_k, control_v in controls.items():
+            if control_v != disk_default_controls[control_k]:
+                new_controls[control_k] = control_v
+        self.config['disks'][image_id]['controls'] = new_controls
 
     def create_client(self, target_iqn, client_iqn):
         target_config = self.config['targets'][target_iqn]

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -403,6 +403,11 @@ iscsi_target_request = {
         }
     ],
     "acl_enabled": True,
+    "auth": {
+        "password": "",
+        "user": "",
+        "mutual_password": "",
+        "mutual_user": ""},
     "target_controls": {},
     "groups": [
         {
@@ -459,6 +464,11 @@ iscsi_target_response = {
         }
     ],
     "acl_enabled": True,
+    "auth": {
+        "password": "",
+        "user": "",
+        "mutual_password": "",
+        "mutual_user": ""},
     'groups': [
         {
             'group_id': 'mygroup',
@@ -495,7 +505,7 @@ class IscsiClientMock(object):
             "gateways": {},
             "targets": {},
             "updated": "",
-            "version": 9
+            "version": 11
         }
 
     @classmethod
@@ -557,6 +567,14 @@ class IscsiClientMock(object):
         self.config['targets'][target_iqn] = {
             "clients": {},
             "acl_enabled": True,
+            "auth": {
+                "username": "",
+                "password": "",
+                "password_encryption_enabled": False,
+                "mutual_username": "",
+                "mutual_password": "",
+                "mutual_password_encryption_enabled": False
+            },
             "controls": target_controls,
             "created": "2019/01/17 09:22:34",
             "disks": [],
@@ -685,8 +703,15 @@ class IscsiClientMock(object):
         self.config['discovery_auth']['mutual_username'] = mutual_user
         self.config['discovery_auth']['mutual_password'] = mutual_password
 
-    def update_targetauth(self, target_iqn, action):
+    def update_targetacl(self, target_iqn, action):
         self.config['targets'][target_iqn]['acl_enabled'] = (action == 'enable_acl')
+
+    def update_targetauth(self, target_iqn, user, password, mutual_user, mutual_password):
+        target_config = self.config['targets'][target_iqn]
+        target_config['auth']['username'] = user
+        target_config['auth']['password'] = password
+        target_config['auth']['mutual_username'] = mutual_user
+        target_config['auth']['mutual_password'] = mutual_password
 
     def get_targetinfo(self, target_iqn):
         # pylint: disable=unused-argument


### PR DESCRIPTION
This PR includes multiple backports in order to avoid merging conflicts.

**nautilus: mgr/dashboard: Validate iSCSI controls**
- backport tracker: https://tracker.ceph.com/issues/40830
- backport of https://github.com/ceph/ceph/pull/28942
- parent tracker: https://tracker.ceph.com/issues/38018

---

**nautilus: mgr/dashboard: Error editing iSCSI image advanced settings**
- backport tracker: https://tracker.ceph.com/issues/42024
- backport of https://github.com/ceph/ceph/pull/30100
- parent tracker: https://tracker.ceph.com/issues/41388

---

**nautilus: mgr/dashboard: Error during iSCSI target edition**
- backport tracker: https://tracker.ceph.com/issues/42030
- backport of https://github.com/ceph/ceph/pull/30349
- parent tracker: https://tracker.ceph.com/issues/41779

---

**nautilus: mgr/dashboard: Support iSCSI target-level CHAP authentication**
- backport tracker: https://tracker.ceph.com/issues/42065
- backport of https://github.com/ceph/ceph/pull/30011
- parent tracker: https://tracker.ceph.com/issues/41576

---

**nautilus: mgr/dashboard: iSCSI control inputs should be rendered based on control "type"**
- backport tracker: https://tracker.ceph.com/issues/42066
- backport of https://github.com/ceph/ceph/pull/30208
- parent tracker: https://tracker.ceph.com/issues/41682

---

**nautilus: mgr/dashboard: Should be possible to set the iSCSI disk WWN and LUN number from the UI**

- backport tracker: https://tracker.ceph.com/issues/42679
- backport of #31056
- parent tracker: https://tracker.ceph.com/issues/41749

----------

**nautilus: mgr/dashboard: iSCSI target details should display the disk WWN and LUN number**

- backport tracker: https://tracker.ceph.com/issues/42356
- backport of #30288
- parent tracker: https://tracker.ceph.com/issues/41742

