### PR TITLE
qa/mgr/balancer: Add cram based test for altering target_max_misplaced_ratio setting

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
@@ -1,0 +1,10 @@
+roles:
+- [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
+tasks:
+- install:
+- ceph:
+    fs: xfs
+- cram:
+    clients:
+      client.0:
+      - src/test/cli-integration/balancer/misplaced.t

--- a/src/test/cli-integration/balancer/misplaced.t
+++ b/src/test/cli-integration/balancer/misplaced.t
@@ -1,0 +1,26 @@
+  $ ceph osd pool create balancer_opt 128
+  pool 'balancer_opt' created
+  $ ceph osd pool application enable balancer_opt rados
+  enabled application 'rados' on pool 'balancer_opt'
+  $ rados bench -p balancer_opt 50 write --no-cleanup > /dev/null
+  $ ceph balancer on
+  $ ceph balancer mode crush-compat
+  $ ceph balancer ls
+  []
+  $ ceph config set osd.* target_max_misplaced_ratio .07
+  $ ceph balancer eval
+  current cluster score [0-9]*\.?[0-9]+.* (re)
+  $ ceph balancer optimize test_plan balancer_opt
+  $ ceph balancer ls
+  [
+      "test_plan"
+  ]
+  $ ceph balancer execute test_plan
+  $ ceph balancer eval
+  current cluster score [0-9]*\.?[0-9]+.* (re)
+# Plan is gone after execution ?
+  $ ceph balancer execute test_plan
+  Error ENOENT: plan test_plan not found
+  [2]
+  $ ceph osd pool rm balancer_opt balancer_opt --yes-i-really-really-mean-it
+  pool 'balancer_opt' removed


### PR DESCRIPTION
Partially fixes: https://tracker.ceph.com/issues/20283

---

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
