### PR TITLE
qa/suite: whitelist PG_AVAILABILITY in rados_api_tests.yaml 

### DIFF
--- a/qa/suites/powercycle/osd/tasks/rados_api_tests.yaml
+++ b/qa/suites/powercycle/osd/tasks/rados_api_tests.yaml
@@ -3,6 +3,7 @@ overrides:
     log-whitelist:
       - reached quota
       - \(POOL_APP_NOT_ENABLED\)
+      - \(PG_AVAILABILITY\)
 tasks:
 - ceph-fuse:
 - workunit:

--- a/qa/suites/rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/basic/tasks/rados_api_tests.yaml
@@ -4,11 +4,12 @@ overrides:
     - reached quota
     - but it is still running
     - overall HEALTH_
-    - (POOL_FULL)
-    - (SMALLER_PGP_NUM)
-    - (CACHE_POOL_NO_HIT_SET)
-    - (CACHE_POOL_NEAR_FULL)
-    - (POOL_APP_NOT_ENABLED)
+    - \(POOL_FULL\)
+    - \(SMALLER_PGP_NUM\)
+    - \(CACHE_POOL_NO_HIT_SET\)
+    - \(CACHE_POOL_NEAR_FULL\)
+    - \(POOL_APP_NOT_ENABLED\)
+    - \(PG_AVAILABILITY\)
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/thrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/thrash/workloads/rados_api_tests.yaml
@@ -3,6 +3,7 @@ overrides:
     log-whitelist:
       - reached quota
       - \(POOL_APP_NOT_ENABLED\)
+      - \(PG_AVAILABILITY\)
     crush_tunables: hammer
     conf:
       client:

--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -9,6 +9,7 @@ overrides:
       - \(REQUEST_SLOW\)
       - \(CACHE_POOL_NEAR_FULL\)
       - \(POOL_APP_NOT_ENABLED\)
+      - \(PG_AVAILABILITY\)
     conf:
       client:
         debug ms: 1


### PR DESCRIPTION
pg will be created when increasing pgp-num and pg-num. so at that
moment, PG_AVAILABILITY is reported. so whitelist it in all tests which
run rados/test.sh. that script exercises ceph_test_rados_api_list.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
