### PR TITLE
cephfs-shell: return non-zero value on error

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -619,7 +619,5 @@ class TestMisc(TestCephFSShell):
         """
         Test that help outputs commands.
         """
-
-        o = self.get_cephfs_shell_cmd_output("help")
-
+        o = self.get_cephfs_shell_cmd_output("help all")
         log.info("output:\n{}".format(o))

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -415,7 +415,8 @@ class CephFSShell(Cmd):
                 traceback.print_exc(file=sys.stdout)
         except Exception as e:
             perror(e)
-            traceback.print_exc(file=sys.stdout)
+            if shell.debug:
+                traceback.print_exc(file=sys.stdout)
 
     class path_to_bytes(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -409,6 +409,10 @@ class CephFSShell(Cmd):
             perror('***\n{}'.format(e))
         except KeyboardInterrupt:
             perror('Command aborted')
+        except libcephfs.Error as e:
+            perror(e.strerror)
+            if shell.debug:
+                traceback.print_exc(file=sys.stdout)
         except Exception as e:
             perror(e)
             traceback.print_exc(file=sys.stdout)

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -41,6 +41,7 @@ except ImportError:
                 try:
                     args = argparser.parse_args(arglist)
                 except SystemExit:
+                    shell.exit_code = 1
                     # argparse exits at seeing bad arguments
                     return
                 else:
@@ -135,6 +136,7 @@ def ls(path, opts=''):
                 yield dent
     except libcephfs.ObjectNotFound as e:
         perror(e)
+        shell.exit_code = 1
 
 
 def glob(path, pattern):
@@ -262,6 +264,7 @@ def copy_from_local(local_path, remote_path):
         try:
             file_ = open(local_path, 'rb')
         except PermissionError:
+            self.exit_code = 1
             perror('error: no permission to read local file {}'.format(
                    local_path.decode('utf-8')))
             return
@@ -270,6 +273,7 @@ def copy_from_local(local_path, remote_path):
         fd = cephfs.open(remote_path, 'w', 0o666)
     except libcephfs.Error as e:
         perror(e)
+        self.exit_code = 1
         return
     progress = 0
     while True:
@@ -351,6 +355,7 @@ class CephFSShell(Cmd):
         try:
             argparse_args = getattr(self, 'argparse_' + command)
         except AttributeError:
+            self.exit_code = 1
             return None
         doc_lines = getattr(
             self, 'do_' + command).__doc__.expandtabs().splitlines()
@@ -407,16 +412,20 @@ class CephFSShell(Cmd):
             return res
         except ConnectionError as e:
             perror('***\n{}'.format(e))
+            self.exit_code = 3
         except KeyboardInterrupt:
             perror('Command aborted')
+            self.exit_code = 130
         except libcephfs.Error as e:
             perror(e.strerror)
             if shell.debug:
                 traceback.print_exc(file=sys.stdout)
+            self.exit_code = 1
         except Exception as e:
             perror(e)
             if shell.debug:
                 traceback.print_exc(file=sys.stdout)
+            self.exit_code = 1
 
     class path_to_bytes(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
@@ -692,6 +701,7 @@ exists.')
                     else:
                         perror('{}: already exists! use --force to overwrite'.format(
                                root_src_dir.decode('utf-8')))
+                        self.exit_code = 1
                         return
 
             for file_ in files:
@@ -1040,6 +1050,7 @@ sub-directories, files')
             os.chdir(os.path.expanduser(args.path))
         except OSError as e:
             perror("Cannot change to {}: {}".format(e.filename, e.strerror))
+            self.exit_code = 1
 
     def complete_lls(self, text, line, begidx, endidx):
         """
@@ -1068,6 +1079,7 @@ sub-directories, files')
                     print_list(items)
                 except OSError as e:
                     perror("'{}': {}".format(e.filename, e.strerror))
+                    self.exit_code = 1
         # Arguments to the with_argpaser decorator function are sticky.
         # The items in args.path do not get overwritten in subsequent calls.
         # The arguments remain in args.paths after the function exits and we
@@ -1170,6 +1182,7 @@ sub-directories, files')
                         f.decode('utf-8')))
                 except libcephfs.Error as e:
                     perror(e)
+                    self.exit_code = 1
                     continue
 
         for path in args.paths:
@@ -1218,6 +1231,7 @@ sub-directories, files')
                                     max_bytes, len(max_bytes),
                                     os.XATTR_REPLACE)
                     perror('max_bytes reset to %d' % args.max_bytes)
+                    self.exit_code = 1
 
             if args.max_files >= 0:
                 max_files = to_bytes(str(args.max_files))
@@ -1231,6 +1245,7 @@ sub-directories, files')
                                     max_files, len(max_files),
                                     os.XATTR_REPLACE)
                     perror('max_files reset to %d' % args.max_files)
+                    self.exit_code = 1
         elif args.op == 'get':
             max_bytes = '0'
             max_files = '0'
@@ -1240,6 +1255,7 @@ sub-directories, files')
                 poutput('max_bytes: %s' % max_bytes)
             except libcephfs.Error:
                 perror('max_bytes is not set')
+                self.exit_code = 1
                 pass
 
             try:
@@ -1248,6 +1264,7 @@ sub-directories, files')
                 poutput('max_files: %s' % max_files)
             except libcephfs.Error:
                 perror('max_files is not set')
+                self.exit_code = 1
                 pass
 
     def do_help(self, line):
@@ -1330,4 +1347,4 @@ if __name__ == '__main__':
     sys.argv.extend([i.strip() for i in ' '.join(args.commands).split(',')])
     setup_cephfs(config_file)
     shell = CephFSShell()
-    shell.cmdloop()
+    sys.exit(shell.cmdloop())


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42100
Fixes: https://tracker.ceph.com/issues/42101


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>