### PR TITLE
qa/rgw: refactor the kms backend configuration

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -1,4 +1,11 @@
 overrides:
+  ceph:
+    conf:
+      client:
+        rgw crypt s3 kms backend: barbican
+        rgw keystone barbican tenant: rgwcrypt
+        rgw keystone barbican user: rgwcrypt-user
+        rgw keystone barbican password: rgwcrypt-pass
   rgw:
     client.0:
       use-keystone-role: client.0

--- a/qa/suites/rgw/crypt/2-kms/testing.yaml
+++ b/qa/suites/rgw/crypt/2-kms/testing.yaml
@@ -1,4 +1,6 @@
 overrides:
-  rgw:
-    client.0:
-      use-testing-role: client.0
+  ceph:
+    conf:
+      client:
+        rgw crypt s3 kms backend: testing
+        rgw crypt s3 kms encryption_keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=

--- a/qa/suites/rgw/crypt/2-kms/vault.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault.yaml
@@ -1,4 +1,9 @@
 overrides:
+  ceph:
+    conf:
+      client:
+        rgw crypt s3 kms backend: vault
+        rgw crypt vault auth: token
   rgw:
     client.0:
       use-vault-role: client.0

--- a/qa/suites/rgw/verify/overrides.yaml
+++ b/qa/suites/rgw/verify/overrides.yaml
@@ -3,6 +3,7 @@ overrides:
     conf:
       client:
         debug rgw: 20
+        rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false
   rgw:

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -245,11 +245,6 @@ def create_secrets(ctx, config):
     (cclient, cconfig) = config.items()[0]
 
     rgw_user = cconfig['rgw_user']
-    ctx.barbican.token[cclient] = {
-        "username": rgw_user["username"],
-        "password": rgw_user["password"],
-        "tenant": rgw_user["tenantName"]
-    }
 
     keystone_role = cconfig.get('use-keystone-role', None)
     keystone_host, keystone_port = ctx.keystone.public_endpoints[keystone_role]
@@ -504,7 +499,6 @@ def task(ctx, config):
 
     ctx.barbican = argparse.Namespace()
     ctx.barbican.endpoints = assign_ports(ctx, config, 9311)
-    ctx.barbican.token = {}
     ctx.barbican.keys = {}
     
     with contextutil.nested(

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -115,7 +115,6 @@ def start_rgw(ctx, config, clients):
 
 
         vault_role = client_config.get('use-vault-role', None)
-        testing_role = client_config.get('use-testing-role', None)
         barbican_role = client_config.get('use-barbican-role', None)
 
         token_path = teuthology.get_testdir(ctx) + '/vault-token'
@@ -154,11 +153,6 @@ def start_rgw(ctx, config, clients):
                 '--rgw_crypt_vault_auth', 'token',
                 '--rgw_crypt_vault_addr', "{}:{}".format(*ctx.vault.endpoints[vault_role]),
                 '--rgw_crypt_vault_token_file', token_path
-            ])
-        elif testing_role is not None:
-            rgw_cmd.extend([
-                '--rgw_crypt_s3_kms_backend', 'testing',
-                '--rgw_crypt_s3_kms_encryption_keys', 'testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo='
             ])
 
         rgw_cmd.extend([

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -131,15 +131,6 @@ def start_rgw(ctx, config, clients):
                 'http://{bhost}:{bport}'.format(bhost=barbican_host,
                                                 bport=barbican_port),
                 ])
-
-            log.info("Barbican access data: %s",ctx.barbican.token[barbican_role])
-            access_data = ctx.barbican.token[barbican_role]
-            rgw_cmd.extend([
-                '--rgw_crypt_s3_kms_backend', 'barbican',
-                '--rgw_keystone_barbican_user', access_data['username'],
-                '--rgw_keystone_barbican_password', access_data['password'],
-                '--rgw_keystone_barbican_tenant', access_data['tenant'],
-                ])
         elif vault_role is not None:
             if not ctx.vault.root_token:
                 raise ConfigError('vault: no "root_token" specified')

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -140,8 +140,6 @@ def start_rgw(ctx, config, clients):
             ctx.cluster.only(client).run(args=['cat', token_path])
 
             rgw_cmd.extend([
-                '--rgw_crypt_s3_kms_backend', 'vault',
-                '--rgw_crypt_vault_auth', 'token',
                 '--rgw_crypt_vault_addr', "{}:{}".format(*ctx.vault.endpoints[vault_role]),
                 '--rgw_crypt_vault_token_file', token_path
             ])


### PR DESCRIPTION
use config overrides where possible, and change the rgw/verify suite to use the 'testing' backend. this resolves some failures in the verify suite where tests default to the 'barbican' backend, but try to use test keys from ceph.conf