### PR TITLE
rgw: prevent bucket reshard scheduling if bucket is resharding

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -25,6 +25,7 @@ extern "C" {
 
 #include "include/util.h"
 
+#include "cls/rgw/cls_rgw_types.h"
 #include "cls/rgw/cls_rgw_client.h"
 
 #include "global/global_init.h"
@@ -2573,6 +2574,13 @@ int check_reshard_bucket_params(rgw::sal::RGWRadosStore *store,
   if (ret < 0) {
     cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
     return ret;
+  }
+
+  if (bucket_info.reshard_status != CLS_RGW_RESHARD_NOT_RESHARDING) {
+    // if in_progress or done then we have an old BucketInfo
+    cerr << "ERROR: the bucket is currently undergoing resharding and "
+      "cannot be added to the reshard list at this time" << std::endl;
+    return -EBUSY;
   }
 
   int num_source_shards = (bucket_info.num_shards > 0 ? bucket_info.num_shards : 1);


### PR DESCRIPTION
radosgw-admin should prevent a bucket from being added to the reshard list if it is currently being resharded.

Tracker: https://tracker.ceph.com/issues/42073