### PR TITLE
mgr/dashboard: Fix translation of variables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/osd-smart-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-smart-list/osd-smart-list.component.ts
@@ -46,15 +46,17 @@ export class OsdSmartListComponent implements OnInit, OnChanges {
         if (this.isSmartError(smartData)) {
           let userMessage = '';
           if (smartData.smartctl_error_code === -22) {
-            const msg =
-              `Smartctl has received an unknown argument (error code ` +
-              `${smartData.smartctl_error_code}). You may be using an incompatible version of ` +
-              `smartmontools.  Version >= 7.0 of smartmontools is required to ` +
-              `succesfully retrieve data.`;
-            userMessage = this.i18n(msg);
+            userMessage = this.i18n(
+              `Smartctl has received an unknown argument (error code
+                {{smartData.smartctl_error_code}}). You may be using an
+                incompatible version of smartmontools. Version >= 7.0 of
+                smartmontools is required to succesfully retrieve data.`,
+              { code: smartData.smartctl_error_code }
+            );
           } else {
-            const msg = `An error with error code ${smartData.smartctl_error_code} occurred.`;
-            userMessage = this.i18n(msg);
+            userMessage = this.i18n('An error with error code {{code}} occurred.', {
+              code: smartData.smartctl_error_code
+            });
           }
           result[deviceId] = {
             error: smartData.error,


### PR DESCRIPTION
Translation of variables is not supported.
Had to pass the string directly into the i18n method.

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
