### PR TITLE
nautilus: mgr/balancer: python3 compatibility issue

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -988,7 +988,7 @@ class Module(MgrModule):
 
         # Make sure roots don't overlap their devices.  If so, we
         # can't proceed.
-        roots = pe.target_by_root.keys()
+        roots = list(pe.target_by_root.keys())
         self.log.debug('roots %s', roots)
         visited = {}
         overlap = {}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42392

---

backport of https://github.com/ceph/ceph/pull/30987
parent tracker: https://tracker.ceph.com/issues/42370

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh