### PR TITLE
mon/OSDMonitor.cc: Allow pool set target_max_(objects/bytes) with SI/IEC units

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7861,9 +7861,9 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
   cmd_getval(cct, cmdmap, "val", val);
 
   // create list of properties that use SI units
-  std::set<std::string> si_items = {};
+  std::set<std::string> si_items = {"target_max_objects"};
   // create list of properties that use IEC units
-  std::set<std::string> iec_items = {"target_size_bytes"};
+  std::set<std::string> iec_items = {"target_max_bytes", "target_size_bytes"};
 
   if (si_items.count(var)) {
     n = strict_si_cast<int64_t>(val.c_str(), &interr);


### PR DESCRIPTION
Fixes : https://tracker.ceph.com/issues/42225

Signed-off-by: Prashant D <pdhange@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
