### PR TITLE
rgw: return earliest expiraton date header and corresponding rule id.

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1645,22 +1645,19 @@ std::string s3_expiration_header(
       rule_expiration_date =
 	boost::optional<ceph::real_time>(
 	  ceph::from_iso_8601(rule.get_expiration().get_date()));
-      rule_id = boost::optional<std::string>(id);
     } else {
       if (rule_expiration.has_days()) {
 	rule_expiration_date =
 	  boost::optional<ceph::real_time>(
 	    mtime + make_timespan(rule_expiration.get_days()*24*60*60));
-	rule_id = boost::optional<std::string>(id);
       }
     }
 
     // update earliest expiration
     if (rule_expiration_date) {
-      if ((! expiration_date) ||
-	  (*expiration_date < *rule_expiration_date)) {
-      expiration_date =
-	boost::optional<ceph::real_time>(rule_expiration_date);
+      if ((! expiration_date) || (*expiration_date > *rule_expiration_date)) {
+        expiration_date = boost::optional<ceph::real_time>(rule_expiration_date);
+        rule_id = boost::optional<std::string>(id);
       }
     }
   }


### PR DESCRIPTION
If there is more than one rule matches，the returned value isn't the earliest expiration date. Besides, rule id doesn't correspond to the expiration date.

Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>

