### PR TITLE
nautilus: doc/ceph-fuse: mention -k option in ceph-fuse man page

### DIFF
--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -50,6 +50,10 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
 
    Connect to specified monitor (instead of looking through ceph.conf).
 
+.. option:: -k <path-to-keyring>
+
+   Provide path to keyring; useful when it's absent in standard locations.
+
 .. option:: --client_mountpoint/-r root_directory
 
    Use root_directory as the mounted root, rather than the full Ceph tree.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42129

---

backport of https://github.com/ceph/ceph/pull/30561
parent tracker: https://tracker.ceph.com/issues/42044

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh
(ceph-backport.sh version: 15.0.0.5775)