### PR TITLE
mds: add ephemeral pinning for subtrees

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -40,6 +40,11 @@
   the commands ``orch ps`` and ``orch ls`` now support ``--format yaml`` and
   ``--format json-pretty``.
 
+* CephFS: Automatic static subtree partitioning policies may now be configured
+  using the new distributed and random ephemeral pinning extended attributes on
+  directories. See the documentation for more information:
+  https://docs.ceph.com/docs/master/cephfs/multimds/
+
 * Cephadm: ``ceph orch apply osd`` supports a ``--preview`` flag that prints a preview of
   the OSD specification before deploying OSDs. This makes it possible to
   verify that the specification is correct, before applying it.

--- a/qa/suites/multimds/basic/tasks/cephfs_test_exports.yaml
+++ b/qa/suites/multimds/basic/tasks/cephfs_test_exports.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - Replacing daemon mds
 tasks:
 - cephfs_test_runner:
     fail_on_skip: false

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -1,4 +1,3 @@
-import time
 import json
 import logging
 from tasks.ceph_test_case import CephTestCase

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -844,9 +844,11 @@ class Filesystem(MDSCluster):
 
         return result
 
-    def get_rank(self, rank=0, status=None):
+    def get_rank(self, rank=None, status=None):
         if status is None:
             status = self.getinfo()
+        if rank is None:
+            rank = 0
         return status.get_rank(self.id, rank)
 
     def rank_restart(self, rank=0, status=None):
@@ -1015,6 +1017,12 @@ class Filesystem(MDSCluster):
     def rank_tell(self, command, rank=0, status=None):
         info = self.get_rank(rank=rank, status=status)
         return json.loads(self.mon_manager.raw_cluster_cmd("tell", 'mds.{0}'.format(info['name']), *command))
+
+    def ranks_tell(self, command, status=None):
+        if status is None:
+            status = self.status()
+        for r in status.get_ranks(self.id):
+            self.rank_tell(command, rank=r['rank'], status=status)
 
     def read_cache(self, path, depth=None):
         cmd = ["dump", "tree", path]

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1021,8 +1021,18 @@ class Filesystem(MDSCluster):
     def ranks_tell(self, command, status=None):
         if status is None:
             status = self.status()
+        out = []
         for r in status.get_ranks(self.id):
-            self.rank_tell(command, rank=r['rank'], status=status)
+            result = self.rank_tell(command, rank=r['rank'], status=status)
+            out.append((r['rank'], result))
+        return sorted(out)
+
+    def ranks_perf(self, f, status=None):
+        perf = self.ranks_tell(["perf", "dump"], status=status)
+        out = []
+        for rank, perf in perf:
+            out.append((rank, f(perf)))
+        return out
 
     def read_cache(self, path, depth=None):
         cmd = ["dump", "tree", path]

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -223,12 +223,16 @@ class CephCluster(object):
     def json_asok(self, command, service_type, service_id, timeout=None):
         if timeout is None:
             timeout = 15*60
+        command.insert(0, '--format=json')
         proc = self.mon_manager.admin_socket(service_type, service_id, command, timeout=timeout)
-        response_data = proc.stdout.getvalue()
-        log.info("_json_asok output: {0}".format(response_data))
-        if response_data.strip():
-            return json.loads(response_data)
+        response_data = proc.stdout.getvalue().strip()
+        if len(response_data) > 0:
+            j = json.loads(response_data)
+            pretty = json.dumps(j, sort_keys=True, indent=2)
+            log.debug(f"_json_asok output\n{pretty}")
+            return j
         else:
+            log.debug(f"_json_asok output empty")
             return None
 
 

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -232,7 +232,7 @@ class CephCluster(object):
             log.debug(f"_json_asok output\n{pretty}")
             return j
         else:
-            log.debug(f"_json_asok output empty")
+            log.debug("_json_asok output empty")
             return None
 
 

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -10,7 +10,7 @@ import os
 import re
 from IPy import IP
 from teuthology.orchestra import run
-from teuthology.orchestra.run import CommandFailedError, ConnectionLostError
+from teuthology.orchestra.run import CommandFailedError, ConnectionLostError, Raw
 from tasks.cephfs.filesystem import Filesystem
 
 log = logging.getLogger(__name__)
@@ -512,6 +512,9 @@ class CephFSMount(object):
         return self.client_remote.run(args=args, stdin=stdin, wait=wait,
                                       stdout=StringIO(), stderr=StringIO(),
                                       cwd=cwd, check_status=check_status)
