### PR TITLE
mgr/dashboard: Wait for iSCSI target put and delete

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -135,7 +135,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
         request['target_iqn'] = target_iqn
         self._task_post('/api/iscsi/target', request)
         self.assertStatus(201)
-        self._delete('/api/iscsi/target/{}'.format(request['target_iqn']))
+        self._task_delete('/api/iscsi/target/{}'.format(request['target_iqn']))
         self.assertStatus(204)
         self._get('/api/iscsi/target')
         self.assertStatus(200)
@@ -365,7 +365,7 @@ class IscsiTest(ControllerTestCase, CLICommandTestMixin):
     def _update_iscsi_target(self, create_request, update_request, response):
         self._task_post('/api/iscsi/target', create_request)
         self.assertStatus(201)
-        self._put('/api/iscsi/target/{}'.format(create_request['target_iqn']), update_request)
+        self._task_put('/api/iscsi/target/{}'.format(create_request['target_iqn']), update_request)
         self.assertStatus(200)
         self._get('/api/iscsi/target/{}'.format(update_request['new_target_iqn']))
         self.assertStatus(200)


### PR DESCRIPTION
This PR applies the same fix from https://github.com/ceph/ceph/pull/30582, but for target put and delete.

Signed-off-by: Ricardo Marques <rimarques@suse.com>
