### PR TITLE
mgr/dashboard: fix python2 failure in home controller 

### DIFF
--- a/src/pybind/mgr/dashboard/__init__.py
+++ b/src/pybind/mgr/dashboard/__init__.py
@@ -56,4 +56,4 @@ else:
     sys.modules['ceph_module'] = mock.Mock()
 
     mgr = mock.Mock()
-    mgr.get_frontend_path.side_effect = lambda: "./frontend/dist"
+    mgr.get_frontend_path.side_effect = lambda: os.path.abspath("./frontend/dist")

--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -52,7 +52,7 @@ class HomeController(BaseController):
                 logger.debug("reached max accepted languages, skipping remaining")
                 break
 
-            tag_match = self.LANG_TAG_RE.match(m[1])
+            tag_match = self.LANG_TAG_RE.match(m.group(1))
             if tag_match is None:
                 raise cherrypy.HTTPError(400, "Malformed 'Accept-Language' header")
             locale = tag_match.group('locale').lower()

--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -95,7 +95,7 @@ class HomeController(BaseController):
                 accept_lang_header = cherrypy.request.headers['Accept-Language']
                 langs = self._parse_accept_language(accept_lang_header)
             else:
-                langs = [DEFAULT_LANGUAGE]
+                langs = [DEFAULT_LANGUAGE.lower()]
             logger.debug("frontend language from headers: %s", langs)
 
         base_dir = self._language_dir(langs)

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -120,7 +120,7 @@ class ControllerTestCase(helper.CPWebCase):
         })
         super(ControllerTestCase, self).__init__(*args, **kwargs)
 
-    def _request(self, url, method, data=None):
+    def _request(self, url, method, data=None, headers=None):
         if not data:
             b = None
             h = None
@@ -128,10 +128,12 @@ class ControllerTestCase(helper.CPWebCase):
             b = json.dumps(data)
             h = [('Content-Type', 'application/json'),
                  ('Content-Length', str(len(b)))]
+        if headers:
+            h = headers
         self.getPage(url, method=method, body=b, headers=h)
 
-    def _get(self, url):
-        self._request(url, 'GET')
+    def _get(self, url, headers=None):
+        self._request(url, 'GET', headers=headers)
 
     def _post(self, url, data=None):
         self._request(url, 'POST', data)

--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+import logging
+
+from . import ControllerTestCase
+from ..controllers.home import HomeController
+
+
+logger = logging.getLogger()
+
+
+class HomeTest(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([HomeController])
+
+    def test_home_default_lang(self):
+        self._get('/')
+        self.assertStatus(200)
+        logger.info(self.body)
+        self.assertIn('<html lang="en">', self.body.decode('utf-8'))
+
+    def test_home_en_us(self):
+        self._get('/', headers=[('Accept-Language', 'en-US')])
+        self.assertStatus(200)
+        logger.info(self.body)
+        self.assertIn('<html lang="en">', self.body.decode('utf-8'))
+
+    def test_home_non_supported_lang(self):
+        self._get('/', headers=[('Accept-Language', 'NO-NO')])
+        self.assertStatus(200)
+        logger.info(self.body)
+        self.assertIn('<html lang="en">', self.body.decode('utf-8'))


### PR DESCRIPTION
This PR fixes a python2 failure when accessing the dashboard.

The stack trace of the failure is:

```
Traceback (most recent call last):
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/.tox/py2/lib/python2.7/site-packages/cherrypy/_cprequest.py", line 631, in respond
    self._do_respond(path_info)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/.tox/py2/lib/python2.7/site-packages/cherrypy/_cprequest.py", line 690, in _do_respond
    response.body = self.handler()
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/.tox/py2/lib/python2.7/site-packages/cherrypy/lib/encoding.py", line 221, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/.tox/py2/lib/python2.7/site-packages/cherrypy/_cptools.py", line 237, in wrap
    return self.newhandler(innerfunc, *args, **kwargs)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/services/exception.py", line 88, in dashboard_exception_handler
    return handler(*args, **kwargs)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/.tox/py2/lib/python2.7/site-packages/cherrypy/_cpdispatch.py", line 60, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/controllers/home.py", line 96, in __call__
    langs = self._parse_accept_language(accept_lang_header)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/plugins/lru_cache.py", line 36, in wrapper
    ret = function(*args, **kwargs)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/controllers/home.py", line 55, in _parse_accept_language
    tag_match = self.LANG_TAG_RE.match(m[1])
TypeError: '_sre.SRE_Match' object has no attribute '__getitem__'
```

I'm also adding a unit test to catch these kind of failures in the home controller.

Signed-off-by: Ricardo Dias <rdias@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
