### PR TITLE
common: Fix the error handling logic in get_device_id.

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -542,15 +542,22 @@ std::string get_device_id(const std::string& devname,
   if (!blkdev.model(buf, sizeof(buf))) {
     model = buf;
   }
-  if (blkdev.serial(buf, sizeof(buf))) {
+  if (!blkdev.serial(buf, sizeof(buf))) {
     serial = buf;
   }
-  if (!model.size() || serial.size()) {
-    if (err) {
+  if (err) {
+    if (model.empty() && serial.empty()) {
+      *err = std::string("fallback method has no model nor serial'");
+      return {};
+    } else if (model.empty()) {
       *err = std::string("fallback method has serial '") + serial
-	+ "'but no model";
+        + "' but no model'";
+      return {};
+    } else if (serial.empty()) {
+      *err = std::string("fallback method has model '") + model
+        + "' but no serial'";
+      return {};
     }
-    return {};
   }
 
   device_id = model + "_" + serial;


### PR DESCRIPTION
When using fallback methods, device id should only be returned when both model and serial are present. The original impl looks like a logical error.

Signed-off-by: Difan Zhang <difan@google.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
