### PR TITLE
nautilus: core: mon/Monitor.cc: fix condition that checks for unrecognized auth mode

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6227,7 +6227,7 @@ int Monitor::handle_auth_request(
     }
     dout(10) << __func__ << " bad authorizer on " << con << dendl;
     return -EACCES;
-  } else if (auth_meta->auth_mode < AUTH_MODE_MON &&
+  } else if (auth_meta->auth_mode < AUTH_MODE_MON ||
 	     auth_meta->auth_mode > AUTH_MODE_MON_MAX) {
     derr << __func__ << " unrecognized auth mode " << auth_meta->auth_mode
 	 << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41705

---

backport of https://github.com/ceph/ceph/pull/30015
parent tracker: https://tracker.ceph.com/issues/41429

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh