### PR TITLE
nautilus: mds: "apply configuration changes through MDSRank" and "recall caps from quiescent sessions" and "drive cap recall while dropping cache"

### DIFF
--- a/qa/tasks/cephfs/test_journal_repair.py
+++ b/qa/tasks/cephfs/test_journal_repair.py
@@ -315,7 +315,7 @@ class TestJournalRepair(CephFSTestCase):
         # Should see one session
         session_data = json.loads(self.fs.table_tool(
             ["all", "show", "session"]))
-        self.assertEqual(len(session_data["0"]["data"]["Sessions"]), 1)
+        self.assertEqual(len(session_data["0"]["data"]["sessions"]), 1)
         self.assertEqual(session_data["0"]["result"], 0)
 
         # Should see no snaps
@@ -344,7 +344,7 @@ class TestJournalRepair(CephFSTestCase):
         # Should see 0 sessions
         session_data = json.loads(self.fs.table_tool(
             ["all", "show", "session"]))
-        self.assertEqual(len(session_data["0"]["data"]["Sessions"]), 0)
+        self.assertEqual(len(session_data["0"]["data"]["sessions"]), 0)
         self.assertEqual(session_data["0"]["result"], 0)
 
         # Should see entire inode range now marked free

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -106,7 +106,7 @@ class TestSessionMap(CephFSTestCase):
         table_json = json.loads(self.fs.table_tool(["0", "show", "session"]))
         log.info("SessionMap: {0}".format(json.dumps(table_json, indent=2)))
         self.assertEqual(table_json['0']['result'], 0)
-        self.assertEqual(len(table_json['0']['data']['Sessions']), 2)
+        self.assertEqual(len(table_json['0']['data']['sessions']), 2)
 
         # Now, induce a "force_open_sessions" event by exporting a dir
         self.mount_a.run_shell(["mkdir", "bravo"])
@@ -147,7 +147,7 @@ class TestSessionMap(CephFSTestCase):
         table_json = json.loads(self.fs.table_tool(["0", "show", "session"]))
         log.info("SessionMap: {0}".format(json.dumps(table_json, indent=2)))
         self.assertEqual(table_json['0']['result'], 0)