+
+    def run_shell_payload(self, payload, **kwargs):
+        return self.run_shell(["bash", "-c", Raw(f"'{payload}'")], **kwargs)
 
     def run_as_user(self, **kwargs):
         """

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -190,3 +190,200 @@ class TestExports(CephFSTestCase):
         # Check if rank1 changed (standby tookover?)
         new_rank1 = self.fs.get_rank(rank=1)
         self.assertEqual(rank1['gid'], new_rank1['gid'])
+
+    def test_ephememeral_pin_distribution(self):
+
+        # Check if the subtree distribution under ephemeral distributed pin is fairly uniform
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        self.mount_a.run_shell(["mkdir", "-p", "a"])
+        self._wait_subtrees(status, 0, [])
+
+        for i in range(0,100):
+          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
+          
+        self._wait_subtrees(status, 0, [])
+
+        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
+
+        self._wait_distributed_subtrees([status, 0, 100])
+
+        # Check if distribution is uniform
+        rank0_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 0))/len(self.get_auth_subtrees(status, 0))
+        self.assertGreaterEqual(rank0_distributed_subtree_ratio, 0.2)
+
+        rank1_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 1))/len(self.get_auth_subtrees(status, 1))
+        self.assertGreaterEqual(rank1_distributed_subtree_ratio, 0.2)
+
+        rank2_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 2))/len(self.get_auth_subtrees(status, 2))
+        self.assertGreaterEqual(rank2_distributed_subtree_ratio, 0.2)
+
+    def test_ephemeral_random(self):
+        
+        # Check if export ephemeral random is applied hierarchically
+        
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        tmp_dir = ""
+        for i in range(0, 100):
+          tmp_dir = tmp_dir + str(i) + "/"
+          self.mount_a.run_shell(["mkdir", "-p", tmp_dir])
+          self.mount_b.setfattr([temp_dir, "ceph.dir.pin.random", "1"])
+
+        count = len(get_random_auth_subtrees(status,0))
+        self.assertEqual(count, 100)
+
+    def test_ephemeral_pin_grow_mds(self):
+        
+        # Increase the no of MDSs and verify that the no of subtrees that migrate are less than 1/3 of the total no of subtrees that are ephemerally pinned
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        for i in range(0,100):
+          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
+        self._wait_subtrees(status, 0, [])
+        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
+        self._wait_distributed_subtrees([status, 0, 100])
+
+        subtrees_old = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items()) 
+        self.fs.set_max_mds(4)
+        self.fs.wait_for_daemons()
+        # Sleeping for a while to allow the ephemeral pin migrations to complete
+        time.sleep(15)
+        subtrees_new = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        for old_subtree in subtrees_old:
+            for new_subtree in subtrees_new:
+                if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
+                    count = count + 1
+                    break
+
+        assertLessEqual((count/subtrees_old), 0.33)
+
+    def test_ephemeral_pin_shrink_mds(self):
+
+        # Shrink the no of MDSs
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        for i in range(0,100):
+          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
+        self._wait_subtrees(status, 0, [])
+        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
+        self._wait_distributed_subtrees([status, 0, 100])
+
+        subtrees_old = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        self.fs.set_max_mds(2)
+        self.fs.wait_for_daemons()
+        time.sleep(15)
+
+        subtrees_new = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        for old_subtree in subtrees_old:
+            for new_subtree in subtrees_new:
+                if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
+                    count = count + 1
+                    break
+
+        assertLessEqual((count/subtrees_old), 0.33)
+
+    def test_ephemeral_pin_unset_config(self):
+
+        # Check if unsetting the distributed pin config results in every distributed pin being unset
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        for i in range(0, 10):
+            self.mount_a.run_shell(["mkdir", "-p", i +"/dummy_dir"])
+            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
+
+        self._wait_distributed_subtrees([status, 0, 10])
+
+        self.fs.mds_asok(["config", "set", "mds_export_ephemeral_distributed_config", "false"])
+        # Sleep for a while to facilitate unsetting of the pins
+        time.sleep(15)
+        
+        for i in range(0, 10):
+            self.assertTrue(self.mount_a.getfattr(i, "ceph.dir.pin.distributed") == "0")
+
+    def test_ephemeral_distributed_pin_unset(self):
+
+        # Test if unsetting the distributed ephemeral pin on a parent directory then the children directory should not be ephemerally pinned anymore
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        for i in range(0, 10):
+            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
+            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
+
+        self._wait_distributed_subtrees([status, 0, 10])
+
+        for i in range(0, 10):
+            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
+            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "0"])
+
+        time.sleep(15)
+
+        subtree_count = len(get_distributed_auth_subtrees(status, 0))
+        assertEqual(subtree_count, 0)
+
+    def test_ephemeral_standby(self):
+
+        # Test if the distribution is unaltered when a Standby MDS takes up a failed rank
+        
+        # Need all my standbys up as well as the active daemons
+        self.wait_for_daemon_start()
+        status = self.fs.status()
+
+        for i in range(0, 10):
+            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
+            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
+
+        self._wait_distributed_subtrees([status, 0, 10])
+
+        original_subtrees = get_ephemerally_pinned_auth_subtrees(status, 0)
+
+        # Flush the journal for rank 0
+        self.fs.rank_asok(["flush", "journal"], rank=0, status=status)
+
+        (original_active, ) = self.fs.get_active_names()
+        original_standbys = self.mds_cluster.get_standby_daemons()
+
+        # Kill the rank 0 daemon's physical process
+        self.fs.mds_stop(original_active)
+
+        grace = float(self.fs.get_config("mds_beacon_grace", service_type="mon"))
+
+        # Wait until the monitor promotes his replacement
+        def promoted():
+            active = self.fs.get_active_names()
+            return active and active[0] in original_standbys
+
+        log.info("Waiting for promotion of one of the original standbys {0}".format(
+            original_standbys))
+        self.wait_until_true(
+            promoted,
+            timeout=grace*2)
+
+        self.fs.wait_for_state('up:active', rank=0, timeout=MDS_RESTART_GRACE)
+
+        new_subtrees = get_ephemerally_pinned_auth_subtrees(status, 0)
+
+        assertEqual(original_subtrees, new_subtrees)

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -1,5 +1,7 @@
 import logging
+import random
 import time
+import unittest
 from tasks.cephfs.fuse_mount import FuseMount
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.orchestra.run import CommandFailedError, Raw
@@ -144,9 +146,9 @@ class TestExports(CephFSTestCase):
 
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
-        self.mount_a.run_shell(f"mkdir -p foo")
+        self.mount_a.run_shell_payload(f"mkdir -p foo")
         self.mount_a.setfattr(f"foo", "ceph.dir.pin", "0")
-        self.mount_a.run_shell(["bash", "-c", Raw(f"'mkdir -p foo/bar/baz && setfattr -n ceph.dir.pin -v 1 foo/bar'")])
+        self.mount_a.run_shell_payload(f"mkdir -p foo/bar/baz && setfattr -n ceph.dir.pin -v 1 foo/bar")
         self._wait_subtrees([('/foo/bar', 1), ('/foo', 0)], status=status)
         self.mount_a.umount_wait() # release all caps
         def _drop():
@@ -191,199 +193,358 @@ class TestExports(CephFSTestCase):
         new_rank1 = self.fs.get_rank(rank=1)
         self.assertEqual(rank1['gid'], new_rank1['gid'])
 
-    def test_ephememeral_pin_distribution(self):
+class TestEphemeralPins(CephFSTestCase):
+    MDSS_REQUIRED = 3
+    CLIENTS_REQUIRED = 1
 
-        # Check if the subtree distribution under ephemeral distributed pin is fairly uniform
+    def setUp(self):
+        CephFSTestCase.setUp(self)
+
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_distributed', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+
+        self.mount_a.run_shell_payload(f"""
+set -e
+
+# Use up a random number of inode numbers so the ephemeral pinning is not the same every test.
+mkdir .inode_number_thrash
+count=$((RANDOM % 1024))
+for ((i = 0; i < count; i++)); do touch .inode_number_thrash/$i; done
+rm -rf .inode_number_thrash
+""")
 
         self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
+        self.status = self.fs.wait_for_daemons()
 
-        status = self.fs.status()
+    def _setup_tree(self, path="tree", export=-1, distributed=False, random=0.0, count=100, wait=True):
+        return self.mount_a.run_shell_payload(f"""
+set -e
+mkdir -p {path}
+{f"setfattr -n ceph.dir.pin -v {export} {path}" if export >= 0 else ""}
+{f"setfattr -n ceph.dir.pin.distributed -v 1 {path}" if distributed else ""}
+{f"setfattr -n ceph.dir.pin.random -v {random} {path}" if random > 0.0 else ""}
+for ((i = 0; i < {count}; i++)); do
+    mkdir -p "{path}/$i"
+    echo file > "{path}/$i/file"
+done
+""", wait=wait)
 
-        self.mount_a.run_shell(["mkdir", "-p", "a"])
-        self._wait_subtrees(status, 0, [])
+    def test_ephemeral_pin_dist_override(self):
+        """
+        That an ephemeral distributed pin overrides a normal export pin.
+        """
 
-        for i in range(0,100):
-          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
-          
-        self._wait_subtrees(status, 0, [])
+        self._setup_tree(distributed=True)
+        subtrees = self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        for s in subtrees:
+            path = s['dir']['path']
+            if path == '/tree':
+                self.assertEqual(s['export_pin'], 0)
+                self.assertEqual(s['auth_first'], 0)
+            elif path.startswith('/tree/'):
+                self.assertEqual(s['export_pin'], -1)
+                self.assertTrue(s['distributed_ephemeral_pin'])
 
-        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
+    def test_ephemeral_pin_dist_override_pin(self):
+        """
+        That an export pin overrides an ephemerally pinned directory.
+        """
 
-        self._wait_distributed_subtrees([status, 0, 100])
+        self._setup_tree(distributed=True, export=0)
+        subtrees = self._wait_distributed_subtrees(100, status=self.status, rank="all", path="/tree/")
+        which = None
+        for s in subtrees:
+            if s['auth_first'] == 1:
+                path = s['dir']['path']
+                self.mount_a.setfattr(path[1:], "ceph.dir.pin", "0")
+                which = path
+                break
+        self.assertIsNotNone(which)
+        time.sleep(15)
+        subtrees = self._get_subtrees(status=self.status, rank=0)
+        for s in subtrees:
+            path = s['dir']['path']
+            if path == which:
+                self.assertEqual(s['auth_first'], 0)
+                self.assertFalse(s['distributed_ephemeral_pin'])
+                return
+        # it has been merged into /tree
+
+    def test_ephemeral_pin_dist_off(self):
+        """
+        That turning off ephemeral distributed pin merges subtrees.
+        """
+
+        self._setup_tree(distributed=True, export=0)
+        self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        self.mount_a.setfattr("tree", "ceph.dir.pin.distributed", "0")
+        self._wait_subtrees([('/tree', 0)], status=self.status)
+
+    def test_ephemeral_pin_dist_conf_off(self):
+        """
+        That turning off ephemeral distributed pin config prevents distribution.
+        """
+
+        self._setup_tree(export=0)
+        self.config_set('mds', 'mds_export_ephemeral_distributed', False)
+        self.mount_a.setfattr("tree", "ceph.dir.pin.distributed", "1")
+        time.sleep(30)
+        self._wait_subtrees([('/tree', 0)], status=self.status)
+
+    def test_ephemeral_pin_dist_conf_off_merge(self):
+        """
+        That turning off ephemeral distributed pin config merges subtrees.
+        """
+
+        self._setup_tree(distributed=True, export=0)
+        self._wait_distributed_subtrees(100, status=self.status)
+        self.config_set('mds', 'mds_export_ephemeral_distributed', False)
+        self._wait_subtrees([('/tree', 0)], timeout=60, status=self.status)
+
+    def test_ephemeral_pin_dist_override_before(self):
+        """
+        That a conventional export pin overrides the distributed policy _before_ distributed policy is set.
+        """
+
+        count = 10
+        self._setup_tree(count=count)
+        test = []
+        for i in range(count):
+            path = f"tree/{i}"
+            self.mount_a.setfattr(path, "ceph.dir.pin", "1")
+            test.append(("/"+path, 1))
+        self.mount_a.setfattr("tree", "ceph.dir.pin.distributed", "1")
+        time.sleep(10) # for something to not happen...
+        self._wait_subtrees(test, timeout=60, status=self.status, rank="all", path="/tree/")
+
+    def test_ephemeral_pin_dist_override_after(self):
+        """
+        That a conventional export pin overrides the distributed policy _after_ distributed policy is set.
+        """
+
+        self._setup_tree(count=10, distributed=True)
+        subtrees = self._wait_distributed_subtrees(10, status=self.status, rank="all")
+        victim = None
+        test = []
+        for s in subtrees:
+            path = s['dir']['path']
+            auth = s['auth_first']
+            if auth in (0, 2) and victim is None:
+                victim = path
+                self.mount_a.setfattr(victim[1:], "ceph.dir.pin", "1")
+                test.append((victim, 1))
+            else:
+                test.append((path, auth))
+        self.assertIsNotNone(victim)
+        self._wait_subtrees(test, status=self.status, rank="all", path="/tree/")
+
+    def test_ephemeral_pin_dist_failover(self):
+        """
+        That MDS failover does not cause unnecessary migrations.
+        """
+
+        # pin /tree so it does not export during failover
+        self._setup_tree(distributed=True, export=0)
+        subtrees = self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        test = [(s['dir']['path'], s['auth_first']) for s in subtrees]
+        before = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+        log.info(f"export stats: {before}")
+        self.fs.rank_fail(rank=1)
+        self.status = self.fs.wait_for_daemons()
+        time.sleep(10) # waiting for something to not happen
+        after = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+        log.info(f"export stats: {after}")
+        self.assertEqual(before, after)
+
+    def test_ephemeral_pin_distribution(self):
+        """
+        That ephemerally pinned subtrees are somewhat evenly distributed.
+        """
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+        count = 1000
+        self._setup_tree(count=count, distributed=True)
+        subtrees = self._wait_distributed_subtrees(count, status=self.status, rank="all")
+        nsubtrees = len(subtrees)
 
         # Check if distribution is uniform
-        rank0_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 0))/len(self.get_auth_subtrees(status, 0))
-        self.assertGreaterEqual(rank0_distributed_subtree_ratio, 0.2)
-
-        rank1_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 1))/len(self.get_auth_subtrees(status, 1))
-        self.assertGreaterEqual(rank1_distributed_subtree_ratio, 0.2)
-
-        rank2_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 2))/len(self.get_auth_subtrees(status, 2))
-        self.assertGreaterEqual(rank2_distributed_subtree_ratio, 0.2)
+        rank0 = list(filter(lambda x: x['auth_first'] == 0, subtrees))
+        rank1 = list(filter(lambda x: x['auth_first'] == 1, subtrees))
+        rank2 = list(filter(lambda x: x['auth_first'] == 2, subtrees))
+        self.assertGreaterEqual(len(rank0)/nsubtrees, 0.2)
+        self.assertGreaterEqual(len(rank1)/nsubtrees, 0.2)
+        self.assertGreaterEqual(len(rank2)/nsubtrees, 0.2)
 
     def test_ephemeral_random(self):
-        
-        # Check if export ephemeral random is applied hierarchically
-        
-        self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
+        """
+        That 100% randomness causes all children to be pinned.
+        """
+        self._setup_tree(random=1.0)
+        self._wait_random_subtrees(100, status=self.status, rank="all")
 
-        status = self.fs.status()
+    def test_ephemeral_random_max(self):
+        """
+        That the config mds_export_ephemeral_random_max is not exceeded.
+        """
 
-        tmp_dir = ""
-        for i in range(0, 100):
-          tmp_dir = tmp_dir + str(i) + "/"
-          self.mount_a.run_shell(["mkdir", "-p", tmp_dir])
-          self.mount_b.setfattr([temp_dir, "ceph.dir.pin.random", "1"])
+        r = 0.5
+        count = 1000
+        self._setup_tree(count=count, random=r)
+        subtrees = self._wait_random_subtrees(int(r*count*.75), status=self.status, rank="all")
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 0.01)
+        self._setup_tree(path="tree/new", count=count)
+        time.sleep(30) # for something not to happen...
+        subtrees = self._get_subtrees(status=self.status, rank="all", path="tree/new/")
+        self.assertLessEqual(len(subtrees), int(.01*count*1.25))
 
-        count = len(get_random_auth_subtrees(status,0))
-        self.assertEqual(count, 100)
+    def test_ephemeral_random_max_config(self):
+        """
+        That the config mds_export_ephemeral_random_max config rejects new OOB policies.
+        """
+
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 0.01)
+        try:
+            p = self._setup_tree(count=1, random=0.02, wait=False)
+            p.wait()
+        except CommandFailedError as e:
+            log.info(f"{e}")
+            self.assertIn("Invalid", p.stderr.getvalue())
+        else:
+            raise RuntimeError("mds_export_ephemeral_random_max ignored!")
+
+    def test_ephemeral_random_dist(self):
+        """
+        That ephemeral random and distributed can coexist with each other.
+        """
+
+        self._setup_tree(random=1.0, distributed=True, export=0)
+        self._wait_distributed_subtrees(100, status=self.status)
+        self._wait_random_subtrees(100, status=self.status)
+
+    def test_ephemeral_random_pin_override_before(self):
+        """
+        That a conventional export pin overrides the random policy before creating new directories.
+        """
+
+        self._setup_tree(count=0, random=1.0)
+        self._setup_tree(path="tree/pin", count=10, export=1)
+        self._wait_subtrees([("/tree/pin", 1)], status=self.status, rank=1, path="/tree/pin")
+
+    def test_ephemeral_random_pin_override_after(self):
+        """
+        That a conventional export pin overrides the random policy after creating new directories.
+        """
+
+        count = 10
+        self._setup_tree(count=0, random=1.0)
+        self._setup_tree(path="tree/pin", count=count)
+        self._wait_random_subtrees(count+1, status=self.status, rank="all")
+        self.mount_a.setfattr(f"tree/pin", "ceph.dir.pin", "1")
+        self._wait_subtrees([("/tree/pin", 1)], status=self.status, rank=1, path="/tree/pin")
+
+    def test_ephemeral_randomness(self):
+        """
+        That the randomness is reasonable.
+        """
+
+        r = random.uniform(0.25, 0.75) # ratios don't work for small r!
+        count = 1000
+        self._setup_tree(count=count, random=r)
+        subtrees = self._wait_random_subtrees(int(r*count*.50), status=self.status, rank="all")
+        time.sleep(30) # for max to not be exceeded
+        subtrees = self._wait_random_subtrees(int(r*count*.50), status=self.status, rank="all")
+        self.assertLessEqual(len(subtrees), int(r*count*1.50))
+
+    def test_ephemeral_random_cache_drop(self):
+        """
+        That the random ephemeral pin does not prevent empty (nothing in cache) subtree merging.
+        """
+
+        count = 100
+        self._setup_tree(count=count, random=1.0)
+        subtrees = self._wait_random_subtrees(count, status=self.status, rank="all")
+        self.mount_a.umount_wait() # release all caps
+        def _drop():
+            self.fs.ranks_tell(["cache", "drop"], status=self.status)
+        self._wait_subtrees([], status=self.status, action=_drop)
+
+    def test_ephemeral_random_failover(self):
+        """
+        That the random ephemeral pins stay pinned across MDS failover.
+        """
+
+        count = 100
+        r = 0.5
+        self._setup_tree(count=count, random=r, export=0)
+        # wait for all random subtrees to be created, not a specific count
+        time.sleep(30)
+        subtrees = self._wait_random_subtrees(1, status=self.status, rank=1)
+        test = [(s['dir']['path'], s['auth_first']) for s in subtrees]
+        before = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+        log.info(f"export stats: {before}")
+        self.fs.rank_fail(rank=1)
+        self.status = self.fs.wait_for_daemons()
+        time.sleep(30) # waiting for something to not happen
+        self._wait_subtrees(test, status=self.status, rank=1)
+        after = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+        log.info(f"export stats: {after}")
+        self.assertEqual(before, after)
 
     def test_ephemeral_pin_grow_mds(self):
-        
-        # Increase the no of MDSs and verify that the no of subtrees that migrate are less than 1/3 of the total no of subtrees that are ephemerally pinned
+        """
+        That consistent hashing works to reduce the number of migrations.
+        """
+
+        self.fs.set_max_mds(2)
+        self.status = self.fs.wait_for_daemons()
+
+        self._setup_tree(distributed=True)
+        subtrees_old = self._wait_distributed_subtrees(100, status=self.status, rank="all")
 
         self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
-
-        for i in range(0,100):
-          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
-        self._wait_subtrees(status, 0, [])
-        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
-        self._wait_distributed_subtrees([status, 0, 100])
-
-        subtrees_old = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items()) 
-        self.fs.set_max_mds(4)
-        self.fs.wait_for_daemons()
+        self.status = self.fs.wait_for_daemons()
+        
         # Sleeping for a while to allow the ephemeral pin migrations to complete
-        time.sleep(15)
-        subtrees_new = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        time.sleep(30)
+        
+        subtrees_new = self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        count = 0
         for old_subtree in subtrees_old:
             for new_subtree in subtrees_new:
                 if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
                     count = count + 1
                     break
 
-        assertLessEqual((count/subtrees_old), 0.33)
+        log.info("{0} migrations have occured due to the cluster resizing".format(count))
+        # ~50% of subtrees from the two rank will migrate to another rank
+        self.assertLessEqual((count/len(subtrees_old)), (0.5)*1.25) # with 25% overbudget
 
     def test_ephemeral_pin_shrink_mds(self):
-
-        # Shrink the no of MDSs
+        """
+        That consistent hashing works to reduce the number of migrations.
+        """
 
         self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
+        self.status = self.fs.wait_for_daemons()
 
-        status = self.fs.status()
+        self._setup_tree(distributed=True)
+        subtrees_old = self._wait_distributed_subtrees(100, status=self.status, rank="all")
 
-        for i in range(0,100):
-          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
-        self._wait_subtrees(status, 0, [])
-        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
-        self._wait_distributed_subtrees([status, 0, 100])
-
-        subtrees_old = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-        time.sleep(15)
+        self.status = self.fs.wait_for_daemons()
+        time.sleep(30)
 
-        subtrees_new = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        subtrees_new = self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        count = 0
         for old_subtree in subtrees_old:
             for new_subtree in subtrees_new:
                 if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
                     count = count + 1
                     break
 
-        assertLessEqual((count/subtrees_old), 0.33)
-
-    def test_ephemeral_pin_unset_config(self):
-
-        # Check if unsetting the distributed pin config results in every distributed pin being unset
-
-        self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
-
-        for i in range(0, 10):
-            self.mount_a.run_shell(["mkdir", "-p", i +"/dummy_dir"])
-            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
-
-        self._wait_distributed_subtrees([status, 0, 10])
-
-        self.fs.mds_asok(["config", "set", "mds_export_ephemeral_distributed_config", "false"])
-        # Sleep for a while to facilitate unsetting of the pins
-        time.sleep(15)
-        
-        for i in range(0, 10):
-            self.assertTrue(self.mount_a.getfattr(i, "ceph.dir.pin.distributed") == "0")
-
-    def test_ephemeral_distributed_pin_unset(self):
-
-        # Test if unsetting the distributed ephemeral pin on a parent directory then the children directory should not be ephemerally pinned anymore
-
-        self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
-
-        for i in range(0, 10):
-            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
-            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
-
-        self._wait_distributed_subtrees([status, 0, 10])
-
-        for i in range(0, 10):
-            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
-            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "0"])
-
-        time.sleep(15)
-
-        subtree_count = len(get_distributed_auth_subtrees(status, 0))
-        assertEqual(subtree_count, 0)
-
-    def test_ephemeral_standby(self):
-
-        # Test if the distribution is unaltered when a Standby MDS takes up a failed rank
-        
-        # Need all my standbys up as well as the active daemons
-        self.wait_for_daemon_start()
-        status = self.fs.status()
-
-        for i in range(0, 10):
-            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
-            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
-
-        self._wait_distributed_subtrees([status, 0, 10])
-
-        original_subtrees = get_ephemerally_pinned_auth_subtrees(status, 0)
-
-        # Flush the journal for rank 0
-        self.fs.rank_asok(["flush", "journal"], rank=0, status=status)
-
-        (original_active, ) = self.fs.get_active_names()
-        original_standbys = self.mds_cluster.get_standby_daemons()
-
-        # Kill the rank 0 daemon's physical process
-        self.fs.mds_stop(original_active)
-
-        grace = float(self.fs.get_config("mds_beacon_grace", service_type="mon"))
-
-        # Wait until the monitor promotes his replacement
-        def promoted():
-            active = self.fs.get_active_names()
-            return active and active[0] in original_standbys
-
-        log.info("Waiting for promotion of one of the original standbys {0}".format(
-            original_standbys))
-        self.wait_until_true(
-            promoted,
-            timeout=grace*2)
-
-        self.fs.wait_for_state('up:active', rank=0, timeout=MDS_RESTART_GRACE)
-
-        new_subtrees = get_ephemerally_pinned_auth_subtrees(status, 0)
-
-        assertEqual(original_subtrees, new_subtrees)
+        log.info("{0} migrations have occured due to the cluster resizing".format(count))
+        # rebalancing from 3 -> 2 may cause half of rank 0/1 to move and all of rank 2
+        self.assertLessEqual((count/len(subtrees_old)), (1.0/3.0/2.0 + 1.0/3.0/2.0 + 1.0/3.0)*1.25) # aka .66 with 25% overbudget

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -12,150 +12,6 @@ class TestExports(CephFSTestCase):
     MDSS_REQUIRED = 2
     CLIENTS_REQUIRED = 2
 
-    def test_export_pin(self):
-        self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
-
-        self.mount_a.run_shell(["mkdir", "-p", "1/2/3"])
-        self._wait_subtrees([], status=status)
-
-        # NOP
-        self.mount_a.setfattr("1", "ceph.dir.pin", "-1")
-        self._wait_subtrees([], status=status)
-
-        # NOP (rank < -1)
-        self.mount_a.setfattr("1", "ceph.dir.pin", "-2341")
-        self._wait_subtrees([], status=status)
-
-        # pin /1 to rank 1
-        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1)], status=status, rank=1)
-
-        # Check export_targets is set properly
-        status = self.fs.status()
-        log.info(status)
-        r0 = status.get_rank(self.fs.id, 0)
-        self.assertTrue(sorted(r0['export_targets']) == [1])
-
-        # redundant pin /1/2 to rank 1
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1), ('/1/2', 1)], status=status, rank=1)
-
-        # change pin /1/2 to rank 0
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status, rank=1)
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status)
-
-        # change pin /1/2/3 to (presently) non-existent rank 2
-        self.mount_a.setfattr("1/2/3", "ceph.dir.pin", "2")
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status)
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status, rank=1)
-
-        # change pin /1/2 back to rank 1
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1), ('/1/2', 1)], status=status, rank=1)
-
-        # add another directory pinned to 1
-        self.mount_a.run_shell(["mkdir", "-p", "1/4/5"])
-        self.mount_a.setfattr("1/4/5", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1), ('/1/2', 1), ('/1/4/5', 1)], status=status, rank=1)
-
-        # change pin /1 to 0
-        self.mount_a.setfattr("1", "ceph.dir.pin", "0")
-        self._wait_subtrees([('/1', 0), ('/1/2', 1), ('/1/4/5', 1)], status=status)
-
-        # change pin /1/2 to default (-1); does the subtree root properly respect it's parent pin?
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "-1")
-        self._wait_subtrees([('/1', 0), ('/1/4/5', 1)], status=status)
-
-        if len(list(status.get_standbys())):
-            self.fs.set_max_mds(3)
-            self.fs.wait_for_state('up:active', rank=2)
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2)], status=status)
-
-            # Check export_targets is set properly
-            status = self.fs.status()
-            log.info(status)
-            r0 = status.get_rank(self.fs.id, 0)
-            self.assertTrue(sorted(r0['export_targets']) == [1,2])
-            r1 = status.get_rank(self.fs.id, 1)
-            self.assertTrue(sorted(r1['export_targets']) == [0])
-            r2 = status.get_rank(self.fs.id, 2)
-            self.assertTrue(sorted(r2['export_targets']) == [])
-
-        # Test rename
-        self.mount_a.run_shell(["mkdir", "-p", "a/b", "aa/bb"])
-        self.mount_a.setfattr("a", "ceph.dir.pin", "1")
-        self.mount_a.setfattr("aa/bb", "ceph.dir.pin", "0")
-        if (len(self.fs.get_active_names()) > 2):
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2), ('/a', 1), ('/aa/bb', 0)], status=status)
-        else:
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/a', 1), ('/aa/bb', 0)], status=status)
-        self.mount_a.run_shell(["mv", "aa", "a/b/"])
-        if (len(self.fs.get_active_names()) > 2):
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2), ('/a', 1), ('/a/b/aa/bb', 0)], status=status)
-        else:
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/a', 1), ('/a/b/aa/bb', 0)], status=status)
-
-    def test_export_pin_getfattr(self):
-        self.fs.set_max_mds(2)
-        status = self.fs.wait_for_daemons()
-
-        self.mount_a.run_shell(["mkdir", "-p", "1/2/3"])
-        self._wait_subtrees([], status=status)
-
-        # pin /1 to rank 0
-        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1)], status=status, rank=1)
-
-        # pin /1/2 to rank 1
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1), ('/1/2', 1)], status=status, rank=1)
-
-        # change pin /1/2 to rank 0
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status, rank=1)
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status)
-
-         # change pin /1/2/3 to (presently) non-existent rank 2
-        self.mount_a.setfattr("1/2/3", "ceph.dir.pin", "2")
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status)
-
-        if len(list(status.get_standbys())):
-            self.fs.set_max_mds(3)
-            self.fs.wait_for_state('up:active', rank=2)
-            self._wait_subtrees([('/1', 1), ('/1/2', 0), ('/1/2/3', 2)], status=status)
-
-        if not isinstance(self.mount_a, FuseMount):
-            p = self.mount_a.client_remote.sh('uname -r', wait=True)
-            dir_pin = self.mount_a.getfattr("1", "ceph.dir.pin")
-            log.debug("mount.getfattr('1','ceph.dir.pin'): %s " % dir_pin)
-            if str(p) < "5" and not(dir_pin):
-                self.skipTest("Kernel does not support getting the extended attribute ceph.dir.pin")
-        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), '1')
-        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), '0')
-        if (len(self.fs.get_active_names()) > 2):
-            self.assertEqual(self.mount_a.getfattr("1/2/3", "ceph.dir.pin"), '2')
-
-    def test_export_pin_cache_drop(self):
-        """
-        That the export pin does not prevent empty (nothing in cache) subtree merging.
-        """
-
-        self.fs.set_max_mds(2)
-        status = self.fs.wait_for_daemons()
-        self.mount_a.run_shell_payload(f"mkdir -p foo")
-        self.mount_a.setfattr(f"foo", "ceph.dir.pin", "0")
-        self.mount_a.run_shell_payload(f"mkdir -p foo/bar/baz && setfattr -n ceph.dir.pin -v 1 foo/bar")
-        self._wait_subtrees([('/foo/bar', 1), ('/foo', 0)], status=status)
-        self.mount_a.umount_wait() # release all caps
-        def _drop():
-            self.fs.ranks_tell(["cache", "drop"], status=status)
-        # drop cache multiple times to clear replica pins
-        self._wait_subtrees([], status=status, action=_drop)
-
     def test_session_race(self):
         """
         Test session creation race.
