### PR TITLE
rbd:delete redundant words when trash restore fails because of same name

### DIFF
--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -491,7 +491,7 @@ int execute_restore(const po::variables_map &vm,
                 << std::endl;
     } else if (r == -EEXIST) {
       std::cerr << "rbd: error: an image with the same name already exists, "
-                << "try again with with a different name"
+                << "try again with a different name"
                 << std::endl;
     } else {
       std::cerr << "rbd: restore error: " << cpp_strerror(r) << std::endl;


### PR DESCRIPTION
when perferm the op of trash restore and an image with the same name exits, the messege as follows comes out with a redundant word "with"
 
rbd: error: an image with the same name already exists, try again with with a different name

Signed-off-by:XiangDong Mu muxiangdong@inspur.com


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
