### PR TITLE
mgr/orchestrator: Fix raise_if_exception for Python 3

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -466,3 +466,17 @@ Usage:
         self._set_backend('')
         assert self._select_orchestrator() is None
         self._set_backend(old_orch)
+
+        e = self.remote('selftest', 'remote_from_orchestrator_cli_self_test', "ZeroDivisionError")
+        try:
+            orchestrator.raise_if_exception(e)
+            assert False
+        except ZeroDivisionError as e:
+            assert e.args == ('hello', 'world')
+
+        e = self.remote('selftest', 'remote_from_orchestrator_cli_self_test', "OrchestratorError")
+        try:
+            orchestrator.raise_if_exception(e)
+            assert False
+        except orchestrator.OrchestratorError as e:
+            assert e.args == ('hello', 'world')

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -444,6 +444,17 @@ class Module(MgrModule):
         else:
             raise RuntimeError("KeyError not raised")
 
+    def remote_from_orchestrator_cli_self_test(self, what):
+        import orchestrator
+        if what == 'OrchestratorError':
+            c = orchestrator.TrivialReadCompletion(result=None)
+            c.exception = orchestrator.OrchestratorError('hello', 'world')
+            return c
+        elif what == "ZeroDivisionError":
+            c = orchestrator.TrivialReadCompletion(result=None)
+            c.exception = ZeroDivisionError('hello', 'world')
+            return c
+        assert False, repr(what)
 
     def shutdown(self):
         self._workload = self.SHUTDOWN


### PR DESCRIPTION
```
➜  mgr git:(orchestrator-raise_if_exception-buildins) ipython3
Python 3.6.8 (default, Aug 20 2019, 17:12:48) 
In [1]: Exception.__module__
Out[1]: 'builtins'
```

instead of `__builtins__` in Python 2

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
