### PR TITLE
mgr/dashboard: tox.ini fixes

### DIFF
--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -15,11 +15,23 @@ addopts =
     --ignore=frontend/ --ignore=module.py
     --instafail
 
+[base]
+deps =
+    -r requirements.txt
+    -c constraints.txt
+
+[base-test]
+deps =
+    -r requirements-test.txt
+
+[base-lint]
+deps =
+    -r requirements-lint.txt
+
 [testenv]
 deps =
-    -rrequirements.txt
-    -cconstraints.txt
-    -rrequirements-test.txt
+    {[base]deps}
+    {[base-test]deps}
 setenv =
     CFLAGS = -DXMLSEC_NO_SIZE_T
     PYTHONUNBUFFERED=1
@@ -30,6 +42,11 @@ commands =
     pytest {posargs}
 
 [testenv:run]
+basepython=python3
+deps =
+    {[base]deps}
+    {[base-test]deps}
+    {[base-lint]deps}
 whitelist_externals = *
 commands = {posargs}
 
@@ -57,27 +74,48 @@ format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(co
 # Allow similarity/code duplication detection
 jobs = 1
 dirs = . controllers plugins services tests
-addopts =
-    -rn
-    --rcfile=.pylintrc
-    --jobs={[pylint]jobs}
+addopts = -rn --rcfile=.pylintrc --jobs={[pylint]jobs}
 
 [rstlint]
-dirs =
-    README.rst
-    HACKING.rst
+dirs = README.rst HACKING.rst
+
+[base-pylint]
+commands =
+    pylint {[pylint]addopts} {[pylint]dirs}
+
+[base-rst]
+commands =
+    rstcheck --report info --debug -- {[rstlint]dirs}
 
 [testenv:lint]
 basepython=python3
 deps =
-    -rrequirements.txt
-    -cconstraints.txt
-    -rrequirements-lint.txt
+    {[base]deps}
+    {[base-lint]deps}
 commands =
-    lint: flake8 {posargs}
-    lint: pylint {[pylint]addopts} {posargs:{[pylint]dirs}}
-    lint: rstcheck --report info --debug {posargs:{[rstlint]dirs}}
+    flake8
+    {[base-pylint]commands}
+    {[base-rst]commands}
 
+[testenv:flake8]
+basepython = python3
+deps = {[base-lint]deps}
+commands =
+    flake8 --config=tox.ini {posargs}
+
+[testenv:pylint]
+basepython = python3
+deps =
+    {[base]deps}
+    {[base-lint]deps}
+commands =
+    pylint {[pylint]addopts} {posargs:{[pylint]dirs}}
+
+[testenv:rst]
+basepython = python3
+deps = {[base-lint]deps}
+commands =
+    rstcheck --report info --debug -- {posargs:{[rstlint]dirs}}
 
 [autopep8]
 addopts =
@@ -92,7 +130,7 @@ addopts =
 [testenv:fix]
 basepython=python3
 deps =
-    -rrequirements-lint.txt
+    {[base-lint]deps}
 commands =
     python --version
     autopep8 {[autopep8]addopts} {posargs:.}


### PR DESCRIPTION
* When running
```tox -e lint <file>``` (note the "file" positional argument)
flake8's max-line-length was ignored, so added ```--config=tox.ini```
to ensure the flake8 config is always loaded even with positional argument.

* When running
```tox -e lint <file>``` the purpose is to lint the python file, but the 3rd command
```rstcheck``` does not make sense to be run when passing positional argument,
so fixed to run only when there is no positional argument (```tox -e lint```, jenkins).

* Added missing dependencies for ```run```: ```tox -e run <...>```.


Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
