### PR TITLE
nautilus: mgr/prometheus: Fix KeyError in get_mgr_status

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -472,6 +472,7 @@ class Module(MgrModule):
 
         all_modules = {module.get('name'):module.get('can_run') for module in mgr_map['available_modules']}
 
+        ceph_release = None
         for mgr in all_mgrs:
             host_version = servers.get((mgr, 'mgr'), ('', ''))
             if mgr == active:
@@ -487,7 +488,7 @@ class Module(MgrModule):
             self.metrics['mgr_status'].set(_state, (
                 'mgr.{}'.format(mgr), 
             ))
-        always_on_modules = mgr_map['always_on_modules'][ceph_release]
+        always_on_modules = mgr_map['always_on_modules'].get(ceph_release, [])
         active_modules = list(always_on_modules)
         active_modules.extend(mgr_map['modules'])
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42144

---

backport of https://github.com/ceph/ceph/pull/30421
parent tracker: https://tracker.ceph.com/issues/41878

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh