### PR TITLE
ceph-volume: PVolumes.filter shouldn't purge itself

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -913,8 +913,9 @@ class PVolumes(list):
     to filter them via keyword arguments.
     """
 
-    def __init__(self):
-        self._populate()
+    def __init__(self, populate=True):
+        if populate:
+            self._populate()
 
     def _populate(self):
         # get all the pvs in the current system

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -960,24 +960,19 @@ class PVolumes(list):
     def filter(self, pv_name=None, pv_uuid=None, pv_tags=None):
         """
         Filter out volumes on top level attributes like ``pv_name`` or by
-        ``pv_tags`` where a dict is required. For example, to find a physical volume
-        that has an OSD ID of 0, the filter would look like::
+        ``pv_tags`` where a dict is required. For example, to find a physical
+        volume that has an OSD ID of 0, the filter would look like::
 
             pv_tags={'ceph.osd_id': '0'}
 
         """
         if not any([pv_name, pv_uuid, pv_tags]):
-            raise TypeError('.filter() requires pv_name, pv_uuid, or pv_tags (none given)')
-        # first find the filtered volumes with the values in self
-        filtered_volumes = self._filter(
-            pv_name=pv_name,
-            pv_uuid=pv_uuid,
-            pv_tags=pv_tags
-        )
-        # then purge everything
-        self._purge()
-        # and add the filtered items
-        self.extend(filtered_volumes)
+            raise TypeError('.filter() requires pv_name, pv_uuid, or pv_tags'
+                            '(none given)')
+
+        filtered_pvs = PVolumes(populate=False)
+        filtered_pvs.extend(self._filter(pv_name, pv_uuid, pv_tags))
+        return filtered_pvs
 
     def get(self, pv_name=None, pv_uuid=None, pv_tags=None):
         """

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -186,8 +186,8 @@ class TestPVolumes(object):
             pv_name='/dev/vg/foo',
             pv_uuid='1111', pv_tags=pv_tags, vg_name='vg')
         pvolumes.append(FooPVolume)
-        pvolumes.filter(pv_tags={'ceph.type': 'journal', 'ceph.osd_id': '2'})
-        assert pvolumes == []
+        assert pvolumes.filter(pv_tags={'ceph.type': 'journal',
+                               'ceph.osd_id': '2'}) == []
 
     def test_filter_by_tags_matches(self, pvolumes, monkeypatch):
         pv_tags = "ceph.type=journal,ceph.osd_id=1"
@@ -195,8 +195,8 @@ class TestPVolumes(object):
             pv_name='/dev/vg/foo',
             pv_uuid='1111', pv_tags=pv_tags, vg_name="vg")
         pvolumes.append(FooPVolume)
-        pvolumes.filter(pv_tags={'ceph.type': 'journal', 'ceph.osd_id': '1'})
-        assert pvolumes == [FooPVolume]
+        assert pvolumes.filter(pv_tags={'ceph.type': 'journal',
+                               'ceph.osd_id': '1'}) == [FooPVolume]
 
 
 class TestGetVG(object):

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -167,6 +167,12 @@ def pvolumes(monkeypatch):
     pvolumes = lvm_api.PVolumes()
     pvolumes._purge()
     return pvolumes
+@pytest.fixture
+def pvolumes_empty(monkeypatch):
+    monkeypatch.setattr('ceph_volume.process.call', lambda x, **kw: ('', '', 0))
+    pvolumes = lvm_api.PVolumes(populate=False)
+    return pvolumes
+
 
 
 @pytest.fixture

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -232,8 +232,7 @@ class Device(object):
             for path in self._get_pv_paths():
                 # check if there was a pv created with the
                 # name of device
-                pvs = lvm.PVolumes()
-                pvs.filter(pv_name=path)
+                pvs = lvm.PVolumes().filter(pv_name=path)
                 has_vgs = [pv.vg_name for pv in pvs if pv.vg_name]
                 if has_vgs:
                     self.vgs = list(set(has_vgs))


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42170




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>