### PR TITLE
ceph-volume-zfs: add the inventory command

### DIFF
--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/__init__.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/__init__.py
@@ -4,3 +4,10 @@
 
 __author__ = """Willem Jan Withagen"""
 __email__ = 'wjw@digiware.nl'
+
+import ceph_volume_zfs.zfs
+
+from collections import namedtuple
+
+sys_info = namedtuple('sys_info', ['devices'])
+sys_info.devices = dict()

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/__init__.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
-from .main import ZFS
+
+import logging
+logger = logging.getLogger(__name__)

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/inventory.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/inventory.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+from textwrap import dedent
+
+# import ceph_volume.process
+
+from ceph_volume_zfs.util.disk import Disks
+
+class Inventory(object):
+
+    help = 'Generate a list of available devices'
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def format_report(self, inventory):
+        if self.args.format == 'json':
+            print(json.dumps(inventory.json_report()))
+        elif self.args.format == 'json-pretty':
+            print(json.dumps(inventory.json_report(), indent=4, sort_keys=True))
+        else:
+            print(inventory.pretty_report())
+
+    def main(self):
+        sub_command_help = dedent("""
+	Generate an inventory of available devices
+        """)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume zfs inventory',
+            description=sub_command_help,
+        )
+        parser.add_argument(
+            'path',
+            nargs='?',
+            default=None,
+            help=('Report on specific disk'),
+        )
+        parser.add_argument(
+            '--format',
+            choices=['plain', 'json', 'json-pretty'],
+            default='plain',
+            help='Output format',
+        )
+
+        self.args = parser.parse_args(self.argv)
+        if self.args.path:
+            self.format_report(Disks(self.args.path)) 
+        else:
+            self.format_report(Disks()) 
+

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/main.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/main.py
@@ -1,20 +1,22 @@
+# vim: expandtab smarttab shiftwidth=4 softtabstop=4
+
 import argparse
 from textwrap import dedent
 from ceph_volume import terminal
 
+from . import inventory
+from . import prepare
+from . import zap
 
-class ZFS(object):
+class ZFSDEV(object):
 
     help = 'Use ZFS to deploy OSDs'
 
     _help = dedent("""
-    Use ZFS to deploy OSDs
+        Use ZFS to deploy OSDs
 
-    {sub_help}
+        {sub_help}
     """)
-
-    mapper = {
-    }
 
     def __init__(self, argv):
         self.argv = argv

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/prepare.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/prepare.py
@@ -1,0 +1,25 @@
+import argparse
+
+from textwrap import dedent
+# from ceph_volume.util import arg_validators
+
+class Prepare(object):
+
+    help = 'Prepare a device'
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def main(self):
+        sub_command_help = dedent("""
+	Prepare a device
+        """)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume zfs prepare',
+            description=sub_command_help,
+        )
+        if len(self.argv) == 0 or len(self.argv) > 0:
+            print("Prepare: Print Help")
+            print(sub_command_help)
+            return
+

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/zap.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/zap.py
@@ -1,0 +1,34 @@
+import argparse
+
+from textwrap import dedent
+# from ceph_volume.util import arg_validators
+
+class Zap(object):
+
+    help = 'Zap a device'
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def main(self):
+        sub_command_help = dedent("""
+	Zap a device
+        """)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume zfs inventory',
+            description=sub_command_help,
+        )
+        parser.add_argument(
+            'devices',
+            metavar='DEVICES',
+            nargs='*',
+            # type=arg_validators.ValidDevice(gpt_ok=True),
+            default=[],
+            help='Path to one or many lv (as vg/lv), partition (as /dev/sda1) or device (as /dev/sda)'
+        )
+
+        if len(self.argv) == 0 or len(self.argv) > 0:
+            print("Zap: Print Help")
+            print(sub_command_help)
+            return
+

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/disk.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/disk.py
@@ -1,0 +1,148 @@
+import re
+
+from ceph_volume.util.disk import human_readable_size
+from ceph_volume import process
+from ceph_volume import sys_info
+
+report_template = """
+/dev/{geomname:<16} {mediasize:<16} {rotational!s:<7} {descr}"""
+# {geomname:<25} {mediasize:<12} {rotational!s:<7} {mode!s:<9} {descr}"""
+
+def geom_disk_parser(block):
+    """
+    Parses lines in 'geom disk list` output.
+
+    Geom name: ada3
+    Providers:
+    1. Name: ada3
+       Mediasize: 40018599936 (37G)
+       Sectorsize: 512
+       Stripesize: 4096
+       Stripeoffset: 0
+       Mode: r2w2e4
+       descr: Corsair CSSD-F40GB2
+       lunid: 5000000000000236
+       ident: 111465010000101800EC
+       rotationrate: 0
+       fwsectors: 63
+       fwheads: 16
+
+    :param line: A string, with the full block for `geom disk list`
+    """
+    pairs = block.split(';')
+    parsed = {}
+    for pair in pairs:
+        if 'Providers' in pair:
+            continue
+        try:
+            column, value = pair.split(':')
+        except ValueError:
+            continue
+        # fixup
+        column = re.sub("\s+", "", column)
+        column= re.sub("^[0-9]+\.", "", column)
+        value = value.strip()
+        value = re.sub('\([0-9A-Z]+\)', '', value)
+        parsed[column.lower()] = value
+    return parsed
+
+def get_disk(diskname):
+    """
+    Captures all available info from geom
+    along with interesting metadata like sectors, size, vendor,
+    solid/rotational, etc...
+
+    Returns a dictionary, with all the geom fields as keys.
+    """
+
+    command = ['/sbin/geom', 'disk', 'list', re.sub('/dev/', '', diskname)]
+    out, err, rc = process.call(command)
+    geom_block = "" 
+    for line in out:
+        line.strip()
+        geom_block += ";" + line
+    disk = geom_disk_parser(geom_block)
+    return disk
+
+def get_disks():
+    command = ['/sbin/geom', 'disk', 'status', '-s']
+    out, err, rc = process.call(command)
+    disks = {}
+    for path in out:
+        dsk, rest1, rest2 = path.split()
+        disk = get_disk(dsk)
+        disks['/dev/'+dsk] = disk
+    return disks
+
+class Disks(object):
+
+    def __init__(self, path=None):
+        if not sys_info.devices:
+            sys_info.devices = get_disks()
+        self.disks = {}
+        for k in sys_info.devices:
+            if path != None:
+                if path in k: 
+                    self.disks[k] = Disk(k)
+            else:
+                self.disks[k] = Disk(k)
+
+    def pretty_report(self, all=True):
+        output = [
+            report_template.format(
+                geomname='Device Path',
+                mediasize='Size',
+                rotational='rotates',
+                descr='Model name',
+                mode='available',
+            )]
+        for disk in sorted(self.disks):
+            output.append(self.disks[disk].report())
+        return ''.join(output)
+        
+    def json_report(self):
+        output = []
+        for disk in sorted(self.disks):
+            output.append(self.disks[disk].json_report())
+        return output
+
+
+class Disk(object):
+
+    report_fields = [
+        'rejected_reasons',
+        'available',
+        'path',
+        'sys_api',
+    ]
+    pretty_report_sys_fields = [
+        'human_readable_size',
+        'model',
+        'removable',
+        'ro',
+        'rotational',
+        'sas_address',
+        'scheduler_mode',
+        'vendor',
+    ]
+
+    def __init__(self, path):
+        self.abspath = path
+        self.path = path
+        self.reject_reasons = []
+        self.available = True
+        self.sys_api = sys_info.devices.get(path)
+
+    def report(self):
+        return report_template.format(
+            geomname=self.sys_api.get('geomname'),
+            mediasize=human_readable_size(int(self.sys_api.get('mediasize'))),
+            rotational=int(self.sys_api.get('rotationrate')) != 0,
+            mode=self.sys_api.get('mode'),
+            descr=self.sys_api.get('descr')
+        )
+
+    def json_report(self):
+        output = {k.strip('_'): v for k, v in vars(self).items()}
+        return output
+

