### PR TITLE
nautilus: tests: add debugging failed osd-release setting

### DIFF
--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
@@ -46,6 +46,8 @@ tasks:
     - ceph config rm global mon_warn_on_msgr2_not_enabled
 - exec:
     mon.a:
+    - ceph osd dump -f json-pretty
+    - ceph versions
     - ceph osd require-osd-release nautilus
     #- ceph osd set-require-min-compat-client nautilus
 - ceph.healthy:

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
@@ -1,8 +1,20 @@
 overrides:
   ceph:
+    mon_bind_msgr2: false
+    mon_bind_addrvec: false
+    log-whitelist:
+    - scrub mismatch
+    - ScrubResult
+    - wrongly marked
+    - \(POOL_APP_NOT_ENABLED\)
+    - \(SLOW_OPS\)
+    - overall HEALTH_
+    - \(MON_MSGR2_NOT_ENABLED\)
     conf:
       global:
         bluestore warn on legacy statfs: false
+      mon:
+        mon warn on osd down out interval zero: false
 
 tasks:
 - mds_pre_upgrade:
@@ -11,8 +23,30 @@ tasks:
     mon.a:
     mon.b:
 - print: "**** done install.upgrade both hosts"
+- ceph.restart:
+    daemons: [mon.*, mgr.*]
+    mon-health-to-clog: false
+    wait-for-healthy: false
+- exec:
+    mon.a:
+      - ceph config set global mon_warn_on_msgr2_not_enabled false
+- ceph.healthy:
+- ceph.restart:
+    daemons: [osd.*]
+    wait-for-healthy: false
+    wait-for-osds-up: true
 - ceph.stop: [mds.*]
 - ceph.restart:
-    daemons: [mon.*, mgr.*, osd.*, mds.*]
-    mon-health-to-clog: false
+    daemons: [mds.*]
+    wait-for-healthy: false
+    wait-for-osds-up: true
+- exec:
+    mon.a:
+    - ceph mon enable-msgr2
+    - ceph config rm global mon_warn_on_msgr2_not_enabled
+- exec:
+    mon.a:
+    - ceph osd require-osd-release nautilus
+    #- ceph osd set-require-min-compat-client nautilus
+- ceph.healthy:
 - print: "**** done ceph.restart"

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
@@ -46,6 +46,8 @@ tasks:
     - ceph config rm global mon_warn_on_msgr2_not_enabled
 - exec:
     mon.a:
+    - ceph osd dump -f json-pretty
+    - ceph versions
     - ceph osd require-osd-release nautilus
     #- ceph osd set-require-min-compat-client nautilus
 - ceph.healthy:

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
@@ -1,8 +1,20 @@
 overrides:
   ceph:
+    mon_bind_msgr2: false
+    mon_bind_addrvec: false
+    log-whitelist:
+    - scrub mismatch
+    - ScrubResult
+    - wrongly marked
+    - \(POOL_APP_NOT_ENABLED\)
+    - \(SLOW_OPS\)
+    - overall HEALTH_
+    - \(MON_MSGR2_NOT_ENABLED\)
     conf:
       global:
         bluestore warn on legacy statfs: false
+      mon:
+        mon warn on osd down out interval zero: false
 
 tasks:
 - mds_pre_upgrade:
@@ -11,8 +23,30 @@ tasks:
     mon.a:
     mon.b:
 - print: "**** done install.upgrade both hosts"
+- ceph.restart:
+    daemons: [mon.*, mgr.*]
+    mon-health-to-clog: false
+    wait-for-healthy: false
+- exec:
+    mon.a:
+      - ceph config set global mon_warn_on_msgr2_not_enabled false
+- ceph.healthy:
+- ceph.restart:
+    daemons: [osd.*]
+    wait-for-healthy: false
+    wait-for-osds-up: true
 - ceph.stop: [mds.*]
 - ceph.restart:
-    daemons: [mon.*, mgr.*, osd.*, mds.*]
-    mon-health-to-clog: false
+    daemons: [mds.*]
+    wait-for-healthy: false
+    wait-for-osds-up: true
+- exec:
+    mon.a:
+    - ceph mon enable-msgr2
+    - ceph config rm global mon_warn_on_msgr2_not_enabled
+- exec:
+    mon.a:
+    - ceph osd require-osd-release nautilus
+    #- ceph osd set-require-min-compat-client nautilus
+- ceph.healthy:
 - print: "**** done ceph.restart"

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1625,14 +1625,10 @@ def restart(ctx, config):
             ctx.daemons.get_daemon(type_, id_, cluster).restart()
             clusters.add(cluster)
     
-    for cluster in clusters:
-        manager = ctx.managers[cluster]
-        for dmon in daemons:
-            if '.' in dmon:
-                dm_parts = dmon.split('.')
-                if dm_parts[1].isdigit():
-                    if dm_parts[0] == 'osd':
-                        manager.mark_down_osd(int(dm_parts[1]))
+    for role in daemons:
+        cluster, type_, id_ = teuthology.split_role(role)
+        if type_ == 'osd':
+            ctx.managers[cluster].mark_down_osd(id_)
 
     if config.get('wait-for-healthy', True):
         for cluster in clusters:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41495

---

backport of https://github.com/ceph/ceph/pull/29715
parent tracker: https://tracker.ceph.com/issues/40773

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh