### PR TITLE
rgw: improvements to SSE-KMS with Vault

### DIFF
--- a/doc/radosgw/barbican.rst
+++ b/doc/radosgw/barbican.rst
@@ -39,6 +39,8 @@ Create a key in Barbican
 See Barbican documentation for `How to Create a Secret`_. Requests to
 Barbican must include a valid Keystone token in the ``X-Auth-Token`` header.
 
+.. note:: Server-side encryption keys must be 256-bit long and base64 encoded.
+
 Example request::
 
    POST /v1/secrets HTTP/1.1

--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -953,7 +953,7 @@ Barbican Settings
 HashiCorp Vault Settings
 ========================
 
-``rgw crypt vault auth```
+``rgw crypt vault auth``
 
 :Description: Type of authentication method to be used. The only method
               currently supported is ``token``.
@@ -969,7 +969,14 @@ HashiCorp Vault Settings
 
 ``rgw crypt vault addr``
 
-:Description: Base URL to the Vault server.
+:Description: Vault server base address, e.g. ``http://vaultserver:8200``.
+:Type: String
+:Default: None
+
+``rgw crypt vault prefix``
+
+:Description: The Vault secret URL prefix, which can be used to restrict access
+              to a particular subset of the secret space, e.g. ``/v1/secret/data``.
 :Type: String
 :Default: None
 

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -14,6 +14,8 @@ Object Gateway stores that data in the Ceph Storage Cluster in encrypted form.
           for SSL termination, ``rgw trust forwarded https`` must be enabled
           before forwarded requests will be trusted as secure.
 
+.. note:: Server-side encryption keys must be 256-bit long and base64 encoded.
+
 Customer-Provided Keys
 ======================
 

--- a/doc/radosgw/vault.rst
+++ b/doc/radosgw/vault.rst
@@ -5,34 +5,85 @@ HashiCorp Vault Integration
 HashiCorp `Vault`_ can be used as a secure key management service for
 `Server-Side Encryption`_ (SSE-KMS).
 
-#. `Vault authentication`_
-#. `Create a key in Vault`_
+#. `Configure Vault`_
 #. `Configure the Ceph Object Gateway`_
+#. `Create a key in Vault`_
 #. `Upload object`_
 
-Vault authentication
-====================
+Configure Vault
+===============
 
-Vault provides several authentication mechanisms. Currently, the Object Gateway
-supports the `token authentication method`_ only.
+Vault provides several Secret Engines, which can store, generate, and encrypt
+data. Currently, the Object Gateway supports the `KV Secrets engine`_ version 2
+only. To enable the KV engine version 2 in Vault, use the Vault command line
+tool::
 
-When authenticating with Vault using the token method, save the token in a
-plain-text file. The path to this file must be provided in the Gateway
-configuration file (see below). For security reasons, ensure the file is
-readable by the Object Gateway only.
+  vault secrets enable kv-v2
+
+Vault also provides several authentication mechanisms. Currently, the Object
+Gateway supports the `token authentication method`_ only. When authenticating
+using the token method, a token must be obtained for the Gateway and saved in a
+file as plain-text.
+
+For security reasons, the Object Gateway should be given a Vault token with a
+restricted policy that allows it to fetch secrets only. Such a policy can be
+created in Vault using the Vault command line utility::
+
+  vault policy write rgw-policy -<<EOF
+    path "secret/data/*" {
+      capabilities = ["read"]
+    }
+  EOF
+
+A token with the policy above can be created by a Vault administrator as
+follows::
+
+  vault token create -policy=rgw-policy
+
+Sample output::
+
+  Key                  Value
+  ---                  -----
+  token                s.72KuPujbc065OdWB71poOmIq
+  token_accessor       jv95ZYBUFv6Ss84x7SCSy6lZ
+  token_duration       768h
+  token_renewable      true
+  token_policies       ["default" "rgw-policy"]
+  identity_policies    []
+  policies             ["default" "rgw-policy"]
+
+The actual token, displayed in the output of the above command, must be saved
+in a file as plain-text. The path to this file must then be provided in the
+Gateway configuration file (see section below). For security reasons, ensure
+the file is readable by the Object Gateway only.
+
+Configure the Ceph Object Gateway
+=================================
+
+Edit the Ceph configuration file to enable Vault as a KMS for server-side
+encryption. The following example uses the ``token`` authentication method (with
+a Vault token stored in a file), sets the Vault server address, and restricts
+the URLs where encryption keys can be retrieved from Vault using a path prefix::
+
+   rgw crypt s3 kms backend = vault
+   rgw crypt vault auth = token
+   rgw crypt vault addr = http://vaultserver:8200
+   rgw crypt vault prefix = /v1/secret/data
+   rgw crypt vault token file = /etc/ceph/vault.token
+
+In this example, the Gateway will only fetch encryption keys under
+``http://vaultserver:8200/v1/secret/data``.
 
 Create a key in Vault
 =====================
 
-Generate and save a 256-bit key in Vault. Vault provides several Secret
-Engines, which store, generate, and encrypt data. Currently, the only secret
-engine supported is the `KV Secrets engine`_ version 2.
+.. note:: Server-side encryption keys must be 256-bit long and base64 encoded.
 
-To create a key in the KV version 2 engine using Vault's command line client,
+To create a key in the KV version 2 engine using Vault's command line tool,
 use the commands below::
 
   export VAULT_ADDR='http://vaultserver:8200'
-  vault kv put secret/myproject/mybucketkey key=$(dd bs=32 count=1 if=/dev/urandom of=/dev/stdout 2>/dev/null | base64)
+  vault kv put secret/myproject/mybucketkey key=$(openssl rand -base64 32)
 
 Output::
 
@@ -49,32 +100,24 @@ Output::
   ---    -----
   key    Ak5dRyLQjwX/wb7vo6Fq1qjsfk1dh2CiSicX+gLAhwk=
 
-The URL to the secret in Vault must be provided in the Gateway configuration
-file (see below).
-
-Configure the Ceph Object Gateway
-=================================
-
-Edit the Ceph configuration file to enable Vault as a KMS for server-side
-encryption::
-
-   rgw crypt s3 kms backend = vault
-   rgw crypt vault auth = token
-   rgw crypt vault addr = http://vaultserver:8200
-   rgw crypt vault token file = /path/to/token.file
-
 Upload object
 =============
 
 When uploading an object, provide the SSE key ID in the request. As an example,
 using the AWS command-line client::
 
-  aws --endpoint=http://radosgw:8000 s3 cp plaintext.txt s3://mybucket/encrypted.txt --sse=aws:kms --sse-kms-key-id /v1/secret/data/myproject/mybucketkey
+  aws --endpoint=http://radosgw:8000 s3 cp plaintext.txt s3://mybucket/encrypted.txt --sse=aws:kms --sse-kms-key-id myproject/mybucketkey
 
-The object gateway will fetch the key from Vault (using the token for
-authentication), encrypt the object and store it in the bucket. Any request to
-downlod the object will require the correct key ID for the Gateway to
-successfully the decrypt it.
+The Object Gateway will fetch the key from Vault, encrypt the object and store
+it in the bucket. Any request to downlod the object will require the correct key
+ID for the Gateway to successfully decrypt it.
+
+Note that the secret will be fetched from Vault using a URL constructed by
+concatenating the base address (``rgw crypt vault addr``), the (optional)
+URL prefix (``rgw crypt vault prefix``), and finally the key ID. In the example
+above, the Gateway will fetch the secret from::
+
+  http://vaultserver:8200/v1/secret/data/myproject/mybucketkey
 
 .. _Server-Side Encryption: ../encryption
 .. _Vault: https://www.vaultproject.io/docs/

--- a/qa/suites/rgw/crypt/2-kms/vault.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault.yaml
@@ -4,6 +4,7 @@ overrides:
       client:
         rgw crypt s3 kms backend: vault
         rgw crypt vault auth: token
+        rgw crypt vault prefix: /v1/kv/data
   rgw:
     client.0:
       use-vault-role: client.0
@@ -11,10 +12,12 @@ overrides:
 tasks:
 - vault:
     client.0:
-      version: 1.2.2
+      install_url: https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip
+      install_sha256: 7725b35d9ca8be3668abe63481f0731ca4730509419b4eb29fa0b0baa4798458
       root_token: test_root_token
+      prefix: /v1/kv/data/
       secrets:
-        - path: /v1/kv/data/my-key-1
+        - path: my-key-1
           secret: a2V5MS5GcWVxKzhzTGNLaGtzQkg5NGVpb1FKcFpGb2c=
-        - path: /v1/kv/data/my-key-2
+        - path: my-key-2
           secret: a2V5Mi5yNUNNMGFzMVdIUVZxcCt5NGVmVGlQQ1k4YWg=

--- a/qa/suites/rgw/crypt/4-tests/s3tests.yaml
+++ b/qa/suites/rgw/crypt/4-tests/s3tests.yaml
@@ -6,5 +6,5 @@ tasks:
         kms_key: my-key-1
         kms_key2: my-key-2
       vault:
-        key_path: /v1/kv/data/my-key-1
-        key_path2: /v1/kv/data/my-key-2
+        key_path: my-key-1
+        key_path2: my-key-2

--- a/qa/suites/smoke/basic/tasks/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rgw_ec_s3tests.yaml
@@ -15,5 +15,6 @@ overrides:
     conf:
       client:
         rgw lc debug interval: 10
+        rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false

--- a/qa/suites/smoke/basic/tasks/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rgw_s3tests.yaml
@@ -11,5 +11,6 @@ overrides:
     conf:
       client:
         rgw lc debug interval: 10
+        rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -136,6 +136,8 @@ def start_rgw(ctx, config, clients):
                 raise ConfigError('vault: no "root_token" specified')
             # create token on file
             ctx.cluster.only(client).run(args=['echo', '-n', ctx.vault.root_token, run.Raw('>'), token_path])
+            log.info("Restrict access to token file")
+            ctx.cluster.only(client).run(args=['chmod', '600', token_path])
             log.info("Token file content")
             ctx.cluster.only(client).run(args=['cat', token_path])
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1499,7 +1499,8 @@ OPTION(rgw_crypt_default_encryption_key, OPT_STR) // base64 encoded key for encr
 OPTION(rgw_crypt_s3_kms_backend, OPT_STR) // Where SSE-KMS encryption keys are stored
 OPTION(rgw_crypt_vault_auth, OPT_STR) // Type of authentication method to be used with Vault
 OPTION(rgw_crypt_vault_token_file, OPT_STR) // Path to the token file for Vault authentication
-OPTION(rgw_crypt_vault_addr, OPT_STR) // URL to Vault server endpoint
+OPTION(rgw_crypt_vault_addr, OPT_STR) // Vault server base address
+OPTION(rgw_crypt_vault_prefix, OPT_STR) // Optional URL prefix to Vault secret path
 
 OPTION(rgw_crypt_s3_kms_encryption_keys, OPT_STR) // extra keys that may be used for aws:kms
                                                       // defined as map "key1=YmluCmJvb3N0CmJvb3N0LQ== key2=b3V0CnNyYwpUZXN0aW5nCg=="

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6604,11 +6604,20 @@ std::vector<Option> get_rgw_options() {
 
     Option("rgw_crypt_vault_addr", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
-    .set_description("Base URL to the Vault server.")
+    .set_description("Vault server base address.")
     .add_see_also({
       "rgw_crypt_s3_kms_backend",
       "rgw_crypt_vault_auth",
-      "rgw_crypt_vault_token_file"}),
+      "rgw_crypt_vault_prefix"}),
+
+    Option("rgw_crypt_vault_prefix", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description("Vault secret URL prefix, which can be used to restrict "
+                     "access to a particular subset of the Vault secret space.")
+    .add_see_also({
+      "rgw_crypt_s3_kms_backend",
+      "rgw_crypt_vault_addr",
+      "rgw_crypt_vault_auth"}),
 
     Option("rgw_crypt_suppress_logs", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)

--- a/src/test/rgw/test_rgw_kms.cc
+++ b/src/test/rgw/test_rgw_kms.cc
@@ -30,3 +30,27 @@ TEST(TestSSEKMS, non_existent_vault_token_file)
       -ENOENT
   );
 }
+
+TEST(TestSSEKMS, concat_url)
+{
+  // Each test has 3 strings:
+  // * the base URL
+  // * the path we want to concatenate
+  // * the exepected final URL
+  std::string tests[9][3] ={
+    {"", "", ""},
+    {"", "bar", "/bar"},
+    {"", "/bar", "/bar"},
+    {"foo", "", "foo"},
+    {"foo", "bar", "foo/bar"},
+    {"foo", "/bar", "foo/bar"},
+    {"foo/", "", "foo/"},
+    {"foo/", "bar", "foo/bar"},
+    {"foo/", "/bar", "foo/bar"},
+  };
+  for (const auto &test: tests) {
+    std::string url(test[0]), path(test[1]), expected(test[2]);
+    concat_url(url, path);
+    ASSERT_EQ(url, expected);
+  }
+}

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -681,7 +681,8 @@ EOF
         ; rgw crypt s3 kms backend = vault
         ; rgw crypt vault auth = token
         ; rgw crypt vault addr = http://127.0.0.1:8200
-        ; rgw crypt vault token file = /path/to/token.file
+        ; rgw crypt vault prefix = /v1/secret/data
+        ; rgw crypt vault token file = $CEPH_CONF_PATH/vault.token
 
 $extra_conf
 EOF


### PR DESCRIPTION
This is a follow-up to address comments from the initial PR adding SSE-KMS support with Vault (https://github.com/ceph/ceph/pull/29783).

* add 'rgw crypt vault prefix' config setting to allow restricting
  secret space in Vault where RGW can retrieve keys from
* refuse Vault token file if permissions are too open
* improve concatenation of URL paths to avoid constructing an invalid
  URL (missing or double '/')
* doc: clarify SSE-KMS keys must be 256-bit long and base64 encoded,
  plus other minor doc improvements
* qa: check SHA256 signature of Vault zip download

Fixes: https://tracker.ceph.com/issues/41062

Signed-off-by: Andrea Baglioni andrea.baglioni@workday.com
Signed-off-by: Sergio de Carvalho sergio.carvalho@workday.com
