### PR TITLE
mimic: mgr/telemetry: Ignore crashes in report when module not enabled

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -288,7 +288,10 @@ class Module(MgrModule):
         for key, value in service_map['services'].items():
             report['services'][key] += 1
 
-        report['crashes'] = self.gather_crashinfo()
+        try:
+            report['crashes'] = self.gather_crashinfo()
+        except ImportError:
+            self.log.debug('Not adding crashes as the crash module is not enabled')
 
         return report
 


### PR DESCRIPTION
The crash module is not guaranteerd to be enabled and this will render
the telemetry module useless:

<pre>
  Error EINVAL: Traceback (most recent call last):
    File "/usr/lib/ceph/mgr/telemetry/module.py", line 325, in handle_command
      report = self.compile_report()
    File "/usr/lib/ceph/mgr/telemetry/module.py", line 291, in compile_report
      report['crashes'] = self.gather_crashinfo()
    File "/usr/lib/ceph/mgr/telemetry/module.py", line 214, in gather_crashinfo
      errno, crashids, err = self.remote('crash', 'do_ls', '', '')
    File "/usr/lib/ceph/mgr/mgr_module.py", line 845, in remote
      args, kwargs)
  ImportError: Module not found
</pre>

We can safely ignore this error and just continue without the crash information.

Fixes: https://tracker.ceph.com/issues/42116

Signed-off-by: Wido den Hollander <wido@42on.com>