### PR TITLE
nautilus: rgw: protect AioResultList by a lock to avoid race condition

### DIFF
--- a/src/rgw/rgw_aio_throttle.cc
+++ b/src/rgw/rgw_aio_throttle.cc
@@ -48,6 +48,7 @@ AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
 
   if (cost > window) {
     p->result = -EDEADLK; // would never succeed
+    std::unique_lock lock{mutex};
     completed.push_back(*p);
   } else {
     get(*p);
@@ -57,6 +58,7 @@ AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
     }
   }
   p.release();
+  std::unique_lock lock{mutex};
   return std::move(completed);
 }
 
@@ -71,6 +73,7 @@ AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
 
   if (cost > window) {
     p->result = -EDEADLK; // would never succeed
+    std::unique_lock lock{mutex};
     completed.push_back(*p);
   } else {
     get(*p);
@@ -80,6 +83,7 @@ AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
     }
   }
   p.release();
+  std::unique_lock lock{mutex};
   return std::move(completed);
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/39660

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
