### PR TITLE
mimic: ceph-volume: fix warnings raised by pytest

### DIFF
--- a/src/ceph-volume/ceph_volume/configuration.py
+++ b/src/ceph-volume/ceph_volume/configuration.py
@@ -8,6 +8,14 @@ import os
 import re
 from ceph_volume import terminal, conf
 from ceph_volume import exceptions
+from sys import version_info as sys_version_info
+
+if sys_version_info.major >= 3:
+    conf_parentclass = configparser.ConfigParser
+elif sys_version_info.major < 3:
+    conf_parentclass = configparser.SafeConfigParser
+else:
+    raise RuntimeError('Not expecting python version > 3 yet.')
 
 
 logger = logging.getLogger(__name__)
@@ -50,7 +58,7 @@ def load(abspath=None):
         ceph_file = open(abspath)
         trimmed_conf = _TrimIndentFile(ceph_file)
         with contextlib.closing(ceph_file):
-            parser.readfp(trimmed_conf)
+            parser.read_conf(trimmed_conf)
             conf.ceph = parser
             return parser
     except configparser.ParsingError as error:
@@ -59,9 +67,9 @@ def load(abspath=None):
         raise RuntimeError('Unable to read configuration file: %s' % abspath)
 
 
-class Conf(configparser.SafeConfigParser):
+class Conf(conf_parentclass):
     """
-    Subclasses from SafeConfigParser to give a few helpers for Ceph
+    Subclasses from ConfigParser to give a few helpers for Ceph
     configuration.
     """
 
@@ -215,3 +223,11 @@ class Conf(configparser.SafeConfigParser):
             for name, val in options.items():
                 if isinstance(val, list):
                     options[name] = '\n'.join(val)
+
+    def read_conf(self, conffile):
+        if sys_version_info.major >= 3:
+            self.read_file(conffile)
+        elif sys_version_info.major < 3:
+            self.readfp(conffile)
+        else:
+            raise RuntimeError('Not expecting python version > 3 yet.')

--- a/src/ceph-volume/ceph_volume/configuration.py
+++ b/src/ceph-volume/ceph_volume/configuration.py
@@ -1,7 +1,3 @@
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
 import contextlib
 import logging
 import os
@@ -11,8 +7,10 @@ from ceph_volume import exceptions
 from sys import version_info as sys_version_info
 
 if sys_version_info.major >= 3:
+    import configparser
     conf_parentclass = configparser.ConfigParser
 elif sys_version_info.major < 3:
+    import ConfigParser as configparser
     conf_parentclass = configparser.SafeConfigParser
 else:
     raise RuntimeError('Not expecting python version > 3 yet.')

--- a/src/ceph-volume/ceph_volume/tests/test_configuration.py
+++ b/src/ceph-volume/ceph_volume/tests/test_configuration.py
@@ -28,13 +28,13 @@ class TestConf(object):
     def test_get_non_existing_list(self):
         cfg = configuration.Conf()
         cfg.is_valid = lambda: True
-        cfg.readfp(self.conf_file)
+        cfg.read_conf(self.conf_file)
         assert cfg.get_list('global', 'key') == []
 
     def test_get_non_existing_list_get_default(self):
         cfg = configuration.Conf()
         cfg.is_valid = lambda: True
-        cfg.readfp(self.conf_file)
+        cfg.read_conf(self.conf_file)
         assert cfg.get_list('global', 'key', ['a']) == ['a']
 
     def test_get_rid_of_comments(self):
@@ -45,7 +45,7 @@ class TestConf(object):
         default = 0  # this is a comment
         """))
 
-        cfg.readfp(conf_file)
+        cfg.read_conf(conf_file)
         assert cfg.get_list('foo', 'default') == ['0']
 
     def test_gets_split_on_commas(self):
@@ -56,7 +56,7 @@ class TestConf(object):
         default = 0,1,2,3  # this is a comment
         """))
 
-        cfg.readfp(conf_file)
+        cfg.read_conf(conf_file)
         assert cfg.get_list('foo', 'default') == ['0', '1', '2', '3']
 
     def test_spaces_and_tabs_are_ignored(self):
@@ -67,7 +67,7 @@ class TestConf(object):
         default = 0,        1,  2 ,3  # this is a comment
         """))
 
-        cfg.readfp(conf_file)
+        cfg.read_conf(conf_file)
         assert cfg.get_list('foo', 'default') == ['0', '1', '2', '3']
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42048

---

backport of https://github.com/ceph/ceph/pull/30422
parent tracker: https://tracker.ceph.com/issues/41907

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh