### PR TITLE
krbd: retry on transient errors from udev_enumerate_scan_devices()

### DIFF
--- a/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_enumerate.yaml
+++ b/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_enumerate.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/krbd_udev_enumerate.sh

--- a/qa/workunits/rbd/krbd_udev_enumerate.sh
+++ b/qa/workunits/rbd/krbd_udev_enumerate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This is a test for https://tracker.ceph.com/issues/41036, but it also
+# triggers https://tracker.ceph.com/issues/41404 in some environments.
+
+set -ex
+
+function assert_exit_codes() {
+    declare -a pids=($@)
+
+    for pid in ${pids[@]}; do
+       wait $pid
+    done
+}
+
+function run_map() {
+    declare -a pids
+
+    for i in {1..300}; do
+        sudo rbd map img$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 301 ]]
+}
+
+function run_unmap_by_dev() {
+    declare -a pids
+
+    run_map
+    for i in {0..299}; do
+        sudo rbd unmap /dev/rbd$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 0 ]]
+}
+
+function run_unmap_by_spec() {
+    declare -a pids
+
+    run_map
+    for i in {1..300}; do
+        sudo rbd unmap img$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 0 ]]
+}
+
+# Can't test with exclusive-lock, don't bother enabling deep-flatten.
+# See https://tracker.ceph.com/issues/42492.
+for i in {1..300}; do
+    rbd create --size 1 --image-feature '' img$i
+done
+
+for i in {1..30}; do
+    echo Iteration $i
+    run_unmap_by_dev
+    run_unmap_by_spec
+done
+
+echo OK

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -814,13 +814,25 @@ static int unmap_image(struct krbd_ctx *ctx, const char *devnode,
     wholedevno = sb.st_rdev;
   }
 
-  r = devno_to_krbd_id(ctx->udev, wholedevno, &id);
-  if (r < 0) {
-    if (r == -ENOENT) {
-      cerr << "rbd: '" << devnode << "' is not an rbd device" << std::endl;
-      r = -EINVAL;
+  for (int tries = 0; ; tries++) {
+    r = devno_to_krbd_id(ctx->udev, wholedevno, &id);
+    if (r == -ENOENT && tries < 2) {
+      usleep(250 * 1000);
+    } else {
+      if (r < 0) {
+        if (r == -ENOENT) {
+          std::cerr << "rbd: '" << devnode << "' is not an rbd device"
+                    << std::endl;
+          r = -EINVAL;
+        }
+        return r;
+      }
+      if (tries) {
+        std::cerr << "rbd: udev enumerate missed a device, tries = " << tries
+                  << std::endl;
+      }
+      break;
     }
-    return r;
   }
 
   return do_unmap(ctx->udev, wholedevno, build_unmap_buf(id, options));
@@ -833,14 +845,25 @@ static int unmap_image(struct krbd_ctx *ctx, const krbd_spec& spec,
   string id;
   int r;
 
-  r = spec_to_devno_and_krbd_id(ctx->udev, spec, &devno, &id);
-  if (r < 0) {
-    if (r == -ENOENT) {
-      cerr << "rbd: " << spec << ": not a mapped image or snapshot"
-           << std::endl;
-      r = -EINVAL;
+  for (int tries = 0; ; tries++) {
+    r = spec_to_devno_and_krbd_id(ctx->udev, spec, &devno, &id);
+    if (r == -ENOENT && tries < 2) {
+      usleep(250 * 1000);
+    } else {
+      if (r < 0) {
+        if (r == -ENOENT) {
+          std::cerr << "rbd: " << spec << ": not a mapped image or snapshot"
+                    << std::endl;
+          r = -EINVAL;
+        }
+        return r;
+      }
+      if (tries) {
+        std::cerr << "rbd: udev enumerate missed a device, tries = " << tries
+                  << std::endl;
+      }
+      break;
     }
-    return r;
   }
 
   return do_unmap(ctx->udev, devno, build_unmap_buf(id, options));


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/41036