### PR TITLE
nautilus: tools/rados: call pool_lookup() after rados is connected

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2106,13 +2106,6 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     with_reference = true;
   }
 
-  i = opts.find("pgid");
-  boost::optional<pg_t> pgid(i != opts.end(), pg_t());
-  if (pgid && (!pgid->parse(i->second.c_str()) || (pool_name && rados.pool_lookup(pool_name) != pgid->pool()))) {
-    cerr << "invalid pgid" << std::endl;
-    return 1;
-  }
-
   // open rados
   ret = rados.init_with_context(g_ceph_context);
   if (ret < 0) {
@@ -2139,6 +2132,13 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 	   << cpp_strerror(ret) << std::endl;
       return 1;
     }
+  }
+
+  i = opts.find("pgid");
+  boost::optional<pg_t> pgid(i != opts.end(), pg_t());
+  if (pgid && (!pgid->parse(i->second.c_str()) || (pool_name && rados.pool_lookup(pool_name) != pgid->pool()))) {
+    cerr << "invalid pgid" << std::endl;
+    return 1;
   }
 
   // open io context.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41963
parent tracker: https://tracker.ceph.com/issues/41875