### PR TITLE
doc: add systemd unit part for FUSE mounts in fstab doc

### DIFF
--- a/doc/cephfs/fstab.rst
+++ b/doc/cephfs/fstab.rst
@@ -2,8 +2,8 @@
  Mount CephFS in your File Systems Table
 ========================================
 
-If you mount CephFS in your file systems table, the Ceph file system will mount
-automatically on startup. 
+If you mount CephFS in your file systems table, the Ceph file system will
+mount automatically on startup.
 
 Kernel Driver
 =============
@@ -13,33 +13,38 @@ following to ``/etc/fstab``::
 
 	[{ipaddress}:{port}]:/ {mount}/{mountpoint} ceph [name=username,secret=secretkey|secretfile=/path/to/secretfile],[{mount.options}]
 
-For example:: 
+For example::
 
-	:/     /mnt/ceph    ceph    name=admin,noatime,_netdev    0       2
+	:/     /mnt/mycephfs    ceph    name=admin,noatime,_netdev    0       2
 	
 The default for the ``name=`` parameter is ``guest``. If the ``secret`` or
 ``secretfile`` options are not specified then the mount helper will attempt to
 find a secret for the given ``name`` in one of the configured keyrings.
- 
-See `User Management`_ for details.
-   
-   
+
 FUSE
 ====
 
-To mount CephFS in your file systems table as a file system in user space, add the
-following to ``/etc/fstab``::
+To mount CephFS in your file systems table as a file system in user space, add
+the following to ``/etc/fstab``::
 
        #DEVICE PATH       TYPE      OPTIONS
-       none    /mnt/ceph  fuse.ceph ceph.id={user-ID}[,ceph.conf={path/to/conf.conf}],_netdev,defaults  0 0
+       none    /mnt/mycephfs  fuse.ceph ceph.id={user-ID}[,ceph.conf={path/to/conf.conf}],_netdev,defaults  0 0
 
 For example::
 
-       none    /mnt/ceph  fuse.ceph ceph.id=myuser,_netdev,defaults  0 0
-       none    /mnt/ceph  fuse.ceph ceph.id=myuser,ceph.conf=/etc/ceph/foo.conf,_netdev,defaults  0 0
+       none    /mnt/mycephfs  fuse.ceph ceph.id=myuser,_netdev,defaults  0 0
+       none    /mnt/mycephfs  fuse.ceph ceph.id=myuser,ceph.conf=/etc/ceph/foo.conf,_netdev,defaults  0 0
 
-Ensure you use the ID (e.g., ``admin``, not ``client.admin``). You can pass any valid 
-``ceph-fuse`` option to the command line this way.
+Ensure you use the ID (e.g., ``admin``, not ``client.admin``). You can pass
+any valid ``ceph-fuse`` option to the command line this way.
+
+``ceph-fuse@.service`` and ``ceph-fuse.target`` systemd units are available.
+As usual, these unit files declare the default dependencies and recommended
+execution context for ``ceph-fuse``. For example, after making the fstab entry
+shown above, ``ceph-fuse`` run following commands::
+
+    systemctl start ceph-fuse@-mnt-mycephfs.service
+    systemctl enable ceph-fuse@-mnt-mycephfs.service
 
 See `User Management`_ for details.
 

--- a/doc/cephfs/fuse.rst
+++ b/doc/cephfs/fuse.rst
@@ -35,18 +35,6 @@ the ``--client_mds_namespace`` command line argument, or add a
 
 See `ceph-fuse`_ for additional details.
 
-To automate mounting ceph-fuse, you may add an entry to the system fstab_.
-Additionally, ``ceph-fuse@.service`` and ``ceph-fuse.target`` systemd units are
-available. As usual, these unit files declare the default dependencies and
-recommended execution context for ``ceph-fuse``. An example ceph-fuse mount on
-``/mnt`` would be::
-
-	sudo systemctl start ceph-fuse@/mnt.service
-
-A persistent mount point can be setup via::
-
-	sudo systemctl enable ceph-fuse@/mnt.service
-
 For troubleshooting, see :ref:`ceph_fuse_debugging`.
 
 .. _ceph-fuse: ../../man/8/ceph-fuse/


### PR DESCRIPTION
To make FUSE-mounted CephFS persist across reboots, user also needs to
start and enable the systemd units. Add that part to the document for
fstab, instead of mentioning it in "Mount CephFS using FUSE" doc. Also,
wrap few lines and rename mountpoint to /mnt/mycephfs in examples to
keep them same across docs.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>