@@ -192,6 +48,113 @@ class TestExports(CephFSTestCase):
         # Check if rank1 changed (standby tookover?)
         new_rank1 = self.fs.get_rank(rank=1)
         self.assertEqual(rank1['gid'], new_rank1['gid'])
+
+class TestExportPin(CephFSTestCase):
+    MDSS_REQUIRED = 3
+    CLIENTS_REQUIRED = 1
+
+    def setUp(self):
+        CephFSTestCase.setUp(self)
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+        self.mount_a.run_shell_payload("mkdir -p 1/2/3/4")
+
+    def test_noop(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "-1")
+        time.sleep(30) # for something to not happen
+        self._wait_subtrees([], status=self.status)
+
+    def test_negative(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "-2341")
+        time.sleep(30) # for something to not happen
+        self._wait_subtrees([], status=self.status)
+
+    def test_empty_pin(self):
+        self.mount_a.setfattr("1/2/3/4", "ceph.dir.pin", "1")
+        time.sleep(30) # for something to not happen
+        self._wait_subtrees([], status=self.status)
+
+    def test_trivial(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+    def test_export_targets(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+        self.status = self.fs.status()
+        r0 = self.status.get_rank(self.fs.id, 0)
+        self.assertTrue(sorted(r0['export_targets']) == [1])
+
+    def test_redundant(self):
+        # redundant pin /1/2 to rank 1
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1), ('/1/2', 1)], status=self.status, rank=1)
+
+    def test_reassignment(self):
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1/2', 1)], status=self.status, rank=1)
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
+        self._wait_subtrees([('/1/2', 0)], status=self.status, rank=0)
+
+    def test_phantom_rank(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "0")
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "10")
+        time.sleep(30) # wait for nothing weird to happen
+        self._wait_subtrees([('/1', 0)], status=self.status)
+
+    def test_nested(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
+        self.mount_a.setfattr("1/2/3", "ceph.dir.pin", "2")
+        self._wait_subtrees([('/1', 1), ('/1/2', 0), ('/1/2/3', 2)], status=self.status, rank=2)
+
+    def test_nested_unset(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "2")
+        self._wait_subtrees([('/1', 1), ('/1/2', 2)], status=self.status, rank=1)
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "-1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+    def test_rename(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self.mount_a.run_shell_payload("mkdir -p 9/8/7")
+        self.mount_a.setfattr("9/8", "ceph.dir.pin", "0")
+        self._wait_subtrees([('/1', 1), ("/9/8", 0)], status=self.status, rank=0)
+        self.mount_a.run_shell_payload("mv 9/8 1/2")
+        self._wait_subtrees([('/1', 1), ("/1/2/8", 0)], status=self.status, rank=0)
+
+    def test_getfattr(self):
+        # pin /1 to rank 0
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
+        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=self.status, rank=1)
+
+        if not isinstance(self.mount_a, FuseMount):
+            p = self.mount_a.client_remote.sh('uname -r', wait=True)
+            dir_pin = self.mount_a.getfattr("1", "ceph.dir.pin")
+            log.debug("mount.getfattr('1','ceph.dir.pin'): %s " % dir_pin)
+            if str(p) < "5" and not(dir_pin):
+                self.skipTest("Kernel does not support getting the extended attribute ceph.dir.pin")
+        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), '1')
+        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), '0')
+
+    def test_export_pin_cache_drop(self):
+        """
+        That the export pin does not prevent empty (nothing in cache) subtree merging.
+        """
+
+        self.mount_a.setfattr(f"1", "ceph.dir.pin", "0")
+        self.mount_a.setfattr(f"1/2", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 0), ('/1/2', 1)], status=self.status)
+        self.mount_a.umount_wait() # release all caps
+        def _drop():
+            self.fs.ranks_tell(["cache", "drop"], status=self.status)
+        # drop cache multiple times to clear replica pins
+        self._wait_subtrees([], status=self.status, action=_drop)
 
 class TestEphemeralPins(CephFSTestCase):
     MDSS_REQUIRED = 3

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -98,9 +98,7 @@ class TestExports(CephFSTestCase):
 
     def test_export_pin_getfattr(self):
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
+        status = self.fs.wait_for_daemons()
 
         self.mount_a.run_shell(["mkdir", "-p", "1/2/3"])
         self._wait_subtrees(status, 0, [])

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -196,10 +196,9 @@ class TestSessionMap(CephFSTestCase):
             self.skipTest("Requires FUSE client to use is_blacklisted()")
 
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-        status = self.fs.status()
+        status = self.fs.wait_for_daemons()
 
-        self.mount_a.run_shell(["mkdir", "d0", "d1"])
+        self.mount_a.run_shell_payload("mkdir {d0,d1} && touch {d0,d1}/file")
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
         self._wait_subtrees([('/d0', 0), ('/d1', 1)], status=status)

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -202,7 +202,7 @@ class TestSessionMap(CephFSTestCase):
         self.mount_a.run_shell(["mkdir", "d0", "d1"])
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self._wait_subtrees(status, 0, [('/d0', 0), ('/d1', 1)])
+        self._wait_subtrees([('/d0', 0), ('/d1', 1)], status=status)
 
         self.mount_a.run_shell(["touch", "d0/f0"])
         self.mount_a.run_shell(["touch", "d1/f0"])

--- a/qa/tasks/cephfs/test_snapshots.py
+++ b/qa/tasks/cephfs/test_snapshots.py
@@ -54,7 +54,7 @@ class TestSnapshots(CephFSTestCase):
         # setup subtrees
         self.mount_a.run_shell(["mkdir", "-p", "d1/dir"])
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
+        self._wait_subtrees([("/d1", 1)], rank=1, path="/d1")
 
         last_created = self._get_last_created_snap(rank=0,status=status)
 
@@ -230,9 +230,7 @@ class TestSnapshots(CephFSTestCase):
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d0/d1", "ceph.dir.pin", "1")
         self.mount_a.setfattr("d0/d2", "ceph.dir.pin", "2")
-        self.wait_until_true(lambda: self._check_subtree(2, '/d0/d2', status=status), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(1, '/d0/d1', status=status), timeout=5)
-        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
+        self._wait_subtrees([("/d0", 0), ("/d0/d1", 1), ("/d0/d2", 2)], rank="all", status=status, path="/d0")
 
         def _check_snapclient_cache(snaps_dump, cache_dump=None, rank=0):
             if cache_dump is None:
@@ -353,11 +351,10 @@ class TestSnapshots(CephFSTestCase):
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
 
-        self.mount_a.run_shell(["mkdir", "-p", "d0/d1"])
+        self.mount_a.run_shell(["mkdir", "-p", "d0/d1/empty"])
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d0/d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(1, '/d0/d1', status=status), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
+        self._wait_subtrees([("/d0", 0), ("/d0/d1", 1)], rank="all", status=status, path="/d0")
 
         self.mount_a.write_test_pattern("d0/d1/file_a", 8 * 1024 * 1024)
         self.mount_a.run_shell(["mkdir", "d0/.snap/s1"])
@@ -375,11 +372,10 @@ class TestSnapshots(CephFSTestCase):
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
 
-        self.mount_a.run_shell(["mkdir", "d0", "d1"])
+        self.mount_a.run_shell_payload("mkdir -p {d0,d1}/empty")
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
+        self._wait_subtrees([("/d0", 0), ("/d1", 1)], rank=0, status=status)
 
         self.mount_a.run_shell(["mkdir", "d0/d3"])
         self.mount_a.run_shell(["mkdir", "d0/.snap/s1"])
@@ -403,12 +399,11 @@ class TestSnapshots(CephFSTestCase):
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
 
