### PR TITLE
nautilus: cmake,rgw: IBM Z build fixes

### DIFF
--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -15,7 +15,13 @@ int main() {
   std::atomic<uint16_t> w2;
   std::atomic<uint32_t> w4;
   std::atomic<uint64_t> w8;
-  return w1 + w2 + w4 + w8;
+#ifdef __s390x__
+  // Boost needs 16-byte atomics for tagged pointers.
+  std::atomic<unsigned __int128> w16;
+#else
+  #define w16 0
+#endif
+  return w1 + w2 + w4 + w8 + w16;
 }
 " ${var})
 endfunction(check_cxx_atomics)

--- a/src/test/rgw/test_rgw_dmclock_scheduler.cc
+++ b/src/test/rgw/test_rgw_dmclock_scheduler.cc
@@ -18,7 +18,9 @@
 #include "rgw/rgw_dmclock_async_scheduler.h"
 
 #include <optional>
+#ifdef HAVE_BOOST_CONTEXT
 #include <boost/asio/spawn.hpp>
+#endif
 #include <gtest/gtest.h>
 #include "acconfig.h"
 #include "global/global_context.h"


### PR DESCRIPTION
This backports the following two changes from mainline in order to enable a build on IBM Z to complete:

https://github.com/ceph/ceph/pull/29430
rgw: tests: Fix building with -DWITH_BOOST_CONTEXT=OFF

https://github.com/ceph/ceph/pull/30638
cmake: Test for 16-byte atomic support on IBM Z
