### PR TITLE
mgr/volumes: fix incorrect snapshot path creation

### DIFF
--- a/src/pybind/mgr/volumes/fs/subvolspec.py
+++ b/src/pybind/mgr/volumes/fs/subvolspec.py
@@ -90,13 +90,13 @@ class SubvolumeSpec(object):
         """
         return the subvolume snapshot path for a given snapshot name
         """
-        return os.path.join(self.subvolume_path, snapdir, snapname)
+        return os.path.join(self.subvolume_path, snapdir.encode('utf-8'), snapname.encode('utf-8'))
 
     def make_group_snap_path(self, snapdir, snapname):
         """
         return the group snapshot path for a given snapshot name
         """
-        return os.path.join(self.group_path, snapdir, snapname)
+        return os.path.join(self.group_path, snapdir.encode('utf-8'), snapname.encode('utf-8'))
 
     def __str__(self):
         return "{0}/{1}".format(self.groupid, self.subvolumeid)


### PR DESCRIPTION
When constructing the snapshot path, the components are a mix of
byte and string type objects. The `os.path.join()` method needs
the components to be of the same type. Hence convert all components
to byte type objects.

Fixes: https://tracker.ceph.com/issues/42096
Signed-off-by: Ramana Raja <rraja@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
