### PR TITLE
nautilus: core: kv/RocksDBStore: tell rocksdb to set mode to 0600, not 0644

### DIFF
--- a/src/common/safe_io.c
+++ b/src/common/safe_io.c
@@ -153,7 +153,8 @@ ssize_t safe_splice_exact(int fd_in, off_t *off_in, int fd_out,
 #endif
 
 int safe_write_file(const char *base, const char *file,
-		    const char *val, size_t vallen)
+		    const char *val, size_t vallen,
+		    unsigned mode)
 {
   int ret;
   char fn[PATH_MAX];
@@ -168,7 +169,7 @@ int safe_write_file(const char *base, const char *file,
 
   snprintf(fn, sizeof(fn), "%s/%s", base, file);
   snprintf(tmp, sizeof(tmp), "%s/%s.tmp", base, file);
-  fd = open(tmp, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+  fd = open(tmp, O_WRONLY|O_CREAT|O_TRUNC, mode);
   if (fd < 0) {
     ret = errno;
     return -ret;

--- a/src/common/safe_io.h
+++ b/src/common/safe_io.h
@@ -62,9 +62,10 @@ extern "C" {
    * Safe functions to read and write an entire file.
    */
   int safe_write_file(const char *base, const char *file,
-			const char *val, size_t vallen);
+		      const char *val, size_t vallen,
+		      unsigned mode);
   int safe_read_file(const char *base, const char *file,
-		       char *val, size_t vallen);
+		     char *val, size_t vallen);
 
 #ifdef __cplusplus
 }

--- a/src/crimson/os/cyan_store.cc
+++ b/src/crimson/os/cyan_store.cc
@@ -252,7 +252,7 @@ void CyanStore::write_meta(const std::string& key,
   std::string v = value;
   v += "\n";
   if (int r = safe_write_file(path.c_str(), key.c_str(),
-                              v.c_str(), v.length());
+                              v.c_str(), v.length(), 0600);
       r < 0) {
     throw std::runtime_error{fmt::format("unable to write_meta({})", key)};
   }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -382,6 +382,8 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
     opt.env = static_cast<rocksdb::Env*>(priv);
   }
 
+  opt.env->SetAllowNonOwnerAccess(false);
+
   // caches
   if (!set_cache_flag) {
     cache_size = g_conf()->rocksdb_cache_size;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -727,7 +727,8 @@ class MonitorDBStore
     string v = value;
     v += "\n";
     int r = safe_write_file(path.c_str(), key.c_str(),
-			    v.c_str(), v.length());
+			    v.c_str(), v.length(),
+			    0600);
     if (r < 0)
       return r;
     return 0;

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -129,7 +129,7 @@ int ObjectStore::write_meta(const std::string& key,
   string v = value;
   v += "\n";
   int r = safe_write_file(path.c_str(), key.c_str(),
-			  v.c_str(), v.length());
+			  v.c_str(), v.length(), 0600);
   if (r < 0)
     return r;
   return 0;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -1377,7 +1377,7 @@ int FileStore::write_superblock()
   bufferlist bl;
   encode(superblock, bl);
   return safe_write_file(basedir.c_str(), "superblock",
-      bl.c_str(), bl.length());
+			 bl.c_str(), bl.length(), 0600);
 }
 
 int FileStore::read_superblock()
@@ -1462,7 +1462,7 @@ int FileStore::write_version_stamp()
   encode(target_version, bl);
 
   return safe_write_file(basedir.c_str(), "store_version",
-      bl.c_str(), bl.length());
+			 bl.c_str(), bl.length(), 0600);
 }
 
 int FileStore::upgrade()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42200

---

backport of https://github.com/ceph/ceph/pull/30679
parent tracker: https://tracker.ceph.com/issues/42114

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh