### PR TITLE
nautilus: mds: recall caps from quiescent sessions

### DIFF
--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -29,8 +29,8 @@ void DecayCounter::decode(bufferlist::const_iterator &p)
 {
   DECODE_START_LEGACY_COMPAT_LEN(5, 4, 4, p);
   if (struct_v < 2) {
-    double half_life = 0.0;
-    decode(half_life, p);
+    double k = 0.0;
+    decode(k, p);
   }
   if (struct_v < 3) {
     double k = 0.0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41865

---

backport of https://github.com/ceph/ceph/pull/28702
parent tracker: https://tracker.ceph.com/issues/22446

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh