### PR TITLE
luminous: tools/rbd-ggate: close log before running postfork

### DIFF
--- a/src/tools/rbd_ggate/main.cc
+++ b/src/tools/rbd_ggate/main.cc
@@ -93,14 +93,13 @@ static int do_map(int argc, const char *argv[])
       cerr << err << std::endl;
       return r;
     }
-
     if (forker.is_parent()) {
-      global_init_postfork_start(g_ceph_context);
       if (forker.parent_wait(err) != 0) {
         return -ENXIO;
       }
       return 0;
     }
+    global_init_postfork_start(g_ceph_context);
   }
 
   common_init_finish(g_ceph_context);
@@ -174,9 +173,8 @@ static int do_map(int argc, const char *argv[])
   std::cout << "/dev/" << drv->get_devname() << std::endl;
 
   if (g_conf->daemonize) {
-    forker.daemonize();
-    global_init_postfork_start(g_ceph_context);
     global_init_postfork_finish(g_ceph_context);
+    forker.daemonize();
   }
 
   init_async_signal_handler();


### PR DESCRIPTION
https://tracker.ceph.com/issues/41621