### PR TITLE
krbd: modprobe before calling build_map_buf()

### DIFF
--- a/qa/rbd/krbd_modprobe.t
+++ b/qa/rbd/krbd_modprobe.t
@@ -1,0 +1,10 @@
+
+  $ sudo modprobe -r rbd
+  $ sudo modprobe -r libceph
+  $ lsmod | grep libceph
+  [1]
+  $ rbd create --size 1 img
+  $ DEV=$(sudo rbd map img)
+  $ sudo grep -q ',key=' /sys/bus/rbd/devices/${DEV#/dev/rbd}/config_info
+  $ sudo rbd unmap $DEV
+  $ rbd rm --no-progress img

--- a/qa/suites/krbd/basic/tasks/krbd_modprobe.yaml
+++ b/qa/suites/krbd/basic/tasks/krbd_modprobe.yaml
@@ -1,0 +1,5 @@
+tasks:
+- cram:
+    clients:
+      client.0:
+      - qa/rbd/krbd_modprobe.t

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -357,13 +357,12 @@ static int map_image(struct krbd_ctx *ctx, const krbd_spec& spec,
   string buf;
   int r;
 
-  r = build_map_buf(ctx->cct, spec, options, &buf);
-  if (r < 0)
-    return r;
-
   /*
    * Modprobe rbd kernel module.  If it supports single-major device
    * number allocation scheme, make sure it's turned on.
+   *
+   * Do this before calling build_map_buf() - it wants "ceph" key type
+   * registered.
    */
   if (access("/sys/bus/rbd", F_OK) != 0) {
     const char *module_options = NULL;
@@ -380,6 +379,10 @@ static int map_image(struct krbd_ctx *ctx, const krbd_spec& spec,
        */
     }
   }
+
+  r = build_map_buf(ctx->cct, spec, options, &buf);
+  if (r < 0)
+    return r;
 
   return do_map(ctx->udev, spec, buf, pname);
 }


### PR DESCRIPTION
Otherwise add_key() in set_kernel_secret() fails as if running against
an ancient kernel and we fall back to secret= in options for the first
image being mapped on the machine.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>