### PR TITLE
enhance osd io-latency and -size statistics tool 

### DIFF
--- a/src/tools/histogram_dump.py
+++ b/src/tools/histogram_dump.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 #
 # Ceph - scalable distributed file system
 #
 # Copyright (C) 2017 OVH
+# Copyright (C) 2019 Marc Schöchlin <ms-github@256bit.org>
 #
 # This is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public
@@ -16,6 +17,8 @@ import subprocess
 import time
 import os
 import argparse
+import glob
+import sys
 
 
 def shorten(val):
@@ -27,20 +30,24 @@ def shorten(val):
     return val
 
 
-def print_histogram(asok, logger, counter, last):
+def create_histogram(sockets, logger, counter, last, seconds):
 
-    try:
-        out = subprocess.check_output(
-            "ceph --admin-daemon {} perf histogram dump".format(asok),
-            shell=True)
-        j = json.loads(out.decode('utf-8'))
-    except Exception as e:
-        return (last,
-                "Couldn't connect to admin socket, result: \n{}".format(e))
+    current_datasets = {}
+    json_d = {}
+    for socket in sockets:
+       try:
+           out = subprocess.check_output(
+               "ceph --admin-daemon {} perf histogram dump".format(socket),
+               shell=True)
+           json_d = json.loads(out.decode('utf-8'))
+       except Exception as e:
+           return (last,
+                   "Couldn't connect to admin socket, result: \n{}".format(e))
+       current_datasets[socket] = json_d['osd'][counter]['values']
 
-    current = j['osd'][counter]['values']
-    axes = j['osd'][counter]['axes']
-    content = ""
+
+    axes = json_d['osd'][counter]['axes']
+    content = "Counter: {} for {}\n(create statistics every {} seconds)\n\n".format(counter,", ".join(sockets),seconds)
 
     content += "{}:\n".format(axes[1]['name'])
     for r in axes[1]['ranges']:
@@ -55,13 +62,34 @@ def print_histogram(asok, logger, counter, last):
     content += ("{0: >"+str(len(axes[1]['ranges'])*5+14)+"}:\n").format(
         axes[0]['name'])
 
+    COL = '\033[91m'
+    ENDC = '\033[0m'
+
+    current = []
+
+    # initalize with zeros
+    for i in range(len(current_datasets[socket])):
+       current.append([])
+       for j in range(len(current_datasets[socket][i])):
+              current[i].append(0)
+
+    # combine data
+    for socket, data in current_datasets.items():
+       for i in range(len(data)):
+           for j in range(len(data[i])):
+              current[i][j] += data[i][j]
+
     for i in range(len(current)):
         for j in range(len(current[i])):
             try:
                 diff = current[i][j] - last[i][j]
             except IndexError:
                 diff = '-'
-            content += "{0: >4} ".format(shorten(diff))
+
+            if diff != "-" and diff != 0:
+                content += "{0}{1: >4}{2} ".format(COL,shorten(diff),ENDC)
+            else:
+                content += "{0: >4} ".format(shorten(diff))
 
         r = axes[0]['ranges'][i]
         content += "{0: >6} : {1}\n".format(
@@ -70,13 +98,17 @@ def print_histogram(asok, logger, counter, last):
     return (current, content)
 
 
-def loop_print(asok, logger, counter):
+def loop_print(sockets, logger, counter, loop_seconds):
     last = []
-    while True:
 
-        last, content = print_histogram(asok, logger, counter, last)
-        print("{}{}".format("\n"*100, content))
-        time.sleep(1)
+    try:
+       while True:
+           last, content = create_histogram(sockets, logger, counter, last, loop_seconds)
+           print("{}{}".format("\n"*100, content))
+           time.sleep(loop_seconds)
+    except KeyboardInterrupt:
+       print("...interupted")
+       sys.exit(0)
 
 
 def main():
@@ -85,7 +117,8 @@ def main():
     parser.add_argument(
         '--asok',
         type=str,
-        default='/var/run/ceph/*.asok',
+        default=['/var/run/ceph/*.asok'],
+        nargs='+',
         help='Path to asok file, can use wildcards')
     parser.add_argument(
         '--logger',
@@ -95,10 +128,23 @@ def main():
         '--counter',
         type=str,
         default='op_w_latency_in_bytes_histogram')
+
+    parser.add_argument(
+        '--loop_seconds',
+        type=int,
+        default=5)
+
     args = parser.parse_args()
 
-    loop_print(args.asok, args.logger, args.counter)
+    sockets = []
+    for asok in args.asok: 
+      sockets = glob.glob(asok) + sockets
 
+    if len(sockets) == 0:
+      print("no suitable socket at {}".format(",".join(sockets)))
+      sys.exit(1)
+ 
+    loop_print(sockets, args.logger, args.counter, args.loop_seconds)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
enhance osd io-latency and -size statistics tool

- add colors to the output to ease interpretation
- add possibility to specify one ore more sockets
- aggregate statistics over multiple sockets
- prevent stacktrace if tool is interrupted by SIGINT
- add possibility to specify the number of data collection
  seconds between loops
- raise loop_seconds default

![58368661-410afa00-7ef0-11e9-9aca-b09d974024a7](https://user-images.githubusercontent.com/288876/66705199-0c270480-ed24-11e9-8fcd-e5753e32ab13.png)

