### PR TITLE
mimic: osd/PeeringState: recover_got - add special handler for empty log

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11514,7 +11514,10 @@ void PrimaryLogPG::recover_got(hobject_t oid, eversion_t v)
 {
   dout(10) << "got missing " << oid << " v " << v << dendl;
   pg_log.recover_got(oid, v, info);
-  if (pg_log.get_log().complete_to != pg_log.get_log().log.end()) {
+  if (pg_log.get_log().log.empty()) {
+    dout(10) << "last_complete now " << info.last_complete
+             << " while log is empty" << dendl;
+  } else if (pg_log.get_log().complete_to != pg_log.get_log().log.end()) {
     dout(10) << "last_complete now " << info.last_complete
 	     << " log.complete_to " << pg_log.get_log().complete_to->version
 	     << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42036

---

backport of https://github.com/ceph/ceph/pull/30503
parent tracker: https://tracker.ceph.com/issues/41816

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh