### PR TITLE
test/crimson: verify msgr v2 behavior with different policies

### DIFF
--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -171,14 +171,39 @@ void Protocol::ack_writes(seq_num_t seq)
   }
 }
 
+seastar::future<stop_t> Protocol::try_exit_sweep() {
+  assert(!is_queued());
+  return socket->flush().then([this] {
+    if (!is_queued()) {
+      // still nothing pending to send after flush,
+      // the dispatching can ONLY stop now
+      ceph_assert(write_dispatching);
+      write_dispatching = false;
+      if (unlikely(exit_open.has_value())) {
+        exit_open->set_value();
+        exit_open = std::nullopt;
+        logger().info("{} write_event: nothing queued at {},"
+                      " set exit_open",
+                      conn, get_state_name(write_state));
+      }
+      return seastar::make_ready_future<stop_t>(stop_t::yes);
+    } else {
+      // something is pending to send during flushing
+      return seastar::make_ready_future<stop_t>(stop_t::no);
+    }
+  });
+}
+
 seastar::future<> Protocol::do_write_dispatch_sweep()
 {
   return seastar::repeat([this] {
     switch (write_state) {
      case write_state_t::open: {
       size_t num_msgs = conn.out_q.size();
-      // we must have something to write...
-      ceph_assert(is_queued());
+      bool still_queued = is_queued();
+      if (unlikely(!still_queued)) {
+        return try_exit_sweep();
+      }
       conn.pending_q.clear();
       conn.pending_q.swap(conn.out_q);
       if (!conn.policy.lossy) {
@@ -199,26 +224,7 @@ seastar::future<> Protocol::do_write_dispatch_sweep()
         assert(ack_left >= acked);
         ack_left -= acked;
         if (!is_queued()) {
-          // good, we have nothing pending to send now.
-          return socket->flush().then([this] {
-            if (!is_queued()) {
-              // still nothing pending to send after flush,
-              // the dispatching can ONLY stop now
-              ceph_assert(write_dispatching);
-              write_dispatching = false;
-              if (unlikely(exit_open.has_value())) {
-                exit_open->set_value();
-                exit_open = std::nullopt;
-                logger().info("{} write_event: nothing queued at {},"
-                              " set exit_open",
-                              conn, get_state_name(write_state));
-              }
-              return seastar::make_ready_future<stop_t>(stop_t::yes);
-            } else {
-              // something is pending to send during flushing
-              return seastar::make_ready_future<stop_t>(stop_t::no);
-            }
-          });
+          return try_exit_sweep();
         } else {
           // messages were enqueued during socket write
           return seastar::make_ready_future<stop_t>(stop_t::no);

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -144,6 +144,7 @@ class Protocol {
   // it needs to wait for exit_open until writing is stopped or failed.
   std::optional<seastar::shared_promise<>> exit_open;
 
+  seastar::future<stop_t> try_exit_sweep();
   seastar::future<> do_write_dispatch_sweep();
   void write_event();
 };

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -2945,8 +2945,8 @@ test_v2_lossy_client(FailoverTest& test) {
       return suite.markdown();
     }).then([&suite] {
       return suite.connect_peer();
-    }).then([&test] {
-      return test.send_bidirectional();
+    }).then([&suite] {
+      return suite.send_peer();
     }).then([&suite] {
       return suite.wait_results(2);
     }).then([] (ConnResults& results) {
@@ -2995,7 +2995,7 @@ test_v2_stateless_server(FailoverTest& test) {
     }).then([&test] {
       return test.peer_connect_me();
     }).then([&test] {
-      return test.send_bidirectional();
+      return test.peer_send_me();
     }).then([&suite] {
       return suite.wait_results(2);
     }).then([] (ConnResults& results) {


### PR DESCRIPTION
Messenger can set 6 different policies (or 4 pairs of policy combinations). This PR verifies these policies with their natures of lossy/standby/resetcheck/server properties. Specifically, verify reset, remote reset, standby and sessioned-connection are working as expected in crimson msgr when client/server side is marked down. Also identified and fixed related issues.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
