### PR TITLE
nautilus: core: mon/MonClient: ENXIO when sending command to down mon

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1938,11 +1938,13 @@ def task(ctx, config):
             # a bunch of scary messages unrelated to our actual run.
             firstmon = teuthology.get_first_mon(ctx, config, config['cluster'])
             (mon0_remote,) = ctx.cluster.only(firstmon).remotes.keys()
+            # try this several times, since tell to mons is lossy.
             mon0_remote.run(
                 args=[
                     'sudo',
                     'ceph',
                     '--cluster', config['cluster'],
+                    '--mon-client-directed-command-retry', '5',
                     'tell',
                     'mon.*',
                     'injectargs',

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -343,6 +343,7 @@ OPTION(mon_client_ping_timeout, OPT_DOUBLE)   // fail if we don't hear back
 OPTION(mon_client_hunt_interval_backoff, OPT_DOUBLE) // each time we reconnect to a monitor, double our timeout
 OPTION(mon_client_hunt_interval_max_multiple, OPT_DOUBLE) // up to a max of 10*default (30 seconds)
 OPTION(mon_client_max_log_entries_per_message, OPT_INT)
+OPTION(mon_client_directed_command_retry, OPT_INT)
 OPTION(client_cache_size, OPT_INT)
 OPTION(client_cache_mid, OPT_FLOAT)
 OPTION(client_use_random_mds, OPT_BOOL)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2235,6 +2235,10 @@ std::vector<Option> get_global_options() {
     .set_default(1000)
     .set_description(""),
 
+    Option("mon_client_directed_command_retry", Option::TYPE_INT, Option::LEVEL_DEV)
+    .set_default(2)
+    .set_description("Number of times to try sending a comamnd directed at a specific monitor"),
+
     Option("mon_max_pool_pg_num", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(65536)
     .set_description(""),

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1010,7 +1010,7 @@ void MonClient::_send_command(MonCommand *r)
 
   if (r->target_rank >= 0 &&
       r->target_rank != monmap.get_rank(peer)) {
-    if (r->send_attempts > 1) {
+    if (r->send_attempts > cct->_conf->mon_client_directed_command_retry) {
       _finish_command(r, -ENXIO, "mon unavailable");
       return;
     }
@@ -1029,7 +1029,7 @@ void MonClient::_send_command(MonCommand *r)
 
   if (r->target_name.length() &&
       r->target_name != monmap.get_name(peer)) {
-    if (r->send_attempts > 1) {
+    if (r->send_attempts > cct->_conf->mon_client_directed_command_retry) {
       _finish_command(r, -ENXIO, "mon unavailable");
       return;
     }

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1001,6 +1001,8 @@ int MonClient::wait_auth_rotating(double timeout)
 
 void MonClient::_send_command(MonCommand *r)
 {
+  ++r->send_attempts;
+
   entity_addr_t peer;
   if (active_con) {
     peer = active_con->get_con()->get_peer_addr();
@@ -1008,6 +1010,10 @@ void MonClient::_send_command(MonCommand *r)
 
   if (r->target_rank >= 0 &&
       r->target_rank != monmap.get_rank(peer)) {
+    if (r->send_attempts > 1) {
+      _finish_command(r, -ENXIO, "mon unavailable");
+      return;
+    }
     ldout(cct, 10) << __func__ << " " << r->tid << " " << r->cmd
 		   << " wants rank " << r->target_rank
 		   << ", reopening session"
@@ -1023,6 +1029,10 @@ void MonClient::_send_command(MonCommand *r)
 
   if (r->target_name.length() &&
       r->target_name != monmap.get_name(peer)) {
+    if (r->send_attempts > 1) {
+      _finish_command(r, -ENXIO, "mon unavailable");
+      return;
+    }
     ldout(cct, 10) << __func__ << " " << r->tid << " " << r->cmd
 		   << " wants mon " << r->target_name
 		   << ", reopening session"
@@ -1048,10 +1058,11 @@ void MonClient::_send_command(MonCommand *r)
 void MonClient::_resend_mon_commands()
 {
   // resend any requests
-  for (map<uint64_t,MonCommand*>::iterator p = mon_commands.begin();
-       p != mon_commands.end();
-       ++p) {
-    _send_command(p->second);
+  map<uint64_t,MonCommand*>::iterator p = mon_commands.begin();
+  while (p != mon_commands.end()) {
+    auto cmd = p->second;
+    ++p;
+    _send_command(cmd); // might remove cmd from mon_commands
   }
 }
 

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1115,6 +1115,7 @@ void MonClient::start_mon_command(const vector<string>& cmd,
 				 bufferlist *outbl, string *outs,
 				 Context *onfinish)
 {
+  ldout(cct,10) << __func__ << " cmd=" << cmd << dendl;
   std::lock_guard l(monc_lock);
   if (!initialized || stopping) {
     if (onfinish) {
@@ -1152,6 +1153,7 @@ void MonClient::start_mon_command(const string &mon_name,
 				 bufferlist *outbl, string *outs,
 				 Context *onfinish)
 {
+  ldout(cct,10) << __func__ << " mon." << mon_name << " cmd=" << cmd << dendl;
   std::lock_guard l(monc_lock);
   if (!initialized || stopping) {
     if (onfinish) {
@@ -1176,6 +1178,7 @@ void MonClient::start_mon_command(int rank,
 				 bufferlist *outbl, string *outs,
 				 Context *onfinish)
 {
+  ldout(cct,10) << __func__ << " rank " << rank << " cmd=" << cmd << dendl;
   std::lock_guard l(monc_lock);
   if (!initialized || stopping) {
     if (onfinish) {

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1117,7 +1117,9 @@ void MonClient::start_mon_command(const vector<string>& cmd,
 {
   std::lock_guard l(monc_lock);
   if (!initialized || stopping) {
-    onfinish->complete(-ECANCELED);
+    if (onfinish) {
+      onfinish->complete(-ECANCELED);
+    }
     return;
   }
   MonCommand *r = new MonCommand(++last_mon_command_tid);
@@ -1152,7 +1154,9 @@ void MonClient::start_mon_command(const string &mon_name,
 {
   std::lock_guard l(monc_lock);
   if (!initialized || stopping) {
-    onfinish->complete(-ECANCELED);
+    if (onfinish) {
+      onfinish->complete(-ECANCELED);
+    }
     return;
   }
   MonCommand *r = new MonCommand(++last_mon_command_tid);
@@ -1174,7 +1178,9 @@ void MonClient::start_mon_command(int rank,
 {
   std::lock_guard l(monc_lock);
   if (!initialized || stopping) {
-    onfinish->complete(-ECANCELED);
+    if (onfinish) {
+      onfinish->complete(-ECANCELED);
+    }
     return;
   }
   MonCommand *r = new MonCommand(++last_mon_command_tid);

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -499,6 +499,7 @@ private:
   struct MonCommand {
     string target_name;
     int target_rank;
+    unsigned send_attempts = 0;
     uint64_t tid;
     vector<string> cmd;
     bufferlist inbl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41548

---

backport of https://github.com/ceph/ceph/pull/29090
parent tracker: https://tracker.ceph.com/issues/40792

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh