### PR TITLE
rgw: do not miss the 1000th element of every iteration during lifecycle processing

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -516,25 +516,22 @@ public:
 
   bool get_obj(rgw_bucket_dir_entry *obj) {
     if (obj_iter == objs.end()) {
-      delay();
-      return false;
-    }
-    if (is_truncated && (obj_iter + 1)==objs.end()) {
-      list_op.params.marker = obj_iter->key;
-
-      int ret = fetch();
-      if (ret < 0) {
-        ldout(store->ctx(), 0) << "ERROR: list_op returned ret=" << ret << dendl;
-        return ret;
-      } 
-      obj_iter = objs.begin();
-      if (obj_iter == objs.end()) {
+      if (!is_truncated) {
+        delay();
         return false;
+      } else {
+        list_op.params.marker = pre_obj.key;
+
+        int ret = fetch();
+        if (ret < 0) {
+          ldout(store->ctx(), 0) << "ERROR: list_op returned ret=" << ret << dendl;
+          return ret;
+        }
       }
       delay();
     }
     *obj = *obj_iter;
-    return true;
+    return obj_iter != objs.end();
   }
 
   rgw_bucket_dir_entry get_prev_obj() {


### PR DESCRIPTION
After each lifecycle processing, approximately 1/1000 objects remain. 
This PR fix that problem.

Signed-off-by: Ilsoo Byun <ilsoobyun@linecorp.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
