### PR TITLE
rbd:add rbd export and rbd import --sync to implement sync io.

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -658,7 +658,7 @@
   
   rbd help export
   usage: rbd export [--pool <pool>] [--namespace <namespace>] [--image <image>] 
-                    [--snap <snap>] [--path <path>] [--no-progress] 
+                    [--snap <snap>] [--path <path>] [--no-progress] [--sync] 
                     [--export-format <export-format>] 
                     <source-image-or-snap-spec> <path-name> 
   
@@ -678,6 +678,7 @@
     --snap arg                   source snapshot name
     --path arg                   export file (or '-' for stdout)
     --no-progress                disable progress output
+    --sync                       open read/write file with O_SYNC
     --export-format arg          format of image file
   
   rbd help export-diff
@@ -1088,7 +1089,7 @@
                     [--journal-object-size <journal-object-size>] 
                     [--journal-pool <journal-pool>] 
                     [--sparse-size <sparse-size>] [--no-progress] 
-                    [--export-format <export-format>] [--pool <pool>] 
+                    [--export-format <export-format>] [--sync] [--pool <pool>] 
                     [--image <image>] 
                     <path-name> <dest-image-spec> 
   
@@ -1121,6 +1122,7 @@
     --journal-pool arg        pool for journal objects
     --sparse-size arg         sparse size in B/K/M [default: 4K]
     --no-progress             disable progress output
+    --sync                    open read/write file with O_SYNC
     --export-format arg       format of image file
     -p [ --pool ] arg         pool name (deprecated)
     --image arg               image name (deprecated)

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -318,6 +318,11 @@ void add_flatten_option(boost::program_options::options_description *opt) {
      "fill clone with parent data (make it independent)");
 }
 
+void add_sync_option(boost::program_options::options_description *opt) {
+  opt->add_options()
+    (SYNC.c_str(), po::bool_switch(), "open read/write file with O_SYNC");
+}
+
 std::string get_short_features_help(bool append_suffix) {
   std::ostringstream oss;
   bool first_feature = true;

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -82,8 +82,10 @@ static const std::string NO_ERROR("no-error");
 
 static const std::string LIMIT("limit");
 
+static const std::string SYNC("sync");
+
 static const std::set<std::string> SWITCH_ARGUMENTS = {
-  WHOLE_OBJECT, NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERROR};
+  WHOLE_OBJECT, NO_PROGRESS, SYNC, PRETTY_FORMAT, VERBOSE, NO_ERROR};
 
 struct ImageSize {};
 struct ImageOrder {};
@@ -184,6 +186,8 @@ void add_verbose_option(boost::program_options::options_description *opt);
 void add_no_error_option(boost::program_options::options_description *opt);
 
 void add_flatten_option(boost::program_options::options_description *opt);
+
+void add_sync_option(boost::program_options::options_description *opt);
 
 std::string get_short_features_help(bool append_suffix);
 std::string get_long_features_help();


### PR DESCRIPTION
add --sync，can set read and write local files as sync io
when uploading and downloading.
It is mainly used to disk speed limit.

Feature: https://tracker.ceph.com/issues/42290
Signed-off-by: wllabs <wllabs@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>