### PR TITLE
qa/suites/rados/singleton/all/ec-lost-unfound: no rbd pool

### DIFF
--- a/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
@@ -14,6 +14,7 @@ openstack:
 tasks:
 - install:
 - ceph:
+    create_rbd_pool: false
     log-whitelist:
       - objects unfound and apparently lost
       - overall HEALTH_


### PR DESCRIPTION
This can interfere with the test.

Signed-off-by: Sage Weil <sage@redhat.com>