### PR TITLE
nautilus: ceph-volume: VolumeGroups.filter shouldn't purge itself

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -708,8 +708,9 @@ class VolumeGroups(list):
     to filter them via keyword arguments.
     """
 
-    def __init__(self):
-        self._populate()
+    def __init__(self, populate=True):
+        if populate:
+            self._populate()
 
     def _populate(self):
         # get all the vgs in the current system

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -762,15 +762,10 @@ class VolumeGroups(list):
         """
         if not any([vg_name, vg_tags]):
             raise TypeError('.filter() requires vg_name or vg_tags (none given)')
-        # first find the filtered volumes with the values in self
-        filtered_groups = self._filter(
-            vg_name=vg_name,
-            vg_tags=vg_tags
-        )
-        # then purge everything
-        self._purge()
-        # and add the filtered items
-        self.extend(filtered_groups)
+
+        filtered_vgs = VolumeGroups(populate=False)
+        filtered_vgs.extend(self._filter(vg_name, vg_tags))
+        return filtered_vgs
 
     def get(self, vg_name=None, vg_tags=None):
         """

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -337,7 +337,7 @@ class TestVolumeGroups(object):
         journal = api.VolumeGroup(vg_name='volume2', vg_tags='ceph.group=plain')
         volume_groups.append(osd)
         volume_groups.append(journal)
-        volume_groups.filter(vg_tags={'ceph.group': 'dmcache'})
+        volume_groups = volume_groups.filter(vg_tags={'ceph.group': 'dmcache'})
         assert len(volume_groups) == 1
         assert volume_groups[0].vg_name == 'volume1'
 
@@ -345,7 +345,7 @@ class TestVolumeGroups(object):
         vg_tags = "ceph.group=dmcache,ceph.disk_type=ssd"
         osd = api.VolumeGroup(vg_name='volume1', vg_path='/dev/vg/lv', vg_tags=vg_tags)
         volume_groups.append(osd)
-        volume_groups.filter(vg_tags={'ceph.group': 'data', 'ceph.disk_type': 'ssd'})
+        volume_groups = volume_groups.filter(vg_tags={'ceph.group': 'data', 'ceph.disk_type': 'ssd'})
         assert volume_groups == []
 
     def test_filter_by_vg_name(self, volume_groups):
@@ -354,13 +354,13 @@ class TestVolumeGroups(object):
         journal = api.VolumeGroup(vg_name='volume2', vg_tags='ceph.type=journal')
         volume_groups.append(osd)
         volume_groups.append(journal)
-        volume_groups.filter(vg_name='ceph_vg')
+        volume_groups = volume_groups.filter(vg_name='ceph_vg')
         assert len(volume_groups) == 1
         assert volume_groups[0].vg_name == 'ceph_vg'
 
     def test_filter_requires_params(self, volume_groups):
         with pytest.raises(TypeError):
-            volume_groups.filter()
+            volume_groups = volume_groups.filter()
 
 
 class TestVolumeGroupFree(object):

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -153,6 +153,10 @@ def volume_groups(monkeypatch):
     vgs._purge()
     return vgs
 
+def volume_groups_empty(monkeypatch):
+    monkeypatch.setattr('ceph_volume.process.call', lambda x, **kw: ('', '', 0))
+    vgs = lvm_api.VolumeGroups(populate=False)
+    return vgs
 
 @pytest.fixture
 def stub_vgs(monkeypatch, volume_groups):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42234

---

backport of https://github.com/ceph/ceph/pull/30707
parent tracker: https://tracker.ceph.com/issues/42171

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh