### PR TITLE
nautilus: ceph-crash: try client.crash[.host] before client.admin; add mon profile

### DIFF
--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -5,6 +5,7 @@
 import argparse
 import logging
 import os
+import socket
 import subprocess
 import sys
 import time
@@ -12,6 +13,9 @@ import time
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
+auth_names = ['client.crash.%s' % socket.gethostname(),
+              'client.crash',
+              'client.admin']
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -22,22 +26,31 @@ def parse_args():
         '-d', '--delay', default=10.0, type=float,
         help='minutes to delay between scans (0 to exit after one)',
     )
+    parser.add_argument(
+        '--name', '-n',
+        help='ceph name to authenticate as (default: try client.crash, client.admin)')
     return parser.parse_args()
 
 
 def post_crash(path):
-    pr = subprocess.Popen(
-        args=['timeout', '30', 'ceph', 'crash', 'post', '-i', '-'],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    f = open(os.path.join(path, 'meta'), 'rb')
-    stdout, stderr = pr.communicate(input=f.read())
-    rc = pr.wait()
-    f.close()
-    if rc != 0:
-        log.warning('post %s failed: %s' % (path, stderr))
+    rc = 0
+    for n in auth_names:
+        pr = subprocess.Popen(
+            args=['timeout', '30', 'ceph',
+                  '-n', n,
+                  'crash', 'post', '-i', '-'],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        f = open(os.path.join(path, 'meta'), 'rb')
+        stdout, stderr = pr.communicate(input=f.read())
+        rc = pr.wait()
+        f.close()
+        if rc != 0:
+            log.warning('post %s as %s failed: %s' % (path, n, stderr))
+        if rc == 0:
+            break
     return rc
 
 
@@ -66,6 +79,8 @@ def scrape_path(path):
 def main():
     args = parse_args()
     postdir = os.path.join(args.path, 'posted')
+    if args.name:
+        auth_names = [args.name]
 
     while not os.path.isdir(postdir):
         log.error("directory %s does not exist; please create" % postdir)

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -32,7 +32,7 @@ def post_crash(path):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    f = open(os.path.join(path, 'meta'), 'r')
+    f = open(os.path.join(path, 'meta'), 'rb')
     stdout, stderr = pr.communicate(input=f.read())
     rc = pr.wait()
     f.close()

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -177,6 +177,9 @@ void MonCapGrant::expand_profile(int daemon_type, const EntityName& name) const
 
 void MonCapGrant::expand_profile_mgr(const EntityName& name) const
 {
+  if (profile == "crash") {
+    profile_grants.push_back(MonCapGrant("crash post"));
+  }
 }
 
 void MonCapGrant::expand_profile_mon(const EntityName& name) const
@@ -308,7 +311,10 @@ void MonCapGrant::expand_profile_mon(const EntityName& name) const
                                 "rbd/mirror/");
     profile_grants.push_back(MonCapGrant("config-key get", "key", constraint));
   }
-
+  else if (profile == "crash") {
+    // TODO: we could limit this to getting the monmap and mgrmap...
+    profile_grants.push_back(MonCapGrant("mon", MON_CAP_R));
+  }
   if (profile == "role-definer") {
     // grants ALL caps to the auth subsystem, read-only on the
     // monitor subsystem and nothing else.


### PR DESCRIPTION
This should be combined with ceph-ansible etc changes to create a ceph.client.crash[.$host].keyring on each host.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>