### PR TITLE
mimic: install-deps.sh: add EPEL repo for non-x86_64 archs as well

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -69,8 +69,8 @@ EOF
     $SUDO update-alternatives --auto gcc
 
     # cmake uses the latter by default
-    $SUDO ln -nsf /usr/bin/gcc /usr/bin/x86_64-linux-gnu-gcc
-    $SUDO ln -nsf /usr/bin/g++ /usr/bin/x86_64-linux-gnu-g++
+    $SUDO ln -nsf /usr/bin/gcc /usr/bin/$(uname -m)-linux-gnu-gcc
+    $SUDO ln -nsf /usr/bin/g++ /usr/bin/$(uname -m)-linux-gnu-g++
 }
 
 function version_lt {

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -215,16 +215,17 @@ else
                 fi
                 ;;
             centos|rhel|ol|virtuozzo)
+                MAJOR_VERSION="$(echo $VERSION_ID | cut -d. -f1)"
                 $SUDO yum install -y yum-utils
                 if test $ID = rhel ; then
-                    $SUDO yum-config-manager --enable rhel-$VERSION_ID-server-optional-rpms
+                    $SUDO yum-config-manager --enable rhel-$MAJOR_VERSION-server-optional-rpms
                 fi
-                $SUDO yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/$VERSION_ID/x86_64/
+                $SUDO yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/$MAJOR_VERSION/x86_64/
                 $SUDO yum install --nogpgcheck -y epel-release
-                $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$VERSION_ID
+                $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
-                if test $ID = centos -a $VERSION_ID = 7 ; then
-		    $SUDO $yumdnf install -y python36-devel
+                if test $ID = centos -a $MAJOR_VERSION = 7 ; then
+                    $SUDO $yumdnf install -y python36-devel
 		    case $(uname -m) in
 			x86_64)
 			    $SUDO yum -y install centos-release-scl

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -51,7 +51,7 @@ EOF
 	$SUDO apt-get install -y g++-7
     fi
 
-    case $codename in
+    case "$codename" in
         trusty)
             old=4.8;;
         xenial)
@@ -69,8 +69,8 @@ EOF
     $SUDO update-alternatives --auto gcc
 
     # cmake uses the latter by default
-    $SUDO ln -nsf /usr/bin/gcc /usr/bin/$(uname -m)-linux-gnu-gcc
-    $SUDO ln -nsf /usr/bin/g++ /usr/bin/$(uname -m)-linux-gnu-g++
+    $SUDO ln -nsf /usr/bin/gcc /usr/bin/${ARCH}-linux-gnu-gcc
+    $SUDO ln -nsf /usr/bin/g++ /usr/bin/${ARCH}-linux-gnu-g++
 }
 
 function version_lt {
@@ -156,7 +156,7 @@ if [ x`uname`x = xFreeBSDx ]; then
     exit
 else
     source /etc/os-release
-    case $ID in
+    case "$ID" in
     debian|ubuntu|devuan)
         echo "Using apt-get to install dependencies"
         $SUDO apt-get install -y devscripts equivs
@@ -203,12 +203,12 @@ else
             builddepcmd="dnf -y builddep --allowerasing"
         fi
         echo "Using $yumdnf to install dependencies"
-	if [ "$ID" = "centos" -a $(uname -m) = aarch64 ]; then
+	if [ "$ID" = "centos" -a "$ARCH" = "aarch64" ]; then
 	    $SUDO yum-config-manager --disable centos-sclo-sclo || true
 	    $SUDO yum-config-manager --disable centos-sclo-rh || true
 	    $SUDO yum remove centos-release-scl || true
 	fi
-        case $ID in
+        case "$ID" in
             fedora)
                 if test $yumdnf = yum; then
                     $SUDO $yumdnf install -y yum-utils
@@ -220,13 +220,12 @@ else
                 if test $ID = rhel ; then
                     $SUDO yum-config-manager --enable rhel-$MAJOR_VERSION-server-optional-rpms
                 fi
-                $SUDO yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/$MAJOR_VERSION/x86_64/
-                $SUDO yum install --nogpgcheck -y epel-release
+                $SUDO yum install --nogpgcheck https://dl.fedoraproject.org/pub/epel/epel-release-latest-$MAJOR_VERSION.noarch.rpm
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
                 if test $ID = centos -a $MAJOR_VERSION = 7 ; then
-                    $SUDO $yumdnf install -y python36-devel
-		    case $(uname -m) in
+		    $SUDO $yumdnf install -y python36-devel
+		    case "$ARCH" in
 			x86_64)
 			    $SUDO yum -y install centos-release-scl
 			    dts_ver=7


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42071

---

backport of https://github.com/ceph/ceph/pull/30557
parent tracker: https://tracker.ceph.com/issues/42023

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh