### PR TITLE
ceph-daemon: deploy ceph daemons with podman and systemd

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -392,6 +392,13 @@ Recommends:    chrony
 %description base
 Base is the package that includes all the files shared amongst ceph servers
 
+%package -n ceph-daemon
+Summary:        Ceph-daemon utility to bootstrap Ceph clusters
+Requires:       podman
+%description -n ceph-daemon
+Ceph-daemon utility to bootstrap a Ceph cluster and manage ceph daemons
+deployed with systemd and podman.
+
 %package -n ceph-common
 Summary:	Ceph Common
 %if 0%{?suse_version}
@@ -583,6 +590,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       python%{_python_buildid}-remoto
+Requires:       ceph-daemon = %{_epoch_prefix}%{version}-%{release}
 %description mgr-ssh
 ceph-mgr-ssh is a ceph-mgr module for orchestration functions using
 direct SSH connections for management operations.
@@ -1310,6 +1318,8 @@ chmod 0644 %{buildroot}%{_docdir}/ceph/sample.ceph.conf
 install -m 0644 -D COPYING %{buildroot}%{_docdir}/ceph/COPYING
 install -m 0644 -D etc/sysctl/90-ceph-osd.conf %{buildroot}%{_sysctldir}/90-ceph-osd.conf
 
+install -m 0755 src/ceph-daemon %{buildroot}%{_sbindir}/ceph-daemon
+
 # firewall templates and /sbin/mount.ceph symlink
 %if 0%{?suse_version}
 mkdir -p %{buildroot}/sbin
@@ -1462,6 +1472,9 @@ if [ $1 -ge 1 ] ; then
     source $SYSCONF_CEPH
   fi
 fi
+
+%files daemon
+%{_sbindir}/ceph-daemon
 
 %files common
 %dir %{_docdir}/ceph

--- a/debian/ceph-daemon.install
+++ b/debian/ceph-daemon.install
@@ -1,0 +1,1 @@
+usr/sbin/ceph-daemon

--- a/debian/control
+++ b/debian/control
@@ -166,6 +166,18 @@ Description: debugging symbols for ceph-base
  .
  This package contains the debugging symbols for ceph-base.
 
+Package: ceph-daemon
+Architecture: linux-any
+Depends: docker.io,
+	 ${python:Depends},
+Description: ceph-daemon utility to bootstrap ceph daemons with systemd and containers
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ The ceph-daemon utility is used to bootstrap a Ceph cluster and to manage
+ ceph daemons deployed with systemd and containers.
+
 Package: ceph-mds
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
@@ -316,6 +328,7 @@ Description: kubernetes events plugin for ceph-mgr
 Package: ceph-mgr-ssh
 Architecture: all
 Depends: ceph-mgr (= ${binary:Version}),
+	 ceph-daemon,
 	 python-six,
          ${misc:Depends},
          ${python:Depends},

--- a/debian/rules
+++ b/debian/rules
@@ -61,6 +61,8 @@ override_dh_auto_install:
 	install -D -m 644 etc/sysctl/90-ceph-osd.conf $(DESTDIR)/etc/sysctl.d/30-ceph-osd.conf
 	install -D -m 600 sudoers.d/ceph-osd-smartctl $(DESTDIR)/etc/sudoers.d/ceph-osd-smartctl
 
+	install -m 755 src/ceph-daemon $(DESTDIR)/usr/sbin/ceph-daemon
+
 # doc/changelog is a directory, which confuses dh_installchangelogs
 override_dh_installchangelogs:
 	dh_installchangelogs --exclude doc/changelog

--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -1,0 +1,133 @@
+============================
+ Installation (ceph-daemon)
+============================
+
+A new Ceph cluster is deployed by bootstrapping a cluster on a single
+node, and then adding additional nodes and daemons via the CLI or GUI
+dashboard.
+
+Get ceph-daemon
+===============
+
+The ``ceph-daemon`` utility is used to bootstrap a new Ceph Cluster.
+You can get the utility by either installing a package provided by
+your Linux distribution::
+
+  sudo apt install -y ceph-daemon   # or,
+  sudo dnf install -y ceph-daemon   # or,
+  sudo yum install -y ceph-daemon
+
+or by simply downloading the standalone script manually::
+
+  curl https://github.com/ceph/ceph/tree/master/src/ceph-daemon > ceph-daemon
+  chmod +x ceph-daemon
+  sudo install -m 0755 ceph-daemon /usr/sbin    # optional!
+
+Bootstrap a new cluster
+=======================
+
+To create a new cluster, you need to know:
+
+* Which *IP address* to use for the cluster's first monitor.  This is
+  normally just the IP for the first cluster node.  If there are
+  multiple networks and interfaces, be sure to choose one that will be
+  accessible by any hosts accessing the Ceph cluster.
+
+To bootstrap the cluster,::
+
+  sudo ceph-daemon bootstrap --mon-ip *<mon-ip>* --output-config ceph.conf --output-keyring ceph.keyring --output-pub-ssh-key ceph.pub
+
+This command does a few things:
+
+* Creates a monitor and manager daemon for the new cluster on the
+  local host.  A minimal configuration file needed to communicate with
+  the new cluster is written to ``ceph.conf`` in the local directory.
+* A copy of the ``client.admin`` administrative (privileged!) secret
+  key is written to ``ceph.keyring`` in the local directory.
+* Generates a new SSH key, and adds the public key to the local root user's
+  ``/root/.ssh/authorized_keys`` file.  A copy of the public key is written
+  to ``ceph.pub`` in the local directory.
+
+Interacting with the cluster
+============================
+
+You can easily start up a container that has all of the Ceph packages
+installed to interact with your cluster::
+
+  sudo ceph-daemon shell --config ceph.conf --keyring ceph.keyring
+
+The ``--config`` and ``--keyring`` arguments will bind those local
+files to the default locations in ``/etc/ceph`` inside the container
+to allow the ``ceph`` CLI utility to work without additional
+arguments.  Inside the container, you can check the cluster status with::
+
+  ceph status
+
+In order to interact with the Ceph cluster outside of a container, you
+need to install the Ceph client packages and install the configuration
+and privileged administrator key in a global location::
+
+  sudo apt install -y ceph-common   # or,
+  sudo dnf install -y ceph-common   # or,
+  sudo yum install -y ceph-common
+
+  sudo install -m 0644 ceph.conf /etc/ceph/ceph.conf
+  sudo install -m 0600 ceph.keyring /etc/ceph/ceph.keyring
+
+Adding hosts to the cluster
+===========================
+
+For each new host you'd like to add to the cluster, you need to do two things:
+
+#. Install the cluster's public SSH key in the new host's root user's
+   ``authorized_keys`` file.  For example,::
+
+     cat ceph.pub | ssh root@*newhost* tee -a /root/.ssh/authorized_keys
+
+#. Tell Ceph that the new node is part of the cluster::
+
+     ceph orchestrator host add *newhost*
+
+Deploying additional monitors
+=============================
+
+Normally a Ceph cluster has at least three (or, preferably, five)
+monitor daemons spread across different hosts.  Since we are deploying
+a monitor, we again need to specify what IP address it will use,
+either as a simple IP address or as a CIDR network name.
+
+To deploy additional monitors,::
+
+  ceph orchestrator mon update *<new-num-monitors>* *<host1:network1> [<host1:network2>...]*
+
+For example, to deploy a second monitor on ``newhost`` using an IP
+address in network ``10.1.2.0/24``,::
+
+  ceph orchestrator mon update 2 newhost:10.1.2.0/24
+
+Deploying OSDs
+==============
+
+To add an OSD to the cluster, you need to know the device name for the
+block device (hard disk or SSD) that will be used.  Then,::
+
+  ceph orchestrator osd create *<host>*:*<path-to-device>*
+
+For example, to deploy an OSD on host *newhost*'s SSD,::
+
+  ceph orchestrator osd create newhost:/dev/disk/by-id/ata-WDC_WDS200T2B0A-00SM50_182294800028
+
+Deploying manager daemons
+=========================
+
+It is a good idea to have at least one backup manager daemon.  To
+deploy one or more new manager daemons,::
+
+  ceph orchestrator mgr update *<new-num-mgrs>* [*<host1>* ...]
+
+Deploying MDSs
+==============
+
+In order to use the CephFS file system, one or more MDS daemons is needed.
+
+TBD

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,6 +17,7 @@ if tags.has('man'):
                          'cephfs/*',
                          'dev/*',
                          'governance.rst',
+                         'bootstrap.rst',
                          'install/*',
                          'mon/*',
                          'rados/*',

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -92,6 +92,7 @@ about Ceph, see our `Architecture`_ section.
    :hidden:
 
    start/intro
+   bootstrap
    start/index
    install/index
    start/kube-helm

--- a/qa/packages/packages.yaml
+++ b/qa/packages/packages.yaml
@@ -2,6 +2,7 @@
 ceph:
   deb:
   - ceph
+  - ceph-daemon
   - ceph-mds
   - ceph-mgr
   - ceph-common
@@ -34,6 +35,7 @@ ceph:
   - ceph-radosgw
   - ceph-test
   - ceph
+  - ceph-daemon
   - ceph-mgr
   - ceph-mgr-dashboard
   - ceph-mgr-diskprediction-cloud

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-mimic.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-mimic.yaml
@@ -11,6 +11,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - print: "**** done installing mimic"
 - ceph:

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-mimic.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-mimic.yaml
@@ -11,6 +11,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - print: "**** done installing mimic"
 - ceph:

--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -21,6 +21,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
       - ceph-mgr
       - libcephfs2
       - libcephfs-devel

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
@@ -18,6 +18,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
       - ceph-mgr
       - libcephfs2
       - libcephfs-devel

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -17,6 +17,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
       - ceph-mgr
       - libcephfs2
       - libcephfs-devel

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
@@ -18,6 +18,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - install.upgrade:
     mon.a:

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
@@ -17,6 +17,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - install.upgrade:
     mon.a:

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
@@ -18,6 +18,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - install.upgrade:
     mon.a:

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
@@ -18,6 +18,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - install.upgrade:
     mon.a:

--- a/qa/suites/upgrade/mimic-x-singleton/1-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x-singleton/1-install/mimic.yaml
@@ -16,6 +16,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - print: "**** done install mimic"
 - ceph:

--- a/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
@@ -13,6 +13,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - print: "**** done installing mimic"
 - ceph:

--- a/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
@@ -10,6 +10,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - print: "**** done install mimic"
 - ceph:

--- a/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
@@ -16,6 +16,7 @@ tasks:
       - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-ssh
+      - ceph-daemon
     extra_packages: ['librados2']
 - print: "**** done install nautilus"
 - ceph:

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -779,15 +779,9 @@ def command_ceph_volume():
     tmp_keyring = None
 
     if args.config_and_keyring:
-        import json
-        if args.config_and_keyring == '-':
-            j = sys.stdin.read()
-        else:
-            with open(args.config_and_keyring, 'r') as f:
-                j = f.read()
-        d = json.loads(j)
-        config = d.get('config')
-        keyring = d.get('keyring')
+        # note: this will always pull from args.config_and_keyring (we
+        # require it) and never args.config or args.keyring.
+        (config, keyring) = get_config_and_keyring()
 
         # tmp keyring file
         tmp_keyring = tempfile.NamedTemporaryFile(mode='w')

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -14,6 +14,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 from distutils.spawn import find_executable
 
 try:
