### PR TITLE
mgr/telemetry: include device health telemetry

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -170,6 +170,25 @@
   cluster-wide and per-pool flags to be backward comaptible with pre-infernalis
   clusters.
 
+* The telemetry module now has a 'device' channel, enabled by default, that
+  will report anonymized hard disk and SSD health metrics to telemetry.ceph.com
+  in order to build and improve device failure prediction algorithms.  Because
+  the content of telemetry reports has changed, you will need to either re-opt-in
+  with::
+
+    ceph telemetry on
+
+  You can view exactly what information will be reported first with::
+
+    ceph telemetry show
+    ceph telemetry show device   # specifically show the device channel
+
+  If you are not comfortable sharing device metrics, you can disable that
+  channel first before re-opting-in:
+
+    ceph config set mgr mgr/telemetry/channel_crash false
+    ceph telemetry on
+
 * Following invalid settings now are not tolerated anymore
   for the command `ceph osd erasure-code-profile set xxx`.
   * invalid `m` for "reed_sol_r6_op" erasure technique

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -641,6 +641,8 @@ class Module(MgrModule):
         except:
             return -1, '', 'unable to invoke diskprediction local or remote plugin'
 
-    def gather_device_report(self):
-        # write me
-        return {}
+    def get_recent_device_metrics(self, devid, min_sample):
+        return self._get_device_metrics(devid, min_sample=min_sample)
+
+    def get_time_format(self):
+        return TIME_FORMAT

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -418,16 +418,11 @@ class Module(MgrModule):
                 ioctx.remove_omap_keys(op, tuple(erase))
             ioctx.operate_write_op(op, devid)
 
-    def show_device_metrics(self, devid, sample):
-        # verify device exists
-        r = self.get("device " + devid)
-        if not r or 'device' not in r.keys():
-            return -errno.ENOENT, '', 'device ' + devid + ' not found'
-        # fetch metrics
+    def _get_device_metrics(self, devid, sample=None, min_sample=None):
         res = {}
         ioctx = self.open_connection(create_if_missing=False)
         if not ioctx:
-            return 0, json.dumps(res, indent=4), ''
+            return {}
         with ioctx:
             with rados.ReadOpCtx() as op:
                 omap_iter, ret = ioctx.get_omap_vals(op, "", sample or '',
@@ -437,6 +432,8 @@ class Module(MgrModule):
                     ioctx.operate_read_op(op, devid)
                     for key, value in list(omap_iter):
                         if sample and key != sample:
+                            break
+                        if min_sample and key < min_sample:
                             break
                         try:
                             v = json.loads(value)
@@ -450,7 +447,15 @@ class Module(MgrModule):
                 except rados.Error as e:
                     self.log.exception("RADOS error reading omap: {0}".format(e))
                     raise
+        return res
 
+    def show_device_metrics(self, devid, sample):
+        # verify device exists
+        r = self.get("device " + devid)
+        if not r or 'device' not in r.keys():
+            return -errno.ENOENT, '', 'device ' + devid + ' not found'
+        # fetch metrics
+        res = self._get_device_metrics(devid, sample=sample)
         return 0, json.dumps(res, indent=4, sort_keys=True), ''
 
     def check_health(self):

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -22,6 +22,8 @@ HEALTH_MESSAGES = {
     DEVICE_HEALTH_TOOMANY: 'Too many daemons are expected to fail soon',
 }
 
+MAX_SAMPLES=500
+
 
 class Module(MgrModule):
     MODULE_OPTIONS = [
@@ -391,7 +393,7 @@ class Module(MgrModule):
         erase = []
         try:
             with rados.ReadOpCtx() as op:
-                omap_iter, ret = ioctx.get_omap_keys(op, "", 500)  # fixme
+                omap_iter, ret = ioctx.get_omap_keys(op, "", MAX_SAMPLES)  # fixme
                 assert ret == 0
                 ioctx.operate_read_op(op, devid)
                 for key, _ in list(omap_iter):
@@ -428,7 +430,8 @@ class Module(MgrModule):
             return 0, json.dumps(res, indent=4), ''
         with ioctx:
             with rados.ReadOpCtx() as op:
-                omap_iter, ret = ioctx.get_omap_vals(op, "", sample or '', 500)  # fixme
+                omap_iter, ret = ioctx.get_omap_vals(op, "", sample or '',
+                                                     MAX_SAMPLES)  # fixme
                 assert ret == 0
                 try:
                     ioctx.operate_read_op(op, devid)

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -31,7 +31,7 @@ LAST_REVISION_RE_OPT_IN = 2
 
 # Latest revision of the telemetry report.  Bump this each time we make
 # *any* change.
-REVISION = 2
+REVISION = 3
 
 # History of revisions
 # --------------------
@@ -45,6 +45,9 @@ REVISION = 2
 #   - added config option changes
 #   - added channels
 #   - added explicit license acknowledgement to the opt-in process
+#
+# Version 3:
+#   - added device health metrics (i.e., SMART data, minus serial number)
 
 class Module(MgrModule):
     config = dict()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -11,7 +11,7 @@ import re
 import requests
 import uuid
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from threading import Event
 from collections import defaultdict
 
@@ -129,7 +129,7 @@ class Module(MgrModule):
             'name': 'channel_device',
             'type': 'bool',
             'default': True,
-            'description': 'Share device health metrics (e.g., SMART data)',
+            'description': 'Share device health metrics (e.g., SMART data, minus potentially identifying info like serial numbers)',
         },
     ]
 
