### PR TITLE
common/secret.c: don't pass uninitialized stack data to the kernel

### DIFF
--- a/src/common/secret.c
+++ b/src/common/secret.c
@@ -69,7 +69,7 @@ int set_kernel_secret(const char *secret, const char *key_name)
     return ret;
   }
 
-  serial = add_key("ceph", key_name, payload, sizeof(payload), KEY_SPEC_PROCESS_KEYRING);
+  serial = add_key("ceph", key_name, payload, ret, KEY_SPEC_PROCESS_KEYRING);
   if (serial == -1) {
     ret = -errno;
   }


### PR DESCRIPTION
ceph_unarmor() returns the number of bytes decoded, which can be (and
usually is) smaller than the size of the payload array.

set_kernel_secret() has behaved this way ever since it was introduced
in commit bee85518e288 ("mount.ceph: Use kernel key management API when
possible.").  The reason it didn't cause problems in the kernel is that
the encoding includes the actual length of the secret and there is no
check for the end of the supplied payload (see ceph_key_preparse() in
net/ceph/crypto.c).

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>