@@ -565,11 +566,31 @@ def command_bootstrap():
             f.write('[client.admin]\n'
                     '\tkey = ' + admin_key + '\n')
             os.fchmod(f.fileno(), 0o600)
-        logging.info('wrote keyring to %s' % args.output_keyring)
+        logging.info('Wrote keyring to %s' % args.output_keyring)
     if args.output_config:
         with open(args.output_config, 'w') as f:
             f.write(config)
-        logging.info('wrote config to %s' % args.output_config)
+        logging.info('Wrote config to %s' % args.output_config)
+
+    logging.info('Waiting for mgr to start...')
+    while True:
+        out = CephContainer(
+            image=args.image,
+            entrypoint='/usr/bin/ceph',
+            args=[
+                '-n', 'mon.',
+                '-k', '/var/lib/ceph/mon/ceph-%s/keyring' % mon_id,
+                '-c', '/var/lib/ceph/mon/ceph-%s/config' % mon_id,
+                'status', '-f', 'json-pretty'],
+            volume_mounts={
+                mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
+            },
+        ).run().decode('utf-8')
+        j = json.loads(out)
+        if j.get('mgrmap', {}).get('available', False):
+            break
+        logging.info('mgr is still not available yet, waiting...')
+        time.sleep(1)
 
     # ssh
     if not args.skip_ssh:
@@ -600,7 +621,7 @@ def command_bootstrap():
                 '-i', '/tmp/key'],
             volume_mounts={
                 mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
-               tmp_key.name: '/tmp/key:z',
+                tmp_key.name: '/tmp/key:z',
             },
         ).run()
         CephContainer(
@@ -625,6 +646,52 @@ def command_bootstrap():
             os.fchmod(f.fileno(), 0o600)  # just in case we created it
             f.write(ssh_pub + '\n')
 
+        logging.info('Enabling ssh module...')
+        CephContainer(
+            image=args.image,
+            entrypoint='/usr/bin/ceph',
+            args=[
+                '-n', 'mon.',
+                '-k', '/var/lib/ceph/mon/ceph-%s/keyring' % mon_id,
+                '-c', '/var/lib/ceph/mon/ceph-%s/config' % mon_id,
+                'mgr', 'module', 'enable', 'ssh'
+            ],
+            volume_mounts={
+                mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
+                tmp_pub.name: '/tmp/pub:z',
+            },
+        ).run()
+        logging.info('Setting orchestrator backend to ssh...')
+        CephContainer(
+            image=args.image,
+            entrypoint='/usr/bin/ceph',
+            args=[
+                '-n', 'mon.',
+                '-k', '/var/lib/ceph/mon/ceph-%s/keyring' % mon_id,
+                '-c', '/var/lib/ceph/mon/ceph-%s/config' % mon_id,
+                'orchestrator', 'set', 'backend', 'ssh'
+            ],
+            volume_mounts={
+                mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
+                tmp_pub.name: '/tmp/pub:z',
+            },
+        ).run()
+        host = get_hostname()
+        logging.info('Adding host %s...' % host)
+        CephContainer(
+            image=args.image,
+            entrypoint='/usr/bin/ceph',
+            args=[
+                '-n', 'mon.',
+                '-k', '/var/lib/ceph/mon/ceph-%s/keyring' % mon_id,
+                '-c', '/var/lib/ceph/mon/ceph-%s/config' % mon_id,
+                'orchestrator', 'host', 'add', host
+            ],
+            volume_mounts={
+                mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
+                tmp_pub.name: '/tmp/pub:z',
+            },
+        ).run()
     return 0
 
 ##################################

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -4,7 +4,6 @@ DEFAULT_IMAGE='ceph/daemon-base'
 DATA_DIR='/var/lib/ceph'
 LOG_DIR='/var/log/ceph'
 UNIT_DIR='/etc/systemd/system'
-VERSION='unknown development version'
 LOG_DIR_MODE=0o770
 DATA_DIR_MODE=0o700
 PODMAN_PREFERENCE = ['podman', 'docker']  # prefer podman to docker

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -491,10 +491,11 @@ def command_bootstrap():
               '--clobber',
               '--fsid', fsid,
               '--addv', mon_id, addr_arg,
-              '/tmp/monmap'],
+              '/tmp/monmap'
+        ],
         volume_mounts={
             tmp_monmap.name: '/tmp/monmap:z',
-            },
+        },
     ).run()
 
     # create mon
@@ -511,7 +512,7 @@ def command_bootstrap():
               '-c', '/dev/null',
               '--monmap', '/tmp/monmap',
               '--keyring', '/tmp/keyring',
-              ] + get_daemon_args(fsid, 'mon', mon_id),
+        ] + get_daemon_args(fsid, 'mon', mon_id),
         volume_mounts={
             log_dir: '/var/log/ceph:z',
             mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -627,6 +627,16 @@ def command_exec():
 
 ##################################
 
+def command_unit():
+    (daemon_type, daemon_id) = args.name.split('.')
+    unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
+    subprocess.call([
+        'systemctl',
+        args.command,
+        unit_name])
+
+##################################
+
 def command_ls():
     ls = []
 
@@ -825,6 +835,21 @@ parser_exec.add_argument(
 parser_exec.add_argument(
     'command', nargs='+',
     help='command')
+
+parser_unit = subparsers.add_parser(
+    'unit', help='operate on the daemon\'s systemd unit')
+parser_unit.set_defaults(func=command_unit)
+parser_unit.add_argument(
+    'command',
+    help='systemd command (start, stop, restart, enable, disable, ...)')
+parser_unit.add_argument(
+    '--fsid',
+    required=True,
+    help='cluster FSID')
+parser_unit.add_argument(
+    '--name', '-n',
+    required=True,
+    help='daemon name (type.id)')
 
 parser_bootstrap = subparsers.add_parser(
     'bootstrap', help='bootstrap a cluster (mon + mgr daemons)')

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -566,34 +566,6 @@ def command_bootstrap():
     mgr_c = get_container(fsid, 'mgr', mgr_id)
     deploy_daemon(fsid, 'mgr', mgr_id, mgr_c, uid, gid, config, mgr_keyring)
 
-    # ssh
-    if not args.skip_ssh:
-        logging.info('Generating ssh key...')
-        (ssh_key, ssh_pub) = gen_ssh_key(fsid)
-        ssh_config = ('Host *\n'
-                      'IdentifyFile /var/lib/ceph/ssh/id_rsa\n'
-                      'User root\n'
-                      'StrictHostKeyChecking no\n')
-        mgr_dir = get_data_dir(args.data_dir, fsid, 'mgr', mgr_id)
-        makedirs(os.path.join(mgr_dir, 'ssh'))
-        os.chown(os.path.join(mgr_dir, 'ssh'), uid, gid)
-        with open(os.path.join(mgr_dir, 'ssh', 'config'), 'w') as f:
-            os.fchown(f.fileno(), uid, gid)
-            f.write(ssh_config)
-        with open(os.path.join(mgr_dir, 'ssh', 'id_rsa'), 'w') as f:
-            os.fchown(f.fileno(), uid, gid)
-            os.fchmod(f.fileno(), 0o600)
-            f.write(ssh_key)
-        with open(os.path.join(mgr_dir, 'ssh', 'id_rsa.pub'), 'w') as f:
-            os.fchown(f.fileno(), uid, gid)
-            os.fchmod(f.fileno(), 0o600)
-            f.write(ssh_pub)
-
-        logging.info('Adding key to root@localhost\'s authorized_keys...')
-        with open('/root/.ssh/authorized_keys', 'a') as f:
-            os.fchmod(f.fileno(), 0o600)  # just in case we created it
-            f.write(ssh_pub + '\n')
-
     # output files
     if args.output_keyring:
         with open(args.output_keyring, 'w') as f:
@@ -605,6 +577,60 @@ def command_bootstrap():
         with open(args.output_config, 'w') as f:
             f.write(config)
         logging.info('wrote config to %s' % args.output_config)
+
+    # ssh
+    if not args.skip_ssh:
+        logging.info('Generating ssh key...')
+        (ssh_key, ssh_pub) = gen_ssh_key(fsid)
+
+        tmp_key = tempfile.NamedTemporaryFile(mode='w')
+        os.fchmod(tmp_key.fileno(), 0o600)
+        os.fchown(tmp_key.fileno(), uid, gid)
+        tmp_key.write(ssh_key)
+        tmp_key.flush()
+        tmp_pub = tempfile.NamedTemporaryFile(mode='w')
+        os.fchmod(tmp_pub.fileno(), 0o600)
+        os.fchown(tmp_pub.fileno(), uid, gid)
+        tmp_pub.write(ssh_pub)
+        tmp_pub.flush()
+
+        CephContainer(
+            image=args.image,
+            entrypoint='/usr/bin/ceph',
+            args=[
+                '-n', 'mon.',
+                '-k', '/var/lib/ceph/mon/ceph-%s/keyring' % mon_id,
+                '-c', '/var/lib/ceph/mon/ceph-%s/config' % mon_id,
+                'config-key',
+                'set',
+                'mgr/ssh/ssh_identity_key',
+                '-i', '/tmp/key'],
+            volume_mounts={
+                mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
+               tmp_key.name: '/tmp/key:z',
+            },
+        ).run()
+        CephContainer(
+            image=args.image,
+            entrypoint='/usr/bin/ceph',
+            args=[
+                '-n', 'mon.',
+                '-k', '/var/lib/ceph/mon/ceph-%s/keyring' % mon_id,
+                '-c', '/var/lib/ceph/mon/ceph-%s/config' % mon_id,
+                'config-key',
+                'set',
+                'mgr/ssh/ssh_identity_pub',
+                '-i', '/tmp/pub'],
+            volume_mounts={
+                mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
+                tmp_pub.name: '/tmp/pub:z',
+            },
+        ).run()
+
+        logging.info('Adding key to root@localhost\'s authorized_keys...')
+        with open('/root/.ssh/authorized_keys', 'a') as f:
+            os.fchmod(f.fileno(), 0o600)  # just in case we created it
+            f.write(ssh_pub + '\n')
 
     return 0
 

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -658,10 +658,8 @@ def command_deploy():
 
 def command_run():
     (daemon_type, daemon_id) = args.name.split('.')
-    (uid, gid) = extract_uid_gid()
     c = get_container(args.fsid, daemon_type, daemon_id)
     subprocess.call(c.run_cmd())
-
 
 ##################################
 
@@ -671,7 +669,6 @@ def command_shell():
     else:
         daemon_type = args.name
         daemon_id = None
-    (uid, gid) = extract_uid_gid()
     c = get_container(args.fsid, daemon_type, daemon_id)
     subprocess.call(c.shell_cmd())
 
@@ -679,7 +676,6 @@ def command_shell():
 
 def command_enter():
     (daemon_type, daemon_id) = args.name.split('.')
-    (uid, gid) = extract_uid_gid()
     c = get_container(args.fsid, daemon_type, daemon_id)
     subprocess.call(c.exec_cmd(['bash']))
 
@@ -687,7 +683,6 @@ def command_enter():
 
 def command_exec():
     (daemon_type, daemon_id) = args.name.split('.')
-    (uid, gid) = extract_uid_gid()
     c = get_container(args.fsid, daemon_type, daemon_id,
                       privileged=args.privileged)
     subprocess.call(c.exec_cmd(args.command))

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -77,7 +77,7 @@ def check_unit(unit_name):
         active = False
     return (enabled, active)
 
-def get_legacy_fsid(cluster):
+def get_legacy_config_fsid(cluster):
     try:
         config = configparser.ConfigParser()
         config.read('/etc/ceph/%s.conf' % cluster)
@@ -86,6 +86,21 @@ def get_legacy_fsid(cluster):
     except:
         return 'unknown'
     return 'unknown'
+
+def get_legacy_daemon_fsid(cluster_name, daemon_type, daemon_id):
+    fsid = None
+    if daemon_type == 'osd':
+        try:
+            with open(os.path.join(args.data_dir,
+                                   daemon_type,
+                                   'ceph-%s' % daemon_id,
+                                   'ceph_fsid'), 'r') as f:
+                fsid = f.read().strip()
+        except:
+            pass
+    if not fsid:
+        fsid = get_legacy_config_fsid(cluster)
+    return fsid
 
 def get_daemon_args(fsid, daemon_type, daemon_id):
     r = [
@@ -818,16 +833,7 @@ def command_ls():
                 if '-' not in j:
                     continue
                 (cluster, daemon_id) = j.split('-', 1)
-                fsid = None
-                if daemon_type == 'osd':
-                    try:
-                        with open(os.path.join(args.data_dir, i, j,
-                                               'ceph_fsid')) as f:
-                            fsid = f.read().strip()
-                    except:
-                        pass
-                if not fsid:
-                    fsid = get_legacy_fsid(cluster)
+                fsid = get_legacy_daemon_fsid(cluster, daemon_type, daemon_id)
                 (enabled, active) = check_unit('ceph-%s@%s' % (daemon_type,
                                                                daemon_id))
                 ls.append({

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -119,16 +119,16 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
             os.fchown(f.fileno(), uid, gid)
 
 def get_config_and_keyring():
-    if args.config_and_key:
+    if args.config_and_keyring:
         import json
-        if args.config_and_key == '-':
+        if args.config_and_keyring == '-':
             j = sys.stdin.read()
         else:
-            with open(args.config_and_key, 'r') as f:
+            with open(args.config_and_keyring, 'r') as f:
                 j = f.read()
         d = json.loads(j)
         config = d.get('config')
-        keyring = '[%s]\n\tkey = %s\n' % (args.name, d.get('key'))
+        keyring = d.get('keyring')
     else:
         if args.key:
             keyring = '[%s]\n\tkey = %s\n' % (args.name, args.key)
@@ -974,7 +974,7 @@ parser_deploy.add_argument(
     '--key',
     help='key for new daemon')
 parser_deploy.add_argument(
-    '--config-and-key',
+    '--config-and-keyring',
     help='JSON file with config and key')
 parser_deploy.add_argument(
     '--mon-ip',

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -598,7 +598,7 @@ def command_run():
     (daemon_type, daemon_id) = args.name.split('.')
     (uid, gid) = extract_uid_gid()
     c = get_container(args.fsid, daemon_type, daemon_id)
-    c.run()
+    subprocess.call(c.run_cmd())
 
 
 ##################################

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -393,6 +393,14 @@ class CephContainer:
             self.image
         ]
 
+    def exec_cmd(self, cmd):
+        return [
+            find_program('podman'),
+            'exec',
+            '-it',
+            self.cname,
+        ] + cmd
+
     def run(self):
         logging.debug(self.run_cmd())
         return subprocess.check_output(self.run_cmd())
@@ -602,6 +610,22 @@ def command_shell():
 
 ##################################
 
+def command_enter():
+    (daemon_type, daemon_id) = args.name.split('.')
+    (uid, gid) = extract_uid_gid()
+    c = get_container(args.fsid, daemon_type, daemon_id)
+    subprocess.call(c.exec_cmd(['bash']))
+
+##################################
+
+def command_exec():
+    (daemon_type, daemon_id) = args.name.split('.')
+    (uid, gid) = extract_uid_gid()
+    c = get_container(args.fsid, daemon_type, daemon_id)
+    subprocess.call(c.exec_cmd(args.command))
+
+##################################
+
 def command_ls():
     ls = []
 
@@ -763,7 +787,7 @@ parser_run.add_argument(
     help='cluster FSID')
 
 parser_shell = subparsers.add_parser(
-    'shell', help='run an interactive shel inside a daemon container')
+    'shell', help='run an interactive shell inside a daemon container')
 parser_shell.set_defaults(func=command_shell)
 parser_shell.add_argument(
     '--fsid',
@@ -773,6 +797,33 @@ parser_shell.add_argument(
     '--name', '-n',
     required=True,
     help='daemon name (type.id)')
+
+parser_enter = subparsers.add_parser(
+    'enter', help='run an interactive shell inside a running daemon container')
+parser_enter.set_defaults(func=command_enter)
+parser_enter.add_argument(
+    '--fsid',
+    required=True,
+    help='cluster FSID')
+parser_enter.add_argument(
+    '--name', '-n',
+    required=True,
+    help='daemon name (type.id)')
+
+parser_exec = subparsers.add_parser(
+    'exec', help='run command inside a running daemon container')
+parser_exec.set_defaults(func=command_exec)
+parser_exec.add_argument(
+    '--fsid',
+    required=True,
+    help='cluster FSID')
+parser_exec.add_argument(
+    '--name', '-n',
+    required=True,
+    help='daemon name (type.id)')
+parser_exec.add_argument(
+    'command', nargs='+',
+    help='command')
 
 parser_bootstrap = subparsers.add_parser(
     'bootstrap', help='bootstrap a cluster (mon + mgr daemons)')

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -84,8 +84,8 @@ def get_legacy_config_fsid(cluster):
         if 'global' in config and 'fsid' in config['global']:
             return config['global']['fsid']
     except:
-        return 'unknown'
-    return 'unknown'
+        return None
+    return None
 
 def get_legacy_daemon_fsid(cluster_name, daemon_type, daemon_id):
     fsid = None
@@ -272,7 +272,8 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
 
     deploy_daemon_units(fsid, daemon_type, daemon_id, c)
 
-def deploy_daemon_units(fsid, daemon_type, daemon_id, c):
+def deploy_daemon_units(fsid, daemon_type, daemon_id, c,
+                        enable=True, start=True):
     # cmd
     data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
     with open(data_dir + '/cmd', 'w') as f:
@@ -290,8 +291,10 @@ def deploy_daemon_units(fsid, daemon_type, daemon_id, c):
     subprocess.check_output(['systemctl', 'daemon-reload'])
 
     unit_name = get_unit_name(fsid, daemon_type, daemon_id)
-    subprocess.check_output(['systemctl', 'enable', unit_name])
-    subprocess.check_output(['systemctl', 'start', unit_name])
+    if enable:
+        subprocess.check_output(['systemctl', 'enable', unit_name])
+    if start:
+        subprocess.check_output(['systemctl', 'start', unit_name])
 
 def install_base_units(fsid):
     """
@@ -864,6 +867,61 @@ def command_ls():
 
 ##################################
 
+def command_adopt():
+    (daemon_type, daemon_id) = args.name.split('.')
+    if args.style == 'legacy':
+        fsid = get_legacy_daemon_fsid(args.cluster, daemon_type, daemon_id)
+        if not fsid:
+            raise RuntimeError('could not detect fsid; add fsid = to ceph.conf')
+
+        # NOTE: implicit assumption here that the units correspond to the
+        # cluster we are adopting based on the /etc/{defaults,sysconfig}/ceph
+        # CLUSTER field.
+        unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
+        (enabled, active) = check_unit(unit_name)
+
+        if active:
+            logging.info('Stopping old systemd unit %s...' % unit_name)
+            subprocess.check_output(['systemctl', 'stop', unit_name])
+        if enabled:
+            logging.info('Disabling old systemd unit %s...' % unit_name)
+            subprocess.check_output(['systemctl', 'disable', unit_name])
+
+        logging.info('Moving data...')
+        makedirs(os.path.join(args.data_dir, fsid))
+        data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
+        subprocess.check_output([
+            'mv',
+            '/var/lib/ceph/%s/%s-%s' % (daemon_type, args.cluster, daemon_id),
+            data_dir])
+        subprocess.check_output([
+            'cp',
+            '/etc/ceph/%s.conf' % args.cluster,
+            os.path.join(data_dir, 'config')])
+
+        logging.info('Moving logs...')
+        log_dir = get_log_dir(args.log_dir, fsid)
+        makedirs(log_dir)
+        try:
+            subprocess.check_output(
+                ['mv',
+                 '/var/log/ceph/%s-%s.%s.log*' % (args.cluster,
+                                                  daemon_type, daemon_id),
+                 os.path.join(log_dir)],
+                shell=True)
+        except:
+            pass
+
+        logging.info('Creating new units...')
+        c = get_container(fsid, daemon_type, daemon_id)
+        deploy_daemon_units(fsid, daemon_type, daemon_id, c,
+                            enable=True,  # unconditionally enable the new unit
+                            start=active)
+    else:
+        raise RuntimeError('adoption of style %s not implemented' % args.style)
+
+##################################
+
 def command_rm_daemon():
     (daemon_type, daemon_id) = args.name.split('.')
     if daemon_type in ['mon', 'osd'] and not args.force:
@@ -943,6 +1001,22 @@ parser_version.set_defaults(func=command_version)
 parser_ls = subparsers.add_parser(
     'ls', help='list daemon instances on this host')
 parser_ls.set_defaults(func=command_ls)
+
+parser_adopt = subparsers.add_parser(
+    'adopt', help='adopt daemon deployed with a different tool')
+parser_adopt.set_defaults(func=command_adopt)
+parser_adopt.add_argument(
+    '--name', '-n',
+    required=True,
+    help='daemon name (type.id)')
+parser_adopt.add_argument(
+    '--style',
+    required=True,
+    help='deployment style (legacy, ...)')
+parser_adopt.add_argument(
+    '--cluster',
+    default='ceph',
+    help='cluster name')
 
 parser_rm_daemon = subparsers.add_parser(
     'rm-daemon', help='remove daemon instance')

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -5,7 +5,8 @@ DATA_DIR='/var/lib/ceph'
 LOG_DIR='/var/log/ceph'
 UNIT_DIR='/etc/systemd/system'
 VERSION='unknown development version'
-
+LOG_DIR_MODE=0o770
+DATA_DIR_MODE=0o700
 PODMAN_PREFERENCE = ['podman', 'docker']  # prefer podman to docker
 
 """
@@ -75,20 +76,42 @@ def is_fsid(s):
         return False
     return True
 
-def makedirs(dir):
-    os.makedirs(dir, exist_ok=True)
+def makedirs(dir, uid, gid, mode):
+    os.makedirs(dir, exist_ok=True, mode=mode)
+    os.chown(dir, uid, gid)
+    os.chmod(dir, mode)   # the above is masked by umask...
+
+def get_data_dir(fsid, t, n):
+    return os.path.join(args.data_dir, fsid, '%s.%s' % (t, n))
+
+def get_log_dir(fsid):
+    return os.path.join(args.log_dir, fsid)
+
+def make_data_dir_base(fsid, uid, gid):
+    data_dir_base = os.path.join(args.data_dir, fsid)
+    makedirs(data_dir_base, uid, gid, DATA_DIR_MODE)
+    return data_dir_base
+
+def make_data_dir(fsid, daemon_type, daemon_id, uid=None, gid=None):
+    if not uid:
+        (uid, gid) = extract_uid_gid()
+    make_data_dir_base(fsid, uid, gid)
+    data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+    makedirs(data_dir, uid, gid, DATA_DIR_MODE)
+    return data_dir
+
+def make_log_dir(fsid, uid=None, gid=None):
+    if not uid:
+        (uid, gid) = extract_uid_gid()
+    log_dir = get_log_dir(fsid)
+    makedirs(log_dir, uid, gid, LOG_DIR_MODE)
+    return log_dir
 
 def find_program(filename):
     name = find_executable(filename)
     if name is None:
         raise ValueError(f'{filename} not found')
     return name
-
-def get_data_dir(base, fsid, t, n):
-    return base + '/' + fsid + '/' + t + '.' + n
-
-def get_log_dir(base, fsid):
-    return base + '/' + fsid
 
 def get_unit_name(fsid, daemon_type, daemon_id):
     return 'ceph-%s@%s.%s' % (fsid, daemon_type, daemon_id)
@@ -149,12 +172,8 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
 
 def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
                        config=None, keyring=None):
-    data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
-    makedirs(data_dir)
-    os.chown(data_dir, uid, gid)
-    log_dir = get_log_dir(args.log_dir, fsid)
-    makedirs(log_dir)
-    os.chown(log_dir, uid, gid)
+    data_dir = make_data_dir(fsid, daemon_type, daemon_id)
+    make_log_dir(fsid)
 
     if config:
         with open(data_dir + '/config', 'w') as f:
@@ -195,11 +214,11 @@ def get_config_and_keyring():
 def get_container_mounts(fsid, daemon_type, daemon_id):
     mounts = {}
     if fsid:
-        log_dir = get_log_dir(args.log_dir, fsid)
+        log_dir = get_log_dir(fsid)
         mounts[log_dir] = '/var/log/ceph:z'
 
     if daemon_id:
-        data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
         cdata_dir = '/var/lib/ceph/%s/ceph-%s' % (daemon_type, daemon_id)
         mounts[data_dir] = cdata_dir + ':z'
         mounts[data_dir + '/config'] = '/etc/ceph/ceph.conf:z'
@@ -258,8 +277,8 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
 
         # --mkfs
         create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid)
-        mon_dir = get_data_dir(args.data_dir, fsid, 'mon', daemon_id)
-        log_dir = get_log_dir(args.log_dir, fsid)
+        mon_dir = get_data_dir(fsid, 'mon', daemon_id)
+        log_dir = get_log_dir(fsid)
         out = CephContainer(
             image=args.image,
             entrypoint='/usr/bin/ceph-mon',
@@ -309,7 +328,7 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
 def deploy_daemon_units(fsid, daemon_type, daemon_id, c,
                         enable=True, start=True):
     # cmd
-    data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
+    data_dir = get_data_dir(fsid, daemon_type, daemon_id)
     with open(data_dir + '/cmd', 'w') as f:
         f.write('#!/bin/sh\n' + ' '.join(c.run_cmd()) + '\n')
         os.fchmod(f.fileno(), 0o700)
@@ -581,8 +600,8 @@ def command_bootstrap():
     # create mon
     logging.info('Creating mon...')
     create_daemon_dirs(fsid, 'mon', mon_id, uid, gid)
-    mon_dir = get_data_dir(args.data_dir, fsid, 'mon', mon_id)
-    log_dir = get_log_dir(args.log_dir, fsid)
+    mon_dir = get_data_dir(fsid, 'mon', mon_id)
+    log_dir = get_log_dir(fsid)
     out = CephContainer(
         image=args.image,
         entrypoint='/usr/bin/ceph-mon',
@@ -785,8 +804,7 @@ def command_run():
 
 def command_shell():
     if args.fsid:
-        log_dir = get_log_dir(args.log_dir, args.fsid)
-        makedirs(log_dir)
+        make_log_dir(args.fsid)
     if args.name:
         if '.' in args.name:
             (daemon_type, daemon_id) = args.name.split('.')
@@ -827,8 +845,7 @@ def command_exec():
 ##################################
 
 def command_ceph_volume():
-    log_dir = get_log_dir(args.log_dir, args.fsid)
-    makedirs(log_dir)
+    make_log_dir(args.fsid)
 
     mounts = get_container_mounts(args.fsid, 'osd', None)
 
@@ -923,6 +940,7 @@ def command_ls():
 
 def command_adopt():
     (daemon_type, daemon_id) = args.name.split('.')
+    (uid, gid) = extract_uid_gid()
     if args.style == 'legacy':
         fsid = get_legacy_daemon_fsid(args.cluster, daemon_type, daemon_id)
         if not fsid:
@@ -942,8 +960,8 @@ def command_adopt():
             subprocess.check_output(['systemctl', 'disable', unit_name])
 
         logging.info('Moving data...')
-        makedirs(os.path.join(args.data_dir, fsid))
-        data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
+        make_data_dir_base(fsid, uid, gid)
+        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
         subprocess.check_output([
             'mv',
             '/var/lib/ceph/%s/%s-%s' % (daemon_type, args.cluster, daemon_id),
@@ -952,10 +970,11 @@ def command_adopt():
             'cp',
             '/etc/ceph/%s.conf' % args.cluster,
             os.path.join(data_dir, 'config')])
+        os.chmod(data_dir, DATA_DIR_MODE)
+        os.chown(data_dir, uid, gid)
 
         logging.info('Moving logs...')
-        log_dir = get_log_dir(args.log_dir, fsid)
-        makedirs(log_dir)
+        log_dir = make_log_dir(fsid, uid=uid, gid=gid)
         try:
             subprocess.check_output(
                 ['mv',
@@ -985,7 +1004,7 @@ def command_rm_daemon():
     unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
     subprocess.check_output(['systemctl', 'stop', unit_name])
     subprocess.check_output(['systemctl', 'disable', unit_name])
-    data_dir = get_data_dir(args.data_dir, args.fsid, daemon_type, daemon_id)
+    data_dir = get_data_dir(args.fsid, daemon_type, daemon_id)
     subprocess.check_output(['rm', '-rf', data_dir])
 
 ##################################

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -44,11 +44,11 @@ from distutils.spawn import find_executable
 
 try:
     from StringIO import StringIO
-except:
+except ImportError:
     pass
 try:
     from io import StringIO
-except:
+except ImportError:
     pass
 
 logging.basicConfig(level=logging.INFO)
@@ -71,7 +71,7 @@ def make_fsid():
 def is_fsid(s):
     try:
         uuid.UUID(s)
-    except:
+    except ValueError:
         return False
     return True
 
@@ -97,12 +97,14 @@ def check_unit(unit_name):
     try:
         out = subprocess.check_output(['systemctl', 'is-enabled', unit_name])
         enabled = out.decode('utf-8').strip() == 'enabled'
-    except:
+    except Exception as e:
+        logging.warning('unable to run systemctl' % e)
         enabled = False
     try:
         out = subprocess.check_output(['systemctl', 'is-active', unit_name])
         active = out.decode('utf-8').strip() == 'active'
-    except:
+    except Exception as e:
+        logging.warning('unable to run systemctl: %s' % e)
         active = False
     return (enabled, active)
 
@@ -112,7 +114,8 @@ def get_legacy_config_fsid(cluster):
         config.read('/etc/ceph/%s.conf' % cluster)
         if 'global' in config and 'fsid' in config['global']:
             return config['global']['fsid']
-    except:
+    except Exception as e:
+        logging.warning('unable to parse \'fsid\' from \'[global]\' section of /etc/ceph/ceph.conf: %s' % e)
         return None
     return None
 
@@ -125,7 +128,7 @@ def get_legacy_daemon_fsid(cluster_name, daemon_type, daemon_id):
                                    'ceph-%s' % daemon_id,
                                    'ceph_fsid'), 'r') as f:
                 fsid = f.read().strip()
-        except:
+        except IOError:
             pass
     if not fsid:
         fsid = get_legacy_config_fsid(cluster)
@@ -960,7 +963,8 @@ def command_adopt():
                                                   daemon_type, daemon_id),
                  os.path.join(log_dir)],
                 shell=True)
-        except:
+        except Exception as e:
+            logging.warning('unable to move log file: %s' % e)
             pass
 
         logging.info('Creating new units...')
@@ -1275,8 +1279,8 @@ else:
         try:
             podman_path = find_program(i)
             break
-        except:
-            logging.debug('could not locate %s' % i)
+        except Exception as e:
+            logging.debug('could not locate %s: %s' % (i, e))
     if not podman_path:
         raise RuntimeError('unable to locate any of %s' % PODMAN_PREFERENCE)
 

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -141,32 +141,44 @@ def get_config_and_keyring():
             config = f.read()
     return (config, keyring)
 
-def get_container(fsid, daemon_type, daemon_id):
-    data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
+def get_container_mounts(fsid, daemon_type, daemon_id):
     log_dir = get_log_dir(args.log_dir, fsid)
-
-    cdata_dir = '/var/lib/ceph/%s/ceph-%s' % (daemon_type, daemon_id)
-    extra_args = []
 
     mounts = {
         log_dir: '/var/log/ceph:z',
-        data_dir: cdata_dir + ':z',
-        data_dir + '/config': '/etc/ceph/ceph.conf:z',
     }
+    if daemon_id:
+        data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
+        cdata_dir = '/var/lib/ceph/%s/ceph-%s' % (daemon_type, daemon_id)
+        mounts[data_dir] = cdata_dir + ':z'
+        mounts[data_dir + '/config'] = '/etc/ceph/ceph.conf:z'
+
     if daemon_type in ['mon', 'osd']:
-        mounts['/run/udev'] = '/run/udev:z'
         mounts['/dev'] = '/dev:z'  # FIXME: narrow this down?
+        mounts['/run/udev'] = '/run/udev:z'
     if daemon_type == 'osd':
         mounts['/sys'] = '/sys:z'  # for numa.cc, pick_address, cgroups, ...
+        mounts['/run/lvm'] = '/run/lvm:z'
+        mounts['/run/lock/lvm'] = '/run/lock/lvm:z'
 
+    return mounts
+
+def get_container(fsid, daemon_type, daemon_id):
+    if daemon_id:
+        dname = daemon_type + '.' + daemon_id
+    else:
+        dname = daemon_type
+    podman_args = []
     return CephContainer(
         image=args.image,
         entrypoint='/usr/bin/ceph-' + daemon_type,
-        args=['-i', daemon_id,
-              '-f', # foreground
-        ] + extra_args + get_daemon_args(fsid, daemon_type, daemon_id),
-        volume_mounts=mounts,
-        dname=daemon_type + '.' + daemon_id,
+        args=[
+            '-i', daemon_id,
+            '-f', # foreground
+        ] + get_daemon_args(fsid, daemon_type, daemon_id),
+        podman_args=podman_args,
+        volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
+        dname=dname,
         cname='ceph-%s-%s.%s' % (fsid, daemon_type, daemon_id),
     )
 

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -644,8 +644,11 @@ def command_deploy():
     if daemon_type == 'mon':
         if args.mon_ip:
             config += '[mon.%s]\n\tpublic_addr = %s\n' % (daemon_id, args.mon_ip)
+        elif args.mon_network:
+            config += '[mon.%s]\n\tpublic_network = %s\n' % (daemon_id,
+                                                             args.mon_network)
         else:
-            raise RuntimeError('must specify --mon-ip')
+            raise RuntimeError('must specify --mon-ip or --mon-network')
     (uid, gid) = extract_uid_gid()
     c = get_container(args.fsid, daemon_type, daemon_id)
     deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
@@ -979,6 +982,9 @@ parser_deploy.add_argument(
 parser_deploy.add_argument(
     '--mon-ip',
     help='mon IP')
+parser_deploy.add_argument(
+    '--mon-network',
+    help='mon network (CIDR)')
 parser_deploy.add_argument(
     '--osd-fsid',
     help='OSD uuid, if creating an OSD container')

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -34,10 +34,12 @@ import configparser
 import json
 import logging
 import os
+import socket
 import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from distutils.spawn import find_executable
 
 try:
@@ -61,15 +63,12 @@ def pathify(p):
     return p
 
 def get_hostname():
-    import socket
     return socket.gethostname()
 
 def make_fsid():
-    import uuid
     return str(uuid.uuid1())
 
 def is_fsid(s):
-    import uuid
     try:
         uuid.UUID(s)
     except:
@@ -167,7 +166,6 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
 
 def get_config_and_keyring():
     if args.config_and_keyring:
-        import json
         if args.config_and_keyring == '-':
             try:
                 j = injected_stdin

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -682,12 +682,44 @@ def command_exec():
 def command_ceph_volume():
     log_dir = get_log_dir(args.log_dir, args.fsid)
     makedirs(log_dir)
+
+    mounts = get_container_mounts(args.fsid, 'osd', None)
+
+    tmp_config = None
+    tmp_keyring = None
+
+    if args.config_and_keyring:
+        import json
+        if args.config_and_keyring == '-':
+            j = sys.stdin.read()
+        else:
+            with open(args.config_and_keyring, 'r') as f:
+                j = f.read()
+        d = json.loads(j)
+        config = d.get('config')
+        keyring = d.get('keyring')
+
+        # tmp keyring file
+        tmp_keyring = tempfile.NamedTemporaryFile(mode='w')
+        os.fchmod(tmp_keyring.fileno(), 0o600)
+        tmp_keyring.write(keyring)
+        tmp_keyring.flush()
+
+        # tmp config file
+        tmp_config = tempfile.NamedTemporaryFile(mode='w')
+        os.fchmod(tmp_config.fileno(), 0o600)
+        tmp_config.write(config)
+        tmp_config.flush()
+
+        mounts[tmp_config.name] = '/etc/ceph/ceph.conf:z'
+        mounts[tmp_keyring.name] = '/var/lib/ceph/bootstrap-osd/ceph.keyring:z'
+
     c = CephContainer(
         image=args.image,
         entrypoint='/usr/sbin/ceph-volume',
         args=args.command,
         podman_args=['--privileged'],
-        volume_mounts=get_container_mounts(args.fsid, 'osd', None),
+        volume_mounts=mounts,
     )
     subprocess.call(c.run_cmd())
 
@@ -913,6 +945,9 @@ parser_ceph_volume.add_argument(
     '--fsid',
     required=True,
     help='cluster FSID')
+parser_ceph_volume.add_argument(
+    '--config-and-keyring',
+    help='JSON file with config and (client.bootrap-osd) key')
 parser_ceph_volume.add_argument(
     'command', nargs='+',
     help='command')

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -662,6 +662,11 @@ def command_bootstrap():
         tmp_pub.write(ssh_pub)
         tmp_pub.flush()
 
+        if args.output_pub_ssh_key:
+            with open(args.output_put_ssh_key, 'w') as f:
+                f.write(ssh_pub)
+            logging.info('Wrote public SSH key to to %s' % args.output_pub_ssh_key)
+
         CephContainer(
             image=args.image,
             entrypoint='/usr/bin/ceph',
@@ -1215,6 +1220,9 @@ parser_bootstrap.add_argument(
 parser_bootstrap.add_argument(
     '--output-config',
     help='location to write conf file to connect to new cluster')
+parser_bootstrap.add_argument(
+    '--output-pub-ssh-key',
+    help='location to write the cluster\'s public SSH key')
 parser_bootstrap.add_argument(
     '--skip-ssh',
     action='store_true',

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -403,6 +403,7 @@ class CephContainer:
             'run',
             '-it',
             '--net=host',
+            '--privileged',
         ] + self.podman_args + envs + vols + [
             '--entrypoint', '/bin/bash',
             self.image

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -6,6 +6,8 @@ LOG_DIR='/var/log/ceph'
 UNIT_DIR='/etc/systemd/system'
 VERSION='unknown development version'
 
+PODMAN_PREFERENCE = ['podman', 'docker']  # prefer podman to docker
+
 """
 You can invoke ceph-daemon in two ways:
 
@@ -48,6 +50,8 @@ except:
     pass
 
 logging.basicConfig(level=logging.INFO)
+
+podman_path = None
 
 ##################################
 
@@ -370,10 +374,10 @@ Before=ceph-{fsid}.target
 LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/environment
-ExecStartPre=-/usr/bin/podman rm ceph-{fsid}-%i
+ExecStartPre=-{podman_path} rm ceph-{fsid}-%i
 ExecStartPre=-mkdir -p /var/run/ceph
 ExecStart={data_dir}/{fsid}/%i/cmd
-ExecStop=-/usr/bin/podman stop ceph-{fsid}-%i
+ExecStop=-{podman_path} stop ceph-{fsid}-%i
 ExecStopPost=-/bin/rm -f /var/run/ceph/{fsid}-%i.asok
 Restart=on-failure
 RestartSec=10s
@@ -384,7 +388,10 @@ StartLimitBurst=5
 
 [Install]
 WantedBy=ceph-{fsid}.target
-""".format(fsid=fsid, data_dir=args.data_dir)
+""".format(
+    podman_path=podman_path,
+    fsid=fsid,
+    data_dir=args.data_dir)
     return u
 
 def gen_ssh_key(fsid):
@@ -432,7 +439,7 @@ class CephContainer:
         ]
         cname = ['--name', self.cname] if self.cname else []
         return [
-            find_program('podman'),
+            podman_path,
             'run',
             '--rm',
             '--net=host',
@@ -450,7 +457,7 @@ class CephContainer:
             '-e', f'NODE_NAME={get_hostname()}',
         ]
         return [
-            find_program('podman'),
+            podman_path,
             'run',
             '-it',
             '--net=host',
@@ -462,7 +469,7 @@ class CephContainer:
 
     def exec_cmd(self, cmd):
         return [
-            find_program('podman'),
+            podman_path,
             'exec',
             '-it',
             self.cname,
@@ -1002,6 +1009,10 @@ parser.add_argument(
     default=DEFAULT_IMAGE,
     help='container image')
 parser.add_argument(
+    '--docker',
+    action='store_true',
+    help='use docker instead of podman')
+parser.add_argument(
     '--data-dir',
     default=DATA_DIR,
     help='base directory for daemon data')
@@ -1225,6 +1236,20 @@ except NameError:
     av = sys.argv[1:]
 
 args = parser.parse_args(av)
+
+# podman or docker?
+if args.docker:
+    podman_path = find_program('docker')
+else:
+    for i in PODMAN_PREFERENCE:
+        try:
+            podman_path = find_program(i)
+            break
+        except:
+            logging.debug('could not locate %s' % i)
+    if not podman_path:
+        raise RuntimeError('unable to locate any of %s' % PODMAN_PREFERENCE)
+
 if 'func' not in args:
     sys.stderr.write('No command specified; pass -h or --help for usage\n')
     sys.exit(1)

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -163,13 +163,13 @@ def get_container_mounts(fsid, daemon_type, daemon_id):
 
     return mounts
 
-def get_container(fsid, daemon_type, daemon_id):
+def get_container(fsid, daemon_type, daemon_id, privileged=False):
     if daemon_id:
         dname = daemon_type + '.' + daemon_id
     else:
         dname = daemon_type
     podman_args = []
-    if daemon_type == 'osd':
+    if daemon_type == 'osd' or privileged:
         podman_args += ['--privileged']
     return CephContainer(
         image=args.image,
@@ -659,7 +659,8 @@ def command_enter():
 def command_exec():
     (daemon_type, daemon_id) = args.name.split('.')
     (uid, gid) = extract_uid_gid()
-    c = get_container(args.fsid, daemon_type, daemon_id)
+    c = get_container(args.fsid, daemon_type, daemon_id,
+                      privileged=args.privileged)
     subprocess.call(c.exec_cmd(args.command))
 
 ##################################
@@ -869,6 +870,10 @@ parser_exec.add_argument(
     '--name', '-n',
     required=True,
     help='daemon name (type.id)')
+parser_exec.add_argument(
+    '--privileged',
+    action='store_true',
+    help='use a privileged container')
 parser_exec.add_argument(
     'command', nargs='+',
     help='command')

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -148,6 +148,7 @@ def get_container(fsid, daemon_type, daemon_id):
     mounts = {
         log_dir: '/var/log/ceph:z',
         data_dir: cdata_dir + ':z',
+        data_dir + '/config': '/etc/ceph/ceph.conf:z',
     }
     if daemon_type in ['mon', 'osd']:
         mounts['/run/udev'] = '/run/udev:z'
@@ -159,7 +160,6 @@ def get_container(fsid, daemon_type, daemon_id):
         image=args.image,
         entrypoint='ceph-' + daemon_type,
         args=['-i', daemon_id,
-              '-c', cdata_dir + '/config',
               '-f', # foreground
         ] + extra_args + get_daemon_args(fsid, daemon_type, daemon_id),
         volume_mounts=mounts,

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -161,7 +161,7 @@ def get_container(fsid, daemon_type, daemon_id):
 
     return CephContainer(
         image=args.image,
-        entrypoint='ceph-' + daemon_type,
+        entrypoint='/usr/bin/ceph-' + daemon_type,
         args=['-i', daemon_id,
               '-f', # foreground
         ] + extra_args + get_daemon_args(fsid, daemon_type, daemon_id),
@@ -173,7 +173,7 @@ def get_container(fsid, daemon_type, daemon_id):
 def extract_uid_gid():
     out = CephContainer(
         image=args.image,
-        entrypoint='grep',
+        entrypoint='/usr/bin/grep',
         args=['ceph', '/etc/passwd'],
     ).run().decode('utf-8')
     (uid, gid) = out.split(':')[2:4]
@@ -202,7 +202,7 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
         log_dir = get_log_dir(args.log_dir, fsid)
         out = CephContainer(
             image=args.image,
-            entrypoint='ceph-mon',
+            entrypoint='/usr/bin/ceph-mon',
             args=['--mkfs',
                   '-i', daemon_id,
                   '--fsid', fsid,
@@ -374,7 +374,7 @@ class CephContainer:
             '--rm',
             '--net=host',
         ] + self.podman_args + cname + envs + vols + [
-            '--entrypoint', f'/usr/bin/{self.entrypoint}',
+            '--entrypoint', self.entrypoint,
             self.image
         ] + self.args
 
@@ -430,17 +430,17 @@ def command_bootstrap():
     logging.info('Creating initial keys...')
     mon_key = CephContainer(
         image=args.image,
-        entrypoint='ceph-authtool',
+        entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
     ).run().decode('utf-8').strip()
     admin_key = CephContainer(
         image=args.image,
-        entrypoint='ceph-authtool',
+        entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
     ).run().decode('utf-8').strip()
     mgr_key = CephContainer(
         image=args.image,
-        entrypoint='ceph-authtool',
+        entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
     ).run().decode('utf-8').strip()
 
@@ -489,7 +489,7 @@ def command_bootstrap():
     os.fchmod(tmp_monmap.fileno(), 0o644)
     out = CephContainer(
         image=args.image,
-        entrypoint='monmaptool',
+        entrypoint='/usr/bin/monmaptool',
         args=['--create',
               '--clobber',
               '--fsid', fsid,
@@ -508,7 +508,7 @@ def command_bootstrap():
     log_dir = get_log_dir(args.log_dir, fsid)
     out = CephContainer(
         image=args.image,
-        entrypoint='ceph-mon',
+        entrypoint='/usr/bin/ceph-mon',
         args=['--mkfs',
               '-i', mon_id,
               '--fsid', fsid,

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -169,6 +169,8 @@ def get_container(fsid, daemon_type, daemon_id):
     else:
         dname = daemon_type
     podman_args = []
+    if daemon_type == 'osd':
+        podman_args += ['--privileged']
     return CephContainer(
         image=args.image,
         entrypoint='/usr/bin/ceph-' + daemon_type,
@@ -238,6 +240,21 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
             fsid, daemon_type, daemon_id,
             uid, gid,
             config, keyring)
+
+    if daemon_type == 'osd' and args.osd_fsid:
+        pc = CephContainer(
+            image=args.image,
+            entrypoint='/usr/sbin/ceph-volume',
+            args=[
+                'lvm', 'activate',
+                daemon_id, args.osd_fsid,
+                '--no-systemd'
+            ],
+            podman_args=['--privileged'],
+            volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
+            cname='ceph-%s-activate-%s.%s' % (fsid, daemon_type, daemon_id),
+        )
+        pc.run()
 
     deploy_daemon_units(fsid, daemon_type, daemon_id, c)
 
@@ -931,6 +948,9 @@ parser_deploy.add_argument(
 parser_deploy.add_argument(
     '--mon-ip',
     help='mon IP')
+parser_deploy.add_argument(
+    '--osd-fsid',
+    help='OSD uuid, if creating an OSD container')
 
 args = parser.parse_args()
 

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -55,6 +55,11 @@ podman_path = None
 
 ##################################
 
+def pathify(p):
+    if '/' not in p:
+        return './' + p
+    return p
+
 def get_hostname():
     import socket
     return socket.gethostname()
@@ -132,7 +137,7 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
         '--default-log-to-file=false',
         '--default-log-to-stderr=true',
         ]
-    if daemon_id:
+    if fsid and daemon_id:
         r += ['--default-admin-socket',
               '/var/run/ceph/' + fsid + '-' + daemon_type + '.' + daemon_id +
               '.asok']
@@ -187,11 +192,11 @@ def get_config_and_keyring():
     return (config, keyring)
 
 def get_container_mounts(fsid, daemon_type, daemon_id):
-    log_dir = get_log_dir(args.log_dir, fsid)
+    mounts = {}
+    if fsid:
+        log_dir = get_log_dir(args.log_dir, fsid)
+        mounts[log_dir] = '/var/log/ceph:z'
 
-    mounts = {
-        log_dir: '/var/log/ceph:z',
-    }
     if daemon_id:
         data_dir = get_data_dir(args.data_dir, fsid, daemon_type, daemon_id)
         cdata_dir = '/var/lib/ceph/%s/ceph-%s' % (daemon_type, daemon_id)
@@ -773,14 +778,29 @@ def command_run():
 ##################################
 
 def command_shell():
-    log_dir = get_log_dir(args.log_dir, args.fsid)
-    makedirs(log_dir)
-    if '.' in args.name:
-        (daemon_type, daemon_id) = args.name.split('.')
+    if args.fsid:
+        log_dir = get_log_dir(args.log_dir, args.fsid)
+        makedirs(log_dir)
+    if args.name:
+        if '.' in args.name:
+            (daemon_type, daemon_id) = args.name.split('.')
+        else:
+            daemon_type = args.name
+            daemon_id = None
     else:
-        daemon_type = args.name
+        daemon_type = 'osd'  # get the most mounts
         daemon_id = None
-    c = get_container(args.fsid, daemon_type, daemon_id)
+    mounts = get_container_mounts(args.fsid, daemon_type, daemon_id)
+    if args.config:
+        mounts[pathify(args.config)] = '/etc/ceph/ceph.conf:z'
+    if args.keyring:
+        mounts[pathify(args.keyring)] = '/etc/ceph/ceph.keyring:z'
+    c = CephContainer(
+        image=args.image,
+        entrypoint='doesnotmatter',
+        args=[],
+        podman_args=['--privileged'],
+        volume_mounts=mounts)
     subprocess.call(c.shell_cmd())
 
 ##################################
@@ -1095,12 +1115,16 @@ parser_shell = subparsers.add_parser(
 parser_shell.set_defaults(func=command_shell)
 parser_shell.add_argument(
     '--fsid',
-    required=True,
     help='cluster FSID')
 parser_shell.add_argument(
     '--name', '-n',
-    required=True,
     help='daemon name (type.id)')
+parser_shell.add_argument(
+    '--config', '-c',
+    help='ceph.conf to pass through to the container')
+parser_shell.add_argument(
+    '--keyring', '-k',
+    help='ceph.keyring to pass through to the container')
 
 parser_enter = subparsers.add_parser(
     'enter', help='run an interactive shell inside a running daemon container')

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -88,10 +88,13 @@ def get_legacy_fsid(cluster):
 
 def get_daemon_args(fsid, daemon_type, daemon_id):
     r = [
-        '--default-admin-socket', '/var/run/ceph/' + fsid + '-' + daemon_type + '.' + daemon_id + '.asok',
         '--default-log-to-file=false',
         '--default-log-to-stderr=true',
         ]
+    if daemon_id:
+        r += ['--default-admin-socket',
+              '/var/run/ceph/' + fsid + '-' + daemon_type + '.' + daemon_id +
+              '.asok']
     r += ['--setuser', 'ceph']
     r += ['--setgroup', 'ceph']
     return r
@@ -604,7 +607,11 @@ def command_run():
 ##################################
 
 def command_shell():
-    (daemon_type, daemon_id) = args.name.split('.')
+    if '.' in args.name:
+        (daemon_type, daemon_id) = args.name.split('.')
+    else:
+        daemon_type = args.name
+        daemon_id = None
     (uid, gid) = extract_uid_gid()
     c = get_container(args.fsid, daemon_type, daemon_id)
     subprocess.call(c.shell_cmd())

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -235,7 +235,7 @@ def extract_uid_gid():
         image=args.image,
         entrypoint='/usr/bin/grep',
         args=['ceph', '/etc/passwd'],
-    ).run().decode('utf-8')
+    ).run()
     (uid, gid) = out.split(':')[2:4]
     return (int(uid), int(gid))
 
@@ -483,7 +483,7 @@ class CephContainer:
 
     def run(self):
         logging.debug(self.run_cmd())
-        return subprocess.check_output(self.run_cmd())
+        return subprocess.check_output(self.run_cmd()).decode('utf-8')
 
 ##################################
 
@@ -509,17 +509,17 @@ def command_bootstrap():
         image=args.image,
         entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
-    ).run().decode('utf-8').strip()
+    ).run().strip()
     admin_key = CephContainer(
         image=args.image,
         entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
-    ).run().decode('utf-8').strip()
+    ).run().strip()
     mgr_key = CephContainer(
         image=args.image,
         entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
-    ).run().decode('utf-8').strip()
+    ).run().strip()
 
     keyring = ('[mon.]\n'
                '\tkey = %s\n'
@@ -640,7 +640,7 @@ def command_bootstrap():
             volume_mounts={
                 mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
             },
-        ).run().decode('utf-8')
+        ).run()
         j = json.loads(out)
         if j.get('mgrmap', {}).get('available', False):
             break

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -6,6 +6,27 @@ LOG_DIR='/var/log/ceph'
 UNIT_DIR='/etc/systemd/system'
 VERSION='unknown development version'
 
+"""
+You can invoke ceph-daemon in two ways:
+
+1. The normal way, at the command line.
+
+2. By piping the script to the python3 binary.  In this latter case, you should
+   prepend one or more lines to the beginning of the script.
+
+   For arguments,
+
+       injected_argv = [...]
+
+   e.g.,
+
+       injected_argv = ['ls']
+
+   For reading stdin from the '--config-and-json -' argument,
+
+       injected_stdin = '...'
+"""
+
 import argparse
 import configparser
 import json
@@ -139,7 +160,10 @@ def get_config_and_keyring():
     if args.config_and_keyring:
         import json
         if args.config_and_keyring == '-':
-            j = sys.stdin.read()
+            try:
+                j = injected_stdin
+            except NameError:
+                j = sys.stdin.read()
         else:
             with open(args.config_and_keyring, 'r') as f:
                 j = f.read()
@@ -1194,8 +1218,13 @@ parser_deploy.add_argument(
     '--osd-fsid',
     help='OSD uuid, if creating an OSD container')
 
-args = parser.parse_args()
+# allow argv to be injected
+try:
+    av = injected_argv
+except NameError:
+    av = sys.argv[1:]
 
+args = parser.parse_args(av)
 if 'func' not in args:
     sys.stderr.write('No command specified; pass -h or --help for usage\n')
     sys.exit(1)

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -618,9 +618,9 @@ def command_bootstrap():
     # output files
     if args.output_keyring:
         with open(args.output_keyring, 'w') as f:
+            os.fchmod(f.fileno(), 0o600)
             f.write('[client.admin]\n'
                     '\tkey = ' + admin_key + '\n')
-            os.fchmod(f.fileno(), 0o600)
         logging.info('Wrote keyring to %s' % args.output_keyring)
     if args.output_config:
         with open(args.output_config, 'w') as f:

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -240,7 +240,7 @@ def get_container(fsid, daemon_type, daemon_id, privileged=False):
         image=args.image,
         entrypoint='/usr/bin/ceph-' + daemon_type,
         args=[
-            '-i', daemon_id,
+            '-n', '%s.%s' % (daemon_type, daemon_id),
             '-f', # foreground
         ] + get_daemon_args(fsid, daemon_type, daemon_id),
         podman_args=podman_args,

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -829,36 +829,39 @@ def command_ls():
     ls = []
 
     # /var/lib/ceph
-    for i in os.listdir(args.data_dir):
-        if i in ['mon', 'osd', 'mds', 'mgr']:
-            daemon_type = i
-            for j in os.listdir(os.path.join(args.data_dir, i)):
-                if '-' not in j:
-                    continue
-                (cluster, daemon_id) = j.split('-', 1)
-                fsid = get_legacy_daemon_fsid(cluster, daemon_type, daemon_id)
-                (enabled, active) = check_unit('ceph-%s@%s' % (daemon_type,
-                                                               daemon_id))
-                ls.append({
-                    'style': 'legacy',
-                    'name': '%s.%s' % (daemon_type, daemon_id),
-                    'fsid': fsid,
-                    'enabled': enabled,
-                    'active': active,
-                })
-        elif is_fsid(i):
-            fsid = i
-            for j in os.listdir(os.path.join(args.data_dir, i)):
-                (daemon_type, daemon_id) = j.split('.', 1)
-                (enabled, active) = check_unit(get_unit_name(fsid, daemon_type,
-                                                             daemon_id))
-                ls.append({
-                    'style': 'ceph-daemon:v1',
-                    'name': '%s.%s' % (daemon_type, daemon_id),
-                    'fsid': fsid,
-                    'enabled': enabled,
-                    'active': active,
-                })
+    if os.path.exists(args.data_dir):
+        for i in os.listdir(args.data_dir):
+            if i in ['mon', 'osd', 'mds', 'mgr']:
+                daemon_type = i
+                for j in os.listdir(os.path.join(args.data_dir, i)):
+                    if '-' not in j:
+                        continue
+                    (cluster, daemon_id) = j.split('-', 1)
+                    fsid = get_legacy_daemon_fsid(cluster, daemon_type,
+                                                  daemon_id) or 'unknown'
+                    (enabled, active) = check_unit('ceph-%s@%s' % (daemon_type,
+                                                                   daemon_id))
+                    ls.append({
+                        'style': 'legacy',
+                        'name': '%s.%s' % (daemon_type, daemon_id),
+                        'fsid': fsid,
+                        'enabled': enabled,
+                        'active': active,
+                    })
+            elif is_fsid(i):
+                fsid = i
+                for j in os.listdir(os.path.join(args.data_dir, i)):
+                    (daemon_type, daemon_id) = j.split('.', 1)
+                    (enabled, active) = check_unit(get_unit_name(fsid,
+                                                                 daemon_type,
+                                                                 daemon_id))
+                    ls.append({
+                        'style': 'ceph-daemon:v1',
+                        'name': '%s.%s' % (daemon_type, daemon_id),
+                        'fsid': fsid,
+                        'enabled': enabled,
+                        'active': active,
+                    })
 
     # /var/lib/rook
     # WRITE ME

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -110,13 +110,14 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
 
     if config:
         with open(data_dir + '/config', 'w') as f:
-            f.write(config)
             os.fchown(f.fileno(), uid, gid)
+            os.fchmod(f.fileno(), 0o600)
+            f.write(config)
     if keyring:
         with open(data_dir + '/keyring', 'w') as f:
-            f.write(keyring)
             os.fchmod(f.fileno(), 0o600)
             os.fchown(f.fileno(), uid, gid)
+            f.write(keyring)
 
 def get_config_and_keyring():
     if args.config_and_keyring:
@@ -228,6 +229,8 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
 
         # write conf
         with open(mon_dir + '/config', 'w') as f:
+            os.fchown(f.fileno(), uid, gid)
+            os.fchmod(f.fileno(), 0o600)
             f.write(config)
     else:
         # dirs, conf, keyring
@@ -543,6 +546,8 @@ def command_bootstrap():
     ).run()
 
     with open(mon_dir + '/config', 'w') as f:
+        os.fchown(f.fileno(), uid, gid)
+        os.fchmod(f.fileno(), 0o600)
         f.write(config)
 
     mon_c = get_container(fsid, 'mon', mon_id)

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -164,10 +164,6 @@ def get_container_mounts(fsid, daemon_type, daemon_id):
     return mounts
 
 def get_container(fsid, daemon_type, daemon_id, privileged=False):
-    if daemon_id:
-        dname = daemon_type + '.' + daemon_id
-    else:
-        dname = daemon_type
     podman_args = []
     if daemon_type == 'osd' or privileged:
         podman_args += ['--privileged']
@@ -180,7 +176,6 @@ def get_container(fsid, daemon_type, daemon_id, privileged=False):
         ] + get_daemon_args(fsid, daemon_type, daemon_id),
         podman_args=podman_args,
         volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
-        dname=dname,
         cname='ceph-%s-%s.%s' % (fsid, daemon_type, daemon_id),
     )
 
@@ -373,19 +368,12 @@ class CephContainer:
                  args=[],
                  volume_mounts={},
                  cname='',
-                 dname='',
                  podman_args=[]):
         self.image = image
         self.entrypoint = entrypoint
         self.args = args
         self.volume_mounts = volume_mounts
         self.cname = cname
-        self.dname = dname
-        if dname:
-            (self.daemon_type, self.daemon_id) = dname.split('.')
-        else:
-            self.daemon_type = None
-            self.daemon_id = None
         self.podman_args = podman_args
 
     def run_cmd(self):

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -875,22 +875,33 @@ def command_rm_cluster():
     if not args.force:
         raise RuntimeError('must pass --force to proceed: '
                            'this command may destroy precious data!')
+
     unit_name = 'ceph-%s.target' % args.fsid
     try:
         subprocess.check_output(['systemctl', 'stop', unit_name])
         subprocess.check_output(['systemctl', 'disable', unit_name])
     except subprocess.CalledProcessError:
         pass
-    # FIXME: disable individual daemon units, too?
+
+    slice_name = 'system-%s.slice' % (
+        ('ceph-%s' % args.fsid).replace('-', '\\x2d'))
+    try:
+        subprocess.check_output(['systemctl', 'stop', slice_name])
+    except subprocess.CalledProcessError:
+        pass
+
+    # FIXME: stop + disable individual daemon units, too?
+
+    # rm units
     subprocess.check_output(['rm', '-f', args.unit_dir +
                              '/ceph-%s@.service' % args.fsid])
     subprocess.check_output(['rm', '-f', args.unit_dir +
                              '/ceph-%s.target' % args.fsid])
     subprocess.check_output(['rm', '-rf',
                   args.unit_dir + '/ceph-%s.target.wants' % args.fsid])
-    # data
+    # rm data
     subprocess.check_output(['rm', '-rf', args.data_dir + '/' + args.fsid])
-    # logs
+    # rm logs
     subprocess.check_output(['rm', '-rf', args.log_dir + '/' + args.fsid])
     subprocess.check_output(['rm', '-rf', args.log_dir +
                              '/*.wants/ceph-%s@*' % args.fsid])

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -652,6 +652,8 @@ def command_run():
 ##################################
 
 def command_shell():
+    log_dir = get_log_dir(args.log_dir, args.fsid)
+    makedirs(log_dir)
     if '.' in args.name:
         (daemon_type, daemon_id) = args.name.split('.')
     else:

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -677,6 +677,20 @@ def command_exec():
 
 ##################################
 
+def command_ceph_volume():
+    log_dir = get_log_dir(args.log_dir, args.fsid)
+    makedirs(log_dir)
+    c = CephContainer(
+        image=args.image,
+        entrypoint='/usr/sbin/ceph-volume',
+        args=args.command,
+        podman_args=['--privileged'],
+        volume_mounts=get_container_mounts(args.fsid, 'osd', None),
+    )
+    subprocess.call(c.run_cmd())
+
+##################################
+
 def command_unit():
     (daemon_type, daemon_id) = args.name.split('.')
     unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
@@ -887,6 +901,17 @@ parser_exec.add_argument(
     action='store_true',
     help='use a privileged container')
 parser_exec.add_argument(
+    'command', nargs='+',
+    help='command')
+
+parser_ceph_volume = subparsers.add_parser(
+    'ceph-volume', help='run ceph-volume inside a container')
+parser_ceph_volume.set_defaults(func=command_ceph_volume)
+parser_ceph_volume.add_argument(
+    '--fsid',
+    required=True,
+    help='cluster FSID')
+parser_ceph_volume.add_argument(
     'command', nargs='+',
     help='command')
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -121,7 +121,7 @@ def get_osd_device_path(osd_lv, lvs, device_type, dmcrypt_secret=None):
     raise RuntimeError('could not find %s with uuid %s' % (device_type, device_uuid))
 
 
-def activate_bluestore(lvs, no_systemd=False, no_tmpfs=False):
+def activate_bluestore(lvs, no_systemd=False, tmpfs=True):
     # find the osd
     osd_lv = lvs.get(lv_tags={'ceph.type': 'block'})
     if not osd_lv:
@@ -136,7 +136,7 @@ def activate_bluestore(lvs, no_systemd=False, no_tmpfs=False):
     osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
     if not system.path_is_mounted(osd_path):
         # mkdir -p and mount as tmpfs
-        prepare_utils.create_osd_path(osd_id, tmpfs=(not no_tmpfs))
+        prepare_utils.create_osd_path(osd_id, tmpfs=tmpfs)
     # XXX This needs to be removed once ceph-bluestore-tool can deal with
     # symlinks that exist in the osd dir
     for link_name in ['block', 'block.db', 'block.wal']:
@@ -262,11 +262,11 @@ class Activate(object):
             logger.info('unable to find a journal associated with the OSD, assuming bluestore')
             return activate_bluestore(lvs,
                                       no_systemd=args.no_systemd,
-                                      no_tmpfs=args.no_tmpfs)
+                                      tmpfs=(not args.no_tmpfs))
         if args.bluestore:
             activate_bluestore(lvs,
                                no_systemd=args.no_systemd,
-                               no_tmpfs=args.no_tmpfs)
+                               tmpfs=(not args.no_tmpfs))
         elif args.filestore:
             activate_filestore(lvs, no_systemd=args.no_systemd)
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -121,7 +121,7 @@ def get_osd_device_path(osd_lv, lvs, device_type, dmcrypt_secret=None):
     raise RuntimeError('could not find %s with uuid %s' % (device_type, device_uuid))
 
 
-def activate_bluestore(lvs, no_systemd=False):
+def activate_bluestore(lvs, no_systemd=False, no_tmpfs=False):
     # find the osd
     osd_lv = lvs.get(lv_tags={'ceph.type': 'block'})
     if not osd_lv:
@@ -136,7 +136,7 @@ def activate_bluestore(lvs, no_systemd=False):
     osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
     if not system.path_is_mounted(osd_path):
         # mkdir -p and mount as tmpfs
-        prepare_utils.create_osd_path(osd_id, tmpfs=True)
+        prepare_utils.create_osd_path(osd_id, tmpfs=(not no_tmpfs))
     # XXX This needs to be removed once ceph-bluestore-tool can deal with
     # symlinks that exist in the osd dir
     for link_name in ['block', 'block.db', 'block.wal']:
@@ -260,9 +260,13 @@ class Activate(object):
                     logger.info('found a journal associated with the OSD, assuming filestore')
                     return activate_filestore(lvs, no_systemd=args.no_systemd)
             logger.info('unable to find a journal associated with the OSD, assuming bluestore')
-            return activate_bluestore(lvs, no_systemd=args.no_systemd)
+            return activate_bluestore(lvs,
+                                      no_systemd=args.no_systemd,
+                                      no_tmpfs=args.no_tmpfs)
         if args.bluestore:
-            activate_bluestore(lvs, no_systemd=args.no_systemd)
+            activate_bluestore(lvs,
+                               no_systemd=args.no_systemd,
+                               no_tmpfs=args.no_tmpfs)
         elif args.filestore:
             activate_filestore(lvs, no_systemd=args.no_systemd)
 
@@ -326,6 +330,12 @@ class Activate(object):
             dest='no_systemd',
             action='store_true',
             help='Skip creating and enabling systemd units and starting OSD services',
+        )
+        parser.add_argument(
+            '--no-tmpfs',
+            dest='no_tmpfs',
+            action='store_true',
+            help='Do not create a tmpfs for the OSD directory',
         )
         if len(self.argv) == 0:
             print(sub_command_help)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5392,13 +5392,13 @@ std::vector<Option> get_global_options() {
     .set_default(0)
     .set_description(""),
 
-  Option("mgr_stats_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-  .set_default((int64_t)PerfCountersBuilder::PRIO_USEFUL)
-  .set_description("Lowest perfcounter priority collected by mgr")
-  .set_long_description("Daemons only set perf counter data to the manager "
-    "daemon if the counter has a priority higher than this.")
-  .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
-               (int64_t)PerfCountersBuilder::PRIO_CRITICAL + 1),
+    Option("mgr_stats_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default((int64_t)PerfCountersBuilder::PRIO_USEFUL)
+    .set_description("Lowest perfcounter priority collected by mgr")
+    .set_long_description("Daemons only set perf counter data to the manager "
+			  "daemon if the counter has a priority higher than this.")
+    .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
+		 (int64_t)PerfCountersBuilder::PRIO_CRITICAL + 1),
 
     Option("journal_zero_on_create", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -431,6 +431,11 @@ std::vector<Option> get_global_options() {
     .add_tag("network")
     .add_see_also("mon_host"),
 
+    Option("image", Option::TYPE_STR, Option::LEVEL_BASIC)
+    .set_description("container image (used by ssh orchestrator)")
+    .set_flag(Option::FLAG_STARTUP)
+    .set_default("ceph/daemon-base"),
+
     // lockdep
     Option("lockdep", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_description("enable lockdep lock dependency analyzer")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5428,6 +5428,11 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("ceph_daemon_path", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("/usr/sbin/ceph-daemon")
+    .add_service("mgr")
+    .set_description("Path to ceph-daemon utility"),
+
     Option("mgr_module_path", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default(CEPH_DATADIR "/mgr")
     .add_service("mgr")

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -257,7 +257,8 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
     cmd_getval(g_ceph_context, cmdmap, "who", who);
 
     EntityName entity;
-    if (!entity.from_str(who)) {
+    if (!entity.from_str(who) &&
+	!entity.from_str(who + ".")) {
       ss << "unrecognized entity '" << who << "'";
       err = -EINVAL;
       goto reply;

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -218,6 +218,9 @@ void MonCapGrant::expand_profile_mon(const EntityName& name) const
     profile_grants.push_back(MonCapGrant("auth", MON_CAP_R | MON_CAP_X));
     profile_grants.push_back(MonCapGrant("config-key", MON_CAP_R | MON_CAP_W));
     profile_grants.push_back(MonCapGrant("config", MON_CAP_R | MON_CAP_W));
+    // ssh orchestrator provisions new daemon keys
+    profile_grants.push_back(MonCapGrant("auth get-or-create"));
+    profile_grants.push_back(MonCapGrant("auth rm"));
   }
   if (profile == "osd" || profile == "mds" || profile == "mon" ||
       profile == "mgr") {

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -555,18 +555,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
     def _create_daemon(self, daemon_type, host, keyring, network=None):
         conn = self._get_connection(host)
         try:
-            monmap = self.get('mon_map')
-            fsid = monmap['fsid']
             name = '%s.%s' % (daemon_type, host)
-
-            # get container image
-            ret, image, err = self.mon_command({
-                'prefix': 'config get',
-                'who': name,
-                'key': 'image',
-            })
-            image = image.strip()
-            self.log.debug('%s container image %s' % (name, image))
 
             # generate config
             ret, config, err = self.mon_command({
@@ -588,14 +577,12 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             extra_args = []
             if network:
                 extra_args += ['--mon-network', network]
-            remoto.process.run(conn, [
-                '/home/sage/src/ceph5/src/ceph-daemon',
-                '--image', image,
-                'deploy',
-                '--fsid', fsid,
-                '--name', name,
-                '--config-and-keyring', '/tmp/foo',
-            ] + extra_args)
+            self._run_ceph_daemon(
+                host, name, 'deploy',
+                [
+                    '--name', name,
+                    '--config-and-keyring', '/tmp/foo'
+                ] + extra_args)
 
             return "Created {} on host '{}'".format(name, host)
 

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -135,8 +135,9 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         try:
             with open(path, 'r') as f:
                 self._ceph_daemon = f.read()
-        except:
-            raise RuntimeError("unable to read ceph-daemon at '%s'" % path)
+        except IOError as e:
+            raise RuntimeError("unable to read ceph-daemon at '%s': %s" % (
+                path, str(e)))
 
         self._worker_pool = multiprocessing.pool.ThreadPool(1)
 

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -458,7 +458,6 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             'config': config,
             'keyring': keyring,
         })
-        self.log.debug('j %s' % j)
 
         devices = drive_group.data_devices.paths
         for device in devices:
@@ -485,7 +484,6 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             ])
         self.log.debug('code %s out %s' % (code, out))
         j = json.loads('\n'.join(out))
-        self.log.debug('j %s' % j)
         fsid = self._cluster_fsid
         for osd_id, osds in j.items():
             for osd in osds:
@@ -552,7 +550,6 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
                 'config': config,
                 'keyring': keyring,
             })
-            self.log.debug('j %s' % j)
 
             out, code = self._run_ceph_daemon(
                 host, name, 'deploy',

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -692,6 +692,7 @@ $extra_conf
 [mgr]
         mgr data = $CEPH_DEV_DIR/mgr.\$id
         mgr module path = $MGR_PYTHON_PATH
+        ceph daemon path = $CEPH_ROOT/src/ceph-daemon
 $DAEMONOPTS
 $extra_conf
 [osd]

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -126,6 +126,7 @@ redirect=0
 smallmds=0
 short=0
 ec=0
+ssh=0
 hitset=""
 overwrite_conf=1
 cephx=1 #turn cephx on by default
@@ -209,6 +210,7 @@ usage=$usage"\t--crimson: use crimson-osd instead of ceph-osd\n"
 usage=$usage"\t--osd-args: specify any extra osd specific options\n"
 usage=$usage"\t--bluestore-devs: comma-separated list of blockdevs to use for bluestore\n"
 usage=$usage"\t--inc-osd: append some more osds into existing vcluster\n"
+usage=$usage"\t--ssh: enable ssh orchestrator with ~/.ssh/id_rsa[.pub]\n"
 
 usage_exit() {
     printf "$usage"
@@ -268,6 +270,9 @@ case $1 in
         ;;
     --msgr21 )
         msgr="21"
+        ;;
+    --ssh )
+        ssh=1
         ;;
     --valgrind )
         [ -z "$2" ] && usage_exit
@@ -953,6 +958,15 @@ EOF
         else
             echo MGR Restful is not working, perhaps the package is not installed?
         fi
+    fi
+
+    if [ "$ssh" -eq 1 ]; then
+        echo Enabling ssh orchestrator
+        ceph_adm config-key set mgr/ssh/ssh_identity_key -i ~/.ssh/id_rsa
+        ceph_adm config-key set mgr/ssh/ssh_identity_pub -i ~/.ssh/id_rsa.pub
+        ceph_adm mgr module enable ssh
+        ceph_adm orchestrator set backend ssh
+        ceph_adm orchestrator host add $HOSTNAME
     fi
 }
 

--- a/test_ceph_daemon.sh
+++ b/test_ceph_daemon.sh
@@ -19,7 +19,8 @@ EOF
     --mon-ip 10.3.64.23 \
     --config c \
     --output-keyring k \
-    --output-config c
+    --output-config c \
+    --skip-ssh
 chmod 644 k c
 
 # mon.b

--- a/test_ceph_daemon.sh
+++ b/test_ceph_daemon.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 fsid=2a833e3f-53e4-49a7-a7a0-bd89d193ab62
+image=ceph/daemon-base:latest-master-devel
 
 ../src/ceph-daemon rm-cluster --fsid $fsid --force
 
@@ -9,32 +10,38 @@ cat <<EOF > c
 log to file = true
 EOF
 
-../src/ceph-daemon bootstrap \
-		   --mon-id a \
-		   --mgr-id x \
-		   --fsid $fsid \
-		   --mon-ip 10.3.64.23 \
-		   --config c \
-		   --output-keyring k \
-		   --output-config c
+../src/ceph-daemon \
+    --image $image \
+    bootstrap \
+    --mon-id a \
+    --mgr-id x \
+    --fsid $fsid \
+    --mon-ip 10.3.64.23 \
+    --config c \
+    --output-keyring k \
+    --output-config c
 chmod 644 k c
 
 # mon.b
-../src/ceph-daemon deploy --name mon.b \
-		   --fsid $fsid \
-		   --mon-ip 10.3.64.27 \
-		   --keyring /var/lib/ceph/$fsid/mon.a/keyring \
-		   --config c
+../src/ceph-daemon \
+    --image $image \
+    deploy --name mon.b \
+    --fsid $fsid \
+    --mon-ip 10.3.64.27 \
+    --keyring /var/lib/ceph/$fsid/mon.a/keyring \
+    --config c
 
 # mgr.b
 bin/ceph -c c -k k auth get-or-create mgr.y \
 	 mon 'allow profile mgr' \
 	 osd 'allow *' \
 	 mds 'allow *' > k-mgr.y
-../src/ceph-daemon deploy --name mgr.y \
-		   --fsid $fsid \
-		   --keyring k-mgr.y \
-		   --config c
+../src/ceph-daemon \
+    --image $image \
+    deploy --name mgr.y \
+    --fsid $fsid \
+    --keyring k-mgr.y \
+    --config c
 
 # mds.{k,j}
 for id in k j; do
@@ -43,10 +50,12 @@ for id in k j; do
 	     mgr 'allow profile mds' \
 	     osd 'allow *' \
 	     mds 'allow *' > k-mds.$id
-    ../src/ceph-daemon deploy --name mds.$id \
-		       --fsid $fsid \
-		       --keyring k-mds.$id \
-		       --config c
+    ../src/ceph-daemon \
+	--image $image \
+	deploy --name mds.$id \
+	--fsid $fsid \
+	--keyring k-mds.$id \
+	--config c
 done
 
 bin/ceph -c c -k k -s


### PR DESCRIPTION
Notes:
- Minimal use of python language features, so that the script will run, unmodified, standalone, on a wide variety of machines.
- There are *no* ceph package dependencies on the host.  Everything is run out of the container image.
- It's assumed that something semi-smart will be running this, like the ssh orchestrator.  So when a daemon is created, for instanced, that thing will precreate the appropriate auth keys for the new daemon and pass them in (along with a sufficient conf).  The exception is the bootstrap command, which will be run by a human.
- The file layout on the host is new:
  * /var/lib/ceph/$fsid/$type.$id
  * /var/log/ceph/$fsid/ceph-$type.$id  (same ceph- prefix to filename, as before...)
  * /var/run/ceph/$fsid-$name.$id (s/ceph/$fsid/, basically)
  * /etc/systemd/system for systemd unit (which is named like ``ceph-$fsid@$type.$id``)
  * nothing in /etc/ceph!


TODO
- [x] bootstrap
- [x] deploy mgr
- [x] ls
- [ ] make ls understand rook mon+osd
- [ ] make ls understand ceph-ansible containerized daemons
- [x] rm-cluster
- [x] rm-daemon
- [x] deploy mon (expand mons)
- [x] deploy osd
- [x] deploy mds
- [ ] deploy rgw
- [x] seamless invocation by mgr/ssh
- [x] ceph-daemon package, included in ceph container image, required by ceph-mgr-ssh