### PR TITLE
luminous: osd: Remove unused osdmap flags full, nearfull from output

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3478,8 +3478,6 @@ void OSDMap::print_summary(Formatter *f, ostream& out,
     f->dump_int("num_osds", get_num_osds());
     f->dump_int("num_up_osds", get_num_up_osds());
     f->dump_int("num_in_osds", get_num_in_osds());
-    f->dump_bool("full", test_flag(CEPH_OSDMAP_FULL) ? true : false);
-    f->dump_bool("nearfull", test_flag(CEPH_OSDMAP_NEARFULL) ? true : false);
     f->dump_unsigned("num_remapped_pgs", get_num_pg_temp());
     f->close_section();
   } else {
@@ -3501,10 +3499,6 @@ void OSDMap::print_oneline_summary(ostream& out) const
       << get_num_osds() << " total, "
       << get_num_up_osds() << " up, "
       << get_num_in_osds() << " in";
-  if (test_flag(CEPH_OSDMAP_FULL))
-    out << "; full flag set";
-  else if (test_flag(CEPH_OSDMAP_NEARFULL))
-    out << "; nearfull flag set";
 }
 
 bool OSDMap::crush_rule_in_use(int rule_id) const

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3502,9 +3502,9 @@ void OSDMap::print_oneline_summary(ostream& out) const
       << get_num_up_osds() << " up, "
       << get_num_in_osds() << " in";
   if (test_flag(CEPH_OSDMAP_FULL))
-    out << " full";
+    out << "; full flag set";
   else if (test_flag(CEPH_OSDMAP_NEARFULL))
-    out << " nearfull";
+    out << "; nearfull flag set";
 }
 
 bool OSDMap::crush_rule_in_use(int rule_id) const


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42138

---

backport of https://github.com/ceph/ceph/pull/30530
parent tracker: https://tracker.ceph.com/issues/42015

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh