### PR TITLE
cephfs-shell: Remove extra length argument passed to setxattr()

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -13,6 +13,7 @@ from time import sleep
 from StringIO import StringIO
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.misc import sudo_write_file
+from teuthology.orchestra.run import CommandFailedError
 
 log = logging.getLogger(__name__)
 
@@ -684,8 +685,11 @@ class TestQuota(TestCephFSShell):
         mount_output = self.get_cephfs_shell_cmd_output('mkdir ' + self.dir_name)
         log.info("cephfs-shell mount output:\n{}".format(mount_output))
 
-    def validate(self, input_val):
-        quota_output = self.get_cephfs_shell_cmd_output('quota set --max_bytes '+input_val[0]+' --max_files '+input_val[1]+ ' '+ self.dir_name)
+    def set_and_get_quota_vals(self, input_val):
+        quota_output = self.run_cephfs_shell_cmd('quota set --max_bytes '
+                                                 + input_val[0] + ' --max_files '
+                                                 + input_val[1] + ' '
+                                                 + self.dir_name)
         log.info("cephfs-shell quota set output:\n{}".format(quota_output))
 
         quota_output = self.get_cephfs_shell_cmd_output('quota get '+ self.dir_name)
@@ -697,17 +701,17 @@ class TestQuota(TestCephFSShell):
     def test_set(self):
         self.create_dir()
         set_values = ('6', '2')
-        self.assertTupleEqual(self.validate(set_values), set_values)
+        self.assertTupleEqual(self.set_and_get_quota_vals(set_values), set_values)
 
     def test_replace_values(self):
         self.test_set()
         set_values = ('20', '4')
-        self.assertTupleEqual(self.validate(set_values), set_values)
+        self.assertTupleEqual(self.set_and_get_quota_vals(set_values), set_values)
 
     def test_set_invalid_dir(self):
         set_values = ('5', '5')
         try:
-            self.assertTupleEqual(self.validate(set_values), set_values)
+            self.assertTupleEqual(self.set_and_get_quota_vals(set_values), set_values)
             raise Exception("Something went wrong!! Values set for non existing directory")
         except IndexError:
             # Test should pass as values cannot be set for non existing directory
@@ -717,7 +721,7 @@ class TestQuota(TestCephFSShell):
         self.create_dir()
         set_values = ('-6', '-5')
         try:
-            self.assertTupleEqual(self.validate(set_values), set_values)
+            self.assertTupleEqual(self.set_and_get_quota_vals(set_values), set_values)
             raise Exception("Something went wrong!! Invalid values set")
         except IndexError:
             # Test should pass as invalid values cannot be set
@@ -727,12 +731,16 @@ class TestQuota(TestCephFSShell):
         self.test_set()
         dir_abspath = path.join(self.mount_a.mountpoint, self.dir_name)
         self.mount_a.run_shell('touch '+dir_abspath+'/file1')
+        file2 = path.join(dir_abspath, "file2")
         try:
-            self.mount_a.run_shell('touch '+dir_abspath+'/file2')
+            self.mount_a.run_shell('touch '+file2)
             raise Exception("Something went wrong!! File creation should have failed")
         except CommandFailedError:
             # Test should pass as file quota set to 2
-            pass
+            # Additional condition to confirm file creation failure
+            if not path.exists(file2):
+                return 0
+            raise
 
     def test_exceed_write_limit(self):
         self.test_set()
@@ -740,12 +748,21 @@ class TestQuota(TestCephFSShell):
         filename = 'test_file'
         file_abspath = path.join(dir_abspath, filename)
         try:
+            # Write should fail as bytes quota is set to 6
             sudo_write_file(self.mount_a.client_remote, file_abspath,
                     'Disk raise Exception')
             raise Exception("Write should have failed")
         except CommandFailedError:
-            # Test should pass as bytes quota set to 6
-            pass
+            # Test should pass only when write command fails
+            path_exists = path.exists(file_abspath)
+            if not path_exists:
+                # Testing with teuthology: No file is created.
+                return 0
+            elif path_exists and not path.getsize(file_abspath):
+                # Testing on Fedora 30: When write fails, empty file gets created.
+                return 0
+            else:
+                raise
 
 #    def test_ls(self):
 #        """

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -681,7 +681,7 @@ class TestQuota(TestCephFSShell):
     dir_name = 'testdir'
 
     def create_dir(self):
-        mount_output = self.mount_a.run_shell('mkdir ' + self.dir_name)
+        mount_output = self.get_cephfs_shell_cmd_output('mkdir ' + self.dir_name)
         log.info("cephfs-shell mount output:\n{}".format(mount_output))
 
     def validate(self, input_val):

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -677,6 +677,76 @@ class TestDF(TestCephFSShell):
         self.validate_df("dumpfile")
 
 