-        self.mount_a.run_shell(["mkdir", "d0", "d1"])
+        self.mount_a.run_shell_payload("mkdir -p {d0,d1}/empty")
 
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
+        self._wait_subtrees([("/d0", 0), ("/d1", 1)], rank=0, status=status)
 
         self.mount_a.run_python(dedent("""
             import os

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -614,7 +614,7 @@ ln dir_1/original dir_2/linkto
 
         # Shut down rank 1
         self.fs.set_max_mds(1)
-        status = self.fs.wait_for_daemons(timeout=120)
+        self.fs.wait_for_daemons(timeout=120)
 
         # See that the stray counter on rank 0 has incremented
         self.assertEqual(self.get_mdc_stat("strays_created", rank_0_id), 1)

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -517,34 +517,16 @@ class TestStrays(CephFSTestCase):
 
         return rank_0_id, rank_1_id
 
-    def _force_migrate(self, to_id, path, watch_ino):
+    def _force_migrate(self, path, rank=1):
         """
         :param to_id: MDS id to move it to
         :param path: Filesystem path (string) to move
         :param watch_ino: Inode number to look for at destination to confirm move
         :return: None
         """
-        self.mount_a.run_shell(["setfattr", "-n", "ceph.dir.pin", "-v", "1", path])
-
-        # Poll the MDS cache dump to watch for the export completing
-        migrated = False
-        migrate_timeout = 60
-        migrate_elapsed = 0
-        while not migrated:
-            data = self.fs.mds_asok(["dump", "cache"], to_id)
-            for inode_data in data:
-                if inode_data['ino'] == watch_ino:
-                    log.debug("Found ino in cache: {0}".format(json.dumps(inode_data, indent=2)))
-                    if inode_data['is_auth'] is True:
-                        migrated = True
-                    break
-
-            if not migrated:
-                if migrate_elapsed > migrate_timeout:
-                    raise RuntimeError("Migration hasn't happened after {0}s!".format(migrate_elapsed))
-                else:
-                    migrate_elapsed += 1
-                    time.sleep(1)
+        self.mount_a.run_shell(["setfattr", "-n", "ceph.dir.pin", "-v", str(rank), path])
+        rpath = "/"+path
+        self._wait_subtrees([(rpath, rank)], rank=rank, path=rpath)
 
     def _is_stopped(self, rank):
         mds_map = self.fs.get_mds_map()
@@ -565,8 +547,7 @@ class TestStrays(CephFSTestCase):
 
         self.mount_a.create_n_files("delete_me/file", file_count)
 
-        self._force_migrate(rank_1_id, "delete_me",
-                            self.mount_a.path_to_ino("delete_me/file_0"))
+        self._force_migrate("delete_me")
 
         self.mount_a.run_shell(["rm", "-rf", Raw("delete_me/*")])
         self.mount_a.umount_wait()
@@ -610,26 +591,21 @@ class TestStrays(CephFSTestCase):
 
         # Create a non-purgeable stray in a ~mds1 stray directory
         # by doing a hard link and deleting the original file
-        self.mount_a.run_shell(["mkdir", "dir_1", "dir_2"])
-        self.mount_a.run_shell(["touch", "dir_1/original"])
-        self.mount_a.run_shell(["ln", "dir_1/original", "dir_2/linkto"])
+        self.mount_a.run_shell_payload("""
+mkdir dir_1 dir_2
+touch dir_1/original
+ln dir_1/original dir_2/linkto
+""")
 
-        self._force_migrate(rank_1_id, "dir_1",
-                            self.mount_a.path_to_ino("dir_1/original"))
+        self._force_migrate("dir_1")
+        self._force_migrate("dir_2", rank=0)
 
         # empty mds cache. otherwise mds reintegrates stray when unlink finishes
         self.mount_a.umount_wait()
-        self.fs.mds_asok(['flush', 'journal'], rank_0_id)
         self.fs.mds_asok(['flush', 'journal'], rank_1_id)
-        self.fs.mds_fail_restart()
-        self.fs.wait_for_daemons()
-
-        active_mds_names = self.fs.get_active_names()
-        rank_0_id = active_mds_names[0]
-        rank_1_id = active_mds_names[1]
+        self.fs.mds_asok(['cache', 'drop'], rank_1_id)
 
         self.mount_a.mount_wait()
-
         self.mount_a.run_shell(["rm", "-f", "dir_1/original"])
         self.mount_a.umount_wait()
 
@@ -638,7 +614,7 @@ class TestStrays(CephFSTestCase):
 
         # Shut down rank 1
         self.fs.set_max_mds(1)
-        self.fs.wait_for_daemons(timeout=120)
+        status = self.fs.wait_for_daemons(timeout=120)
 
         # See that the stray counter on rank 0 has incremented
         self.assertEqual(self.get_mdc_stat("strays_created", rank_0_id), 1)
@@ -955,8 +931,7 @@ class TestStrays(CephFSTestCase):
 
         self.mount_a.create_n_files("delete_me/file", file_count)
 
-        self._force_migrate(rank_1_id, "delete_me",
-                            self.mount_a.path_to_ino("delete_me/file_0"))
+        self._force_migrate("delete_me")
 
         begin = datetime.datetime.now()
         self.mount_a.run_shell(["rm", "-rf", Raw("delete_me/*")])
@@ -969,4 +944,3 @@ class TestStrays(CephFSTestCase):
 
         duration = (end - begin).total_seconds()
         self.assertLess(duration, (file_count * tick_period) * 0.25)
-

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -601,7 +601,7 @@ class TestVolumes(CephFSTestCase):
         path = self._fs_cmd("subvolume", "getpath", self.volname, subvolume)
         path = os.path.dirname(path) # get subvolume path
 
-        subtrees = self._get_subtrees(status=status, rank=1)
+        self._get_subtrees(status=status, rank=1)
         self._wait_subtrees([(path, 1)], status=status)
 
     def test_subvolumegroup_pin_distributed(self):
@@ -621,7 +621,7 @@ class TestVolumes(CephFSTestCase):
 
     def test_subvolume_pin_random(self):
         self.fs.set_max_mds(2)
-        status = self.fs.wait_for_daemons()
+        self.fs.wait_for_daemons()
         self.config_set('mds', 'mds_export_ephemeral_random', True)
 
         subvolume = self._generate_random_subvolume_name()

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8000,7 +8000,7 @@ std::vector<Option> get_mds_options() {
     .set_description("allow setting directory export pins to particular ranks"),
 
     Option("mds_export_ephemeral_random", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_flag(Option::FLAG_RUNTIME)
     .set_description("allow ephemeral random pinning of the loaded subtrees")
     .set_long_description("probabilistically pin the loaded directory inode and the subtree beneath it to an MDS based on the consistent hash of the inode number. The higher this value the more likely the loaded subtrees get pinned"),
@@ -8013,7 +8013,7 @@ std::vector<Option> get_mds_options() {
     .add_see_also("mds_export_ephemeral_random"),
 
     Option("mds_export_ephemeral_distributed", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_flag(Option::FLAG_RUNTIME)
     .set_description("allow ephemeral distributed pinning of the loaded subtrees")
     .set_long_description("pin the immediate child directories of the loaded directory inode based on the consistent hash of the child's inode number. "),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8005,6 +8005,13 @@ std::vector<Option> get_mds_options() {
     .set_description("allow ephemeral random pinning of the loaded subtrees")
     .set_long_description("probabilistically pin the loaded directory inode and the subtree beneath it to an MDS based on the consistent hash of the inode number. The higher this value the more likely the loaded subtrees get pinned"),
 
+    Option("mds_export_ephemeral_random_max", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.01)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("the maximum percent permitted for random ephemeral pin policy")
+    .set_min_max(0.0, 1.0)
+    .add_see_also("mds_export_ephemeral_random"),
+
     Option("mds_export_ephemeral_distributed", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_flag(Option::FLAG_RUNTIME)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7999,6 +7999,18 @@ std::vector<Option> get_mds_options() {
     .set_default(true)
     .set_description("allow setting directory export pins to particular ranks"),
 
+    Option("mds_export_ephemeral_random", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("allow ephemeral random pinning of the loaded subtrees")
+    .set_long_description("probabilistically pin the loaded directory inode and the subtree beneath it to an MDS based on the consistent hash of the inode number. The higher this value the more likely the loaded subtrees get pinned"),
+
+    Option("mds_export_ephemeral_distributed", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("allow ephemeral distributed pinning of the loaded subtrees")
+    .set_long_description("pin the immediate child directories of the loaded directory inode based on the consistent hash of the child's inode number. "),
+
     Option("mds_bal_sample_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(3.0)
     .set_description("interval in seconds between balancer ticks"),

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1857,6 +1857,7 @@ CDentry *CDir::_load_dentry(
         if (in->inode.is_dirty_rstat())
           in->mark_dirty_rstat();
 
+        in->maybe_export_ephemeral_random_pin(true);
         //in->hack_accessed = false;
         //in->hack_load_stamp = ceph_clock_now();
         //num_new_inodes_loaded++;

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1857,7 +1857,7 @@ CDentry *CDir::_load_dentry(
         if (in->inode.is_dirty_rstat())
           in->mark_dirty_rstat();
 
-        in->maybe_ephemeral_rand();
+        in->maybe_ephemeral_rand(true);
         //in->hack_accessed = false;
         //in->hack_load_stamp = ceph_clock_now();
         //num_new_inodes_loaded++;

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1857,7 +1857,7 @@ CDentry *CDir::_load_dentry(
         if (in->inode.is_dirty_rstat())
           in->mark_dirty_rstat();
 
-        in->maybe_export_ephemeral_random_pin(true);
+        in->maybe_ephemeral_rand();
         //in->hack_accessed = false;
         //in->hack_load_stamp = ceph_clock_now();
         //num_new_inodes_loaded++;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5514,6 +5514,7 @@ double CInode::get_ephemeral_rand(bool inherit) const
    * have a parent yet.
    */
   const CInode *in = this;
+  double max = mdcache->export_ephemeral_random_max;
   while (true) {
     if (in->is_system())
       break;
@@ -5525,7 +5526,7 @@ double CInode::get_ephemeral_rand(bool inherit) const
       break;
 
     if (in->get_inode().export_ephemeral_random_pin > 0.0)
-      return in->get_inode().export_ephemeral_random_pin;
+      return std::min(in->get_inode().export_ephemeral_random_pin, max);
 
     /* An export_pin overrides only if no closer parent (incl. this one) has a
      * random pin set.

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -325,6 +325,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int STATE_QUEUEDEXPORTPIN	= (1<<17);
   static const int STATE_TRACKEDBYOFT		= (1<<18);  // tracked by open file table
   static const int STATE_DELAYEDEXPORTPIN	= (1<<19);
+  static const int STATE_DISTEPHEMERALPIN       = (1<<20);
+  static const int STATE_RANDEPHEMERALPIN       = (1<<21);
   // orphan inode needs notification of releasing reference
   static const int STATE_ORPHAN =	STATE_NOTIFYREF;
 
@@ -332,7 +334,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     (STATE_DIRTY|STATE_NEEDSRECOVER|STATE_DIRTYPARENT|STATE_DIRTYPOOL);
   static const int MASK_STATE_EXPORT_KEPT =
     (STATE_FROZEN|STATE_AMBIGUOUSAUTH|STATE_EXPORTINGCAPS|
-     STATE_QUEUEDEXPORTPIN|STATE_TRACKEDBYOFT|STATE_DELAYEDEXPORTPIN);
+     STATE_QUEUEDEXPORTPIN|STATE_TRACKEDBYOFT|STATE_DELAYEDEXPORTPIN|
+     STATE_DISTEPHEMERALPIN|STATE_RANDEPHEMERALPIN);
 
   // -- waiters --
   static const uint64_t WAIT_DIR         = (1<<0);
@@ -361,22 +364,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   }
 
   std::map<int, std::unique_ptr<BatchOp>> batch_ops;
-
-  bool is_export_ephemeral_distributed_pinned = false;
-  bool is_export_ephemeral_random_pinned = false;
-
-  bool is_export_ephemeral_distributed_migrating = false;
-  bool is_export_ephemeral_random_migrating = false;
-
-  void finish_export_ephemeral_distributed_migration() {
-    is_export_ephemeral_distributed_migrating = false;
-    is_export_ephemeral_distributed_pinned = true;
-  }
-
-  void finish_export_ephemeral_random_migration() {
-    is_export_ephemeral_random_migrating = false;
-    is_export_ephemeral_random_pinned = true;
-  }
 
   std::string_view pin_name(int p) const override;
 
@@ -925,15 +912,31 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     return !projected_parent.empty();
   }
 
-  void maybe_export_pin(bool update=false);
-  void maybe_export_ephemeral_random_pin(bool update=false);
-  void maybe_export_ephemeral_distributed_pin(bool update=false);
+  mds_rank_t get_export_pin(bool inherit=true, bool ephemeral=true) const;
   void set_export_pin(mds_rank_t rank);
-  void set_export_ephemeral_random_pin(double probablitiy=0);
-  void set_export_ephemeral_distributed_pin(bool val=false);
-  mds_rank_t get_export_pin(bool inherit=true) const;
-  double get_export_ephemeral_random_pin(bool inherit=true) const;
-  bool get_export_ephemeral_distributed_pin() const;
+  void queue_export_pin(mds_rank_t target);
+  void maybe_export_pin(bool update=false);
+
+  void set_ephemeral_dist(bool yes);
+  void maybe_ephemeral_dist(bool update=false);
+  void maybe_ephemeral_dist_children(bool update=false);
+  void setxattr_ephemeral_dist(bool val=false);
+  bool is_ephemeral_dist() const {
+    return state_test(STATE_DISTEPHEMERALPIN);
+  }
+
+  double get_ephemeral_rand(bool inherit=true) const;
+  void set_ephemeral_rand(bool yes);
+  void maybe_ephemeral_rand();
+  void setxattr_ephemeral_rand(double prob=0.0);
+  bool is_ephemeral_rand() const {
+    return state_test(STATE_RANDEPHEMERALPIN);
+  }
+
+  bool is_ephemerally_pinned() const {
+    return state_test(STATE_DISTEPHEMERALPIN) ||
+           state_test(STATE_RANDEPHEMERALPIN);
+  }
   bool is_exportable(mds_rank_t dest) const;
 
   void print(std::ostream& out) override;
@@ -973,8 +976,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   // list item node for when we have unpropagated rstat data
   elist<CInode*>::item dirty_rstat_item;
-
-  elist<CInode*>::item ephemeral_pin_inode;
 
   mempool::mds_co::set<client_t> client_snap_caps;
   mempool::mds_co::compact_map<snapid_t, mempool::mds_co::set<client_t> > client_need_snapflush;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -362,6 +362,22 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   std::map<int, std::unique_ptr<BatchOp>> batch_ops;
 
+  bool is_export_ephemeral_distributed_pinned = false;
+  bool is_export_ephemeral_random_pinned = false;
+
+  bool is_export_ephemeral_distributed_migrating = false;
+  bool is_export_ephemeral_random_migrating = false;
+
+  void finish_export_ephemeral_distributed_migration() {
+    is_export_ephemeral_distributed_migrating = false;
+    is_export_ephemeral_distributed_pinned = true;
+  }
+
+  void finish_export_ephemeral_random_migration() {
+    is_export_ephemeral_random_migrating = false;
+    is_export_ephemeral_random_pinned = true;
+  }
+
   std::string_view pin_name(int p) const override;
 
   std::ostream& print_db_line_prefix(std::ostream& out) override;
@@ -910,8 +926,14 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   }
 
   void maybe_export_pin(bool update=false);
+  void maybe_export_ephemeral_random_pin(bool update=false);
+  void maybe_export_ephemeral_distributed_pin(bool update=false);
   void set_export_pin(mds_rank_t rank);
+  void set_export_ephemeral_random_pin(double probablitiy=0);
+  void set_export_ephemeral_distributed_pin(bool val=false);
   mds_rank_t get_export_pin(bool inherit=true) const;
+  double get_export_ephemeral_random_pin(bool inherit=true) const;
+  bool get_export_ephemeral_distributed_pin() const;
   bool is_exportable(mds_rank_t dest) const;
 
   void print(std::ostream& out) override;
@@ -951,6 +973,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   // list item node for when we have unpropagated rstat data
   elist<CInode*>::item dirty_rstat_item;
+
+  elist<CInode*>::item ephemeral_pin_inode;
 
   mempool::mds_co::set<client_t> client_snap_caps;
   mempool::mds_co::compact_map<snapid_t, mempool::mds_co::set<client_t> > client_need_snapflush;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -129,17 +129,18 @@ void MDBalancer::handle_export_pins(void)
 	  mds->mdcache->try_subtree_merge(dir);
 	}
       } else if (export_pin == mds->get_nodeid()) {
-	if (dir->state_test(CDir::STATE_CREATING) ||
-	    dir->is_frozen() || dir->is_freezing()) {
+        if (dir->state_test(CDir::STATE_AUXSUBTREE)) {
+          ceph_assert(dir->is_subtree_root());
+        } else if (dir->state_test(CDir::STATE_CREATING) ||
+	           dir->is_frozen() || dir->is_freezing()) {
 	  // try again later
 	  remove = false;
 	  continue;
-	}
-	if (!dir->is_subtree_root()) {
+	} else if (!dir->is_subtree_root()) {
 	  dir->state_set(CDir::STATE_AUXSUBTREE);
 	  mds->mdcache->adjust_subtree_auth(dir, mds->get_nodeid());
 	  dout(10) << " create aux subtree on " << *dir << dendl;
-	} else if (!dir->state_test(CDir::STATE_AUXSUBTREE)) {
+	} else {
 	  dout(10) << " set auxsubtree bit on " << *dir << dendl;
 	  dir->state_set(CDir::STATE_AUXSUBTREE);
 	}

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -145,7 +145,12 @@ void MDBalancer::handle_export_pins(void)
 	  dir->state_set(CDir::STATE_AUXSUBTREE);
 	}
       } else {
-	mds->mdcache->migrator->export_dir(dir, export_pin);
+        /* Only export a directory if it's non-empty. An empty directory will
+         * be sent back by the importer.
+         */
+        if (dir->get_num_head_items() > 0) {
+	  mds->mdcache->migrator->export_dir(dir, export_pin);
+        }
 	remove = false;
       }
     }

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -101,13 +101,15 @@ void MDBalancer::handle_export_pins(void)
     ceph_assert(in->is_dir());
     mds_rank_t export_pin = in->get_export_pin(false);
     if (export_pin >= mds->mdsmap->get_max_mds()) {
-      dout(20) << " delay export pin on " << *in << dendl;
+      dout(20) << " delay export_pin=" << export_pin << " on " << *in << dendl;
       in->state_clear(CInode::STATE_QUEUEDEXPORTPIN);
       q.erase(cur);
 
       in->state_set(CInode::STATE_DELAYEDEXPORTPIN);
       mds->mdcache->export_pin_delayed_queue.insert(in);
       continue;
+    } else {
+      dout(20) << " executing export_pin=" << export_pin << " on " << *in << dendl;
     }
 
     bool remove = true;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -99,14 +99,7 @@ void MDBalancer::handle_export_pins(void)
     auto cur = it++;
     CInode *in = *cur;
     ceph_assert(in->is_dir());
-    mds_rank_t export_pin = MDS_RANK_NONE;
-    // Making sure the ephemeral pin does not override export pin
-    if (in->get_export_pin(false) != MDS_RANK_NONE)
-      export_pin = in->get_export_pin(false);
-    else if (in->is_export_ephemeral_distributed_migrating || in->is_export_ephemeral_random_migrating) {
-      export_pin = mds->mdcache->hash_into_rank_bucket(in->ino(), mds->mdsmap->get_max_mds());
-      dout(10) << "Ephemeral export pin set on" << *in << dendl;
-    }
+    mds_rank_t export_pin = in->get_export_pin(false);
     if (export_pin >= mds->mdsmap->get_max_mds()) {
       dout(20) << " delay export_pin=" << export_pin << " on " << *in << dendl;
       in->state_clear(CInode::STATE_QUEUEDEXPORTPIN);

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -113,8 +113,7 @@ void MDBalancer::handle_export_pins(void)
     }
 
     bool remove = true;
-    auto&& dfls = in->get_dirfrags();
-    for (auto dir : dfls) {
+    for (auto&& dir : in->get_dirfrags()) {
       if (!dir->is_auth())
 	continue;
 

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -49,6 +49,8 @@ public:
    */
   void tick();
 
+  void handle_export_pins(void);
+
   void subtract_export(CDir *ex);
   void add_import(CDir *im);
   void adjust_pop_for_rename(CDir *pdir, CDir *dir, bool inc);
@@ -85,8 +87,6 @@ private:
   //MDSMap is up to date
   void prep_rebalance(int beat);
   int mantle_prep_rebalance();
-
-  void handle_export_pins(void);
 
   mds_load_t get_load();
   int localize_balancer();

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -155,6 +155,7 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
 
   export_ephemeral_distributed_config =  g_conf().get_val<bool>("mds_export_ephemeral_distributed");
   export_ephemeral_random_config =  g_conf().get_val<bool>("mds_export_ephemeral_random");
+  export_ephemeral_random_max = g_conf().get_val<double>("mds_export_ephemeral_random_max");
 
   lru.lru_set_midpoint(g_conf().get_val<double>("mds_cache_mid"));
 
@@ -242,6 +243,9 @@ void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDS
       in->maybe_ephemeral_rand();
     }
     mds->balancer->handle_export_pins();
+  }
+  if (changed.count("mds_export_ephemeral_random_max")) {
+    export_ephemeral_random_max = g_conf().get_val<double>("mds_export_ephemeral_random_max");
   }
   if (changed.count("mds_health_cache_threshold"))
     cache_health_threshold = g_conf().get_val<double>("mds_health_cache_threshold");

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -1283,14 +1283,16 @@ CDir *MDCache::get_projected_subtree_root(CDir *dir)
 void MDCache::remove_subtree(CDir *dir)
 {
   dout(10) << "remove_subtree " << *dir << dendl;
-  ceph_assert(subtrees.count(dir));
-  ceph_assert(subtrees[dir].empty());
-  subtrees.erase(dir);
+  auto it = subtrees.find(dir);
+  ceph_assert(it != subtrees.end());
+  subtrees.erase(it);
   dir->put(CDir::PIN_SUBTREE);
   if (dir->get_parent_dir()) {
     CDir *p = get_subtree_root(dir->get_parent_dir());
-    ceph_assert(subtrees[p].count(dir));
-    subtrees[p].erase(dir);
+    auto it = subtrees.find(p);
+    ceph_assert(it != subtrees.end());
+    auto count = it->second.erase(dir);
+    ceph_assert(count == 1);
   }
 }
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1001,6 +1001,8 @@ class MDCache {
 
   OpenFileTable open_file_table;
 
+  double export_ephemeral_random_max = 0.0;
+
  protected:
   // track master requests whose slaves haven't acknowledged commit
   struct umaster {

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -215,6 +215,14 @@ class MDCache {
 
   void advance_stray();
 
+  bool get_export_ephemeral_distributed_config(void) const {
+    return export_ephemeral_distributed_config;
+  }
+
+  bool get_export_ephemeral_random_config(void) const {
+    return export_ephemeral_random_config;
+  }
+
   /**
    * Call this when you know that a CDentry is ready to be passed
    * on to StrayManager (i.e. this is a stray you've just created)
@@ -226,6 +234,8 @@ class MDCache {
 
     stray_manager.eval_stray(dn);
   }
+
+  mds_rank_t hash_into_rank_bucket(inodeno_t ino, mds_rank_t max_mds);
 
   void maybe_eval_stray(CInode *in, bool delay=false);
   void clear_dirty_bits_for_stray(CInode* diri);
@@ -898,7 +908,7 @@ class MDCache {
   void discard_delayed_expire(CDir *dir);
 
   // -- mdsmap --
-  void handle_mdsmap(const MDSMap &mdsmap);
+  void handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap);
 
   int dump_cache() { return dump_cache({}, nullptr); }
   int dump_cache(std::string_view filename);
@@ -1299,6 +1309,9 @@ class MDCache {
   bool forward_all_requests_to_auth;
   std::array<CInode *, NUM_STRAY> strays{}; // my stray dir
 
+  bool export_ephemeral_distributed_config;
+  bool export_ephemeral_random_config;
+
   // File size recovery
   RecoveryQueue recovery_queue;
 
@@ -1315,6 +1328,8 @@ class MDCache {
   map<dirfrag_t, ufragment> uncommitted_fragments;
 
   map<dirfrag_t,fragment_info_t> fragments;
+
+  elist<CInode*> ephemeral_pins;
 
   DecayCounter trim_counter;
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -235,7 +235,7 @@ class MDCache {
     stray_manager.eval_stray(dn);
   }
 
-  mds_rank_t hash_into_rank_bucket(inodeno_t ino, mds_rank_t max_mds);
+  mds_rank_t hash_into_rank_bucket(inodeno_t ino);
 
   void maybe_eval_stray(CInode *in, bool delay=false);
   void clear_dirty_bits_for_stray(CInode* diri);
@@ -996,6 +996,8 @@ class MDCache {
   /* Because exports may fail, this set lets us keep track of inodes that need exporting. */
   std::set<CInode *> export_pin_queue;
   std::set<CInode *> export_pin_delayed_queue;
+  std::set<CInode *> rand_ephemeral_pins;
+  std::set<CInode *> dist_ephemeral_pins;
 
   OpenFileTable open_file_table;
 
@@ -1328,8 +1330,6 @@ class MDCache {
   map<dirfrag_t, ufragment> uncommitted_fragments;
 
   map<dirfrag_t,fragment_info_t> fragments;
-
-  elist<CInode*> ephemeral_pins;
 
   DecayCounter trim_counter;
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2939,7 +2939,10 @@ void MDSRank::command_get_subtrees(Formatter *f)
       f->dump_bool("is_auth", dir->is_auth());
       f->dump_int("auth_first", dir->get_dir_auth().first);
       f->dump_int("auth_second", dir->get_dir_auth().second);
-      f->dump_int("export_pin", dir->inode->get_export_pin());
+      f->dump_int("export_pin", dir->inode->get_export_pin(false, false));
+      f->dump_bool("distributed_ephemeral_pin", dir->inode->is_ephemeral_dist());
+      f->dump_bool("random_ephemeral_pin", dir->inode->is_ephemeral_rand());
+      f->dump_int("ephemeral_pin", mdcache->hash_into_rank_bucket(dir->inode->ino()));
       f->open_object_section("dir");
       dir->dump(f);
       f->close_section();
@@ -3596,8 +3599,8 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_dump_cache_threshold_file",
     "mds_dump_cache_threshold_formatter",
     "mds_enable_op_tracker",
-    "mds_export_ephemeral_random"
-    "mds_export_ephemeral_distributed"
+    "mds_export_ephemeral_random",
+    "mds_export_ephemeral_distributed",
     "mds_health_cache_threshold",
     "mds_inject_migrator_session_race",
     "mds_log_pause",
@@ -3648,6 +3651,8 @@ void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::s
 
   finisher->queue(new LambdaContext([this, changed](int) {
     std::scoped_lock lock(mds_lock);
+
+    dout(10) << "flushing conf change to components: " << changed << dendl;
 
     if (changed.count("mds_log_pause") && !g_conf()->mds_log_pause) {
       mdlog->kick_submitter();

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2472,7 +2472,7 @@ void MDSRankDispatcher::handle_mds_map(
       scrubstack->scrub_abort(c);
     }
   }
-  mdcache->handle_mdsmap(*mdsmap);
+  mdcache->handle_mdsmap(*mdsmap, oldmap);
   if (metric_aggregator != nullptr) {
     metric_aggregator->notify_mdsmap(*mdsmap);
   }
@@ -3596,6 +3596,8 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_dump_cache_threshold_file",
     "mds_dump_cache_threshold_formatter",
     "mds_enable_op_tracker",
+    "mds_export_ephemeral_random"
+    "mds_export_ephemeral_distributed"
     "mds_health_cache_threshold",
     "mds_inject_migrator_session_race",
     "mds_log_pause",

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3600,6 +3600,7 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_dump_cache_threshold_formatter",
     "mds_enable_op_tracker",
     "mds_export_ephemeral_random",
+    "mds_export_ephemeral_random_max",
     "mds_export_ephemeral_distributed",
     "mds_health_cache_threshold",
     "mds_inject_migrator_session_race",

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -790,7 +790,7 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
   ceph_assert(dest != mds->get_nodeid());
    
   CDir* parent = dir->inode->get_projected_parent_dir();
-  if (!mds->is_stopping() && !dir->inode->is_exportable(dest)) {
+  if (!mds->is_stopping() && !dir->inode->is_exportable(dest) && dir->get_num_head_items() > 0) {
     dout(7) << "Cannot export to mds." << dest << " " << *dir << ": dir is export pinned" << dendl;
     return;
   } else if (!(mds->is_active() || mds->is_stopping())) {

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2236,6 +2236,11 @@ void Migrator::export_finish(CDir *dir)
     mut->cleanup();
   }
 
+  if (dir->get_inode()->is_export_ephemeral_distributed_migrating)
+    dir->get_inode()->finish_export_ephemeral_distributed_migration();
+  else if (dir->get_inode()->is_export_ephemeral_random_migrating)
+    dir->get_inode()->finish_export_ephemeral_random_migration();
+
   if (parent)
     child_export_finish(parent, true);
 
@@ -3135,7 +3140,29 @@ void Migrator::import_finish(CDir *dir, bool notify, bool last)
   MutationRef mut = it->second.mut;
   import_state.erase(it);
 
-  mds->mdlog->start_submit_entry(new EImportFinish(dir, true));
+  // start the journal entry
+  EImportFinish *le = new EImportFinish(dir, true);
+  mds->mdlog->start_entry(le);
+
+  CInode *in = dir->get_inode();
+
+  CDentry *pdn = in->get_parent_dn();
+
+  if (in->get_export_ephemeral_random_pin(false)) {    // Lazy checks. FIXME
+    le->metablob.add_primary_dentry(pdn, in, false, false, false, false,
+          false, true);
+    in->is_export_ephemeral_random_pinned = true;
+    cache->ephemeral_pins.push_back(&in->ephemeral_pin_inode);
+  } else if (pdn->get_dir()->get_inode()
+        && pdn->get_dir()->get_inode()->get_export_ephemeral_distributed_pin()) {
+      le->metablob.add_primary_dentry(pdn, in, false, false, false, false,
+          true, false);
+      in->is_export_ephemeral_distributed_pinned = true;
+      cache->ephemeral_pins.push_back(&in->ephemeral_pin_inode);
+  }
+
+  // log it
+  mds->mdlog->submit_entry(le);
 
   // process delayed expires
   cache->process_delayed_expire(dir);
@@ -3175,7 +3202,6 @@ void Migrator::import_finish(CDir *dir, bool notify, bool last)
     export_empty_import(dir);
   }
 }
-
 
 void Migrator::decode_import_inode(CDentry *dn, bufferlist::const_iterator& blp,
 				   mds_rank_t oldauth, LogSegment *ls,

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5638,7 +5638,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
 
     client_t exclude_ct = mdr->get_client();
     mdcache->broadcast_quota_to_client(cur, exclude_ct, true);
-  } else if (name.find("ceph.dir.pin") == 0) {
+  } else if (name == "ceph.dir.pin"sv) {
     if (!cur->is_dir() || cur->is_root()) {
       respond_to_request(mdr, -EINVAL);
       return;
@@ -5660,7 +5660,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     auto &pi = cur->project_inode();
     cur->set_export_pin(rank);
     pip = &pi.inode;
-  }  else if (name.find("ceph.dir.pin.random") == 0) {
+  } else if (name == "ceph.dir.pin.random"sv) {
     if (!cur->is_dir() || cur->is_root()) {
       respond_to_request(mdr, -EINVAL);
       return;
@@ -5681,7 +5681,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     auto &pi = cur->project_inode();
     cur->set_export_ephemeral_random_pin(val);
     pip = &pi.inode;
-  } else if (name.find("ceph.dir.pin.distributed") == 0) {
+  } else if (name == "ceph.dir.pin.distributed"sv) {
     if (!cur->is_dir() || cur->is_root()) {
       respond_to_request(mdr, -EINVAL);
       return;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5675,6 +5675,14 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
       return;
     }
 
+    if (val < 0.0 || 1.0 < val) {
+      respond_to_request(mdr, -EDOM);
+      return;
+    } else if (mdcache->export_ephemeral_random_max < val) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
     if (!xlock_policylock(mdr, cur))
       return;
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6011,7 +6011,7 @@ public:
     } else if (newi->inode.is_dir()) {
       // We do this now so that the linkages on the new directory are stable.
       newi->maybe_ephemeral_dist();
-      newi->maybe_ephemeral_rand();
+      newi->maybe_ephemeral_rand(true);
     }
 
     // hit pop

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -65,6 +65,8 @@ public:
     static const int STATE_DIRTYPARENT = (1<<1);
     static const int STATE_DIRTYPOOL   = (1<<2);
     static const int STATE_NEED_SNAPFLUSH = (1<<3);
+    static const int STATE_EPHEMERAL_DISTRIBUTED = (1<<4);
+    static const int STATE_EPHEMERAL_RANDOM = (1<<5);
     std::string  dn;         // dentry
     snapid_t dnfirst, dnlast;
     version_t dnv{0};
@@ -111,6 +113,8 @@ public:
     bool is_dirty_parent() const { return (state & STATE_DIRTYPARENT); }
     bool is_dirty_pool() const { return (state & STATE_DIRTYPOOL); }
     bool need_snapflush() const { return (state & STATE_NEED_SNAPFLUSH); }
+    bool is_export_ephemeral_distributed() const { return (state & STATE_EPHEMERAL_DISTRIBUTED); }
+    bool is_export_ephemeral_random() const { return (state & STATE_EPHEMERAL_RANDOM); }
 
     void print(ostream& out) const {
       out << " fullbit dn " << dn << " [" << dnfirst << "," << dnlast << "] dnv " << dnv
@@ -434,12 +438,15 @@ private:
   // return remote pointer to to-be-journaled inode
   void add_primary_dentry(CDentry *dn, CInode *in, bool dirty,
 			  bool dirty_parent=false, bool dirty_pool=false,
-			  bool need_snapflush=false) {
+			  bool need_snapflush=false, bool export_ephemeral_distributed=false,
+			  bool export_ephemeral_random=false) {
     __u8 state = 0;
     if (dirty) state |= fullbit::STATE_DIRTY;
     if (dirty_parent) state |= fullbit::STATE_DIRTYPARENT;
     if (dirty_pool) state |= fullbit::STATE_DIRTYPOOL;
     if (need_snapflush) state |= fullbit::STATE_NEED_SNAPFLUSH;
+    if (export_ephemeral_distributed) state |= fullbit::STATE_EPHEMERAL_DISTRIBUTED;
+    if (export_ephemeral_random) state |= fullbit::STATE_EPHEMERAL_RANDOM;
     add_primary_dentry(add_dir(dn->get_dir(), false), dn, in, state);
   }
   void add_primary_dentry(dirlump& lump, CDentry *dn, CInode *in, __u8 state) {

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -65,8 +65,7 @@ public:
     static const int STATE_DIRTYPARENT = (1<<1);
     static const int STATE_DIRTYPOOL   = (1<<2);
     static const int STATE_NEED_SNAPFLUSH = (1<<3);
-    static const int STATE_EPHEMERAL_DISTRIBUTED = (1<<4);
-    static const int STATE_EPHEMERAL_RANDOM = (1<<5);
+    static const int STATE_EPHEMERAL_RANDOM = (1<<4);
     std::string  dn;         // dentry
     snapid_t dnfirst, dnlast;
     version_t dnv{0};
@@ -113,7 +112,6 @@ public:
     bool is_dirty_parent() const { return (state & STATE_DIRTYPARENT); }
     bool is_dirty_pool() const { return (state & STATE_DIRTYPOOL); }
     bool need_snapflush() const { return (state & STATE_NEED_SNAPFLUSH); }
-    bool is_export_ephemeral_distributed() const { return (state & STATE_EPHEMERAL_DISTRIBUTED); }
     bool is_export_ephemeral_random() const { return (state & STATE_EPHEMERAL_RANDOM); }
 
     void print(ostream& out) const {
@@ -438,20 +436,21 @@ private:
   // return remote pointer to to-be-journaled inode
   void add_primary_dentry(CDentry *dn, CInode *in, bool dirty,
 			  bool dirty_parent=false, bool dirty_pool=false,
-			  bool need_snapflush=false, bool export_ephemeral_distributed=false,
-			  bool export_ephemeral_random=false) {
+			  bool need_snapflush=false) {
     __u8 state = 0;
     if (dirty) state |= fullbit::STATE_DIRTY;
     if (dirty_parent) state |= fullbit::STATE_DIRTYPARENT;
     if (dirty_pool) state |= fullbit::STATE_DIRTYPOOL;
     if (need_snapflush) state |= fullbit::STATE_NEED_SNAPFLUSH;
-    if (export_ephemeral_distributed) state |= fullbit::STATE_EPHEMERAL_DISTRIBUTED;
-    if (export_ephemeral_random) state |= fullbit::STATE_EPHEMERAL_RANDOM;
     add_primary_dentry(add_dir(dn->get_dir(), false), dn, in, state);
   }
   void add_primary_dentry(dirlump& lump, CDentry *dn, CInode *in, __u8 state) {
     if (!in) 
       in = dn->get_projected_linkage()->get_inode();
+
+    if (in->is_ephemeral_rand()) {
+      state |= fullbit::STATE_EPHEMERAL_RANDOM;
+    }
 
     // make note of where this inode was last journaled
     in->last_journaled = event_seq;

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -530,7 +530,7 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
     if (is_export_ephemeral_random()) {
       dout(15) << "random ephemeral pin on " << *in << dendl;
       in->set_ephemeral_rand(true);
-      in->maybe_ephemeral_rand();
+      in->maybe_ephemeral_rand(true);
     }
     in->maybe_ephemeral_dist();
     in->maybe_export_pin();

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -526,6 +526,11 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
 {
   in->inode = inode;
   in->xattrs = xattrs;
+  if (in->inode.is_dir()) {
+    in->is_export_ephemeral_distributed_pinned = is_export_ephemeral_distributed();
+    in->is_export_ephemeral_random_pinned = is_export_ephemeral_random();
+    dout(10) << "I'm in update_inode inside journal.cc and is_export_ephemeral_distrib for inode " << *in << "is" << in->is_export_ephemeral_distributed_pinned << dendl;
+  }
   in->maybe_export_pin();
   if (in->inode.is_dir()) {
     if (!(in->dirfragtree == dirfragtree)) {

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -527,12 +527,13 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
   in->inode = inode;
   in->xattrs = xattrs;
   if (in->inode.is_dir()) {
-    in->is_export_ephemeral_distributed_pinned = is_export_ephemeral_distributed();
-    in->is_export_ephemeral_random_pinned = is_export_ephemeral_random();
-    dout(10) << "I'm in update_inode inside journal.cc and is_export_ephemeral_distrib for inode " << *in << "is" << in->is_export_ephemeral_distributed_pinned << dendl;
-  }
-  in->maybe_export_pin();
-  if (in->inode.is_dir()) {
+    if (is_export_ephemeral_random()) {
+      dout(15) << "random ephemeral pin on " << *in << dendl;
+      in->set_ephemeral_rand(true);
+      in->maybe_ephemeral_rand();
+    }
+    in->maybe_ephemeral_dist();
+    in->maybe_export_pin();
     if (!(in->dirfragtree == dirfragtree)) {
       dout(10) << "EMetaBlob::fullbit::update_inode dft " << in->dirfragtree << " -> "
 	       << dirfragtree << " on " << *in << dendl;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -596,6 +596,9 @@ struct inode_t {
 
   mds_rank_t export_pin = MDS_RANK_NONE;
 
+  double export_ephemeral_random_pin = 0;
+  bool export_ephemeral_distributed_pin = false;
+
   // special stuff
   version_t version = 0;           // auth only
   version_t file_data_version = 0; // auth only
@@ -618,7 +621,7 @@ private:
 template<template<typename> class Allocator>
 void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
 {
-  ENCODE_START(15, 6, bl);
+  ENCODE_START(16, 6, bl);
 
   encode(ino, bl);
   encode(rdev, bl);
@@ -670,13 +673,16 @@ void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
 
   encode(export_pin, bl);
 
+  encode(export_ephemeral_random_pin, bl);
+  encode(export_ephemeral_distributed_pin, bl);
+
   ENCODE_FINISH(bl);
 }
 
 template<template<typename> class Allocator>
 void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(15, 6, 6, p);
+  DECODE_START_LEGACY_COMPAT_LEN(16, 6, 6, p);
 
   decode(ino, p);
   decode(rdev, p);
@@ -766,6 +772,14 @@ void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
     export_pin = MDS_RANK_NONE;
   }
 
+  if (struct_v >= 16) {
+    decode(export_ephemeral_random_pin, p);
+    decode(export_ephemeral_distributed_pin, p);
+  } else {
+    export_ephemeral_random_pin = 0;
+    export_ephemeral_distributed_pin = false;
+  }
+
   DECODE_FINISH(p);
 }
 
@@ -803,6 +817,8 @@ void inode_t<Allocator>::dump(ceph::Formatter *f) const
   f->dump_unsigned("time_warp_seq", time_warp_seq);
   f->dump_unsigned("change_attr", change_attr);
   f->dump_int("export_pin", export_pin);
+  f->dump_int("export_ephemeral_random_pin", export_ephemeral_random_pin);
+  f->dump_int("export_ephemeral_distributed_pin", export_ephemeral_distributed_pin);
 
   f->open_array_section("client_ranges");
   for (const auto &p : client_ranges) {

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -818,7 +818,7 @@ void inode_t<Allocator>::dump(ceph::Formatter *f) const
   f->dump_unsigned("change_attr", change_attr);
   f->dump_int("export_pin", export_pin);
   f->dump_int("export_ephemeral_random_pin", export_ephemeral_random_pin);
-  f->dump_int("export_ephemeral_distributed_pin", export_ephemeral_distributed_pin);
+  f->dump_bool("export_ephemeral_distributed_pin", export_ephemeral_distributed_pin);
 
   f->open_array_section("client_ranges");
   for (const auto &p : client_ranges) {

--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import cephfs
 
 from .snapshot_util import mksnap, rmsnap
+from .pin_util import pin
 from .template import GroupTemplate
 from ..fs_util import listdir, get_ancestor_xattr
 from ..exception import VolumeException
@@ -60,6 +61,9 @@ class Group(GroupTemplate):
             if ve.errno == -errno.ENOENT and self.is_default_group():
                 return []
             raise
+
+    def pin(self, pin_type, pin_setting):
+        return pin(self.fs, self.path, pin_type, pin_setting)
 
     def create_snapshot(self, snapname):
         snappath = os.path.join(self.path,

--- a/src/pybind/mgr/volumes/fs/operations/pin_util.py
+++ b/src/pybind/mgr/volumes/fs/operations/pin_util.py
@@ -1,0 +1,34 @@
+import os
+import errno
+
+import cephfs
+
+from ..exception import VolumeException
+from distutils.util import strtobool
+
+_pin_value = {
+    "export": lambda x: int(x),
+    "distributed": lambda x: int(strtobool(x)),
+    "random": lambda x: float(x),
+}
+_pin_xattr = {
+    "export": "ceph.dir.pin",
+    "distributed": "ceph.dir.pin.distributed",
+    "random": "ceph.dir.pin.random",
+}
+
+def pin(fs, path, pin_type, pin_setting):
+    """
+    Set a pin on a directory.
+    """
+    assert pin_type in _pin_xattr
+
+    try:
+        pin_setting = _pin_value[pin_type](pin_setting)
+    except ValueError as e:
+        raise VolumeException(-errno.EINVAL, f"pin value wrong type: {pin_setting}")
+
+    try:
+        fs.setxattr(path, _pin_xattr[pin_type], str(pin_setting).encode('utf-8'), 0)
+    except cephfs.Error as e:
+        raise VolumeException(-e.args[0], e.args[1])

--- a/src/pybind/mgr/volumes/fs/operations/template.py
+++ b/src/pybind/mgr/volumes/fs/operations/template.py
@@ -95,6 +95,16 @@ class SubvolumeTemplate(object):
         """
         raise VolumeException(-errno.ENOTSUP, "operation not supported.")
 
+    def pin(self, pin_type, pin_setting):
+        """
+        pin a subvolume
+
+        :param pin_type: type of pin
+        :param pin_setting: setting for pin
+        :return: None
+        """
+        raise VolumeException(-errno.ENOTSUP, "operation not supported.")
+
     def create_snapshot(self, snapname):
         """
         snapshot a subvolume.

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -6,6 +6,7 @@ from hashlib import md5
 
 import cephfs
 
+from ..pin_util import pin
 from .metadata_manager import MetadataManager
 from ..trash import create_trashcan, open_trashcan
 from ...fs_util import get_ancestor_xattr
@@ -194,6 +195,9 @@ class SubvolumeBase(object):
             except cephfs.Error as e:
                 raise VolumeException(-e.args[0], "Cannot set new size for the subvolume. '{0}'".format(e.args[1]))
         return newsize, subvolstat.st_size
+
+    def pin(self, pin_type, pin_setting):
+        return pin(self.fs, self.base_path, pin_type, pin_setting)
 
     def init_config(self, version, subvolume_type, subvolume_path, subvolume_state):
         self.metadata_mgr.init(version, subvolume_type, subvolume_path, subvolume_state)

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -203,6 +203,24 @@ class VolumeClient(CephfsClient):
             ret = self.volume_exception_to_retval(ve)
         return ret
 
+    def subvolume_pin(self, **kwargs):
+        ret         = 0, "", ""
+        volname     = kwargs['vol_name']
+        subvolname  = kwargs['sub_name']
+        pin_type    = kwargs['pin_type']
+        pin_setting = kwargs['pin_setting']
+        groupname   = kwargs['group_name']
+
+        try:
+            with open_volume(self, volname) as fs_handle:
+                with open_group(fs_handle, self.volspec, groupname) as group:
+                    with open_subvol(fs_handle, self.volspec, group, subvolname) as subvolume:
+                        subvolume.pin(pin_type, pin_setting)
+                        ret = 0, json.dumps({}), ""
+        except VolumeException as ve:
+            ret = self.volume_exception_to_retval(ve)
+        return ret
+
     def subvolume_getpath(self, **kwargs):
         ret        = None
         volname    = kwargs['vol_name']
@@ -500,6 +518,22 @@ class VolumeClient(CephfsClient):
         except VolumeException as ve:
             if not ve.errno == -errno.ENOENT:
                 ret = self.volume_exception_to_retval(ve)
+        return ret
+
+    def pin_subvolume_group(self, **kwargs):
+        ret           = 0, "", ""
+        volname       = kwargs['vol_name']
+        groupname     = kwargs['group_name']
+        pin_type      = kwargs['pin_type']
+        pin_setting   = kwargs['pin_setting']
+
+        try:
+            with open_volume(self, volname) as fs_handle:
+                with open_group(fs_handle, self.volspec, groupname) as group:
+                    group.pin(pin_type, pin_setting)
+                    ret = 0, json.dumps({}), ""
+        except VolumeException as ve:
+            ret = self.volume_exception_to_retval(ve)
         return ret
 
     ### group snapshot

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -114,6 +114,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'r'
         },
         {
+            'cmd': 'fs subvolumegroup pin'
+                   ' name=vol_name,type=CephString'
+                   ' name=group_name,type=CephString,req=true'
+                   ' name=pin_type,type=CephChoices,strings=export|distributed|random'
+                   ' name=pin_setting,type=CephString,req=true',
+            'desc': "Set MDS pinning policy for subvolumegroup",
+            'perm': 'rw'
+        },
+        {
             'cmd': 'fs subvolumegroup snapshot ls '
                    'name=vol_name,type=CephString '
                    'name=group_name,type=CephString ',
@@ -184,6 +193,16 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=group_name,type=CephString,req=false '
                    'name=no_shrink,type=CephBool,req=false ',
             'desc': "Resize a CephFS subvolume",
+            'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolume pin'
+                   ' name=vol_name,type=CephString'
+                   ' name=sub_name,type=CephString'
+                   ' name=pin_type,type=CephChoices,strings=export|distributed|random'
+                   ' name=pin_setting,type=CephString,req=true'
+                   ' name=group_name,type=CephString,req=false',
+            'desc': "Set MDS pinning policy for subvolume",
             'perm': 'rw'
         },
         {
@@ -384,6 +403,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                       sub_name=cmd['sub_name'],
                                       group_name=cmd.get('group_name', None))
 
+    def _cmd_fs_subvolumegroup_pin(self, inbuf, cmd):
+        return self.vc.pin_subvolume_group(vol_name=cmd['vol_name'],
+            group_name=cmd['group_name'], pin_type=cmd['pin_type'],
+            pin_setting=cmd['pin_setting'])
+
     def _cmd_fs_subvolumegroup_snapshot_create(self, inbuf, cmd):
         return self.vc.create_subvolume_group_snapshot(vol_name=cmd['vol_name'],
                                                        group_name=cmd['group_name'],
@@ -427,6 +451,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.vc.resize_subvolume(vol_name=cmd['vol_name'], sub_name=cmd['sub_name'],
                                         new_size=cmd['new_size'], group_name=cmd.get('group_name', None),
                                         no_shrink=cmd.get('no_shrink', False))
+
+    def _cmd_fs_subvolume_pin(self, inbuf, cmd):
+        return self.vc.subvolume_pin(vol_name=cmd['vol_name'],
+            sub_name=cmd['sub_name'], pin_type=cmd['pin_type'],
+            pin_setting=cmd['pin_setting'],
+            group_name=cmd.get('group_name', None))
 
     def _cmd_fs_subvolume_snapshot_protect(self, inbuf, cmd):
         return self.vc.protect_subvolume_snapshot(vol_name=cmd['vol_name'], sub_name=cmd['sub_name'],


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/41302 and https://tracker.ceph.com/issues/41541
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
