### PR TITLE
[DNM] cls_fifo: fifo over RADOS

### DIFF
--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -264,3 +264,20 @@ install(TARGETS cls_cas DESTINATION ${cls_dir})
 set(cls_cas_client_srcs
   cas/cls_cas_client.cc)
 add_library(cls_cas_client STATIC ${cls_cas_client_srcs})
+
+# cls_fifo
+set(cls_fifo_srcs fifo/cls_fifo.cc)
+add_library(cls_fifo SHARED ${cls_fifo_srcs})
+set_target_properties(cls_fifo PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH ""
+  CXX_VISIBILITY_PRESET hidden)
+install(TARGETS cls_fifo DESTINATION ${cls_dir})
+
+set(cls_fifo_client_srcs
+  fifo/cls_fifo_client.cc
+  fifo/cls_fifo_types.cc
+  fifo/cls_fifo_ops.cc)
+add_library(cls_fifo_client STATIC ${cls_fifo_client_srcs})
+

--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -266,7 +266,7 @@ set(cls_cas_client_srcs
 add_library(cls_cas_client STATIC ${cls_cas_client_srcs})
 
 # cls_fifo
-set(cls_fifo_srcs fifo/cls_fifo.cc)
+set(cls_fifo_srcs fifo/cls_fifo.cc fifo/cls_fifo_types.cc)
 add_library(cls_fifo SHARED ${cls_fifo_srcs})
 set_target_properties(cls_fifo PROPERTIES
   VERSION "1.0.0"

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -197,12 +197,12 @@ static int read_header(cls_method_context_t hctx,
   return 0;
 }
 
-static int fifo_create_op(cls_method_context_t hctx,
+static int fifo_meta_create_op(cls_method_context_t hctx,
                           bufferlist *in, bufferlist *out)
 {
   CLS_LOG(20, "%s", __func__);
 
-  cls_fifo_create_op op;
+  cls_fifo_meta_create_op op;
   try {
     auto iter = in->cbegin();
     decode(op, iter);
@@ -272,12 +272,12 @@ static int fifo_create_op(cls_method_context_t hctx,
   return 0;
 }
 
-static int fifo_update_state_op(cls_method_context_t hctx,
+static int fifo_meta_update_op(cls_method_context_t hctx,
                                 bufferlist *in, bufferlist *out)
 {
   CLS_LOG(20, "%s", __func__);
 
-  cls_fifo_update_state_op op;
+  cls_fifo_meta_update_op op;
   try {
     auto iter = in->cbegin();
     decode(op, iter);
@@ -318,12 +318,12 @@ static int fifo_update_state_op(cls_method_context_t hctx,
   return 0;
 }
 
-static int fifo_get_info_op(cls_method_context_t hctx,
+static int fifo_meta_get_op(cls_method_context_t hctx,
                           bufferlist *in, bufferlist *out)
 {
   CLS_LOG(20, "%s", __func__);
 
-  cls_fifo_get_info_op op;
+  cls_fifo_meta_get_op op;
   try {
     auto iter = in->cbegin();
     decode(op, iter);
@@ -332,7 +332,7 @@ static int fifo_get_info_op(cls_method_context_t hctx,
     return -EINVAL;
   }
 
-  cls_fifo_get_info_op_reply reply;
+  cls_fifo_meta_get_op_reply reply;
   int r = read_header(hctx, op.objv, &reply.info);
   if (r < 0) {
     return r;
@@ -343,12 +343,12 @@ static int fifo_get_info_op(cls_method_context_t hctx,
   return 0;
 }
 
-static int fifo_init_part_op(cls_method_context_t hctx,
+static int fifo_part_init_op(cls_method_context_t hctx,
                              bufferlist *in, bufferlist *out)
 {
   CLS_LOG(20, "%s", __func__);
 
-  cls_fifo_init_part_op op;
+  cls_fifo_part_init_op op;
   try {
     auto iter = in->cbegin();
     decode(op, iter);
@@ -476,28 +476,28 @@ CLS_INIT(fifo)
   CLS_LOG(20, "Loaded fifo class!");
 
   cls_handle_t h_class;
-  cls_method_handle_t h_fifo_create_op;
-  cls_method_handle_t h_fifo_get_info_op;
-  cls_method_handle_t h_fifo_init_part_op;
-  cls_method_handle_t h_fifo_update_state_op;
+  cls_method_handle_t h_fifo_meta_create_op;
+  cls_method_handle_t h_fifo_meta_get_op;
+  cls_method_handle_t h_fifo_meta_update_op;
+  cls_method_handle_t h_fifo_part_init_op;
   cls_method_handle_t h_fifo_part_push_op;;
 
   cls_register("fifo", &h_class);
-  cls_register_cxx_method(h_class, "fifo_create",
+  cls_register_cxx_method(h_class, "fifo_meta_create",
                           CLS_METHOD_RD | CLS_METHOD_WR,
-                          fifo_create_op, &h_fifo_create_op);
+                          fifo_meta_create_op, &h_fifo_meta_create_op);
 
-  cls_register_cxx_method(h_class, "fifo_get_info",
+  cls_register_cxx_method(h_class, "fifo_meta_get",
                           CLS_METHOD_RD,
-                          fifo_get_info_op, &h_fifo_get_info_op);
+                          fifo_meta_get_op, &h_fifo_meta_get_op);
 
-  cls_register_cxx_method(h_class, "fifo_init_part",
+  cls_register_cxx_method(h_class, "fifo_meta_update",
                           CLS_METHOD_RD | CLS_METHOD_WR,
-                          fifo_init_part_op, &h_fifo_init_part_op);
+                          fifo_meta_update_op, &h_fifo_meta_update_op);
 
-  cls_register_cxx_method(h_class, "fifo_update_state",
+  cls_register_cxx_method(h_class, "fifo_part_init",
                           CLS_METHOD_RD | CLS_METHOD_WR,
-                          fifo_update_state_op, &h_fifo_update_state_op);
+                          fifo_part_init_op, &h_fifo_part_init_op);
 
   cls_register_cxx_method(h_class, "fifo_part_push",
                           CLS_METHOD_RD | CLS_METHOD_WR,

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -295,15 +295,41 @@ static int fifo_meta_update_op(cls_method_context_t hctx,
   }
 
   if (op.head_part_num) {
+    header.tags.erase(header.head_part_num);
     header.head_part_num = *op.head_part_num;
+    auto iter = header.tags.find(header.head_part_num);
+    if (iter != header.tags.end()) {
+      header.head_tag = iter->second;
+    } else {
+      header.head_tag.erase();
+    }
   }
 
-  if (op.head_tag) {
-    header.head_tag = *op.head_tag;
+  if (op.min_push_part_num) {
+    header.min_push_part_num = *op.min_push_part_num;
   }
 
-  if (op.head_prepare_status) {
-    header.head_prepare_status = *op.head_prepare_status;
+  if (op.max_push_part_num) {
+    header.max_push_part_num = *op.max_push_part_num;
+  }
+
+  for (auto& entry : op.journal_entries_add) {
+    if (header.journal.find(entry.part_num) != header.journal.end()) {
+      /* don't allow multiple concurrent operations on the same part,
+         racing clients should use objv to avoid races anyway */
+      CLS_LOG(10, "%s(): NOTICE: multiple concurrent operations on same part are not allowed, part num=%lld", __func__, (long long)entry.part_num);
+      return -EINVAL;
+    }
+
+    header.journal[entry.part_num] = std::move(entry);
+
+    if (entry.op == fifo_journal_entry_t::Op::OP_CREATE) {
+      header.tags[entry.part_num] = entry.part_tag;
+    }
+  }
+
+  for (auto& entry : op.journal_entries_rm) {
+    header.journal.erase(entry.part_num);
   }
 
   r = write_header(hctx, header);

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -386,6 +386,8 @@ static int fifo_init_part_op(cls_method_context_t hctx,
   part_header.tag = op.tag;
   part_header.params = op.data_params;
 
+  cls_gen_random_bytes((char *)&part_header.magic, sizeof(part_header.magic));
+
   r = write_part_header(hctx, part_header);
   if (r < 0) {
     CLS_LOG(10, "%s(): failed to write header: r=%d", __func__, r);

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -700,9 +700,17 @@ static int fifo_part_list_op(cls_method_context_t hctx,
     return r;
   }
 
+  if (op.tag &&
+      !(part_header.tag == *op.tag)) {
+    CLS_LOG(10, "%s(): bad tag", __func__);
+    return -EINVAL;
+  }
+
   EntryReader reader(hctx, part_header, op.ofs);
 
   cls_fifo_part_list_op_reply reply;
+
+  reply.tag = part_header.tag;
 
   for (int i = 0; i < op.max_entries && !reader.end(); ++i) {
     bufferlist data;

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -1,0 +1,233 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/** \file
+ *
+ * This is an OSD class that implements methods for management
+ * and use of fifo
+ *
+ */
+
+#include <errno.h>
+
+#include "objclass/objclass.h"
+
+#include "cls/fifo/cls_fifo_ops.h"
+#include "cls/fifo/cls_fifo_types.h"
+
+
+using namespace rados::cls::fifo;
+
+
+CLS_VER(1,0)
+CLS_NAME(fifo)
+
+struct cls_fifo_header {
+  string id;
+  struct {
+    string name;
+    string ns;
+  } pool;
+  string oid_prefix;
+
+  uint64_t tail_obj_num{0};
+  uint64_t head_obj_num{0};
+
+  string head_tag;
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(id, bl);
+    encode(pool.name, bl);
+    encode(pool.ns, bl);
+    encode(oid_prefix, bl);
+    encode(tail_obj_num, bl);
+    encode(head_obj_num, bl);
+    encode(head_tag, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(id, bl);
+    decode(pool.name, bl);
+    decode(pool.ns, bl);
+    decode(oid_prefix, bl);
+    decode(tail_obj_num, bl);
+    decode(head_obj_num, bl);
+    decode(head_tag, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_header)
+
+struct cls_fifo_data_obj_header {
+  string tag;
+
+  fifo_data_params_t params;
+
+  uint64_t magic{0};
+
+  uint64_t min_ofs{0};
+  uint64_t max_ofs{0};
+  uint64_t min_index{0};
+  uint64_t max_index{0};
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(tag, bl);
+    encode(params, bl);
+    encode(magic, bl);
+    encode(min_ofs, bl);
+    encode(max_ofs, bl);
+    encode(min_index, bl);
+    encode(max_index, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(tag, bl);
+    decode(params, bl);
+    decode(magic, bl);
+    decode(min_ofs, bl);
+    decode(max_ofs, bl);
+    decode(min_index, bl);
+    decode(max_index, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_data_obj_header)
+
+struct cls_fifo_entry_header_pre {
+/* FIXME: le64_t */
+  uint64_t magic{0};
+  uint64_t header_size{0};
+};
+
+struct cls_fifo_entry_header {
+  uint64_t index{0};
+  uint64_t size{0};
+  ceph::real_time mtime;
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(index, bl);
+    encode(size, bl);
+    encode(mtime, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(index, bl);
+    decode(size, bl);
+    decode(mtime, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_entry_header)
+
+
+static string new_oid_prefix(string id, std::optional<string>& val)
+{
+  if (val) {
+    return *val;
+  }
+
+#define PREFIX_RND_SIZE 12
+
+  char buf[PREFIX_RND_SIZE + 1];
+  buf[PREFIX_RND_SIZE] = 0;
+
+  cls_gen_rand_base64(buf, sizeof(buf) - 1);
+
+  char s[id.size() + 1 + sizeof(buf) + 16];
+  snprintf(s, sizeof(s), "%s.%s", id.c_str(), buf);
+  return s;
+}
+
+static int fifo_create_op(cls_method_context_t hctx,
+                          bufferlist *in, bufferlist *out)
+{
+  CLS_LOG(20, "%s", __func__);
+
+  cls_fifo_create_op op;
+  try {
+    auto iter = in->cbegin();
+    decode(op, iter);
+  } catch (const buffer::error &err) {
+    CLS_ERR("ERROR: %s(): failed to decode request", __func__);
+    return -EINVAL;
+  }
+
+  uint64_t size;
+
+  int r = cls_cxx_stat2(hctx, &size, nullptr);
+  if (r < 0 && r != -ENOENT) {
+    CLS_ERR("ERROR: %s(): cls_cxx_stat2() on obj returned %d", __func__, r);
+    return r;
+  }
+  if (op.exclusive && r == 0) {
+    CLS_LOG(10, "%s(): exclusive create but queue already exists", __func__);
+    return -EEXIST;
+  }
+
+  if (r == 0) {
+    bufferlist bl;
+    r = cls_cxx_read2(hctx, 0, size, &bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
+    if (r < 0) {
+      CLS_ERR("ERROR: %s(): cls_cxx_read2() on obj returned %d", __func__, r);
+      return r;
+    }
+
+    cls_fifo_header header;
+    try {
+      auto iter = bl.cbegin();
+      decode(header, iter);
+    } catch (buffer::error& err) {
+      CLS_ERR("ERROR: %s(): failed decoding header", __func__);
+      return -EIO;
+    }
+
+    if (!(header.id == op.id &&
+          header.pool.name == op.pool.name &&
+          header.pool.ns == op.pool.ns &&
+          (!op.oid_prefix ||
+           header.oid_prefix == *op.oid_prefix))) {
+      CLS_LOG(10, "%s(): failed to re-create existing queue with different params", __func__);
+      return -EINVAL;
+    }
+
+    return 0; /* already exists */
+  }
+  cls_fifo_header header;
+  
+  header.id = op.id;
+  header.oid_prefix = new_oid_prefix(op.id, op.oid_prefix);
+  header.pool.name = op.pool.name;
+  header.pool.ns = op.pool.ns;
+
+  bufferlist bl;
+  encode(header, bl);
+
+  r = cls_cxx_write_full(hctx, &bl);
+  if (r < 0) {
+    CLS_LOG(10, "%s(): failed to write header: r=%d", __func__, r);
+    return r;
+  }
+
+  return 0;
+}
+
+CLS_INIT(fifo)
+{
+  CLS_LOG(20, "Loaded fifo class!");
+
+  cls_handle_t h_class;
+  cls_method_handle_t h_fifo_create_op;
+
+  cls_register("fifo", &h_class);
+  cls_register_cxx_method(h_class, "fifo_create",
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          fifo_create_op, &h_fifo_create_op);
+
+  return;
+}

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -430,7 +430,9 @@ static int fifo_part_push_op(cls_method_context_t hctx,
     return -EINVAL;
   }
 
-  if (op.total_len > part_header.params.max_entry_size) {
+  uint64_t effective_len = op.total_len + op.data_bufs.size() * part_entry_overhead;
+
+  if (effective_len > part_header.params.max_entry_size + part_entry_overhead) {
     return -EINVAL;
   }
 

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -738,7 +738,11 @@ static int fifo_part_list_op(cls_method_context_t hctx,
 
   reply.tag = part_header.tag;
 
-  for (int i = 0; i < op.max_entries && !reader.end(); ++i) {
+#define LIST_MAX_ENTRIES 512
+
+  auto max_entries = std::min(op.max_entries, (int)LIST_MAX_ENTRIES);
+
+  for (int i = 0; i < max_entries && !reader.end(); ++i) {
     bufferlist data;
     ceph::real_time mtime;
     uint64_t ofs;
@@ -751,6 +755,8 @@ static int fifo_part_list_op(cls_method_context_t hctx,
 
     reply.entries.emplace_back(std::move(data), ofs, mtime);
   }
+
+  reply.more = !reader.end();
 
   encode(reply, *out);
 

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -30,6 +30,8 @@ struct cls_fifo_header {
   } pool;
   string oid_prefix;
 
+  fifo_data_params_t data_params;
+
   uint64_t tail_obj_num{0};
   uint64_t head_obj_num{0};
 
@@ -41,6 +43,7 @@ struct cls_fifo_header {
     encode(pool.name, bl);
     encode(pool.ns, bl);
     encode(oid_prefix, bl);
+    encode(data_params, bl);
     encode(tail_obj_num, bl);
     encode(head_obj_num, bl);
     encode(head_tag, bl);
@@ -52,6 +55,7 @@ struct cls_fifo_header {
     decode(pool.name, bl);
     decode(pool.ns, bl);
     decode(oid_prefix, bl);
+    decode(data_params, bl);
     decode(tail_obj_num, bl);
     decode(head_obj_num, bl);
     decode(head_tag, bl);
@@ -204,6 +208,10 @@ static int fifo_create_op(cls_method_context_t hctx,
   header.oid_prefix = new_oid_prefix(op.id, op.oid_prefix);
   header.pool.name = op.pool.name;
   header.pool.ns = op.pool.ns;
+
+  header.data_params.max_obj_size = op.max_obj_size;
+  header.data_params.max_entry_size = op.max_entry_size;
+  header.data_params.full_size_threshold = op.max_obj_size - op.max_entry_size;
 
   bufferlist bl;
   encode(header, bl);

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -31,16 +31,17 @@ namespace rados {
   namespace cls {
     namespace fifo {
       int ClsFIFO::meta_create(librados::ObjectWriteOperation *rados_op,
+                               const string& id,
                                const MetaCreateParams& params) {
         cls_fifo_meta_create_op op;
 
         auto& state = params.state;
 
-        if (state.id.empty()) {
+        if (id.empty()) {
           return -EINVAL;
         }
 
-        op.id = state.id;
+        op.id = id;
         op.objv = state.objv;
         op.oid_prefix = state.oid_prefix;
         op.max_part_size = state.max_part_size;
@@ -573,7 +574,7 @@ namespace rados {
           ClsFIFO::MetaCreateParams default_params;
           ClsFIFO::MetaCreateParams *params = (create_params ? &(*create_params) : &default_params);
 
-          int r = ClsFIFO::meta_create(&op, *params);
+          int r = ClsFIFO::meta_create(&op, id, *params);
           if (r < 0) {
             return r;
           }

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -167,7 +167,8 @@ namespace rados {
         }
 
         op.tag = state.tag;
-        op.data = state.data;
+        op.data_bufs.emplace_back(state.data);
+        op.total_len = state.data.length();
 
         bufferlist in;
         encode(op, in);

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -23,9 +23,9 @@ using namespace librados;
 namespace rados {
   namespace cls {
     namespace fifo {
-      int FIFO::create(librados::ObjectWriteOperation *rados_op,
-                       const CreateParams& params) {
-        cls_fifo_create_op op;
+      int FIFO::meta_create(librados::ObjectWriteOperation *rados_op,
+                            const MetaCreateParams& params) {
+        cls_fifo_meta_create_op op;
 
         auto& state = params.state;
 
@@ -48,16 +48,16 @@ namespace rados {
 
         bufferlist in;
         encode(op, in);
-        rados_op->exec("fifo", "fifo_create", in);
+        rados_op->exec("fifo", "fifo_meta_create", in);
 
         return 0;
       }
 
-      int FIFO::get_info(librados::IoCtx& ioctx,
+      int FIFO::meta_get(librados::IoCtx& ioctx,
                          const string& oid,
-                         const GetInfoParams& params,
+                         const MetaGetParams& params,
                          fifo_info_t *result) {
-        cls_fifo_get_info_op op;
+        cls_fifo_meta_get_op op;
 
         auto& state = params.state;
 
@@ -69,7 +69,7 @@ namespace rados {
         bufferlist out;
         int op_ret;
         encode(op, in);
-        rop.exec("fifo", "fifo_get_info", in, &out, &op_ret);
+        rop.exec("fifo", "fifo_meta_get", in, &out, &op_ret);
 
         int r = ioctx.operate(oid, &rop, nullptr);
         if (r < 0) {
@@ -80,7 +80,7 @@ namespace rados {
           return op_ret;
         }
 
-        cls_fifo_get_info_op_reply reply;
+        cls_fifo_meta_get_op_reply reply;
         auto iter = out.cbegin();
         try {
           decode(reply, iter);
@@ -93,9 +93,9 @@ namespace rados {
         return 0;
       }
 
-      int FIFO::update_state(librados::ObjectWriteOperation *rados_op,
-                             const UpdateStateParams& params) {
-        cls_fifo_update_state_op op;
+      int FIFO::meta_update(librados::ObjectWriteOperation *rados_op,
+                             const MetaUpdateParams& params) {
+        cls_fifo_meta_update_op op;
 
         auto& state = params.state;
 
@@ -111,14 +111,14 @@ namespace rados {
 
         bufferlist in;
         encode(op, in);
-        rados_op->exec("fifo", "fifo_update_state", in);
+        rados_op->exec("fifo", "fifo_meta_update", in);
 
         return 0;
       }
 
-      int FIFO::init_part(librados::ObjectWriteOperation *rados_op,
-                          const InitPartParams& params) {
-        cls_fifo_init_part_op op;
+      int FIFO::part_init(librados::ObjectWriteOperation *rados_op,
+                          const PartInitParams& params) {
+        cls_fifo_part_init_op op;
 
         auto& state = params.state;
 
@@ -131,7 +131,7 @@ namespace rados {
 
         bufferlist in;
         encode(op, in);
-        rados_op->exec("fifo", "fifo_init_part", in);
+        rados_op->exec("fifo", "fifo_part_init", in);
 
         return 0;
       }

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -36,13 +36,13 @@ namespace rados {
         op.id = state.id;
         op.objv = state.objv;
         op.oid_prefix = state.oid_prefix;
-        op.max_obj_size = state.max_obj_size;
+        op.max_part_size = state.max_part_size;
         op.max_entry_size = state.max_entry_size;
         op.exclusive = state.exclusive;
 
-        if (op.max_obj_size == 0 ||
+        if (op.max_part_size == 0 ||
             op.max_entry_size == 0 ||
-            op.max_entry_size > op.max_obj_size) {
+            op.max_entry_size > op.max_part_size) {
           return -EINVAL;
         }
 
@@ -104,8 +104,8 @@ namespace rados {
         }
 
         op.objv = state.objv;
-        op.tail_obj_num = state.tail_obj_num;
-        op.head_obj_num = state.head_obj_num;
+        op.tail_part_num = state.tail_part_num;
+        op.head_part_num = state.head_part_num;
         op.head_tag = state.head_tag;
         op.head_prepare_status = state.head_prepare_status;
 

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -151,7 +151,23 @@ namespace rados {
 
         bufferlist in;
         encode(op, in);
-        rados_op->exec("fifo", "fifo_push_part", in);
+        rados_op->exec("fifo", "fifo_part_push", in);
+
+        return 0;
+      }
+
+      int FIFO::trim_part(librados::ObjectWriteOperation *rados_op,
+                          const TrimPartParams& params) {
+        cls_fifo_part_trim_op op;
+
+        auto& state = params.state;
+
+        op.tag = state.tag;
+        op.ofs = state.ofs;
+
+        bufferlist in;
+        encode(op, in);
+        rados_op->exec("fifo", "fifo_part_trim", in);
 
         return 0;
       }

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -662,6 +662,11 @@ namespace rados {
               << meta_info.max_push_part_num << " new_head_num=" << meta_info.max_push_part_num << dendl;
             return -EIO;
           }
+
+          if (meta_info.head_part_num >= new_head_num) {
+            /* raced with head creation by another client */
+            return 0;
+          }
         }
 
         int i;

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -95,6 +95,27 @@ namespace rados {
 
         return 0;
       }
+
+      int FIFO::init_part(librados::ObjectWriteOperation *rados_op,
+                       const InitPartParams& params) {
+        cls_fifo_init_part_op op;
+
+        auto& state = params.state;
+
+        if (state.tag.empty()) {
+          return -EINVAL;
+        }
+
+        op.tag = state.tag;
+        op.data_params = state.data_params;
+
+        bufferlist in;
+        encode(op, in);
+        rados_op->exec("fifo", "fifo_init_part", in);
+
+        return 0;
+      }
+
     } // namespace fifo
   } // namespace cls
 } // namespace rados

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -35,6 +35,7 @@ namespace rados {
         }
 
         op.id = state.id;
+        op.objv = state.objv;
         op.pool.name = state.pool.name;
         op.pool.ns = state.pool.ns;
         op.oid_prefix = state.oid_prefix;

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -1,0 +1,52 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "include/rados/librados.hpp"
+
+using namespace librados;
+
+#include "cls/fifo/cls_fifo_ops.h"
+#include "cls/fifo/cls_fifo_client.h"
+
+namespace rados {
+  namespace cls {
+    namespace fifo {
+      int FIFO::create(librados::ObjectWriteOperation *rados_op,
+                       const CreateParams& params) {
+        cls_fifo_create_op op;
+
+        auto& state = params.state;
+
+        if (state.id.empty() ||
+            state.pool.name.empty()) {
+          return -EINVAL;
+        }
+
+        op.id = state.id;
+        op.pool.name = state.pool.name;
+        op.pool.ns = state.pool.ns;
+        op.oid_prefix = state.oid_prefix;
+        op.exclusive = state.exclusive;
+
+        bufferlist in;
+        encode(op, in);
+        rados_op->exec("fifo", "fifo_create", in);
+
+        return 0;
+      }
+    } // namespace fifo
+  } // namespace cls
+} // namespace rados
+

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -38,7 +38,15 @@ namespace rados {
         op.pool.name = state.pool.name;
         op.pool.ns = state.pool.ns;
         op.oid_prefix = state.oid_prefix;
+        op.max_obj_size = state.max_obj_size;
+        op.max_entry_size = state.max_entry_size;
         op.exclusive = state.exclusive;
+
+        if (op.max_obj_size == 0 ||
+            op.max_entry_size == 0 ||
+            op.max_entry_size > op.max_obj_size) {
+          return -EINVAL;
+        }
 
         bufferlist in;
         encode(op, in);

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -64,7 +64,9 @@ namespace rados {
       int ClsFIFO::meta_get(librados::IoCtx& ioctx,
                             const string& oid,
                             const MetaGetParams& params,
-                            fifo_info_t *result) {
+                            fifo_info_t *result,
+                            uint32_t *part_header_size,
+                            uint32_t *part_entry_overhead) {
         cls_fifo_meta_get_op op;
 
         auto& state = params.state;
@@ -97,6 +99,14 @@ namespace rados {
         }
 
         *result = reply.info;
+
+        if (part_header_size) {
+          *part_header_size = reply.part_header_size;
+        }
+
+        if (part_entry_overhead) {
+          *part_entry_overhead = reply.part_entry_overhead;
+        }
 
         return 0;
       }
@@ -402,7 +412,9 @@ namespace rados {
         int r = ClsFIFO::meta_get(*ioctx,
                                   meta_oid,
                                   get_params,
-                                  &meta_info);
+                                  &meta_info,
+                                  &part_header_size,
+                                  &part_entry_overhead);
         if (r < 0) {
           return r;
         }

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -136,6 +136,26 @@ namespace rados {
         return 0;
       }
 
+      int FIFO::push_part(librados::ObjectWriteOperation *rados_op,
+                          const PushPartParams& params) {
+        cls_fifo_part_push_op op;
+
+        auto& state = params.state;
+
+        if (state.tag.empty()) {
+          return -EINVAL;
+        }
+
+        op.tag = state.tag;
+        op.data = state.data;
+
+        bufferlist in;
+        encode(op, in);
+        rados_op->exec("fifo", "fifo_push_part", in);
+
+        return 0;
+      }
+
     } // namespace fifo
   } // namespace cls
 } // namespace rados

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -29,15 +29,12 @@ namespace rados {
 
         auto& state = params.state;
 
-        if (state.id.empty() ||
-            state.pool.name.empty()) {
+        if (state.id.empty()) {
           return -EINVAL;
         }
 
         op.id = state.id;
         op.objv = state.objv;
-        op.pool.name = state.pool.name;
-        op.pool.ns = state.pool.ns;
         op.oid_prefix = state.oid_prefix;
         op.max_obj_size = state.max_obj_size;
         op.max_entry_size = state.max_entry_size;
@@ -96,8 +93,31 @@ namespace rados {
         return 0;
       }
 
+      int FIFO::update_state(librados::ObjectWriteOperation *rados_op,
+                             const UpdateStateParams& params) {
+        cls_fifo_update_state_op op;
+
+        auto& state = params.state;
+
+        if (state.objv.empty()) {
+          return -EINVAL;
+        }
+
+        op.objv = state.objv;
+        op.tail_obj_num = state.tail_obj_num;
+        op.head_obj_num = state.head_obj_num;
+        op.head_tag = state.head_tag;
+        op.head_prepare_status = state.head_prepare_status;
+
+        bufferlist in;
+        encode(op, in);
+        rados_op->exec("fifo", "fifo_update_state", in);
+
+        return 0;
+      }
+
       int FIFO::init_part(librados::ObjectWriteOperation *rados_op,
-                       const InitPartParams& params) {
+                          const InitPartParams& params) {
         cls_fifo_init_part_op op;
 
         auto& state = params.state;

--- a/src/cls/fifo/cls_fifo_client.cc
+++ b/src/cls/fifo/cls_fifo_client.cc
@@ -842,7 +842,9 @@ namespace rados {
           }
         }
 
-        *more = part_more;
+        bool at_head = (part_num > meta_info.head_part_num); /* advanced beyond head */
+
+        *more = (!at_head) || part_more;
 
         return 0;
       }

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -94,7 +94,9 @@ namespace rados {
         static int meta_get(librados::IoCtx& ioctx,
                             const string& oid,
                             const MetaGetParams& params,
-                            rados::cls::fifo::fifo_info_t *result);
+                            rados::cls::fifo::fifo_info_t *result,
+                            uint32_t *part_header_size,
+                            uint32_t *part_entry_overhead);
 
         /* update */
 
@@ -268,6 +270,9 @@ namespace rados {
 
         fifo_info_t meta_info;
 
+        uint32_t part_header_size;
+        uint32_t part_entry_overhead;
+
         bool is_open{false};
 
         string craft_marker(int64_t part_num,
@@ -326,6 +331,16 @@ namespace rados {
 
         const fifo_info_t& get_meta() const {
           return meta_info;
+        }
+
+        void get_part_layout_info(uint32_t *header_size, uint32_t *entry_overhead) {
+          if (header_size) {
+            *header_size = part_header_size;
+          }
+
+          if (entry_overhead) {
+            *entry_overhead = part_entry_overhead;
+          }
         }
 
         int push(bufferlist& bl);

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -34,7 +34,6 @@ namespace rados {
           struct State {
             static constexpr uint64_t default_max_part_size = 4 * 1024 * 1024;
             static constexpr uint64_t default_max_entry_size = 32 * 1024;
-            std::string id;
             std::optional<fifo_objv_t> objv;
             std::optional<std::string> oid_prefix;
             bool exclusive{false};
@@ -42,10 +41,6 @@ namespace rados {
             uint64_t max_entry_size{default_max_entry_size};
           } state;
 
-          MetaCreateParams& id(const std::string& id) {
-            state.id = id;
-            return *this;
-          }
           MetaCreateParams& oid_prefix(const std::string& oid_prefix) {
             state.oid_prefix = oid_prefix;
             return *this;
@@ -69,6 +64,7 @@ namespace rados {
         };
 
         static int meta_create(librados::ObjectWriteOperation *op,
+                               const string& id,
                                const MetaCreateParams& params);
 
         /* get info */

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -124,6 +124,10 @@ namespace rados {
             state.tail_part_num = tail_part_num;
             return *this;
           }
+          MetaUpdateParams& head_part_num(std::optional<uint64_t> head_part_num) {
+            state.head_part_num = head_part_num;
+            return *this;
+          }
           MetaUpdateParams& head_part_num(uint64_t head_part_num) {
             state.head_part_num = head_part_num;
             return *this;
@@ -138,6 +142,12 @@ namespace rados {
           }
           MetaUpdateParams& max_push_part_num(uint64_t num) {
             state.max_push_part_num = num;
+            return *this;
+          }
+          MetaUpdateParams& journal_entry_add(std::optional<rados::cls::fifo::fifo_journal_entry_t> entry) {
+            if (entry) {
+              state.journal_entries_add.push_back(*entry);
+            }
             return *this;
           }
           MetaUpdateParams& journal_entry_add(const rados::cls::fifo::fifo_journal_entry_t& entry) {
@@ -294,13 +304,15 @@ namespace rados {
 
         int process_journal_entry(const fifo_journal_entry_t& entry,
                                   int64_t& tail_part_num,
+                                  int64_t& head_part_num,
                                   int64_t& max_part_num);
         int process_journal_entries(vector<fifo_journal_entry_t> *processed,
                                     int64_t& tail_part_num,
+                                    int64_t& head_part_num,
                                     int64_t& max_part_num);
         int process_journal();
 
-        int prepare_new_part();
+        int prepare_new_part(bool is_head);
         int prepare_new_head();
 
         int push_entry(int64_t part_num, bufferlist& bl);

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -148,6 +148,27 @@ namespace rados {
 
         static int init_part(librados::ObjectWriteOperation *op,
                              const InitPartParams& params);
+
+	/* push part */
+
+        struct PushPartParams {
+          struct State {
+            string tag;
+            bufferlist data;
+          } state;
+
+          PushPartParams& tag(const std::string& tag) {
+            state.tag = tag;
+            return *this;
+          }
+          PushPartParams& data(bufferlist& bl) {
+            state.data = bl;
+            return *this;
+          }
+        };
+
+        static int push_part(librados::ObjectWriteOperation *op,
+                             const PushPartParams& params);
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -244,6 +244,7 @@ namespace rados {
                              const ListPartParams& params,
                              std::vector<cls_fifo_part_list_entry_t> *pentries,
                              bool *more,
+                             bool *full_part = nullptr,
                              string *ptag = nullptr);
 
         static int get_part_info(librados::IoCtx& ioctx,

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -1,0 +1,67 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+
+#pragma once
+
+#include "cls/fifo/cls_fifo_types.h"
+
+namespace rados {
+  namespace cls {
+    namespace fifo {
+
+      class FIFO {
+      public:
+        struct CreateParams {
+          struct State {
+            std::string id;
+            struct {
+              std::string name;
+              std::string ns;
+            } pool;
+            std::optional<std::string> oid_prefix;
+            bool exclusive{false};
+          } state;
+
+          CreateParams& id(const std::string& id) {
+            state.id = id;
+            return *this;
+          }
+          CreateParams& pool(const std::string& name, std::optional<std::string> ns = nullopt) {
+            state.pool.name = name;
+            if (ns) {
+              state.pool.ns = *ns;
+            }
+            return *this;
+          }
+          CreateParams& oid_prefix(const std::string& oid_prefix) {
+            state.oid_prefix = oid_prefix;
+            return *this;
+          }
+          CreateParams& exclusive(bool exclusive) {
+            state.exclusive = exclusive;
+            return *this;
+          }
+        };
+
+        static int create(librados::ObjectWriteOperation *op,
+                          const CreateParams& params);
+      };
+    } // namespace fifo
+  }  // namespace cls
+} // namespace rados

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -230,7 +230,14 @@ namespace rados {
                              const string& oid,
                              const ListPartParams& params,
                              std::vector<cls_fifo_part_list_op_reply::entry> *pentries,
+                             bool *more,
                              string *ptag = nullptr);
+      };
+
+      struct fifo_entry {
+        bufferlist data;
+        string marker;
+        ceph::real_time mtime;
       };
 
       class Manager {
@@ -245,6 +252,13 @@ namespace rados {
         fifo_info_t meta_info;
 
         bool is_open{false};
+
+        string craft_marker(int64_t part_num,
+                        uint64_t part_ofs);
+
+        bool parse_marker(const string& marker,
+                          int64_t *part_num,
+                          uint64_t *part_ofs);
 
         int update_meta(FIFO::MetaUpdateParams& update_params,
                         bool *canceled);
@@ -261,6 +275,8 @@ namespace rados {
         int prepare_new_head();
 
         int push_entry(int64_t part_num, bufferlist& bl);
+
+
       public:
         Manager(CephContext *_cct,
                 const string& _id) : cct(_cct),
@@ -281,6 +297,11 @@ namespace rados {
                  std::optional<FIFO::MetaCreateParams> create_params = std::nullopt);
 
         int push(bufferlist& bl);
+
+        int list(int max_entries,
+                 std::optional<string> marker,
+                 vector<fifo_entry> *result,
+                 bool *more);
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -189,6 +189,34 @@ namespace rados {
 
         static int trim_part(librados::ObjectWriteOperation *op,
                              const TrimPartParams& params);
+	/* list part */
+
+        struct ListPartParams {
+          struct State {
+            std::optional<string> tag;
+            uint64_t ofs;
+            int max_entries{100};
+          } state;
+
+          ListPartParams& tag(const std::string& tag) {
+            state.tag = tag;
+            return *this;
+          }
+          ListPartParams& ofs(uint64_t ofs) {
+            state.ofs = ofs;
+            return *this;
+          }
+          ListPartParams& max_entries(int _max_entries) {
+            state.max_entries = _max_entries;
+            return *this;
+          }
+        };
+
+        static int list_part(librados::IoCtx& ioctx,
+                             const string& oid,
+                             const ListPartParams& params,
+                             std::vector<cls_fifo_part_list_op_reply::entry> *pentries,
+                             string *ptag = nullptr);
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -30,7 +30,7 @@ namespace rados {
 
         /* create */
 
-        struct CreateParams {
+        struct MetaCreateParams {
           struct State {
             static constexpr uint64_t default_max_obj_size = 4 * 1024 * 1024;
             static constexpr uint64_t default_max_entry_size = 32 * 1024;
@@ -42,59 +42,59 @@ namespace rados {
             uint64_t max_entry_size{default_max_entry_size};
           } state;
 
-          CreateParams& id(const std::string& id) {
+          MetaCreateParams& id(const std::string& id) {
             state.id = id;
             return *this;
           }
-          CreateParams& oid_prefix(const std::string& oid_prefix) {
+          MetaCreateParams& oid_prefix(const std::string& oid_prefix) {
             state.oid_prefix = oid_prefix;
             return *this;
           }
-          CreateParams& exclusive(bool exclusive) {
+          MetaCreateParams& exclusive(bool exclusive) {
             state.exclusive = exclusive;
             return *this;
           }
-          CreateParams& max_obj_size(uint64_t max_obj_size) {
+          MetaCreateParams& max_obj_size(uint64_t max_obj_size) {
             state.max_obj_size = max_obj_size;
             return *this;
           }
-          CreateParams& max_entry_size(uint64_t max_entry_size) {
+          MetaCreateParams& max_entry_size(uint64_t max_entry_size) {
             state.max_entry_size = max_entry_size;
             return *this;
           }
-          CreateParams& objv(const std::string& instance, uint64_t ver) {
+          MetaCreateParams& objv(const std::string& instance, uint64_t ver) {
             state.objv = fifo_objv_t{instance, ver};
             return *this;
           }
         };
 
-        static int create(librados::ObjectWriteOperation *op,
-                          const CreateParams& params);
+        static int meta_create(librados::ObjectWriteOperation *op,
+                               const MetaCreateParams& params);
 
         /* get info */
 
-        struct GetInfoParams {
+        struct MetaGetParams {
           struct State {
             std::optional<fifo_objv_t> objv;
           } state;
 
-          GetInfoParams& objv(const fifo_objv_t& v) {
+          MetaGetParams& objv(const fifo_objv_t& v) {
             state.objv = v;
             return *this;
           }
-          GetInfoParams& objv(const std::string& instance, uint64_t ver) {
+          MetaGetParams& objv(const std::string& instance, uint64_t ver) {
             state.objv = fifo_objv_t{instance, ver};
             return *this;
           }
         };
-        static int get_info(librados::IoCtx& ioctx,
+        static int meta_get(librados::IoCtx& ioctx,
                             const string& oid,
-                            const GetInfoParams& params,
+                            const MetaGetParams& params,
                             rados::cls::fifo::fifo_info_t *result);
 
         /* update */
 
-        struct UpdateStateParams {
+        struct MetaUpdateParams {
           struct State {
             rados::cls::fifo::fifo_objv_t objv;
 
@@ -104,50 +104,50 @@ namespace rados {
             std::optional<rados::cls::fifo::fifo_prepare_status_t> head_prepare_status;
           } state;
 
-          UpdateStateParams& objv(const fifo_objv_t& objv) {
+          MetaUpdateParams& objv(const fifo_objv_t& objv) {
             state.objv = objv;
             return *this;
           }
-          UpdateStateParams& tail_obj_num(uint64_t tail_obj_num) {
+          MetaUpdateParams& tail_obj_num(uint64_t tail_obj_num) {
             state.tail_obj_num = tail_obj_num;
             return *this;
           }
-          UpdateStateParams& head_obj_num(uint64_t head_obj_num) {
+          MetaUpdateParams& head_obj_num(uint64_t head_obj_num) {
             state.head_obj_num = head_obj_num;
             return *this;
           }
-          UpdateStateParams& head_tag(const std::string& head_tag) {
+          MetaUpdateParams& head_tag(const std::string& head_tag) {
             state.head_tag = head_tag;
             return *this;
           }
-          UpdateStateParams& head_prepare_status(const rados::cls::fifo::fifo_prepare_status_t& head_prepare_status) {
+          MetaUpdateParams& head_prepare_status(const rados::cls::fifo::fifo_prepare_status_t& head_prepare_status) {
             state.head_prepare_status = head_prepare_status;
             return *this;
           }
         };
 
-        static int update_state(librados::ObjectWriteOperation *rados_op,
-                                const UpdateStateParams& params);
+        static int meta_update(librados::ObjectWriteOperation *rados_op,
+                                const MetaUpdateParams& params);
         /* init part */
 
-        struct InitPartParams {
+        struct PartInitParams {
           struct State {
             string tag;
             rados::cls::fifo::fifo_data_params_t data_params;
           } state;
 
-          InitPartParams& tag(const std::string& tag) {
+          PartInitParams& tag(const std::string& tag) {
             state.tag = tag;
             return *this;
           }
-          InitPartParams& data_params(const rados::cls::fifo::fifo_data_params_t& data_params) {
+          PartInitParams& data_params(const rados::cls::fifo::fifo_data_params_t& data_params) {
             state.data_params = data_params;
             return *this;
           }
         };
 
-        static int init_part(librados::ObjectWriteOperation *op,
-                             const InitPartParams& params);
+        static int part_init(librados::ObjectWriteOperation *op,
+                             const PartInitParams& params);
 
 	/* push part */
 

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -25,7 +25,7 @@ namespace rados {
   namespace cls {
     namespace fifo {
 
-      class FIFO {
+      class ClsFIFO {
       public:
 
         /* create */
@@ -229,7 +229,7 @@ namespace rados {
         static int list_part(librados::IoCtx& ioctx,
                              const string& oid,
                              const ListPartParams& params,
-                             std::vector<cls_fifo_part_list_op_reply::entry> *pentries,
+                             std::vector<cls_fifo_part_list_entry_t> *pentries,
                              bool *more,
                              string *ptag = nullptr);
       };
@@ -240,7 +240,7 @@ namespace rados {
         ceph::real_time mtime;
       };
 
-      class Manager {
+      class FIFO {
         CephContext *cct;
         string id;
 
@@ -260,7 +260,7 @@ namespace rados {
                           int64_t *part_num,
                           uint64_t *part_ofs);
 
-        int update_meta(FIFO::MetaUpdateParams& update_params,
+        int update_meta(ClsFIFO::MetaUpdateParams& update_params,
                         bool *canceled);
         int read_meta(std::optional<fifo_objv_t> objv = std::nullopt);
 
@@ -280,9 +280,9 @@ namespace rados {
                       std::optional<string> tag);
 
       public:
-        Manager(CephContext *_cct,
-                const string& _id) : cct(_cct),
-                                    id(_id) {
+        FIFO(CephContext *_cct,
+             const string& _id) : cct(_cct),
+                                  id(_id) {
           meta_oid = id;
         }
 
@@ -296,7 +296,7 @@ namespace rados {
         }
 
         int open(bool create,
-                 std::optional<FIFO::MetaCreateParams> create_params = std::nullopt);
+                 std::optional<ClsFIFO::MetaCreateParams> create_params = std::nullopt);
 
         int push(bufferlist& bl);
 

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -243,6 +243,10 @@ namespace rados {
                              std::vector<cls_fifo_part_list_entry_t> *pentries,
                              bool *more,
                              string *ptag = nullptr);
+
+        static int get_part_info(librados::IoCtx& ioctx,
+                                 const string& oid,
+                                 rados::cls::fifo::fifo_part_header_t *header);
       };
 
       struct fifo_entry {
@@ -250,6 +254,8 @@ namespace rados {
         string marker;
         ceph::real_time mtime;
       };
+
+      using fifo_part_info = rados::cls::fifo::fifo_part_header_t;
 
       class FIFO {
         CephContext *cct;
@@ -330,6 +336,9 @@ namespace rados {
                  bool *more);
 
         int trim(const string& marker);
+
+        int get_part_info(int64_t part_num,
+                          fifo_part_info *result);
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -191,7 +191,7 @@ namespace rados {
             uint64_t ofs;
           } state;
 
-          TrimPartParams& tag(const std::string& tag) {
+          TrimPartParams& tag(std::optional<std::string> tag) {
             state.tag = tag;
             return *this;
           }
@@ -275,7 +275,9 @@ namespace rados {
         int prepare_new_head();
 
         int push_entry(int64_t part_num, bufferlist& bl);
-
+        int trim_part(int64_t part_num,
+                      uint64_t ofs,
+                      std::optional<string> tag);
 
       public:
         Manager(CephContext *_cct,
@@ -302,6 +304,8 @@ namespace rados {
                  std::optional<string> marker,
                  vector<fifo_entry> *result,
                  bool *more);
+
+        int trim(const string& marker);
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -32,13 +32,13 @@ namespace rados {
 
         struct MetaCreateParams {
           struct State {
-            static constexpr uint64_t default_max_obj_size = 4 * 1024 * 1024;
+            static constexpr uint64_t default_max_part_size = 4 * 1024 * 1024;
             static constexpr uint64_t default_max_entry_size = 32 * 1024;
             std::string id;
             std::optional<fifo_objv_t> objv;
             std::optional<std::string> oid_prefix;
             bool exclusive{false};
-            uint64_t max_obj_size{default_max_obj_size};
+            uint64_t max_part_size{default_max_part_size};
             uint64_t max_entry_size{default_max_entry_size};
           } state;
 
@@ -54,8 +54,8 @@ namespace rados {
             state.exclusive = exclusive;
             return *this;
           }
-          MetaCreateParams& max_obj_size(uint64_t max_obj_size) {
-            state.max_obj_size = max_obj_size;
+          MetaCreateParams& max_part_size(uint64_t max_part_size) {
+            state.max_part_size = max_part_size;
             return *this;
           }
           MetaCreateParams& max_entry_size(uint64_t max_entry_size) {
@@ -98,8 +98,8 @@ namespace rados {
           struct State {
             rados::cls::fifo::fifo_objv_t objv;
 
-            std::optional<uint64_t> tail_obj_num;
-            std::optional<uint64_t> head_obj_num;
+            std::optional<uint64_t> tail_part_num;
+            std::optional<uint64_t> head_part_num;
             std::optional<string> head_tag;
             std::optional<rados::cls::fifo::fifo_prepare_status_t> head_prepare_status;
           } state;
@@ -108,12 +108,12 @@ namespace rados {
             state.objv = objv;
             return *this;
           }
-          MetaUpdateParams& tail_obj_num(uint64_t tail_obj_num) {
-            state.tail_obj_num = tail_obj_num;
+          MetaUpdateParams& tail_part_num(uint64_t tail_part_num) {
+            state.tail_part_num = tail_part_num;
             return *this;
           }
-          MetaUpdateParams& head_obj_num(uint64_t head_obj_num) {
-            state.head_obj_num = head_obj_num;
+          MetaUpdateParams& head_part_num(uint64_t head_part_num) {
+            state.head_part_num = head_part_num;
             return *this;
           }
           MetaUpdateParams& head_tag(const std::string& head_tag) {

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -114,6 +114,10 @@ namespace rados {
             state.objv = objv;
             return *this;
           }
+          MetaUpdateParams& tail_part_num(std::optional<uint64_t> tail_part_num) {
+            state.tail_part_num = tail_part_num;
+            return *this;
+          }
           MetaUpdateParams& tail_part_num(uint64_t tail_part_num) {
             state.tail_part_num = tail_part_num;
             return *this;
@@ -124,6 +128,10 @@ namespace rados {
           }
           MetaUpdateParams& min_push_part_num(uint64_t num) {
             state.min_push_part_num = num;
+            return *this;
+          }
+          MetaUpdateParams& max_push_part_num(std::optional<uint64_t> num) {
+            state.max_push_part_num = num;
             return *this;
           }
           MetaUpdateParams& max_push_part_num(uint64_t num) {
@@ -267,11 +275,17 @@ namespace rados {
                         bool *canceled);
         int do_read_meta(std::optional<fifo_objv_t> objv = std::nullopt);
 
-        int create_part(int64_t part_num, const string& tag);
-        int remove_part(int64_t part_num, const string& tag);
+        int create_part(int64_t part_num, const string& tag,
+                        int64_t& max_part_num);
+        int remove_part(int64_t part_num, const string& tag,
+                        int64_t& tail_part_num);
 
-        int process_journal_entry(const fifo_journal_entry_t& entry);
-        int process_journal_entries(vector<fifo_journal_entry_t> *processed);
+        int process_journal_entry(const fifo_journal_entry_t& entry,
+                                  int64_t& tail_part_num,
+                                  int64_t& max_part_num);
+        int process_journal_entries(vector<fifo_journal_entry_t> *processed,
+                                    int64_t& tail_part_num,
+                                    int64_t& max_part_num);
         int process_journal();
 
         int prepare_new_part();

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -83,6 +83,10 @@ namespace rados {
             std::optional<fifo_objv_t> objv;
           } state;
 
+          GetInfoParams& objv(const fifo_objv_t& v) {
+            state.objv = v;
+            return *this;
+          }
           GetInfoParams& objv(const std::string& instance, uint64_t ver) {
             state.objv = fifo_objv_t{instance, ver};
             return *this;

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -32,6 +32,7 @@ namespace rados {
             static constexpr uint64_t default_max_obj_size = 4 * 1024 * 1024;
             static constexpr uint64_t default_max_entry_size = 32 * 1024;
             std::string id;
+            std::optional<fifo_objv_t> objv;
             struct {
               std::string name;
               std::string ns;
@@ -67,6 +68,10 @@ namespace rados {
           }
           CreateParams& max_entry_size(uint64_t max_entry_size) {
             state.max_entry_size = max_entry_size;
+            return *this;
+          }
+          CreateParams& objv(const std::string& instance, uint64_t ver) {
+            state.objv = fifo_objv_t{instance, ver};
             return *this;
           }
         };

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -138,6 +138,9 @@ namespace rados {
             state.journal_entries_rm = entries;
             return *this;
           }
+
+          int apply_update(CephContext *cct,
+                           rados::cls::fifo::fifo_info_t *info);
         };
 
         static int meta_update(librados::ObjectWriteOperation *rados_op,

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -27,6 +27,9 @@ namespace rados {
 
       class FIFO {
       public:
+
+        /* create */
+
         struct CreateParams {
           struct State {
             static constexpr uint64_t default_max_obj_size = 4 * 1024 * 1024;
@@ -78,6 +81,9 @@ namespace rados {
 
         static int create(librados::ObjectWriteOperation *op,
                           const CreateParams& params);
+
+        /* get info */
+
         struct GetInfoParams {
           struct State {
             std::optional<fifo_objv_t> objv;
@@ -97,6 +103,26 @@ namespace rados {
                             const GetInfoParams& params,
                             rados::cls::fifo::fifo_info_t *result);
 
+        /* init part */
+
+        struct InitPartParams {
+          struct State {
+            string tag;
+            rados::cls::fifo::fifo_data_params_t data_params;
+          } state;
+
+          InitPartParams& tag(const std::string& tag) {
+            state.tag = tag;
+            return *this;
+          }
+          InitPartParams& data_params(const rados::cls::fifo::fifo_data_params_t& data_params) {
+            state.data_params = data_params;
+            return *this;
+          }
+        };
+
+        static int init_part(librados::ObjectWriteOperation *op,
+                             const InitPartParams& params);
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -78,6 +78,10 @@ namespace rados {
             std::optional<fifo_objv_t> objv;
           } state;
 
+          MetaGetParams& objv(std::optional<fifo_objv_t>& v) {
+            state.objv = v;
+            return *this;
+          }
           MetaGetParams& objv(const fifo_objv_t& v) {
             state.objv = v;
             return *this;
@@ -217,6 +221,37 @@ namespace rados {
                              const ListPartParams& params,
                              std::vector<cls_fifo_part_list_op_reply::entry> *pentries,
                              string *ptag = nullptr);
+      };
+
+      class Manager {
+        CephContext *cct;
+        string id;
+
+        string meta_oid;
+
+        std::optional<librados::IoCtx> _ioctx;
+        librados::IoCtx *ioctx{nullptr};
+
+        fifo_info_t meta_info;
+      public:
+        Manager(CephContext *_cct,
+                const string& _id) : cct(_cct),
+                                    id(_id) {
+          meta_oid = id;
+        }
+
+        int init_ioctx(librados::Rados *rados,
+                       const string& pool,
+                       std::optional<string> pool_ns);
+
+        int init_ioctx(librados::IoCtx *_ioctx) {
+          ioctx = ioctx;
+          return 0;
+        }
+
+        int open(bool create,
+                 std::optional<FIFO::MetaCreateParams> create_params = std::nullopt);
+
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -78,6 +78,21 @@ namespace rados {
 
         static int create(librados::ObjectWriteOperation *op,
                           const CreateParams& params);
+        struct GetInfoParams {
+          struct State {
+            std::optional<fifo_objv_t> objv;
+          } state;
+
+          GetInfoParams& objv(const std::string& instance, uint64_t ver) {
+            state.objv = fifo_objv_t{instance, ver};
+            return *this;
+          }
+        };
+        static int get_info(librados::IoCtx& ioctx,
+                            const string& oid,
+                            const GetInfoParams& params,
+                            rados::cls::fifo::fifo_info_t *result);
+
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -29,6 +29,8 @@ namespace rados {
       public:
         struct CreateParams {
           struct State {
+            static constexpr uint64_t default_max_obj_size = 4 * 1024 * 1024;
+            static constexpr uint64_t default_max_entry_size = 32 * 1024;
             std::string id;
             struct {
               std::string name;
@@ -36,6 +38,8 @@ namespace rados {
             } pool;
             std::optional<std::string> oid_prefix;
             bool exclusive{false};
+            uint64_t max_obj_size{default_max_obj_size};
+            uint64_t max_entry_size{default_max_entry_size};
           } state;
 
           CreateParams& id(const std::string& id) {
@@ -55,6 +59,14 @@ namespace rados {
           }
           CreateParams& exclusive(bool exclusive) {
             state.exclusive = exclusive;
+            return *this;
+          }
+          CreateParams& max_obj_size(uint64_t max_obj_size) {
+            state.max_obj_size = max_obj_size;
+            return *this;
+          }
+          CreateParams& max_entry_size(uint64_t max_entry_size) {
+            state.max_entry_size = max_entry_size;
             return *this;
           }
         };

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -169,6 +169,26 @@ namespace rados {
 
         static int push_part(librados::ObjectWriteOperation *op,
                              const PushPartParams& params);
+	/* trim part */
+
+        struct TrimPartParams {
+          struct State {
+            std::optional<string> tag;
+            uint64_t ofs;
+          } state;
+
+          TrimPartParams& tag(const std::string& tag) {
+            state.tag = tag;
+            return *this;
+          }
+          TrimPartParams& ofs(uint64_t ofs) {
+            state.ofs = ofs;
+            return *this;
+          }
+        };
+
+        static int trim_part(librados::ObjectWriteOperation *op,
+                             const TrimPartParams& params);
       };
     } // namespace fifo
   }  // namespace cls

--- a/src/cls/fifo/cls_fifo_client.h
+++ b/src/cls/fifo/cls_fifo_client.h
@@ -36,10 +36,6 @@ namespace rados {
             static constexpr uint64_t default_max_entry_size = 32 * 1024;
             std::string id;
             std::optional<fifo_objv_t> objv;
-            struct {
-              std::string name;
-              std::string ns;
-            } pool;
             std::optional<std::string> oid_prefix;
             bool exclusive{false};
             uint64_t max_obj_size{default_max_obj_size};
@@ -48,13 +44,6 @@ namespace rados {
 
           CreateParams& id(const std::string& id) {
             state.id = id;
-            return *this;
-          }
-          CreateParams& pool(const std::string& name, std::optional<std::string> ns = nullopt) {
-            state.pool.name = name;
-            if (ns) {
-              state.pool.ns = *ns;
-            }
             return *this;
           }
           CreateParams& oid_prefix(const std::string& oid_prefix) {
@@ -103,6 +92,42 @@ namespace rados {
                             const GetInfoParams& params,
                             rados::cls::fifo::fifo_info_t *result);
 
+        /* update */
+
+        struct UpdateStateParams {
+          struct State {
+            rados::cls::fifo::fifo_objv_t objv;
+
+            std::optional<uint64_t> tail_obj_num;
+            std::optional<uint64_t> head_obj_num;
+            std::optional<string> head_tag;
+            std::optional<rados::cls::fifo::fifo_prepare_status_t> head_prepare_status;
+          } state;
+
+          UpdateStateParams& objv(const fifo_objv_t& objv) {
+            state.objv = objv;
+            return *this;
+          }
+          UpdateStateParams& tail_obj_num(uint64_t tail_obj_num) {
+            state.tail_obj_num = tail_obj_num;
+            return *this;
+          }
+          UpdateStateParams& head_obj_num(uint64_t head_obj_num) {
+            state.head_obj_num = head_obj_num;
+            return *this;
+          }
+          UpdateStateParams& head_tag(const std::string& head_tag) {
+            state.head_tag = head_tag;
+            return *this;
+          }
+          UpdateStateParams& head_prepare_status(const rados::cls::fifo::fifo_prepare_status_t& head_prepare_status) {
+            state.head_prepare_status = head_prepare_status;
+            return *this;
+          }
+        };
+
+        static int update_state(librados::ObjectWriteOperation *rados_op,
+                                const UpdateStateParams& params);
         /* init part */
 
         struct InitPartParams {

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -82,15 +82,21 @@ WRITE_CLASS_ENCODER(cls_fifo_meta_get_op)
 struct cls_fifo_meta_get_op_reply
 {
   rados::cls::fifo::fifo_info_t info;
+  uint32_t part_header_size{0};
+  uint32_t part_entry_overhead{0}; /* per entry extra data that is stored */
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
     encode(info, bl);
+    encode(part_header_size, bl);
+    encode(part_entry_overhead, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(info, bl);
+    decode(part_header_size, bl);
+    decode(part_entry_overhead, bl);
     DECODE_FINISH(bl);
   }
 };

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -166,6 +166,26 @@ struct cls_fifo_part_push_op
 };
 WRITE_CLASS_ENCODER(cls_fifo_part_push_op)
 
+struct cls_fifo_part_trim_op
+{
+  std::optional<string> tag;
+  uint64_t ofs{0};
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(tag, bl);
+    encode(ofs, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(tag, bl);
+    decode(ofs, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_part_trim_op)
+
 struct cls_fifo_part_list_op
 {
   uint64_t ofs{0};

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -188,17 +188,20 @@ WRITE_CLASS_ENCODER(cls_fifo_part_trim_op)
 
 struct cls_fifo_part_list_op
 {
+  std::optional<string> tag;
   uint64_t ofs{0};
   int max_entries{100};
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
+    encode(tag, bl);
     encode(ofs, bl);
     encode(max_entries, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
     DECODE_START(1, bl);
+    decode(tag, bl);
     decode(ofs, bl);
     decode(max_entries, bl);
     DECODE_FINISH(bl);
@@ -235,15 +238,18 @@ struct cls_fifo_part_list_op_reply
     }
   };
 
+  string tag;
   vector<entry> entries;
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
+    encode(tag, bl);
     encode(entries, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
     DECODE_START(1, bl);
+    decode(tag, bl);
     decode(entries, bl);
     DECODE_FINISH(bl);
   }

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -20,7 +20,7 @@
 #include "include/utime.h"
 #include "cls/fifo/cls_fifo_types.h"
 
-struct cls_fifo_create_op
+struct cls_fifo_meta_create_op
 {
   string id;
   std::optional<rados::cls::fifo::fifo_objv_t> objv;
@@ -60,9 +60,9 @@ struct cls_fifo_create_op
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(cls_fifo_create_op)
+WRITE_CLASS_ENCODER(cls_fifo_meta_create_op)
 
-struct cls_fifo_get_info_op
+struct cls_fifo_meta_get_op
 {
   std::optional<rados::cls::fifo::fifo_objv_t> objv;
 
@@ -77,9 +77,9 @@ struct cls_fifo_get_info_op
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(cls_fifo_get_info_op)
+WRITE_CLASS_ENCODER(cls_fifo_meta_get_op)
 
-struct cls_fifo_get_info_op_reply
+struct cls_fifo_meta_get_op_reply
 {
   rados::cls::fifo::fifo_info_t info;
 
@@ -94,9 +94,9 @@ struct cls_fifo_get_info_op_reply
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(cls_fifo_get_info_op_reply)
+WRITE_CLASS_ENCODER(cls_fifo_meta_get_op_reply)
 
-struct cls_fifo_init_part_op
+struct cls_fifo_part_init_op
 {
   string tag;
   rados::cls::fifo::fifo_data_params_t data_params;
@@ -114,7 +114,7 @@ struct cls_fifo_init_part_op
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(cls_fifo_init_part_op)
+WRITE_CLASS_ENCODER(cls_fifo_part_init_op)
 
 struct cls_fifo_part_push_op
 {
@@ -136,7 +136,7 @@ struct cls_fifo_part_push_op
 };
 WRITE_CLASS_ENCODER(cls_fifo_part_push_op)
 
-struct cls_fifo_update_state_op
+struct cls_fifo_meta_update_op
 {
   rados::cls::fifo::fifo_objv_t objv;
 
@@ -164,4 +164,4 @@ struct cls_fifo_update_state_op
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(cls_fifo_update_state_op)
+WRITE_CLASS_ENCODER(cls_fifo_meta_update_op)

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -116,6 +116,26 @@ struct cls_fifo_init_part_op
 };
 WRITE_CLASS_ENCODER(cls_fifo_init_part_op)
 
+struct cls_fifo_part_push_op
+{
+  string tag;
+  bufferlist data;
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(tag, bl);
+    encode(data, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(tag, bl);
+    decode(data, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_part_push_op)
+
 struct cls_fifo_update_state_op
 {
   rados::cls::fifo::fifo_objv_t objv;

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -62,57 +62,37 @@ struct cls_fifo_create_op
 };
 WRITE_CLASS_ENCODER(cls_fifo_create_op)
 
-struct cls_fifo_get_op
+struct cls_fifo_get_info_op
 {
-  void encode(bufferlist &bl) const {
-    ENCODE_START(1, 1, bl);
-    ENCODE_FINISH(bl);
-  }
-  void decode(bufferlist::const_iterator &bl) {
-    DECODE_START(1, bl);
-    DECODE_FINISH(bl);
-  }
-};
-WRITE_CLASS_ENCODER(cls_fifo_get_op)
-
-struct cls_fifo_get_op_reply
-{
-  string id;
   std::optional<rados::cls::fifo::fifo_objv_t> objv;
-  struct {
-    string name;
-    string ns;
-  } pool;
-  string oid_prefix;
-
-  uint64_t max_obj_size{0};
-  uint64_t max_entry_size{0};
-
-  uint64_t tail_obj_num{0};
-  uint64_t head_obj_num{0};
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
-    encode(id, bl);
     encode(objv, bl);
-    encode(pool.name, bl);
-    encode(pool.ns, bl);
-    encode(oid_prefix, bl);
-    encode(max_obj_size, bl);
-    encode(max_entry_size, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
     DECODE_START(1, bl);
-    decode(id, bl);
     decode(objv, bl);
-    decode(pool.name, bl);
-    decode(pool.ns, bl);
-    decode(oid_prefix, bl);
-    decode(max_obj_size, bl);
-    decode(max_entry_size, bl);
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(cls_fifo_get_op_reply)
+WRITE_CLASS_ENCODER(cls_fifo_get_info_op)
+
+struct cls_fifo_get_info_op_reply
+{
+  rados::cls::fifo::fifo_info_t info;
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(info, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(info, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_get_info_op_reply)
 

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -237,3 +237,33 @@ struct cls_fifo_part_list_op_reply
   }
 };
 WRITE_CLASS_ENCODER(cls_fifo_part_list_op_reply)
+
+struct cls_fifo_part_get_info_op
+{
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_part_get_info_op)
+
+struct cls_fifo_part_get_info_op_reply
+{
+  rados::cls::fifo::fifo_part_header_t header;
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(header, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(header, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_part_get_info_op_reply)

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -116,3 +116,32 @@ struct cls_fifo_init_part_op
 };
 WRITE_CLASS_ENCODER(cls_fifo_init_part_op)
 
+struct cls_fifo_update_state_op
+{
+  rados::cls::fifo::fifo_objv_t objv;
+
+  std::optional<uint64_t> tail_obj_num;
+  std::optional<uint64_t> head_obj_num;
+  std::optional<string> head_tag;
+  std::optional<rados::cls::fifo::fifo_prepare_status_t> head_prepare_status;
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(objv, bl);
+    encode(tail_obj_num, bl);
+    encode(head_obj_num, bl);
+    encode(head_tag, bl);
+    encode(head_prepare_status, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(objv, bl);
+    decode(tail_obj_num, bl);
+    decode(head_obj_num, bl);
+    decode(head_tag, bl);
+    decode(head_prepare_status, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_update_state_op)

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -161,18 +161,21 @@ WRITE_CLASS_ENCODER(cls_fifo_part_init_op)
 struct cls_fifo_part_push_op
 {
   string tag;
-  bufferlist data;
+  std::vector<bufferlist> data_bufs;
+  uint64_t total_len{0};
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
     encode(tag, bl);
-    encode(data, bl);
+    encode(data_bufs, bl);
+    encode(total_len, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(tag, bl);
-    decode(data, bl);
+    decode(data_bufs, bl);
+    decode(total_len, bl);
     DECODE_FINISH(bl);
   }
 };

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -30,7 +30,7 @@ struct cls_fifo_meta_create_op
   } pool;
   std::optional<string> oid_prefix;
 
-  uint64_t max_obj_size{0};
+  uint64_t max_part_size{0};
   uint64_t max_entry_size{0};
 
   bool exclusive{false};
@@ -42,7 +42,7 @@ struct cls_fifo_meta_create_op
     encode(pool.name, bl);
     encode(pool.ns, bl);
     encode(oid_prefix, bl);
-    encode(max_obj_size, bl);
+    encode(max_part_size, bl);
     encode(max_entry_size, bl);
     encode(exclusive, bl);
     ENCODE_FINISH(bl);
@@ -54,7 +54,7 @@ struct cls_fifo_meta_create_op
     decode(pool.name, bl);
     decode(pool.ns, bl);
     decode(oid_prefix, bl);
-    decode(max_obj_size, bl);
+    decode(max_part_size, bl);
     decode(max_entry_size, bl);
     decode(exclusive, bl);
     DECODE_FINISH(bl);
@@ -140,16 +140,16 @@ struct cls_fifo_meta_update_op
 {
   rados::cls::fifo::fifo_objv_t objv;
 
-  std::optional<uint64_t> tail_obj_num;
-  std::optional<uint64_t> head_obj_num;
+  std::optional<uint64_t> tail_part_num;
+  std::optional<uint64_t> head_part_num;
   std::optional<string> head_tag;
   std::optional<rados::cls::fifo::fifo_prepare_status_t> head_prepare_status;
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
     encode(objv, bl);
-    encode(tail_obj_num, bl);
-    encode(head_obj_num, bl);
+    encode(tail_part_num, bl);
+    encode(head_part_num, bl);
     encode(head_tag, bl);
     encode(head_prepare_status, bl);
     ENCODE_FINISH(bl);
@@ -157,8 +157,8 @@ struct cls_fifo_meta_update_op
   void decode(bufferlist::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(objv, bl);
-    decode(tail_obj_num, bl);
-    decode(head_obj_num, bl);
+    decode(tail_part_num, bl);
+    decode(head_part_num, bl);
     decode(head_tag, bl);
     decode(head_prepare_status, bl);
     DECODE_FINISH(bl);

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -29,6 +29,9 @@ struct cls_fifo_create_op
   } pool;
   std::optional<string> oid_prefix;
 
+  uint64_t max_obj_size{0};
+  uint64_t max_entry_size{0};
+
   bool exclusive{false};
 
   void encode(bufferlist &bl) const {
@@ -37,6 +40,8 @@ struct cls_fifo_create_op
     encode(pool.name, bl);
     encode(pool.ns, bl);
     encode(oid_prefix, bl);
+    encode(max_obj_size, bl);
+    encode(max_entry_size, bl);
     encode(exclusive, bl);
     ENCODE_FINISH(bl);
   }
@@ -46,6 +51,8 @@ struct cls_fifo_create_op
     decode(pool.name, bl);
     decode(pool.ns, bl);
     decode(oid_prefix, bl);
+    decode(max_obj_size, bl);
+    decode(max_entry_size, bl);
     decode(exclusive, bl);
     DECODE_FINISH(bl);
   }

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ * Copyright (C) 2019 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "include/types.h"
+#include "include/utime.h"
+#include "cls/fifo/cls_fifo_types.h"
+
+struct cls_fifo_create_op
+{
+  string id;
+  struct {
+    string name;
+    string ns;
+  } pool;
+  std::optional<string> oid_prefix;
+
+  bool exclusive{false};
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(id, bl);
+    encode(pool.name, bl);
+    encode(pool.ns, bl);
+    encode(oid_prefix, bl);
+    encode(exclusive, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(id, bl);
+    decode(pool.name, bl);
+    decode(pool.ns, bl);
+    decode(oid_prefix, bl);
+    decode(exclusive, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_create_op)
+

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -96,3 +96,23 @@ struct cls_fifo_get_info_op_reply
 };
 WRITE_CLASS_ENCODER(cls_fifo_get_info_op_reply)
 
+struct cls_fifo_init_part_op
+{
+  string tag;
+  rados::cls::fifo::fifo_data_params_t data_params;
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(tag, bl);
+    encode(data_params, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(tag, bl);
+    decode(data_params, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_init_part_op)
+

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -226,12 +226,15 @@ struct cls_fifo_part_list_op_reply
   string tag;
   vector<rados::cls::fifo::cls_fifo_part_list_entry_t> entries;
   bool more{false};
+  bool full_part{false}; /* whether part is full or still can be written to.
+                            A non full part is by definition head part */
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
     encode(tag, bl);
     encode(entries, bl);
     encode(more, bl);
+    encode(full_part, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
@@ -239,6 +242,7 @@ struct cls_fifo_part_list_op_reply
     decode(tag, bl);
     decode(entries, bl);
     decode(more, bl);
+    decode(full_part, bl);
     DECODE_FINISH(bl);
   }
 };

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -23,6 +23,7 @@
 struct cls_fifo_create_op
 {
   string id;
+  std::optional<rados::cls::fifo::fifo_objv_t> objv;
   struct {
     string name;
     string ns;
@@ -37,6 +38,7 @@ struct cls_fifo_create_op
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
     encode(id, bl);
+    encode(objv, bl);
     encode(pool.name, bl);
     encode(pool.ns, bl);
     encode(oid_prefix, bl);
@@ -48,6 +50,7 @@ struct cls_fifo_create_op
   void decode(bufferlist::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(id, bl);
+    decode(objv, bl);
     decode(pool.name, bl);
     decode(pool.ns, bl);
     decode(oid_prefix, bl);
@@ -58,4 +61,58 @@ struct cls_fifo_create_op
   }
 };
 WRITE_CLASS_ENCODER(cls_fifo_create_op)
+
+struct cls_fifo_get_op
+{
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_get_op)
+
+struct cls_fifo_get_op_reply
+{
+  string id;
+  std::optional<rados::cls::fifo::fifo_objv_t> objv;
+  struct {
+    string name;
+    string ns;
+  } pool;
+  string oid_prefix;
+
+  uint64_t max_obj_size{0};
+  uint64_t max_entry_size{0};
+
+  uint64_t tail_obj_num{0};
+  uint64_t head_obj_num{0};
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(id, bl);
+    encode(objv, bl);
+    encode(pool.name, bl);
+    encode(pool.ns, bl);
+    encode(oid_prefix, bl);
+    encode(max_obj_size, bl);
+    encode(max_entry_size, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(id, bl);
+    decode(objv, bl);
+    decode(pool.name, bl);
+    decode(pool.ns, bl);
+    decode(oid_prefix, bl);
+    decode(max_obj_size, bl);
+    decode(max_entry_size, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_fifo_get_op_reply)
 

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -246,17 +246,20 @@ struct cls_fifo_part_list_op_reply
 
   string tag;
   vector<entry> entries;
+  bool more{false};
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
     encode(tag, bl);
     encode(entries, bl);
+    encode(more, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(tag, bl);
     decode(entries, bl);
+    decode(more, bl);
     DECODE_FINISH(bl);
   }
 };

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -102,16 +102,20 @@ struct cls_fifo_meta_update_op
 
   std::optional<uint64_t> tail_part_num;
   std::optional<uint64_t> head_part_num;
-  std::optional<string> head_tag;
-  std::optional<rados::cls::fifo::fifo_prepare_status_t> head_prepare_status;
+  std::optional<uint64_t> min_push_part_num;
+  std::optional<uint64_t> max_push_part_num;
+  std::vector<rados::cls::fifo::fifo_journal_entry_t> journal_entries_add;
+  std::vector<rados::cls::fifo::fifo_journal_entry_t> journal_entries_rm;
 
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);
     encode(objv, bl);
     encode(tail_part_num, bl);
     encode(head_part_num, bl);
-    encode(head_tag, bl);
-    encode(head_prepare_status, bl);
+    encode(min_push_part_num, bl);
+    encode(max_push_part_num, bl);
+    encode(journal_entries_add, bl);
+    encode(journal_entries_rm, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
@@ -119,8 +123,10 @@ struct cls_fifo_meta_update_op
     decode(objv, bl);
     decode(tail_part_num, bl);
     decode(head_part_num, bl);
-    decode(head_tag, bl);
-    decode(head_prepare_status, bl);
+    decode(min_push_part_num, bl);
+    decode(max_push_part_num, bl);
+    decode(journal_entries_add, bl);
+    decode(journal_entries_rm, bl);
     DECODE_FINISH(bl);
   }
 };

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -217,35 +217,8 @@ WRITE_CLASS_ENCODER(cls_fifo_part_list_op)
 
 struct cls_fifo_part_list_op_reply
 {
-  struct entry {
-    bufferlist data;
-    uint64_t ofs;
-    ceph::real_time mtime;
-
-    entry() {}
-    entry(bufferlist&& _data,
-          uint64_t _ofs,
-          ceph::real_time _mtime) : data(std::move(_data)), ofs(_ofs), mtime(_mtime) {}
-
-
-    void encode(bufferlist &bl) const {
-      ENCODE_START(1, 1, bl);
-      encode(data, bl);
-      encode(ofs, bl);
-      encode(mtime, bl);
-      ENCODE_FINISH(bl);
-    }
-    void decode(bufferlist::const_iterator &bl) {
-      DECODE_START(1, bl);
-      decode(data, bl);
-      decode(ofs, bl);
-      decode(mtime, bl);
-      DECODE_FINISH(bl);
-    }
-  };
-
   string tag;
-  vector<entry> entries;
+  vector<rados::cls::fifo::cls_fifo_part_list_entry_t> entries;
   bool more{false};
 
   void encode(bufferlist &bl) const {
@@ -263,5 +236,4 @@ struct cls_fifo_part_list_op_reply
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(cls_fifo_part_list_op_reply::entry)
 WRITE_CLASS_ENCODER(cls_fifo_part_list_op_reply)

--- a/src/cls/fifo/cls_fifo_types.cc
+++ b/src/cls/fifo/cls_fifo_types.cc
@@ -1,0 +1,28 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "cls_fifo_types.h"
+
+
+string rados::cls::fifo::fifo_info_t::next_part_oid()
+{
+  auto part = next_part();
+
+  char buf[oid_prefix.size() + 32];
+  snprintf(buf, sizeof(buf), "%s.%lld", oid_prefix.c_str(), (long long)part);
+
+  return string(buf);
+}
+

--- a/src/cls/fifo/cls_fifo_types.cc
+++ b/src/cls/fifo/cls_fifo_types.cc
@@ -15,8 +15,6 @@
 
 #include "cls_fifo_types.h"
 
-#include "objclass/objclass.h"
-
 string rados::cls::fifo::fifo_info_t::part_oid(int64_t part_num)
 {
   char buf[oid_prefix.size() + 32];
@@ -25,18 +23,9 @@ string rados::cls::fifo::fifo_info_t::part_oid(int64_t part_num)
   return string(buf);
 }
 
-string rados::cls::fifo::fifo_info_t::generate_tag()
-{
-#define HEADER_TAG_SIZE 16
-    char buf[HEADER_TAG_SIZE + 1];
-    buf[HEADER_TAG_SIZE] = 0;
-    cls_gen_rand_base64(buf, sizeof(buf) - 1);
-    return string(buf);
-}
-
-void rados::cls::fifo::fifo_info_t::prepare_next_journal_entry(fifo_journal_entry_t *entry)
+void rados::cls::fifo::fifo_info_t::prepare_next_journal_entry(fifo_journal_entry_t *entry, const string& tag)
 {
   entry->op = fifo_journal_entry_t::Op::OP_CREATE;
   entry->part_num = max_push_part_num + 1;
-  entry->part_tag = generate_tag();
+  entry->part_tag = tag;
 }

--- a/src/cls/fifo/cls_fifo_types.cc
+++ b/src/cls/fifo/cls_fifo_types.cc
@@ -29,3 +29,60 @@ void rados::cls::fifo::fifo_info_t::prepare_next_journal_entry(fifo_journal_entr
   entry->part_num = max_push_part_num + 1;
   entry->part_tag = tag;
 }
+
+int rados::cls::fifo::fifo_info_t::apply_update(std::optional<uint64_t>& _tail_part_num,
+                                                std::optional<uint64_t>& _head_part_num,
+                                                std::optional<uint64_t>& _min_push_part_num,
+                                                std::optional<uint64_t>& _max_push_part_num,
+                                                std::vector<rados::cls::fifo::fifo_journal_entry_t>& journal_entries_add,
+                                                std::vector<rados::cls::fifo::fifo_journal_entry_t>& journal_entries_rm,
+                                                string *err)
+{
+  if (_tail_part_num) {
+    tail_part_num = *_tail_part_num;
+  }
+
+  if (_head_part_num) {
+    tags.erase(head_part_num);
+    head_part_num = *_head_part_num;
+    auto iter = tags.find(head_part_num);
+    if (iter != tags.end()) {
+      head_tag = iter->second;
+    } else {
+      head_tag.erase();
+    }
+  }
+
+  if (_min_push_part_num) {
+    min_push_part_num = *_min_push_part_num;
+  }
+
+  if (_max_push_part_num) {
+    max_push_part_num = *_max_push_part_num;
+  }
+
+  for (auto& entry : journal_entries_add) {
+    if (journal.find(entry.part_num) != journal.end()) {
+      /* don't allow multiple concurrent operations on the same part,
+         racing clients should use objv to avoid races anyway */
+      if (err) {
+        stringstream ss;
+        ss << "multiple concurrent operations on same part are not allowed, part num=" << entry.part_num;
+        *err = ss.str();
+      }
+      return -EINVAL;
+    }
+
+    if (entry.op == fifo_journal_entry_t::Op::OP_CREATE) {
+      tags[entry.part_num] = entry.part_tag;
+    }
+
+    journal[entry.part_num] = std::move(entry);
+  }
+
+  for (auto& entry : journal_entries_rm) {
+    journal.erase(entry.part_num);
+  }
+
+  return 0;
+}

--- a/src/cls/fifo/cls_fifo_types.cc
+++ b/src/cls/fifo/cls_fifo_types.cc
@@ -15,14 +15,28 @@
 
 #include "cls_fifo_types.h"
 
+#include "objclass/objclass.h"
 
-string rados::cls::fifo::fifo_info_t::next_part_oid()
+string rados::cls::fifo::fifo_info_t::part_oid(int64_t part_num)
 {
-  auto part = next_part();
-
   char buf[oid_prefix.size() + 32];
-  snprintf(buf, sizeof(buf), "%s.%lld", oid_prefix.c_str(), (long long)part);
+  snprintf(buf, sizeof(buf), "%s.%lld", oid_prefix.c_str(), (long long)part_num);
 
   return string(buf);
 }
 
+string rados::cls::fifo::fifo_info_t::generate_tag()
+{
+#define HEADER_TAG_SIZE 16
+    char buf[HEADER_TAG_SIZE + 1];
+    buf[HEADER_TAG_SIZE] = 0;
+    cls_gen_rand_base64(buf, sizeof(buf) - 1);
+    return string(buf);
+}
+
+void rados::cls::fifo::fifo_info_t::prepare_next_journal_entry(fifo_journal_entry_t *entry)
+{
+  entry->op = fifo_journal_entry_t::Op::OP_CREATE;
+  entry->part_num = max_push_part_num + 1;
+  entry->part_tag = generate_tag();
+}

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -78,6 +78,12 @@ namespace rados {
         }
         void dump(Formatter *f) const;
         void decode_json(JSONObj *obj);
+
+        bool operator==(const fifo_data_params_t& rhs) const {
+          return (max_obj_size == rhs.max_obj_size &&
+                  max_entry_size == rhs.max_entry_size &&
+                  full_size_threshold == rhs.full_size_threshold);
+        }
       };
       WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_data_params_t)
 

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -27,19 +27,22 @@ namespace rados {
     namespace fifo {
 
       struct fifo_data_params_t {
+        uint64_t max_obj_size{0};
+        uint64_t max_entry_size{0};
         uint64_t full_size_threshold{0};
-        uint64_t max_size{0};
 
         void encode(bufferlist &bl) const {
           ENCODE_START(1, 1, bl);
+          encode(max_obj_size, bl);
+          encode(max_entry_size, bl);
           encode(full_size_threshold, bl);
-          encode(max_size, bl);
           ENCODE_FINISH(bl);
         }
         void decode(bufferlist::const_iterator &bl) {
           DECODE_START(1, bl);
+          decode(max_obj_size, bl);
+          decode(max_entry_size, bl);
           decode(full_size_threshold, bl);
-          decode(max_size, bl);
           DECODE_FINISH(bl);
         }
         void dump(Formatter *f) const;

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -187,6 +187,35 @@ namespace rados {
         void decode_json(JSONObj *obj);
       };
       WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_info_t)
+
+      struct cls_fifo_part_list_entry_t {
+        bufferlist data;
+        uint64_t ofs;
+        ceph::real_time mtime;
+
+        cls_fifo_part_list_entry_t() {}
+        cls_fifo_part_list_entry_t(bufferlist&& _data,
+                                   uint64_t _ofs,
+                                   ceph::real_time _mtime) : data(std::move(_data)), ofs(_ofs), mtime(_mtime) {}
+
+
+        void encode(bufferlist &bl) const {
+          ENCODE_START(1, 1, bl);
+          encode(data, bl);
+          encode(ofs, bl);
+          encode(mtime, bl);
+          ENCODE_FINISH(bl);
+        }
+        void decode(bufferlist::const_iterator &bl) {
+          DECODE_START(1, bl);
+          decode(data, bl);
+          decode(ofs, bl);
+          decode(mtime, bl);
+          DECODE_FINISH(bl);
+        }
+      };
+      WRITE_CLASS_ENCODER(rados::cls::fifo::cls_fifo_part_list_entry_t)
+
     }
   }
 }

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -153,6 +153,14 @@ namespace rados {
         string part_oid(int64_t part_num);
         void prepare_next_journal_entry(fifo_journal_entry_t *entry, const string& tag);
 
+        int apply_update(std::optional<uint64_t>& _tail_part_num,
+                         std::optional<uint64_t>& _head_part_num,
+                         std::optional<uint64_t>& _min_push_part_num,
+                         std::optional<uint64_t>& _max_push_part_num,
+                         std::vector<rados::cls::fifo::fifo_journal_entry_t>& journal_entries_add,
+                         std::vector<rados::cls::fifo::fifo_journal_entry_t>& journal_entries_rm,
+                         string *err);
+
         void encode(bufferlist &bl) const {
           ENCODE_START(1, 1, bl);
           encode(id, bl);

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -25,6 +25,31 @@ class JSONObj;
 namespace rados {
   namespace cls {
     namespace fifo {
+      struct fifo_objv_t {
+        string instance;
+        uint64_t ver{0};
+
+        void encode(bufferlist &bl) const {
+          ENCODE_START(1, 1, bl);
+          encode(instance, bl);
+          encode(ver, bl);
+          ENCODE_FINISH(bl);
+        }
+        void decode(bufferlist::const_iterator &bl) {
+          DECODE_START(1, bl);
+          decode(instance, bl);
+          decode(ver, bl);
+          DECODE_FINISH(bl);
+        }
+        void dump(Formatter *f) const;
+        void decode_json(JSONObj *obj);
+
+        bool operator==(const fifo_objv_t& rhs) const {
+          return (instance == rhs.instance &&
+                  ver == rhs.ver);
+        }
+      };
+      WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_objv_t)
 
       struct fifo_data_params_t {
         uint64_t max_obj_size{0};

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -62,20 +62,20 @@ namespace rados {
       WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_objv_t)
 
       struct fifo_data_params_t {
-        uint64_t max_obj_size{0};
+        uint64_t max_part_size{0};
         uint64_t max_entry_size{0};
         uint64_t full_size_threshold{0};
 
         void encode(bufferlist &bl) const {
           ENCODE_START(1, 1, bl);
-          encode(max_obj_size, bl);
+          encode(max_part_size, bl);
           encode(max_entry_size, bl);
           encode(full_size_threshold, bl);
           ENCODE_FINISH(bl);
         }
         void decode(bufferlist::const_iterator &bl) {
           DECODE_START(1, bl);
-          decode(max_obj_size, bl);
+          decode(max_part_size, bl);
           decode(max_entry_size, bl);
           decode(full_size_threshold, bl);
           DECODE_FINISH(bl);
@@ -84,7 +84,7 @@ namespace rados {
         void decode_json(JSONObj *obj);
 
         bool operator==(const fifo_data_params_t& rhs) const {
-          return (max_obj_size == rhs.max_obj_size &&
+          return (max_part_size == rhs.max_part_size &&
                   max_entry_size == rhs.max_entry_size &&
                   full_size_threshold == rhs.full_size_threshold);
         }
@@ -130,20 +130,20 @@ namespace rados {
         string oid_prefix;
         fifo_data_params_t data_params;
 
-        uint64_t tail_obj_num{0};
-        uint64_t head_obj_num{0};
+        uint64_t tail_part_num{0};
+        uint64_t head_part_num{0};
         string head_tag;
 
         fifo_prepare_status_t head_prepare_status;
 
         uint64_t next_part() {
           if (head_prepare_status == fifo_prepare_status_t::STATUS_INIT) {
-            return head_obj_num;
+            return head_part_num;
           }
           if (head_prepare_status == fifo_prepare_status_t::STATUS_PREPARE) {
             return head_prepare_status.head_num;
           }
-          return head_obj_num + 1;
+          return head_part_num + 1;
         }
 
         string next_part_oid();
@@ -154,8 +154,8 @@ namespace rados {
           encode(objv, bl);
           encode(oid_prefix, bl);
           encode(data_params, bl);
-          encode(tail_obj_num, bl);
-          encode(head_obj_num, bl);
+          encode(tail_part_num, bl);
+          encode(head_part_num, bl);
           encode(head_tag, bl);
           encode(head_prepare_status, bl);
           ENCODE_FINISH(bl);
@@ -166,8 +166,8 @@ namespace rados {
           decode(objv, bl);
           decode(oid_prefix, bl);
           decode(data_params, bl);
-          decode(tail_obj_num, bl);
-          decode(head_obj_num, bl);
+          decode(tail_part_num, bl);
+          decode(head_part_num, bl);
           decode(head_tag, bl);
           decode(head_prepare_status, bl);
           DECODE_FINISH(bl);

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -48,6 +48,12 @@ namespace rados {
           return (instance == rhs.instance &&
                   ver == rhs.ver);
         }
+
+        string to_str() {
+          char buf[instance.size() + 32];
+          snprintf(buf, sizeof(buf), "%s{%lld}", instance.c_str(), (long long)ver);
+          return string(buf);
+        }
       };
       WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_objv_t)
 
@@ -106,6 +112,7 @@ namespace rados {
 
       struct fifo_info_t {
         string id;
+        fifo_objv_t objv;
         struct {
           string name;
           string ns;
@@ -122,6 +129,7 @@ namespace rados {
         void encode(bufferlist &bl) const {
           ENCODE_START(1, 1, bl);
           encode(id, bl);
+          encode(objv, bl);
           encode(pool.name, bl);
           encode(pool.ns, bl);
           encode(oid_prefix, bl);
@@ -135,6 +143,7 @@ namespace rados {
         void decode(bufferlist::const_iterator &bl) {
           DECODE_START(1, bl);
           decode(id, bl);
+          decode(objv, bl);
           decode(pool.name, bl);
           decode(pool.ns, bl);
           decode(oid_prefix, bl);
@@ -149,8 +158,12 @@ namespace rados {
         void decode_json(JSONObj *obj);
       };
       WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_info_t)
-
     }
   }
+}
+
+static inline ostream& operator<<(ostream& os, const rados::cls::fifo::fifo_objv_t& objv)
+{
+  return os << objv.instance << "{" << objv.ver << "}";
 }
 

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -93,10 +93,12 @@ namespace rados {
 
       struct fifo_journal_entry_t {
         enum Op {
-          OP_UNKNOWN = 0,
-          OP_CREATE  = 1,
-          OP_REMOVE  = 2,
+          OP_UNKNOWN  = 0,
+          OP_CREATE   = 1,
+          OP_SET_HEAD = 2,
+          OP_REMOVE   = 3,
         } op{OP_UNKNOWN};
+
         int64_t part_num{0};
         string part_tag;
 
@@ -140,7 +142,7 @@ namespace rados {
         string head_tag;
         map<int64_t, string> tags;
 
-        std::map<int64_t, fifo_journal_entry_t> journal;
+        std::multimap<int64_t, fifo_journal_entry_t> journal;
 
         bool need_new_head() {
           return (head_part_num < min_push_part_num);

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -151,8 +151,7 @@ namespace rados {
         }
 
         string part_oid(int64_t part_num);
-        static string generate_tag();
-        void prepare_next_journal_entry(fifo_journal_entry_t *entry);
+        void prepare_next_journal_entry(fifo_journal_entry_t *entry, const string& tag);
 
         void encode(bufferlist &bl) const {
           ENCODE_START(1, 1, bl);

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -224,6 +224,43 @@ namespace rados {
       };
       WRITE_CLASS_ENCODER(rados::cls::fifo::cls_fifo_part_list_entry_t)
 
+      struct fifo_part_header_t {
+        string tag;
+
+        fifo_data_params_t params;
+
+        uint64_t magic{0};
+
+        uint64_t min_ofs{0};
+        uint64_t max_ofs{0};
+        uint64_t min_index{0};
+        uint64_t max_index{0};
+
+        void encode(bufferlist &bl) const {
+          ENCODE_START(1, 1, bl);
+          encode(tag, bl);
+          encode(params, bl);
+          encode(magic, bl);
+          encode(min_ofs, bl);
+          encode(max_ofs, bl);
+          encode(min_index, bl);
+          encode(max_index, bl);
+          ENCODE_FINISH(bl);
+        }
+        void decode(bufferlist::const_iterator &bl) {
+          DECODE_START(1, bl);
+          decode(tag, bl);
+          decode(params, bl);
+          decode(magic, bl);
+          decode(min_ofs, bl);
+          decode(max_ofs, bl);
+          decode(min_index, bl);
+          decode(max_index, bl);
+          DECODE_FINISH(bl);
+        }
+      };
+      WRITE_CLASS_ENCODER(fifo_part_header_t)
+
     }
   }
 }

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -1,0 +1,128 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+
+#include "include/encoding.h"
+#include "include/types.h"
+
+
+class JSONObj;
+
+namespace rados {
+  namespace cls {
+    namespace fifo {
+
+      struct fifo_data_params_t {
+        uint64_t full_size_threshold{0};
+        uint64_t max_size{0};
+
+        void encode(bufferlist &bl) const {
+          ENCODE_START(1, 1, bl);
+          encode(full_size_threshold, bl);
+          encode(max_size, bl);
+          ENCODE_FINISH(bl);
+        }
+        void decode(bufferlist::const_iterator &bl) {
+          DECODE_START(1, bl);
+          decode(full_size_threshold, bl);
+          decode(max_size, bl);
+          DECODE_FINISH(bl);
+        }
+        void dump(Formatter *f) const;
+        void decode_json(JSONObj *obj);
+      };
+      WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_data_params_t)
+
+      struct fifo_prepare_status_t {
+        enum Status {
+          STATUS_INIT = 0,
+          STATUS_PREPARE = 1,
+          STATUS_COMPLETE = 2,
+        } status{STATUS_INIT};
+        uint64_t head_num;
+        string head_tag;
+
+        void encode(bufferlist &bl) const {
+          ENCODE_START(1, 1, bl);
+          encode((int)status, bl);
+          encode(head_num, bl);
+          encode(head_tag, bl);
+          ENCODE_FINISH(bl);
+        }
+        void decode(bufferlist::const_iterator &bl) {
+          DECODE_START(1, bl);
+          int i;
+          decode(i, bl);
+          status = (Status)i;
+          decode(head_num, bl);
+          decode(head_tag, bl);
+          DECODE_FINISH(bl);
+        }
+        void dump(Formatter *f) const;
+      };
+      WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_prepare_status_t)
+
+      struct fifo_info_t {
+        string id;
+        struct {
+          string name;
+          string ns;
+        } pool;
+        string oid_prefix;
+        fifo_data_params_t data_params;
+
+        uint64_t tail_obj_num{0};
+        uint64_t head_obj_num{0};
+        string head_tag;
+
+        fifo_prepare_status_t head_prepare_status;
+
+        void encode(bufferlist &bl) const {
+          ENCODE_START(1, 1, bl);
+          encode(id, bl);
+          encode(pool.name, bl);
+          encode(pool.ns, bl);
+          encode(oid_prefix, bl);
+          encode(data_params, bl);
+          encode(tail_obj_num, bl);
+          encode(head_obj_num, bl);
+          encode(head_tag, bl);
+          encode(head_prepare_status, bl);
+          ENCODE_FINISH(bl);
+        }
+        void decode(bufferlist::const_iterator &bl) {
+          DECODE_START(1, bl);
+          decode(id, bl);
+          decode(pool.name, bl);
+          decode(pool.ns, bl);
+          decode(oid_prefix, bl);
+          decode(data_params, bl);
+          decode(tail_obj_num, bl);
+          decode(head_obj_num, bl);
+          decode(head_tag, bl);
+          decode(head_prepare_status, bl);
+          DECODE_FINISH(bl);
+        }
+        void dump(Formatter *f) const;
+        void decode_json(JSONObj *obj);
+      };
+      WRITE_CLASS_ENCODER(rados::cls::fifo::fifo_info_t)
+
+    }
+  }
+}
+

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -8,6 +8,7 @@ target_include_directories(unit-main PRIVATE
   $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>)
 
 add_subdirectory(cls_hello)
+add_subdirectory(cls_fifo)
 add_subdirectory(cls_lock)
 add_subdirectory(cls_log)
 add_subdirectory(cls_numops)

--- a/src/test/cls_fifo/CMakeLists.txt
+++ b/src/test/cls_fifo/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(ceph_test_cls_fifo
+  test_cls_fifo.cc
+  )
+target_link_libraries(ceph_test_cls_fifo
+  cls_fifo_client
+  librados
+  global
+  ${UNITTEST_LIBS}
+  ${BLKID_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+  ${CRYPTO_LIBS}
+  ${EXTRALIBS}
+  radostest-cxx
+  )
+install(TARGETS
+  ceph_test_cls_fifo
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/cls_fifo/test_cls_fifo.cc
+++ b/src/test/cls_fifo/test_cls_fifo.cc
@@ -79,6 +79,18 @@ TEST(ClsFIFO, TestCreate) {
   ASSERT_EQ(-EINVAL, FIFO::create(&op,
                                   FIFO::CreateParams()
                                   .id("fifo")));
+  ASSERT_EQ(-EINVAL, FIFO::create(&op,
+                     FIFO::CreateParams()
+                     .id("fifo")
+                     .pool(pool_name)
+                     .max_obj_size(0)));
+
+  ASSERT_EQ(-EINVAL, FIFO::create(&op,
+                     FIFO::CreateParams()
+                     .id("fifo")
+                     .pool(pool_name)
+                     .max_entry_size(0)));
+
   ASSERT_EQ(0, FIFO::create(&op,
                FIFO::CreateParams()
                .id("fifo")

--- a/src/test/cls_fifo/test_cls_fifo.cc
+++ b/src/test/cls_fifo/test_cls_fifo.cc
@@ -61,7 +61,7 @@ TEST(ClsFIFO, TestCreate) {
   ASSERT_EQ(-EINVAL, fifo_create(ioctx, oid,
                      FIFO::MetaCreateParams()
                      .id(fifo_id)
-                     .max_obj_size(0)));
+                     .max_part_size(0)));
 
   ASSERT_EQ(-EINVAL, fifo_create(ioctx, oid,
                      FIFO::MetaCreateParams()

--- a/src/test/cls_fifo/test_cls_fifo.cc
+++ b/src/test/cls_fifo/test_cls_fifo.cc
@@ -1,0 +1,97 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#include <iostream>
+#include <errno.h>
+
+#include "include/types.h"
+#include "include/rados/librados.hpp"
+
+#include "test/librados/test_cxx.h"
+#include "gtest/gtest.h"
+
+using namespace librados;
+
+#include "cls/fifo/cls_fifo_client.h"
+
+using namespace rados::cls::fifo;
+
+#if 0
+void lock_info(IoCtx *ioctx, string& oid, string& name, map<locker_id_t, locker_info_t>& lockers,
+	       ClsLockType *assert_type, string *assert_tag)
+{
+  ClsLockType lock_type = LOCK_NONE;
+  string tag;
+  lockers.clear();
+  ASSERT_EQ(0, get_lock_info(ioctx, oid, name, &lockers, &lock_type, &tag));
+  cout << "lock: " << name << std::endl;
+  cout << "  lock_type: " << cls_lock_type_str(lock_type) << std::endl;
+  cout << "  tag: " << tag << std::endl;
+  cout << "  lockers:" << std::endl;
+
+  if (assert_type) {
+    ASSERT_EQ(*assert_type, lock_type);
+  }
+
+  if (assert_tag) {
+    ASSERT_EQ(*assert_tag, tag);
+  }
+
+  map<locker_id_t, locker_info_t>::iterator liter;
+  for (liter = lockers.begin(); liter != lockers.end(); ++liter) {
+    const locker_id_t& locker = liter->first;
+    cout << "    " << locker.locker << " expiration=" << liter->second.expiration
+         << " addr=" << liter->second.addr << " cookie=" << locker.cookie << std::endl;
+  }
+}
+
+void lock_info(IoCtx *ioctx, string& oid, string& name, map<locker_id_t, locker_info_t>& lockers)
+{
+  lock_info(ioctx, oid, name, lockers, NULL, NULL);
+}
+#endif
+
+TEST(ClsFIFO, TestCreate) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  ObjectWriteOperation op;
+
+  ASSERT_EQ(-EINVAL, FIFO::create(&op,
+                                  FIFO::CreateParams()));
+
+  string fifo_id = "fifo";
+
+  ASSERT_EQ(-EINVAL, FIFO::create(&op,
+                                  FIFO::CreateParams()
+                                  .id("fifo")));
+  ASSERT_EQ(0, FIFO::create(&op,
+               FIFO::CreateParams()
+               .id("fifo")
+               .pool(pool_name)));
+
+  string oid = fifo_id;
+  ASSERT_EQ(0, ioctx.operate(oid, &op));
+
+  uint64_t size;
+  struct timespec ts;
+  ASSERT_EQ(0, ioctx.stat2(oid, &size, &ts));
+  ASSERT_GT(size, 0);
+
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
+}
+

--- a/src/test/cls_fifo/test_cls_fifo.cc
+++ b/src/test/cls_fifo/test_cls_fifo.cc
@@ -435,11 +435,18 @@ TEST(FIFO, TestMultipleParts) {
     ASSERT_EQ(0, fifo.list(max_entries, marker, &result, &more));
     ASSERT_EQ(max_entries - i - 1, result.size());
     ASSERT_EQ(false, more);
-
-    auto info = fifo.get_meta();
   }
 
+  info = fifo.get_meta();
   ASSERT_EQ(info.head_part_num, info.tail_part_num);
+
+  fifo_part_info part_info;
+
+  for (int i = 0; i < info.tail_part_num; ++i) {
+    ASSERT_EQ(-ENOENT, fifo.get_part_info(i, &part_info));
+  }
+
+  ASSERT_EQ(0, fifo.get_part_info(info.tail_part_num, &part_info));
 
   ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
 }

--- a/src/test/cls_fifo/test_cls_fifo.cc
+++ b/src/test/cls_fifo/test_cls_fifo.cc
@@ -134,5 +134,80 @@ TEST(ClsFIFO, TestGetInfo) {
                .objv(objv),
                &info));
 
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
+}
+
+TEST(FIFO, TestOpenDefault) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  string fifo_id = "fifo";
+
+  FIFO fifo(g_ceph_context, fifo_id, &ioctx);
+
+  /* pre-open ops that should fail */
+  ASSERT_EQ(-EINVAL, fifo.read_meta());
+
+  bufferlist bl;
+  ASSERT_EQ(-EINVAL, fifo.push(bl));
+
+  ASSERT_EQ(-EINVAL, fifo.list(100, nullopt, nullptr, nullptr));
+  ASSERT_EQ(-EINVAL, fifo.trim(string()));
+
+  ASSERT_EQ(-ENOENT, fifo.open(false));
+
+  /* first successful create */
+  ASSERT_EQ(0, fifo.open(true));
+
+  ASSERT_EQ(0, fifo.read_meta()); /* force reading from backend */
+
+  auto info = fifo.get_meta();
+
+  ASSERT_EQ(info.id, fifo_id);
+
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
+}
+
+TEST(FIFO, TestOpenParams) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  string fifo_id = "fifo";
+
+  FIFO fifo(g_ceph_context, fifo_id, &ioctx);
+
+  uint64_t max_part_size = 10 * 1024;
+  uint64_t max_entry_size = 128;
+  string oid_prefix = "foo.123.";
+
+  fifo_objv_t objv;
+  objv.instance = "fooz";
+  objv.ver = 10;
+
+
+  /* first successful create */
+  ASSERT_EQ(0, fifo.open(true,
+                         ClsFIFO::MetaCreateParams()
+                         .max_part_size(max_part_size)
+                         .max_entry_size(max_entry_size)
+                         .oid_prefix(oid_prefix)
+                         .objv(objv)));
+
+  ASSERT_EQ(0, fifo.read_meta()); /* force reading from backend */
+
+  auto info = fifo.get_meta();
+
+  ASSERT_EQ(info.id, fifo_id);
+  ASSERT_EQ(info.data_params.max_part_size, max_part_size);
+  ASSERT_EQ(info.data_params.max_entry_size, max_entry_size);
+  ASSERT_EQ(info.objv, objv);
+
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
 }
 

--- a/src/test/cls_fifo/test_cls_fifo.cc
+++ b/src/test/cls_fifo/test_cls_fifo.cc
@@ -148,3 +148,41 @@ TEST(ClsFIFO, TestCreate) {
   ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
 }
 
+TEST(ClsFIFO, TestGetInfo) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  string fifo_id = "fifo";
+  string oid = fifo_id;
+
+  fifo_info_t info;
+
+  /* first successful create */
+  ASSERT_EQ(0, fifo_create(ioctx, oid,
+               FIFO::CreateParams()
+               .id(fifo_id)
+               .pool(pool_name)));
+
+  ASSERT_EQ(0, FIFO::get_info(ioctx, oid,
+               FIFO::GetInfoParams(), &info));
+
+  ASSERT_TRUE(!info.objv.instance.empty());
+
+  ASSERT_EQ(0, FIFO::get_info(ioctx, oid,
+               FIFO::GetInfoParams()
+               .objv(info.objv),
+               &info));
+
+  fifo_objv_t objv;
+  objv.instance="foo";
+  objv.ver = 12;
+  ASSERT_EQ(-ECANCELED, FIFO::get_info(ioctx, oid,
+               FIFO::GetInfoParams()
+               .objv(objv),
+               &info));
+
+}
+

--- a/src/test/cls_fifo/test_cls_fifo.cc
+++ b/src/test/cls_fifo/test_cls_fifo.cc
@@ -121,15 +121,23 @@ TEST(ClsFIFO, TestGetInfo) {
   ASSERT_EQ(0, fifo_create(ioctx, oid, fifo_id,
                ClsFIFO::MetaCreateParams()));
 
+  uint32_t part_header_size;
+  uint32_t part_entry_overhead;
+
   ASSERT_EQ(0, ClsFIFO::meta_get(ioctx, oid,
-               ClsFIFO::MetaGetParams(), &info));
+               ClsFIFO::MetaGetParams(), &info,
+               &part_header_size, &part_entry_overhead));
+
+  ASSERT_GT(part_header_size, 0);
+  ASSERT_GT(part_entry_overhead, 0);
 
   ASSERT_TRUE(!info.objv.instance.empty());
 
   ASSERT_EQ(0, ClsFIFO::meta_get(ioctx, oid,
                ClsFIFO::MetaGetParams()
                .objv(info.objv),
-               &info));
+               &info,
+               &part_header_size, &part_entry_overhead));
 
   fifo_objv_t objv;
   objv.instance="foo";
@@ -137,7 +145,8 @@ TEST(ClsFIFO, TestGetInfo) {
   ASSERT_EQ(-ECANCELED, ClsFIFO::meta_get(ioctx, oid,
                ClsFIFO::MetaGetParams()
                .objv(objv),
-               &info));
+               &info,
+               &part_header_size, &part_entry_overhead));
 
   ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
 }


### PR DESCRIPTION
This is an implementation of fifo queue over rados. Data is appended to rados object until it's full. At that point data will be written to a new object. Data is read from the tail sequentially (can be iterated using marker). Data can be trimmed (up to and including marker).

Queue has a header object (meta), and zero or more data objects (parts).

The software has two layers: the higher level client operations side that deals with the application apis, and manages the meta and parts, and there’s the objclass level that deals with the rados layout of meta and part objects. There are different objclass methods that deal with reading and modifying each of these entities.

A single part has max possible size, however, it may become full once a certain smaller size is reached (full_size_threshold). It is imperative that once a part has reached its capacity, it will not allow any more writes into it. For this reason, it is important that data being written to the queue does not exceed max_entry_size . This is enforced, by the higher level client api.

Written entries go to the current head object, and when it’s full, a new head part is created. When listing entries, data is iterated from tail to the current head. Trim can either change the pointer within the current tail object, and if needed it removes tail objects.

A unitest has been created to test functionality.

TODO:
 - async api
 - adapt code to new rados writes return value capabilities
 - parallel push test (currently only tests sequential writes from multiple clients)


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
