### PR TITLE
nautilus: doc/mgr/telemetry: update default interval

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -56,10 +56,10 @@ Telemetry can be disabled with::
 Interval
 --------
 
-The module compiles and sends a new report every 72 hours by default.
+The module compiles and sends a new report every 24 hours by default.
 You can adjust this interval with::
 
-  ceph config set mgr mgr/telemetry/interval 24    # report every day
+  ceph config set mgr mgr/telemetry/interval 72    # report every three days
 
 Contact and Description
 -----------------------


### PR DESCRIPTION
Commit 712987d533 changed the default interval to 24h;
updating the docs to match (this also should go to
the Nautilus branch as that commit landed there too
in https://github.com/ceph/ceph/pull/27709)

Signed-off-by: Tim Serong <tserong@suse.com>
(cherry picked from commit 3c8793c4bd077db2796b512a3b59cd6a01cb3a8c)