### PR TITLE
cephfs-shell: make compatible with cmd2 versions after 0.9.13

### DIFF
--- a/doc/cephfs/cephfs-shell.rst
+++ b/doc/cephfs/cephfs-shell.rst
@@ -238,18 +238,21 @@ Usage:
 * name - name of the alias being looked up, added, or replaced
 * value - what the alias will be resolved to (if adding or replacing) this can contain spaces and does not need to be quoted
 
-pyscript
---------
+run_pyscript
+------------
 
 Runs a python script file inside the console
 
 Usage: 
     
-    pyscript <script_path> [script_arguments]
+    run_pyscript <script_path> [script_arguments]
 
 * Console commands can be executed inside this script with cmd ("your command")
-  However, you cannot run nested "py" or "pyscript" commands from within this script
-  Paths or arguments that contain spaces must be enclosed in quotes
+  However, you cannot run nested "py" or "pyscript" commands from within this
+  script. Paths or arguments that contain spaces must be enclosed in quotes
+
+.. note:: This command is available as ``pyscript`` for cmd2 versions 0.9.13
+   or less.
 
 py
 --

--- a/doc/cephfs/cephfs-shell.rst
+++ b/doc/cephfs/cephfs-shell.rst
@@ -328,18 +328,21 @@ Usage:
 
 * file_path - path to a file to open in editor
 
-load
-----
+run_script
+----------
 
 Runs commands in script file that is encoded as either ASCII or UTF-8 text.
+Each command in the script should be separated by a newline.
 
 Usage:  
     
-    load <file_path>
+    run_script <file_path>
+
 
 * file_path - a file path pointing to a script
 
-* Script should contain one command per line, just like command would betyped in console.
+.. note:: This command is available as ``load`` for cmd2 versions 0.9.13
+   or less.
 
 shell
 -----

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -5,7 +5,6 @@ import argparse
 import os
 import os.path
 import sys
-from cmd2 import Cmd
 import cephfs as libcephfs
 import shutil
 import traceback
@@ -15,6 +14,10 @@ import math
 import re
 import shlex
 import stat
+
+from cmd2 import Cmd
+from cmd2 import __version__ as cmd2_version
+from distutils.version import LooseVersion
 
 if sys.version_info.major < 3:
     raise RuntimeError("cephfs-shell is only compatible with python3")
@@ -1332,7 +1335,10 @@ if __name__ == '__main__':
     if args.config:
         config_file = args.config
     if args.batch:
-        args.commands = ['load ' + args.batch, ',quit']
+        if LooseVersion(cmd2_version) <= LooseVersion("0.9.13"):
+            args.commands = ['load ' + args.batch, ',quit']
+        else:
+            args.commands = ['run_script ' +  args.batch, ',quit']
     if args.test:
         args.commands.extend(['-t,'] + [arg + ',' for arg in args.test])
     sys.argv.clear()


### PR DESCRIPTION
"load" command from cmd2 has been renamed to "run_script".

Fixes: https://tracker.ceph.com/issues/42057



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>