### PR TITLE
doc: improve in mount.ceph man page

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -143,6 +143,11 @@ Options
 
   - ``clean``: client reconnects to the ceph cluster automatically when it detects that it has been blacklisted. During reconnect, client drops dirty data/metadata, invalidates page caches and writable file handles.  After reconnect, file locks become stale because the MDS loses track of them. If an inode contains any stale file locks, read/write on the inode is not allowed until applications release all stale file locks.
 
+
+:command: `mds_namespace=<fs-name>`
+    Specify the non-default file system to be mounted. Not passing this option
+    mounts the default file system.
+
 Mount Secrets
 =============
 If the `secret` and `secretfile` options are not specified on the command-line
@@ -178,6 +183,10 @@ automatically invoked by mount(8) like so::
 
         mount -t ceph monhost:/ /mnt/foo
 
+If you have more than one file system on your Ceph cluster, you can mount the
+non-default FS on your local FS as follows::
+
+    mount -t ceph :/ /mnt/mycephfs2 -o name=fs,mds_namespace=mycephfs2
 
 Availability
 ============

--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 ========================================
- mount.ceph -- mount a ceph file system
+ mount.ceph -- mount a Ceph file system
 ========================================
 
 .. program:: mount.ceph
@@ -9,184 +9,206 @@
 Synopsis
 ========
 
-| **mount.ceph** [*monaddr1*\ ,\ *monaddr2*\ ,...]:/[*subdir*] *dir* [
+| **mount.ceph** [*mon1_socket*\ ,\ *mon2_socket*\ ,...]:/[*subdir*] *dir* [
   -o *options* ]
 
 
 Description
 ===========
 
-**mount.ceph** is a helper for mounting the Ceph file system on
-a Linux host. It serves to resolve monitor hostname(s) into IP
-addresses and read authentication keys from disk; the Linux kernel
-client component does most of the real work. In fact, it is possible
-to mount a non-authenticated Ceph file system without mount.ceph by
-specifying monitor address(es) by IP::
+**mount.ceph** is a helper for mounting the Ceph file system on a Linux host.
+It serves to resolve monitor hostname(s) into IP addresses and read
+authentication keys from disk; the Linux kernel client component does most of
+the real work. In fact, it is possible to mount a non-authenticated Ceph file
+system without mount.ceph by specifying monitor address(es) by IP::
 
-        mount -t ceph 1.2.3.4:/ mountpoint
+        mount -t ceph 1.2.3.4:/ /mnt/mycephfs
 
-Each monitor address monaddr takes the form host[:port]. If the port
-is not specified, the Ceph default of 6789 is assumed.
-
-Multiple monitor addresses can be separated by commas. Only one
-responsible monitor is needed to successfully mount; the client will
-learn about all monitors from any responsive monitor. However, it is a
-good idea to specify more than one in case one happens to be down at
-the time of mount.
+The first argument is the device part of the mount command. It includes host's
+socket and path within CephFS that will be mounted at the mount point. The
+socket, obviously, takes the form ip_address[:port]. If the port is not
+specified, the Ceph default of 6789 is assumed. Multiple monitor addresses can
+be passed by separating them by commas. Only one monitor is needed to mount
+successfully; the client will learn about all monitors from any responsive
+monitor. However, it is a good idea to specify more than one in case the one
+happens to be down at the time of mount.
 
 If the host portion of the device is left blank, then **mount.ceph** will
 attempt to determine monitor addresses using local configuration files
-and/or DNS SRV records.
+and/or DNS SRV records. In similar way, if authentication is enabled on Ceph
+cluster (which is done using CephX) and options ``secret`` and ``secretfile``
+are not specified in the command, the mount helper will spawn a child process
+that will use the standard Ceph library routines to find a keyring and fetch
+the secret from it.
 
-A subdirectory subdir may be specified if a subset of the file system
-is to be mounted.
+A sub-directory of the file system can be mounted by specifying the (absolute)
+path to the sub-directory right after ":" after the socket in the device part
+of the mount command.
 
-Mount helper application conventions dictate that the first two
-options are device to be mounted and destination path. Options must be
+Mount helper application conventions dictate that the first two options are
+device to be mounted and the mountpoint for that device. Options must be
 passed only after these fixed arguments.
 
 
 Options
 =======
 
-:command:`wsize`
-  int (bytes), max write size. Default: 16777216 (16*1024*1024) (writeback uses smaller of wsize
-  and stripe unit)
-
-:command:`rsize`
-  int (bytes), max read size. Default: 16777216 (16*1024*1024)
-
-:command:`rasize`
-  int (bytes), max readahead. Default: 8388608 (8192*1024)
-
-:command:`osdtimeout`
-  int (seconds), Default: 60
-
-:command:`osdkeepalive`
-  int, Default: 5
-
-:command:`mount_timeout`
-  int (seconds), Default: 60
-
-:command:`osd_idle_ttl`
-  int (seconds), Default: 60
-
-:command:`caps_wanted_delay_min`
-  int, cap release delay, Default: 5
-
-:command:`caps_wanted_delay_max`
-  int, cap release delay, Default: 60
-
-:command:`cap_release_safety`
-  int, Default: calculated
-
-:command:`readdir_max_entries`
-  int, Default: 1024
-
-:command:`readdir_max_bytes`
-  int, Default: 524288 (512*1024)
-
-:command:`write_congestion_kb`
-  int (kb), max writeback in flight. scale with available
-  memory. Default: calculated from available memory
-
-:command:`snapdirname`
-  string, set the name of the hidden snapdir. Default: .snap
-
-:command:`name`
-  RADOS user to authenticate as when using cephx. Default: guest
-
-:command:`secret`
-  secret key for use with cephx. This option is insecure because it exposes
-  the secret on the command line. To avoid this, use the secretfile option.
-
-:command:`secretfile`
-  path to file containing the secret key to use with cephx
-
-:command:`ip`
-  my ip
-
-:command:`noshare`
-  create a new client instance, instead of sharing an existing
-  instance of a client mounting the same cluster
-
-:command:`dirstat`
-  funky `cat dirname` for stats, Default: off
-
-:command:`nodirstat`
-  no funky `cat dirname` for stats
-
-:command:`rbytes`
-  Report the recursive size of the directory contents for st_size on
-  directories.  Default: off
-
-:command:`norbytes`
-  Do not report the recursive size of the directory contents for
-  st_size on directories.
-
-:command:`nocrc`
-  no data crc on writes
-
-:command:`noasyncreaddir`
-  no dcache readdir
+Basic
+-----
 
 :command:`conf`
-  Path to a ceph.conf file. This is used to initialize the ceph context
-  for autodiscovery of monitor addresses and auth secrets. The default is
-  to use the standard search path for ceph.conf files.
-
-:command:`recover_session=<no|clean>`
-  Set auto reconnect mode in the case where the client is blacklisted. The
-  available modes are ``no`` and ``clean``. The default is ``no``.
-
-  - ``no``: never attempt to reconnect when client detects that it has been blacklisted. Blacklisted clients will not attempt to reconnect and their operations will fail too.
-
-  - ``clean``: client reconnects to the ceph cluster automatically when it detects that it has been blacklisted. During reconnect, client drops dirty data/metadata, invalidates page caches and writable file handles.  After reconnect, file locks become stale because the MDS loses track of them. If an inode contains any stale file locks, read/write on the inode is not allowed until applications release all stale file locks.
-
+    Path to a ceph.conf file. This is used to initialize the Ceph context
+    for autodiscovery of monitor addresses and auth secrets. The default is
+    to use the standard search path for ceph.conf files.
 
 :command: `mds_namespace=<fs-name>`
-    Specify the non-default file system to be mounted. Not passing this option
-    mounts the default file system.
+      Specify the non-default file system to be mounted. Not passing this
+      option mounts the default file system.
 
-Mount Secrets
-=============
-If the `secret` and `secretfile` options are not specified on the command-line
-then the mount helper will spawn a child process that will use the standard
-ceph library routines to find a keyring and fetch the secret from it.
+:command:`mount_timeout`
+    int (seconds), Default: 60
+
+:command:`name`
+    RADOS user to authenticate as when using CephX. Default: guest
+
+:command:`secret`
+    secret key for use with CephX. This option is insecure because it exposes
+    the secret on the command line. To avoid this, use the secretfile option.
+
+:command:`secretfile`
+    path to file containing the secret key to use with CephX
+
+:command:`recover_session=<no|clean>`
+    Set auto reconnect mode in the case where the client is blacklisted. The
+    available modes are ``no`` and ``clean``. The default is ``no``.
+
+    - ``no``: never attempt to reconnect when client detects that it has been
+       blacklisted. Blacklisted clients will not attempt to reconnect and
+       their operations will fail too.
+
+    - ``clean``: client reconnects to the Ceph cluster automatically when it
+      detects that it has been blacklisted. During reconnect, client drops
+      dirty data/metadata, invalidates page caches and writable file handles.
+      After reconnect, file locks become stale because the MDS loses track of
+      them. If an inode contains any stale file locks, read/write on the inode
+      is not allowed until applications release all stale file locks.
+
+Advanced
+--------
+:command:`cap_release_safety`
+    int, Default: calculated
+
+:command:`caps_wanted_delay_max`
+    int, cap release delay, Default: 60
+
+:command:`caps_wanted_delay_min`
+    int, cap release delay, Default: 5
+
+:command:`dirstat`
+    funky `cat dirname` for stats, Default: off
+
+:command:`nodirstat`
+    no funky `cat dirname` for stats
+
+:command:`ip`
+    my ip
+
+:command:`noasyncreaddir`
+    no dcache readdir
+
+:command:`nocrc`
+    no data crc on writes
+
+:command:`noshare`
+    create a new client instance, instead of sharing an existing instance of
+    a client mounting the same cluster
+
+:command:`osdkeepalive`
+    int, Default: 5
+
+:command:`osdtimeout`
+    int (seconds), Default: 60
+
+:command:`osd_idle_ttl`
+    int (seconds), Default: 60
+
+:command:`rasize`
+    int (bytes), max readahead. Default: 8388608 (8192*1024)
+
+:command:`rbytes`
+    Report the recursive size of the directory contents for st_size on
+    directories.  Default: off
+
+:command:`norbytes`
+    Do not report the recursive size of the directory contents for
+    st_size on directories.
+
+:command:`readdir_max_bytes`
+    int, Default: 524288 (512*1024)
+
+:command:`readdir_max_entries`
+    int, Default: 1024
+
+:command:`rsize`
+    int (bytes), max read size. Default: 16777216 (16*1024*1024)
+
+:command:`snapdirname`
+    string, set the name of the hidden snapdir. Default: .snap
+
+:command:`write_congestion_kb`
+    int (kb), max writeback in flight. scale with available
+    memory. Default: calculated from available memory
+
+:command:`wsize`
+    int (bytes), max write size. Default: 16777216 (16*1024*1024) (writeback
+    uses smaller of wsize and stripe unit)
+
 
 Examples
 ========
 
 Mount the full file system::
 
-        mount.ceph monhost:/ /mnt/foo
+    mount.ceph :/ /mnt/mycephfs
 
-If there are multiple monitors::
+Assuming mount.ceph is installed properly, it should be automatically invoked
+by mount(8)::
 
-        mount.ceph monhost1,monhost2,monhost3:/ /mnt/foo
+    mount -t ceph :/ /mnt/mycephfs
 
-If :doc:`ceph-mon <ceph-mon>`\(8) is running on a non-standard
-port::
+Mount only part of the namespace/file system::
 
-        mount.ceph monhost1:7000,monhost2:7000,monhost3:7000:/ /mnt/foo
+    mount.ceph :/some/directory/in/cephfs /mnt/mycephfs
 
-To automatically determine the monitor addresses from local configuration::
+Mount non-default FS, in case cluster has multiple FSs::
 
-        mount.ceph :/ /mnt/foo
+    mount -t ceph :/ /mnt/mycephfs2 -o mds_namespace=mycephfs2
 
-To mount only part of the namespace::
+Pass the monitor host's IP address, optionally::
 
-        mount.ceph monhost1:/some/small/thing /mnt/thing
+    mount.ceph 192.168.0.1:/ /mnt/mycephfs
 
-Assuming mount.ceph(8) is installed properly, it should be
-automatically invoked by mount(8) like so::
+Pass the port along with IP address if it's running on a non-standard port::
 
-        mount -t ceph monhost:/ /mnt/foo
+    mount.ceph 192.168.0.1:7000:/ /mnt/mycephfs
 
-If you have more than one file system on your Ceph cluster, you can mount the
-non-default FS on your local FS as follows::
+If there are multiple monitors, passes addresses separated by a comma::
 
-    mount -t ceph :/ /mnt/mycephfs2 -o name=fs,mds_namespace=mycephfs2
+   mount.ceph 192.168.0.1,192.168.0.2,192.168.0.3:/ /mnt/mycephfs
+
+If authentication is enabled on Ceph cluster::
+
+    mount.ceph :/ /mnt/mycephfs -o name=fs_username
+
+Pass secret key for CephX user optionally::
+
+    mount.ceph :/ /mnt/mycephfs -o name=fs_username,secret=AQATSKdNGBnwLhAAnNDKnH65FmVKpXZJVasUeQ==
+
+Pass file containing secret key to avoid leaving secret key in shell's command
+history::
+
+    mount.ceph :/ /mnt/mycephfs -o name=fs_username,secretfile=/etc/ceph/fs_username.secret
+
 
 Availability
 ============
@@ -194,6 +216,7 @@ Availability
 **mount.ceph** is part of Ceph, a massively scalable, open-source, distributed storage system. Please
 refer to the Ceph documentation at http://ceph.com/docs for more
 information.
+
 
 See also
 ========


### PR DESCRIPTION
Add new examples to show how to mount with and without authentication,
mon sockets and secret keys for CephX users in mount command, don't show
monitor's IP address in every example, use real IP addresses instead of
just writing "monhost", use non-standard port number in non-standard
socket number example and keep the mount point same across all examples.

Add `mount -t ceph` example to synopsis, replace "monaddr1" by
"mon1_socket", since it doesn't necessarily have to be only IP
addresses.
    
Rearrange options alphabetically so that it's easy to find them,
increase indentation for "Options" section from 2 to 4 spaces, wrap
lines that are too long and elaborate explanation wherever necessary.

Fixes: https://tracker.ceph.com/issues/42406



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>