### PR TITLE
nautilus: mon/OSDMonitor: add check for crush rule size in pool set size command

### DIFF
--- a/qa/workunits/mon/pool_ops.sh
+++ b/qa/workunits/mon/pool_ops.sh
@@ -25,6 +25,16 @@ ceph osd pool set foo size 10
 expect_false ceph osd pool set foo size 0
 expect_false ceph osd pool set foo size 20
 
+ceph osd pool set foo size 3
+ceph osd getcrushmap -o crush
+crushtool -d crush -o crush.txt
+sed -i 's/max_size 10/max_size 3/' crush.txt
+crushtool -c crush.txt -o crush.new
+ceph osd setcrushmap -i crush.new
+expect_false ceph osd pool set foo size 4
+ceph osd setcrushmap -i crush
+rm -f crush crush.txt crush.new
+
 # should fail due to safety interlock
 expect_false ceph osd pool delete foo
 expect_false ceph osd pool delete foo foo

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7151,6 +7151,9 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       ss << "pool size must be between 1 and 10";
       return -EINVAL;
     }
+    if (!osdmap.crush->check_crush_rule(p.get_crush_rule(), p.type, n, ss)) {
+      return -EINVAL;
+    }
     int r = check_pg_num(pool, p.get_pg_num(), n, &ss);
     if (r < 0) {
       return r;


### PR DESCRIPTION
mon/OSDMonitor: add check for crush rule size in pool set size command
Backport tracker: https://tracker.ceph.com/issues/42326