### PR TITLE
nautilus: core: osd: rollforward may need to mark pglog dirty

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -727,7 +727,7 @@ public:
     if (log.roll_forward_to(
 	  roll_forward_to,
 	  h))
-      dirty_log = false;
+      dirty_log = true;
   }
 
   eversion_t get_can_rollback_to() const {

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -88,13 +88,19 @@ public:
     mempool::osd_pglog::list<pg_log_entry_t>::reverse_iterator
       rollback_info_trimmed_to_riter;
 
+    /*
+     * return true if we need to mark the pglog as dirty
+     */
     template <typename F>
-    void advance_can_rollback_to(eversion_t to, F &&f) {
-      if (to > can_rollback_to)
-	can_rollback_to = to;
+    bool advance_can_rollback_to(eversion_t to, F &&f) {
+      bool dirty_log = to > can_rollback_to || to > rollback_info_trimmed_to;
+      if (dirty_log) {
+	if (to > can_rollback_to)
+	  can_rollback_to = to;
 
-      if (to > rollback_info_trimmed_to)
-	rollback_info_trimmed_to = to;
+	if (to > rollback_info_trimmed_to)
+	  rollback_info_trimmed_to = to;
+      }
 
       while (rollback_info_trimmed_to_riter != log.rbegin()) {
 	--rollback_info_trimmed_to_riter;
@@ -104,6 +110,8 @@ public:
 	}
 	f(*rollback_info_trimmed_to_riter);
       }
+
+      return dirty_log;
     }
 
     void reset_rollback_info_trimmed_to_riter() {
@@ -158,8 +166,8 @@ public:
 	  h->trim(entry);
 	});
     }
-    void roll_forward_to(eversion_t to, LogEntryHandler *h) {
-      advance_can_rollback_to(
+    bool roll_forward_to(eversion_t to, LogEntryHandler *h) {
+      return advance_can_rollback_to(
 	to,
 	[&](pg_log_entry_t &entry) {
 	  h->rollforward(entry);
@@ -563,6 +571,7 @@ protected:
   bool pg_log_debug;
   /// Log is clean on [dirty_to, dirty_from)
   bool touched_log;
+  bool dirty_log;
   bool clear_divergent_priors;
   bool rebuilt_missing_with_deletes = false;
 
@@ -588,7 +597,7 @@ protected:
   }
 public:
   bool is_dirty() const {
-    return !touched_log ||
+    return !touched_log || dirty_log ||
       (dirty_to != eversion_t()) ||
       (dirty_from != eversion_t::max()) ||
       (writeout_from != eversion_t::max()) ||
@@ -634,6 +643,7 @@ protected:
     dirty_to = eversion_t();
     dirty_from = eversion_t::max();
     touched_log = true;
+    dirty_log = false;
     trimmed.clear();
     trimmed_dups.clear();
     writeout_from = eversion_t::max();
@@ -654,6 +664,7 @@ public:
     cct(cct),
     pg_log_debug(!(cct && !(cct->_conf->osd_debug_pg_log_writeout))),
     touched_log(false),
+    dirty_log(false),
     clear_divergent_priors(false)
   { }
 
@@ -713,9 +724,10 @@ public:
   void roll_forward_to(
     eversion_t roll_forward_to,
     LogEntryHandler *h) {
-    log.roll_forward_to(
-      roll_forward_to,
-      h);
+    if (log.roll_forward_to(
+	  roll_forward_to,
+	  h))
+      dirty_log = false;
   }
 
   eversion_t get_can_rollback_to() const {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40504

---

backport of https://github.com/ceph/ceph/pull/28621
parent tracker: https://tracker.ceph.com/issues/40403

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh