### PR TITLE
rgw: fix copy object issue

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5285,6 +5285,9 @@ void RGWCopyObj::execute()
 	   this,
 	   s->yield);
 
+  if(-ERR_PRECONDITION_FAILED == op_ret) {
+    s->err.message = "At least one of the pre-conditions you specified did not hold";
+  }
   const auto ret = rgw::notify::publish(s, s->object, s->obj_size, mtime, etag, rgw::notify::ObjectCreatedCopy, store);
   if (ret < 0) {
     ldpp_dout(this, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4112,6 +4112,9 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
 
   ret = read_op.prepare(y);
   if (ret < 0) {
+    if (ret == -ERR_NOT_MODIFIED) {
+      return -ERR_PRECONDITION_FAILED;
+    }
     return ret;
   }
   if (src_attrs.count(RGW_ATTR_CRYPT_MODE)) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3204,8 +3204,8 @@ int RGWCopyObj_ObjStore_S3::get_params()
 {
   if_mod = s->info.env->get("HTTP_X_AMZ_COPY_IF_MODIFIED_SINCE");
   if_unmod = s->info.env->get("HTTP_X_AMZ_COPY_IF_UNMODIFIED_SINCE");
-  if_match = s->info.env->get("HTTP_X_AMZ_COPY_IF_MATCH");
-  if_nomatch = s->info.env->get("HTTP_X_AMZ_COPY_IF_NONE_MATCH");
+  if_match = s->info.env->get("HTTP_X_AMZ_COPY_SOURCE_IF_MATCH");
+  if_nomatch = s->info.env->get("HTTP_X_AMZ_COPY_SOURCE_IF_NONE_MATCH");
 
   src_tenant_name = s->src_tenant_name;
   src_bucket_name = s->src_bucket_name;


### PR DESCRIPTION
rgw:fix copy object successfully when the value of CopySourceIfMatch does not match its entity tag(ETag)
rgw:fix error return code when the value of CopySourceIfNoneMatch match its entity tag(ETag).

Signed-off-by: DHB-liuhong <liuhong@cmss.chinamobile.com>


