### PR TITLE
test/bmap_allocator_replay_test: improving allocator replay tool.

### DIFF
--- a/src/test/objectstore/bmap_allocator_replay_test.cc
+++ b/src/test/objectstore/bmap_allocator_replay_test.cc
@@ -32,21 +32,30 @@ int replay_and_check_for_duplicate(char* fname)
   bool init_done = false;
   char s[4096];
   char* sp, *token;
+  interval_set<uint64_t> owned_by_app;
   while (true) {
     if (fgets(s, sizeof(s), f) == nullptr) {
       break;
     }
     sp = strstr(s, "init_add_free");
+    if (!sp) {
+      sp = strstr(s, "release");
+    }
     if (sp) {
       //2019-05-30 03:23:46.780 7f889a5edf00 10 fbmap_alloc 0x5642ed370600 init_add_free 0x100000~680000000
       // or
       //2019-05-30 03:23:46.780 7f889a5edf00 10 fbmap_alloc 0x5642ed370600 init_add_free done
-      if (!init_done) { 
+      // or
+      // 2019 - 10 - 08T16:19 : 32.257 + 0300 7f5679f3fe80 10 fbmap_alloc 0x564fab96f100 release 0x450000~10000
+      // or
+      // 2019 - 10 - 08T16 : 19 : 32.257 + 0300 7f5679f3fe80 10 fbmap_alloc 0x564fab96f100 release done
+      if (strstr(sp, "done") != nullptr) {
+        continue;
+      }
+      std::cout << s << std::endl;
+      if (!init_done) {
 	std::cerr << "error: no allocator init before: " << s << std::endl;
 	return -1;
-      }
-      if (strstr(sp, "done") != nullptr) {
-	continue;
       }
       uint64_t offs, len;
       strtok(sp, " ~");
@@ -57,10 +66,22 @@ int replay_and_check_for_duplicate(char* fname)
       ceph_assert(token);
       len = strtoul(token, nullptr, 16);
       if (len == 0) {
-	std::cerr << "error: init_add_free: " << s << std::endl;
+	std::cerr << "error: " << sp <<": " << s << std::endl;
 	return -1;
       }
-      alloc->init_add_free(offs, len);
+      if (!owned_by_app.contains(offs, len)) {
+        std::cerr << "error: unexpected return to allocator, not owned by app: "
+		  << s << std::endl;
+	return -1;
+      }
+      owned_by_app.erase(offs, len);
+      if (strstr(sp, "init_add_free") != nullptr) {
+        alloc->init_add_free(offs, len);
+      } else {
+        PExtentVector release_set;
+        release_set.emplace_back(offs, len);
+        alloc->release(release_set);
+      }
       continue;
     }
     sp = strstr(s, "init_rm_free");
@@ -68,12 +89,14 @@ int replay_and_check_for_duplicate(char* fname)
       //2019-05-30 03:23:46.912 7f889a5edf00 10 fbmap_alloc 0x5642ed370600 init_rm_free 0x100000~680000000
       // or 
       // 2019-05-30 03:23:46.916 7f889a5edf00 10 fbmap_alloc 0x5642ed370600 init_rm_free done
-      if (!init_done) { 
+
+      if (strstr(sp, "done") != nullptr) {
+        continue;
+      }
+      std::cout << s << std::endl;
+      if (!init_done) {
 	std::cerr << "error: no allocator init before: " << s << std::endl;
 	return -1;
-      }
-      if (strstr(sp, "done") != nullptr) {
-	continue;
       }
       uint64_t offs, len;
       strtok(sp, " ~");
@@ -84,10 +107,20 @@ int replay_and_check_for_duplicate(char* fname)
       ceph_assert(token);
       len = strtoul(token, nullptr, 16);
       if (len == 0) {
-	std::cerr << "error: init_rm_free: " << s << std::endl;
+	std::cerr << "error: " << sp <<": " << s << std::endl;
 	return -1;
       }
       alloc->init_rm_free(offs, len);
+
+      if (owned_by_app.intersects(offs, len)) {
+        std::cerr
+         << "error: unexpected takeover from allocator, already owned by app: "
+	 << s << std::endl;
+	return -1;
+      } else {
+	owned_by_app.insert(offs, len);
+      }
+
       continue;
     }
     sp = strstr(s, "allocate");
@@ -95,13 +128,16 @@ int replay_and_check_for_duplicate(char* fname)
       //2019-05-30 03:23:48.780 7f889a5edf00 10 fbmap_alloc 0x5642ed370600 allocate 0x80000000/100000,0,0
       // and need to bypass  
       // 2019-05-30 03:23:48.780 7f889a5edf00 10 fbmap_alloc 0x5642ed370600 allocate 0x69d400000~200000/100000,0,0
-      if (!init_done) { 
-	std::cerr << "error: no allocator init before: " << s << std::endl;
-	return -1;
-      }
+
       // Very simple and stupid check to bypass actual allocations
       if (strstr(sp, "~") != nullptr) {
-	continue;
+        continue;
+      }
+
+      std::cout << s << std::endl;
+      if (!init_done) {
+	std::cerr << "error: no allocator init before: " << s << std::endl;
+	return -1;
       }
       uint64_t want, alloc_unit;
       strtok(sp, " /");
@@ -115,23 +151,29 @@ int replay_and_check_for_duplicate(char* fname)
 	std::cerr << "error: allocate: " << s << std::endl;
 	return -1;
       }
+      tmp.clear();
       auto allocated = alloc->allocate(want, alloc_unit, 0, 0, &tmp);
       std::cout << "allocated TOTAL: " << allocated << std::endl;
-      interval_set<uint64_t> intervals;
+      for (auto& ee : tmp) {
+        std::cerr << "dump extent: " << std::hex
+          << ee.offset << "~" << ee.length
+          << std::dec << std::endl;
+      }
+      std::cerr << "dump completed." << std::endl;
       for (auto& e : tmp) {
-	if (intervals.intersects(e.offset, e.length)) {
-  	  std::cerr << "error: duplicate extent: " << std::hex
+	if (owned_by_app.intersects(e.offset, e.length)) {
+	  std::cerr << "error: unexpected allocated extent: " << std::hex
 		    << e.offset << "~" << e.length
 	            << " dumping all allocations:" << std::dec << std::endl;
 	  for (auto& ee : tmp) {
-	    std::cerr <<"dump: extent: " << std::hex
+	    std::cerr <<"dump extent: " << std::hex
 	              << ee.offset << "~" << ee.length
 		      << std::dec << std::endl;
 	  }
 	  std::cerr <<"dump completed." << std::endl;
 	  return -1;
 	} else {
-	  intervals.insert(e.offset, e.length);
+	  owned_by_app.insert(e.offset, e.length);
 	}
       }
       continue;
@@ -140,7 +182,8 @@ int replay_and_check_for_duplicate(char* fname)
     sp = strstr(s, "BitmapAllocator");
     if (sp) {
       // 2019-05-30 03:23:43.460 7f889a5edf00 10 fbmap_alloc 0x5642ed36e900 BitmapAllocator 0x15940000000/100000
-      if (init_done) { 
+      std::cout << s << std::endl;
+      if (init_done) {
 	std::cerr << "error: duplicate init: " << s << std::endl;
 	return -1;
       }
@@ -158,6 +201,7 @@ int replay_and_check_for_duplicate(char* fname)
       }
       alloc.reset(Allocator::create(g_ceph_context, string("bitmap"), total,
 				    alloc_unit));
+      owned_by_app.insert(0, total);
 
       init_done = true;
       continue;


### PR DESCRIPTION
- better check for intersections/duplicates
- process init_add_free/init_rm_free to build more consistent state
view.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
