### PR TITLE
mgr/dashboard: CephFS snapshot management UI

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.html
@@ -25,9 +25,17 @@
         </cd-table>
 
         <legend i18n>Snapshots</legend>
-        <cd-table [sorts]="snapshot.sortProperties"
-                  [data]="selectedDir.snapshots"
-                  [columns]="snapshot.columns">
+        <cd-table [data]="selectedDir.snapshots"
+                  [columns]="snapshot.columns"
+                  identifier="name"
+                  forceIdentifier="true"
+                  selectionType="multiClick"
+                  (updateSelection)="snapshot.updateSelection($event)">
+          <cd-table-actions class="table-actions"
+                            [permission]="permission"
+                            [selection]="snapshot.selection"
+                            [tableActions]="snapshot.tableActions">
+          </cd-table-actions>
         </cd-table>
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -61,6 +61,21 @@ describe('CephfsService', () => {
     const req = httpTesting.expectOne('api/cephfs/1/ls_dir?depth=2');
     expect(req.request.method).toBe('GET');
     service.lsDir(2, '/some/path').subscribe();
-    httpTesting.expectOne('api/cephfs/2/ls_dir?depth=2&path=%2Fsome%2Fpath');
+    httpTesting.expectOne('api/cephfs/2/ls_dir?depth=2&path=%252Fsome%252Fpath');
+  });
+
+  it('should call mkSnapshot', () => {
+    service.mkSnapshot(3, '/some/path').subscribe();
+    const req = httpTesting.expectOne('api/cephfs/3/mk_snapshot?path=%252Fsome%252Fpath');
+    expect(req.request.method).toBe('POST');
+
+    service.mkSnapshot(4, '/some/other/path', 'snap').subscribe();
+    httpTesting.expectOne('api/cephfs/4/mk_snapshot?path=%252Fsome%252Fother%252Fpath&name=snap');
+  });
+
+  it('should call rmSnapshot', () => {
+    service.rmSnapshot(1, '/some/path', 'snap').subscribe();
+    const req = httpTesting.expectOne('api/cephfs/1/rm_snapshot?path=%252Fsome%252Fpath&name=snap');
+    expect(req.request.method).toBe('POST');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -1,11 +1,14 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
+import * as _ from 'lodash';
 import { Observable } from 'rxjs';
 
+import { cdEncode } from '../decorators/cd-encode';
 import { CephfsDir } from '../models/cephfs-directory-models';
 import { ApiModule } from './api.module';
 
+@cdEncode
 @Injectable({
   providedIn: ApiModule
 })
@@ -44,5 +47,21 @@ export class CephfsService {
 
   getMdsCounters(id) {
     return this.http.get(`${this.baseURL}/${id}/mds_counters`);
+  }
+
+  mkSnapshot(id, path, name?) {
+    let params = new HttpParams();
+    params = params.append('path', path);
+    if (!_.isUndefined(name)) {
+      params = params.append('name', name);
+    }
+    return this.http.post(`${this.baseURL}/${id}/mk_snapshot`, null, { params: params });
+  }
+
+  rmSnapshot(id, path, name) {
+    let params = new HttpParams();
+    params = params.append('path', path);
+    params = params.append('name', name);
+    return this.http.post(`${this.baseURL}/${id}/rm_snapshot`, null, { params: params });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -18,6 +18,7 @@ import { BackButtonComponent } from './back-button/back-button.component';
 import { ConfigOptionComponent } from './config-option/config-option.component';
 import { ConfirmationModalComponent } from './confirmation-modal/confirmation-modal.component';
 import { CriticalConfirmationModalComponent } from './critical-confirmation-modal/critical-confirmation-modal.component';
+import { FormModalComponent } from './form-modal/form-modal.component';
 import { GrafanaComponent } from './grafana/grafana.component';
 import { HelperComponent } from './helper/helper.component';
 import { LanguageSelectorComponent } from './language-selector/language-selector.component';
@@ -67,7 +68,8 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     BackButtonComponent,
     RefreshSelectorComponent,
     ConfigOptionComponent,
-    AlertPanelComponent
+    AlertPanelComponent,
+    FormModalComponent
   ],
   providers: [],
   exports: [
@@ -88,6 +90,11 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     ConfigOptionComponent,
     AlertPanelComponent
   ],
-  entryComponents: [ModalComponent, CriticalConfirmationModalComponent, ConfirmationModalComponent]
+  entryComponents: [
+    ModalComponent,
+    CriticalConfirmationModalComponent,
+    ConfirmationModalComponent,
+    FormModalComponent
+  ]
 })
 export class ComponentsModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
@@ -1,0 +1,46 @@
+<cd-modal [modalRef]="bsModalRef">
+  <ng-container *ngIf="titleText"
+                class="modal-title">
+    {{ titleText }}
+  </ng-container>
+  <ng-container class="modal-content">
+    <form [formGroup]="formGroup"
+          novalidate>
+      <div class="modal-body">
+        <p *ngIf="message">{{ message }}</p>
+        <ng-container *ngFor="let field of fields">
+          <div class="form-group row">
+            <ng-container [ngSwitch]="field.type">
+              <ng-template [ngSwitchCase]="'inputText'">
+                <label *ngIf="field.label"
+                       class="col-form-label col-sm-3"
+                       [for]="field.name">
+                  {{ field.label }}
+                </label>
+                <div [ngClass]="{'col-sm-9': field.label, 'col-sm-12': !field.label}">
+                  <input type="text"
+                         class="form-control"
+                         [id]="field.name"
+                         [name]="field.name"
+                         [formControlName]="field.name">
+                  <span *ngIf="formGroup.hasError('required', field.name)"
+                        class="invalid-feedback"
+                        i18n>This field is required.</span>
+                </div>
+              </ng-template>
+            </ng-container>
+          </div>
+        </ng-container>
+      </div>
+      <div class="modal-footer">
+        <div class="button-group text-right">
+          <cd-submit-button [form]="formGroup"
+                            (submitAction)="onSubmitForm(formGroup.value)">
+            {{ submitButtonText }}
+          </cd-submit-button>
+          <cd-back-button [back]="bsModalRef.hide"></cd-back-button>
+        </div>
+      </div>
+    </form>
+  </ng-container>
+</cd-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
+import { BsModalRef, ModalModule } from 'ngx-bootstrap/modal';
+
+import {
+  configureTestBed,
+  FixtureHelper,
+  i18nProviders
+} from '../../../../testing/unit-test-helper';
+import { SharedModule } from '../../shared.module';
+import { FormModalComponent } from './form-modal.component';
+
+describe('InputModalComponent', () => {
+  let component: FormModalComponent;
+  let fixture: ComponentFixture<FormModalComponent>;
+  let fh: FixtureHelper;
+  let submitted;
+
+  const initialState = {
+    titleText: 'Some title',
+    message: 'Some description',
+    fields: [
+      {
+        type: 'inputText',
+        name: 'requiredField',
+        value: 'some-value',
+        required: true
+      },
+      {
+        type: 'inputText',
+        name: 'optionalField',
+        label: 'Optional'
+      }
+    ],
+    submitButtonText: 'Submit button name',
+    onSubmit: (values) => (submitted = values)
+  };
+
+  configureTestBed({
+    imports: [
+      ModalModule.forRoot(),
+      NgBootstrapFormValidationModule.forRoot(),
+      RouterTestingModule,
+      ReactiveFormsModule,
+      SharedModule
+    ],
+    providers: [i18nProviders, BsModalRef]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormModalComponent);
+    component = fixture.componentInstance;
+    Object.assign(component, initialState);
+    fixture.detectChanges();
+    fh = new FixtureHelper(fixture);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('has the defined title', () => {
+    fh.expectTextToBe('.modal-title', 'Some title');
+  });
+
+  it('has the defined description', () => {
+    fh.expectTextToBe('.modal-body > p', 'Some description');
+  });
+
+  it('should display both inputs', () => {
+    fh.expectElementVisible('#requiredField', true);
+    fh.expectElementVisible('#optionalField', true);
+  });
+
+  it('has one defined label field', () => {
+    fh.expectTextToBe('.col-form-label', 'Optional');
+  });
+
+  it('has a predefined values for requiredField', () => {
+    fh.expectFormFieldToBe('#requiredField', 'some-value');
+  });
+
+  it('gives back all form values on submit', () => {
+    component.onSubmitForm(component.formGroup.value);
+    expect(submitted).toEqual({
+      requiredField: 'some-value',
+      optionalField: null
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import * as _ from 'lodash';
+import { BsModalRef } from 'ngx-bootstrap/modal';
+
+import { CdFormBuilder } from '../../forms/cd-form-builder';
+
+interface CdFormFieldConfig {
+  type: 'textInput';
+  name: string;
+  label?: string;
+  value?: any;
+  required?: boolean;
+}
+
+@Component({
+  selector: 'cd-form-modal',
+  templateUrl: './form-modal.component.html',
+  styleUrls: ['./form-modal.component.scss']
+})
+export class FormModalComponent implements OnInit {
+  // Input
+  titleText: string;
+  message: string;
+  fields: CdFormFieldConfig[];
+  submitButtonText: string;
+  onSubmit: Function;
+
+  // Internal
+  formGroup: FormGroup;
+
+  constructor(public bsModalRef: BsModalRef, private formBuilder: CdFormBuilder) {}
+
+  createForm() {
+    const controlsConfig = {};
+    this.fields.forEach((field) => {
+      const validators = [];
+      if (_.isBoolean(field.required) && field.required) {
+        validators.push(Validators.required);
+      }
+      controlsConfig[field.name] = new FormControl(_.defaultTo(field.value, null), { validators });
+    });
+    this.formGroup = this.formBuilder.group(controlsConfig);
+  }
+
+  ngOnInit() {
+    this.createForm();
+  }
+
+  onSubmitForm(values) {
+    this.bsModalRef.hide();
+    if (_.isFunction(this.onSubmit)) {
+      this.onSubmit(values);
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -237,6 +237,10 @@ export class FixtureHelper {
     expect(props['value'] || props['checked'].toString()).toBe(value);
   }
 
+  expectTextToBe(css: string, value: string) {
+    expect(this.getText(css)).toBe(value);
+  }
+
   clickElement(css: string) {
     this.getElementByCss(css).triggerEventHandler('click', null);
     this.fixture.detectChanges();


### PR DESCRIPTION
CephFS snapshots can now be created on a directory basis. Multiple
snapshots can be deleted at once.

Fixes: https://tracker.ceph.com/issues/41791

Signed-off-by: Volker Theile <vtheile@suse.com>
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
