### PR TITLE
rgw: set correct storage class for post object upload

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2133,6 +2133,18 @@ int RGWPostObj_ObjStore_S3::get_params()
     env.add_var("Content-Type", content_type);
   }
 
+  std::string storage_class;
+  part_str(parts, "x-amz-storage-class", &storage_class);
+
+  if (! storage_class.empty()) {
+    s->dest_placement.storage_class = storage_class;
+    if (!store->svc()->zone->get_zone_params().valid_placement(s->dest_placement)) {
+      ldpp_dout(this, 0) << "NOTICE: invalid dest placement: " << s->dest_placement.to_str() << dendl;
+      err_msg = "The storage class you specified is not valid";
+      return -EINVAL;
+    }
+  }
+
   map<string, struct post_form_part, ltstr_nocase>::iterator piter =
     parts.upper_bound(RGW_AMZ_META_PREFIX);
   for (; piter != parts.end(); ++piter) {


### PR DESCRIPTION
we need get x-amz-storage-class from the form

fix https://tracker.ceph.com/issues/42336

test script
```
#!/usr/bin/python
from boto3.session import Session
import boto3
import botocore
botocore.session.Session().set_debug_logger()
bucketname = 'test1'
objectname = 'prefix/keyv7'
access_key = "yly"
secret_key = "yly"
url = "http://127.0.0.1:7480"

session = Session(access_key, secret_key)
s3_client = session.client(
    's3',
    endpoint_url=url,
    use_ssl = False,
)
#import ipdb; ipdb.set_trace() # BREAKPOINT

conditions = [
    ["starts-with", "$Content-Type", "image/"],
    ["starts-with", "$key", "prefix/"],
    {'x-amz-storage-class': 'STANDARD_IA'},
    # {"success_action_redirect": "http://www.baidu.com"},
    ["content-length-range", 0, 20000000],
]
form_data = s3_client.generate_presigned_post(
    Conditions = conditions,
    Bucket = bucketname,
    Key=objectname
)

form_data["fields"]['Content-Type'] = 'image/png'
form_data["fields"]['key'] = objectname
form_data["fields"]['x-amz-storage-class'] = 'STANDARD_IA'
# form_data["fields"]['success_action_redirect'] = 'http://www.baidu.com'


files = {"file": open('/root/5M', 'rb')}

import requests
import logging
from requests_toolbelt.utils import dump
logging.basicConfig(level=logging.DEBUG)

response = requests.post(form_data["url"], data=form_data["fields"], files=files)
data = dump.dump_all(response)
print(data.decode('utf-8'))
```

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>
