### PR TITLE
mds: Reorganize class members in MDSDaemon header

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -63,8 +63,6 @@
 // cons/des
 MDSDaemon::MDSDaemon(std::string_view n, Messenger *m, MonClient *mc) :
   Dispatcher(m->cct),
-  mds_lock(ceph::make_mutex("MDSDaemon::mds_lock")),
-  stopping(false),
   timer(m->cct, mds_lock),
   gss_ktfile_client(m->cct->_conf.get_val<std::string>("gss_ktab_client_file")),
   beacon(m->cct, mc, n),
@@ -73,8 +71,6 @@ MDSDaemon::MDSDaemon(std::string_view n, Messenger *m, MonClient *mc) :
   monc(mc),
   mgrc(m->cct, m, &mc->monmap),
   log_client(m->cct, messenger, &mc->monmap, LogClient::NO_FLAGS),
-  mds_rank(NULL),
-  asok_hook(NULL),
   starttime(mono_clock::now())
 {
   orig_argc = 0;

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -42,15 +42,8 @@ class MonClient;
 
 class MDSDaemon : public Dispatcher {
  public:
-  /* Global MDS lock: every time someone takes this, they must
-   * also check the `stopping` flag.  If stopping is true, you
-   * must either do nothing and immediately drop the lock, or
-   * never drop the lock again (i.e. call respawn()) */
-  ceph::mutex  mds_lock;
-  bool         stopping;
-
-  SafeTimer    timer;
-  std::string gss_ktfile_client{};
+  MDSDaemon(std::string_view n, Messenger *m, MonClient *mc);
+  ~MDSDaemon() override;
 
   mono_time get_starttime() const {
     return starttime;
@@ -59,26 +52,6 @@ class MDSDaemon : public Dispatcher {
     mono_time now = mono_clock::now();
     return chrono::duration<double>(now-starttime);
   }
-
- protected:
-  Beacon  beacon;
-
-  std::string name;
-
-  Messenger    *messenger;
-  MonClient    *monc;
-  MgrClient     mgrc;
-  std::unique_ptr<MDSMap> mdsmap;
-  LogClient    log_client;
-  LogChannelRef clog;
-
-  MDSRankDispatcher *mds_rank;
-
- public:
-  MDSDaemon(std::string_view n, Messenger *m, MonClient *mc);
-  ~MDSDaemon() override;
-  int orig_argc;
-  const char **orig_argv;
 
   // handle a signal (e.g., SIGTERM)
   void handle_signal(int signum);
@@ -92,26 +65,31 @@ class MDSDaemon : public Dispatcher {
    * such that deleting xlists doesn't assert.
    */
   bool is_clean_shutdown();
- protected:
-  // tick and other timer fun
-  Context *tick_event = nullptr;
-  void     reset_tick();
 
-  void wait_for_omap_osds();
+  /* Global MDS lock: every time someone takes this, they must
+   * also check the `stopping` flag.  If stopping is true, you
+   * must either do nothing and immediately drop the lock, or
+   * never drop the lock again (i.e. call respawn()) */
+  ceph::mutex mds_lock = ceph::make_mutex("MDSDaemon::mds_lock");
+  bool stopping = false;
 
- private:
-  bool ms_dispatch2(const ref_t<Message> &m) override;
-  int ms_handle_authentication(Connection *con) override;
-  void ms_handle_accept(Connection *con) override;
-  void ms_handle_connect(Connection *con) override;
-  bool ms_handle_reset(Connection *con) override;
-  void ms_handle_remote_reset(Connection *con) override;
-  bool ms_handle_refused(Connection *con) override;
+  SafeTimer    timer;
+  std::string gss_ktfile_client{};
+
+  int orig_argc;
+  const char **orig_argv;
+
 
  protected:
   // admin socket handling
   friend class MDSSocketHook;
-  class MDSSocketHook *asok_hook;
+
+  // special message types
+  friend class C_MDS_Send_Command_Reply;
+
+  void reset_tick();
+  void wait_for_omap_osds();
+
   void set_up_admin_socket();
   void clean_up_admin_socket();
   void check_ops_in_flight(); // send off any slow ops to monitor
@@ -135,12 +113,9 @@ class MDSDaemon : public Dispatcher {
   void respawn();
 
   void tick();
-  
-protected:
+
   bool handle_core_message(const cref_t<Message> &m);
   
-  // special message types
-  friend class C_MDS_Send_Command_Reply;
   static void send_command_reply(const cref_t<MCommand> &m, MDSRank* mds_rank, int r,
 				 bufferlist outbl, std::string_view outs);
   int _handle_command(
@@ -154,7 +129,23 @@ protected:
   void handle_mds_map(const cref_t<MMDSMap> &m);
   void _handle_mds_map(const MDSMap &oldmap);
 
-private:
+  Beacon beacon;
+
+  std::string name;
+
+  Messenger    *messenger;
+  MonClient    *monc;
+  MgrClient     mgrc;
+  std::unique_ptr<MDSMap> mdsmap;
+  LogClient    log_client;
+  LogChannelRef clog;
+
+  MDSRankDispatcher *mds_rank = nullptr;
+
+  // tick and other timer fun
+  Context *tick_event = nullptr;
+  class MDSSocketHook *asok_hook = nullptr;
+ private:
   struct MDSCommand {
     MDSCommand(std::string_view signature, std::string_view help)
         : cmdstring(signature), helpstring(help)
@@ -164,6 +155,14 @@ private:
     std::string helpstring;
     std::string module = "mds";
   };
+
+  bool ms_dispatch2(const ref_t<Message> &m) override;
+  int ms_handle_authentication(Connection *con) override;
+  void ms_handle_accept(Connection *con) override;
+  void ms_handle_connect(Connection *con) override;
+  bool ms_handle_reset(Connection *con) override;
+  void ms_handle_remote_reset(Connection *con) override;
+  bool ms_handle_refused(Connection *con) override;
 
   static const std::vector<MDSCommand>& get_commands();
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42371
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
