### PR TITLE
luminous ceph-volume: do not fail when trying to remove crypt mapper

### DIFF
--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -103,7 +103,8 @@ def dmcrypt_close(mapping):
         logger.debug('device mapper path does not exist %s' % mapping)
         logger.debug('will skip cryptsetup removal')
         return
-    process.run(['cryptsetup', 'remove', mapping])
+    # don't be strict about the remove call, but still warn on the terminal if it fails
+    process.run(['cryptsetup', 'remove', mapping], stop_on_error=False)
 
 
 def get_dmcrypt_key(osd_id, osd_fsid, lockbox_keyring=None):


### PR DESCRIPTION
In a containerized context, at some point, need to run `simple scan` on a device
from a separate container (not the existing and running corresponding container
to that device), but this can't work because when it tries to remove the
mapper which is still in use by the corresponding running osd container,
it fails.
This can be a bit more permissive and simply throw a warning.

Closes: https://tracker.ceph.com/issues/41392

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
Backport of: https://github.com/ceph/ceph/pull/30490