### PR TITLE
test: add librados-based startup/shutdown racer test

### DIFF
--- a/cmake/modules/FindSanitizers.cmake
+++ b/cmake/modules/FindSanitizers.cmake
@@ -20,7 +20,7 @@ foreach(component ${Sanitizers_FIND_COMPONENTS})
     elseif(NOT CMAKE_POSITION_INDEPENDENT_CODE)
       message(SEND_ERROR "TSan requires all code to be position independent")
     endif()
-    set(Sanitizers_Thread_COMPILE_OPTIONS "-fsanitize=thread")
+    set(Sanitizers_thread_COMPILE_OPTIONS "-fsanitize=thread")
   elseif(component STREQUAL "undefined_behavior")
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88684
     set(Sanitizers_undefined_behavior_COMPILE_OPTIONS "-fsanitize=undefined;-fno-sanitize=vptr")

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -16,6 +16,8 @@
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
 #include "gtest/gtest.h"
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #include <errno.h>
 #include <map>
@@ -307,4 +309,37 @@ TEST_F(LibRadosMisc, MinCompatClient) {
 
   ASSERT_LE(-1, require_min_compat_client);
   ASSERT_GT(CEPH_RELEASE_MAX, require_min_compat_client);
+}
+
+static void shutdown_racer_func()
+{
+  const int niter = 32;
+  rados_t rad;
+  int i;
+
+  for (i = 0; i < niter; ++i) {
+    ASSERT_EQ("", connect_cluster(&rad));
+    rados_shutdown(rad);
+  }
+}
+
+// See trackers #20988 and #42026
+TEST_F(LibRadosMisc, ShutdownRace)
+{
+  const int nthreads = 128;
+  std::thread threads[nthreads];
+
+  // Need a bunch of fd's for this test
+  struct rlimit rold, rnew;
+  ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &rold), 0);
+  rnew = rold;
+  rnew.rlim_cur = rnew.rlim_max;
+  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rnew), 0);
+
+  for (int i = 0; i < nthreads; ++i)
+    threads[i] = std::thread(shutdown_racer_func);
+
+  for (int i = 0; i < nthreads; ++i)
+    threads[i].join();
+  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
 }


### PR DESCRIPTION
We have a testcase for libcephfs that spawns a bunch of threads that then create separate ceph mounts and immediately tear them down. Recently, we've started seeing some failures that don't seem to be cephfs specific (see https://tracker.ceph.com/issues/42026).

This PR just adds a librados-based equivalent test that also seems to exhibit the same problem.
When run under valgrind, you'll see out-of-bounds accesses and complaints about bogus file descriptors, mostly down in the EventCenter code.