### PR TITLE
mds: avoid running rejoin_gather_finish() core

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5921,8 +5921,8 @@ bool MDCache::open_undef_inodes_dirfrags()
 
   MDSGatherBuilder gather(g_ceph_context,
       new MDSInternalContextWrapper(mds,
-	new FunctionContext([this](int r) {
-	    if (rejoin_gather.empty())
+	new LambdaContext([this](int r) {
+	    if (rejoin_gather.empty() && rejoin_ack_gather.count(mds->get_nodeid()))
 	      rejoin_gather_finish();
 	  })
 	)


### PR DESCRIPTION
if rejoin_ack_gather is empty, running rejoin_gather_finish() will core.

Fixes: https://tracker.ceph.com/issues/42289
Signed-off-by: Xiao Guodong xiaogd@inspur.com