### PR TITLE
rgw: fix librgw write wrong closed in NFS3

### DIFF
--- a/src/common/ceph_timer.h
+++ b/src/common/ceph_timer.h
@@ -253,6 +253,46 @@ namespace ceph {
 
 	return true;
       }
+     
+      // Pause the timer event
+      bool pause_event(uint64_t id) {
+        std::lock_guard<std::mutex> l(lock);
+        event key(id);
+        typename event_set_type::iterator it = events.find(key);
+        if (it == events.end()) {
+          return false;
+        }
+
+        event& e = *it;
+
+        schedule.erase(e);
+        return true;
+      }
+
+      // Resume the timer event
+      bool resume_event(uint64_t id) {
+        std::lock_guard<std::mutex> l(lock);
+        event key(id);
+        typename event_set_type::iterator it = events.find(key);
+        if (it == events.end()) {
+          return false;
+        }
+        event& e = *it;
+        typename TC::time_point now = TC::now();
+        if (e.t <= now) {
+          typename TC::duration duration(std::chrono::seconds(1));
+          typename TC::time_point future = (now + duration);
+          e.t = future;
+        }
+        auto i = schedule.insert(e);
+        /* If the event we have just inserted comes before everything
+         * else, we need to adjust our timeout. */
+        if (i.first == schedule.begin()) {
+          cond.notify_one();
+        }
+        
+        return true;
+      }
 
       // Cancel an event. If the event has already come and gone (or you
       // never submitted it) you will receive false. Otherwise you will

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -560,7 +560,7 @@ namespace rgw {
     int readdir(rgw_readdir_cb rcb, void *cb_arg, readdir_offset offset,
 		bool *eof, uint32_t flags);
 
-    int write(uint64_t off, size_t len, size_t *nbytes, void *buffer);
+    int write(uint64_t off, size_t len, size_t *nbytes, void *buffer, bool* retry);
 
     int commit(uint64_t offset, uint64_t length, uint32_t flags) {
       /* NFS3 and NFSv4 COMMIT implementation
@@ -2367,7 +2367,9 @@ public:
   void put_data(off_t off, buffer::list& _bl) {
     if (off != real_ofs) {
       eio = true;
+      return;
     }
+    eio = false;
     data.claim(_bl);
     real_ofs += data.length();
     ofs = off; /* consumed in exec_continue() */


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42056

Signed-off-by: Tao Chen <chentao@umcloud.com>

Mount nfs via librgw, then dd test on export directory. But dd has a write error.
Both the dd sequential write and the FIO sequential write can reproduce the nfs3_write problem.
This is a solution that uses retry when it is wrong.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
