### PR TITLE
rgw: Expiration days can't be zero and  transition days can be zero

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -863,7 +863,7 @@ public:
 
     auto mtime = get_effective_mtime(oc);
     bool is_expired;
-    if (transition.days <= 0) {
+    if (transition.days < 0) {
       if (transition.date == boost::none) {
         ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": no transition day/date set in rule, skipping" << dendl;
         return false;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -86,7 +86,7 @@ public:
   bool valid() const {
     if (!days.empty() && !date.empty()) {
       return false;
-    } else if (!days.empty() && get_days() < 0) {
+    } else if (!days.empty() && get_days() <= 0) {
       return false;
     }
     //We've checked date in xml parsing
@@ -130,7 +130,7 @@ public:
   bool valid() const {
     if (!days.empty() && !date.empty()) {
       return false;
-    } else if (!days.empty() && get_days() <=0) {
+    } else if (!days.empty() && get_days() < 0) {
       return false;
     }
     //We've checked date in xml parsing


### PR DESCRIPTION
As described in https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleExpiration.html, expiration days must be none-zero positive. 
I've tested against S3, the expiration  and noncurrent expiration days can't be zero. Transition days can be zero when the storage class is glacier.
Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


