### PR TITLE
nautilus: mgr/BaseMgrStandbyModule: drop GIL in ceph_get_module_option()

### DIFF
--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -69,6 +69,7 @@ ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
     derr << "Invalid args!" << dendl;
     return nullptr;
   }
+  PyThreadState *tstate = PyEval_SaveThread();
   std::string final_key;
   std::string value;
   bool found = false;
@@ -80,6 +81,7 @@ ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
     final_key = what;
     found = self->this_module->get_config(final_key, &value);
   }
+  PyEval_RestoreThread(tstate);
   if (found) {
     dout(10) << __func__ << " " << final_key << " found: " << value
 	     << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42124

---

backport of https://github.com/ceph/ceph/pull/30625
parent tracker: https://tracker.ceph.com/issues/42087

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh