### PR TITLE
ceph-volume: VolumeGroups.filter shouldn't purge itself

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -764,15 +764,10 @@ class VolumeGroups(list):
         """
         if not any([vg_name, vg_tags]):
             raise TypeError('.filter() requires vg_name or vg_tags (none given)')
-        # first find the filtered volumes with the values in self
-        filtered_groups = self._filter(
-            vg_name=vg_name,
-            vg_tags=vg_tags
-        )
-        # then purge everything
-        self._purge()
-        # and add the filtered items
-        self.extend(filtered_groups)
+
+        filtered_vgs = VolumeGroups(populate=False)
+        filtered_vgs.extend(self._filter(vg_name, vg_tags))
+        return filtered_vgs
 
     def get(self, vg_name=None, vg_tags=None):
         """

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -710,8 +710,9 @@ class VolumeGroups(list):
     to filter them via keyword arguments.
     """
 
-    def __init__(self):
-        self._populate()
+    def __init__(self, populate=True):
+        if populate:
+            self._populate()
 
     def _populate(self):
         # get all the vgs in the current system

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -337,7 +337,7 @@ class TestVolumeGroups(object):
         journal = api.VolumeGroup(vg_name='volume2', vg_tags='ceph.group=plain')
         volume_groups.append(osd)
         volume_groups.append(journal)
-        volume_groups.filter(vg_tags={'ceph.group': 'dmcache'})
+        volume_groups = volume_groups.filter(vg_tags={'ceph.group': 'dmcache'})
         assert len(volume_groups) == 1
         assert volume_groups[0].vg_name == 'volume1'
 
@@ -345,7 +345,7 @@ class TestVolumeGroups(object):
         vg_tags = "ceph.group=dmcache,ceph.disk_type=ssd"
         osd = api.VolumeGroup(vg_name='volume1', vg_path='/dev/vg/lv', vg_tags=vg_tags)
         volume_groups.append(osd)
-        volume_groups.filter(vg_tags={'ceph.group': 'data', 'ceph.disk_type': 'ssd'})
+        volume_groups = volume_groups.filter(vg_tags={'ceph.group': 'data', 'ceph.disk_type': 'ssd'})
         assert volume_groups == []
 
     def test_filter_by_vg_name(self, volume_groups):
@@ -354,13 +354,13 @@ class TestVolumeGroups(object):
         journal = api.VolumeGroup(vg_name='volume2', vg_tags='ceph.type=journal')
         volume_groups.append(osd)
         volume_groups.append(journal)
-        volume_groups.filter(vg_name='ceph_vg')
+        volume_groups = volume_groups.filter(vg_name='ceph_vg')
         assert len(volume_groups) == 1
         assert volume_groups[0].vg_name == 'ceph_vg'
 
     def test_filter_requires_params(self, volume_groups):
         with pytest.raises(TypeError):
-            volume_groups.filter()
+            volume_groups = volume_groups.filter()
 
 
 class TestVolumeGroupFree(object):

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -153,6 +153,10 @@ def volume_groups(monkeypatch):
     vgs._purge()
     return vgs
 
+def volume_groups_empty(monkeypatch):
+    monkeypatch.setattr('ceph_volume.process.call', lambda x, **kw: ('', '', 0))
+    vgs = lvm_api.VolumeGroups(populate=False)
+    return vgs
 
 @pytest.fixture
 def stub_vgs(monkeypatch, volume_groups):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42171


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>