### PR TITLE
nautilus: mds: reject sessionless messages

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7775,6 +7775,11 @@ std::vector<Option> get_mds_options() {
     .set_default(true)
     .set_description("additional reply to clients that metadata requests are complete but not yet durable"),
 
+    Option("mds_replay_unsafe_with_closed_session", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("complete all the replay request when mds is restarted, no matter the session is closed or not"),
+
     Option("mds_default_dir_hash", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(CEPH_STR_HASH_RJENKINS)
     .set_description("hash function to select directory fragment for dentry name"),

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1831,7 +1831,7 @@ void Locker::file_update_finish(CInode *in, MutationRef& mut, unsigned flags,
 
   if (ack) {
     Session *session = mds->get_session(client);
-    if (session) {
+    if (session && !session->is_closed()) {
       // "oldest flush tid" > 0 means client uses unique TID for each flush
       if (ack->get_oldest_flush_tid() > 0)
         session->add_completed_flush(ack->get_client_tid());

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3679,6 +3679,7 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_recall_warning_decay_rate",
     "mds_request_load_average_decay_rate",
     "mds_session_cache_liveness_decay_rate",
+    "mds_replay_unsafe_with_closed_session",
     NULL
   };
   return KEYS;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1261,7 +1261,6 @@ void Server::handle_client_reconnect(const MClientReconnect::const_ref &m)
   if (!session->is_open()) {
     dout(0) << " ignoring msg from not-open session" << *m << dendl;
     auto reply = MClientSession::create(CEPH_SESSION_CLOSE);
-    reply->metadata["error_string"] = "session is not open";
     mds->send_message(reply, m->get_connection());
     return;
   }

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -105,6 +105,7 @@ private:
   feature_bitset_t supported_features;
   feature_bitset_t required_client_features;
 
+  bool replay_unsafe_with_closed_session = false;
   double cap_revoke_eviction_timeout = 0;
 
   friend class MDSContinuation;


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/41853
* https://tracker.ceph.com/issues/43345

possibly a backport of

* https://github.com/ceph/ceph/pull/29059
* https://github.com/ceph/ceph/pull/29594
* https://github.com/ceph/ceph/pull/32318

parent trackers:

* https://tracker.ceph.com/issues/40784
* https://tracker.ceph.com/issues/41329

---

updated using ceph-backport.sh version 15.0.0.6950
