### PR TITLE
common: rename 'image' to 'container_image'

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -431,7 +431,7 @@ std::vector<Option> get_global_options() {
     .add_tag("network")
     .add_see_also("mon_host"),
 
-    Option("image", Option::TYPE_STR, Option::LEVEL_BASIC)
+    Option("container_image", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("container image (used by ssh orchestrator)")
     .set_flag(Option::FLAG_STARTUP)
     .set_default("ceph/daemon-base"),

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -356,7 +356,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             ret, image, err = self.mon_command({
                 'prefix': 'config get',
                 'who': entity,
-                'key': 'image',
+                'key': 'container_image',
             })
             image = image.strip()
             self.log.debug('%s container image %s' % (entity, image))


### PR DESCRIPTION
This conflicted with the rbd CLI --image argument.