### PR TITLE
mgr/dashboard: Remove unused RBD "configuration" endpoint

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -12,7 +12,7 @@ import cherrypy
 import rbd
 
 from . import ApiController, RESTController, Task, UpdatePermission, \
-              DeletePermission, CreatePermission, ReadPermission
+              DeletePermission, CreatePermission
 from .. import mgr
 from ..security import Scope
 from ..services.ceph_service import CephService
@@ -349,11 +349,6 @@ class Rbd(RESTController):
         """
         rbd_inst = rbd.RBD()
         return _rbd_call(pool_name, rbd_inst.trash_move, image_name, delay)
-
-    @RESTController.Resource()
-    @ReadPermission
-    def configuration(self, pool_name, image_name):
-        return RbdConfiguration(pool_name, image_name).list()
 
 
 @ApiController('/block/image/{pool_name}/{image_name}/snap', Scope.RBD_IMAGE)


### PR DESCRIPTION
RBD "configuration" endpoint is not being used so I'm proposing to remove it to avoid maintenance efford (e.g. when adding support for RBD namespaces)

Signed-off-by: Ricardo Marques <rimarques@suse.com>
