### PR TITLE
ceph-backport.sh: automate setting of milestone and component label, implement --version option

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -17,7 +17,7 @@
 #
 #
 
-SCRIPT_VERSION=
+SCRIPT_VERSION="15.0.0.5775"
 full_path="$0"
 this_script=$(basename "$full_path")
 how_to_get_setup_advice="For additional setup advice, run:  ${this_script} --setup-advice"

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -98,11 +98,19 @@ function cherry_pick_phase {
     debug "Counting commits in ${original_pr_url}"
     remote_api_output=$(curl --silent https://api.github.com/repos/ceph/ceph/pulls/${original_pr}?access_token=${github_token})
     number=$(echo ${remote_api_output} | jq .commits)
-    if [ -z "$number" -o "$number" = "null" ] ; then
+    singular_or_plural_commit=
+    if [ "$number" -eq "$number" ] 2>/dev/null ; then
+        # \$number is an integer
+        if [ "$number" -eq "1" ] ; then
+            singular_or_plural_commit="commit"
+        else
+            singular_or_plural_commit="commits"
+        fi
+    else
         error "Could not determine the number of commits in ${original_pr_url}"
         bail_out_github_api "$remote_api_output"
     fi
-    info "Found $number commits in ${original_pr_url}"
+    info "Found $number $singular_or_plural_commit in $original_pr_url"
 
     debug "Fetching latest commits from $upstream_remote"
     git fetch $upstream_remote

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -18,7 +18,7 @@
 #
 
 this_script=$(basename "$0")
-how_to_get_setup_advice="For setup advice, run:  ${this_script} --setup-advice"
+how_to_get_setup_advice="For additional setup advice, run:  ${this_script} --setup-advice"
 
 if [[ $* == *--debug* ]]; then
     set -x
@@ -176,55 +176,6 @@ function init_mandatory_vars {
     fork_remote="${fork_remote:-$(deduce_remote fork)}"
 }
 
-function setup_summary {
-    local not_set="!!! NOT SET !!!"
-    local redmine_user_id_display="$not_set"
-    local redmine_key_display="$not_set"
-    local github_user_display="$not_set"
-    local github_token_display="$not_set"
-    local upstream_remote_display="$not_set"
-    local fork_remote_display="$not_set"
-    [ "$redmine_user_id" ] && redmine_user_id_display="$redmine_user_id"
-    [ "$redmine_key" ] && redmine_key_display="(OK, not shown)"
-    [ "$github_user" ] && github_user_display="$github_user"
-    [ "$github_token" ] && github_token_display="(OK, not shown)"
-    [ "$upstream_remote" ] && upstream_remote_display="$upstream_remote"
-    [ "$fork_remote" ] && fork_remote_display="$fork_remote"
-    debug Re-checking mandatory variables
-    test "$redmine_key"      || failed_mandatory_var_check redmine_key
-    test "$redmine_user_id"  || failed_mandatory_var_check redmine_user_id
-    test "$github_user"      || failed_mandatory_var_check github_user
-    test "$github_token"     || failed_mandatory_var_check github_token
-    test "$upstream_remote"  || failed_mandatory_var_check upstream_remote
-    test "$fork_remote"      || failed_mandatory_var_check fork_remote
-    test "$redmine_endpoint" || failed_mandatory_var_check redmine_endpoint
-    test "$github_endpoint"  || failed_mandatory_var_check github_endpoint
-    if [ "$SETUP_ONLY" ] ; then
-        read -r -d '' setup_summary <<EOM || true > /dev/null 2>&1
-redmine_user_id  $redmine_user_id_display
-redmine_key      $redmine_key_display
-github_user      $github_user_display
-github_token     $github_token_display
-upstream_remote  $upstream_remote_display
-fork_remote      $fork_remote_display
-EOM
-        log bare "================================"
-        log bare "Setup summary"
-        log bare "--------------------------------"
-        log bare "variable name    value"
-        log bare "--------------------------------"
-        log bare "$setup_summary"
-        log bare "================================"
-    elif [ "$VERBOSE" ] ; then
-        debug "redmine_user_id  $redmine_user_id_display"
-        debug "redmine_key      $redmine_key_display"
-        debug "github_user      $github_user_display"
-        debug "github_token     $github_token_display"
-        debug "upstream_remote  $upstream_remote_display"
-        debug "fork_remote      $fork_remote_display"
-    fi
-}
-
 function log {
     local level="$1"
     shift
@@ -338,6 +289,57 @@ actually using the script to stage a backport, run:
     ${this_script} --setup
 
 EOM
+}
+
+function setup_report {
+    local not_set="!!! NOT SET !!!"
+    local redmine_endpoint_display="${redmine_endpoint:-$not_set}"
+    local redmine_user_id_display="${redmine_user_id:-$not_set}"
+    local github_endpoint_display="${github_endpoint:-$not_set}"
+    local github_user_display="${github_user:-$not_set}"
+    local upstream_remote_display="${upstream_remote:-$not_set}"
+    local fork_remote_display="${fork_remote:-$not_set}"
+    local redmine_key_display=""
+    local github_token_display=""
+    [ "$redmine_key" ] && redmine_key_display="(OK, not shown)" || redmine_key_display="$not_set"
+    [ "$github_token" ] && github_token_display="(OK, not shown)" || github_token_display="$not_set"
+    debug Re-checking mandatory variables
+    test "$redmine_key"      || failed_mandatory_var_check redmine_key
+    test "$redmine_user_id"  || failed_mandatory_var_check redmine_user_id
+    test "$github_user"      || failed_mandatory_var_check github_user
+    test "$github_token"     || failed_mandatory_var_check github_token
+    test "$upstream_remote"  || failed_mandatory_var_check upstream_remote
+    test "$fork_remote"      || failed_mandatory_var_check fork_remote
+    test "$redmine_endpoint" || failed_mandatory_var_check redmine_endpoint
+    test "$github_endpoint"  || failed_mandatory_var_check github_endpoint
+    if [ "$SETUP_ONLY" ] ; then
+        read -r -d '' setup_summary <<EOM || true > /dev/null 2>&1
+redmine_endpoint $redmine_endpoint
+redmine_user_id  $redmine_user_id_display
+redmine_key      $redmine_key_display
+github_endpoint  $github_endpoint
+github_user      $github_user_display
+github_token     $github_token_display
+upstream_remote  $upstream_remote_display
+fork_remote      $fork_remote_display
+EOM
+        log bare "================================"
+        log bare "Setup report"
+        log bare "--------------------------------"
+        log bare "variable name    value"
+        log bare "--------------------------------"
+        log bare "$setup_summary"
+        log bare "================================"
+    elif [ "$VERBOSE" ] ; then
+        debug "redmine_endpoint $redmine_endpoint_display"
+        debug "redmine_user_id  $redmine_user_id_display"
+        debug "redmine_key      $redmine_key_display"
+        debug "github_endpoint  $github_endpoint_display"
+        debug "github_user      $github_user_display"
+        debug "github_token     $github_token_display"
+        debug "upstream_remote  $upstream_remote_display"
+        debug "fork_remote      $fork_remote_display"
+    fi
 }
 
 function troubleshooting_advice {
@@ -558,7 +560,7 @@ BACKPORT_COMMON=$HOME/bin/backport_common.sh
 setup_ok="1"
 init_github_user
 init_mandatory_vars
-setup_summary
+setup_report
 if [ "$setup_ok" ] ; then
     if [ "$SETUP_ONLY" ] ; then
         log bare "Overall setup is OK"
@@ -569,6 +571,7 @@ if [ "$setup_ok" ] ; then
 else
     if [ "$SETUP_ONLY" ] ; then
         log bare "Setup is NOT OK"
+        log bare "(hint) set variables via the environment"
         log bare "$how_to_get_setup_advice"
         false
     else

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -174,7 +174,7 @@ function deduce_remote {
 
 function display_version_message_and_exit {
     echo "$this_script: Ceph backporting script, version $SCRIPT_VERSION"
-    exit 0
+    exit 0 
 }
 
 function eol {
@@ -815,7 +815,7 @@ pgrep firefox >/dev/null && firefox ${backport_pr_url}
 
 debug "Updating backport tracker issue ${redmine_url}"
 redmine_status=2 # In Progress
-remote_api_status_code=$(curl --write-out %{http_code} --output /dev/null --silent -X PUT --header 'Content-type: application/json' --data-binary '{"issue":{"description":"https://github.com/ceph/ceph/pull/'$backport_pr_number'","status_id":'$redmine_status',"assigned_to_id":'$redmine_user_id'},"notes":"Updated automatically by ceph-backport.sh version '$SCRIPT_VERSION'"}' ${redmine_url}'.json?key='$redmine_key)
+remote_api_status_code=$(curl --write-out %{http_code} --output /dev/null --silent -X PUT --header 'Content-type: application/json' --data-binary '{"issue":{"description":"https://github.com/ceph/ceph/pull/'$backport_pr_number'","status_id":'$redmine_status',"assigned_to_id":'$redmine_user_id',"notes":"Updated automatically by ceph-backport.sh version '$SCRIPT_VERSION'"}}' ${redmine_url}'.json?key='$redmine_key)
 if [ "${remote_api_status_code:0:1}" = "2" ] ; then
     info "${redmine_url} updated"
 elif [ "${remote_api_status_code:0:1}" = "4" ] ; then

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -261,6 +261,8 @@ redmine_user_id # "Logged in as foobar", click on foobar link, Redmine User ID
                 # is in the URL, i.e. https://tracker.ceph.com/users/[redmine_user_id]
 github_token    # https://github.com/settings/tokens -> Generate new token ->
                 # ensure it has "Full control of private repositories" scope
+                # see also:
+                # https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
 github_user     # Your github username
 
 The above variables must be set explicitly, as the script has no way of

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -124,7 +124,7 @@ function deduce_remote {
         true
     else
         error "Cannot auto-determine ${remote_type}_remote"
-        info "Please set this variable explicitly and also file a bug report at ${redmine_endpoint}"
+        info "There is something wrong with your remotes - to start with, check 'git remote -v'"
         false
     fi
     echo "$remote"


### PR DESCRIPTION
ceph-backport.sh only tries to set the milestone if explicitly told to do so via a command-line option. It also relies on an explicit command-line option to determine which component label to set.

That's not good enough for our dear users.

This PR also improves error reporting in cases when the user does not have elevated permissions on `ceph/ceph.git` and/or `tracker.ceph.com`.

Finally, this PR implements a `--version` option, along with a semi-automated mechanism for setting the version number - for the convenience of the script maintainer.