### PR TITLE
pybind/cephfs: add cephfs python API removexattr()

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -132,6 +132,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
                       const void *value, size_t size, int flags)
     int ceph_getxattr(ceph_mount_info *cmount, const char *path, const char *name,
                       void *value, size_t size)
+    int ceph_removexattr(ceph_mount_info *cmount, const char *path, const char *name)
     int ceph_write(ceph_mount_info *cmount, int fd, const char *buf, int64_t size, int64_t offset)
     int ceph_read(ceph_mount_info *cmount, int fd, char *buf, int64_t size, int64_t offset)
     int ceph_flock(ceph_mount_info *cmount, int fd, int operation, uint64_t owner)
@@ -1096,6 +1097,26 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "error in setxattr")
 
+    def removexattr(self, path, name):
+        """
+        Remove an extended attribute of a file.
+
+        :param path: path of the file.
+        :param name: name of the extended attribute to remove.
+        """
+        self.require_state("mounted")
+
+        name = cstr(name, 'name')
+        path = cstr(path, 'path')
+
+        cdef:
+            char *_path = path
+            char *_name = name
+
+        with nogil:
+            ret = ceph_removexattr(self.cluster, _path, _name)
+        if ret < 0:
+            raise make_ex(ret, "error in removexattr")
 
     def stat(self, path, follow_symlink=True):
         """

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -111,6 +111,9 @@ def test_xattr():
     # Pass explicit size, and we'll get the value
     assert_equal(300, len(cephfs.getxattr("/", "user.big", 300)))
 
+    cephfs.removexattr("/", "user.key")
+    # user.key is already removed
+    assert_raises(libcephfs.NoData, cephfs.getxattr, "/", "user.key")
 
 @with_setup(setup_test)
 def test_rename():


### PR DESCRIPTION
Signed-off-by: bingyi zhang <zhangbingyi@umcloud.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
