### PR TITLE
ceph-volume: revert --no-tmpfs change

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -121,7 +121,7 @@ def get_osd_device_path(osd_lv, lvs, device_type, dmcrypt_secret=None):
     raise RuntimeError('could not find %s with uuid %s' % (device_type, device_uuid))
 
 
-def activate_bluestore(lvs, no_systemd=False, tmpfs=True):
+def activate_bluestore(lvs, no_systemd=False, no_tmpfs=False):
     # find the osd
     osd_lv = lvs.get(lv_tags={'ceph.type': 'block'})
     if not osd_lv:
@@ -136,7 +136,7 @@ def activate_bluestore(lvs, no_systemd=False, tmpfs=True):
     osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
     if not system.path_is_mounted(osd_path):
         # mkdir -p and mount as tmpfs
-        prepare_utils.create_osd_path(osd_id, tmpfs=tmpfs)
+        prepare_utils.create_osd_path(osd_id, tmpfs=(not no_tmpfs))
     # XXX This needs to be removed once ceph-bluestore-tool can deal with
     # symlinks that exist in the osd dir
     for link_name in ['block', 'block.db', 'block.wal']:
@@ -262,11 +262,11 @@ class Activate(object):
             logger.info('unable to find a journal associated with the OSD, assuming bluestore')
             return activate_bluestore(lvs,
                                       no_systemd=args.no_systemd,
-                                      tmpfs=(not args.no_tmpfs))
+                                      no_tmpfs=args.no_tmpfs)
         if args.bluestore:
             activate_bluestore(lvs,
                                no_systemd=args.no_systemd,
-                               tmpfs=(not args.no_tmpfs))
+                               no_tmpfs=args.no_tmpfs)
         elif args.filestore:
             activate_filestore(lvs, no_systemd=args.no_systemd)
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -121,7 +121,7 @@ def get_osd_device_path(osd_lv, lvs, device_type, dmcrypt_secret=None):
     raise RuntimeError('could not find %s with uuid %s' % (device_type, device_uuid))
 
 
-def activate_bluestore(lvs, no_systemd=False, no_tmpfs=False):
+def activate_bluestore(lvs, no_systemd=False):
     # find the osd
     osd_lv = lvs.get(lv_tags={'ceph.type': 'block'})
     if not osd_lv:
@@ -136,7 +136,7 @@ def activate_bluestore(lvs, no_systemd=False, no_tmpfs=False):
     osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
     if not system.path_is_mounted(osd_path):
         # mkdir -p and mount as tmpfs
-        prepare_utils.create_osd_path(osd_id, tmpfs=(not no_tmpfs))
+        prepare_utils.create_osd_path(osd_id, tmpfs=True)
     # XXX This needs to be removed once ceph-bluestore-tool can deal with
     # symlinks that exist in the osd dir
     for link_name in ['block', 'block.db', 'block.wal']:
@@ -260,13 +260,9 @@ class Activate(object):
                     logger.info('found a journal associated with the OSD, assuming filestore')
                     return activate_filestore(lvs, no_systemd=args.no_systemd)
             logger.info('unable to find a journal associated with the OSD, assuming bluestore')
-            return activate_bluestore(lvs,
-                                      no_systemd=args.no_systemd,
-                                      no_tmpfs=args.no_tmpfs)
+            return activate_bluestore(lvs, no_systemd=args.no_systemd)
         if args.bluestore:
-            activate_bluestore(lvs,
-                               no_systemd=args.no_systemd,
-                               no_tmpfs=args.no_tmpfs)
+            activate_bluestore(lvs, no_systemd=args.no_systemd)
         elif args.filestore:
             activate_filestore(lvs, no_systemd=args.no_systemd)
 
@@ -330,12 +326,6 @@ class Activate(object):
             dest='no_systemd',
             action='store_true',
             help='Skip creating and enabling systemd units and starting OSD services',
-        )
-        parser.add_argument(
-            '--no-tmpfs',
-            dest='no_tmpfs',
-            action='store_true',
-            help='Do not create a tmpfs for the OSD directory',
         )
         if len(self.argv) == 0:
             print(sub_command_help)


### PR DESCRIPTION
This broke things, but more importantly it didn't end up being necessary: c-v seems to skip the tmpfs part if the data directory already exists, so ceph-daemon works as intended without any changes.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>