### PR TITLE
rbd: add --merge to disk-usage

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -273,13 +273,15 @@ Commands
   (in bytes), the length of the region (in bytes), and either 'zero' or 'data' to indicate
   whether the region is known to be zeros or may contain other data.
 
-:command:`du` [-p | --pool *pool-name*] [*image-spec* | *snap-spec*]
+:command:`du` [-p | --pool *pool-name*] [*image-spec* | *snap-spec*] [--merge-snapshots]
   Will calculate the provisioned and actual disk usage of all images and
   associated snapshots within the specified pool.  It can also be used against
   individual images and snapshots.
 
   If the RBD fast-diff feature is not enabled on images, this operation will
   require querying the OSDs for every potential object within the image.
+
+  The --merge-snapshots will merge snapshots used space into their parent images.
 
 :command:`export` [--export-format *format (1 or 2)*] (*image-spec* | *snap-spec*) [*dest-path*]
   Export image to dest path (use - for stdout).

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -637,6 +637,7 @@
   usage: rbd disk-usage [--pool <pool>] [--namespace <namespace>] 
                         [--image <image>] [--snap <snap>] [--format <format>] 
                         [--pretty-format] [--from-snap <from-snap>] [--exact] 
+                        [--merge-snapshots] 
                         <image-or-snap-spec> 
   
   Show disk usage stats for pool, image or snapshot.
@@ -655,6 +656,7 @@
     --pretty-format       pretty formatting (json and xml)
     --from-snap arg       snapshot starting point
     --exact               compute exact disk usage (slow)
+    --merge-snapshots     merge snapshot sizes with its image
   
   rbd help export
   usage: rbd export [--pool <pool>] [--namespace <namespace>] [--image <image>] 


### PR DESCRIPTION
Rbd has a disk usage subcommand, that allow an administrator to get information about "who uses the disk space"

However, when you have many snapshots per image, it become confusing to find which rbd image (VM / virtual disk / ..) "own" that space

The following patch adds a *--merge* option to this subcommand.
Using it, *rbd* will merge the *USED* size from snapshots back to their parent image

Here is an example:
Current behavior:
```
root@host:~/ceph/build# ./bin/rbd -p poolbackup du
NAME                                                     PROVISIONED USED    
vm-100-disk-2@backup;daily;30;2019-09-17T17:20:06.724599      20 GiB  76 MiB 
vm-100-disk-2                                                 20 GiB  60 MiB 
vm-103-disk-1@backup;daily;30;2019-10-18T02:00:06.109693      20 GiB  44 MiB 
vm-103-disk-1                                                 20 GiB     0 B 
vm-131-disk-1@backup;daily;30;2019-10-18T01:00:06.888400      20 GiB 852 MiB 
vm-131-disk-1                                                 20 GiB 440 MiB 
vm-133-disk-1@backup;daily;30;2019-09-17T17:20:06.734643     200 GiB 139 GiB 
vm-133-disk-1                                                200 GiB 140 GiB 
vm-148-disk-1@backup;daily;30;2019-10-18T02:00:16.295747      20 GiB  60 MiB 
vm-148-disk-1                                                 20 GiB     0 B 
vm-165-disk-1@backup;daily;30;2019-09-17T17:20:06.742159     200 GiB 1.4 GiB 
vm-165-disk-1                                                200 GiB 1.4 GiB 
<TOTAL>                                                      480 GiB 283 GiB 
```

Proposed behavior:
```
root@abweb1:~/ceph/build# ./bin/rbd -p poolbackup du --merge
NAME          PROVISIONED USED    
vm-100-disk-2      20 GiB 136 MiB 
vm-103-disk-1      20 GiB  44 MiB 
vm-131-disk-1      20 GiB 1.3 GiB 
vm-133-disk-1     200 GiB 279 GiB 
vm-148-disk-1      20 GiB  60 MiB 
vm-165-disk-1     200 GiB 2.8 GiB 
<TOTAL>           480 GiB 283 GiB 
```

Signed-off-by: Alexandre Bruyelles <ceph@jack.fr.eu.org>
