### PR TITLE
mimic: rgw: datalog/mdlog trim commands loop until done

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6823,8 +6823,12 @@ next:
     }
     RGWMetadataLog *meta_log = store->meta_mgr->get_log(period_id);
 
-    ret = meta_log->trim(shard_id, start_time.to_real_time(), end_time.to_real_time(), start_marker, end_marker);
-    if (ret < 0) {
+    // trim until -ENODATA
+    do {
+      ret = meta_log->trim(shard_id, start_time.to_real_time(),
+                           end_time.to_real_time(), start_marker, end_marker);
+    } while (ret == 0);
+    if (ret < 0 && ret != -ENODATA) {
       cerr << "ERROR: meta_log->trim(): " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2198,32 +2198,11 @@ int RGWDataChangesLog::get_info(int shard_id, RGWDataChangesLogInfo *info)
 int RGWDataChangesLog::trim_entries(int shard_id, const real_time& start_time, const real_time& end_time,
                                     const string& start_marker, const string& end_marker)
 {
-  int ret;
-
   if (shard_id > num_shards)
     return -EINVAL;
 
-  ret = store->time_log_trim(oids[shard_id], start_time, end_time, start_marker, end_marker);
-
-  if (ret == -ENOENT || ret == -ENODATA)
-    ret = 0;
-
-  return ret;
-}
-
-int RGWDataChangesLog::trim_entries(const real_time& start_time, const real_time& end_time,
-                                    const string& start_marker, const string& end_marker)
-{
-  for (int shard = 0; shard < num_shards; shard++) {
-    int ret = store->time_log_trim(oids[shard], start_time, end_time, start_marker, end_marker);
-    if (ret == -ENOENT || ret == -ENODATA) {
-      continue;
-    }
-    if (ret < 0)
-      return ret;
-  }
-
-  return 0;
+  return store->time_log_trim(oids[shard_id], start_time, end_time,
+                               start_marker, end_marker, nullptr);
 }
 
 bool RGWDataChangesLog::going_down()

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -512,8 +512,6 @@ public:
 		   bool *truncated);
   int trim_entries(int shard_id, const real_time& start_time, const real_time& end_time,
                    const string& start_marker, const string& end_marker);
-  int trim_entries(const real_time& start_time, const real_time& end_time,
-                   const string& start_marker, const string& end_marker);
   int get_info(int shard_id, RGWDataChangesLogInfo *info);
   int lock_exclusive(int shard_id, timespan duration, string& zone_id, string& owner_id) {
     return store->lock_exclusive(store->get_zone_params().log_pool, oids[shard_id], duration, zone_id, owner_id);

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -222,14 +222,8 @@ int RGWMetadataLog::trim(int shard_id, const real_time& from_time, const real_ti
   string oid;
   get_shard_oid(shard_id, oid);
 
-  int ret;
-
-  ret = store->time_log_trim(oid, from_time, end_time, start_marker, end_marker);
-
-  if (ret == -ENOENT || ret == -ENODATA)
-    ret = 0;
-
-  return ret;
+  return store->time_log_trim(oid, from_time, end_time, start_marker,
+                              end_marker, nullptr);
 }
   
 int RGWMetadataLog::lock_exclusive(int shard_id, timespan duration, string& zone_id, string& owner_id) {


### PR DESCRIPTION
NOTE: commits taken verbatim from the luminous backport PR https://github.com/ceph/ceph/pull/29713

---

backport tracker: https://tracker.ceph.com/issues/41324

---

backport of https://github.com/ceph/ceph/pull/29448
parent tracker: https://tracker.ceph.com/issues/41045

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh