### PR TITLE
qa: tolerate ECONNRESET errcode during logrotate

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -175,7 +175,7 @@ def ceph_log(ctx, config):
                 except SSHException as e:
                     log.debug("Missed logrotate, SSHException")
                 except socket.error as e:
-                    if e.errno == errno.EHOSTUNREACH:
+                    if e.errno in (errno.EHOSTUNREACH, errno.ECONNRESET):
                         log.debug("Missed logrotate, host unreachable")
                     else:
                         raise


### PR DESCRIPTION
Handler `ECONNRESET` should suffice here -- paramiko either raises an `SSHException` or `socket.error` in such cases.

Ran with `--suite kcephfs --filter client-recovery`: http://pulpito.ceph.com/vshankar-2019-10-09_09:22:26-kcephfs-wip-41800-distro-basic-mira/