### PR TITLE
osd/PeeringState: base lease support checks on features, not require_osd_release

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1129,7 +1129,7 @@ void PeeringState::send_lease()
 
 void PeeringState::proc_lease(const pg_lease_t& l)
 {
-  if (get_osdmap()->require_osd_release < ceph_release_t::octopus) {
+  if (!HAVE_FEATURE(upacting_features, SERVER_OCTOPUS)) {
     return;
   }
   if (!is_nonprimary()) {
@@ -1172,7 +1172,7 @@ void PeeringState::proc_lease(const pg_lease_t& l)
 
 void PeeringState::proc_lease_ack(int from, const pg_lease_ack_t& a)
 {
-  if (get_osdmap()->require_osd_release < ceph_release_t::octopus) {
+  if (!HAVE_FEATURE(upacting_features, SERVER_OCTOPUS)) {
     return;
   }
   auto now = pl->get_mnow();
@@ -1220,7 +1220,7 @@ void PeeringState::recalc_readable_until()
 
 bool PeeringState::check_prior_readable_down_osds(const OSDMapRef& map)
 {
-  if (get_osdmap()->require_osd_release < ceph_release_t::octopus) {
+  if (!HAVE_FEATURE(upacting_features, SERVER_OCTOPUS)) {
     return false;
   }
   bool changed = false;
@@ -2375,7 +2375,7 @@ void PeeringState::activate(
     purged.intersection_of(to_trim, info.purged_snaps);
     to_trim.subtract(purged);
 
-    if (get_osdmap()->require_osd_release >= ceph_release_t::octopus) {
+    if (HAVE_FEATURE(upacting_features, SERVER_OCTOPUS)) {
       renew_lease(pl->get_mnow());
       schedule_renew_lease();
     }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -754,8 +754,9 @@ void PrimaryLogPG::maybe_force_recovery()
 
 bool PrimaryLogPG::check_laggy(OpRequestRef& op)
 {
-  if (get_osdmap()->require_osd_release < ceph_release_t::octopus) {
-    dout(10) << __func__ << " require_osd_release < octopus" << dendl;
+  if (!HAVE_FEATURE(recovery_state.get_min_upacting_features(),
+		    SERVER_OCTOPUS)) {
+    dout(20) << __func__ << " not all upacting has SERVER_OCTOPUS" << dendl;
     return true;
   }
   if (state_test(PG_STATE_WAIT)) {
@@ -788,7 +789,8 @@ bool PrimaryLogPG::check_laggy(OpRequestRef& op)
 
 bool PrimaryLogPG::check_laggy_requeue(OpRequestRef& op)
 {
-  if (get_osdmap()->require_osd_release < ceph_release_t::octopus) {
+  if (!HAVE_FEATURE(recovery_state.get_min_upacting_features(),
+		    SERVER_OCTOPUS)) {
     return true;
   }
   if (!state_test(PG_STATE_WAIT) && !state_test(PG_STATE_LAGGY)) {


### PR DESCRIPTION
The require_osd_release value will change at an arbitrary point in time,
midway through a peering interval.  That can leave us in a state where
we are midway through an interval and suddenly enforcing checks on leases
we don't have.

In contrast, the upacting features change at an interval boundary, which
lets us adjust our behavior for the whole interval.

Signed-off-by: Sage Weil <sage@redhat.com>