### PR TITLE
qa/suites/rados/thrash-old-clients: exclude ceph-daemon on nautilus installs

### DIFF
--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
@@ -11,6 +11,8 @@ overrides:
 tasks:
 - install:
     branch: nautilus
+    exclude_packages:
+      - ceph-daemon
 - install.upgrade:
     mon.a:
     mon.b:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
@@ -10,6 +10,8 @@ overrides:
 tasks:
 - install:
     branch: nautilus
+    exclude_packages:
+      - ceph-daemon
 - install.upgrade:
     mon.a:
     mon.b:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
@@ -5,6 +5,8 @@ overrides:
 tasks:
 - install:
     branch: nautilus
+    exclude_packages:
+      - ceph-daemon
 - install.upgrade:
     mon.a:
     mon.b:


### PR DESCRIPTION
i did the original addition by grepping for ceph-mgr-ssh, but that's
included in nautilus so I missed this one!




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>