### PR TITLE
rgw: add abort multipart date and rule-id header to init multipart upload response

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1735,7 +1735,7 @@ bool s3_multipart_abort_header(
     std::optional<ceph::real_time> rule_abort_date;
     if (mp_expiration.has_days()) {
       rule_abort_date = std::optional<ceph::real_time>(
-              mtime + make_timespan(mp_expiration.get_days()*24*60*60));
+              mtime + make_timespan(mp_expiration.get_days()*24*60*60 - ceph::real_clock::to_time_t(mtime)%(24*60*60) + 24*60*60));
     }
 
     // update earliest abort date

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1716,15 +1716,15 @@ bool s3_multipart_abort_header(
     return false;
   } /* catch */
 
-  boost::optional<ceph::real_time> abort_date_tmp;
-  boost::optional<std::string> rule_id_tmp;
+  std::optional<ceph::real_time> abort_date_tmp;
+  std::optional<std::string_view> rule_id_tmp;
   const auto& rule_map = config.get_rule_map();
   for (const auto& ri : rule_map) {
     const auto& rule = ri.second;
-    auto& id = rule.get_id();
-    auto& filter = rule.get_filter();
-    auto& prefix = filter.has_prefix()?filter.get_prefix():rule.get_prefix();
-    auto& mp_expiration = rule.get_mp_expiration();
+    const auto& id = rule.get_id();
+    const auto& filter = rule.get_filter();
+    const auto& prefix = filter.has_prefix()?filter.get_prefix():rule.get_prefix();
+    const auto& mp_expiration = rule.get_mp_expiration();
     if (!rule.is_enabled()) {
       continue;
     }
@@ -1732,11 +1732,10 @@ bool s3_multipart_abort_header(
       continue;
     }
 
-    boost::optional<ceph::real_time> rule_abort_date;
-    const LCExpiration& rule_abort_multipart =mp_expiration;
-    if (rule_abort_multipart.has_days()) {
-      rule_abort_date = boost::optional<ceph::real_time>(
-              mtime + make_timespan(rule_abort_multipart.get_days()*24*60*60));
+    std::optional<ceph::real_time> rule_abort_date;
+    if (mp_expiration.has_days()) {
+      rule_abort_date = std::optional<ceph::real_time>(
+              mtime + make_timespan(mp_expiration.get_days()*24*60*60));
     }
 
     // update earliest abort date
@@ -1744,8 +1743,8 @@ bool s3_multipart_abort_header(
       if ((! abort_date_tmp) ||
           (*abort_date_tmp > *rule_abort_date)) {
         abort_date_tmp =
-                boost::optional<ceph::real_time>(rule_abort_date);
-        rule_id_tmp = boost::optional<std::string>(id);
+                std::optional<ceph::real_time>(rule_abort_date);
+        rule_id_tmp = std::optional<std::string_view>(id);
       }
     }
   }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1691,4 +1691,71 @@ std::string s3_expiration_header(
 
 } /* rgwlc_s3_expiration_header */
 
+bool s3_multipart_abort_header(
+  DoutPrefixProvider* dpp,
+  const rgw_obj_key& obj_key,
+  const ceph::real_time& mtime,
+  const std::map<std::string, buffer::list>& bucket_attrs,
+  ceph::real_time& abort_date,
+  std::string& rule_id)
+{
+  CephContext* cct = dpp->get_cct();
+  RGWLifecycleConfiguration config(cct);
+
+  const auto& aiter = bucket_attrs.find(RGW_ATTR_LC);
+  if (aiter == bucket_attrs.end())
+    return false;
+
+  bufferlist::const_iterator iter{&aiter->second};
+  try {
+    config.decode(iter);
+  } catch (const buffer::error& e) {
+    ldpp_dout(dpp, 0) << __func__
+                      <<  "() decode life cycle config failed"
+                      << dendl;
+    return false;
+  } /* catch */
+
+  boost::optional<ceph::real_time> abort_date_tmp;
+  boost::optional<std::string> rule_id_tmp;
+  const auto& rule_map = config.get_rule_map();
+  for (const auto& ri : rule_map) {
+    const auto& rule = ri.second;
+    auto& id = rule.get_id();
+    auto& filter = rule.get_filter();
+    auto& prefix = filter.has_prefix()?filter.get_prefix():rule.get_prefix();
+    auto& mp_expiration = rule.get_mp_expiration();
+    if (!rule.is_enabled()) {
+      continue;
+    }
+    if(!prefix.empty() && !boost::starts_with(obj_key.name, prefix)) {
+      continue;
+    }
+
+    boost::optional<ceph::real_time> rule_abort_date;
+    const LCExpiration& rule_abort_multipart =mp_expiration;
+    if (rule_abort_multipart.has_days()) {
+      rule_abort_date = boost::optional<ceph::real_time>(
+              mtime + make_timespan(rule_abort_multipart.get_days()*24*60*60));
+    }
+
+    // update earliest abort date
+    if (rule_abort_date) {
+      if ((! abort_date_tmp) ||
+          (*abort_date_tmp > *rule_abort_date)) {
+        abort_date_tmp =
+                boost::optional<ceph::real_time>(rule_abort_date);
+        rule_id_tmp = boost::optional<std::string>(id);
+      }
+    }
+  }
+  if (abort_date_tmp && rule_id_tmp) {
+    abort_date = *abort_date_tmp;
+    rule_id = *rule_id_tmp;
+    return true;
+  } else {
+    return false;
+  }
+}
+
 } /* namespace rgw::lc */

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -522,6 +522,14 @@ std::string s3_expiration_header(
   const ceph::real_time& mtime,
   const std::map<std::string, buffer::list>& bucket_attrs);
 
+bool s3_multipart_abort_header(
+  DoutPrefixProvider* dpp,
+  const rgw_obj_key& obj_key,
+  const ceph::real_time& mtime,
+  const std::map<std::string, buffer::list>& bucket_attrs,
+  ceph::real_time& abort_date,
+  std::string& rule_id);
+
 } // namespace rgw::lc
 
 #endif

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5945,6 +5945,7 @@ void RGWInitMultipart::execute()
     obj_op.meta.owner = s->owner.get_id();
     obj_op.meta.category = RGWObjCategory::MultiMeta;
     obj_op.meta.flags = PUT_OBJ_CREATE_EXCL;
+    obj_op.meta.mtime = &mtime;
 
     multipart_upload_info upload_info;
     upload_info.dest_placement = s->dest_placement;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1717,6 +1717,7 @@ class RGWInitMultipart : public RGWOp {
 protected:
   string upload_id;
   RGWAccessControlPolicy policy;
+  ceph::real_time mtime;
 
 public:
   RGWInitMultipart() {}

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -106,6 +106,14 @@ static inline std::string get_s3_expiration_header(
     s, s->object, s->tagset, mtime, s->bucket_attrs);
 }
 
+static inline bool get_s3_multipart_abort_header(
+  struct req_state* s, const ceph::real_time& mtime,
+  ceph::real_time& date, std::string& rule_id)
+{
+  return rgw::lc::s3_multipart_abort_header(
+          s, s->object, mtime, s->bucket_attrs, date, rule_id);
+}
+
 struct response_attr_param {
   const char *param;
   const char *http_attr;
@@ -3658,6 +3666,13 @@ void RGWInitMultipart_ObjStore_S3::send_response()
   dump_errno(s);
   for (auto &it : crypt_http_responses)
      dump_header(s, it.first, it.second);
+  ceph::real_time abort_date;
+  string rule_id;
+  bool exist_multipart_abort = get_s3_multipart_abort_header(s, mtime, abort_date, rule_id);
+  if (exist_multipart_abort) {
+    dump_time_header(s, "x-amz-abort-date", abort_date);
+    dump_header_if_nonempty(s, "x-amz-abort-rule-id", rule_id);
+  }
   end_header(s, this, "application/xml");
   if (op_ret == 0) {
     dump_start(s);


### PR DESCRIPTION
If abort multipart upload is configured in lifecycle, `x-amz-abort-date` and `x-amz-abort-rule-id` should be returned in response header.
https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html

Fixes: https://tracker.ceph.com/issues/45077

Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>

