### PR TITLE
mgr: fix weird health-alert daemon key

### DIFF
--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -11,6 +11,23 @@ ostream& operator<<(ostream& os,
   return os << daemon.first << "." << daemon.second;
 }
 
+// define operator<<(ostream&, const vector<DaemonKey>&) after
+// ostream& operator<<(ostream&, const DaemonKey&), so that C++'s
+// ADL can use the former instead of using the generic one:
+// operator<<(ostream&, const std::pair<A,B>&)
+ostream& operator<<(
+   ostream& os,
+   const vector<DaemonHealthMetricCollector::DaemonKey>& daemons)
+{
+  os << "[";
+  for (auto d = daemons.begin(); d != daemons.end(); ++d) {
+    if (d != daemons.begin()) os << ",";
+    os << *d;
+  }
+  os << "]";
+  return os;
+}
+
 namespace {
 
 class SlowOps final : public DaemonHealthMetricCollector {


### PR DESCRIPTION
Was:
  19 slow ops, oldest one blocked for 34 sec, daemons [osd,2,osd,4] have slow ops.

Now:
  153 slow ops, oldest one blocked for 38 sec, daemons [osd.3,osd.4,osd.5] have slow ops.

Fixes: https://tracker.ceph.com/issues/42079
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
