### PR TITLE
luminous: mgr/BaseMgrStandbyModule: drop GIL in ceph_config_get()

### DIFF
--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -69,7 +69,10 @@ ceph_config_get(BaseMgrStandbyModule *self, PyObject *args)
     return nullptr;
   }
 
+  PyThreadState *tstate = PyEval_SaveThread();
   std::string value;
+  PyEval_RestoreThread(tstate);
+
   bool found = self->this_module->get_config(what, &value);
   if (found) {
     dout(10) << "ceph_config_get " << what << " found: " << value.c_str() << dendl;


### PR DESCRIPTION
otherwise we will have deadlock
this change also maps the same logic in `ceph_config_get()` in mgr/BaseMgrModule.cc

Fixes: https://tracker.ceph.com/issues/42086
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
