### PR TITLE
cmake: bump libceph-common SO version for compliance

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -415,7 +415,7 @@ add_library(ceph-common SHARED ${ceph_common_objs})
 target_link_libraries(ceph-common ${ceph_common_deps})
 # appease dpkg-shlibdeps
 set_target_properties(ceph-common PROPERTIES
-  SOVERSION 0
+  SOVERSION 2
   SKIP_RPATH TRUE)
 if(NOT APPLE AND NOT FREEBSD)
   # Apple uses Mach-O, not ELF. so this option does not apply to APPLE.


### PR DESCRIPTION
`libceph-common.so.*` is included in the librados2 package. The openSUSE Shared
Library Packaging Policy [1] states that "A versioned package is allowed to ship
multiple library files, provided they share the same numbers and these numbers
always change in lockstep throughout."

[1] https://en.opensuse.org/openSUSE:Shared_library_packaging_policy

Fixes: https://tracker.ceph.com/issues/42353
Signed-off-by: Nathan Cutler <ncutler@suse.com>
