### PR TITLE
cmake: dashboard: enable frontend on arm64

### DIFF
--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(dashboard)
+if(WITH_MGR_DASHBOARD_FRONTEND)
+  add_subdirectory(dashboard)
+endif()
 add_subdirectory(insights)
 add_subdirectory(ansible)
 add_subdirectory(orchestrator_cli)

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -17,8 +17,6 @@ function(add_npm_command)
     COMMENT ${NC_COMMENT})
 endfunction(add_npm_command)
 
-if(WITH_MGR_DASHBOARD_FRONTEND)
-
 if(WITH_SYSTEM_NPM)
   set(mgr-dashboard-nodeenv-dir )
   set(nodeenv "")
@@ -121,7 +119,6 @@ add_custom_target(mgr-dashboard-frontend-build
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend)
 
 add_dependencies(tests mgr-dashboard-frontend-build)
-endif(WITH_MGR_DASHBOARD_FRONTEND)
 
 if(WITH_TESTS)
   include(AddCephTest)

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -17,7 +17,7 @@ function(add_npm_command)
     COMMENT ${NC_COMMENT})
 endfunction(add_npm_command)
 
-if(WITH_MGR_DASHBOARD_FRONTEND AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64|arm|ARM")
+if(WITH_MGR_DASHBOARD_FRONTEND)
 
 if(WITH_SYSTEM_NPM)
   set(mgr-dashboard-nodeenv-dir )
@@ -121,7 +121,7 @@ add_custom_target(mgr-dashboard-frontend-build
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend)
 
 add_dependencies(tests mgr-dashboard-frontend-build)
-endif(WITH_MGR_DASHBOARD_FRONTEND AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64|arm|ARM")
+endif(WITH_MGR_DASHBOARD_FRONTEND)
 
 if(WITH_TESTS)
   include(AddCephTest)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
