### PR TITLE
nautilus: pybind/rados: fix set_omap() crash on py3

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -3365,6 +3365,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise Error("Rados(): keys and values must have the same number of items")
 
         keys = cstr_list(keys, 'keys')
+        values = cstr_list(values, 'values')
         cdef:
             WriteOp _write_op = write_op
             size_t key_num = len(keys)

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -3366,12 +3366,13 @@ returned %d, but should return zero on success." % (self.name, ret))
 
         keys = cstr_list(keys, 'keys')
         values = cstr_list(values, 'values')
+        lens = [len(v) for v in values]
         cdef:
             WriteOp _write_op = write_op
             size_t key_num = len(keys)
             char **_keys = to_bytes_array(keys)
             char **_values = to_bytes_array(values)
-            size_t *_lens = to_csize_t_array([len(v) for v in values])
+            size_t *_lens = to_csize_t_array(lens)
 
         try:
             with nogil:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42083

---

backport of https://github.com/ceph/ceph/pull/29096
parent tracker: https://tracker.ceph.com/issues/42082

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh