### PR TITLE
rgw: set correct storage class for RGWListBucketMultiparts

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5965,6 +5965,7 @@ void RGWInitMultipart::execute()
     obj_op.meta.owner = s->owner.get_id();
     obj_op.meta.category = RGWObjCategory::MultiMeta;
     obj_op.meta.flags = PUT_OBJ_CREATE_EXCL;
+    obj_op.meta.storage_class = s->dest_placement.storage_class;
 
     multipart_upload_info upload_info;
     upload_info.dest_placement = s->dest_placement;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2999,6 +2999,8 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
     bufferlist bl;
     encode(*meta.manifest, bl);
     op.setxattr(RGW_ATTR_MANIFEST, bl);
+  } else if (meta.flags == PUT_OBJ_CREATE_EXCL) {
+    storage_class = meta.storage_class;
   }
 
   for (iter = attrs.begin(); iter != attrs.end(); ++iter) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -810,6 +810,7 @@ public:
         bool modify_tail;
         bool completeMultipart;
         bool appendable;
+        string storage_class;
 
         MetaParams() : mtime(NULL), rmattrs(NULL), data(NULL), manifest(NULL), ptag(NULL),
                  remove_objs(NULL), category(RGWObjCategory::Main), flags(0),

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3837,7 +3837,8 @@ void RGWListBucketMultiparts_ObjStore_S3::send_response()
       s->formatter->dump_string("UploadId", mp.get_upload_id());
       dump_owner(s, s->user->get_id(), s->user->get_display_name(), "Initiator");
       dump_owner(s, s->user->get_id(), s->user->get_display_name());
-      s->formatter->dump_string("StorageClass", "STANDARD");
+      auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->obj.meta.storage_class);
+      s->formatter->dump_string("StorageClass", storage_class.c_str());
       dump_time(s, "Initiated", &iter->obj.meta.mtime);
       s->formatter->close_section();
     }


### PR DESCRIPTION
we should get the correct storgae class for non standard storage class object uncomplete multipart upload when list bucket all multiparts

fix https://tracker.ceph.com/issues/42344

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>

test script 
```
#!/usr/bin/python
from boto3.session import Session
import boto3
import botocore
botocore.session.Session().set_debug_logger()
access_key = "yly"
secret_key = "yly"
url = "http://127.0.0.1:7480"
session = Session(access_key, secret_key)
config = boto3.session.Config(connect_timeout=30000, read_timeout=30000, retries={'max_attempts': 0})
s3_client = session.client('s3', endpoint_url=url, config=config)
src_bucket = "test1"
src_obj = "100222M22"


mpu = s3_client.create_multipart_upload(Bucket=src_bucket, Key=src_obj, StorageClass='STANDARD_IA')

response = s3_client.list_multipart_uploads(
    Bucket=src_bucket,
    Delimiter='',
    MaxUploads=10,
    Prefix=''
)

```

here is aws return
```
<?xml version="1.0" encoding="UTF-8"?>
<ListMultipartUploadsResult
    xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <Bucket>ylyb1</Bucket>
    <KeyMarker></KeyMarker>
    <UploadIdMarker></UploadIdMarker>
    <NextKeyMarker>100222M22</NextKeyMarker>
    <NextUploadIdMarker>Sud4Vl7_.Qbn1kO89cm.FAfbT1ME2zmp0g4d1r.b2_XR6OYk5DWts9Nd6BxtjWdfJdKc6tsi1CJiIVt9z7Hg5g--</NextUploadIdMarker>
    <MaxUploads>10</MaxUploads>
    <IsTruncated>false</IsTruncated>
    <Upload>
        <Key>100222M22</Key>
        <UploadId>Sud4Vl7_.Qbn1kO89cm.FAfbT1ME2zmp0g4d1r.b2_XR6OYk5DWts9Nd6BxtjWdfJdKc6tsi1CJiIVt9z7Hg5g--</UploadId>
        <Initiator>
            <ID>d8c826aaaa5812a67e0b5ad7a7cc8e03f91e2917d9ae0418c8b2532383745e3c</ID>
            <DisplayName>cmsscloud</DisplayName>
        </Initiator>
        <Owner>
            <ID>d8c826aaaa5812a67e0b5ad7a7cc8e03f91e2917d9ae0418c8b2532383745e3c</ID>
            <DisplayName>cmsscloud</DisplayName>
        </Owner>
        <StorageClass>STANDARD_IA</StorageClass>
        <Initiated>2019-10-23T14:18:41.000Z</Initiated>
    </Upload>
</ListMultipartUploadsResult>
```