### PR TITLE
packaging: add missing dependency for ceph-volume

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -375,6 +375,7 @@ Package: ceph-osd
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
          lvm2,
+         python-pkg-resources,
 	 sudo,
          ${misc:Depends},
          ${python:Depends},


### PR DESCRIPTION
Typical error fixed:

```
Traceback (most recent call last):
  File "/usr/sbin/ceph-volume", line 6, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
