### PR TITLE
rgw: compression info should be same during multipart uploading

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6042,7 +6042,7 @@ void RGWCompleteMultipart::execute()
       }
 
       bool part_compressed = (obj_part.cs_info.compression_type != "none");
-      if ((obj_iter != obj_parts.begin()) &&
+      if ((handled_parts > 0) &&
           ((part_compressed != compressed) ||
             (cs_info.compression_type != obj_part.cs_info.compression_type))) {
           ldpp_dout(this, 0) << "ERROR: compression type was changed during multipart upload ("


### PR DESCRIPTION
Compression info should be same during one multipart upload request. One multipart upload may contain more than 1000 parts. We should compare compression info apart  from the first part. 

Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>



