### PR TITLE
rgw: fix librgw write wrong closed in NFS3

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1315,7 +1315,7 @@ namespace rgw {
   } /* RGWFileHandle::readdir */
 
   int RGWFileHandle::write(uint64_t off, size_t len, size_t *bytes_written,
-			   void *buffer)
+			   void *buffer, bool *retry)
   {
     using std::get;
     using WriteCompletion = RGWLibFS::WriteCompletion;
@@ -1402,7 +1402,36 @@ namespace rgw {
 #endif
 
     f->write_req->put_data(off, bl);
+
+    /*
+     * NFS Client may not always send data sequentially,
+     * so the expected offset may not equal to the real offset.
+     * In such situation we let writer wait until the offset is
+     * correct.
+     */
+    if (f->write_req->eio == true) {
+       *retry = true;
+       RGWLibFS::write_timer.adjust_event(
+          f->write_req->timer_id, std::chrono::seconds(10));
+      return 0; 
+    }
+
+    /* 
+     * Pause/Resume write timer in order to avoid writing 
+     * stream being wrongly closed when writing operation 
+     * is executing in rados layer
+     */
+    if (stateless_open()) {
+      /* pause write timer */
+      RGWLibFS::write_timer.pause_event(f->write_req->timer_id);
+    }
+
     rc = f->write_req->exec_continue();
+
+    if (stateless_open()) {
+      /* resume write timer */
+      RGWLibFS::write_timer.resume_event(f->write_req->timer_id);
+    }
 
     if (rc == 0) {
       size_t min_size = off + len;
@@ -2274,8 +2303,12 @@ int rgw_write(struct rgw_fs *rgw_fs,
 {
   RGWFileHandle* rgw_fh = get_rgwfh(fh);
   int rc;
-
   *bytes_written = 0;
+
+  /* variables for writer retry count */
+  bool retry = false;
+  int max_retry = 10;
+  int cnt_retry = 0;
 
   if (! rgw_fh->is_file())
     return -EISDIR;
@@ -2289,8 +2322,15 @@ int rgw_write(struct rgw_fs *rgw_fs,
       return -EPERM;
   }
 
-  rc = rgw_fh->write(offset, length, bytes_written, buffer);
-
+  rc = rgw_fh->write(offset, length, bytes_written, buffer, &retry);
+  
+  /* Retry until offset is correct or max retry time reach */
+  while (retry && cnt_retry < max_retry) {
+    sleep(1);
+    retry = false;
+    cnt_retry++;
+    rc = rgw_fh->write(offset, length, bytes_written, buffer, &retry);
+  }
   return rc;
 }
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -602,7 +602,7 @@ namespace rgw {
     int readdir(rgw_readdir_cb rcb, void *cb_arg, readdir_offset offset,
 		bool *eof, uint32_t flags);
 
-    int write(uint64_t off, size_t len, size_t *nbytes, void *buffer);
+    int write(uint64_t off, size_t len, size_t *nbytes, void *buffer, bool* retry);
 
     int commit(uint64_t offset, uint64_t length, uint32_t flags) {
       /* NFS3 and NFSv4 COMMIT implementation
@@ -2494,7 +2494,9 @@ public:
   void put_data(off_t off, buffer::list& _bl) {
     if (off != real_ofs) {
       eio = true;
+      return;
     }
+    eio = false;
     data.claim(_bl);
     real_ofs += data.length();
     ofs = off; /* consumed in exec_continue() */


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42056

Signed-off-by: Tao Chen <chentao@umcloud.com>

Mount nfs via librgw, then dd test on export directory. But dd has a write error.
Both the dd sequential write and the FIO sequential write can reproduce the nfs3_write problem.
This is a solution that uses retry when it is wrong.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
