### PR TITLE
mimic: rgw: add missing admin property when sync user info

### DIFF
--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -472,6 +472,9 @@ void RGWUserInfo::dump(Formatter *f) const
   if (system) { /* no need to show it for every user */
     encode_json("system", (bool)system, f);
   }
+  if (admin) {
+    encode_json("admin", (bool)admin, f);
+  }
   encode_json("default_placement", default_placement, f);
   encode_json("placement_tags", placement_tags, f);
   encode_json("bucket_quota", bucket_quota, f);
@@ -550,7 +553,9 @@ void RGWUserInfo::decode_json(JSONObj *obj)
   bool sys = false;
   JSONDecoder::decode_json("system", sys, obj);
   system = (__u8)sys;
+  bool ad = false;
   JSONDecoder::decode_json("default_placement", default_placement, obj);
+  admin = (__u8)ad;
   JSONDecoder::decode_json("placement_tags", placement_tags, obj);
   JSONDecoder::decode_json("bucket_quota", bucket_quota, obj);
   JSONDecoder::decode_json("user_quota", user_quota, obj);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41975

---

backport of https://github.com/ceph/ceph/pull/30127
parent tracker: https://tracker.ceph.com/issues/41643

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh