### PR TITLE
mgr/dashboard: tasks: only unblock controller thread after TaskManager thread

### DIFF
--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -585,6 +585,7 @@ class Task(object):
         return str(self)
 
     def _run(self):
+        NotificationQueue.register(self._handle_task_finished, 'cd_task_finished', 100)
         with self.lock:
             assert not self.running
             self.executor.init(self)
@@ -610,9 +611,13 @@ class Task(object):
             if not self.exception:
                 self.set_progress(100, True)
         NotificationQueue.new_notification('cd_task_finished', self)
-        self.event.set()
         logger.debug("TK: execution of %s finished in: %s s", self,
                      self.duration)
+
+    def _handle_task_finished(self, task):
+        if self == task:
+            NotificationQueue.deregister(self._handle_task_finished)
+            self.event.set()
 
     def wait(self, timeout=None):
         with self.lock:


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/42187

Signed-off-by: Ricardo Dias <rdias@suse.com>


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