@@ -293,9 +293,50 @@ class Module(MgrModule):
 
     def gather_device_report(self):
         try:
-            return self.remote('devicehealth', 'gather_device_report')
+            time_format = self.remote('devicehealth', 'get_time_format')
         except:
             return None
+        cutoff = datetime.utcnow() - timedelta(hours=self.interval * 2)
+        min_sample = cutoff.strftime(time_format)
+
+        devices = self.get('devices')['devices']
+
+        res = {}
+        for d in devices:
+            devid = d['devid']
+            try:
+                m = self.remote('devicehealth', 'get_recent_device_metrics',
+                                devid, min_sample)
+            except:
+                continue
+
+            # anonymize host id
+            try:
+                host = d['location'][0]['host']
+            except:
+                continue
+            anon_host = self.get_store('host-id/%s' % host)
+            if not anon_host:
+                anon_host = str(uuid.uuid1())
+                self.set_store('host-id/%s' % host, anon_host)
+            m['host_id'] = anon_host
+
+            # anonymize device id
+            (vendor, model, serial) = devid.split('_')
+            anon_devid = self.get_store('devid-id/%s' % devid)
+            if not anon_devid:
+                anon_devid = '%s_%s_%s' % (vendor, model, uuid.uuid1())
+                self.set_store('devid-id/%s' % devid, anon_devid)
+
+            self.log.info('devid %s / %s, host %s / %s' % (devid, anon_devid,
+                                                           host, anon_host))
+
+            # anonymize the smartctl report itself
+            for k in ['serial_number']:
+                m.pop(k)
+
+            res[anon_devid] = m
+        return res
 
     def compile_report(self, channels=[]):
         if not channels:

--- a/src/telemetry/server/ceph_telemetry/app.py
+++ b/src/telemetry/server/ceph_telemetry/app.py
@@ -2,7 +2,7 @@
 import argparse
 from flask_restful import Api
 from flask import Flask
-from ceph_telemetry.rest import Index, Report
+from ceph_telemetry.rest import Index, Report, Device
 
 
 def create_app(name):
@@ -10,6 +10,7 @@ def create_app(name):
     api = Api(app, catch_all_404s=True)
     api.add_resource(Index, '/')
     api.add_resource(Report, '/report')
+    api.add_resource(Device, '/device')
     return app
 
 

--- a/src/telemetry/server/ceph_telemetry/rest/device.py
+++ b/src/telemetry/server/ceph_telemetry/rest/device.py
@@ -1,0 +1,40 @@
+from flask import request, jsonify
+from flask_restful import Resource
+import datetime
+import hashlib
+import json
+import copy
+import psycopg2
+
+class Device(Resource):
+    def __init__(self, report=None):
+        super(Device, self).__init__()
+        self.report = report
+        with open('/opt/telemetry/pg_pass.txt', 'r') as f:
+            p = f.read()
+            self.pg_password = p.strip()
+
+    def put(self):
+        self.report = request.get_json(force=True)
+
+        self.post_to_postgres()
+
+        return jsonify(status=True)
+
+    def _connect_pg(self):
+        return psycopg2.connect(
+            host='localhost',
+            database='telemetry',
+            user='telemetry',
+            password=self.pg_password,
+            )
+
+    def post_to_postgres(self):
+        conn = self._connect_pg()
+        cur = conn.cursor()
+        for devid, devinfo in self.report:
+            for stamp, report in devinfo:
+                cur.execute(
+                    'INSERT INTO device_report (device_id, report_stamp, report) VALUES (%s,%s,%s) ON CONFLICT DO NOTHING',
+                    (devid, stamp, report))
+        conn.commit()


### PR DESCRIPTION
My current thinking:

- We eventually want to collect device metrics from more than just Ceph. Whenever we write a new reporter, we can add a device-only reporting endpoint to telemetry.ceph.com endpoint.  For now, we can dump the telemetry in the same database.
- Better to start scraping the health metrics sooner rather than later.  Unlike the ceph telemetry, the device telemetry has more long-term value (to train models etc), whereas old cluster telemetry isn't as interesting.
