### PR TITLE
qa/rgw: drop some objectstore types

### DIFF
--- a/qa/suites/rgw/multifs/objectstore
+++ b/qa/suites/rgw/multifs/objectstore
@@ -1,1 +1,1 @@
-.qa/objectstore
+.qa/objectstore_cephfs

--- a/qa/suites/rgw/singleton/objectstore
+++ b/qa/suites/rgw/singleton/objectstore
@@ -1,1 +1,1 @@
-.qa/objectstore
+.qa/objectstore_cephfs

--- a/qa/suites/rgw/thrash/objectstore
+++ b/qa/suites/rgw/thrash/objectstore
@@ -1,1 +1,1 @@
-.qa/objectstore
+.qa/objectstore_cephfs

--- a/qa/suites/rgw/verify/objectstore
+++ b/qa/suites/rgw/verify/objectstore
@@ -1,1 +1,1 @@
-.qa/objectstore
+.qa/objectstore_cephfs


### PR DESCRIPTION
use the subset of objectstore configurations from .qa/objectstore_cephfs
instead of .qa/objectstore

this reduces the size of a full rgw suite from 307 jobs to 133