### PR TITLE
mds : clean up data written to unsafe inodes

### DIFF
--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -82,13 +82,13 @@ void InoTable::apply_alloc_ids(interval_set<inodeno_t>& ids)
 }
 
 
-void InoTable::project_release_ids(interval_set<inodeno_t>& ids) 
+void InoTable::project_release_ids(const interval_set<inodeno_t>& ids) 
 {
   dout(10) << "project_release_ids " << ids << " to " << projected_free << "/" << free << dendl;
   projected_free.insert(ids);
   ++projected_version;
 }
-void InoTable::apply_release_ids(interval_set<inodeno_t>& ids) 
+void InoTable::apply_release_ids(const interval_set<inodeno_t>& ids) 
 {
   dout(10) << "apply_release_ids " << ids << " to " << projected_free << "/" << free << dendl;
   free.insert(ids);

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -32,8 +32,8 @@ class InoTable : public MDSTable {
   void project_alloc_ids(interval_set<inodeno_t>& inos, int want);
   void apply_alloc_ids(interval_set<inodeno_t>& inos);
 
-  void project_release_ids(interval_set<inodeno_t>& inos);
-  void apply_release_ids(interval_set<inodeno_t>& inos);
+  void project_release_ids(const interval_set<inodeno_t>& inos);
+  void apply_release_ids(const interval_set<inodeno_t>& inos);
 
   void replay_alloc_id(inodeno_t ino);
   void replay_alloc_ids(interval_set<inodeno_t>& inos);

--- a/src/mds/LogEvent.cc
+++ b/src/mds/LogEvent.cc
@@ -32,6 +32,7 @@
 #include "events/ESlaveUpdate.h"
 #include "events/EOpen.h"
 #include "events/ECommitted.h"
+#include "events/EPurged.h"
 
 #include "events/ETableClient.h"
 #include "events/ETableServer.h"
@@ -84,6 +85,7 @@ std::string_view LogEvent::get_type_str() const
   case EVENT_SLAVEUPDATE: return "SLAVEUPDATE";
   case EVENT_OPEN: return "OPEN";
   case EVENT_COMMITTED: return "COMMITTED";
+  case EVENT_PURGED: return "PURGED";
   case EVENT_TABLECLIENT: return "TABLECLIENT";
   case EVENT_TABLESERVER: return "TABLESERVER";
   case EVENT_NOOP: return "NOOP";
@@ -109,6 +111,7 @@ const std::map<std::string, LogEvent::EventType> LogEvent::types = {
   {"SLAVEUPDATE", EVENT_SLAVEUPDATE},
   {"OPEN", EVENT_OPEN},
   {"COMMITTED", EVENT_COMMITTED},
+  {"PURGED", EVENT_PURGED},
   {"TABLECLIENT", EVENT_TABLECLIENT},
   {"TABLESERVER", EVENT_TABLESERVER},
   {"NOOP", EVENT_NOOP}
@@ -179,6 +182,9 @@ std::unique_ptr<LogEvent> LogEvent::decode_event(bufferlist::const_iterator& p, 
     break;
   case EVENT_COMMITTED:
     le = std::make_unique<ECommitted>();
+    break;
+  case EVENT_PURGED:
+    le = std::make_unique<EPurged>();
     break;
   case EVENT_TABLECLIENT:
     le = std::make_unique<ETableClient>();

--- a/src/mds/LogEvent.h
+++ b/src/mds/LogEvent.h
@@ -34,6 +34,7 @@
 #define EVENT_SLAVEUPDATE  21
 #define EVENT_OPEN         22
 #define EVENT_COMMITTED    23
+#define EVENT_PURGED       24
 
 #define EVENT_TABLECLIENT  42
 #define EVENT_TABLESERVER  43

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -726,6 +726,10 @@ class MDCache {
   void remove_recovered_truncate(CInode *in, LogSegment *ls);
   void start_recovered_truncates();
 
+  // purge unsafe inodes
+  void start_purge_inodes();
+  void purge_inodes(const interval_set<inodeno_t>& i, LogSegment *ls);
+
   CDir *get_auth_container(CDir *in);
   CDir *get_export_container(CDir *dir);
   void find_nested_exports(CDir *dir, set<CDir*>& s);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1985,6 +1985,7 @@ void MDSRank::recovery_done(int oldstate)
     return;
 
   mdcache->start_recovered_truncates();
+  mdcache->start_purge_inodes();
   mdcache->do_file_recover();
 
   // tell connected clients

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -141,7 +141,8 @@ public:
 
   void handle_client_session(const cref_t<MClientSession> &m);
   void _session_logged(Session *session, uint64_t state_seq, 
-		       bool open, version_t pv, interval_set<inodeno_t>& inos,version_t piv);
+		       bool open, version_t pv, const interval_set<inodeno_t>& inos,version_t piv,
+		       const interval_set<inodeno_t>& purge_inos, LogSegment *ls);
   version_t prepare_force_open_sessions(map<client_t,entity_inst_t> &cm,
 					map<client_t,client_metadata_t>& cmm,
 					map<client_t,pair<Session*,uint64_t> >& smap);
@@ -151,9 +152,9 @@ public:
   void finish_flush_session(Session *session, version_t seq);
   void terminate_sessions();
   void find_idle_sessions();
-  void kill_session(Session *session, Context *on_safe);
+  void kill_session(Session *session, Context *on_safe, bool need_purge_inos = false);
   size_t apply_blacklist(const std::set<entity_addr_t> &blacklist);
-  void journal_close_session(Session *session, int state, Context *on_safe);
+  void journal_close_session(Session *session, int state, Context *on_safe, bool need_purge_inos = false);
 
   set<client_t> client_reclaim_gather;
   size_t get_num_pending_reclaim() const { return client_reclaim_gather.size(); }

--- a/src/mds/events/EPurged.h
+++ b/src/mds/events/EPurged.h
@@ -1,0 +1,51 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MDS_EPURGE_H
+#define CEPH_MDS_EPURGE_H
+
+#include "common/config.h"
+#include "include/types.h"
+
+#include "../LogEvent.h"
+
+class EPurged : public LogEvent {
+
+ protected:
+    interval_set<inodeno_t> inos;
+    version_t inotablev{0};
+    LogSegment::seq_t seq;
+ public:
+ EPurged() : LogEvent(EVENT_PURGED) {
+    }
+ EPurged(interval_set<inodeno_t> i, version_t iv, LogSegment::seq_t _seq = 0) :
+   LogEvent(EVENT_PURGED), inos(std::move(i)), inotablev(iv), seq(_seq) {
+    }
+    void encode(bufferlist& bl, uint64_t features) const override;
+    void decode(bufferlist::const_iterator& bl) override;
+    void dump(Formatter *f) const override;
+    void print(ostream& out) const override {
+
+        if (inotablev)
+            out << "Eurge complete";
+        else
+            out << "Eurge inodes ";
+    }
+
+    void update_segment() override;
+    void replay(MDSRank *mds) override;
+};
+WRITE_CLASS_ENCODER_FEATURES(EPurged)
+
+#endif // CEPH_MDS_EPURGE_H

--- a/src/mds/events/ESession.h
+++ b/src/mds/events/ESession.h
@@ -29,6 +29,8 @@ class ESession : public LogEvent {
   interval_set<inodeno_t> inos;
   version_t inotablev{0};
 
+  interval_set<inodeno_t> purge_inos;
+  
   // Client metadata stored during open
   client_metadata_t client_metadata;
 
@@ -40,9 +42,11 @@ class ESession : public LogEvent {
     client_inst(inst), open(o), cmapv(v), inotablev(0),
     client_metadata(cm) { }
   ESession(const entity_inst_t& inst, bool o, version_t v,
-	   const interval_set<inodeno_t>& i, version_t iv) :
+	   interval_set<inodeno_t> i, version_t iv,
+	   interval_set<inodeno_t> _purge_inos) :
     LogEvent(EVENT_SESSION),
-    client_inst(inst), open(o), cmapv(v), inos(i), inotablev(iv) { }
+    client_inst(inst), open(o), cmapv(v), inos(std::move(i)), inotablev(iv),
+    purge_inos(std::move(_purge_inos)) {}
 
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -26,6 +26,7 @@
 #include "events/ESlaveUpdate.h"
 #include "events/EOpen.h"
 #include "events/ECommitted.h"
+#include "events/EPurged.h"
 
 #include "events/EExport.h"
 #include "events/EImportStart.h"
@@ -261,6 +262,10 @@ void LogSegment::try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int o
     dout(10) << "try_to_expire waiting for truncate of " << **p << dendl;
     (*p)->add_waiter(CInode::WAIT_TRUNC, gather_bld.new_sub());
   }
+  // purge inodes
+  dout(10) << "try_to_expire waiting for purge of " << purge_inodes << dendl;
+  if (purge_inodes.size())
+    set_purged_cb(gather_bld.new_sub());
   
   if (gather_bld.has_subs()) {
     dout(6) << "LogSegment(" << seq << "/" << offset << ").try_to_expire waiting" << dendl;
@@ -270,7 +275,6 @@ void LogSegment::try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int o
     dout(6) << "LogSegment(" << seq << "/" << offset << ").try_to_expire success" << dendl;
   }
 }
-
 
 // -----------------------
 // EMetaBlob
@@ -1602,6 +1606,60 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDSlaveUpdate *slaveup)
 }
 
 // -----------------------
+// EPurged
+void EPurged::update_segment()
+{
+  if (inos.size() && inotablev)
+    get_segment()->inotablev = inotablev;
+  return;
+}
+
+void EPurged::replay(MDSRank *mds)
+{
+  if (inos.size()) {
+    LogSegment *ls = mds->mdlog->get_segment(seq);
+    if (ls) {
+      ls->purge_inodes.subtract(inos);
+    }
+    if (mds->inotable->get_version() >= inotablev) {
+      dout(10) << "EPurged.replay inotable " << mds->inotable->get_version()
+	       << " >= " << inotablev << ", noop" << dendl;
+    } else {
+      dout(10) << "EPurged.replay inotable " << mds->inotable->get_version()
+	       << " < " << inotablev << " " << dendl;
+      mds->inotable->replay_release_ids(inos);
+      assert(mds->inotable->get_version() == inotablev);
+    }
+  }
+  update_segment();
+}
+
+void EPurged::encode(bufferlist& bl, uint64_t features) const
+{
+  ENCODE_START(1, 1, bl);
+  encode(inos, bl);
+  encode(inotablev, bl);
+  encode(seq, bl);
+  ENCODE_FINISH(bl);
+}
+
+void EPurged::decode(bufferlist::const_iterator& bl)
+{
+  DECODE_START(1, bl);
+  decode(inos, bl);
+  decode(inotablev, bl);
+  decode(seq, bl);
+  DECODE_FINISH(bl);
+}
+
+void EPurged::dump(Formatter *f) const
+{
+  f->dump_stream("inos") << inos;
+  f->dump_int("inotable version", inotablev);
+  f->dump_int("segment seq", seq);
+}
+
+// -----------------------
 // ESession
 
 void ESession::update_segment()
@@ -1613,6 +1671,9 @@ void ESession::update_segment()
 
 void ESession::replay(MDSRank *mds)
 {
+  if (purge_inos.size())
+    get_segment()->purge_inodes.insert(purge_inos);
+  
   if (mds->sessionmap.get_version() >= cmapv) {
     dout(10) << "ESession.replay sessionmap " << mds->sessionmap.get_version() 
 	     << " >= " << cmapv << ", noop" << dendl;
@@ -1673,7 +1734,7 @@ void ESession::replay(MDSRank *mds)
 
 void ESession::encode(bufferlist &bl, uint64_t features) const
 {
-  ENCODE_START(5, 5, bl);
+  ENCODE_START(6, 5, bl);
   encode(stamp, bl);
   encode(client_inst, bl, features);
   encode(open, bl);
@@ -1681,12 +1742,13 @@ void ESession::encode(bufferlist &bl, uint64_t features) const
   encode(inos, bl);
   encode(inotablev, bl);
   encode(client_metadata, bl);
+  encode(purge_inos, bl);
   ENCODE_FINISH(bl);
 }
 
 void ESession::decode(bufferlist::const_iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(5, 3, 3, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(6, 3, 3, bl);
   if (struct_v >= 2)
     decode(stamp, bl);
   decode(client_inst, bl);
@@ -1699,6 +1761,10 @@ void ESession::decode(bufferlist::const_iterator &bl)
   } else if (struct_v >= 5) {
     decode(client_metadata, bl);
   }
+  if (struct_v >= 6){
+    decode(purge_inos, bl);
+  }
+    
   DECODE_FINISH(bl);
 }
 

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -323,6 +323,7 @@ int Filer::purge_range(inodeno_t ino,
   if (num_obj == 1) {
     object_t oid = file_object_t(ino, first_obj);
     object_locator_t oloc = OSDMap::file_to_object_locator(*layout);
+    ldout(cct, 10) << "purge_range removing " << oid << dendl;
     objecter->remove(oid, oloc, snapc, mtime, flags, oncommit);
     return 0;
   }


### PR DESCRIPTION
  when client create file, if early_reply is set true, it may occur that the metadata has not been written to journal and the file data is successfully written to the journal of osd, and then mds is crushed

fix : https://tracker.ceph.com/issues/43208

Signed-off-by: simon gao <simon29rock@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
