### PR TITLE
rgw: dmclock: wait until the request is handled.

### DIFF
--- a/src/rgw/rgw_dmclock_sync_scheduler.cc
+++ b/src/rgw/rgw_dmclock_sync_scheduler.cc
@@ -27,8 +27,9 @@ int SyncScheduler::add_request(const client_id& client, const ReqParams& params,
     }
     queue.request_completed();
     // Perform a blocking wait until the request callback is called
-    if (std::unique_lock<std::mutex> lk(req_mtx); rstate != ReqState::Wait) {
-      req_cv.wait(lk, [&rstate] {return rstate != ReqState::Wait;});
+    {
+      std::unique_lock lock{req_mtx};
+      req_cv.wait(lock, [&rstate] {return rstate != ReqState::Wait;});
     }
     if (rstate == ReqState::Cancelled) {
       //FIXME: decide on error code for cancelled request


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
[rgw dmclock]:fix a logic issue in dmclock code.
   Recently, we are testing the dmclock code in rgw. After we merged  the sync scheduler part and test it , found it doesn't work. Finally I found a error as this commit. 
   the restate initial value is ReqState::Wait, so when rgw_dmclock_sync_scheduler.cc:line 30 , it should wait the mutex lock and block the process request thread. the origin code is **!=**, it is unreasonable. I think it should be corrected.

-    if (std::unique_lock<std::mutex> lk(req_mtx); rstate != ReqState::Wait) {
+    if (std::unique_lock<std::mutex> lk(req_mtx); rstate == ReqState::Wait) {
       req_cv.wait(lk, [&rstate] {return rstate != ReqState::Wait;});
     }
fixes: https://tracker.ceph.com/issues/42217
Signed-off-by: GaryHyg  huygbj@inspur.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
