### PR TITLE
rgw: set bucket attr twice when delete lifecycle config.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5514,16 +5514,6 @@ void RGWDeleteLC::execute()
       return;
     }
   }
-  map<string, bufferlist> attrs = s->bucket_attrs;
-  attrs.erase(RGW_ATTR_LC);
-  op_ret = store->ctl()->bucket->set_bucket_instance_attrs(s->bucket_info, attrs,
-							&s->bucket_info.objv_tracker,
-							s->yield);
-  if (op_ret < 0) {
-    ldpp_dout(this, 0) << "RGWLC::RGWDeleteLC() failed to set attrs on bucket="
-        << s->bucket.name << " returned err=" << op_ret << dendl;
-    return;
-  }
 
   op_ret = store->getRados()->get_lc()->remove_bucket_config(s->bucket_info, s->bucket_attrs);
   if (op_ret < 0) {


### PR DESCRIPTION
Bucket attr is also set in `store->getRados()->get_lc()->remove_bucket_config`. 

Fixes：https://tracker.ceph.com/issues/44093

Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


