### PR TITLE
os/bluestore: memorize layout of BlueFS on management.

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -362,11 +362,12 @@ private:
   void _compact_log_sync();
   void _compact_log_async(std::unique_lock<ceph::mutex>& l);
 
-  void _rewrite_log_sync(bool allocate_with_fallback,
-			 int super_dev,
-			 int log_dev,
-			 int new_log_dev,
-			 int flags);
+  void _rewrite_log_and_layout_sync(bool allocate_with_fallback,
+				    int super_dev,
+				    int log_dev,
+				    int new_log_dev,
+				    int flags,
+				    std::optional<bluefs_layout_t> layout);
 
   //void _aio_finish(void *priv);
 
@@ -419,7 +420,7 @@ public:
   int mount();
   int maybe_verify_layout(const bluefs_layout_t& layout) const;
   void umount();
-  int prepare_new_device(int id);
+  int prepare_new_device(int id, const bluefs_layout_t& layout);
   
   int log_dump();
 
@@ -433,11 +434,13 @@ public:
   int device_migrate_to_new(
     CephContext *cct,
     const set<int>& devs_source,
-    int dev_target);
+    int dev_target,
+    const bluefs_layout_t& layout);
   int device_migrate_to_existing(
     CephContext *cct,
     const set<int>& devs_source,
-    int dev_target);
+    int dev_target,
+    const bluefs_layout_t& layout);
 
   uint64_t get_used();
   uint64_t get_total(unsigned id);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6353,6 +6353,7 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
     }
 
     reserved = BDEV_LABEL_BLOCK_SIZE;
+    bluefs_layout.dedicated_wal = true;
   } else if (id == BlueFS::BDEV_NEWDB) {
     string p = path + "/block.db";
     r = _setup_block_symlink_or_file("block.db", dev_path,
@@ -6373,6 +6374,8 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
       ceph_assert(r == 0);
     }
     reserved = SUPER_RESERVED;
+    bluefs_layout.shared_bdev = BlueFS::BDEV_SLOW;
+    bluefs_layout.dedicated_db = true;
   }
 
   bluefs->umount();
@@ -6383,7 +6386,7 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
     reserved,
     bluefs->get_block_device_size(id) - reserved);
 
-  r = bluefs->prepare_new_device(id);
+  r = bluefs->prepare_new_device(id, bluefs_layout);
   ceph_assert(r == 0);
 
   if (r < 0) {
@@ -6449,7 +6452,14 @@ int BlueStore::migrate_to_existing_bluefs_device(const set<int>& devs_source,
 	 << dendl;
     return -ENOSPC;
   }
-  r = bluefs->device_migrate_to_existing(cct, devs_source, id);
+  if (devs_source.count(BlueFS::BDEV_DB)) {
+    bluefs_layout.shared_bdev = BlueFS::BDEV_DB;
+    bluefs_layout.dedicated_db = false;
+  }
+  if (devs_source.count(BlueFS::BDEV_WAL)) {
+    bluefs_layout.dedicated_wal = false;
+  }
+  r = bluefs->device_migrate_to_existing(cct, devs_source, id, bluefs_layout);
   if (r < 0) {
     derr << __func__ << " failed during BlueFS migration, " << cpp_strerror(r) << dendl;
     goto shutdown;
@@ -6492,9 +6502,12 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
   if (devs_source.count(BlueFS::BDEV_DB) &&
       bluefs_layout.shared_bdev != BlueFS::BDEV_DB) {
     link_db = path + "/block.db";
+    bluefs_layout.shared_bdev = BlueFS::BDEV_DB;
+    bluefs_layout.dedicated_db = false;
   }
   if (devs_source.count(BlueFS::BDEV_WAL)) {
     link_wal = path + "/block.wal";
+    bluefs_layout.dedicated_wal = false;
   }
 
   size_t target_size;
@@ -6502,6 +6515,7 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
   if (id == BlueFS::BDEV_NEWWAL) {
     target_name = "block.wal";
     target_size = cct->_conf->bluestore_block_wal_size;
+    bluefs_layout.dedicated_wal = true;
 
     r = bluefs->add_block_device(BlueFS::BDEV_NEWWAL, dev_path,
 				 cct->_conf->bdev_enable_discard);
@@ -6519,6 +6533,8 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
   } else if (id == BlueFS::BDEV_NEWDB) {
     target_name = "block.db";
     target_size = cct->_conf->bluestore_block_db_size;
+    bluefs_layout.shared_bdev = BlueFS::BDEV_SLOW;
+    bluefs_layout.dedicated_db = true;
 
     r = bluefs->add_block_device(BlueFS::BDEV_NEWDB, dev_path,
 				 cct->_conf->bdev_enable_discard);
@@ -6541,7 +6557,7 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
   bluefs->add_block_extent(
     id, reserved, bluefs->get_block_device_size(id) - reserved);
 
-  r = bluefs->device_migrate_to_new(cct, devs_source, id);
+  r = bluefs->device_migrate_to_new(cct, devs_source, id, bluefs_layout);
 
   if (r < 0) {
     derr << __func__ << " failed during BlueFS migration, " << cpp_strerror(r) << dendl;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41744
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
