### PR TITLE
nautilus: cephfs: client: remove Inode.dir_contacts field and handle bad whence value to llseek gracefully

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1047,20 +1047,6 @@ void Client::update_dir_dist(Inode *in, DirStat *dst)
 
   // replicated
   in->dir_replicated = !dst->dist.empty();  // FIXME that's just one frag!
-  
-  // dist
-  /*
-  if (!st->dirfrag_dist.empty()) {   // FIXME
-    set<int> dist = st->dirfrag_dist.begin()->second;
-    if (dist.empty() && !in->dir_contacts.empty())
-      ldout(cct, 9) << "lost dist spec for " << in->ino 
-              << " " << dist << dendl;
-    if (!dist.empty() && in->dir_contacts.empty()) 
-      ldout(cct, 9) << "got dist spec for " << in->ino 
-              << " " << dist << dendl;
-    in->dir_contacts = dist;
-  }
-  */
 }
 
 void Client::clear_dir_complete_and_ordered(Inode *diri, bool complete)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8874,7 +8874,8 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
     break;
 
   default:
-    ceph_abort();
+    ldout(cct, 1) << __func__ << ": invalid whence value " << whence << dendl;
+    return -EINVAL;
   }
 
   if (pos < 0) {

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -443,12 +443,6 @@ void Inode::dump(Formatter *f) const
   f->dump_unsigned("flags", flags);
 
   if (is_dir()) {
-    if (!dir_contacts.empty()) {
-      f->open_object_section("dir_contants");
-      for (set<int>::iterator p = dir_contacts.begin(); p != dir_contacts.end(); ++p)
-	f->dump_int("mds", *p);
-      f->close_section();
-    }
     f->dump_int("dir_hashed", (int)dir_hashed);
     f->dump_int("dir_replicated", (int)dir_replicated);
   }

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -191,7 +191,6 @@ struct Inode {
   // about the dir (if this is one!)
   Dir       *dir;     // if i'm a dir.
   fragtree_t dirfragtree;
-  set<int>  dir_contacts;
   uint64_t dir_release_count, dir_ordered_count;
   bool dir_hashed, dir_replicated;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42145

---

backport of https://github.com/ceph/ceph/pull/30580
parent tracker: https://tracker.ceph.com/issues/41871

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh
(ceph-backport.sh version: 15.0.0.5775)