### PR TITLE
mgr: use a struct for DaemonKey

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -29,6 +29,7 @@
 #include "PyModuleRegistry.h"
 
 #include "ActivePyModules.h"
+#include "DaemonKey.h"
 #include "DaemonServer.h"
 
 #define dout_context g_ceph_context
@@ -63,23 +64,19 @@ void ActivePyModules::dump_server(const std::string &hostname,
   f->open_array_section("services");
   std::string ceph_version;
 
-  for (const auto &i : dmc) {
-    std::lock_guard l(i.second->lock);
-    const auto &key = i.first;
-    const std::string &str_type = key.first;
-    const std::string &svc_name = key.second;
-
+  for (const auto &[key, state] : dmc) {
+    std::lock_guard l(state->lock);
     // TODO: pick the highest version, and make sure that
     // somewhere else (during health reporting?) we are
     // indicating to the user if we see mixed versions
-    auto ver_iter = i.second->metadata.find("ceph_version");
-    if (ver_iter != i.second->metadata.end()) {
-      ceph_version = i.second->metadata.at("ceph_version");
+    auto ver_iter = state->metadata.find("ceph_version");
+    if (ver_iter != state->metadata.end()) {
+      ceph_version = state->metadata.at("ceph_version");
     }
 
     f->open_object_section("service");
-    f->dump_string("type", str_type);
-    f->dump_string("id", svc_name);
+    f->dump_string("type", key.type);
+    f->dump_string("id", key.name);
     f->close_section();
   }
   f->close_section();
@@ -130,7 +127,7 @@ PyObject *ActivePyModules::get_metadata_python(
   const std::string &svc_type,
   const std::string &svc_id)
 {
-  auto metadata = daemon_state.get(DaemonKey(svc_type, svc_id));
+  auto metadata = daemon_state.get(DaemonKey{svc_type, svc_id});
   if (metadata == nullptr) {
     derr << "Requested missing service " << svc_type << "." << svc_id << dendl;
     Py_RETURN_NONE;
@@ -150,7 +147,7 @@ PyObject *ActivePyModules::get_daemon_status_python(
   const std::string &svc_type,
   const std::string &svc_id)
 {
-  auto metadata = daemon_state.get(DaemonKey(svc_type, svc_id));
+  auto metadata = daemon_state.get(DaemonKey{svc_type, svc_id});
   if (metadata == nullptr) {
     derr << "Requested missing service " << svc_type << "." << svc_id << dendl;
     Py_RETURN_NONE;
@@ -243,12 +240,12 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     auto dmc = daemon_state.get_by_service("osd");
     PyEval_RestoreThread(tstate);
 
-    for (const auto &i : dmc) {
-      std::lock_guard l(i.second->lock);
-      f.open_object_section(i.first.second.c_str());
-      f.dump_string("hostname", i.second->hostname);
-      for (const auto &j : i.second->metadata) {
-        f.dump_string(j.first.c_str(), j.second);
+    for (const auto &[key, state] : dmc) {
+      std::lock_guard l(state->lock);
+      f.open_object_section(key.name.c_str());
+      f.dump_string("hostname", state->hostname);
+      for (const auto &[name, val] : state->metadata) {
+        f.dump_string(name.c_str(), val);
       }
       f.close_section();
     }
@@ -681,7 +678,7 @@ PyObject* ActivePyModules::with_perf_counters(
   PyFormatter f;
   f.open_array_section(path.c_str());
 
-  auto metadata = daemon_state.get(DaemonKey(svc_name, svc_id));
+  auto metadata = daemon_state.get(DaemonKey{svc_name, svc_id});
   if (metadata) {
     std::lock_guard l2(metadata->lock);
     if (metadata->perf_counters.instances.count(path)) {
@@ -775,7 +772,7 @@ PyObject* ActivePyModules::get_perf_schema_python(
   } else if (svc_id.empty()) {
     daemons = daemon_state.get_by_service(svc_type);
   } else {
-    auto key = DaemonKey(svc_type, svc_id);
+    auto key = DaemonKey{svc_type, svc_id};
     // so that the below can be a loop in all cases
     auto got = daemon_state.get(key);
     if (got != nullptr) {
@@ -785,13 +782,8 @@ PyObject* ActivePyModules::get_perf_schema_python(
 
   PyFormatter f;
   if (!daemons.empty()) {
-    for (auto statepair : daemons) {
-      auto key = statepair.first;
-      auto state = statepair.second;
-
-      std::ostringstream daemon_name;
-      daemon_name << key.first << "." << key.second;
-      f.open_object_section(daemon_name.str().c_str());
+    for (auto& [key, state] : daemons) {
+      f.open_object_section(ceph::to_string(key).c_str());
 
       std::lock_guard l(state->lock);
       for (auto ctr_inst_iter : state->perf_counters.instances) {

--- a/src/mgr/CMakeLists.txt
+++ b/src/mgr/CMakeLists.txt
@@ -7,6 +7,7 @@ set(mgr_srcs
   BaseMgrStandbyModule.cc
   ClusterState.cc
   DaemonHealthMetricCollector.cc
+  DaemonKey.cc
   DaemonServer.cc
   DaemonState.cc
   Gil.cc

--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -4,30 +4,6 @@
 #include "include/types.h"
 #include "DaemonHealthMetricCollector.h"
 
-
-
-ostream& operator<<(ostream& os,
-                    const DaemonHealthMetricCollector::DaemonKey& daemon) {
-  return os << daemon.first << "." << daemon.second;
-}
-
-// define operator<<(ostream&, const vector<DaemonKey>&) after
-// ostream& operator<<(ostream&, const DaemonKey&), so that C++'s
-// ADL can use the former instead of using the generic one:
-// operator<<(ostream&, const std::pair<A,B>&)
-ostream& operator<<(
-   ostream& os,
-   const vector<DaemonHealthMetricCollector::DaemonKey>& daemons)
-{
-  os << "[";
-  for (auto d = daemons.begin(); d != daemons.end(); ++d) {
-    if (d != daemons.begin()) os << ",";
-    os << *d;
-  }
-  os << "]";
-  return os;
-}
-
 namespace {
 
 class SlowOps final : public DaemonHealthMetricCollector {

--- a/src/mgr/DaemonHealthMetricCollector.h
+++ b/src/mgr/DaemonHealthMetricCollector.h
@@ -4,11 +4,11 @@
 #include <string>
 
 #include "DaemonHealthMetric.h"
+#include "DaemonKey.h"
 #include "mon/health_check.h"
 
 class DaemonHealthMetricCollector {
 public:
-  using DaemonKey = std::pair<std::string, std::string>;
   static std::unique_ptr<DaemonHealthMetricCollector> create(daemon_metric m);
   void update(const DaemonKey& daemon, const DaemonHealthMetric& metric) {
     if (_is_relevant(metric.get_type())) {

--- a/src/mgr/DaemonKey.cc
+++ b/src/mgr/DaemonKey.cc
@@ -1,0 +1,35 @@
+#include "DaemonKey.h"
+
+std::pair<DaemonKey, bool> DaemonKey::parse(const std::string& s)
+{
+  auto p = s.find('.');
+  if (p == s.npos) {
+    return {{}, false};
+  } else {
+    return {DaemonKey{s.substr(0, p), s.substr(p + 1)}, true};
+  }
+}
+
+bool operator<(const DaemonKey& lhs, const DaemonKey& rhs)
+{
+  if (int cmp = lhs.type.compare(rhs.type); cmp < 0) {
+    return true;
+  } else if (cmp > 0) {
+    return false;
+  } else {
+    return lhs.name < rhs.name;
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const DaemonKey& key)
+{
+  return os << key.type << '.' << key.name;
+}
+
+namespace ceph {
+std::string to_string(const DaemonKey& key)
+{
+  return key.type + '.' + key.name;
+}
+}
+

--- a/src/mgr/DaemonKey.h
+++ b/src/mgr/DaemonKey.h
@@ -1,0 +1,24 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <ostream>
+#include <string>
+#include <utility>
+
+// Unique reference to a daemon within a cluster
+struct DaemonKey
+{
+  std::string type; // service type, like "osd", "mon"
+  std::string name; // service id / name, like "1", "a"
+  static std::pair<DaemonKey, bool> parse(const std::string& s);
+};
+
+bool operator<(const DaemonKey& lhs, const DaemonKey& rhs);
+std::ostream& operator<<(std::ostream& os, const DaemonKey& key);
+
+namespace ceph {
+  std::string to_string(const DaemonKey& key);
+}
+

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -27,16 +27,10 @@
 
 // For PerfCounterType
 #include "messages/MMgrReport.h"
+#include "DaemonKey.h"
 
 namespace ceph {
   class Formatter;
-}
-
-// Unique reference to a daemon within a cluster
-typedef std::pair<std::string, std::string> DaemonKey;
-
-static inline std::string to_string(const DaemonKey& dk) {
-  return dk.first + "." + dk.second;
 }
 
 // An instance of a performance counter type, within

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -69,31 +69,27 @@ void MetadataUpdate::finish(int r)
 {
   daemon_state.clear_updating(key);
   if (r == 0) {
-    if (key.first == "mds" || key.first == "osd" || 
-        key.first == "mgr" || key.first == "mon") {
+    if (key.type == "mds" || key.type == "osd" ||
+        key.type == "mgr" || key.type == "mon") {
       json_spirit::mValue json_result;
       bool read_ok = json_spirit::read(
           outbl.to_str(), json_result);
       if (!read_ok) {
-        dout(1) << "mon returned invalid JSON for "
-                << key.first << "." << key.second << dendl;
+        dout(1) << "mon returned invalid JSON for " << key << dendl;
         return;
       }
       if (json_result.type() != json_spirit::obj_type) {
-        dout(1) << "mon returned valid JSON "
-                << key.first << "." << key.second
+        dout(1) << "mon returned valid JSON " << key
 		<< " but not an object: '" << outbl.to_str() << "'" << dendl;
         return;
       }
-      dout(4) << "mon returned valid metadata JSON for "
-              << key.first << "." << key.second << dendl;
+      dout(4) << "mon returned valid metadata JSON for " << key << dendl;
 
       json_spirit::mObject daemon_meta = json_result.get_obj();
 
       // Skip daemon who doesn't have hostname yet
       if (daemon_meta.count("hostname") == 0) {
-        dout(1) << "Skipping incomplete metadata entry for "
-                << key.first << "." << key.second << dendl;
+        dout(1) << "Skipping incomplete metadata entry for " << key << dendl;
         return;
       }
 
@@ -107,9 +103,9 @@ void MetadataUpdate::finish(int r)
       DaemonStatePtr state;
       if (daemon_state.exists(key)) {
         state = daemon_state.get(key);
-        if (key.first == "mds" || key.first == "mgr" || key.first == "mon") {
+        if (key.type == "mds" || key.type == "mgr" || key.type == "mon") {
           daemon_meta.erase("name");
-        } else if (key.first == "osd") {
+        } else if (key.type == "osd") {
           daemon_meta.erase("id");
         }
         daemon_meta.erase("hostname");
@@ -124,9 +120,9 @@ void MetadataUpdate::finish(int r)
         state->key = key;
         state->hostname = daemon_meta.at("hostname").get_str();
 
-        if (key.first == "mds" || key.first == "mgr" || key.first == "mon") {
+        if (key.type == "mds" || key.type == "mgr" || key.type == "mon") {
           daemon_meta.erase("name");
-        } else if (key.first == "osd") {
+        } else if (key.type == "osd") {
           daemon_meta.erase("id");
         }
         daemon_meta.erase("hostname");
@@ -143,9 +139,8 @@ void MetadataUpdate::finish(int r)
       ceph_abort();
     }
   } else {
-    dout(1) << "mon failed to return metadata for "
-            << key.first << "." << key.second << ": "
-	    << cpp_strerror(r) << dendl;
+    dout(1) << "mon failed to return metadata for " << key
+	    << ": " << cpp_strerror(r) << dendl;
   }
 }
 
@@ -333,8 +328,8 @@ void Mgr::load_all_metadata()
     }
 
     DaemonStatePtr dm = std::make_shared<DaemonState>(daemon_state.types);
-    dm->key = DaemonKey("mds",
-                        daemon_meta.at("name").get_str());
+    dm->key = DaemonKey{"mds",
+                        daemon_meta.at("name").get_str()};
     dm->hostname = daemon_meta.at("hostname").get_str();
 
     daemon_meta.erase("name");
@@ -355,8 +350,8 @@ void Mgr::load_all_metadata()
     }
 
     DaemonStatePtr dm = std::make_shared<DaemonState>(daemon_state.types);
-    dm->key = DaemonKey("mon",
-                        daemon_meta.at("name").get_str());
+    dm->key = DaemonKey{"mon",
+                        daemon_meta.at("name").get_str()};
     dm->hostname = daemon_meta.at("hostname").get_str();
 
     daemon_meta.erase("name");
@@ -380,8 +375,8 @@ void Mgr::load_all_metadata()
     dout(4) << osd_metadata.at("hostname").get_str() << dendl;
 
     DaemonStatePtr dm = std::make_shared<DaemonState>(daemon_state.types);
-    dm->key = DaemonKey("osd",
-                        stringify(osd_metadata.at("id").get_int()));
+    dm->key = DaemonKey{"osd",
+                        stringify(osd_metadata.at("id").get_int())};
     dm->hostname = osd_metadata.at("hostname").get_str();
 
     osd_metadata.erase("id");
@@ -440,7 +435,7 @@ void Mgr::handle_osd_map()
 
       // Consider whether to update the daemon metadata (new/restarted daemon)
       bool update_meta = false;
-      const auto k = DaemonKey("osd", stringify(osd_id));
+      const auto k = DaemonKey{"osd", std::to_string(osd_id)};
       if (daemon_state.is_updating(k)) {
         continue;
       }
@@ -585,7 +580,7 @@ void Mgr::handle_fs_map(ref_t<MFSMap> m)
     // Remember which MDS exists so that we can cull any that don't
     names_exist.insert(info.name);
 
-    const auto k = DaemonKey("mds", info.name);
+    const auto k = DaemonKey{"mds", info.name};
     if (daemon_state.is_updating(k)) {
       continue;
     }


### PR DESCRIPTION
instead of using `std::pair<>` for presenting it. there are three
advantages:

1. better names for readability: `type` and `name` are better names
   than `first` and `second`
2. so we can specliaze its behavior by its type: define
   `operator<<` once, and use it everywhere. no need to worry
   about ADL to pickup the generic operator of `operator<< (..., pair<>)`
   anymore. so we can safely use `<< key`, and no need to
   use `<< key.first << '.' << key.second`. kill the printed form of
   `osd,1` once and for all, all of them are now "osd.1".
3. consolidate the print/parse in a single place

Fixes: https://tracker.ceph.com/issues/42079
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
