### PR TITLE
mimic: osd: merge replica log on primary need according to replica log's crt

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -848,8 +848,7 @@ protected:
     const hobject_t &hoid,               ///< [in] object we are merging
     const mempool::osd_pglog::list<pg_log_entry_t> &orig_entries, ///< [in] entries for hoid to merge
     const pg_info_t &info,              ///< [in] info for merging entries
-    eversion_t olog_can_rollback_to,     ///< [in] rollback boundary
-    eversion_t original_can_rollback_to,     ///< [in] original rollback boundary
+    eversion_t olog_can_rollback_to,     ///< [in] rollback boundary of input InedexedLog
     missing_type &missing,               ///< [in,out] missing to adjust, use
     LogEntryHandler *rollbacker,         ///< [in] optional rollbacker object
     const DoutPrefixProvider *dpp        ///< [in] logging provider
@@ -1013,17 +1012,11 @@ protected:
     ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
                        << " olog_can_rollback_to: "
                        << olog_can_rollback_to << dendl;
-    ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
-                       << " original_crt: "
-                       << original_can_rollback_to << dendl;
     /// Distinguish between 4) and 5)
     for (list<pg_log_entry_t>::const_reverse_iterator i = entries.rbegin();
 	 i != entries.rend();
 	 ++i) {
-      /// Use original_can_rollback_to instead of olog_can_rollback_to to check
-      //  if we can rollback or not. This is to ensure that we don't try to rollback
-      //  to an object that has been deleted and doesn't exist.
-      if (!i->can_rollback() || i->version <= original_can_rollback_to) {
+      if (!i->can_rollback() || i->version <= olog_can_rollback_to) {
 	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid << " cannot rollback "
 			   << *i << dendl;
 	can_rollback = false;
@@ -1036,7 +1029,7 @@ protected:
       for (list<pg_log_entry_t>::const_reverse_iterator i = entries.rbegin();
 	   i != entries.rend();
 	   ++i) {
-	assert(i->can_rollback() && i->version > original_can_rollback_to);
+	assert(i->can_rollback() && i->version > olog_can_rollback_to);
 	ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
 			   << " rolling back " << *i << dendl;
 	if (rollbacker)
@@ -1072,8 +1065,7 @@ protected:
     const IndexedLog &log,               ///< [in] log to merge against
     mempool::osd_pglog::list<pg_log_entry_t> &entries,       ///< [in] entries to merge
     const pg_info_t &oinfo,              ///< [in] info for merging entries
-    eversion_t olog_can_rollback_to,     ///< [in] rollback boundary
-    eversion_t original_can_rollback_to, ///< [in] original rollback boundary
+    eversion_t olog_can_rollback_to,     ///< [in] rollback boundary of input IndexedLog
     missing_type &omissing,              ///< [in,out] missing to adjust, use
     LogEntryHandler *rollbacker,         ///< [in] optional rollbacker object
     const DoutPrefixProvider *dpp        ///< [in] logging provider
@@ -1089,7 +1081,6 @@ protected:
 	i->second,
 	oinfo,
 	olog_can_rollback_to,
-        original_can_rollback_to,
 	omissing,
 	rollbacker,
 	dpp);
@@ -1112,7 +1103,6 @@ protected:
       oe.soid,
       entries,
       info,
-      log.get_can_rollback_to(),
       log.get_can_rollback_to(),
       missing,
       rollbacker,

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2931,7 +2931,6 @@ TEST_F(PGLogTest, _merge_object_divergent_entries) {
     _merge_object_divergent_entries(log, hoid,
                                     orig_entries, oinfo,
                                     log.get_can_rollback_to(),
-                                    log.get_can_rollback_to(),
                                     missing, &rollbacker,
                                     this);
     // No core dump
@@ -2957,7 +2956,6 @@ TEST_F(PGLogTest, _merge_object_divergent_entries) {
     LogHandler rollbacker;
     _merge_object_divergent_entries(log, hoid,
                                     orig_entries, oinfo,
-                                    log.get_can_rollback_to(),
                                     log.get_can_rollback_to(),
                                     missing, &rollbacker,
                                     this);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41457

---

backport of https://github.com/ceph/ceph/pull/29590
parent tracker: https://tracker.ceph.com/issues/41194

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh