### PR TITLE
librbd: force reacquire lock if blacklist is disabled

### DIFF
--- a/src/librbd/ManagedLock.cc
+++ b/src/librbd/ManagedLock.cc
@@ -593,7 +593,7 @@ void ManagedLock<I>::send_reacquire_lock() {
   }
 
   m_new_cookie = encode_lock_cookie(watch_handle);
-  if (m_cookie == m_new_cookie) {
+  if (m_cookie == m_new_cookie && m_blacklist_on_break_lock) {
     ldout(m_cct, 10) << "skipping reacquire since cookie still valid"
                      << dendl;
     auto ctx = create_context_callback<


### PR DESCRIPTION
backgroud info: most our APPs rely on shared Cinder cloud disk, whose access is controlled by HA setup, since Nova/Qemu does not reopen the blacklisted images automatically, we have the blacklisting feature disabled by default. but this causes another issue:

1. create a test image `I`
2. client `A` opens and writes to image `I` (client `A` obtains the exclusive lock)
3. disconnect `A`'s network more than 30s (client `A` lost watch on OSD side)
4. client `B` opens and writes to image I (client `A` is dead now, client `B` steals the exclusive lock from client `A` without blacklisting client `A` since we disabled the blacklisting feature)
5. restore `A`'s network (client `A` rewatch and may **gets the same lock cookie** as the previous lost one, without updating lock cookie on OSD side [1], now both `A` and `B` are exclusive lock owners)
6. client `C` try to create a snapshot of image `I` and errors out with `duplicate lock owners detected`:
```
2019-10-16 08:27:31.252706 7f859bfff700 20 librbd::watcher::Notifier: 0x7f858c05d7d0 handle_notify: r=0
2019-10-16 08:27:31.252720 7f859bfff700 20 librbd::watcher::Notifier: 0x7f858c05d7d0 handle_notify: pending=0
rbd: failed to create snapshot: (22) Invalid argument
2019-10-16 08:27:31.252802 7f859b7fe700 20 librbd::image_watcher::NotifyLockOwner: 0x7f8594002530 handle_notify: r=0
2019-10-16 08:27:31.252829 7f859b7fe700 -1 librbd::image_watcher::NotifyLockOwner: 0x7f8594002530 handle_notify: duplicate lock owners detected
```

[1] https://github.com/ceph/ceph/blob/master/src/librbd/ManagedLock.cc#L596

Signed-off-by: luo.runbing <luo.runbing@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
