### PR TITLE
ceph-backport.sh: implement --milestones feature and more-careful vetting

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -828,7 +828,7 @@ fi
 #
 
 BACKPORT_COMMON=$HOME/bin/backport_common.sh
-[ -f "$BACKPORT_COMMON" ] && source $HOME/bin/backport_common.sh
+[ -f "$BACKPORT_COMMON" ] && source "$BACKPORT_COMMON"
 setup_ok="1"
 init_github_user
 init_mandatory_vars

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -17,7 +17,7 @@
 #
 #
 
-SCRIPT_VERSION="15.0.0.5775"
+SCRIPT_VERSION="15.0.0.6270"
 full_path="$0"
 this_script=$(basename "$full_path")
 how_to_get_setup_advice="For setup advice, run: \"${this_script} --setup-advice | less\""

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -123,6 +123,7 @@ function check_tracker_status {
 
 function cherry_pick_phase {
     local base_branch=
+    local merged=
     local number_of_commits=
     local offset=0
     local singular_or_plural_commit=
@@ -151,6 +152,13 @@ function cherry_pick_phase {
         error "${original_pr_url} is targeting ${base_branch}: cowardly refusing to perform automated cherry-pick"
         info "Out of an abundance of caution, the script only automates cherry-picking of commits from PRs targeting \"ceph:master\"."
         info "You can still use the script to stage the backport, though. Just prepare the local branch \"${local_branch}\" manually and re-run the script."
+        false
+    fi
+    merged=$(echo ${remote_api_output} | jq -r .merged)
+    if [ "$merged" = "true" ] ; then
+        true
+    else
+        error "${original_pr_url} is not merged yet: cowardly refusing to perform automated cherry-pick"
         false
     fi
     number_of_commits=$(echo ${remote_api_output} | jq .commits)

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -755,7 +755,7 @@ fi
 # process command-line arguments
 #
 
-munged_options=$(getopt -o c:dhmpsv --long "component:,debug,help,milestones,prepare,set-milestone,setup,setup-advice,troubleshooting-advice,update-version,usage-advice,verbose,version" -n "$this_script" -- "$@")
+munged_options=$(getopt -o c:dhpsv --long "component:,debug,help,milestones,prepare,setup,setup-advice,troubleshooting-advice,update-version,usage-advice,verbose,version" -n "$this_script" -- "$@")
 eval set -- "$munged_options"
 
 ADVICE=""

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -787,6 +787,7 @@ if git status >/dev/null 2>&1 ; then
     debug "In a local git clone. Good."
 else
     error "This script must be run from inside a local git clone"
+    info "$how_to_get_setup_advice"
     false
 fi
 

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -177,9 +177,7 @@ function cherry_pick_phase {
         if git cherry-pick -x "pr-$original_pr~$i" ; then
             true
         else
-            if [ "$VERBOSE" ] ; then
-                git status
-            fi
+            [ "$VERBOSE" ] && git status
             error "Cherry pick failed"
             info "Next, manually fix conflicts and complete the current cherry-pick"
             if [ "$i" -gt "0" ] >/dev/null 2>&1 ; then
@@ -356,25 +354,32 @@ function log {
     prefix="${this_script}: "
     verbose_only=
     case $level in
+        bare)
+            prefix=
+            ;;
+        debug)
+            prefix="${prefix}DEBUG: "
+            verbose_only="yes"
+            ;;
         err*)
             prefix="${prefix}ERROR: "
             ;;
         info)
             :
             ;;
-        bare)
-            prefix=
-            ;;
         overwrite)
             trailing_newline=
             prefix=
             ;;
+        verbose)
+            verbose_only="yes"
+            ;;
+        verbose_en)
+            verbose_only="yes"
+            trailing_newline=
+            ;;
         warn|warning)
             prefix="${prefix}WARNING: "
-            ;;
-        debug|verbose)
-            prefix="${prefix}DEBUG: "
-            verbose_only="1"
             ;;
     esac
     if [ "$verbose_only" -a -z "$VERBOSE" ] ; then
@@ -399,10 +404,7 @@ function milestone_number_from_remote_api {
         echo "$mn"
     else
         error "Could not determine milestone number of ->$milestone<-"
-        if [ "$VERBOSE" ] ; then
-            info "GitHub API said:"
-            log bare "$remote_api_output"
-        fi
+        verbose_en "GitHub API said:\n${remote_api_output}\n"
         info "Valid values are $(curl --silent -X GET 'https://api.github.com/repos/ceph/ceph/milestones?access_token='$github_token | jq '.[].title')"
         info "(This probably means the Release field of ${redmine_url} is populated with"
         info "an unexpected value - i.e. it does not match any of the GitHub milestones.)"
@@ -674,6 +676,10 @@ EOM
 
 function verbose {
     log verbose "$@"
+}
+
+function verbose_en {
+    log verbose_en "$@"
 }
 
 function vet_pr_milestone {


### PR DESCRIPTION
This PR implements `ceph-backport.sh --milestones` which will find and fix PRs that are missing a milestone (or have the wrong milestone).

It also tries to be more careful in several areas:

* refuse to stage a backport if the backport tracker issue is closed
* check that the Backport tracker issue's "release" field is actually one of the active milestones on GitHub
* if `github_user` is not set, do not fall back to `$USER` (this leads to confusing behavior when the actual GitHub username is something other than `$USER`)
* even when `github_token` is set, do an actual GitHub API call and bail out if GitHub does not recognize the token
* refuse to cherry-pick from a PR that targets any branch other than `ceph:master`
* refuse to cherry-pick from a PR that isn't merged