### PR TITLE
librbd: v1 clones are restricted to the same namespace

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -680,6 +680,16 @@ test_namespace() {
     rbd rm rbd/test2/image2
     rbd rm rbd/image2
 
+    # v1 clones are supported within the same namespace
+    rbd create $RBD_CREATE_ARGS --size 1G rbd/test1/image3
+    rbd snap create rbd/test1/image3@1
+    rbd snap protect rbd/test1/image3@1
+    rbd clone --rbd-default-clone-format 1 rbd/test1/image3@1 rbd/test1/image4
+    rbd rm rbd/test1/image4
+    rbd snap unprotect rbd/test1/image3@1
+    rbd snap rm rbd/test1/image3@1
+    rbd rm rbd/test1/image3
+
     rbd create $RBD_CREATE_ARGS --size 1G --namespace test1 image2
     expect_fail rbd namespace remove rbd/test1
 

--- a/src/librbd/image/AttachChildRequest.cc
+++ b/src/librbd/image/AttachChildRequest.cc
@@ -46,8 +46,7 @@ void AttachChildRequest<I>::v1_add_child() {
   ldout(m_cct, 15) << dendl;
 
   librados::ObjectWriteOperation op;
-  cls_client::add_child(&op, {m_parent_image_ctx->md_ctx.get_id(),
-                              m_parent_image_ctx->md_ctx.get_namespace(),
+  cls_client::add_child(&op, {m_parent_image_ctx->md_ctx.get_id(), "",
                               m_parent_image_ctx->id,
                               m_parent_snap_id}, m_image_ctx->id);
 

--- a/src/librbd/image/DetachChildRequest.cc
+++ b/src/librbd/image/DetachChildRequest.cc
@@ -326,6 +326,8 @@ void DetachChildRequest<I>::clone_v1_remove_child() {
   auto cct = m_image_ctx.cct;
   ldout(cct, 5) << dendl;
 
+  m_parent_spec.pool_namespace = "";
+
   librados::ObjectWriteOperation op;
   librbd::cls_client::remove_child(&op, m_parent_spec, m_image_ctx.id);
 


### PR DESCRIPTION
Therefore the v1 parent spec should not attempt to populate the
namespace.

Fixes: https://tracker.ceph.com/issues/41938
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
