### PR TITLE
mgr/dashboard: wait for iscsi/target create/put

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -107,7 +107,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw1"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
-        self._post('/api/iscsi/target', request)
+        self._task_post('/api/iscsi/target', request)
         self.assertStatus(201)
         self._get('/api/iscsi/target')
         self.assertStatus(200)
@@ -120,7 +120,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw2"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
-        self._post('/api/iscsi/target', request)
+        self._task_post('/api/iscsi/target', request)
         self.assertStatus(201)
         self._get('/api/iscsi/target/{}'.format(request['target_iqn']))
         self.assertStatus(200)
@@ -133,7 +133,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         target_iqn = "iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw3"
         request = copy.deepcopy(iscsi_target_request)
         request['target_iqn'] = target_iqn
-        self._post('/api/iscsi/target', request)
+        self._task_post('/api/iscsi/target', request)
         self.assertStatus(201)
         self._delete('/api/iscsi/target/{}'.format(request['target_iqn']))
         self.assertStatus(204)
@@ -354,7 +354,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         create_request['target_iqn'] = target_iqn
         create_request['groups'].append(copy.deepcopy(create_request['groups'][0]))
         create_request['groups'][1]['group_id'] = 'mygroup2'
-        self._post('/api/iscsi/target', create_request)
+        self._task_post('/api/iscsi/target', create_request)
         self.assertStatus(400)
         self.assertJsonBody({
             'detail': 'Each initiator can only be part of 1 group at a time',
@@ -363,7 +363,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         })
 
     def _update_iscsi_target(self, create_request, update_request, response):
-        self._post('/api/iscsi/target', create_request)
+        self._task_post('/api/iscsi/target', create_request)
         self.assertStatus(201)
         self._put('/api/iscsi/target/{}'.format(create_request['target_iqn']), update_request)
         self.assertStatus(200)


### PR DESCRIPTION
IscsiTarget.create() returns a Task, so we need to wait for its
completion before moving on.

the same applies to IscsiTarget.put()

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