+class TestQuota(TestCephFSShell):
+    dir_name = 'testdir'
+
+    def create_dir(self):
+        mount_output = self.mount_a.run_shell('mkdir ' + self.dir_name)
+        log.info("cephfs-shell mount output:\n{}".format(mount_output))
+
+    def validate(self, input_val):
+        quota_output = self.get_cephfs_shell_cmd_output('quota set --max_bytes '+input_val[0]+' --max_files '+input_val[1]+ ' '+ self.dir_name)
+        log.info("cephfs-shell quota set output:\n{}".format(quota_output))
+
+        quota_output = self.get_cephfs_shell_cmd_output('quota get '+ self.dir_name)
+        log.info("cephfs-shell quota get output:\n{}".format(quota_output))
+
+        quota_output = quota_output.split()
+        return quota_output[1], quota_output[3]
+
+    def test_set(self):
+        self.create_dir()
+        set_values = ('6', '2')
+        self.assertTupleEqual(self.validate(set_values), set_values)
+
+    def test_replace_values(self):
+        self.test_set()
+        set_values = ('20', '4')
+        self.assertTupleEqual(self.validate(set_values), set_values)
+
+    def test_set_invalid_dir(self):
+        set_values = ('5', '5')
+        try:
+            self.assertTupleEqual(self.validate(set_values), set_values)
+            raise Exception("Something went wrong!! Values set for non existing directory")
+        except IndexError:
+            # Test should pass as values cannot be set for non existing directory
+            pass
+
+    def test_set_invalid_values(self):
+        self.create_dir()
+        set_values = ('-6', '-5')
+        try:
+            self.assertTupleEqual(self.validate(set_values), set_values)
+            raise Exception("Something went wrong!! Invalid values set")
+        except IndexError:
+            # Test should pass as invalid values cannot be set
+            pass
+
+    def test_exceed_file_limit(self):
+        self.test_set()
+        dir_abspath = path.join(self.mount_a.mountpoint, self.dir_name)
+        self.mount_a.run_shell('touch '+dir_abspath+'/file1')
+        try:
+            self.mount_a.run_shell('touch '+dir_abspath+'/file2')
+            raise Exception("Something went wrong!! File creation should have failed")
+        except CommandFailedError:
+            # Test should pass as file quota set to 2
+            pass
+
+    def test_exceed_write_limit(self):
+        self.test_set()
+        dir_abspath = path.join(self.mount_a.mountpoint, self.dir_name)
+        filename = 'test_file'
+        file_abspath = path.join(dir_abspath, filename)
+        try:
+            sudo_write_file(self.mount_a.client_remote, file_abspath,
+                    'Disk raise Exception')
+            raise Exception("Write should have failed")
+        except CommandFailedError:
+            # Test should pass as bytes quota set to 6
+            pass
+
 #    def test_ls(self):
 #        """
 #        Test that ls passes

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1258,13 +1258,11 @@ class CephFSShell(Cmd):
                 max_bytes = to_bytes(str(args.max_bytes))
                 try:
                     cephfs.setxattr(args.path, 'ceph.quota.max_bytes',
-                                    max_bytes, len(max_bytes),
-                                    os.XATTR_CREATE)
+                                    max_bytes, os.XATTR_CREATE)
                     poutput('max_bytes set to %d' % args.max_bytes)
                 except libcephfs.Error:
                     cephfs.setxattr(args.path, 'ceph.quota.max_bytes',
-                                    max_bytes, len(max_bytes),
-                                    os.XATTR_REPLACE)
+                                    max_bytes, os.XATTR_REPLACE)
                     perror('max_bytes reset to %d' % args.max_bytes)
                     self.exit_code = 1
 
@@ -1272,13 +1270,11 @@ class CephFSShell(Cmd):
                 max_files = to_bytes(str(args.max_files))
                 try:
                     cephfs.setxattr(args.path, 'ceph.quota.max_files',
-                                    max_files, len(max_files),
-                                    os.XATTR_CREATE)
+                                    max_files, os.XATTR_CREATE)
                     poutput('max_files set to %d' % args.max_files)
                 except libcephfs.Error:
                     cephfs.setxattr(args.path, 'ceph.quota.max_files',
-                                    max_files, len(max_files),
-                                    os.XATTR_REPLACE)
+                                    max_files, os.XATTR_REPLACE)
                     perror('max_files reset to %d' % args.max_files)
                     self.exit_code = 1
         elif args.op == 'get':

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1281,18 +1281,16 @@ class CephFSShell(Cmd):
             max_bytes = '0'
             max_files = '0'
             try:
-                max_bytes = cephfs.getxattr(args.path,
-                                            'ceph.quota.max_bytes')
-                poutput('max_bytes: %s' % max_bytes)
+                max_bytes = cephfs.getxattr(args.path, 'ceph.quota.max_bytes')
+                poutput('max_bytes: {}'.format(max_bytes.decode('utf-8')))
             except libcephfs.Error:
                 perror('max_bytes is not set')
                 self.exit_code = 1
                 pass
 
             try:
-                max_files = cephfs.getxattr(args.path,
-                                            'ceph.quota.max_files')
-                poutput('max_files: %s' % max_files)
+                max_files = cephfs.getxattr(args.path, 'ceph.quota.max_files')
+                poutput('max_files: {}'.format(max_files.decode('utf-8')))
             except libcephfs.Error:
                 perror('max_files is not set')
                 self.exit_code = 1


### PR DESCRIPTION
Length is computed before calling ceph_setxattr() in setxattr() definition.

Fixes: https://tracker.ceph.com/issues/42238
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