--- a/src/ceph-volume/plugin/zfs/setup.py
+++ b/src/ceph-volume/plugin/zfs/setup.py
@@ -23,8 +23,6 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
     description="Manage Ceph OSDs on ZFS pool/volume/filesystem",
@@ -34,14 +32,13 @@ setup(
     keywords='ceph-volume-zfs',
     name='ceph-volume-zfs',
     packages=find_packages(include=['ceph_volume_zfs']),
-    scripts=['bin/ceph-volume-zfs'],
     setup_requires=setup_requirements,
     url='https://github.com/ceph/ceph/src/ceph-volume/plugin/zfs',
     version='0.1.0',
     zip_safe=False,
     entry_points = dict(
         ceph_volume_handlers = [
-            'zfs = ceph_volume_zfs.main:ZFSVOL',
+            'zfs = ceph_volume_zfs.zfs:ZFS',
         ],
     ),
 )


### PR DESCRIPTION
```
usage: ceph-volume zfs inventory [-h] [--format {plain,json,json-pretty}]
                                 [path]

Generate an inventory of available devices

positional arguments:
  path                  Report on specific disk

optional arguments:
  -h, --help            show this help message and exit
  --format {plain,json,json-pretty}
                        Output format
```

Which genrates:
```
wjw@zfstest.digiware.nl> ceph-volume zfs inventory

/dev/Device Path      Size             rotates Model name
/dev/ada0             232.89 GB        True    ST3250318AS
/dev/ada1             232.89 GB        True    ST3250318AS
/dev/ada2             223.57 GB        False   INTEL SSDSC2BB240G6
/dev/ada3             37.27 GB         False   Corsair CSSD-F40GB2

```

or:
```
wjw@zfstest.digiware.nl> ceph-volume zfs inventory --format json-pretty ada3
[
    {
        "abspath": "/dev/ada3",
        "available": true,
        "path": "/dev/ada3",
        "reject_reasons": [],
        "sys_api": {
            "descr": "Corsair CSSD-F40GB2",
            "fwheads": "16",
            "fwsectors": "63",
            "geomname": "ada3",
            "ident": "111465010000101800EC",
            "lunid": "5000000000000236",
            "mediasize": "40018599936 ",
            "mode": "r2w2e6",
            "name": "ada3",
            "rotationrate": "0",
            "sectorsize": "512",
            "stripeoffset": "0",
            "stripesize": "4096"
        }
    }
]
```

Fixes: https://tracker.ceph.com/issues/42498
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>