### PR TITLE
rgw: fix SignatureDoesNotMatch when use ipv6 address in s3 client

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -2032,9 +2032,17 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
   bool s3website_enabled = api_priority_s3website >= 0;
 
   if (info.host.size()) {
-    ssize_t pos = info.host.find(':');
-    if (pos >= 0) {
-      info.host = info.host.substr(0, pos);
+    ssize_t pos;
+    if (info.host.find('[') == 0) {
+      pos = info.host.find(']');
+      if (pos >=1) {
+        info.host = info.host.substr(1, pos-1);
+      }
+    } else {
+      pos = info.host.find(':');
+      if (pos >= 0) {
+        info.host = info.host.substr(0, pos);
+      }
     }
     ldout(s->cct, 10) << "host=" << info.host << dendl;
     string domain;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -727,6 +727,10 @@ class RGWHandler_REST_Obj_S3Website;
 
 static inline bool looks_like_ip_address(const char *bucket)
 {
+  struct in6_addr a;
+  if (inet_pton(AF_INET6, bucket, static_cast<void*>(&a)) == 1) {
+    return true;
+  }
   int num_periods = 0;
   bool expect_period = false;
   for (const char *b = bucket; *b; ++b) {


### PR DESCRIPTION
here is my s3 java sdk test ipv6

```
        AWSCredentials credentials = new BasicAWSCredentials("yly", "yly");
        ClientConfiguration s3_opts = new ClientConfiguration();
        s3_opts.setSignerOverride("S3SignerType");
        AmazonS3 s3_client = new AmazonS3Client(credentials, s3_opts);
        s3_client.setEndpoint("http://[2409:8050:3000:5000:1400::238]");
        s3_client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
        s3_client.listObjects("test1");
```
and it is 403 SignatureDoesNotMatch error

the rgw log below
```
2019-10-08T15:00:45.853+0800 7f5571da4700 15 req 1 0.007999973s s3:get_obj string_to_sign=GET

application/octet-stream
Tue, 08 Oct 2019 07:00:45 GMT
/[2409/test1/
2019-10-08T15:00:45.853+0800 7f5571da4700 15 req 1 0.007999973s s3:get_obj server signature=uWtjhLmR4ADsAdmrRWgTnJrRObI=
2019-10-08T15:00:45.853+0800 7f5571da4700 15 req 1 0.007999973s s3:get_obj client signature=3Ad+klS9c4Irf+A/D/4YGgUgE4M=
2019-10-08T15:00:45.853+0800 7f5571da4700 15 req 1 0.007999973s s3:get_obj compare=-66
2019-10-08T15:00:45.853+0800 7f5571da4700 20 req 1 0.007999973s s3:get_obj rgw::auth::s3::LocalEngine denied with reason=-2027
2019-10-08T15:00:45.853+0800 7f5571da4700 20 req 1 0.007999973s s3:get_obj rgw::auth::s3::AWSAuthStrategy denied with reason=-2027
2019-10-08T15:00:45.853+0800 7f5571da4700 20 req 1 0.007999973s s3:get_obj rgw::auth::StrategyRegistry::s3_main_strategy_t: trying rgw::auth::s3::AWSAuthStrategy
2019-10-08T15:00:45.853+0800 7f5571da4700 20 req 1 0.007999973s s3:get_obj rgw::auth::s3::AWSAuthStrategy: trying rgw::auth::s3::LocalEngine
2019-10-08T15:00:45.853+0800 7f5571da4700 10 get_canon_resource(): dest=/[2409/test1/
2019-10-08T15:00:45.853+0800 7f5571da4700 10 req 1 0.007999973s string_to_sign:
GET

application/octet-stream
Tue, 08 Oct 2019 07:00:45 GMT
/[2409/test1/    <== wrong here
2019-10-08T15:00:45.853+0800 7f5571da4700 15 req 1 0.007999973s s3:get_obj string_to_sign=GET

application/octet-stream
Tue, 08 Oct 2019 07:00:45 GMT
/[2409/test1/
```

fix: https://tracker.ceph.com/issues/42218