### PR TITLE
rgw: set correct storage class for RGWListMultipart

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6250,10 +6250,12 @@ void RGWListMultipart::execute()
   mp.init(s->object.name, upload_id);
   meta_oid = mp.get_meta();
 
-  op_ret = get_multipart_info(store, s, meta_oid, &policy, nullptr, nullptr);
+  multipart_upload_info upload_info;
+  op_ret = get_multipart_info(store, s, meta_oid, &policy, nullptr, &upload_info);
   if (op_ret < 0)
     return;
 
+  storage_class = upload_info.dest_placement.get_storage_class();
   op_ret = list_multipart_parts(store, s, upload_id, meta_oid, max_parts,
 				marker, parts, NULL, &truncated);
 }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1766,6 +1766,7 @@ public:
 class RGWListMultipart : public RGWOp {
 protected:
   string upload_id;
+  string storage_class;
   map<uint32_t, RGWUploadPartInfo> parts;
   int max_parts;
   int marker;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3171,7 +3171,7 @@ void RGWListMultipart_ObjStore_S3::send_response()
     s->formatter->dump_string("Bucket", s->bucket_name);
     s->formatter->dump_string("Key", s->object.name);
     s->formatter->dump_string("UploadId", upload_id);
-    s->formatter->dump_string("StorageClass", "STANDARD");
+    s->formatter->dump_string("StorageClass", storage_class);
     s->formatter->dump_int("PartNumberMarker", marker);
     s->formatter->dump_int("NextPartNumberMarker", cur_max);
     s->formatter->dump_int("MaxParts", max_parts);


### PR DESCRIPTION
we should get the correct storgae class for non standard storage class object uncomplete multipart upload

fix https://tracker.ceph.com/issues/42337

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>



test script
```
#!/usr/bin/python
from boto3.session import Session
import boto3
import botocore
botocore.session.Session().set_debug_logger()
access_key = "yly"
secret_key = "yly"
url = "http://127.0.0.1:7480"
session = Session(access_key, secret_key)
config = boto3.session.Config(connect_timeout=30000, read_timeout=30000, retries={'max_attempts': 0})
s3_client = session.client('s3', endpoint_url=url, config=config)
src_bucket = "test1"
src_obj = "100222M22"

mpu = s3_client.create_multipart_upload(Bucket=src_bucket, Key=src_obj, 

uploadid = mpu["UploadId"]
res = s3_client.list_parts(
    Bucket=src_bucket,
    Key=src_obj,
    MaxParts=1000,
    UploadId=uploadid
)
```

here is what aws s3 return
```
<?xml version="1.0" encoding="UTF-8"?>
<ListPartsResult
    xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <Bucket>ylyb1</Bucket>
    <Key>100222M22</Key>
    <UploadId>Sud4Vl7_.Qbn1kO89cm.FAfbT1ME2zmp0g4d1r.b2_XR6OYk5DWts9Nd6BxtjWdfJdKc6tsi1CJiIVt9z7Hg5g--</UploadId>
    <Initiator>
        <ID>d8c826aaaa5812a67e0b5ad7a7cc8e03f91e2917d9ae0418c8b2532383745e3c</ID>
        <DisplayName>cmsscloud</DisplayName>
    </Initiator>
    <Owner>
        <ID>d8c826aaaa5812a67e0b5ad7a7cc8e03f91e2917d9ae0418c8b2532383745e3c</ID>
        <DisplayName>cmsscloud</DisplayName>
    </Owner>
    <StorageClass>STANDARD_IA</StorageClass>
    <PartNumberMarker>0</PartNumberMarker>
    <NextPartNumberMarker>0</NextPartNumberMarker>
    <MaxParts>1000</MaxParts>
    <IsTruncated>false</IsTruncated>
</ListPartsResult>


```