### PR TITLE
luminous: rgw: mitigate bucket list with max-entries excessively high

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5645,7 +5645,7 @@ int RGWRados::Bucket::List::list_objects_ordered(int64_t max_p,
 
   int count = 0;
   bool truncated = true;
-  const int64_t max = // protect against memory issues and non-positive vals
+  const int64_t max = // protect against memory issues and negative vals
     std::min(bucket_list_objects_absolute_max, std::max(int64_t(0), max_p));
   int read_ahead = std::max(cct->_conf->rgw_list_bucket_min_readahead, max);
 
@@ -5836,8 +5836,8 @@ int RGWRados::Bucket::List::list_objects_unordered(int64_t max_p,
   int count = 0;
   bool truncated = true;
 
-  const int64_t max = // protect against memory issues and non-positive vals
-    std::min(bucket_list_objects_absolute_max, std::max(int64_t(1), max_p));
+  const int64_t max = // protect against memory issues and negative vals
+    std::min(bucket_list_objects_absolute_max, std::max(int64_t(0), max_p));
 
   // read a few extra in each call to cls_bucket_list_unordered in
   // case some are filtered out due to namespace matching, versioning,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5610,6 +5610,15 @@ int RGWRados::Bucket::update_bucket_id(const string& new_bucket_id)
 }
 
 
+static inline std::string after_delim(std::string delim)
+{
+  // assert: ! delim.empty()
+  std::string result{delim.data(), delim.length()};
+  result += char(255);
+  return result;
+}
+
+
 /**
  * Get ordered listing of the objects in a bucket.
  *
@@ -5625,7 +5634,7 @@ int RGWRados::Bucket::update_bucket_id(const string& new_bucket_id)
  * common_prefixes: if delim is filled in, any matching prefixes are placed here.
  * is_truncated: if number of objects in the bucket is bigger than max, then truncated.
  */
-int RGWRados::Bucket::List::list_objects_ordered(int64_t max,
+int RGWRados::Bucket::List::list_objects_ordered(int64_t max_p,
 						 vector<rgw_bucket_dir_entry> *result,
 						 map<string, bool> *common_prefixes,
 						 bool *is_truncated)
@@ -5636,7 +5645,9 @@ int RGWRados::Bucket::List::list_objects_ordered(int64_t max,
 
   int count = 0;
   bool truncated = true;
-  int read_ahead = std::max(cct->_conf->rgw_list_bucket_min_readahead,max);
+  const int64_t max = // protect against memory issues and non-positive vals
+    std::min(bucket_list_objects_absolute_max, std::max(int64_t(0), max_p));
+  int read_ahead = std::max(cct->_conf->rgw_list_bucket_min_readahead, max);
 
   result->clear();
 
@@ -5813,7 +5824,7 @@ done:
  * is_truncated: if number of objects in the bucket is bigger than max, then
  *               truncated.
  */
-int RGWRados::Bucket::List::list_objects_unordered(int64_t max,
+int RGWRados::Bucket::List::list_objects_unordered(int64_t max_p,
 						   vector<rgw_bucket_dir_entry> *result,
 						   map<string, bool> *common_prefixes,
 						   bool *is_truncated)
@@ -5824,6 +5835,9 @@ int RGWRados::Bucket::List::list_objects_unordered(int64_t max,
 
   int count = 0;
   bool truncated = true;
+
+  const int64_t max = // protect against memory issues and non-positive vals
+    std::min(bucket_list_objects_absolute_max, std::max(int64_t(1), max_p));
 
   // read a few extra in each call to cls_bucket_list_unordered in
   // case some are filtered out due to namespace matching, versioning,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3005,6 +3005,9 @@ public:
 
     class List {
     protected:
+      // absolute maximum number of objects that
+      // list_objects_(un)ordered can return
+      static constexpr int64_t bucket_list_objects_absolute_max = 25000;
 
       RGWRados::Bucket *target;
       rgw_obj_key next_marker;


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/41104
* https://tracker.ceph.com/issues/41808

---

backport of

* https://github.com/ceph/ceph/pull/29179
* https://github.com/ceph/ceph/pull/30146

parent trackers:

* https://tracker.ceph.com/issues/40872
* https://tracker.ceph.com/issues/41655

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh