### PR TITLE
nautilus: rbd-mirror: cannot restore deferred deletion mirrored images

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -134,6 +134,7 @@ set(librbd_internal_srcs
   operation/SparsifyRequest.cc
   operation/TrimRequest.cc
   trash/MoveRequest.cc
+  trash/RemoveRequest.cc
   watcher/Notifier.cc
   watcher/RewatchRequest.cc
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc)

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -782,7 +782,8 @@ int Image<I>::remove(IoCtx& io_ctx, const std::string &image_name,
         if (r == -ENOTEMPTY || r == -EBUSY || r == -EMLINK) {
           // best-effort try to restore the image if the removal
           // failed for possible expected reasons
-          Trash<I>::restore(io_ctx, trash_image_source, image_id, image_name);
+          Trash<I>::restore(io_ctx, {cls::rbd::TRASH_IMAGE_SOURCE_REMOVING},
+                            image_id, image_name);
         }
       }
       return r;

--- a/src/librbd/api/Migration.cc
+++ b/src/librbd/api/Migration.cc
@@ -1175,7 +1175,8 @@ template <typename I>
 int Migration<I>::v2_relink_src_image() {
   ldout(m_cct, 10) << dendl;
 
-  int r = Trash<I>::restore(m_src_io_ctx, RBD_TRASH_IMAGE_SOURCE_MIGRATION,
+  int r = Trash<I>::restore(m_src_io_ctx,
+                            {cls::rbd::TRASH_IMAGE_SOURCE_MIGRATION},
                             m_src_image_ctx->id, m_src_image_ctx->name);
   if (r < 0) {
     lderr(m_cct) << "failed restoring image from trash: " << cpp_strerror(r)

--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -31,6 +31,12 @@
 namespace librbd {
 namespace api {
 
+template <typename I>
+const typename Trash<I>::TrashImageSources Trash<I>::RESTORE_SOURCE_WHITELIST {
+    cls::rbd::TRASH_IMAGE_SOURCE_USER,
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING
+  };
+
 namespace {
 
 template <typename I>
@@ -544,7 +550,8 @@ int Trash<I>::remove(IoCtx &io_ctx, const std::string &image_id, bool force,
 }
 
 template <typename I>
-int Trash<I>::restore(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
+int Trash<I>::restore(librados::IoCtx &io_ctx,
+                      const TrashImageSources& trash_image_sources,
                       const std::string &image_id,
                       const std::string &image_new_name) {
   CephContext *cct((CephContext *)io_ctx.cct());
@@ -559,10 +566,10 @@ int Trash<I>::restore(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
     return r;
   }
 
-  if (trash_spec.source !=  static_cast<cls::rbd::TrashImageSource>(source)) {
-    lderr(cct) << "Current trash source: " << trash_spec.source
-               << " does not match expected: "
-               << static_cast<cls::rbd::TrashImageSource>(source) << dendl;
+  if (trash_image_sources.count(trash_spec.source) == 0) {
+    lderr(cct) << "Current trash source '" << trash_spec.source << "' "
+               << "does not match expected: "
+               << trash_image_sources << dendl;
     return -EINVAL;
   }
 

--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -19,6 +19,7 @@
 #include "librbd/mirror/DisableRequest.h"
 #include "librbd/mirror/EnableRequest.h"
 #include "librbd/trash/MoveRequest.h"
+#include "librbd/trash/RemoveRequest.h"
 #include <json_spirit/json_spirit.h>
 #include "librbd/journal/DisabledPolicy.h"
 #include "librbd/image/ListWatchersRequest.h"
@@ -517,41 +518,17 @@ int Trash<I>::remove(IoCtx &io_ctx, const std::string &image_id, bool force,
     return -EBUSY;
   }
 
-  r = cls_client::trash_state_set(&io_ctx, image_id,
-                                  cls::rbd::TRASH_IMAGE_STATE_REMOVING,
-                                  cls::rbd::TRASH_IMAGE_STATE_NORMAL);
-  if (r < 0 && r != -EOPNOTSUPP) {
-    lderr(cct) << "error setting trash image state: "
-               << cpp_strerror(r) << dendl;
-    return r;
-  }
-
   ThreadPool *thread_pool;
   ContextWQ *op_work_queue;
   ImageCtx::get_thread_pool_instance(cct, &thread_pool, &op_work_queue);
 
   C_SaferCond cond;
-  auto req = librbd::image::RemoveRequest<I>::create(
-    io_ctx, "", image_id, force, true, prog_ctx, op_work_queue, &cond);
+  auto req = librbd::trash::RemoveRequest<I>::create(
+      io_ctx, image_id, op_work_queue, force, prog_ctx, &cond);
   req->send();
 
   r = cond.wait();
   if (r < 0) {
-    lderr(cct) << "error removing image " << image_id
-               << ", which is pending deletion" << dendl;
-    int ret = cls_client::trash_state_set(&io_ctx, image_id,
-                                          cls::rbd::TRASH_IMAGE_STATE_NORMAL,
-                                          cls::rbd::TRASH_IMAGE_STATE_REMOVING);
-    if (ret < 0 && ret != -EOPNOTSUPP) {
-      lderr(cct) << "error setting trash image state: "
-                 << cpp_strerror(ret) << dendl;
-    }
-    return r;
-  }
-  r = cls_client::trash_remove(&io_ctx, image_id);
-  if (r < 0 && r != -ENOENT) {
-    lderr(cct) << "error removing image " << image_id
-               << " from rbd_trash object" << dendl;
     return r;
   }
 

--- a/src/librbd/api/Trash.h
+++ b/src/librbd/api/Trash.h
@@ -6,6 +6,8 @@
 
 #include "include/rados/librados_fwd.hpp"
 #include "include/rbd/librbd.hpp"
+#include "cls/rbd/cls_rbd_types.h"
+#include <set>
 #include <string>
 #include <vector>
 
@@ -19,6 +21,8 @@ namespace api {
 
 template <typename ImageCtxT = librbd::ImageCtx>
 struct Trash {
+  typedef std::set<cls::rbd::TrashImageSource> TrashImageSources;
+  static const TrashImageSources RESTORE_SOURCE_WHITELIST;
 
   static int move(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
                   const std::string &image_name, uint64_t delay);
@@ -34,7 +38,8 @@ struct Trash {
                    float threshold, ProgressContext& pctx);
   static int remove(librados::IoCtx &io_ctx, const std::string &image_id,
                     bool force, ProgressContext& prog_ctx);
-  static int restore(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
+  static int restore(librados::IoCtx &io_ctx,
+                     const TrashImageSources& trash_image_sources,
                      const std::string &image_id,
                      const std::string &image_new_name);
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -643,8 +643,8 @@ namespace librbd {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, trash_undelete_enter, io_ctx.get_pool_name().c_str(),
                io_ctx.get_id(), id, name);
-    int r = librbd::api::Trash<>::restore(io_ctx, RBD_TRASH_IMAGE_SOURCE_USER,
-                                          id, name);
+    int r = librbd::api::Trash<>::restore(
+      io_ctx, librbd::api::Trash<>::RESTORE_SOURCE_WHITELIST, id, name);
     tracepoint(librbd, trash_undelete_exit, r);
     return r;
   }
@@ -3298,8 +3298,8 @@ extern "C" int rbd_trash_restore(rados_ioctx_t p, const char *id,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, trash_undelete_enter, io_ctx.get_pool_name().c_str(),
              io_ctx.get_id(), id, name);
-  int r = librbd::api::Trash<>::restore(io_ctx, RBD_TRASH_IMAGE_SOURCE_USER,
-                                        id, name);
+  int r = librbd::api::Trash<>::restore(
+      io_ctx, librbd::api::Trash<>::RESTORE_SOURCE_WHITELIST, id, name);
   tracepoint(librbd, trash_undelete_exit, r);
   return r;
 }

--- a/src/librbd/trash/RemoveRequest.cc
+++ b/src/librbd/trash/RemoveRequest.cc
@@ -1,0 +1,171 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/trash/RemoveRequest.h"
+#include "common/WorkQueue.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Utils.h"
+#include "librbd/image/RemoveRequest.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::trash::RemoveRequest: " << this \
+                           << " " << __func__ << ": "
+
+namespace librbd {
+namespace trash {
+
+using util::create_context_callback;
+using util::create_rados_callback;
+
+template <typename I>
+void RemoveRequest<I>::send() {
+  set_state();
+}
+
+template <typename I>
+void RemoveRequest<I>::set_state() {
+  ldout(m_cct, 10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  cls_client::trash_state_set(&op, m_image_id, m_trash_set_state,
+                              m_trash_expect_state);
+
+  auto aio_comp = create_rados_callback<
+      RemoveRequest<I>, &RemoveRequest<I>::handle_set_state>(this);
+  int r = m_io_ctx.aio_operate(RBD_TRASH, aio_comp, &op);
+  ceph_assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void RemoveRequest<I>::handle_set_state(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -EOPNOTSUPP) {
+    lderr(m_cct) << "error setting trash image state: " << cpp_strerror(r)
+                 << dendl;
+    if (m_ret_val == 0) {
+      m_ret_val = r;
+    }
+    if (m_trash_set_state == cls::rbd::TRASH_IMAGE_STATE_REMOVING) {
+      close_image();
+    } else {
+      finish(m_ret_val);
+    }
+    return;
+  }
+
+  if (m_trash_set_state == cls::rbd::TRASH_IMAGE_STATE_REMOVING) {
+    remove_image();
+  } else {
+    ceph_assert(m_trash_set_state == cls::rbd::TRASH_IMAGE_STATE_NORMAL);
+    finish(m_ret_val < 0 ? m_ret_val : r);
+  };
+}
+
+template <typename I>
+void RemoveRequest<I>::close_image() {
+  if (m_image_ctx == nullptr) {
+    finish(m_ret_val);
+    return;
+  }
+
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<
+      RemoveRequest<I>, &RemoveRequest<I>::handle_close_image>(this);
+  m_image_ctx->state->close(ctx);
+}
+
+template <typename I>
+void RemoveRequest<I>::handle_close_image(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    ldout(m_cct, 5) << "failed to close image:" << cpp_strerror(r) << dendl;
+  }
+
+  m_image_ctx->destroy();
+  m_image_ctx = nullptr;
+  finish(m_ret_val);
+}
+
+template <typename I>
+void RemoveRequest<I>::remove_image() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = create_context_callback<
+      RemoveRequest<I>, &RemoveRequest<I>::handle_remove_image>(this);
+  if (m_image_ctx != nullptr) {
+    auto req = librbd::image::RemoveRequest<I>::create(
+        m_io_ctx, m_image_ctx, m_force, true, m_prog_ctx, m_op_work_queue, ctx);
+    req->send();
+  } else {
+    auto req = librbd::image::RemoveRequest<I>::create(
+        m_io_ctx, "", m_image_id, m_force, true, m_prog_ctx, m_op_work_queue,
+        ctx);
+    req->send();
+  }
+}
+
+template <typename I>
+void RemoveRequest<I>::handle_remove_image(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    ldout(m_cct, 5) << "failed to remove image:" << cpp_strerror(r) << dendl;
+
+    m_ret_val = r;
+    m_trash_set_state = cls::rbd::TRASH_IMAGE_STATE_NORMAL;
+    m_trash_expect_state = cls::rbd::TRASH_IMAGE_STATE_REMOVING;
+    set_state();
+    return;
+  }
+
+  m_image_ctx = nullptr;
+  remove_trash_entry();
+}
+
+template <typename I>
+void RemoveRequest<I>::remove_trash_entry() {
+  ldout(m_cct, 10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  cls_client::trash_remove(&op, m_image_id);
+
+  auto aio_comp = create_rados_callback<
+      RemoveRequest<I>, &RemoveRequest<I>::handle_remove_trash_entry>(this);
+  int r = m_io_ctx.aio_operate(RBD_TRASH, aio_comp, &op);
+  ceph_assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void RemoveRequest<I>::handle_remove_trash_entry(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "error removing trash entry: " << cpp_strerror(r) << dendl;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void RemoveRequest<I>::finish(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace trash
+} // namespace librbd
+
+template class librbd::trash::RemoveRequest<librbd::ImageCtx>;

--- a/src/librbd/trash/RemoveRequest.h
+++ b/src/librbd/trash/RemoveRequest.h
@@ -1,0 +1,119 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_TRASH_REMOVE_REQUEST_H
+#define CEPH_LIBRBD_TRASH_REMOVE_REQUEST_H
+
+#include "include/utime.h"
+#include "include/rados/librados.hpp"
+#include "cls/rbd/cls_rbd_types.h"
+#include <string>
+
+class CephContext;
+class Context;
+class ContextWQ;
+
+namespace librbd {
+
+class ProgressContext;
+
+struct ImageCtx;
+
+namespace trash {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class RemoveRequest {
+public:
+  static RemoveRequest* create(librados::IoCtx &io_ctx,
+                               const std::string &image_id,
+                               ContextWQ *op_work_queue, bool force,
+                               ProgressContext &prog_ctx, Context *on_finish) {
+    return new RemoveRequest(io_ctx, image_id, op_work_queue, force, prog_ctx,
+                             on_finish);
+  }
+
+  static RemoveRequest* create(librados::IoCtx &io_ctx, ImageCtxT *image_ctx,
+                               ContextWQ *op_work_queue, bool force,
+                               ProgressContext &prog_ctx, Context *on_finish) {
+    return new RemoveRequest(io_ctx, image_ctx, op_work_queue, force, prog_ctx,
+                             on_finish);
+  }
+
+
+  RemoveRequest(librados::IoCtx &io_ctx, const std::string &image_id,
+                ContextWQ *op_work_queue, bool force, ProgressContext &prog_ctx,
+                Context *on_finish)
+    : m_io_ctx(io_ctx), m_image_id(image_id), m_op_work_queue(op_work_queue),
+      m_force(force), m_prog_ctx(prog_ctx), m_on_finish(on_finish),
+      m_cct(reinterpret_cast<CephContext *>(io_ctx.cct())) {
+  }
+
+  RemoveRequest(librados::IoCtx &io_ctx, ImageCtxT *image_ctx,
+                ContextWQ *op_work_queue, bool force, ProgressContext &prog_ctx,
+                Context *on_finish)
+    : m_io_ctx(io_ctx), m_image_ctx(image_ctx), m_image_id(m_image_ctx->id),
+      m_op_work_queue(op_work_queue), m_force(force), m_prog_ctx(prog_ctx),
+      m_on_finish(on_finish),
+      m_cct(reinterpret_cast<CephContext *>(io_ctx.cct())) {
+  }
+
+  void send();
+
+private:
+  /*
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * SET_STATE (removing) * * * * * * *> CLOSE_IMAGE
+   *    |                                    |
+   *    v                                    |
+   * REMOVE_IMAGE * * *> SET_STATE (normal)  |
+   *    |                   |                |
+   *    v                   |                |
+   * REMOVE_TRASH_ENTRY     |                |
+   *    |                   |                |
+   *    v                   |                |
+   * <finish> <-------------/<---------------/
+   *
+   * @endverbatim
+   */
+
+  librados::IoCtx &m_io_ctx;
+  ImageCtxT *m_image_ctx = nullptr;
+  std::string m_image_id;
+  ContextWQ *m_op_work_queue;
+  bool m_force;
+  ProgressContext &m_prog_ctx;
+  Context *m_on_finish;
+
+  CephContext *m_cct;
+
+  cls::rbd::TrashImageState m_trash_set_state =
+      cls::rbd::TRASH_IMAGE_STATE_REMOVING;
+  cls::rbd::TrashImageState m_trash_expect_state =
+      cls::rbd::TRASH_IMAGE_STATE_NORMAL;
+  int m_ret_val = 0;
+
+  void set_state();
+  void handle_set_state(int r);
+
+  void close_image();
+  void handle_close_image(int r);
+
+  void remove_image();
+  void handle_remove_image(int r);
+
+  void remove_trash_entry();
+  void handle_remove_trash_entry(int r);
+
+  void finish(int r);
+};
+
+} // namespace trash
+} // namespace librbd
+
+extern template class librbd::trash::RemoveRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_TRASH_REMOVE_REQUEST_H

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -103,6 +103,7 @@ set(unittest_librbd_srcs
   operation/test_mock_SnapshotUnprotectRequest.cc
   operation/test_mock_TrimRequest.cc
   trash/test_mock_MoveRequest.cc
+  trash/test_mock_RemoveRequest.cc
   watcher/test_mock_RewatchRequest.cc
   )
 add_executable(unittest_librbd

--- a/src/test/librbd/test_Trash.cc
+++ b/src/test/librbd/test_Trash.cc
@@ -89,4 +89,20 @@ TEST_F(TestTrash, UserRemovingSource) {
   ASSERT_EQ(expected_images, images);
 }
 
+TEST_F(TestTrash, RestoreMirroringSource) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::RBD rbd;
+  librbd::Image image;
+  std::string image_id;
+  ASSERT_EQ(0, rbd.open(m_ioctx, image, m_image_name.c_str()));
+  ASSERT_EQ(0, image.get_id(&image_id));
+  ASSERT_EQ(0, image.close());
+
+  ASSERT_EQ(0, api::Trash<>::move(m_ioctx, RBD_TRASH_IMAGE_SOURCE_MIRRORING,
+                                  m_image_name, 0));
+  ASSERT_EQ(0, rbd.trash_restore(m_ioctx, image_id.c_str(),
+                                 m_image_name.c_str()));
+}
+
 } // namespace librbd

--- a/src/test/librbd/trash/test_mock_RemoveRequest.cc
+++ b/src/test/librbd/trash/test_mock_RemoveRequest.cc
@@ -1,0 +1,231 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockExclusiveLock.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockImageState.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/Utils.h"
+#include "librbd/image/TypeTraits.h"
+#include "librbd/image/RemoveRequest.h"
+#include "librbd/internal.h"
+#include "librbd/trash/RemoveRequest.h"
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public MockImageCtx {
+  MockTestImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
+namespace image {
+
+// template <>
+// struct TypeTraits<MockTestImageCtx> {
+//   typedef librbd::MockContextWQ ContextWQ;
+// };
+
+template <>
+class RemoveRequest<MockTestImageCtx> {
+private:
+  typedef ::librbd::image::TypeTraits<MockTestImageCtx> TypeTraits;
+  typedef typename TypeTraits::ContextWQ ContextWQ;
+public:
+  static RemoveRequest *s_instance;
+  static RemoveRequest *create(librados::IoCtx &ioctx,
+                               const std::string &image_name,
+                               const std::string &image_id,
+                               bool force, bool from_trash_remove,
+                               ProgressContext &prog_ctx,
+                               ContextWQ *op_work_queue,
+                               Context *on_finish) {
+    ceph_assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  static RemoveRequest *create(librados::IoCtx &ioctx, MockTestImageCtx *image_ctx,
+                               bool force, bool from_trash_remove,
+                               ProgressContext &prog_ctx,
+                               ContextWQ *op_work_queue,
+                               Context *on_finish) {
+    ceph_assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  Context *on_finish = nullptr;
+
+  RemoveRequest() {
+    s_instance = this;
+  }
+
+  MOCK_METHOD0(send, void());
+};
+
+RemoveRequest<MockTestImageCtx> *RemoveRequest<MockTestImageCtx>::s_instance;
+
+} // namespace image
+} // namespace librbd
+
+#include "librbd/trash/RemoveRequest.cc"
+
+namespace librbd {
+namespace trash {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::StrEq;
+
+struct TestMockTrashRemoveRequest : public TestMockFixture {
+  typedef RemoveRequest<librbd::MockTestImageCtx> MockRemoveRequest;
+  typedef image::RemoveRequest<librbd::MockTestImageCtx> MockImageRemoveRequest;
+
+  NoOpProgressContext m_prog_ctx;
+
+  void expect_set_state(MockTestImageCtx& mock_image_ctx,
+                        cls::rbd::TrashImageState trash_set_state,
+                        cls::rbd::TrashImageState trash_expect_state,
+                        int r) {
+    bufferlist in_bl;
+    encode(mock_image_ctx.id, in_bl);
+    encode(trash_set_state, in_bl);
+    encode(trash_expect_state, in_bl);
+
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(StrEq("rbd_trash"), _, StrEq("rbd"), StrEq("trash_state_set"),
+                     ContentsEqual(in_bl), _, _))
+      .WillOnce(Return(r));
+  }
+
+  void expect_set_deleting_state(MockTestImageCtx& mock_image_ctx, int r) {
+    expect_set_state(mock_image_ctx, cls::rbd::TRASH_IMAGE_STATE_REMOVING,
+                     cls::rbd::TRASH_IMAGE_STATE_NORMAL, r);
+  }
+
+  void expect_restore_normal_state(MockTestImageCtx& mock_image_ctx, int r) {
+    expect_set_state(mock_image_ctx, cls::rbd::TRASH_IMAGE_STATE_NORMAL,
+                     cls::rbd::TRASH_IMAGE_STATE_REMOVING, r);
+  }
+
+  void expect_close_image(MockTestImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(*mock_image_ctx.state, close(_))
+      .WillOnce(Invoke([r](Context *on_finish) {
+                  on_finish->complete(r);
+                }));
+    EXPECT_CALL(mock_image_ctx, destroy());
+  }
+
+  void expect_remove_image(MockImageRemoveRequest& mock_image_remove_request,
+                           int r) {
+    EXPECT_CALL(mock_image_remove_request, send())
+      .WillOnce(Invoke([&mock_image_remove_request, r]() {
+          mock_image_remove_request.on_finish->complete(r);
+        }));
+  }
+
+  void expect_remove_trash_entry(MockTestImageCtx& mock_image_ctx,
+                                 int r) {
+    bufferlist in_bl;
+    encode(mock_image_ctx.id, in_bl);
+
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(StrEq("rbd_trash"), _, StrEq("rbd"), StrEq("trash_remove"),
+                     ContentsEqual(in_bl), _, _))
+      .WillOnce(Return(r));
+  }
+};
+
+TEST_F(TestMockTrashRemoveRequest, Success) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageRemoveRequest mock_image_remove_request;
+
+  InSequence seq;
+  expect_set_deleting_state(mock_image_ctx, 0);
+  expect_remove_image(mock_image_remove_request, 0);
+  expect_remove_trash_entry(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  auto req = MockRemoveRequest::create(mock_image_ctx.md_ctx, &mock_image_ctx,
+                                       nullptr, false, m_prog_ctx, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+TEST_F(TestMockTrashRemoveRequest, SetDeletingStateError) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageRemoveRequest mock_image_remove_request;
+
+  InSequence seq;
+  expect_set_deleting_state(mock_image_ctx, -EINVAL);
+  expect_close_image(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  auto req = MockRemoveRequest::create(mock_image_ctx.md_ctx, &mock_image_ctx,
+                                       nullptr, false, m_prog_ctx, &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockTrashRemoveRequest, RemoveImageError) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageRemoveRequest mock_image_remove_request;
+
+  InSequence seq;
+  expect_set_deleting_state(mock_image_ctx, 0);
+  expect_remove_image(mock_image_remove_request, -EINVAL);
+  expect_restore_normal_state(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  auto req = MockRemoveRequest::create(mock_image_ctx.md_ctx, &mock_image_ctx,
+                                       nullptr, false, m_prog_ctx, &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockTrashRemoveRequest, RemoveTrashEntryError) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageRemoveRequest mock_image_remove_request;
+
+  InSequence seq;
+  expect_set_deleting_state(mock_image_ctx, 0);
+  expect_remove_image(mock_image_remove_request, 0);
+  expect_remove_trash_entry(mock_image_ctx, -EINVAL);
+
+  C_SaferCond ctx;
+  auto req = MockRemoveRequest::create(mock_image_ctx.md_ctx, &mock_image_ctx,
+                                       nullptr, false, m_prog_ctx, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+} // namespace trash
+} // namespace librbd

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -27,9 +27,9 @@ add_executable(unittest_rbd_mirror
   test_mock_LeaderWatcher.cc
   test_mock_PoolReplayer.cc
   test_mock_PoolWatcher.cc
-  image_deleter/test_mock_RemoveRequest.cc
   image_deleter/test_mock_SnapshotPurgeRequest.cc
   image_deleter/test_mock_TrashMoveRequest.cc
+  image_deleter/test_mock_TrashRemoveRequest.cc
   image_deleter/test_mock_TrashWatcher.cc
   image_replayer/test_mock_BootstrapRequest.cc
   image_replayer/test_mock_CreateImageRequest.cc

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashMoveRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashMoveRequest.cc
@@ -98,6 +98,7 @@ struct ResetRequest<MockTestImageCtx> {
                               const std::string &mirror_uuid,
                               ContextWQ *op_work_queue, Context *on_finish) {
     ceph_assert(s_instance != nullptr);
+    EXPECT_EQ(librbd::Journal<>::LOCAL_MIRROR_UUID, mirror_uuid);
     s_instance->on_finish = on_finish;
     return s_instance;
   }

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashRemoveRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashRemoveRequest.cc
@@ -4,8 +4,9 @@
 #include "test/rbd_mirror/test_mock_fixture.h"
 #include "cls/rbd/cls_rbd_types.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/TrashWatcher.h"
 #include "librbd/Utils.h"
-#include "librbd/image/RemoveRequest.h"
+#include "librbd/trash/RemoveRequest.h"
 #include "tools/rbd_mirror/Threads.h"
 #include "tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.h"
 #include "tools/rbd_mirror/image_deleter/TrashRemoveRequest.h"
@@ -24,7 +25,25 @@ struct MockTestImageCtx : public librbd::MockImageCtx {
 
 } // anonymous namespace
 
-namespace image {
+template<>
+struct TrashWatcher<MockTestImageCtx> {
+  static TrashWatcher* s_instance;
+  static void notify_image_removed(librados::IoCtx&,
+                                   const std::string& image_id, Context *ctx) {
+    ceph_assert(s_instance != nullptr);
+    s_instance->notify_image_removed(image_id, ctx);
+  }
+
+  MOCK_METHOD2(notify_image_removed, void(const std::string&, Context*));
+
+  TrashWatcher() {
+    s_instance = this;
+  }
+};
+
+TrashWatcher<MockTestImageCtx>* TrashWatcher<MockTestImageCtx>::s_instance = nullptr;
+
+namespace trash {
 
 template <>
 struct RemoveRequest<librbd::MockTestImageCtx> {
@@ -32,17 +51,13 @@ struct RemoveRequest<librbd::MockTestImageCtx> {
   Context *on_finish = nullptr;
 
   static RemoveRequest *create(librados::IoCtx &io_ctx,
-                               const std::string &image_name,
                                const std::string &image_id,
-                               bool force,
-                               bool remove_from_trash,
-                               librbd::ProgressContext &progress_ctx,
                                ContextWQ *work_queue,
+                               bool force,
+                               librbd::ProgressContext &progress_ctx,
                                Context *on_finish) {
     ceph_assert(s_instance != nullptr);
-    EXPECT_TRUE(image_name.empty());
     EXPECT_TRUE(force);
-    EXPECT_TRUE(remove_from_trash);
     s_instance->construct(image_id);
     s_instance->on_finish = on_finish;
     return s_instance;
@@ -58,7 +73,7 @@ struct RemoveRequest<librbd::MockTestImageCtx> {
 
 RemoveRequest<librbd::MockTestImageCtx>* RemoveRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
 
-} // namespace image
+} // namespace trash
 } // namespace librbd
 
 namespace rbd {
@@ -111,7 +126,32 @@ class TestMockImageDeleterTrashRemoveRequest : public TestMockFixture {
 public:
   typedef TrashRemoveRequest<librbd::MockTestImageCtx> MockTrashRemoveRequest;
   typedef SnapshotPurgeRequest<librbd::MockTestImageCtx> MockSnapshotPurgeRequest;
-  typedef librbd::image::RemoveRequest<librbd::MockTestImageCtx> MockImageRemoveRequest;
+  typedef librbd::TrashWatcher<librbd::MockTestImageCtx> MockTrashWatcher;
+  typedef librbd::trash::RemoveRequest<librbd::MockTestImageCtx> MockLibrbdTrashRemoveRequest;
+
+  void expect_trash_get(const cls::rbd::TrashImageSpec& trash_spec, int r) {
+    using ceph::encode;
+    EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
+                exec(StrEq(RBD_TRASH), _, StrEq("rbd"),
+                     StrEq("trash_get"), _, _, _))
+      .WillOnce(WithArg<5>(Invoke([trash_spec, r](bufferlist* bl) {
+                             encode(trash_spec, *bl);
+                             return r;
+                           })));
+  }
+
+  void expect_trash_state_set(const std::string& image_id, int r) {
+    bufferlist in_bl;
+    encode(image_id, in_bl);
+    encode(cls::rbd::TRASH_IMAGE_STATE_REMOVING, in_bl);
+    encode(cls::rbd::TRASH_IMAGE_STATE_NORMAL, in_bl);
+
+    EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
+                exec(StrEq(RBD_TRASH), _, StrEq("rbd"),
+                     StrEq("trash_state_set"),
+                     ContentsEqual(in_bl), _, _))
+      .WillOnce(Return(r));
+  }
 
   void expect_get_snapcontext(const std::string& image_id,
                               const ::SnapContext &snapc, int r) {
@@ -137,7 +177,7 @@ public:
                 }));
   }
 
-  void expect_image_remove(MockImageRemoveRequest &image_remove_request,
+  void expect_image_remove(MockLibrbdTrashRemoveRequest &image_remove_request,
                            const std::string &image_id, int r) {
     EXPECT_CALL(image_remove_request, construct(image_id));
     EXPECT_CALL(image_remove_request, send())
@@ -146,17 +186,36 @@ public:
                     image_remove_request.on_finish, r);
                 }));
   }
+
+  void expect_notify_image_removed(MockTrashWatcher& mock_trash_watcher,
+                                   const std::string& image_id) {
+    EXPECT_CALL(mock_trash_watcher, notify_image_removed(image_id, _))
+      .WillOnce(WithArg<1>(Invoke([this](Context *ctx) {
+                             m_threads->work_queue->queue(ctx, 0);
+                           })));
+  }
+
 };
 
 TEST_F(TestMockImageDeleterTrashRemoveRequest, Success) {
   InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  expect_trash_state_set("image id", 0);
+
   expect_get_snapcontext("image id", {1, {1}}, 0);
 
   MockSnapshotPurgeRequest mock_snapshot_purge_request;
   expect_snapshot_purge(mock_snapshot_purge_request, "image id", 0);
 
-  MockImageRemoveRequest mock_image_remove_request;
+  MockLibrbdTrashRemoveRequest mock_image_remove_request;
   expect_image_remove(mock_image_remove_request, "image id", 0);
+
+  MockTrashWatcher mock_trash_watcher;
+  expect_notify_image_removed(mock_trash_watcher, "image id");
 
   C_SaferCond ctx;
   ErrorResult error_result;
@@ -167,12 +226,124 @@ TEST_F(TestMockImageDeleterTrashRemoveRequest, Success) {
   ASSERT_EQ(0, ctx.wait());
 }
 
+TEST_F(TestMockImageDeleterTrashRemoveRequest, TrashDNE) {
+  InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, -ENOENT);
+
+  C_SaferCond ctx;
+  ErrorResult error_result;
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashRemoveRequest, TrashError) {
+  InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, -EPERM);
+
+  C_SaferCond ctx;
+  ErrorResult error_result;
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(-EPERM, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashRemoveRequest, TrashSourceIncorrect) {
+  InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  C_SaferCond ctx;
+  ErrorResult error_result;
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashRemoveRequest, TrashStateIncorrect) {
+  InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  trash_image_spec.state = cls::rbd::TRASH_IMAGE_STATE_RESTORING;
+  expect_trash_get(trash_image_spec, 0);
+
+  C_SaferCond ctx;
+  ErrorResult error_result;
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(-EBUSY, ctx.wait());
+  ASSERT_EQ(ERROR_RESULT_RETRY_IMMEDIATELY, error_result);
+}
+
+TEST_F(TestMockImageDeleterTrashRemoveRequest, TrashSetStateDNE) {
+  InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  expect_trash_state_set("image id", -ENOENT);
+
+  C_SaferCond ctx;
+  ErrorResult error_result;
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashRemoveRequest, TrashSetStateError) {
+  InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  expect_trash_state_set("image id", -EPERM);
+
+  C_SaferCond ctx;
+  ErrorResult error_result;
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(-EPERM, ctx.wait());
+}
+
 TEST_F(TestMockImageDeleterTrashRemoveRequest, GetSnapContextDNE) {
   InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  expect_trash_state_set("image id", 0);
+
   expect_get_snapcontext("image id", {1, {1}}, -ENOENT);
 
-  MockImageRemoveRequest mock_image_remove_request;
+  MockLibrbdTrashRemoveRequest mock_image_remove_request;
   expect_image_remove(mock_image_remove_request, "image id", 0);
+
+  MockTrashWatcher mock_trash_watcher;
+  expect_notify_image_removed(mock_trash_watcher, "image id");
 
   C_SaferCond ctx;
   ErrorResult error_result;
@@ -185,6 +356,13 @@ TEST_F(TestMockImageDeleterTrashRemoveRequest, GetSnapContextDNE) {
 
 TEST_F(TestMockImageDeleterTrashRemoveRequest, GetSnapContextError) {
   InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  expect_trash_state_set("image id", 0);
+
   expect_get_snapcontext("image id", {1, {1}}, -EINVAL);
 
   C_SaferCond ctx;
@@ -198,6 +376,13 @@ TEST_F(TestMockImageDeleterTrashRemoveRequest, GetSnapContextError) {
 
 TEST_F(TestMockImageDeleterTrashRemoveRequest, PurgeSnapshotBusy) {
   InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  expect_trash_state_set("image id", 0);
+
   expect_get_snapcontext("image id", {1, {1}}, 0);
 
   MockSnapshotPurgeRequest mock_snapshot_purge_request;
@@ -215,6 +400,13 @@ TEST_F(TestMockImageDeleterTrashRemoveRequest, PurgeSnapshotBusy) {
 
 TEST_F(TestMockImageDeleterTrashRemoveRequest, PurgeSnapshotError) {
   InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  expect_trash_state_set("image id", 0);
+
   expect_get_snapcontext("image id", {1, {1}}, 0);
 
   MockSnapshotPurgeRequest mock_snapshot_purge_request;
@@ -231,12 +423,19 @@ TEST_F(TestMockImageDeleterTrashRemoveRequest, PurgeSnapshotError) {
 
 TEST_F(TestMockImageDeleterTrashRemoveRequest, RemoveError) {
   InSequence seq;
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "image name", {}, {}};
+  expect_trash_get(trash_image_spec, 0);
+
+  expect_trash_state_set("image id", 0);
+
   expect_get_snapcontext("image id", {1, {1}}, 0);
 
   MockSnapshotPurgeRequest mock_snapshot_purge_request;
   expect_snapshot_purge(mock_snapshot_purge_request, "image id", 0);
 
-  MockImageRemoveRequest mock_image_remove_request;
+  MockLibrbdTrashRemoveRequest mock_image_remove_request;
   expect_image_remove(mock_image_remove_request, "image id", -EINVAL);
 
   C_SaferCond ctx;

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashRemoveRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashRemoveRequest.cc
@@ -7,8 +7,8 @@
 #include "librbd/Utils.h"
 #include "librbd/image/RemoveRequest.h"
 #include "tools/rbd_mirror/Threads.h"
-#include "tools/rbd_mirror/image_deleter/RemoveRequest.h"
 #include "tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.h"
+#include "tools/rbd_mirror/image_deleter/TrashRemoveRequest.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "test/librbd/mock/MockImageCtx.h"
 
@@ -93,7 +93,7 @@ SnapshotPurgeRequest<librbd::MockTestImageCtx>* SnapshotPurgeRequest<librbd::Moc
 } // namespace mirror
 } // namespace rbd
 
-#include "tools/rbd_mirror/image_deleter/RemoveRequest.cc"
+#include "tools/rbd_mirror/image_deleter/TrashRemoveRequest.cc"
 
 namespace rbd {
 namespace mirror {
@@ -107,9 +107,9 @@ using ::testing::StrEq;
 using ::testing::WithArg;
 using ::testing::WithArgs;
 
-class TestMockImageDeleterRemoveRequest : public TestMockFixture {
+class TestMockImageDeleterTrashRemoveRequest : public TestMockFixture {
 public:
-  typedef RemoveRequest<librbd::MockTestImageCtx> MockRemoveRequest;
+  typedef TrashRemoveRequest<librbd::MockTestImageCtx> MockTrashRemoveRequest;
   typedef SnapshotPurgeRequest<librbd::MockTestImageCtx> MockSnapshotPurgeRequest;
   typedef librbd::image::RemoveRequest<librbd::MockTestImageCtx> MockImageRemoveRequest;
 
@@ -132,7 +132,8 @@ public:
     EXPECT_CALL(snapshot_purge_request, construct(image_id));
     EXPECT_CALL(snapshot_purge_request, send())
       .WillOnce(Invoke([this, &snapshot_purge_request, r]() {
-                  m_threads->work_queue->queue(snapshot_purge_request.on_finish, r);
+                  m_threads->work_queue->queue(
+                    snapshot_purge_request.on_finish, r);
                 }));
   }
 
@@ -141,12 +142,13 @@ public:
     EXPECT_CALL(image_remove_request, construct(image_id));
     EXPECT_CALL(image_remove_request, send())
       .WillOnce(Invoke([this, &image_remove_request, r]() {
-                  m_threads->work_queue->queue(image_remove_request.on_finish, r);
+                  m_threads->work_queue->queue(
+                    image_remove_request.on_finish, r);
                 }));
   }
 };
 
-TEST_F(TestMockImageDeleterRemoveRequest, Success) {
+TEST_F(TestMockImageDeleterTrashRemoveRequest, Success) {
   InSequence seq;
   expect_get_snapcontext("image id", {1, {1}}, 0);
 
@@ -158,14 +160,14 @@ TEST_F(TestMockImageDeleterRemoveRequest, Success) {
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
 
-TEST_F(TestMockImageDeleterRemoveRequest, GetSnapContextDNE) {
+TEST_F(TestMockImageDeleterTrashRemoveRequest, GetSnapContextDNE) {
   InSequence seq;
   expect_get_snapcontext("image id", {1, {1}}, -ENOENT);
 
@@ -174,27 +176,27 @@ TEST_F(TestMockImageDeleterRemoveRequest, GetSnapContextDNE) {
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
 
-TEST_F(TestMockImageDeleterRemoveRequest, GetSnapContextError) {
+TEST_F(TestMockImageDeleterTrashRemoveRequest, GetSnapContextError) {
   InSequence seq;
   expect_get_snapcontext("image id", {1, {1}}, -EINVAL);
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockImageDeleterRemoveRequest, PurgeSnapshotBusy) {
+TEST_F(TestMockImageDeleterTrashRemoveRequest, PurgeSnapshotBusy) {
   InSequence seq;
   expect_get_snapcontext("image id", {1, {1}}, 0);
 
@@ -203,15 +205,15 @@ TEST_F(TestMockImageDeleterRemoveRequest, PurgeSnapshotBusy) {
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EBUSY, ctx.wait());
   ASSERT_EQ(ERROR_RESULT_RETRY_IMMEDIATELY, error_result);
 }
 
-TEST_F(TestMockImageDeleterRemoveRequest, PurgeSnapshotError) {
+TEST_F(TestMockImageDeleterTrashRemoveRequest, PurgeSnapshotError) {
   InSequence seq;
   expect_get_snapcontext("image id", {1, {1}}, 0);
 
@@ -220,14 +222,14 @@ TEST_F(TestMockImageDeleterRemoveRequest, PurgeSnapshotError) {
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockImageDeleterRemoveRequest, RemoveError) {
+TEST_F(TestMockImageDeleterTrashRemoveRequest, RemoveError) {
   InSequence seq;
   expect_get_snapcontext("image id", {1, {1}}, 0);
 
@@ -239,9 +241,9 @@ TEST_F(TestMockImageDeleterRemoveRequest, RemoveError) {
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
+  auto req = MockTrashRemoveRequest::create(m_local_io_ctx, "image id",
+                                            &error_result,
+                                            m_threads->work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -21,9 +21,9 @@ set(rbd_mirror_internal
   ServiceDaemon.cc
   Threads.cc
   Types.cc
-  image_deleter/RemoveRequest.cc
   image_deleter/SnapshotPurgeRequest.cc
   image_deleter/TrashMoveRequest.cc
+  image_deleter/TrashRemoveRequest.cc
   image_deleter/TrashWatcher.cc
   image_map/LoadRequest.cc
   image_map/Policy.cc

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -25,14 +25,13 @@
 #include "librbd/ImageState.h"
 #include "librbd/Journal.h"
 #include "librbd/Operations.h"
-#include "librbd/image/RemoveRequest.h"
 #include "cls/rbd/cls_rbd_client.h"
 #include "cls/rbd/cls_rbd_types.h"
 #include "librbd/Utils.h"
 #include "ImageDeleter.h"
 #include "tools/rbd_mirror/Threads.h"
-#include "tools/rbd_mirror/image_deleter/RemoveRequest.h"
 #include "tools/rbd_mirror/image_deleter/TrashMoveRequest.h"
+#include "tools/rbd_mirror/image_deleter/TrashRemoveRequest.h"
 #include "tools/rbd_mirror/image_deleter/TrashWatcher.h"
 #include <map>
 #include <sstream>
@@ -388,7 +387,7 @@ void ImageDeleter<I>::remove_image(DeleteInfoRef delete_info) {
       m_async_op_tracker.finish_op();
     });
 
-  auto req = image_deleter::RemoveRequest<I>::create(
+  auto req = image_deleter::TrashRemoveRequest<I>::create(
     m_local_io_ctx, delete_info->image_id, &delete_info->error_result,
     m_threads->work_queue, ctx);
   req->send();

--- a/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
@@ -159,7 +159,7 @@ void TrashMoveRequest<I>::reset_journal() {
     TrashMoveRequest<I>, &TrashMoveRequest<I>::handle_reset_journal>(this);
   auto req = librbd::journal::ResetRequest<I>::create(
     m_io_ctx, m_image_id, librbd::Journal<>::IMAGE_CLIENT_ID,
-    m_mirror_uuid, m_op_work_queue, ctx);
+    librbd::Journal<>::LOCAL_MIRROR_UUID, m_op_work_queue, ctx);
   req->send();
 }
 

--- a/src/tools/rbd_mirror/image_deleter/TrashRemoveRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashRemoveRequest.cc
@@ -9,8 +9,9 @@
 #include "cls/rbd/cls_rbd_client.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Journal.h"
+#include "librbd/TrashWatcher.h"
 #include "librbd/Utils.h"
-#include "librbd/image/RemoveRequest.h"
+#include "librbd/trash/RemoveRequest.h"
 #include "tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.h"
 
 #define dout_context g_ceph_context
@@ -29,6 +30,95 @@ using librbd::util::create_rados_callback;
 template <typename I>
 void TrashRemoveRequest<I>::send() {
   *m_error_result = ERROR_RESULT_RETRY;
+
+  get_trash_image_spec();
+}
+
+template <typename I>
+void TrashRemoveRequest<I>::get_trash_image_spec() {
+  dout(10) << dendl;
+
+  librados::ObjectReadOperation op;
+  librbd::cls_client::trash_get_start(&op, m_image_id);
+
+  auto aio_comp = create_rados_callback<
+    TrashRemoveRequest<I>,
+    &TrashRemoveRequest<I>::handle_get_trash_image_spec>(this);
+  m_out_bl.clear();
+  int r = m_io_ctx.aio_operate(RBD_TRASH, aio_comp, &op, &m_out_bl);
+  ceph_assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void TrashRemoveRequest<I>::handle_get_trash_image_spec(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r == 0) {
+    auto bl_it = m_out_bl.cbegin();
+    r = librbd::cls_client::trash_get_finish(&bl_it, &m_trash_image_spec);
+  }
+
+  if (r == -ENOENT || (r >= 0 && m_trash_image_spec.source !=
+                                   cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING)) {
+    dout(10) << "image id " << m_image_id << " not in mirroring trash" << dendl;
+    finish(0);
+    return;
+  } else if (r < 0) {
+    derr << "error getting image id " << m_image_id << " info from trash: "
+         << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  if (m_trash_image_spec.state != cls::rbd::TRASH_IMAGE_STATE_NORMAL &&
+      m_trash_image_spec.state != cls::rbd::TRASH_IMAGE_STATE_REMOVING) {
+    dout(10) << "image " << m_image_id << " is not in an expected trash state: "
+             << m_trash_image_spec.state << dendl;
+    *m_error_result = ERROR_RESULT_RETRY_IMMEDIATELY;
+    finish(-EBUSY);
+    return;
+  }
+
+  set_trash_state();
+}
+
+template <typename I>
+void TrashRemoveRequest<I>::set_trash_state() {
+  if (m_trash_image_spec.state == cls::rbd::TRASH_IMAGE_STATE_REMOVING) {
+    get_snap_context();
+    return;
+  }
+
+  dout(10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::trash_state_set(&op, m_image_id,
+                                      cls::rbd::TRASH_IMAGE_STATE_REMOVING,
+                                      cls::rbd::TRASH_IMAGE_STATE_NORMAL);
+
+  auto aio_comp = create_rados_callback<
+    TrashRemoveRequest<I>,
+    &TrashRemoveRequest<I>::handle_set_trash_state>(this);
+  int r = m_io_ctx.aio_operate(RBD_TRASH, aio_comp, &op);
+  ceph_assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void TrashRemoveRequest<I>::handle_set_trash_state(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r == -ENOENT) {
+    dout(10) << "image id " << m_image_id << " not in mirroring trash" << dendl;
+    finish(0);
+    return;
+  } else if (r < 0 && r != -EOPNOTSUPP) {
+    derr << "error setting trash image state for image id " << m_image_id
+         << ": " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
 
   get_snap_context();
 }
@@ -111,8 +201,8 @@ void TrashRemoveRequest<I>::remove_image() {
   auto ctx = create_context_callback<
     TrashRemoveRequest<I>,
     &TrashRemoveRequest<I>::handle_remove_image>(this);
-  auto req = librbd::image::RemoveRequest<I>::create(
-    m_io_ctx, "", m_image_id, true, true, m_progress_ctx, m_op_work_queue,
+  auto req = librbd::trash::RemoveRequest<I>::create(
+    m_io_ctx, m_image_id, m_op_work_queue, true, m_progress_ctx,
     ctx);
   req->send();
 }
@@ -134,6 +224,27 @@ void TrashRemoveRequest<I>::handle_remove_image(int r) {
          << cpp_strerror(r) << dendl;
     finish(r);
     return;
+  }
+
+  notify_trash_removed();
+}
+
+template <typename I>
+void TrashRemoveRequest<I>::notify_trash_removed() {
+  dout(10) << dendl;
+
+  Context *ctx = create_context_callback<
+    TrashRemoveRequest<I>,
+    &TrashRemoveRequest<I>::handle_notify_trash_removed>(this);
+  librbd::TrashWatcher<I>::notify_image_removed(m_io_ctx, m_image_id, ctx);
+}
+
+template <typename I>
+void TrashRemoveRequest<I>::handle_notify_trash_removed(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to notify trash watchers: " << cpp_strerror(r) << dendl;
   }
 
   finish(0);

--- a/src/tools/rbd_mirror/image_deleter/TrashRemoveRequest.h
+++ b/src/tools/rbd_mirror/image_deleter/TrashRemoveRequest.h
@@ -6,6 +6,7 @@
 
 #include "include/rados/librados.hpp"
 #include "include/buffer.h"
+#include "cls/rbd/cls_rbd_types.h"
 #include "librbd/internal.h"
 #include "tools/rbd_mirror/image_deleter/Types.h"
 #include <string>
@@ -47,13 +48,22 @@ private:
    * <start>
    *    |
    *    v
+   * GET_TRASH_IMAGE_SPEC
+   *    |
+   *    v
+   * SET_TRASH_STATE
+   *    |
+   *    v
    * GET_SNAP_CONTEXT
    *    |
    *    v
    * PURGE_SNAPSHOTS
    *    |
    *    v
-   * REMOVE_IMAGE
+   * TRASH_REMOVE
+   *    |
+   *    v
+   * NOTIFY_TRASH_REMOVE
    *    |
    *    v
    * <finish>
@@ -68,8 +78,15 @@ private:
   Context *m_on_finish;
 
   ceph::bufferlist m_out_bl;
+  cls::rbd::TrashImageSpec m_trash_image_spec;
   bool m_has_snapshots = false;
   librbd::NoOpProgressContext m_progress_ctx;
+
+  void get_trash_image_spec();
+  void handle_get_trash_image_spec(int r);
+
+  void set_trash_state();
+  void handle_set_trash_state(int r);
 
   void get_snap_context();
   void handle_get_snap_context(int r);
@@ -79,6 +96,9 @@ private:
 
   void remove_image();
   void handle_remove_image(int r);
+
+  void notify_trash_removed();
+  void handle_notify_trash_removed(int r);
 
   void finish(int r);
 

--- a/src/tools/rbd_mirror/image_deleter/TrashRemoveRequest.h
+++ b/src/tools/rbd_mirror/image_deleter/TrashRemoveRequest.h
@@ -1,8 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#ifndef CEPH_RBD_MIRROR_IMAGE_DELETER_REMOVE_REQUEST_H
-#define CEPH_RBD_MIRROR_IMAGE_DELETER_REMOVE_REQUEST_H
+#ifndef CEPH_RBD_MIRROR_IMAGE_DELETER_TRASH_REMOVE_REQUEST_H
+#define CEPH_RBD_MIRROR_IMAGE_DELETER_TRASH_REMOVE_REQUEST_H
 
 #include "include/rados/librados.hpp"
 #include "include/buffer.h"
@@ -20,19 +20,20 @@ namespace mirror {
 namespace image_deleter {
 
 template <typename ImageCtxT = librbd::ImageCtx>
-class RemoveRequest {
+class TrashRemoveRequest {
 public:
-  static RemoveRequest* create(librados::IoCtx &io_ctx,
-                               const std::string &image_id,
-                               ErrorResult *error_result,
-                               ContextWQ *op_work_queue, Context *on_finish) {
-    return new RemoveRequest(io_ctx, image_id, error_result, op_work_queue,
-                             on_finish);
+  static TrashRemoveRequest* create(librados::IoCtx &io_ctx,
+                                    const std::string &image_id,
+                                    ErrorResult *error_result,
+                                    ContextWQ *op_work_queue,
+                                    Context *on_finish) {
+    return new TrashRemoveRequest(io_ctx, image_id, error_result, op_work_queue,
+                                  on_finish);
   }
 
-  RemoveRequest(librados::IoCtx &io_ctx, const std::string &image_id,
-                ErrorResult *error_result, ContextWQ *op_work_queue,
-                Context *on_finish)
+  TrashRemoveRequest(librados::IoCtx &io_ctx, const std::string &image_id,
+                     ErrorResult *error_result, ContextWQ *op_work_queue,
+                     Context *on_finish)
     : m_io_ctx(io_ctx), m_image_id(image_id), m_error_result(error_result),
       m_op_work_queue(op_work_queue), m_on_finish(on_finish) {
   }
@@ -87,6 +88,6 @@ private:
 } // namespace mirror
 } // namespace rbd
 
-extern template class rbd::mirror::image_deleter::RemoveRequest<librbd::ImageCtx>;
+extern template class rbd::mirror::image_deleter::TrashRemoveRequest<librbd::ImageCtx>;
 
-#endif // CEPH_RBD_MIRROR_IMAGE_DELETER_REMOVE_REQUEST_H
+#endif // CEPH_RBD_MIRROR_IMAGE_DELETER_TRASH_REMOVE_REQUEST_H


### PR DESCRIPTION
https://tracker.ceph.com/issues/41883