### PR TITLE
nautilus: build/ops: admin/build-doc: use python3

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -20,7 +20,7 @@ if command -v dpkg >/dev/null; then
         exit 1
     fi
 elif command -v yum >/dev/null; then
-    for package in python-devel python-pip python-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel Cython graphviz; do
+    for package in python36-devel python36-pip python36-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel python36-Cython graphviz; do
 	if ! rpm -q --whatprovides $package >/dev/null ; then
 		missing="${missing:+$missing }$package"
 	fi
@@ -57,7 +57,7 @@ cd build-doc
 [ -z "$vdir" ] && vdir="$TOPDIR/build-doc/virtualenv"
 
 if [ ! -e $vdir ]; then
-    virtualenv --system-site-packages $vdir
+    virtualenv --python=python3 --system-site-packages $vdir
 fi
 $vdir/bin/pip install --quiet -r $TOPDIR/admin/doc-requirements.txt
 

--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,7 +1,4 @@
-Sphinx == 1.8.3
+Sphinx == 2.1.2
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
-# newer versions of breathe will require Sphinx >= 2.0.0 and are Python3 only
-breathe==4.12.0
-# 4.2 is not yet release at the time of writing, to address CVE-2017-18342,
-# we have to use its beta release.
-pyyaml>=4.2b1
+breathe == 4.13.1
+pyyaml >= 5.1.2

--- a/doc_deps.deb.txt
+++ b/doc_deps.deb.txt
@@ -1,8 +1,8 @@
 git
 gcc
-python-dev
-python-pip
-python-virtualenv
+python3-dev
+python3-pip
+python3-virtualenv
 doxygen
 ditaa
 libxml2-dev
@@ -10,4 +10,4 @@ libxslt1-dev
 graphviz
 ant
 zlib1g-dev
-cython
+cython3


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42105

---

backport of https://github.com/ceph/ceph/pull/29528
parent tracker: https://tracker.ceph.com/issues/42103

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh