### PR TITLE
librbd: fix rbd_features_to_string output

### DIFF
--- a/src/librbd/Features.cc
+++ b/src/librbd/Features.cc
@@ -34,8 +34,8 @@ std::string rbd_features_to_string(uint64_t features,
   std::string r;
   for (auto& i : RBD_FEATURE_MAP) {
     if (features & i.second) {
-      if (r.empty()) {
-	r += ",";
+      if (!r.empty()) {
+      r += ",";
       }
       r += i.first;
       features &= ~i.second;


### PR DESCRIPTION
if features = 61, it will output ",deep-flattenexclusive-lockfast-difflayeringobject-map".
I think "deep-flatten,exclusive-lock,fast-diff,layering,object-map" is suitable output.

Signed-off-by: Zheng Yin <zhengyin@cmss.chinamobile.com>

