### PR TITLE
nautilus: cephfs: mds returns -5(EIO) error when the deleted file does not exist

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8642,7 +8642,7 @@ void MDCache::_open_ino_backtrace_fetched(inodeno_t ino, bufferlist& bl, int err
   if (err == 0) {
     if (backtrace.ancestors.empty()) {
       dout(10) << " got empty backtrace " << dendl;
-      err = -EIO;
+      err = -ESTALE;
     } else if (!info.ancestors.empty()) {
       if (info.ancestors[0] == backtrace.ancestors[0]) {
 	dout(10) << " got same parents " << info.ancestors[0] << " 2 times" << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42147

---

backport of https://github.com/ceph/ceph/pull/30403
parent tracker: https://tracker.ceph.com/issues/41868

this backport was staged using https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh
(ceph-backport.sh version: 15.0.0.5775)