### PR TITLE
test/crimson: cbt test does rand-reads instead of seq-reads.

### DIFF
--- a/src/test/crimson/cbt/radosbench_4K_read.yaml
+++ b/src/test/crimson/cbt/radosbench_4K_read.yaml
@@ -13,6 +13,7 @@ tasks:
         pool_profile: 'replicated'
         read_time: 30
         read_only: true
+        readmode: 'rand'
         prefill_time: 3
         acceptable:
           bandwidth: '(or (greater) (near 0.05))'


### PR DESCRIPTION
The rationale behind the change is not only that random read performance tends to be more important and meaningful. Actually, the current procedure is broken because of how `rados bench` internally operates: the number of seq read operations is limited by the number of write ops used to create the data set (`write` with the `--no-cleanup` option):

  ```cpp
  int ObjBencher::write_bench(/* ... */) {
    // ...
    //write object size/number data for read benchmarks
    encode(data.object_size, b_write);
    encode(data.finished, b_write);

    //...

  int ObjBencher::fetch_bench_metadata(// ...
                                       int* num_ops, /* ... */) {
    // ...
    decode(*object_size, p);
    decode(*num_ops, p);

  int ObjBencher::seq_read_bench(
    int seconds_to_run, int num_ops, int num_objects,
    int concurrentios, int pid, bool no_verify) {

    // ...

    //start initial reads
    for (int i = 0; i < concurrentios; ++i) {
      // ...
      ++data.started;
    }

    // ...

    while ((seconds_to_run && mono_clock::now() < finish_time) &&
           num_ops > data.started) {
  ```

This makes significant problem as the cbt test uses short (3 sec.) period of prefill. In the consequence, the sequential read testing takes around half-second.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
