### PR TITLE
mimic: rgw: asio: check the remote endpoint before processing requests

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -167,9 +167,14 @@ void handle_connection(RGWProcessEnv& env, Stream& stream,
     RGWRequest req{env.store->get_new_req_id()};
 
     auto& socket = stream.lowest_layer();
+    const auto& remote_endpoint = socket.remote_endpoint(ec);
+    if (ec) {
+      ldout(cct, 1) << "failed to connect client: " << ec.message() << dendl;
+      return;
+    }
     StreamIO real_client{stream, parser, buffer, is_ssl,
                          socket.local_endpoint(),
-                         socket.remote_endpoint()};
+                         remote_endpoint};
 
     auto real_client_io = rgw::io::add_reordering(
                             rgw::io::add_buffering(cct,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41570

---

backport of https://github.com/ceph/ceph/pull/29967
parent tracker: https://tracker.ceph.com/issues/40018

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh