### PR TITLE
nautilus: test/cls_rbd: removed mirror peer pool test cases

### DIFF
--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1808,8 +1808,8 @@ int mirror_peer_list(librados::IoCtx *ioctx,
 
 int mirror_peer_add(librados::IoCtx *ioctx, const std::string &uuid,
                     const std::string &cluster_name,
-                    const std::string &client_name, int64_t pool_id) {
-  cls::rbd::MirrorPeer peer(uuid, cluster_name, client_name, pool_id);
+                    const std::string &client_name) {
+  cls::rbd::MirrorPeer peer(uuid, cluster_name, client_name, -1);
   bufferlist in_bl;
   encode(peer, in_bl);
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -385,8 +385,7 @@ int mirror_peer_list(librados::IoCtx *ioctx,
                      std::vector<cls::rbd::MirrorPeer> *peers);
 int mirror_peer_add(librados::IoCtx *ioctx, const std::string &uuid,
                     const std::string &cluster_name,
-                    const std::string &client_name,
-                    int64_t pool_id = -1);
+                    const std::string &client_name);
 int mirror_peer_remove(librados::IoCtx *ioctx,
                        const std::string &uuid);
 int mirror_peer_set_client(librados::IoCtx *ioctx,

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1555,21 +1555,17 @@ TEST_F(TestClsRbd, mirror) {
   ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid2", "cluster2", "admin"));
   ASSERT_EQ(-ESTALE, mirror_peer_add(&ioctx, "uuid2", "cluster3", "foo"));
   ASSERT_EQ(-EEXIST, mirror_peer_add(&ioctx, "uuid3", "cluster1", "foo"));
-  ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid3", "cluster3", "admin", 123));
+  ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid3", "cluster3", "admin"));
   ASSERT_EQ(-EEXIST, mirror_peer_add(&ioctx, "uuid4", "cluster3", "admin"));
-  ASSERT_EQ(-EEXIST, mirror_peer_add(&ioctx, "uuid4", "cluster3", "admin", 123));
-  ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid4", "cluster3", "admin", 234));
 
   ASSERT_EQ(0, mirror_peer_list(&ioctx, &peers));
   std::vector<cls::rbd::MirrorPeer> expected_peers = {
     {"uuid1", "cluster1", "client", -1},
     {"uuid2", "cluster2", "admin", -1},
-    {"uuid3", "cluster3", "admin", 123},
-    {"uuid4", "cluster3", "admin", 234}};
+    {"uuid3", "cluster3", "admin", -1}};
   ASSERT_EQ(expected_peers, peers);
 
   ASSERT_EQ(0, mirror_peer_remove(&ioctx, "uuid5"));
-  ASSERT_EQ(0, mirror_peer_remove(&ioctx, "uuid4"));
   ASSERT_EQ(0, mirror_peer_remove(&ioctx, "uuid2"));
 
   ASSERT_EQ(-ENOENT, mirror_peer_set_client(&ioctx, "uuid4", "new client"));
@@ -1581,7 +1577,7 @@ TEST_F(TestClsRbd, mirror) {
   ASSERT_EQ(0, mirror_peer_list(&ioctx, &peers));
   expected_peers = {
     {"uuid1", "cluster1", "new client", -1},
-    {"uuid3", "new cluster", "admin", 123}};
+    {"uuid3", "new cluster", "admin", -1}};
   ASSERT_EQ(expected_peers, peers);
   ASSERT_EQ(-EBUSY, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_DISABLED));
 


### PR DESCRIPTION
The mirror peer pool id has never been used and has been dropped
from the Octopus release. This will fix the breakage in the test
cases where the pool id was tested.

Fixes: https://tracker.ceph.com/issues/42333
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