-        self.assertEqual(len(table_json['0']['data']['Sessions']), 0)
+        self.assertEqual(len(table_json['0']['data']['sessions']), 0)
 
     def _sudo_write_file(self, remote, path, data):
         """

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6328,7 +6328,7 @@ int Client::_lookup(Inode *dir, const string& dname, int mask, InodeRef *target,
 	ldout(cct, 20) << " bad lease, cap_ttl " << s.cap_ttl << ", cap_gen " << s.cap_gen
 		       << " vs lease_gen " << dn->lease_gen << dendl;
       }
-      // dir lease?
+      // dir shared caps?
       if (dir->caps_issued_mask(CEPH_CAP_FILE_SHARED, true)) {
 	if (dn->cap_shared_gen == dir->shared_gen &&
 	    (!dn->inode || dn->inode->caps_issued_mask(mask, true)))

--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -51,7 +51,7 @@ void DecayCounter::dump(Formatter *f) const
 {
   decay();
   f->dump_float("value", val);
-  f->dump_float("halflife", rate.k);
+  f->dump_float("halflife", rate.get_halflife());
 }
 
 void DecayCounter::generate_test_instances(std::list<DecayCounter*>& ls)

--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -29,8 +29,8 @@ void DecayCounter::decode(bufferlist::const_iterator &p)
 {
   DECODE_START_LEGACY_COMPAT_LEN(5, 4, 4, p);
   if (struct_v < 2) {
-    double half_life = 0.0;
-    decode(half_life, p);
+    double k = 0.0;
+    decode(k, p);
   }
   if (struct_v < 3) {
     double k = 0.0;

--- a/src/common/DecayCounter.h
+++ b/src/common/DecayCounter.h
@@ -43,7 +43,10 @@ public:
 
   void set_halflife(double hl) {
     k = log(.5) / hl;
-  }    
+  }
+  double get_halflife() const {
+    return log(.5) / k;
+  }
 
 private:
   double k = 0;             // k = ln(.5)/half_life

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -59,19 +59,16 @@ class OpHistory {
   set<pair<utime_t, TrackedOpRef> > slow_op;
   ceph::mutex ops_history_lock = ceph::make_mutex("OpHistory::ops_history_lock");
   void cleanup(utime_t now);
-  uint32_t history_size;
-  uint32_t history_duration;
-  uint32_t history_slow_op_size;
-  uint32_t history_slow_op_threshold;
-  std::atomic_bool shutdown;
+  std::atomic_size_t history_size{0};
+  std::atomic_uint32_t history_duration{0};
+  std::atomic_size_t history_slow_op_size{0};
+  std::atomic_uint32_t history_slow_op_threshold{0};
+  std::atomic_bool shutdown{false};
   OpHistoryServiceThread opsvc;
   friend class OpHistoryServiceThread;
 
 public:
-  OpHistory()
-    : history_size(0), history_duration(0),
-      history_slow_op_size(0), history_slow_op_threshold(0),
-      shutdown(false), opsvc(this) {
+  OpHistory() : opsvc(this) {
     opsvc.create("OpHistorySvc");
   }
   ~OpHistory() {
@@ -91,11 +88,11 @@ public:
   void dump_ops(utime_t now, Formatter *f, set<string> filters = {""}, bool by_duration=false);
   void dump_slow_ops(utime_t now, Formatter *f, set<string> filters = {""});
   void on_shutdown();
-  void set_size_and_duration(uint32_t new_size, uint32_t new_duration) {
+  void set_size_and_duration(size_t new_size, uint32_t new_duration) {
     history_size = new_size;
     history_duration = new_duration;
   }
-  void set_slow_op_size_and_threshold(uint32_t new_size, uint32_t new_threshold) {
+  void set_slow_op_size_and_threshold(size_t new_size, uint32_t new_threshold) {
     history_slow_op_size = new_size;
     history_slow_op_threshold = new_threshold;
   }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7648,6 +7648,18 @@ std::vector<Option> get_mds_options() {
     .set_default(60.0)
     .set_description("decay rate for warning on slow session cap recall"),
 
+    Option("mds_session_cache_liveness_decay_rate", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .add_see_also("mds_session_cache_liveness_magnitude")
+    .set_default(5_min)
+    .set_description("decay rate for session liveness leading to preemptive cap recall")
+    .set_long_description("This determines how long a session needs to be quiescent before the MDS begins preemptively recalling capabilities. The default of 5 minutes will cause 10 halvings of the decay counter after 1 hour, or 1/1024. The default magnitude of 10 (1^10 or 1024) is chosen so that the MDS considers a previously chatty session (approximately) to be quiescent after 1 hour."),
+
+    Option("mds_session_cache_liveness_magnitude", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .add_see_also("mds_session_cache_liveness_decay_rate")
+    .set_default(10)
+    .set_description("decay magnitude for preemptively recalling caps on quiet client")
+    .set_long_description("This is the order of magnitude difference (in base 2) of the internal liveness decay counter and the number of capabilities the session holds. When this difference occurs, the MDS treats the session as quiescent and begins recalling capabilities."),
+
     Option("mds_freeze_tree_timeout", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(30)
     .set_description(""),

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -7,6 +7,7 @@
  */
 
 #include <string.h>
+#include <stdbool.h>
 #include "msgr.h"
 
 /*
@@ -394,7 +395,7 @@ static inline int ceph_osd_op_mode_cache(int op)
 {
 	return op & CEPH_OSD_OP_MODE_CACHE;
 }
-static inline int ceph_osd_op_uses_extent(int op)
+static inline bool ceph_osd_op_uses_extent(int op)
 {
 	switch(op) {
 	case CEPH_OSD_OP_READ:

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3066,14 +3066,14 @@ void Locker::process_request_cap_release(MDRequestRef& mdr, client_t client, con
       if (dn) {
 	ClientLease *l = dn->get_client_lease(client);
 	if (l) {
-	  dout(10) << "process_cap_release removing lease on " << *dn << dendl;
+	  dout(10) << __func__ << " removing lease on " << *dn << dendl;
 	  dn->remove_client_lease(l, this);
 	} else {
-	  dout(7) << "process_cap_release client." << client
+	  dout(7) << __func__ << " client." << client
 		  << " doesn't have lease on " << *dn << dendl;
 	}
       } else {
-	dout(7) << "process_cap_release client." << client << " released lease on dn "
+	dout(7) << __func__ << " client." << client << " released lease on dn "
 		<< dir->dirfrag() << "/" << dname << " which dne" << dendl;
       }
     }
@@ -3083,7 +3083,7 @@ void Locker::process_request_cap_release(MDRequestRef& mdr, client_t client, con
   if (!cap)
     return;
 
-  dout(10) << "process_cap_release client." << client << " " << ccap_string(caps) << " on " << *in
+  dout(10) << __func__ << " client." << client << " " << ccap_string(caps) << " on " << *in
 	   << (mdr ? "" : " (DEFERRED, no mdr)")
 	   << dendl;
     

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -82,9 +82,7 @@ MDBalancer::MDBalancer(MDSRank *m, Messenger *msgr, MonClient *monc) :
   bal_fragment_interval = g_conf().get_val<int64_t>("mds_bal_fragment_interval");
 }
 
-void MDBalancer::handle_conf_change(const ConfigProxy& conf,
-				    const std::set <std::string> &changed,
-				    const MDSMap &mds_map)
+void MDBalancer::handle_conf_change(const std::set<std::string>& changed, const MDSMap& mds_map)
 {
   if (changed.count("mds_bal_fragment_dirs"))
     bal_fragment_dirs = g_conf().get_val<bool>("mds_bal_fragment_dirs");

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -44,9 +44,7 @@ public:
 
   MDBalancer(MDSRank *m, Messenger *msgr, MonClient *monc);
 
-  void handle_conf_change(const ConfigProxy& conf,
-                          const std::set <std::string> &changed,
-                          const MDSMap &mds_map);
+  void handle_conf_change(const std::set<std::string>& changed, const MDSMap& mds_map);
 
   int proc_message(const Message::const_ref &m);
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -175,7 +175,8 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
           trim_client_leases();
           trim();
           check_memory_usage();
-          mds->server->recall_client_state(nullptr, Server::RecallFlags::ENFORCE_MAX);
+          auto flags = Server::RecallFlags::ENFORCE_MAX|Server::RecallFlags::ENFORCE_LIVENESS;
+          mds->server->recall_client_state(nullptr, flags);
           upkeep_last_trim = clock::now();
         } else {
           dout(10) << "cache not ready for trimming" << dendl;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -198,9 +198,7 @@ MDCache::~MDCache()
     upkeeper.join();
 }
 
-void MDCache::handle_conf_change(const ConfigProxy& conf,
-                                 const std::set <std::string> &changed,
-                                 const MDSMap &mdsmap)
+void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDSMap& mdsmap)
 {
   if (changed.count("mds_cache_size"))
     cache_inode_limit = g_conf().get_val<int64_t>("mds_cache_size");
@@ -216,8 +214,8 @@ void MDCache::handle_conf_change(const ConfigProxy& conf,
     trim_counter = DecayCounter(g_conf().get_val<double>("mds_cache_trim_decay_rate"));
   }
 
-  migrator->handle_conf_change(conf, changed, mdsmap);
-  mds->balancer->handle_conf_change(conf, changed, mdsmap);
+  migrator->handle_conf_change(changed, mdsmap);
+  mds->balancer->handle_conf_change(changed, mdsmap);
 }
 
 void MDCache::log_stat()

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7626,7 +7626,7 @@ void MDCache::check_memory_usage()
   mds->mlogger->set(l_mdm_heap, last.get_heap());
 
   if (cache_toofull()) {
-    mds->server->recall_client_state(nullptr);
+    mds->server->recall_client_state(nullptr, Server::RecallFlags::TRIM);
   }
 
   // If the cache size had exceeded its limit, but we're back in bounds

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -775,9 +775,7 @@ public:
  public:
   explicit MDCache(MDSRank *m, PurgeQueue &purge_queue_);
   ~MDCache();
-  void handle_conf_change(const ConfigProxy& conf,
-                          const std::set <std::string> &changed,
-                          const MDSMap &mds_map);
+  void handle_conf_change(const std::set<std::string>& changed, const MDSMap& mds_map);
   
   // debug
   void log_stat();

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -337,110 +337,6 @@ void MDSDaemon::clean_up_admin_socket()
   asok_hook = NULL;
 }
 
-const char** MDSDaemon::get_tracked_conf_keys() const
-{
-  static const char* KEYS[] = {
-    "mds_op_complaint_time", "mds_op_log_threshold",
-    "mds_op_history_size", "mds_op_history_duration",
-    "mds_enable_op_tracker",
-    "mds_log_pause",
-    // clog & admin clog
-    "clog_to_monitors",
-    "clog_to_syslog",
-    "clog_to_syslog_facility",
-    "clog_to_syslog_level",
-    "clog_to_graylog",
-    "clog_to_graylog_host",
-    "clog_to_graylog_port",
-    // MDCache
-    "mds_cache_size",
-    "mds_cache_memory_limit",
-    "mds_cache_reservation",
-    "mds_health_cache_threshold",
-    "mds_cache_mid",
-    "mds_dump_cache_threshold_formatter",
-    "mds_cache_trim_decay_rate",
-    "mds_dump_cache_threshold_file",
-    // MDBalancer
-    "mds_bal_fragment_dirs",
-    "mds_bal_fragment_interval",
-    // PurgeQueue
-    "mds_max_purge_ops",
-    "mds_max_purge_ops_per_pg",
-    "mds_max_purge_files",
-    // Migrator
-    "mds_max_export_size",
-    "mds_inject_migrator_session_race",
-    "host",
-    "fsid",
-    "mds_cap_revoke_eviction_timeout",
-    // SessionMap
-    "mds_request_load_average_decay_rate",
-    "mds_recall_max_decay_rate",
-    NULL
-  };
-  return KEYS;
-}
-
-void MDSDaemon::handle_conf_change(const ConfigProxy& conf,
-			     const std::set <std::string> &changed)
-{
-  // We may be called within mds_lock (via `tell`) or outwith the
-  // lock (via admin socket `config set`), so handle either case.
-  const bool initially_locked = mds_lock.is_locked_by_me();
-  if (!initially_locked) {
-    mds_lock.Lock();
-  }
-
-  if (changed.count("mds_op_complaint_time") ||
-      changed.count("mds_op_log_threshold")) {
-    if (mds_rank) {
-      mds_rank->op_tracker.set_complaint_and_threshold(conf->mds_op_complaint_time,
-                                             conf->mds_op_log_threshold);
-    }
-  }
-  if (changed.count("mds_op_history_size") ||
-      changed.count("mds_op_history_duration")) {
-    if (mds_rank) {
-      mds_rank->op_tracker.set_history_size_and_duration(conf->mds_op_history_size,
-                                               conf->mds_op_history_duration);
-    }
-  }
-  if (changed.count("mds_enable_op_tracker")) {
-    if (mds_rank) {
-      mds_rank->op_tracker.set_tracking(conf->mds_enable_op_tracker);
-    }
-  }
-  if (changed.count("clog_to_monitors") ||
-      changed.count("clog_to_syslog") ||
-      changed.count("clog_to_syslog_level") ||
-      changed.count("clog_to_syslog_facility") ||
-      changed.count("clog_to_graylog") ||
-      changed.count("clog_to_graylog_host") ||
-      changed.count("clog_to_graylog_port") ||
-      changed.count("host") ||
-      changed.count("fsid")) {
-    if (mds_rank) {
-      mds_rank->update_log_config();
-    }
-  }
-
-  if (!g_conf()->mds_log_pause && changed.count("mds_log_pause")) {
-    if (mds_rank) {
-      mds_rank->mdlog->kick_submitter();
-    }
-  }
-
-  if (mds_rank) {
-    mds_rank->handle_conf_change(conf, changed);
-  }
-
-  if (!initially_locked) {
-    mds_lock.Unlock();
-  }
-}
-
-
 int MDSDaemon::init()
 {
   dout(10) << sizeof(MDSCacheObject) << "\tMDSCacheObject" << dendl;
@@ -532,7 +428,6 @@ int MDSDaemon::init()
   // Set up admin socket before taking mds_lock, so that ordering
   // is consistent (later we take mds_lock within asok callbacks)
   set_up_admin_socket();
-  g_conf().add_observer(this);
   mds_lock.Lock();
   if (beacon.get_want_state() == MDSMap::STATE_DNE) {
     suicide();  // we could do something more graceful here
@@ -1040,14 +935,6 @@ void MDSDaemon::suicide()
   if (tick_event) {
     timer.cancel_event(tick_event);
     tick_event = 0;
-  }
-
-  //because add_observer is called after set_up_admin_socket
-  //so we can use asok_hook to avoid assert in the remove_observer
-  if (asok_hook != NULL) {
-    mds_lock.Unlock();
-    g_conf().remove_observer(this);
-    mds_lock.Lock();
   }
 
   clean_up_admin_socket();

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1227,9 +1227,6 @@ void MDSDaemon::ms_handle_accept(Connection *con)
   // request to open a session (initial state of Session is `closed`)
   if (!s) {
     s = new Session(con);
-    s->info.auth_name = con->get_peer_entity_name();
-    s->info.inst.addr = con->get_peer_socket_addr();
-    s->info.inst.name = n;
     dout(10) << " new session " << s << " for " << s->info.inst
 	     << " con " << con << dendl;
     con->set_priv(RefCountedPtr{s, false});

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -40,7 +40,7 @@
 class Messenger;
 class MonClient;
 
-class MDSDaemon : public Dispatcher, public md_config_obs_t {
+class MDSDaemon : public Dispatcher {
  public:
   /* Global MDS lock: every time someone takes this, they must
    * also check the `stopping` flag.  If stopping is true, you
@@ -92,11 +92,6 @@ class MDSDaemon : public Dispatcher, public md_config_obs_t {
    * such that deleting xlists doesn't assert.
    */
   bool is_clean_shutdown();
-
-  // config observer bits
-  const char** get_tracked_conf_keys() const override;
-  void handle_conf_change(const ConfigProxy& conf,
-			  const std::set <std::string> &changed) override;
  protected:
   // tick and other timer fun
   Context *tick_event = nullptr;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3603,43 +3603,40 @@ epoch_t MDSRank::get_osd_epoch() const
 const char** MDSRankDispatcher::get_tracked_conf_keys() const
 {
   static const char* KEYS[] = {
-    "mds_op_complaint_time", "mds_op_log_threshold",
-    "mds_op_history_size", "mds_op_history_duration",
-    "mds_enable_op_tracker",
-    "mds_log_pause",
-    // clog & admin clog
+    "clog_to_graylog",
+    "clog_to_graylog_host",
+    "clog_to_graylog_port",
     "clog_to_monitors",
     "clog_to_syslog",
     "clog_to_syslog_facility",
     "clog_to_syslog_level",
-    "clog_to_graylog",
-    "clog_to_graylog_host",
-    "clog_to_graylog_port",
-    // MDCache
-    "mds_cache_size",
-    "mds_cache_memory_limit",
-    "mds_cache_reservation",
-    "mds_health_cache_threshold",
-    "mds_cache_mid",
-    "mds_dump_cache_threshold_formatter",
-    "mds_cache_trim_decay_rate",
-    "mds_dump_cache_threshold_file",
-    // MDBalancer
+    "fsid",
+    "host",
     "mds_bal_fragment_dirs",
     "mds_bal_fragment_interval",
-    // PurgeQueue
+    "mds_cache_memory_limit",
+    "mds_cache_mid",
+    "mds_cache_reservation",
+    "mds_cache_size",
+    "mds_cache_trim_decay_rate",
+    "mds_cap_revoke_eviction_timeout",
+    "mds_dump_cache_threshold_file",
+    "mds_dump_cache_threshold_formatter",
+    "mds_enable_op_tracker",
+    "mds_health_cache_threshold",
+    "mds_inject_migrator_session_race",
+    "mds_log_pause",
+    "mds_max_export_size",
+    "mds_max_purge_files",
     "mds_max_purge_ops",
     "mds_max_purge_ops_per_pg",
-    "mds_max_purge_files",
-    // Migrator
-    "mds_max_export_size",
-    "mds_inject_migrator_session_race",
-    "host",
-    "fsid",
-    "mds_cap_revoke_eviction_timeout",
-    // SessionMap
-    "mds_request_load_average_decay_rate",
+    "mds_op_complaint_time",
+    "mds_op_history_duration",
+    "mds_op_history_size",
+    "mds_op_log_threshold",
     "mds_recall_max_decay_rate",
+    "mds_recall_warning_decay_rate",
+    "mds_request_load_average_decay_rate",
     NULL
   };
   return KEYS;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2754,39 +2754,18 @@ void MDSRankDispatcher::dump_sessions(const SessionFilter &filter, Formatter *f)
 {
   // Dump sessions, decorated with recovery/replay status
   f->open_array_section("sessions");
-  const ceph::unordered_map<entity_name_t, Session*> session_map = sessionmap.get_sessions();
-  for (auto& p : session_map) {
-    if (!p.first.is_client()) {
+  for (auto& [name, s] : sessionmap.get_sessions()) {
+    if (!name.is_client()) {
       continue;
     }
-
-    Session *s = p.second;
 
     if (!filter.match(*s, std::bind(&Server::waiting_for_reconnect, server, std::placeholders::_1))) {
       continue;
     }
 
-    f->open_object_section("session");
-    f->dump_int("id", p.first.num());
-
-    f->dump_int("num_leases", s->leases.size());
-    f->dump_int("num_caps", s->caps.size());
-
-    f->dump_string("state", s->get_state_name());
-    if (s->is_open() || s->is_stale()) {
-      f->dump_unsigned("request_load_avg", s->get_load_avg());
-    }
-    f->dump_float("uptime", s->get_session_uptime());
-    f->dump_int("replay_requests", is_clientreplay() ? s->get_request_count() : 0);
-    f->dump_unsigned("completed_requests", s->get_num_completed_requests());
-    f->dump_bool("reconnecting", server->waiting_for_reconnect(p.first.num()));
-    f->dump_stream("inst") << s->info.inst;
-    f->open_object_section("client_metadata");
-    s->info.client_metadata.dump(f);
-    f->close_section(); // client_metadata
-    f->close_section(); //session
+    f->dump_object("session", *s);
   }
-  f->close_section(); //sessions
+  f->close_section(); // sessions
 }
 
 void MDSRank::command_scrub_start(Formatter *f,

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3616,6 +3616,7 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_recall_max_decay_rate",
     "mds_recall_warning_decay_rate",
     "mds_request_load_average_decay_rate",
+    "mds_session_cache_liveness_decay_rate",
     NULL
   };
   return KEYS;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -328,7 +328,8 @@ private:
     auto duration = std::chrono::duration<double>(now-recall_start).count();
 
     MDSGatherBuilder *gather = new MDSGatherBuilder(g_ceph_context);
-    auto [throttled, count] = server->recall_client_state(gather, Server::RecallFlags::STEADY);
+    auto flags = Server::RecallFlags::STEADY|Server::RecallFlags::TRIM;
+    auto [throttled, count] = server->recall_client_state(gather, flags);
     dout(10) << __func__
              << (throttled ? " (throttled)" : "")
              << " recalled " << count << " caps" << dendl;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -819,6 +819,8 @@ void MDSRankDispatcher::shutdown()
 
   dout(1) << __func__ << ": shutting down rank " << whoami << dendl;
 
+  g_conf().remove_observer(this);
+
   timer.shutdown();
 
   // MDLog has to shut down before the finisher, because some of its
@@ -3472,7 +3474,9 @@ MDSRankDispatcher::MDSRankDispatcher(
     Context *suicide_hook_)
   : MDSRank(whoami_, mds_lock_, clog_, timer_, beacon_, mdsmap_,
       msgr, monc_, respawn_hook_, suicide_hook_)
-{}
+{
+  g_conf().add_observer(this);
+}
 
 bool MDSRankDispatcher::handle_command(
   const cmdmap_t &cmdmap,
@@ -3596,3 +3600,85 @@ epoch_t MDSRank::get_osd_epoch() const
   return objecter->with_osdmap(std::mem_fn(&OSDMap::get_epoch));  
 }
 
+const char** MDSRankDispatcher::get_tracked_conf_keys() const
+{
+  static const char* KEYS[] = {
+    "mds_op_complaint_time", "mds_op_log_threshold",
+    "mds_op_history_size", "mds_op_history_duration",
+    "mds_enable_op_tracker",
+    "mds_log_pause",
+    // clog & admin clog
+    "clog_to_monitors",
+    "clog_to_syslog",
+    "clog_to_syslog_facility",
+    "clog_to_syslog_level",
+    "clog_to_graylog",
+    "clog_to_graylog_host",
+    "clog_to_graylog_port",
+    // MDCache
+    "mds_cache_size",
+    "mds_cache_memory_limit",
+    "mds_cache_reservation",
+    "mds_health_cache_threshold",
+    "mds_cache_mid",
+    "mds_dump_cache_threshold_formatter",
+    "mds_cache_trim_decay_rate",
+    "mds_dump_cache_threshold_file",
+    // MDBalancer
+    "mds_bal_fragment_dirs",
+    "mds_bal_fragment_interval",
+    // PurgeQueue
+    "mds_max_purge_ops",
+    "mds_max_purge_ops_per_pg",
+    "mds_max_purge_files",
+    // Migrator
+    "mds_max_export_size",
+    "mds_inject_migrator_session_race",
+    "host",
+    "fsid",
+    "mds_cap_revoke_eviction_timeout",
+    // SessionMap
+    "mds_request_load_average_decay_rate",
+    "mds_recall_max_decay_rate",
+    NULL
+  };
+  return KEYS;
+}
+
+void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::set<std::string>& changed)
+{
+  // XXX with or without mds_lock!
+
+  if (changed.count("mds_op_complaint_time") || changed.count("mds_op_log_threshold")) {
+    op_tracker.set_complaint_and_threshold(conf->mds_op_complaint_time, conf->mds_op_log_threshold);
+  }
+  if (changed.count("mds_op_history_size") || changed.count("mds_op_history_duration")) {
+    op_tracker.set_history_size_and_duration(conf->mds_op_history_size, conf->mds_op_history_duration);
+  }
+  if (changed.count("mds_enable_op_tracker")) {
+    op_tracker.set_tracking(conf->mds_enable_op_tracker);
+  }
+  if (changed.count("clog_to_monitors") ||
+      changed.count("clog_to_syslog") ||
+      changed.count("clog_to_syslog_level") ||
+      changed.count("clog_to_syslog_facility") ||
+      changed.count("clog_to_graylog") ||
+      changed.count("clog_to_graylog_host") ||
+      changed.count("clog_to_graylog_port") ||
+      changed.count("host") ||
+      changed.count("fsid")) {
+    update_log_config();
+  }
+
+  finisher->queue(new FunctionContext([this, changed](int r) {
+    std::scoped_lock lock(mds_lock);
+
+    if (changed.count("mds_log_pause") && !g_conf()->mds_log_pause) {
+      mdlog->kick_submitter();
+    }
+    sessionmap.handle_conf_change(changed);
+    server->handle_conf_change(changed);
+    mdcache->handle_conf_change(changed, *mdsmap);
+    purge_queue.handle_conf_change(changed, *mdsmap);
+  }));
+}

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -620,7 +620,7 @@ public:
   void handle_osd_map();
   void update_log_config();
 
-  const char** get_tracked_conf_keys() const final;
+  const char** get_tracked_conf_keys() const override final;
   void handle_conf_change(const ConfigProxy& conf, const std::set<std::string>& changed) override;
 
   bool handle_command(

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -235,15 +235,6 @@ class MDSRank {
 
     void handle_write_error(int err);
 
-    void handle_conf_change(const ConfigProxy& conf,
-                            const std::set <std::string> &changed)
-    {
-      sessionmap.handle_conf_change(conf, changed);
-      server->handle_conf_change(conf, changed);
-      mdcache->handle_conf_change(conf, changed, *mdsmap);
-      purge_queue.handle_conf_change(conf, changed, *mdsmap);
-    }
-
     void update_mlogger();
   protected:
     // Flag to indicate we entered shutdown: anyone seeing this to be true
@@ -315,7 +306,6 @@ class MDSRank {
 
     void create_logger();
   public:
-
     void queue_waiter(MDSContext *c) {
       finished_queue.push_back(c);
       progress_thread.signal();
@@ -618,7 +608,7 @@ private:
  * the service/dispatcher stuff like init/shutdown that subsystems should
  * never touch.
  */
-class MDSRankDispatcher : public MDSRank
+class MDSRankDispatcher : public MDSRank, public md_config_obs_t
 {
 public:
   void init();
@@ -629,6 +619,9 @@ public:
   void handle_mds_map(const MMDSMap::const_ref &m, const MDSMap &oldmap);
   void handle_osd_map();
   void update_log_config();
+
+  const char** get_tracked_conf_keys() const final;
+  void handle_conf_change(const ConfigProxy& conf, const std::set<std::string>& changed) override;
 
   bool handle_command(
     const cmdmap_t &cmdmap,

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -3589,14 +3589,12 @@ Migrator::Migrator(MDSRank *m, MDCache *c) : mds(m), cache(c) {
   inject_session_race = g_conf().get_val<bool>("mds_inject_migrator_session_race");
 }
 
-void Migrator::handle_conf_change(const ConfigProxy& conf,
-                                  const std::set <std::string> &changed,
-                                  const MDSMap &mds_map)
+void Migrator::handle_conf_change(const std::set<std::string>& changed, const MDSMap& mds_map)
 {
   if (changed.count("mds_max_export_size"))
     max_export_size = g_conf().get_val<Option::size_t>("mds_max_export_size");
   if (changed.count("mds_inject_migrator_session_race")) {
-    inject_session_race = conf.get_val<bool>("mds_inject_migrator_session_race");
+    inject_session_race = g_conf().get_val<bool>("mds_inject_migrator_session_race");
     dout(0) << "mds_inject_migrator_session_race is " << inject_session_race << dendl;
   }
 }

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -102,9 +102,7 @@ public:
   // -- cons --
   Migrator(MDSRank *m, MDCache *c);
 
-  void handle_conf_change(const ConfigProxy& conf,
-                          const std::set <std::string> &changed,
-                          const MDSMap &mds_map);
+  void handle_conf_change(const std::set<std::string>& changed, const MDSMap& mds_map);
 
 protected:
   struct export_base_t {

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -229,8 +229,8 @@ typedef boost::intrusive_ptr<MutationImpl> MutationRef;
 
 
 
-/** active_request_t
- * state we track for requests we are currently processing.
+/**
+ * MDRequestImpl: state we track for requests we are currently processing.
  * mostly information about locks held, so that we can drop them all
  * the request is finished or forwarded.  see request_*().
  */

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -651,9 +651,7 @@ void PurgeQueue::update_op_limit(const MDSMap &mds_map)
   }
 }
 
-void PurgeQueue::handle_conf_change(const ConfigProxy& conf,
-			     const std::set <std::string> &changed,
-                             const MDSMap &mds_map)
+void PurgeQueue::handle_conf_change(const std::set<std::string>& changed, const MDSMap& mds_map)
 {
   if (changed.count("mds_max_purge_ops")
       || changed.count("mds_max_purge_ops_per_pg")) {
@@ -664,7 +662,7 @@ void PurgeQueue::handle_conf_change(const ConfigProxy& conf,
       // We might have gone from zero to a finite limit, so
       // might need to kick off consume.
       dout(4) << "maybe start work again (max_purge_files="
-              << conf->mds_max_purge_files << dendl;
+              << g_conf()->mds_max_purge_files << dendl;
       finisher.queue(new FunctionContext([this](int r){
         std::lock_guard l(lock);
         _consume();

--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -208,9 +208,7 @@ public:
 
   void update_op_limit(const MDSMap &mds_map);
 
-  void handle_conf_change(const ConfigProxy& conf,
-                          const std::set <std::string> &changed,
-                          const MDSMap &mds_map);
+  void handle_conf_change(const std::set<std::string>& changed, const MDSMap& mds_map);
 
   PurgeQueue(
       CephContext *cct_,

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1562,8 +1562,9 @@ void Server::recover_filelocks(CInode *in, bufferlist locks, int64_t client)
 std::pair<bool, uint64_t> Server::recall_client_state(MDSGatherBuilder* gather, RecallFlags flags)
 {
   const auto now = clock::now();
-  const bool steady = flags&RecallFlags::STEADY;
-  const bool enforce_max = flags&RecallFlags::ENFORCE_MAX;
+  const bool steady = !!(flags&RecallFlags::STEADY);
+  const bool enforce_max = !!(flags&RecallFlags::ENFORCE_MAX);
+  const bool trim = !!(flags&RecallFlags::TRIM);
 
   const auto max_caps_per_client = g_conf().get_val<uint64_t>("mds_max_caps_per_client");
   const auto min_caps_per_client = g_conf().get_val<uint64_t>("mds_min_caps_per_client");
@@ -1575,14 +1576,14 @@ std::pair<bool, uint64_t> Server::recall_client_state(MDSGatherBuilder* gather, 
            << " min=" << min_caps_per_client
            << " max=" << max_caps_per_client
            << " total=" << Capability::count()
-           << " flags=0x" << std::hex << flags
+           << " flags=" << flags
            << dendl;
 
   /* trim caps of sessions with the most caps first */
   std::multimap<uint64_t, Session*> caps_session;
-  auto f = [&caps_session, enforce_max, max_caps_per_client](auto& s) {
+  auto f = [&caps_session, enforce_max, trim, max_caps_per_client](auto& s) {
     auto num_caps = s->caps.size();
-    if (!enforce_max || num_caps > max_caps_per_client) {
+    if (trim || (enforce_max && num_caps > max_caps_per_client)) {
       caps_session.emplace(std::piecewise_construct, std::forward_as_tuple(num_caps), std::forward_as_tuple(s));
     }
   };

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1566,6 +1566,7 @@ std::pair<bool, uint64_t> Server::recall_client_state(MDSGatherBuilder* gather, 
   const auto now = clock::now();
   const bool steady = !!(flags&RecallFlags::STEADY);
   const bool enforce_max = !!(flags&RecallFlags::ENFORCE_MAX);
+  const bool enforce_liveness = !!(flags&RecallFlags::ENFORCE_LIVENESS);
   const bool trim = !!(flags&RecallFlags::TRIM);
 
   const auto max_caps_per_client = g_conf().get_val<uint64_t>("mds_max_caps_per_client");
@@ -1573,6 +1574,7 @@ std::pair<bool, uint64_t> Server::recall_client_state(MDSGatherBuilder* gather, 
   const auto recall_global_max_decay_threshold = g_conf().get_val<Option::size_t>("mds_recall_global_max_decay_threshold");
   const auto recall_max_caps = g_conf().get_val<Option::size_t>("mds_recall_max_caps");
   const auto recall_max_decay_threshold = g_conf().get_val<Option::size_t>("mds_recall_max_decay_threshold");
+  const auto cache_liveness_magnitude = g_conf().get_val<Option::size_t>("mds_session_cache_liveness_magnitude");
 
   dout(7) << __func__ << ":"
            << " min=" << min_caps_per_client
@@ -1583,9 +1585,10 @@ std::pair<bool, uint64_t> Server::recall_client_state(MDSGatherBuilder* gather, 
 
   /* trim caps of sessions with the most caps first */
   std::multimap<uint64_t, Session*> caps_session;
-  auto f = [&caps_session, enforce_max, trim, max_caps_per_client](auto& s) {
+  auto f = [&caps_session, enforce_max, enforce_liveness, trim, max_caps_per_client, cache_liveness_magnitude](auto& s) {
     auto num_caps = s->caps.size();
-    if (trim || (enforce_max && num_caps > max_caps_per_client)) {
+    auto cache_liveness = s->get_session_cache_liveness();
+    if (trim || (enforce_max && num_caps > max_caps_per_client) || (enforce_liveness && cache_liveness < (num_caps>>cache_liveness_magnitude))) {
       caps_session.emplace(std::piecewise_construct, std::forward_as_tuple(num_caps), std::forward_as_tuple(s));
     }
   };

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1208,6 +1208,7 @@ void Server::reconnect_clients(MDSContext *reconnect_done_)
   for (auto session : sessions) {
     if (session->is_open()) {
       client_reconnect_gather.insert(session->get_client());
+      session->set_reconnecting(true);
       session->last_cap_renew = now;
     }
   }
@@ -1357,6 +1358,7 @@ void Server::handle_client_reconnect(const MClientReconnect::const_ref &m)
 
     // remove from gather set
     client_reconnect_gather.erase(from);
+    session->set_reconnecting(false);
     if (client_reconnect_gather.empty())
       reconnect_gather_finish();
   }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1082,8 +1082,7 @@ void Server::evict_cap_revoke_non_responders() {
   }
 }
 
-void Server::handle_conf_change(const ConfigProxy& conf,
-                                const std::set <std::string> &changed) {
+void Server::handle_conf_change(const std::set<std::string>& changed) {
   if (changed.count("mds_cap_revoke_eviction_timeout")) {
     cap_revoke_eviction_timeout = g_conf().get_val<double>("mds_cap_revoke_eviction_timeout");
     dout(20) << __func__ << " cap revoke eviction timeout changed to "

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -174,6 +174,7 @@ public:
     STEADY = (1<<0),
     ENFORCE_MAX = (1<<1),
     TRIM = (1<<2),
+    ENFORCE_LIVENESS = (1<<3),
   };
   std::pair<bool, uint64_t> recall_client_state(MDSGatherBuilder* gather, RecallFlags=RecallFlags::NONE);
   void force_clients_readonly();

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -169,12 +169,13 @@ public:
   void reconnect_tick();
   void recover_filelocks(CInode *in, bufferlist locks, int64_t client);
 
-  enum RecallFlags {
+  enum class RecallFlags : uint64_t {
     NONE = 0,
     STEADY = (1<<0),
     ENFORCE_MAX = (1<<1),
+    TRIM = (1<<2),
   };
-  std::pair<bool, uint64_t> recall_client_state(MDSGatherBuilder* gather, enum RecallFlags=RecallFlags::NONE);
+  std::pair<bool, uint64_t> recall_client_state(MDSGatherBuilder* gather, RecallFlags=RecallFlags::NONE);
   void force_clients_readonly();
 
   // -- requests --
@@ -352,5 +353,22 @@ private:
   DecayCounter recall_throttle;
   time last_recall_state;
 };
+
+static inline constexpr auto operator|(Server::RecallFlags a, Server::RecallFlags b) {
+  using T = std::underlying_type<Server::RecallFlags>::type;
+  return static_cast<Server::RecallFlags>(static_cast<T>(a) | static_cast<T>(b));
+}
+static inline constexpr auto operator&(Server::RecallFlags a, Server::RecallFlags b) {
+  using T = std::underlying_type<Server::RecallFlags>::type;
+  return static_cast<Server::RecallFlags>(static_cast<T>(a) & static_cast<T>(b));
+}
+static inline std::ostream& operator<<(std::ostream& os, const Server::RecallFlags& f) {
+  using T = std::underlying_type<Server::RecallFlags>::type;
+  return os << "0x" << std::hex << static_cast<T>(f) << std::dec;
+}
+static inline constexpr bool operator!(const Server::RecallFlags& f) {
+  using T = std::underlying_type<Server::RecallFlags>::type;
+  return static_cast<T>(f) == static_cast<T>(0);
+}
 
 #endif

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -343,8 +343,7 @@ public:
 			       bool finish_mdr);
 
   void evict_cap_revoke_non_responders();
-  void handle_conf_change(const ConfigProxy& conf,
-                          const std::set <std::string> &changed);
+  void handle_conf_change(const std::set<std::string>& changed);
 
 private:
   void reply_client_request(MDRequestRef& mdr, const MClientReply::ref &reply);

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1019,8 +1019,7 @@ void SessionMap::hit_session(Session *session) {
   session->hit_session();
 }
 
-void SessionMap::handle_conf_change(const ConfigProxy &conf,
-                                    const std::set <std::string> &changed)
+void SessionMap::handle_conf_change(const std::set<std::string>& changed)
 {
   auto apply_to_open_sessions = [this](auto f) {
     if (auto it = by_state.find(Session::STATE_OPEN); it != by_state.end()) {

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1001,7 +1001,7 @@ int Session::check_access(CInode *in, unsigned mask,
   if (!auth_caps.is_capable(path, in->inode.uid, in->inode.gid, in->inode.mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
 			    new_uid, new_gid,
-			    socket_addr)) {
+			    info.inst.addr)) {
     return -EACCES;
   }
   return 0;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -874,18 +874,16 @@ void SessionMap::save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
  * Calculate the length of the `requests` member list,
  * because elist does not have a size() method.
  *
- * O(N) runtime.  This would be const, but elist doesn't
- * have const iterators.
+ * O(N) runtime.
  */
-size_t Session::get_request_count()
+size_t Session::get_request_count() const
 {
   size_t result = 0;
 
-  elist<MDRequestImpl*>::iterator p = requests.begin(
-      member_offset(MDRequestImpl, item_session_request));
-  while (!p.end()) {
+  auto it = requests.begin(member_offset(MDRequestImpl, item_session_request));
+  while (!it.end()) {
     ++result;
-    ++p;
+    ++it;
   }
 
   return result;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1037,7 +1037,6 @@ void SessionMap::handle_conf_change(const std::set<std::string>& changed)
 
   if (changed.count("mds_request_load_average_decay_rate")) {
     auto d = g_conf().get_val<double>("mds_request_load_average_decay_rate");
-    dout(20) << __func__ << " decay rate changed to " << d << dendl;
 
     decay_rate = d;
     total_load_avg = DecayCounter(d);

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -794,8 +794,7 @@ private:
 
 public:
   void hit_session(Session *session);
-  void handle_conf_change(const ConfigProxy &conf,
-                          const std::set <std::string> &changed);
+  void handle_conf_change(const std::set <std::string> &changed);
 };
 
 std::ostream& operator<<(std::ostream &out, const Session &s);

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -96,8 +96,11 @@ public:
     }
   }
 
+  void dump(Formatter *f) const;
+
 private:
   int state = STATE_CLOSED;
+  bool reconnecting = false;
   uint64_t state_seq = 0;
   int importing_count = 0;
   friend class SessionMap;
@@ -155,6 +158,9 @@ public:
       state_seq++;
     }
   }
+
+  void set_reconnecting(bool s) { reconnecting = s; }
+
   void decode(bufferlist::const_iterator &p);
   template<typename T>
   void set_client_metadata(T&& meta)

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -606,8 +606,8 @@ public:
   }
 
   bool is_any_state(int state) const {
-    map<int,xlist<Session*>* >::const_iterator p = by_state.find(state);
-    if (p == by_state.end() || p->second->empty())
+    auto it = by_state.find(state);
+    if (it == by_state.end() || it->second->empty())
       return false;
     return true;
   }

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -601,8 +601,7 @@ public:
   // sessions
   void decode_legacy(bufferlist::const_iterator& blp) override;
   bool empty() const { return session_map.empty(); }
-  const ceph::unordered_map<entity_name_t, Session*>& get_sessions() const
-  {
+  const auto& get_sessions() const {
     return session_map;
   }
 

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -172,7 +172,6 @@ public:
 protected:
   ConnectionRef connection;
 public:
-  entity_addr_t socket_addr;
   xlist<Session*>::item item_session_list;
 
   list<Message::ref> preopen_out_queue;  ///< messages for client, queued before they connect
@@ -422,8 +421,11 @@ public:
 
   void set_connection(ConnectionRef con) {
     connection = std::move(con);
-    if (connection) {
-      socket_addr = connection->get_peer_socket_addr();
+    auto& c = connection;
+    if (c) {
+      info.auth_name = c->get_peer_entity_name();
+      info.inst.addr = c->get_peer_socket_addr();
+      info.inst.name = entity_name_t(c->get_peer_type(), c->get_peer_global_id());
     }
   }
   const ConnectionRef& get_connection() const {

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -176,8 +176,11 @@ public:
 
   list<Message::ref> preopen_out_queue;  ///< messages for client, queued before they connect
 
-  elist<MDRequestImpl*> requests;
-  size_t get_request_count();
+  /* This is mutable to allow get_request_count to be const. elist does not
+   * support const iterators yet.
+   */
+  mutable elist<MDRequestImpl*> requests;
+  size_t get_request_count() const;
 
   interval_set<inodeno_t> pending_prealloc_inos; // journaling prealloc, will be added to prealloc_inos
 

--- a/src/mds/locks.c
+++ b/src/mds/locks.c
@@ -1,8 +1,3 @@
-// there must be a better way?
-typedef char bool;
-#define false 0
-#define true  1
-
 #include "include/int_types.h"
 
 #include <string.h>

--- a/src/mds/locks.h
+++ b/src/mds/locks.h
@@ -1,10 +1,10 @@
-
 #ifndef CEPH_MDS_LOCKS_H
 #define CEPH_MDS_LOCKS_H
+#include <stdbool.h>
 
 struct sm_state_t {
   int next;         // 0 if stable
-  char loner;
+  bool loner;
   int replica_state;
   char can_read;
   char can_read_projected;

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -542,8 +542,8 @@ void session_info_t::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("used_inos");
-  for (interval_set<inodeno_t>::const_iterator p = prealloc_inos.begin();
-       p != prealloc_inos.end();
+  for (interval_set<inodeno_t>::const_iterator p = used_inos.begin();
+       p != used_inos.end();
        ++p) {
     f->open_object_section("ino_range");
     f->dump_unsigned("start", p.get_start());

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -462,8 +462,8 @@ void client_metadata_t::decode(bufferlist::const_iterator& p)
 void client_metadata_t::dump(Formatter *f) const
 {
   f->dump_stream("features") << features;
-  for (const auto& p : kv_map)
-    f->dump_string(p.first.c_str(), p.second);
+  for (const auto& [name, val] : kv_map)
+    f->dump_string(name.c_str(), val);
 }
 
 /*
@@ -520,41 +520,33 @@ void session_info_t::dump(Formatter *f) const
   f->dump_stream("inst") << inst;
 
   f->open_array_section("completed_requests");
-  for (map<ceph_tid_t,inodeno_t>::const_iterator p = completed_requests.begin();
-       p != completed_requests.end();
-       ++p) {
+  for (const auto& [tid, ino] : completed_requests) {
     f->open_object_section("request");
-    f->dump_unsigned("tid", p->first);
-    f->dump_stream("created_ino") << p->second;
+    f->dump_unsigned("tid", tid);
+    f->dump_stream("created_ino") << ino;
     f->close_section();
   }
   f->close_section();
 
   f->open_array_section("prealloc_inos");
-  for (interval_set<inodeno_t>::const_iterator p = prealloc_inos.begin();
-       p != prealloc_inos.end();
-       ++p) {
+  for (const auto& [start, len] : prealloc_inos) {
     f->open_object_section("ino_range");
-    f->dump_unsigned("start", p.get_start());
-    f->dump_unsigned("length", p.get_len());
+    f->dump_unsigned("start", start);
+    f->dump_unsigned("length", len);
     f->close_section();
   }
   f->close_section();
 
   f->open_array_section("used_inos");
-  for (interval_set<inodeno_t>::const_iterator p = used_inos.begin();
-       p != used_inos.end();
-       ++p) {
+  for (const auto& [start, len] : used_inos) {
     f->open_object_section("ino_range");
-    f->dump_unsigned("start", p.get_start());
-    f->dump_unsigned("length", p.get_len());
+    f->dump_unsigned("start", start);
+    f->dump_unsigned("length", len);
     f->close_section();
   }
   f->close_section();
 
-  f->open_array_section("client_metadata");
-  client_metadata.dump(f);
-  f->close_section();
+  f->dump_object("client_metadata", client_metadata);
 }
 
 void session_info_t::generate_test_instances(list<session_info_t*>& ls)


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/41865
* https://tracker.ceph.com/issues/41899
* https://tracker.ceph.com/issues/42339

---

backport of:

* https://github.com/ceph/ceph/pull/27199 (5 commits)
* https://github.com/ceph/ceph/pull/28702 (13 commits)
* https://github.com/ceph/ceph/pull/28951 (2 commits)
* https://github.com/ceph/ceph/pull/30389 (1 commit)

GRAND TOTAL: 21 commits

parent trackers:

* https://tracker.ceph.com/issues/22446
* https://tracker.ceph.com/issues/40694
* https://tracker.ceph.com/issues/41835
