### PR TITLE
mgr/BaseMgrStandbyModule: drop GIL in ceph_get_module_option()

### DIFF
--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -69,6 +69,7 @@ ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
     derr << "Invalid args!" << dendl;
     return nullptr;
   }
+  PyThreadState *tstate = PyEval_SaveThread();
   std::string final_key;
   std::string value;
   bool found = false;
@@ -80,6 +81,7 @@ ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
     final_key = what;
     found = self->this_module->get_config(final_key, &value);
   }
+  PyEval_RestoreThread(tstate);
   if (found) {
     dout(10) << __func__ << " " << final_key << " found: " << value
 	     << dendl;


### PR DESCRIPTION
always drop GIL when performing block ops

Fixes: https://tracker.ceph.com/issues/42087
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
