### PR TITLE
mimic: ceph-volume: PVolumes.filter shouldn't purge itself

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -883,8 +883,9 @@ class PVolumes(list):
     to filter them via keyword arguments.
     """
 
-    def __init__(self):
-        self._populate()
+    def __init__(self, populate=True):
+        if populate:
+            self._populate()
 
     def _populate(self):
         # get all the pvs in the current system

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -930,24 +930,19 @@ class PVolumes(list):
     def filter(self, pv_name=None, pv_uuid=None, pv_tags=None):
         """
         Filter out volumes on top level attributes like ``pv_name`` or by
-        ``pv_tags`` where a dict is required. For example, to find a physical volume
-        that has an OSD ID of 0, the filter would look like::
+        ``pv_tags`` where a dict is required. For example, to find a physical
+        volume that has an OSD ID of 0, the filter would look like::
 
             pv_tags={'ceph.osd_id': '0'}
 
         """
         if not any([pv_name, pv_uuid, pv_tags]):
-            raise TypeError('.filter() requires pv_name, pv_uuid, or pv_tags (none given)')
-        # first find the filtered volumes with the values in self
-        filtered_volumes = self._filter(
-            pv_name=pv_name,
-            pv_uuid=pv_uuid,
-            pv_tags=pv_tags
-        )
-        # then purge everything
-        self._purge()
-        # and add the filtered items
-        self.extend(filtered_volumes)
+            raise TypeError('.filter() requires pv_name, pv_uuid, or pv_tags'
+                            '(none given)')
+
+        filtered_pvs = PVolumes(populate=False)
+        filtered_pvs.extend(self._filter(pv_name, pv_uuid, pv_tags))
+        return filtered_pvs
 
     def get(self, pv_name=None, pv_uuid=None, pv_tags=None):
         """

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -186,8 +186,8 @@ class TestPVolumes(object):
             pv_name='/dev/vg/foo',
             pv_uuid='1111', pv_tags=pv_tags, vg_name='vg')
         pvolumes.append(FooPVolume)
-        pvolumes.filter(pv_tags={'ceph.type': 'journal', 'ceph.osd_id': '2'})
-        assert pvolumes == []
+        assert pvolumes.filter(pv_tags={'ceph.type': 'journal',
+                               'ceph.osd_id': '2'}) == []
 
     def test_filter_by_tags_matches(self, pvolumes, monkeypatch):
         pv_tags = "ceph.type=journal,ceph.osd_id=1"
@@ -195,8 +195,8 @@ class TestPVolumes(object):
             pv_name='/dev/vg/foo',
             pv_uuid='1111', pv_tags=pv_tags, vg_name="vg")
         pvolumes.append(FooPVolume)
-        pvolumes.filter(pv_tags={'ceph.type': 'journal', 'ceph.osd_id': '1'})
-        assert pvolumes == [FooPVolume]
+        assert pvolumes.filter(pv_tags={'ceph.type': 'journal',
+                               'ceph.osd_id': '1'}) == [FooPVolume]
 
 
 class TestGetVG(object):

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -167,6 +167,12 @@ def pvolumes(monkeypatch):
     pvolumes = lvm_api.PVolumes()
     pvolumes._purge()
     return pvolumes
+@pytest.fixture
+def pvolumes_empty(monkeypatch):
+    monkeypatch.setattr('ceph_volume.process.call', lambda x, **kw: ('', '', 0))
+    pvolumes = lvm_api.PVolumes(populate=False)
+    return pvolumes
+
 
 
 @pytest.fixture

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -227,8 +227,7 @@ class Device(object):
             for path in self._get_pv_paths():
                 # check if there was a pv created with the
                 # name of device
-                pvs = lvm.PVolumes()
-                pvs.filter(pv_name=path)
+                pvs = lvm.PVolumes().filter(pv_name=path)
                 has_vgs = [pv.vg_name for pv in pvs if pv.vg_name]
                 if has_vgs:
                     self.vgs = list(set(has_vgs))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42235

---

backport of https://github.com/ceph/ceph/pull/30703
parent tracker: https://tracker.ceph.com/issues/42170

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh