### PR TITLE
qa/suites/rados/thrash: increase async and partial recovery test coverage

### DIFF
--- a/qa/suites/rados/thrash/2-recovery-overrides/more-async-partial-recovery.yaml
+++ b/qa/suites/rados/thrash/2-recovery-overrides/more-async-partial-recovery.yaml
@@ -1,0 +1,6 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        osd_async_recovery_min_cost: 1
+        osd_object_clean_region_max_num_intervals: 1000

--- a/qa/suites/rados/thrash/2-recovery-overrides/more-async-recovery.yaml
+++ b/qa/suites/rados/thrash/2-recovery-overrides/more-async-recovery.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        osd_async_recovery_min_cost: 1

--- a/qa/suites/rados/thrash/2-recovery-overrides/more-partial-recovery.yaml
+++ b/qa/suites/rados/thrash/2-recovery-overrides/more-partial-recovery.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        osd_object_clean_region_max_num_intervals: 1000


### PR DESCRIPTION
This should increase the amount of async and partial recovery and hopefully let us catch more bugs during thrashing.

Signed-off-by: Neha Ojha <nojha@redhat.com>
