### PR TITLE
luminous: common/ceph_context: avoid unnecessary wait during service thread shutdown

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -135,6 +135,9 @@ public:
   {
     while (1) {
       Mutex::Locker l(_lock);
+      if (_exit_thread) {
+        break;
+      }
 
       if (_cct->_conf->heartbeat_interval) {
         utime_t interval(_cct->_conf->heartbeat_interval, 0);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42393

---

backport of https://github.com/ceph/ceph/pull/30947
parent tracker: https://tracker.ceph.com/issues/42332

this backport was staged using ceph-backport.sh version 15.0.0.6113
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh