### PR TITLE
do_cmake.sh: Add CEPH_GIT_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,17 @@ Build instructions:
 
 (Note: do_cmake.sh now defaults to creating a debug build of ceph that can
 be up to 5x slower with some workloads. Please pass 
-"-DCMAKE_BUILD_TYPE=RelWithDebInfo" to do_cmake.sh to create a non-debug 
+"-DCMAKE_BUILD_TYPE=RelWithDebInfo" to do_cmake.sh to create a non-debug
 release.)
 
+(Note: `make` alone will use only one CPU thread, this could take a while. use
+the `-j` option to use more threads. Something like `make -j$(nproc)` would be
+a good start.
+
 This assumes you make your build dir a subdirectory of the ceph.git
-checkout. If you put it elsewhere, just replace `..` in do_cmake.sh with a
-correct path to the checkout. Any additional CMake args can be specified
-setting ARGS before invoking do_cmake. See [cmake options](#cmake-options) 
+checkout. If you put it elsewhere, just point `CEPH_GIT_DIR`to the correct
+path to the checkout. Any additional CMake args can be specified setting ARGS
+before invoking do_cmake. See [cmake options](#cmake-options)
 for more details. Eg.
 
     ARGS="-DCMAKE_C_COMPILER=gcc-7" ./do_cmake.sh

--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -3,7 +3,8 @@ set -x
 
 git submodule update --init --recursive
 
-[ -z "$BUILD_DIR" ] && BUILD_DIR=build
+: ${BUILD_DIR:=build}
+: ${CEPH_GIT_DIR:=..}
 
 if [ -e $BUILD_DIR ]; then
     echo "'$BUILD_DIR' dir already exists; either rm -rf '$BUILD_DIR' and re-run, or set BUILD_DIR env var to a different directory name"
@@ -54,7 +55,7 @@ if type cmake3 > /dev/null 2>&1 ; then
 else
     CMAKE=cmake
 fi
-${CMAKE} $ARGS "$@" .. || exit 1
+${CMAKE} $ARGS "$@" $CEPH_GIT_DIR || exit 1
 set +x
 
 # minimal config to find plugins


### PR DESCRIPTION
This patch adds a new env variables that users can set to define the
location of the checked out ceph git repo.

The documentation mentions having to go edit the script directly to
point to the ceph git directory if the build dir isn't in the
top directory of the checked out git repo. This patch changes the '..'
into an env variable, CEPH_GIT_DIR, that defaults to '..'. To make it
easy to script and change.

This allows someone to do things like:

 export CEPH_GIT_DIR=~/git/ceph
 ./do_cmake.sh

or

 CEPH_GIT_DIR=~/git/ceph ./do_cmake.sh

Which is much better then editing the script directly.
The README.md has been modified to mention this variable and also
includes a drive by to mention `make -j` for new contributors to
build ceph quicker.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
