### PR TITLE
nautilus: mgr: fix weird health-alert daemon key

### DIFF
--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -11,6 +11,23 @@ ostream& operator<<(ostream& os,
   return os << daemon.first << "." << daemon.second;
 }
 
+// define operator<<(ostream&, const vector<DaemonKey>&) after
+// ostream& operator<<(ostream&, const DaemonKey&), so that C++'s
+// ADL can use the former instead of using the generic one:
+// operator<<(ostream&, const std::pair<A,B>&)
+ostream& operator<<(
+   ostream& os,
+   const vector<DaemonHealthMetricCollector::DaemonKey>& daemons)
+{
+  os << "[";
+  for (auto d = daemons.begin(); d != daemons.end(); ++d) {
+    if (d != daemons.begin()) os << ",";
+    os << *d;
+  }
+  os << "]";
+  return os;
+}
+
 namespace {
 
 class SlowOps final : public DaemonHealthMetricCollector {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42125

---

backport of https://github.com/ceph/ceph/pull/30617
parent tracker: https://tracker.ceph.com/issues/42079

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh