### PR TITLE
common/options: Increase the default number of RGW bucket shards

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5691,7 +5691,7 @@ std::vector<Option> get_rgw_options() {
     .set_description("The maximum number of metadata items that can be put via single request"),
 
     Option("rgw_override_bucket_index_max_shards", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(0)
+    .set_default(11)
     .set_description(""),
 
     Option("rgw_bucket_index_max_aio", Option::TYPE_UINT, Option::LEVEL_ADVANCED)

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -560,7 +560,7 @@ struct RGWZone {
   bool sync_from_all;
   set<std::string> sync_from; /* list of zones to sync from */
 
-  RGWZone() : log_meta(false), log_data(false), read_only(false), bucket_index_max_shards(0),
+  RGWZone() : log_meta(false), log_data(false), read_only(false), bucket_index_max_shards(11),
               sync_from_all(true) {}
 
   void encode(bufferlist& bl) const {


### PR DESCRIPTION
With the performance improvements in ordered bucket listing we are seeing in #30853, we can increase the default number of RGW bucket shards seemingly with minimal impact on bucket list performance.  This PR rather aggressively changes the default number of bucket index shards to 64.  If after testing this looks too aggressive we can back this off to 32 or 16.

Impacts from a larger number of bucket index shards:

* More objects can be written without the impact of bucket splits
* Higher degrees of parallelism for much faster per-bucket write throughput with concurrent threads
* No obvious read performance impact
* Prior to #30853 much slower bucket list throughput, though this now appears to be mostly mitigated

Slightly outdated performance data is here:

https://docs.google.com/spreadsheets/d/17SiwtVWy3jJdeXocFXrcPFvn8F5x1m8525BwjTevvME/edit?usp=sharing

More results incoming as we run tests and modify code.  Marking this DNM for the moment as we should definitely merge #30853 first.

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
