### PR TITLE
mgr/dashboard: Disable cache for static files

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -105,6 +105,8 @@ class HomeController(BaseController):
             cherrypy.response.headers['Vary'] = "{}, Accept-Language"
         else:
             cherrypy.response.headers['Vary'] = "Accept-Language"
+
+        cherrypy.response.headers['Cache-control'] = "no-cache"
         return serve_file(full_path)
 
 


### PR DESCRIPTION
Browser's caching sometimes prevents changing the language of the dashboard.
We now send a header telling the browser to never cache those files.

Fixes: https://tracker.ceph.com/issues/42376

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
