### PR TITLE
luminous: client: _readdir_cache_cb() may use the readdir_cache already clear

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7819,9 +7819,15 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
       continue;
     }
 
+    int idx = pd - dir->readdir_cache.begin();
     int r = _getattr(dn->inode, caps, dirp->perms);
     if (r < 0)
       return r;
+    
+    // the content of readdir_cache may change after _getattr(), so pd may be invalid iterator    
+    pd = dir->readdir_cache.begin() + idx;
+    if (pd >= dir->readdir_cache.end() || *pd != dn)
+      return -EAGAIN;
 
     struct ceph_statx stx;
     struct dirent de;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42039

---

backport of https://github.com/ceph/ceph/pull/29526
parent tracker: https://tracker.ceph.com/issues/41148

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh