### PR TITLE
rgw: support encoding-type param for list bucket multiparts

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1810,6 +1810,7 @@ protected:
   map<string, bool> common_prefixes;
   bool is_truncated;
   int default_max;
+  bool encode_url {false};
 
 public:
   RGWListBucketMultiparts() {

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1599,6 +1599,16 @@ int RGWListBucketMultiparts_ObjStore::get_params()
     return op_ret;
   }
 
+  if (auto encoding_type = s->info.args.get_optional("encoding-type");
+      encoding_type != boost::none) {
+    if (strcasecmp(encoding_type->c_str(), "url") != 0) {
+      op_ret = -EINVAL;
+      ldout(s->cct, 5) << "ERROR: bad encoding type: " << encoding_type << dendl;
+      return op_ret;
+    }
+    encode_url = true;
+  }
+
   string key_marker = s->info.args.get("key-marker");
   string upload_id_marker = s->info.args.get("upload-id-marker");
   if (!key_marker.empty())

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3216,8 +3216,13 @@ void RGWListBucketMultiparts_ObjStore_S3::send_response()
     for (iter = uploads.begin(); iter != uploads.end(); ++iter) {
       RGWMPObj& mp = iter->mp;
       s->formatter->open_array_section("Upload");
-      s->formatter->dump_string("Key", mp.get_key());
-      s->formatter->dump_string("UploadId", mp.get_upload_id());
+      if (encode_url) {
+        s->formatter->dump_string("Key", url_encode(mp.get_key(), false));
+        s->formatter->dump_string("UploadId", url_encode(mp.get_upload_id(), false));
+      } else {
+        s->formatter->dump_string("Key", mp.get_key());
+        s->formatter->dump_string("UploadId", mp.get_upload_id());
+      }
       dump_owner(s, s->user->user_id, s->user->display_name, "Initiator");
       dump_owner(s, s->user->user_id, s->user->display_name);
       s->formatter->dump_string("StorageClass", "STANDARD");
@@ -3226,10 +3231,13 @@ void RGWListBucketMultiparts_ObjStore_S3::send_response()
     }
     if (!common_prefixes.empty()) {
       s->formatter->open_array_section("CommonPrefixes");
-      map<string, bool>::iterator pref_iter;
-      for (pref_iter = common_prefixes.begin();
-	   pref_iter != common_prefixes.end(); ++pref_iter) {
-	s->formatter->dump_string("CommonPrefixes.Prefix", pref_iter->first);
+      for (const auto& kv : common_prefixes) {
+        if (encode_url) {
+          s->formatter->dump_string("CommonPrefixes.Prefix",
+                                    url_encode(kv.first, false));
+        } else {
+          s->formatter->dump_string("CommonPrefixes.Prefix", kv.first);
+        }
       }
       s->formatter->close_section();
     }


### PR DESCRIPTION
url encode keys, upload ids & prefixes based on encoding-type, reject invalid
encoding types at the param parsing phase

Fixes: https://tracker.ceph.com/issues/42372
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>