### PR TITLE
qa/suites/rados/thrash-old-clients: tolerate MON_DOWN

### DIFF
--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -3,6 +3,8 @@ overrides:
     mon_bind_addrvec: false
     mon_bind_msgr2: false
     crush_tunables: hammer
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         ms bind msgr2: false

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     mon_bind_addrvec: false
     mon_bind_msgr2: false
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         ms type: async

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     mon_bind_addrvec: false
     mon_bind_msgr2: false
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         mon warn on msgr2 not enabled: false

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     mon_bind_msgr2: false
     mon_bind_addrvec: false
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         ms type: async

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     mon_bind_addrvec: false
     mon_bind_msgr2: false
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         mon warn on msgr2 not enabled: false

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     mon_bind_addrvec: false
     mon_bind_msgr2: false
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         ms type: async

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     mon_bind_addrvec: false
     mon_bind_msgr2: false
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         ms type: async

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     mon_bind_msgr2: false
     mon_bind_addrvec: false
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         ms type: async

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+      - \(MON_DOWN\)
     conf:
       global:
         ms type: async

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - \(MON_DOWN\)
 tasks:
 - install:
     branch: nautilus


### PR DESCRIPTION
The first thing this test does is upgrade all mons.

Signed-off-by: Sage Weil <sage@redhat.com>