### PR TITLE
luminous: osd: merge replica log on primary need according to replica log's crt

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -257,11 +257,11 @@ void PGLog::proc_replica_log(
     limit :
     first_non_divergent->version;
 
-  // We need to preserve the original crt before it gets updated in rewind_from_head().
-  // Later, in merge_object_divergent_entries(), we use it to check whether we can rollback
-  // a divergent entry or not.
-  eversion_t original_crt = log.get_can_rollback_to();
-  dout(20) << __func__ << " original_crt = " << original_crt << dendl;
+  // we merge and adjust the replica's log, rollback the rollbackable divergent entry, 
+  // remove the unrollbackable divergent entry and mark the according object as missing. 
+  // the rollback boundary must choose crt of the olog which going to be merged. 
+  // The replica log's(olog) crt will not be modified, so it could get passed
+  // to _merge_divergent_entries() directly.
   IndexedLog folog(olog);
   auto divergent = folog.rewind_from_head(lu);
   _merge_divergent_entries(
@@ -269,7 +269,6 @@ void PGLog::proc_replica_log(
     divergent,
     oinfo,
     olog.get_can_rollback_to(),
-    original_crt,
     omissing,
     0,
     this);
@@ -333,7 +332,6 @@ void PGLog::rewind_divergent_log(eversion_t newhead,
     log,
     divergent,
     info,
-    log.get_can_rollback_to(),
     original_crt,
     missing,
     rollbacker,
@@ -460,7 +458,6 @@ void PGLog::merge_log(pg_info_t &oinfo, pg_log_t &olog, pg_shard_t fromosd,
       log,
       divergent,
       info,
-      log.get_can_rollback_to(),
       original_crt,
       missing,
       rollbacker,

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2930,7 +2930,6 @@ TEST_F(PGLogTest, _merge_object_divergent_entries) {
     _merge_object_divergent_entries(log, hoid,
                                     orig_entries, oinfo,
                                     log.get_can_rollback_to(),
-                                    log.get_can_rollback_to(),
                                     missing, &rollbacker,
                                     this);
     // No core dump
@@ -2956,7 +2955,6 @@ TEST_F(PGLogTest, _merge_object_divergent_entries) {
     LogHandler rollbacker;
     _merge_object_divergent_entries(log, hoid,
                                     orig_entries, oinfo,
-                                    log.get_can_rollback_to(),
                                     log.get_can_rollback_to(),
                                     missing, &rollbacker,
                                     this);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41458

---

backport of https://github.com/ceph/ceph/pull/29590
parent tracker: https://tracker.ceph.com/issues/41194

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh