### PR TITLE
mimic: cephfs: client: fix lazyio_synchronize() to update file size

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10221,8 +10221,11 @@ int Client::lazyio_synchronize(int fd, loff_t offset, size_t count)
   Inode *in = f->inode.get();
   
   _fsync(f, true);
-  if (_release(in))
-    check_caps(in, 0);
+  if (_release(in)) {
+    int r =_getattr(in, CEPH_STAT_CAP_SIZE, f->actor_perms);
+    if (r < 0) 
+      return r;
+  }
   return 0;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41887

---

backport of https://github.com/ceph/ceph/pull/29705
parent tracker: https://tracker.ceph.com/issues/41310

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh