### PR TITLE
qa/rgw: whitelist SLOW_OPS failures against ec pools

### DIFF
--- a/qa/rgw_pool_type/ec-profile.yaml
+++ b/qa/rgw_pool_type/ec-profile.yaml
@@ -1,4 +1,7 @@
 overrides:
+  ceph:
+    log-whitelist:
+    - \(SLOW_OPS\) # see https://tracker.ceph.com/issues/41834
   rgw:
     ec-data-pool: true
     erasure_code_profile:

--- a/qa/rgw_pool_type/ec.yaml
+++ b/qa/rgw_pool_type/ec.yaml
@@ -1,4 +1,7 @@
 overrides:
+  ceph:
+    log-whitelist:
+    - \(SLOW_OPS\) # see https://tracker.ceph.com/issues/41834
   rgw:
     ec-data-pool: true
   s3tests:


### PR DESCRIPTION
a temporary workaround for SLOW_OPS failures due to https://tracker.ceph.com/issues/41834