### PR TITLE
os/bluestore: set STATE_KV_SUBMITTED properly.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11174,7 +11174,6 @@ void BlueStore::_txc_finalize_kv(TransContext *txc, KeyValueDB::Transaction t)
 void BlueStore::_txc_apply_kv(TransContext *txc, bool sync_submit_transaction)
 {
   ceph_assert(txc->state == TransContext::STATE_KV_QUEUED);
-  txc->state = TransContext::STATE_KV_SUBMITTED;
   {
 #if defined(WITH_LTTNG)
     auto start = mono_clock::now();
@@ -11182,6 +11181,7 @@ void BlueStore::_txc_apply_kv(TransContext *txc, bool sync_submit_transaction)
 
     int r = cct->_conf->bluestore_debug_omit_kv_commit ? 0 : db->submit_transaction(txc->t);
     ceph_assert(r == 0);
+    txc->state = TransContext::STATE_KV_SUBMITTED;
 
 #if defined(WITH_LTTNG)
     if (txc->tracing) {


### PR DESCRIPTION
TXC's state was set before actual DB update which improperly permits
OpSequencer::flush to proceed.

This is a regression caused by:
https://github.com/ceph/ceph/pull/29674/commits/a2fa546d02cfe2a910413acdec5ef11dbfacb359

Fixes: https://tracker.ceph.com/issues/42189

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
