### PR TITLE
mgr/dashboard: add password expiration date

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -622,7 +622,7 @@ We provide a set of CLI commands to manage user accounts:
 
 - *Create User*::
 
-  $ ceph dashboard ac-user-create [--force-password] <username> [<password>] [<rolename>] [<name>] [<email>] [--enabled]
+  $ ceph dashboard ac-user-create [--force-password] <username> [<password>] [<rolename>] [<name>] [<email>] [--enabled] [<pwd_expiration_date>]
 
 - *Delete User*::
 

--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -44,7 +44,8 @@ class AuthTest(DashboardTestCase):
             'token': JLeaf(str),
             'username': JLeaf(str),
             'permissions': JObj(sub_elems={}, allow_unknown=True),
-            'sso': JLeaf(bool)
+            'sso': JLeaf(bool),
+            'pwdExpirationDate': JLeaf(int, none=True)
         }, allow_unknown=False))
         self._validate_jwt_token(data['token'], "admin", data['permissions'])
 

--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -502,7 +502,7 @@ valid-metaclass-classmethod-first-arg=mcs
 max-args=5
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -20,7 +20,12 @@ class Auth(RESTController):
     """
 
     def create(self, username, password):
-        user_perms = AuthManager.authenticate(username, password)
+        user_data = AuthManager.authenticate(username, password)
+        user_perms, pwd_expiration_date = None, None
+        if user_data:
+            user_perms = user_data.get('permissions')
+            pwd_expiration_date = user_data.get('pwdExpirationDate')
+
         if user_perms is not None:
             logger.debug('Login successful')
             token = JwtManager.gen_token(username)
@@ -30,6 +35,7 @@ class Auth(RESTController):
                 'token': token,
                 'username': username,
                 'permissions': user_perms,
+                'pwdExpirationDate': pwd_expiration_date,
                 'sso': mgr.SSO_DB.protocol == 'saml2'
             }
 

--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -13,7 +13,9 @@ from ..exceptions import DashboardException
 
 @Controller('/api/prometheus_receiver', secure=False)
 class PrometheusReceiver(BaseController):
-    ''' The receiver is needed in order to receive alert notifications (reports) '''
+    """
+    The receiver is needed in order to receive alert notifications (reports)
+    """
     notifications = []
 
     @Endpoint('POST', path='/')

--- a/src/pybind/mgr/dashboard/controllers/settings.py
+++ b/src/pybind/mgr/dashboard/controllers/settings.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 import cherrypy
 
-from . import ApiController, RESTController
+from . import ApiController, RESTController, UiApiController
 from ..settings import Settings as SettingsModule, Options
 from ..security import Scope
 
@@ -66,3 +66,13 @@ class Settings(RESTController):
         with self._attribute_handler(kwargs) as data:
             for name, value in data.items():
                 setattr(SettingsModule, self._to_native(name), value)
+
+
+@UiApiController('/standard_settings')
+class StandardSettings(RESTController):
+    def list(self):
+        return {
+            'user_pwd_expiration_span': SettingsModule.USER_PWD_EXPIRATION_SPAN,
+            'user_pwd_expiration_warning_1': SettingsModule.USER_PWD_EXPIRATION_WARNING_1,
+            'user_pwd_expiration_warning_2': SettingsModule.USER_PWD_EXPIRATION_WARNING_2
+        }

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -103,6 +103,12 @@ class RoleNotInUser(Exception):
             .format(rolename, username))
 
 
+class PwdExpirationDateNotValid(Exception):
+    def __init__(self):
+        super(PwdExpirationDateNotValid, self).__init__(
+            "The password expiration date must not be in the past")
+
+
 class GrafanaError(Exception):
     pass
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/app.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.component.html
@@ -15,6 +15,7 @@
   <!-- Page content -->
   <div ng-sidebar-content>
     <block-ui>
+      <cd-pwd-expiration-notification *ngIf="!isLoginActive()"></cd-pwd-expiration-notification>
       <cd-navigation *ngIf="!isLoginActive()"></cd-navigation>
       <div class="container-fluid"
            [ngClass]="{'full-height':isLoginActive(), 'dashboard':isDashboardPage()} ">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -79,7 +79,6 @@ import { ServicesComponent } from './services/services.component';
     MgrModulesModule,
     TypeaheadModule.forRoot(),
     TimepickerModule.forRoot(),
-    BsDatepickerModule.forRoot(),
     NgBootstrapFormValidationModule,
     CephSharedModule
   ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
+import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { PopoverModule } from 'ngx-bootstrap/popover';
 import { TabsModule } from 'ngx-bootstrap/tabs';
@@ -32,7 +33,8 @@ import { UserTabsComponent } from './user-tabs/user-tabs.component';
     SharedModule,
     TabsModule.forRoot(),
     RouterModule,
-    NgBootstrapFormValidationModule
+    NgBootstrapFormValidationModule,
+    BsDatepickerModule.forRoot()
   ],
   declarations: [
     LoginComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
@@ -54,7 +54,13 @@ export class LoginComponent implements OnInit {
             window.location.replace(login.login_url);
           }
         } else {
-          this.authStorageService.set(login.username, token, login.permissions, login.sso);
+          this.authStorageService.set(
+            login.username,
+            token,
+            login.permissions,
+            login.sso,
+            login.pwdExpirationDate
+          );
           this.router.navigate(['']);
         }
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -1,7 +1,11 @@
+<cd-loading-panel *ngIf="!pwdExpirationSettings"
+                  i18n>Loading...</cd-loading-panel>
+
 <div class="col-sm-12 col-lg-6">
   <form name="userForm"
         #formDir="ngForm"
         [formGroup]="userForm"
+        *ngIf="pwdExpirationSettings"
         novalidate>
     <div class="card">
       <div i18n="form title|Example: Create Pool@@formTitle"
@@ -96,6 +100,41 @@
             <span class="invalid-feedback"
                   *ngIf="userForm.showError('confirmpassword', formDir, 'match')"
                   i18n>Password confirmation doesn't match the password.</span>
+          </div>
+        </div>
+
+        <!-- Password expiration date -->
+        <div class="form-group row"
+             *ngIf="showExpirationDateField()">
+          <label class="col-form-label col-sm-3"
+                 for="pwdExpirationDate">
+            <ng-container i18n>Password expiration date</ng-container>
+            <span class="required"
+                  *ngIf="pwdExpirationSettings.pwdExpirationSpan > 0"></span>
+          </label>
+          <div class="col-sm-9">
+            <div class="input-group">
+              <input type="text"
+                     class="form-control"
+                     i18n-placeholder
+                     placeholder="Password expiration date..."
+                     [bsConfig]="bsConfig"
+                     [minDate]="minDate"
+                     bsDatepicker
+                     id="pwdExpirationDate"
+                     name="pwdExpirationDate"
+                     formControlName="pwdExpirationDate">
+              <span class="input-group-append">
+                <button type="button"
+                        class="btn btn-light"
+                        (click)="clearExpirationDate()">
+                  <i class="icon-prepend {{ icons.destroy }}"></i>
+                </button>
+              </span>
+              <span class="invalid-feedback"
+                    *ngIf="userForm.showError('pwdExpirationDate', formDir, 'required')"
+                    i18n>This field is required.</span>
+            </div>
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -6,12 +6,14 @@ import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
+import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
 import { configureTestBed, FormHelper, i18nProviders } from '../../../../testing/unit-test-helper';
 import { RoleService } from '../../../shared/api/role.service';
+import { SettingsService } from '../../../shared/api/settings.service';
 import { UserService } from '../../../shared/api/user.service';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
@@ -50,7 +52,8 @@ describe('UserFormComponent', () => {
         ComponentsModule,
         ToastrModule.forRoot(),
         SharedModule,
-        ButtonsModule.forRoot()
+        ButtonsModule.forRoot(),
+        BsDatepickerModule.forRoot()
       ],
       declarations: [UserFormComponent, FakeComponent],
       providers: i18nProviders
@@ -85,9 +88,15 @@ describe('UserFormComponent', () => {
     });
 
     it('should not disable fields', () => {
-      ['username', 'name', 'password', 'confirmpassword', 'email', 'roles'].forEach((key) =>
-        expect(form.get(key).disabled).toBeFalsy()
-      );
+      [
+        'username',
+        'name',
+        'password',
+        'confirmpassword',
+        'email',
+        'roles',
+        'pwdExpirationDate'
+      ].forEach((key) => expect(form.get(key).disabled).toBeFalsy());
     });
 
     it('should validate username required', () => {
@@ -151,7 +160,8 @@ describe('UserFormComponent', () => {
         name: 'User 0',
         email: 'user0@email.com',
         roles: ['administrator'],
-        enabled: true
+        enabled: true,
+        pwdExpirationDate: undefined
       };
       formHelper.setMultipleValues(user);
       formHelper.setValue('confirmpassword', user.password);
@@ -171,7 +181,8 @@ describe('UserFormComponent', () => {
       name: 'User 1',
       email: 'user1@email.com',
       roles: ['administrator'],
-      enabled: true
+      enabled: true,
+      pwdExpirationDate: undefined
     };
     const roles = [
       {
@@ -196,15 +207,24 @@ describe('UserFormComponent', () => {
         }
       }
     ];
+    const pwdExpirationSettings = {
+      user_pwd_expiration_warning_1: 10,
+      user_pwd_expiration_warning_2: 5,
+      user_pwd_expiration_span: 90
+    };
 
     beforeEach(() => {
       spyOn(userService, 'get').and.callFake(() => of(user));
       spyOn(TestBed.get(RoleService), 'list').and.callFake(() => of(roles));
       setUrl('/user-management/users/edit/user1');
+      spyOn(TestBed.get(SettingsService), 'pwdExpirationSettings').and.callFake(() =>
+        of(pwdExpirationSettings)
+      );
       component.ngOnInit();
       const req = httpTesting.expectOne('api/role');
       expect(req.request.method).toBe('GET');
       req.flush(roles);
+      httpTesting.expectOne('ui-api/standard_settings');
     });
 
     afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.model.ts
@@ -1,6 +1,7 @@
 export class UserFormModel {
   username: string;
   password: string;
+  pwdExpirationDate: number;
   name: string;
   email: string;
   roles: Array<string>;

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -13,6 +13,7 @@ import { CdTableAction } from '../../../shared/models/cd-table-action';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permission } from '../../../shared/models/permissions';
+import { CdDatePipe } from '../../../shared/pipes/cd-date.pipe';
 import { EmptyPipe } from '../../../shared/pipes/empty.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
@@ -48,6 +49,7 @@ export class UserListComponent implements OnInit {
     private authStorageService: AuthStorageService,
     private i18n: I18n,
     private urlBuilder: URLBuilderService,
+    private cdDatePipe: CdDatePipe,
     public actionLabels: ActionLabelsI18n
   ) {
     this.permission = this.authStorageService.getPermissions().user;
@@ -103,12 +105,23 @@ export class UserListComponent implements OnInit {
         prop: 'enabled',
         flexGrow: 1,
         cellTransformation: CellTemplate.checkIcon
+      },
+      {
+        name: this.i18n('Password expiration date'),
+        prop: 'pwdExpirationDate',
+        flexGrow: 1,
+        pipe: this.cdDatePipe
       }
     ];
   }
 
   getUsers() {
     this.userService.list().subscribe((users: Array<any>) => {
+      users.forEach((user) => {
+        if (user['pwdExpirationDate'] && user['pwdExpirationDate'] > 0) {
+          user['pwdExpirationDate'] = user['pwdExpirationDate'] * 1000;
+        }
+      });
       this.users = users;
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
@@ -27,7 +27,13 @@ export class AuthService {
   login(credentials: Credentials): Observable<LoginResponse> {
     return this.http.post('api/auth', credentials).pipe(
       tap((resp: LoginResponse) => {
-        this.authStorageService.set(resp.username, resp.token, resp.permissions, resp.sso);
+        this.authStorageService.set(
+          resp.username,
+          resp.token,
+          resp.permissions,
+          resp.sso,
+          resp.pwdExpirationDate
+        );
       })
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.ts
@@ -1,7 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
-import * as _ from 'lodash';
+import { Observable } from 'rxjs';
+
+import { CdPwdExpirationSettings } from '../models/cd-pwd-expiration-settings';
 import { ApiModule } from './api.module';
 
 @Injectable({
@@ -46,5 +48,9 @@ export class SettingsService {
 
   validateGrafanaDashboardUrl(uid) {
     return this.http.get(`api/grafana/validation/${uid}`);
+  }
+
+  pwdExpirationSettings(): Observable<CdPwdExpirationSettings> {
+    return this.http.get<CdPwdExpirationSettings>('ui-api/standard_settings');
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { ChartsModule } from 'ng2-charts';
@@ -25,6 +26,7 @@ import { LanguageSelectorComponent } from './language-selector/language-selector
 import { LoadingPanelComponent } from './loading-panel/loading-panel.component';
 import { ModalComponent } from './modal/modal.component';
 import { NotificationsSidebarComponent } from './notifications-sidebar/notifications-sidebar.component';
+import { PwdExpirationNotificationComponent } from './pwd-expiration-notification/pwd-expiration-notification.component';
 import { RefreshSelectorComponent } from './refresh-selector/refresh-selector.component';
 import { SelectBadgesComponent } from './select-badges/select-badges.component';
 import { SelectComponent } from './select/select.component';
@@ -48,7 +50,8 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     ModalModule.forRoot(),
     DirectivesModule,
     BsDropdownModule,
-    NgBootstrapFormValidationModule
+    NgBootstrapFormValidationModule,
+    RouterModule
   ],
   declarations: [
     ViewCacheComponent,
@@ -69,7 +72,8 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     RefreshSelectorComponent,
     ConfigOptionComponent,
     AlertPanelComponent,
-    FormModalComponent
+    FormModalComponent,
+    PwdExpirationNotificationComponent
   ],
   providers: [],
   exports: [
@@ -88,7 +92,8 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     SelectComponent,
     RefreshSelectorComponent,
     ConfigOptionComponent,
-    AlertPanelComponent
+    AlertPanelComponent,
+    PwdExpirationNotificationComponent
   ],
   entryComponents: [
     ModalComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.html
@@ -1,0 +1,13 @@
+<alert class="no-margin-bottom"
+       type="{{ alertType }}"
+       *ngIf="expirationDays != null && expirationDays <= pwdExpirationSettings.pwdExpirationWarning1"
+       [dismissible]="true">
+  <div *ngIf="expirationDays === 0"
+       i18n>Your password will expire in <strong>less than 1</strong> day. Click
+  <a routerLink="/user-profile/edit"
+     class="alert-link">here</a> to change it now.</div>
+  <div *ngIf="expirationDays > 0"
+       i18n>Your password will expire in <strong>{{ expirationDays }}</strong> day(s). Click
+  <a routerLink="/user-profile/edit"
+     class="alert-link">here</a> to change it now.</div>
+</alert>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.scss
@@ -1,0 +1,3 @@
+::ng-deep .no-margin-bottom .alert {
+  margin-bottom: 0;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.spec.ts
@@ -1,0 +1,120 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Routes } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { of as observableOf } from 'rxjs';
+
+import { AlertModule } from 'ngx-bootstrap/alert';
+
+import { configureTestBed } from '../../../../testing/unit-test-helper';
+
+import { SettingsService } from '../../api/settings.service';
+import { AuthStorageService } from '../../services/auth-storage.service';
+import { PwdExpirationNotificationComponent } from './pwd-expiration-notification.component';
+
+describe('PwdExpirationNotificationComponent', () => {
+  let component: PwdExpirationNotificationComponent;
+  let fixture: ComponentFixture<PwdExpirationNotificationComponent>;
+  let settingsService: SettingsService;
+  let authStorageService: AuthStorageService;
+
+  @Component({ selector: 'cd-fake', template: '' })
+  class FakeComponent {}
+
+  const routes: Routes = [{ path: 'login', component: FakeComponent }];
+
+  configureTestBed({
+    declarations: [PwdExpirationNotificationComponent, FakeComponent],
+    imports: [
+      AlertModule.forRoot(),
+      HttpClientTestingModule,
+      RouterTestingModule.withRoutes(routes)
+    ],
+    providers: [SettingsService, AuthStorageService]
+  });
+
+  describe('password expiration date has been set', () => {
+    beforeEach(() => {
+      authStorageService = TestBed.get(AuthStorageService);
+      settingsService = TestBed.get(SettingsService);
+      spyOn(authStorageService, 'getPwdExpirationDate').and.returnValue(1645488000);
+      spyOn(settingsService, 'pwdExpirationSettings').and.returnValue(
+        observableOf({
+          user_pwd_expiration_warning_1: 10,
+          user_pwd_expiration_warning_2: 5,
+          user_pwd_expiration_span: 90
+        })
+      );
+      fixture = TestBed.createComponent(PwdExpirationNotificationComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      component.ngOnInit();
+      expect(component).toBeTruthy();
+    });
+
+    it('should set warning levels', () => {
+      component.ngOnInit();
+      expect(component.pwdExpirationSettings.pwdExpirationWarning1).toBe(10);
+      expect(component.pwdExpirationSettings.pwdExpirationWarning2).toBe(5);
+    });
+
+    it('should calculate password expiration in days', () => {
+      const dateValue = Date;
+      spyOn(global, 'Date').and.callFake((date) => {
+        if (date) {
+          return new dateValue(date);
+        } else {
+          return new Date('2022-02-18T00:00:00.000Z');
+        }
+      });
+      component.ngOnInit();
+      expect(component['expirationDays']).toBe(4);
+    });
+
+    it('should set alert type warning correctly', () => {
+      const dateValue = Date;
+      spyOn(global, 'Date').and.callFake((date) => {
+        if (date) {
+          return new dateValue(date);
+        } else {
+          return new Date('2022-02-14T00:00:00.000Z');
+        }
+      });
+      component.ngOnInit();
+      expect(component['alertType']).toBe('warning');
+    });
+
+    it('should set alert type danger correctly', () => {
+      const dateValue = Date;
+      spyOn(global, 'Date').and.callFake((date) => {
+        if (date) {
+          return new dateValue(date);
+        } else {
+          return new Date('2022-02-18T00:00:00.000Z');
+        }
+      });
+      component.ngOnInit();
+      expect(component['alertType']).toBe('danger');
+    });
+  });
+
+  describe('password expiration date has not been set', () => {
+    beforeEach(() => {
+      authStorageService = TestBed.get(AuthStorageService);
+      spyOn(authStorageService, 'getPwdExpirationDate').and.returnValue(null);
+      fixture = TestBed.createComponent(PwdExpirationNotificationComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should calculate no expirationDays', () => {
+      component.ngOnInit();
+      expect(component['expirationDays']).toBeUndefined();
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+
+import { SettingsService } from '../../api/settings.service';
+import { CdPwdExpirationSettings } from '../../models/cd-pwd-expiration-settings';
+import { AuthStorageService } from '../../services/auth-storage.service';
+
+@Component({
+  selector: 'cd-pwd-expiration-notification',
+  templateUrl: './pwd-expiration-notification.component.html',
+  styleUrls: ['./pwd-expiration-notification.component.scss']
+})
+export class PwdExpirationNotificationComponent implements OnInit {
+  alertType: string;
+  expirationDays: number;
+  pwdExpirationSettings: CdPwdExpirationSettings;
+
+  constructor(
+    private settingsService: SettingsService,
+    private authStorageService: AuthStorageService
+  ) {}
+
+  ngOnInit() {
+    this.settingsService.pwdExpirationSettings().subscribe((pwdExpirationSettings) => {
+      this.pwdExpirationSettings = new CdPwdExpirationSettings(pwdExpirationSettings);
+      const pwdExpirationDate = this.authStorageService.getPwdExpirationDate();
+      if (pwdExpirationDate) {
+        this.expirationDays = this.getExpirationDays(pwdExpirationDate);
+        if (this.expirationDays <= this.pwdExpirationSettings.pwdExpirationWarning2) {
+          this.alertType = 'danger';
+        } else {
+          this.alertType = 'warning';
+        }
+      }
+    });
+  }
+
+  private getExpirationDays(pwdExpirationDate: number): number {
+    if (pwdExpirationDate) {
+      const current = new Date();
+      const expiration = new Date(pwdExpirationDate * 1000);
+      return Math.floor((expiration.valueOf() - current.valueOf()) / (1000 * 3600 * 24));
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-pwd-expiration-settings.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-pwd-expiration-settings.ts
@@ -1,0 +1,11 @@
+export class CdPwdExpirationSettings {
+  pwdExpirationSpan = 0;
+  pwdExpirationWarning1: number;
+  pwdExpirationWarning2: number;
+
+  constructor(data) {
+    this.pwdExpirationSpan = data.user_pwd_expiration_span;
+    this.pwdExpirationWarning1 = data.user_pwd_expiration_warning_1;
+    this.pwdExpirationWarning2 = data.user_pwd_expiration_warning_2;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/login-response.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/login-response.ts
@@ -2,5 +2,6 @@ export class LoginResponse {
   username: string;
   token: string;
   permissions: object;
+  pwdExpirationDate: number;
   sso: boolean;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.ts
@@ -8,16 +8,24 @@ import { Permissions } from '../models/permissions';
 export class AuthStorageService {
   constructor() {}
 
-  set(username: string, token: string, permissions: object = {}, sso = false) {
+  set(
+    username: string,
+    token: string,
+    permissions: object = {},
+    sso = false,
+    pwdExpirationDate: number = null
+  ) {
     localStorage.setItem('dashboard_username', username);
     localStorage.setItem('access_token', token);
     localStorage.setItem('dashboard_permissions', JSON.stringify(new Permissions(permissions)));
+    localStorage.setItem('user_pwd_expiration_date', String(pwdExpirationDate));
     localStorage.setItem('sso', String(sso));
   }
 
   remove() {
     localStorage.removeItem('access_token');
     localStorage.removeItem('dashboard_username');
+    localStorage.removeItem('user_pwd_expiration_data');
   }
 
   getToken(): string {
@@ -36,6 +44,10 @@ export class AuthStorageService {
     return JSON.parse(
       localStorage.getItem('dashboard_permissions') || JSON.stringify(new Permissions({}))
     );
+  }
+
+  getPwdExpirationDate(): number {
+    return Number(localStorage.getItem('user_pwd_expiration_date'));
   }
 
   isSSO() {

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -12,16 +12,19 @@ import threading
 import time
 import re
 
+from datetime import datetime, timedelta
+
 import bcrypt
 
 from mgr_module import CLIReadCommand, CLIWriteCommand
 
 from .. import mgr
 from ..security import Scope, Permission
+from ..settings import Settings
 from ..exceptions import RoleAlreadyExists, RoleDoesNotExist, ScopeNotValid, \
                          PermissionNotValid, RoleIsAssociatedWithUser, \
                          UserAlreadyExists, UserDoesNotExist, ScopeNotInRole, \
-                         RoleNotInUser, PasswordCheckException
+                         RoleNotInUser, PasswordCheckException, PwdExpirationDateNotValid
 
 
 logger = logging.getLogger('access_control')
@@ -265,7 +268,7 @@ SYSTEM_ROLES = {
 
 class User(object):
     def __init__(self, username, password, name=None, email=None, roles=None,
-                 last_update=None, enabled=True):
+                 last_update=None, enabled=True, pwd_expiration_date=None):
         self.username = username
         self.password = password
         self.name = name
@@ -279,9 +282,20 @@ class User(object):
         else:
             self.last_update = last_update
         self._enabled = enabled
+        self.pwd_expiration_date = pwd_expiration_date
+        if self.pwd_expiration_date is None:
+            self.refresh_pwd_expiration_date()
 
     def refresh_last_update(self):
         self.last_update = int(time.time())
+
+    def refresh_pwd_expiration_date(self):
+        if Settings.USER_PWD_EXPIRATION_SPAN > 0:
+            expiration_date = datetime.utcnow() + timedelta(
+                days=Settings.USER_PWD_EXPIRATION_SPAN)
+            self.pwd_expiration_date = int(time.mktime(expiration_date.timetuple()))
+        else:
+            self.pwd_expiration_date = None
 
     @property
     def enabled(self):
@@ -298,6 +312,7 @@ class User(object):
     def set_password_hash(self, hashed_password):
         self.password = hashed_password
         self.refresh_last_update()
+        self.refresh_pwd_expiration_date()
 
     def compare_password(self, password):
         """
@@ -309,6 +324,12 @@ class User(object):
         """
         pass_hash = password_hash(password, salt_password=self.password)
         return pass_hash == self.password
+
+    def is_pwd_expired(self):
+        if self.pwd_expiration_date:
+            current_time = int(time.mktime(datetime.utcnow().timetuple()))
+            return self.pwd_expiration_date < current_time
+        return False
 
     def set_roles(self, roles):
         self.roles = set(roles)
@@ -351,14 +372,15 @@ class User(object):
             'name': self.name,
             'email': self.email,
             'lastUpdate': self.last_update,
-            'enabled': self.enabled
+            'enabled': self.enabled,
+            'pwdExpirationDate': self.pwd_expiration_date
         }
 
     @classmethod
     def from_dict(cls, u_dict, roles):
         return User(u_dict['username'], u_dict['password'], u_dict['name'],
                     u_dict['email'], {roles[r] for r in u_dict['roles']},
-                    u_dict['lastUpdate'], u_dict['enabled'])
+                    u_dict['lastUpdate'], u_dict['enabled'], u_dict['pwdExpirationDate'])
 
 
 class AccessControlDB(object):
@@ -398,12 +420,16 @@ class AccessControlDB(object):
 
             del self.roles[name]
 
-    def create_user(self, username, password, name, email, enabled=True):
+    def create_user(self, username, password, name, email, enabled=True, pwd_expiration_date=None):
         logger.debug("creating user: username=%s", username)
         with self.lock:
             if username in self.users:
                 raise UserAlreadyExists(username)
-            user = User(username, password_hash(password), name, email, enabled=enabled)
+            if pwd_expiration_date and \
+               (pwd_expiration_date < int(time.mktime(datetime.utcnow().timetuple()))):
+                raise PwdExpirationDateNotValid()
+            user = User(username, password_hash(password), name, email, enabled=enabled,
+                        pwd_expiration_date=pwd_expiration_date)
             self.users[username] = user
             return user
 
@@ -467,6 +493,7 @@ class AccessControlDB(object):
 
                 for user, _ in v1_db['users'].items():
                     v1_db['users'][user]['enabled'] = True
+                    v1_db['users'][user]['pwdExpirationDate'] = None
 
                 self.roles = {rn: Role.from_dict(r) for rn, r in v1_db.get('roles', {}).items()}
                 self.users = {un: User.from_dict(u, dict(self.roles, **SYSTEM_ROLES))
@@ -644,10 +671,12 @@ def ac_user_show_cmd(_, username=None):
                  'name=name,type=CephString,req=false '
                  'name=email,type=CephString,req=false '
                  'name=enabled,type=CephBool,req=false '
-                 'name=force_password,type=CephBool,req=false',
+                 'name=force_password,type=CephBool,req=false '
+                 'name=pwd_expiration_date,type=CephInt,req=false',
                  'Create a user')
 def ac_user_create_cmd(_, username, password=None, rolename=None, name=None,
-                       email=None, enabled=True, force_password=False):
+                       email=None, enabled=True, force_password=False,
+                       pwd_expiration_date=None):
     try:
         role = mgr.ACCESS_CTRL_DB.get_role(rolename) if rolename else None
     except RoleDoesNotExist as ex:
@@ -659,7 +688,8 @@ def ac_user_create_cmd(_, username, password=None, rolename=None, name=None,
         if not force_password:
             pw_check = PasswordCheck(password, username)
             pw_check.check_all()
-        user = mgr.ACCESS_CTRL_DB.create_user(username, password, name, email, enabled)
+        user = mgr.ACCESS_CTRL_DB.create_user(username, password, name, email,
+                                              enabled, pwd_expiration_date)
     except PasswordCheckException as ex:
         return -errno.EINVAL, '', str(ex)
     except UserAlreadyExists as ex:
@@ -850,8 +880,10 @@ class LocalAuthenticator(object):
         try:
             user = mgr.ACCESS_CTRL_DB.get_user(username)
             if user.password:
-                if user.enabled and user.compare_password(password):
-                    return user.permissions_dict()
+                if user.enabled and user.compare_password(password) \
+                   and not user.is_pwd_expired():
+                    return {'permissions': user.permissions_dict(),
+                            'pwdExpirationDate': user.pwd_expiration_date}
         except UserDoesNotExist:
             logger.debug("User '%s' does not exist", username)
         return None

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -52,6 +52,16 @@ class Options(object):
     # iSCSI management settings
     ISCSI_API_SSL_VERIFICATION = (True, bool)
 
+    # user management settings
+    # Time span of user passwords to expire in days.
+    # The default value is '0' which means that user passwords are
+    # never going to expire.
+    USER_PWD_EXPIRATION_SPAN = (0, int)
+    # warning levels to notify the user that the password is going
+    # to expire soon
+    USER_PWD_EXPIRATION_WARNING_1 = (10, int)
+    USER_PWD_EXPIRATION_WARNING_2 = (5, int)
+
     @staticmethod
     def has_default_value(name):
         return getattr(Settings, name, None) is None or \


### PR DESCRIPTION
# Part 1: add password expiration date

Add a 'pwd_expiration_date' field to the User object to be able to set password expiration date per user.

There are two options to set a password expiration date for a user:

1. Set the 'USER_PWD_DEFAULT_SPAN' setting. If defined the expiration date of the password will be calculated automatically based on the given value. It will also be updated automatically when the user changes the password.
2. Set an expiration date by setting the 'pwdExpirationDate' field when creating a user.

Add two more settings in addition: USER_PWD_EXPIRATION_WARNING_1 and USER_PWD_EXPIRATION_WARNING_2. These two settings are defining the amount of days to notify the user that his password will expiration soon.

It's not possible to set the 'pwd_expiration_date' field to a date in the past.

If the password of a user is already expired he is no longer
allowed to log into the dashboard.

# Part 2: add password expiration warning banner

It adds a new component to notify the user about the expiration of the
password. The banner is shown on top of the page and can be dismissed
by the user.

Open (and not covered) issues: Please find them as "Further questions" in https://tracker.ceph.com/issues/40329

Fixes: https://tracker.ceph.com/issues/40329
Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
