### PR TITLE
mimic: rgw: fix list versions starts with version_id=null

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -281,7 +281,11 @@ static int encode_list_index_key(cls_method_context_t hctx, const cls_rgw_obj_ke
   }
 
   string obj_index_key;
-  encode_obj_index_key(key, &obj_index_key);
+  cls_rgw_obj_key tmp_key(key);
+  if (tmp_key.instance == "null") {
+    tmp_key.instance.clear();
+  }
+  encode_obj_versioned_data_key(tmp_key, &obj_index_key);
 
   rgw_bucket_dir_entry entry;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41979

---

backport of https://github.com/ceph/ceph/pull/29897
parent tracker: https://tracker.ceph.com/issues/41433

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh