### PR TITLE
mgr/dashboard: Bucket names cannot be formatted as IP address

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -12,6 +12,7 @@ import { ActionLabelsI18n, URLVerbs } from '../../../shared/constants/app.consta
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
+import { CdValidators } from '../../../shared/forms/cd-validators';
 import { NotificationService } from '../../../shared/services/notification.service';
 
 @Component({
@@ -161,6 +162,19 @@ export class RgwBucketFormComponent implements OnInit {
     }
   }
 
+  /**
+   * Validate the bucket name. In general, bucket names should follow domain
+   * name constraints:
+   * - Bucket names must be unique.
+   * - Bucket names cannot be formatted as IP address.
+   * - Bucket names can be between 3 and 63 characters long.
+   * - Bucket names must not contain uppercase characters or underscores.
+   * - Bucket names must start with a lowercase letter or number.
+   * - Bucket names must be a series of one or more labels. Adjacent
+   *   labels are separated by a single period (.). Bucket names can
+   *   contain lowercase letters, numbers, and hyphens. Each label must
+   *   start and end with a lowercase letter or a number.
+   */
   bucketNameValidator(): AsyncValidatorFn {
     const rgwBucketService = this.rgwBucketService;
     return (control: AbstractControl): Promise<ValidationErrors | null> => {
@@ -171,13 +185,42 @@ export class RgwBucketFormComponent implements OnInit {
           resolve(null);
           return;
         }
-        // Validate the bucket name.
-        const nameRe = /^[0-9A-Za-z][\w-\.]{2,254}$/;
-        if (!nameRe.test(control.value)) {
+        const constraints = [];
+        // - Bucket names cannot be formatted as IP address.
+        constraints.push((name) => {
+          const validatorFn = CdValidators.ip();
+          return !validatorFn(name);
+        });
+        // - Bucket names can be between 3 and 63 characters long.
+        constraints.push((name) => _.inRange(name.length, 3, 64));
+        // - Bucket names must not contain uppercase characters or underscores.
+        // - Bucket names must start with a lowercase letter or number.
+        // - Bucket names must be a series of one or more labels. Adjacent
+        //   labels are separated by a single period (.). Bucket names can
+        //   contain lowercase letters, numbers, and hyphens. Each label must
+        //   start and end with a lowercase letter or a number.
+        constraints.push((name) => {
+          const labels = _.split(name, '.');
+          return _.every(labels, (label) => {
+            // Bucket names must not contain uppercase characters or underscores.
+            if (label !== _.toLower(label) || label.includes('_')) {
+              return false;
+            }
+            // Bucket names can contain lowercase letters, numbers, and hyphens.
+            if (!/[0-9a-z-]/.test(label)) {
+              return false;
+            }
+            // Each label must start and end with a lowercase letter or a number.
+            return _.every([0, label.length], (index) => {
+              return /[a-z]/.test(label[index]) || _.isInteger(_.parseInt(label[index]));
+            });
+          });
+        });
+        if (!_.every(constraints, (func) => func(control.value))) {
           resolve({ bucketNameInvalid: true });
           return;
         }
-        // Does any bucket with the given name already exist?
+        // - Bucket names must be unique.
         rgwBucketService.exists(control.value).subscribe((resp: boolean) => {
           if (!resp) {
             resolve(null);


### PR DESCRIPTION
In general, bucket names should follow domain name constraints:
- Bucket names must be unique.
- Bucket names cannot be formatted as IP address.
- Bucket names can be between 3 and 63 characters long.
- Bucket names must not contain uppercase characters or underscores.
- Bucket names must start with a lowercase letter or number.
- Bucket names must be a series of one or more labels. Adjacent labels are separated by a single period (.). Bucket names can contain lowercase letters, numbers, and hyphens. Each label must start and end with a lowercase letter or a number.

Fixes: https://tracker.ceph.com/issues/42069

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
