### PR TITLE
mimic: mds: reject sessionless messages

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -321,6 +321,9 @@ void Server::handle_client_session(MClientSession *m)
 
   if (!session) {
     dout(0) << " ignoring sessionless msg " << *m << dendl;
+    MClientSession *reply = new MClientSession(CEPH_SESSION_REJECT);
+    reply->metadata["error_string"] = "sessionless";
+    mds->send_message(reply, m->get_connection());
     m->put();
     return;
   }
@@ -1022,6 +1025,10 @@ void Server::handle_client_reconnect(MClientReconnect *m)
   client_t from = m->get_source().num();
   Session *session = mds->get_session(m);
   if (!session) {
+    dout(0) << " ignoring sessionless msg " << *m << dendl;
+    MClientSession *reply = new MClientSession(CEPH_SESSION_REJECT);
+    reply->metadata["error_string"] = "sessionless";
+    mds->send_message(reply, m->get_connection());
     m->put();
     return;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41854

---

backport of https://github.com/ceph/ceph/pull/29594
parent tracker: https://tracker.ceph.com/issues/41329

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh