### PR TITLE
luminous: tests: qa/workunits/rados/test_librados_build.sh: install build deps

### DIFF
--- a/qa/workunits/ceph-helpers-root.sh
+++ b/qa/workunits/ceph-helpers-root.sh
@@ -17,26 +17,30 @@
 
 #######################################################################
 
+function distro_id() {
+    source /etc/os-release
+    echo $ID
+}
+
 function install() {
     for package in "$@" ; do
         install_one $package
     done
-    return 0
 }
 
 function install_one() {
-    case $(lsb_release -si) in
-        Ubuntu|Debian|Devuan)
-            sudo apt-get install -y "$@"
+    case $(distro_id) in
+        ubuntu|debian|devuan)
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"
             ;;
-        CentOS|Fedora|RedHatEnterpriseServer)
+        centos|fedora|rhel)
             sudo yum install -y "$@"
             ;;
-        *SUSE*)
+        opensuse*|suse|sles)
             sudo zypper --non-interactive install "$@"
             ;;
         *)
-            echo "$(lsb_release -si) is unknown, $@ will have to be installed manually."
+            echo "$(distro_id) is unknown, $@ will have to be installed manually."
             ;;
     esac
 }

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -2,29 +2,8 @@
 ############################################
 #			Helper functions
 ############################################
-function install() {
-    for package in "$@" ; do
-        install_one $package
-    done
-    return 0
-}
+source $(dirname $0)/../ceph-helpers-root.sh
 
-function install_one() {
-    case $(lsb_release -si) in
-        Ubuntu|Debian|Devuan)
-            sudo apt-get install -y --force-yes "$@"
-            ;;
-        CentOS|Fedora|RedHatEnterpriseServer)
-            sudo yum install -y "$@"
-            ;;
-        *SUSE*)
-            sudo zypper --non-interactive install "$@"
-            ;;
-        *)
-            echo "$(lsb_release -si) is unknown, $@ will have to be installed manually."
-            ;;
-    esac
-}
 ############################################
 #			Install required tools
 ############################################
@@ -38,15 +17,15 @@ CURRENT_PATH=`pwd`
 ############################################
 # install prerequisites
 # for rocksdb
-case $(lsb_release -si) in
-	Ubuntu|Debian|Devuan)
+case $(distro_id) in
+	ubuntu|debian|devuan)
 		install g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev librados-dev
 		;;
-	CentOS|Fedora|RedHatEnterpriseServer)
+	centos|fedora|rhel)
 		install gcc-c++.x86_64 gflags-devel snappy-devel zlib zlib-devel bzip2 bzip2-devel librados2-devel.x86_64
 		;;
 	*)
-        echo "$(lsb_release -si) is unknown, $@ will have to be installed manually."
+        echo "$(distro_id) is unknown, $@ will have to be installed manually."
         ;;
 esac
 

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -24,6 +24,9 @@ case $(distro_id) in
 	centos|fedora|rhel)
 		install gcc-c++.x86_64 gflags-devel snappy-devel zlib zlib-devel bzip2 bzip2-devel librados2-devel.x86_64
 		;;
+	opensuse*|suse|sles)
+		install gcc-c++ snappy-devel zlib-devel libbz2-devel
+		;;
 	*)
         echo "$(distro_id) is unknown, $@ will have to be installed manually."
         ;;

--- a/qa/workunits/rados/test_librados_build.sh
+++ b/qa/workunits/rados/test_librados_build.sh
@@ -8,6 +8,8 @@
 # libradosstriper headers, boost headers, etc. - are already installed.
 #
 
+source $(dirname $0)/../ceph-helpers-root.sh
+
 trap cleanup EXIT
 
 SOURCES="hello_radosstriper.cc
@@ -56,6 +58,14 @@ function run_binaries () {
 }
 
 pushd $DESTDIR
+case $(distro_id) in
+    centos|fedora|rhel|opensuse*|suse|sles)
+        install gcc-c++ make librados-devel;;
+    ubuntu|debian|devuan)
+        install g++ make librados-dev;;
+    *)
+        echo "$(distro_id) is unknown, $@ will have to be installed manually."
+esac
 get_sources
 check_sources
 make all-system


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40318

---

backport of https://github.com/ceph/ceph/pull/28484
parent tracker: https://tracker.ceph.com/issues/40155

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh