### PR TITLE
msg: fix comments in Messenger.h after the set -> std::set switch.

### DIFF
--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -233,7 +233,7 @@ public:
   }
 
   /**
-   * std::Set the name of the local entity. The name is reported to others and
+   * set the name of the local entity. The name is reported to others and
    * can be changed while the system is running, but doing so at incorrect
    * times may have bad results.
    *
@@ -242,7 +242,7 @@ public:
   void set_myname(const entity_name_t& m) { my_name = m; }
 
   /**
-   * std::Set the unknown address components for this Messenger.
+   * set the unknown address components for this Messenger.
    * This is useful if the Messenger doesn't know its full address just by
    * binding, but another Messenger on the same interface has already learned
    * its full address. This function does not fill in known address elements,
@@ -252,7 +252,7 @@ public:
    */
   virtual bool set_addr_unknowns(const entity_addrvec_t &addrs) = 0;
   /**
-   * std::Set the address for this Messenger. This is useful if the Messenger
+   * set the address for this Messenger. This is useful if the Messenger
    * binds to a specific address but advertises a different address on the
    * the network.
    *
@@ -282,7 +282,7 @@ public:
    * @{
    */
   /**
-   * std::Set the cluster protocol in use by this daemon.
+   * set the cluster protocol in use by this daemon.
    * This is an init-time function and cannot be called after calling
    * start() or bind().
    *
@@ -290,7 +290,7 @@ public:
    */
   virtual void set_cluster_protocol(int p) = 0;
   /**
-   * std::Set a policy which is applied to all peers who do not have a type-specific
+   * set a policy which is applied to all peers who do not have a type-specific
    * Policy.
    * This is an init-time function and cannot be called after calling
    * start() or bind().
@@ -299,7 +299,7 @@ public:
    */
   virtual void set_default_policy(Policy p) = 0;
   /**
-   * std::Set a policy which is applied to all peers of the given type.
+   * set a policy which is applied to all peers of the given type.
    * This is an init-time function and cannot be called after calling
    * start() or bind().
    *
@@ -308,7 +308,7 @@ public:
    */
   virtual void set_policy(int type, Policy p) = 0;
   /**
-   * std::Set the Policy associated with a type of peer.
+   * set the Policy associated with a type of peer.
    *
    * This can be called either on initial setup, or after connections
    * are already established.  However, the policies for existing
@@ -326,7 +326,7 @@ public:
    */
   virtual Policy get_default_policy() = 0;
   /**
-   * std::Set Throttlers applied to all Messages from the given type of peer
+   * set Throttlers applied to all Messages from the given type of peer
    *
    * This is an init-time function and cannot be called after calling
    * start() or bind().
@@ -339,7 +339,7 @@ public:
    */
   virtual void set_policy_throttlers(int type, Throttle *bytes, Throttle *msgs=NULL) = 0;
   /**
-   * std::Set the default send priority
+   * set the default send priority
    *
    * This is an init-time function and must be called *before* calling
    * start().
@@ -351,7 +351,7 @@ public:
     default_send_priority = p;
   }
   /**
-   * std::Set the priority(SO_PRIORITY) for all packets to be sent on this socket.
+   * set the priority(SO_PRIORITY) for all packets to be sent on this socket.
    *
    * Linux uses this value to order the networking queues: packets with a higher
    * priority may be processed first depending on the selected device queueing
@@ -451,7 +451,7 @@ public:
    * Perform any resource allocation, thread startup, etc
    * that is required before attempting to connect to other
    * Messengers or transmit messages.
-   * Once this function completes, started shall be std::set to true.
+   * Once this function completes, started shall be set to true.
    *
    * @return 0 on success; -errno on failure.
    */


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
