### PR TITLE
nautilus: cephfs: client: add procession of SEEK_HOLE and SEEK_DATA in lseek

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8871,6 +8871,13 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
   int r;
   loff_t pos = -1;
 
+  if (whence == SEEK_END || whence == SEEK_DATA || whence == SEEK_HOLE) {
+    r = _getattr(in, CEPH_STAT_CAP_SIZE, f->actor_perms);
+    if (r < 0) {
+      return r;
+    }
+  }
+
   switch (whence) {
   case SEEK_SET:
     pos = offset;
@@ -8881,10 +8888,24 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
     break;
 
   case SEEK_END:
-    r = _getattr(in, CEPH_STAT_CAP_SIZE, f->actor_perms);
-    if (r < 0)
-      return r;
     pos = in->size + offset;
+    break;
+
+  case SEEK_DATA:
+    if (offset < 0 || offset >= in->size) {
+      r = -ENXIO;
+      return offset; 
+    }
+    pos = offset;
+    break;
+
+  case SEEK_HOLE:
+    if (offset < 0 || offset >= in->size) {
+      r = -ENXIO;
+      pos = offset; 
+    } else {
+      pos = in->size;
+    }
     break;
 
   default:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42121

---

backport of https://github.com/ceph/ceph/pull/30416
parent tracker: https://tracker.ceph.com/issues/42107

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh
(ceph-backport.sh version: 15.0.0.5775)