### PR TITLE
nautilus: osd: fix possible crash on sending dynamic perf stats report

### DIFF
--- a/src/osd/DynamicPerfStats.h
+++ b/src/osd/DynamicPerfStats.h
@@ -169,10 +169,15 @@ public:
   }
 
   void add_to_reports(
-      const std::map<OSDPerfMetricQuery, OSDPerfMetricLimits> & limits,
+      const std::map<OSDPerfMetricQuery, OSDPerfMetricLimits> &limits,
       std::map<OSDPerfMetricQuery, OSDPerfMetricReport> *reports) {
     for (auto &it : data) {
       auto &query = it.first;
+      auto limit_it = limits.find(query);
+      if (limit_it == limits.end()) {
+        continue;
+      }
+      auto &query_limits = limit_it->second;
       auto &counters = it.second;
       auto &report = (*reports)[query];
 
@@ -182,7 +187,7 @@ public:
       auto &descriptors = report.performance_counter_descriptors;
       ceph_assert(descriptors.size() > 0);
 
-      if (!is_limited(limits.at(query), counters.size())) {
+      if (!is_limited(query_limits, counters.size())) {
         for (auto &it_counters : counters) {
           auto &bl = report.group_packed_performance_counters[it_counters.first];
           query.pack_counters(it_counters.second, &bl);
@@ -190,7 +195,7 @@ public:
         continue;
       }
 
-      for (auto &limit : limits.at(query)) {
+      for (auto &limit : query_limits) {
         size_t index = 0;
         for (; index < descriptors.size(); index++) {
           if (descriptors[index] == limit.order_by) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10308,11 +10308,9 @@ void OSD::set_perf_queries(
   std::vector<PGRef> pgs;
   _get_pgs(&pgs);
   for (auto& pg : pgs) {
-    if (pg->is_primary()) {
-      pg->lock();
-      pg->set_dynamic_perf_stats_queries(supported_queries);
-      pg->unlock();
-    }
+    pg->lock();
+    pg->set_dynamic_perf_stats_queries(supported_queries);
+    pg->unlock();
   }
 }
 
@@ -10322,17 +10320,15 @@ void OSD::get_perf_reports(
   _get_pgs(&pgs);
   DynamicPerfStats dps;
   for (auto& pg : pgs) {
-    if (pg->is_primary()) {
-      // m_perf_queries can be modified only in set_perf_queries by mgr client
-      // request, and it is protected by by mgr client's lock, which is held
-      // when set_perf_queries/get_perf_reports are called, so we may not hold
-      // m_perf_queries_lock here.
-      DynamicPerfStats pg_dps(m_perf_queries);
-      pg->lock();
-      pg->get_dynamic_perf_stats(&pg_dps);
-      pg->unlock();
-      dps.merge(pg_dps);
-    }
+    // m_perf_queries can be modified only in set_perf_queries by mgr client
+    // request, and it is protected by by mgr client's lock, which is held
+    // when set_perf_queries/get_perf_reports are called, so we may not hold
+    // m_perf_queries_lock here.
+    DynamicPerfStats pg_dps(m_perf_queries);
+    pg->lock();
+    pg->get_dynamic_perf_stats(&pg_dps);
+    pg->unlock();
+    dps.merge(pg_dps);
   }
   dps.add_to_reports(m_perf_limits, reports);
   dout(20) << "reports for " << reports->size() << " queries" << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42095

---

backport of https://github.com/ceph/ceph/pull/30454
parent tracker: https://tracker.ceph.com/issues/41891

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh