### PR TITLE
mgr/dashboard: comment failing QA suites out

### DIFF
--- a/qa/suites/rados/mgr/tasks/dashboard.yaml
+++ b/qa/suites/rados/mgr/tasks/dashboard.yaml
@@ -34,13 +34,13 @@ tasks:
         - tasks.mgr.dashboard.test_cluster_configuration
         - tasks.mgr.dashboard.test_erasure_code_profile
         - tasks.mgr.dashboard.test_ganesha
-        - tasks.mgr.dashboard.test_health
+        # - tasks.mgr.dashboard.test_health
         - tasks.mgr.dashboard.test_host
         - tasks.mgr.dashboard.test_logs
         - tasks.mgr.dashboard.test_mgr_module
         - tasks.mgr.dashboard.test_monitor
         - tasks.mgr.dashboard.test_osd
-        - tasks.mgr.dashboard.test_perf_counters
+        # - tasks.mgr.dashboard.test_perf_counters
         - tasks.mgr.dashboard.test_pool
         - tasks.mgr.dashboard.test_rbd
         - tasks.mgr.dashboard.test_requests

--- a/qa/suites/rados/mgr/tasks/dashboard.yaml
+++ b/qa/suites/rados/mgr/tasks/dashboard.yaml
@@ -32,20 +32,20 @@ tasks:
         - tasks.mgr.dashboard.test_auth
         - tasks.mgr.dashboard.test_cephfs
         - tasks.mgr.dashboard.test_cluster_configuration
+        - tasks.mgr.dashboard.test_erasure_code_profile
+        - tasks.mgr.dashboard.test_ganesha
         - tasks.mgr.dashboard.test_health
         - tasks.mgr.dashboard.test_host
         - tasks.mgr.dashboard.test_logs
+        - tasks.mgr.dashboard.test_mgr_module
         - tasks.mgr.dashboard.test_monitor
         - tasks.mgr.dashboard.test_osd
         - tasks.mgr.dashboard.test_perf_counters
-        - tasks.mgr.dashboard.test_summary
-        - tasks.mgr.dashboard.test_rgw
-        - tasks.mgr.dashboard.test_rbd
         - tasks.mgr.dashboard.test_pool
+        - tasks.mgr.dashboard.test_rbd
         - tasks.mgr.dashboard.test_requests
+        - tasks.mgr.dashboard.test_rgw
         - tasks.mgr.dashboard.test_role
         - tasks.mgr.dashboard.test_settings
+        - tasks.mgr.dashboard.test_summary
         - tasks.mgr.dashboard.test_user
-        - tasks.mgr.dashboard.test_erasure_code_profile
-        - tasks.mgr.dashboard.test_mgr_module
-        - tasks.mgr.dashboard.test_ganesha


### PR DESCRIPTION
The PR consists of two Parts:

1. Sort QA suites alphabetically
Sort QA suites alphabetically to recognize a missing suite faster.

2. Comment questionable suites out
We're currently facing some issues with our integration tests. Because of that we agreed on commenting questionable suites out to be able to run all other suites on open pull requests.

'test_health' and 'test_perf_counters' are commented out because they led to issues in relation to https://tracker.ceph.com/issues/41538. As soon as the issue has been fixed, we need to re-add
these two suites again.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
