### PR TITLE
nautilus: cephfs: client: EINVAL may be returned when offset is 0

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8877,7 +8877,7 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
     break;
 
   case SEEK_CUR:
-    pos += offset;
+    pos = f->pos + offset;
     break;
 
   case SEEK_END:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42035

---

backport of https://github.com/ceph/ceph/pull/30312
parent tracker: https://tracker.ceph.com/issues/41837

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh
(ceph-backport.sh version: 15.0.0.5775)