### PR TITLE
librados,test,rgw: cleanups to deprecate safe_cb related functions

### DIFF
--- a/examples/librados/hello_world_c.c
+++ b/examples/librados/hello_world_c.c
@@ -146,7 +146,7 @@ int main(int argc, const char **argv)
     }
     // allocate the completion from librados
     rados_completion_t read_completion;
-    ret = rados_aio_create_completion(NULL, NULL, NULL, &read_completion);
+    ret = rados_aio_create_completion2(NULL, NULL, &read_completion);
     if (ret < 0) {
       printf("couldn't create completion! error %d\n", ret);
       ret = EXIT_FAILURE;

--- a/src/cls/journal/cls_journal_client.cc
+++ b/src/cls/journal/cls_journal_client.cc
@@ -50,7 +50,7 @@ struct C_ClientList : public C_AioExec {
 
     outbl.clear();
     librados::AioCompletion *rados_completion =
-       librados::Rados::aio_create_completion(this, rados_callback, NULL);
+       librados::Rados::aio_create_completion(this, rados_callback);
     int r = ioctx.aio_operate(oid, rados_completion, &op, &outbl);
     ceph_assert(r == 0);
     rados_completion->release();
@@ -111,7 +111,7 @@ struct C_ImmutableMetadata : public C_AioExec {
     op.exec("journal", "get_pool_id", inbl);
 
     librados::AioCompletion *rados_completion =
-      librados::Rados::aio_create_completion(this, rados_callback, NULL);
+      librados::Rados::aio_create_completion(this, rados_callback);
     int r = ioctx.aio_operate(oid, rados_completion, &op, &outbl);
     ceph_assert(r == 0);
     rados_completion->release();
@@ -151,7 +151,7 @@ struct C_MutableMetadata : public C_AioExec {
     op.exec("journal", "get_active_set", inbl);
 
     librados::AioCompletion *rados_completion =
-      librados::Rados::aio_create_completion(this, rados_callback, NULL);
+      librados::Rados::aio_create_completion(this, rados_callback);
     int r = ioctx.aio_operate(oid, rados_completion, &op, &outbl);
     ceph_assert(r == 0);
     rados_completion->release();

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -636,7 +636,7 @@ int cls_rgw_get_dir_header_async(IoCtx& io_ctx, string& oid, RGWGetDirHeader_CB 
   ObjectReadOperation op;
   GetDirHeaderCompletion *cb = new GetDirHeaderCompletion(ctx);
   op.exec(RGW_CLASS, RGW_BUCKET_LIST, in, cb);
-  AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+  AioCompletion *c = librados::Rados::aio_create_completion(nullptr, nullptr);
   int r = io_ctx.aio_operate(oid, c, &op, NULL);
   c->release();
   if (r < 0)

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -99,7 +99,7 @@ public:
   bool aio_operate(librados::IoCtx& io_ctx, const string& oid, librados::ObjectReadOperation *op) {
     std::lock_guard l{lock};
     BucketIndexAioArg *arg = new BucketIndexAioArg(get_next(), this);
-    librados::AioCompletion *c = librados::Rados::aio_create_completion((void*)arg, NULL, bucket_index_op_completion_cb);
+    librados::AioCompletion *c = librados::Rados::aio_create_completion((void*)arg, bucket_index_op_completion_cb);
     int r = io_ctx.aio_operate(oid, c, (librados::ObjectReadOperation*)op, NULL);
     if (r >= 0) {
       add_pending(arg->id, c, oid);
@@ -115,7 +115,7 @@ public:
   bool aio_operate(librados::IoCtx& io_ctx, const string& oid, librados::ObjectWriteOperation *op) {
     std::lock_guard l{lock};
     BucketIndexAioArg *arg = new BucketIndexAioArg(get_next(), this);
-    librados::AioCompletion *c = librados::Rados::aio_create_completion((void*)arg, NULL, bucket_index_op_completion_cb);
+    librados::AioCompletion *c = librados::Rados::aio_create_completion((void*)arg, bucket_index_op_completion_cb);
     int r = io_ctx.aio_operate(oid, c, (librados::ObjectWriteOperation*)op);
     if (r >= 0) {
       add_pending(arg->id, c, oid);

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1857,7 +1857,7 @@ typedef void (*rados_callback_t)(rados_completion_t cb, void *arg);
  *
  * @param cb_arg application-defined data passed to the callback functions
  * @param cb_complete the function to be called when the operation is
- * in memory on all relpicas
+ * in memory on all replicas
  * @param cb_safe the function to be called when the operation is on
  * stable storage on all replicas
  * @param pc where to store the completion
@@ -1867,6 +1867,23 @@ CEPH_RADOS_API int rados_aio_create_completion(void *cb_arg,
                                                rados_callback_t cb_complete,
                                                rados_callback_t cb_safe,
 				               rados_completion_t *pc);
+
+/**
+ * Constructs a completion to use with asynchronous operations
+ *
+ * The complete callback corresponds to operation being acked.
+ *
+ * @note BUG: this should check for ENOMEM instead of throwing an exception
+ *
+ * @param cb_arg application-defined data passed to the callback functions
+ * @param cb_complete the function to be called when the operation is committed
+ * on all replicas
+ * @param pc where to store the completion
+ * @returns 0
+ */
+CEPH_RADOS_API int rados_aio_create_completion2(void *cb_arg,
+						rados_callback_t cb_complete,
+						rados_completion_t *pc);
 
 /**
  * Block until an operation completes

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1890,7 +1890,8 @@ CEPH_RADOS_API int rados_aio_wait_for_complete(rados_completion_t c);
  * @param c operation to wait for
  * @returns 0
  */
-CEPH_RADOS_API int rados_aio_wait_for_safe(rados_completion_t c);
+CEPH_RADOS_API int rados_aio_wait_for_safe(rados_completion_t c)
+  __attribute__((deprecated));
 
 /**
  * Has an asynchronous operation completed?
@@ -1936,7 +1937,8 @@ CEPH_RADOS_API int rados_aio_wait_for_complete_and_cb(rados_completion_t c);
  * @param c operation to wait for
  * @returns 0
  */
-CEPH_RADOS_API int rados_aio_wait_for_safe_and_cb(rados_completion_t c);
+CEPH_RADOS_API int rados_aio_wait_for_safe_and_cb(rados_completion_t c)
+  __attribute__((deprecated));
 
 /**
  * Has an asynchronous operation and callback completed

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -192,15 +192,16 @@ inline namespace v14_2_0 {
   struct CEPH_RADOS_API AioCompletion {
     AioCompletion(AioCompletionImpl *pc_) : pc(pc_) {}
     int set_complete_callback(void *cb_arg, callback_t cb);
-    int set_safe_callback(void *cb_arg, callback_t cb);
+    int set_safe_callback(void *cb_arg, callback_t cb)
+      __attribute__ ((deprecated));
     int wait_for_complete();
-    int wait_for_safe();
+    int wait_for_safe() __attribute__ ((deprecated));
     int wait_for_complete_and_cb();
-    int wait_for_safe_and_cb();
+    int wait_for_safe_and_cb() __attribute__ ((deprecated));
     bool is_complete();
-    bool is_safe();
+    bool is_safe() __attribute__ ((deprecated));
     bool is_complete_and_cb();
-    bool is_safe_and_cb();
+    bool is_safe_and_cb() __attribute__ ((deprecated));
     int get_return_value();
     int get_version() __attribute__ ((deprecated));
     uint64_t get_version64();

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1476,7 +1476,9 @@ inline namespace v14_2_0 {
    // -- aio --
     static AioCompletion *aio_create_completion();
     static AioCompletion *aio_create_completion(void *cb_arg, callback_t cb_complete,
-						callback_t cb_safe);
+						callback_t cb_safe)
+      __attribute__ ((deprecated));
+    static AioCompletion *aio_create_completion(void *cb_arg, callback_t cb_complete);
     
     friend std::ostream& operator<<(std::ostream &oss, const Rados& r);
   private:

--- a/src/include/radosstriper/libradosstriper.hpp
+++ b/src/include/radosstriper/libradosstriper.hpp
@@ -22,15 +22,15 @@ namespace libradosstriper
     MultiAioCompletion(MultiAioCompletionImpl *pc_) : pc(pc_) {}
     ~MultiAioCompletion();
     int set_complete_callback(void *cb_arg, librados::callback_t cb);
-    int set_safe_callback(void *cb_arg, librados::callback_t cb);
+    int set_safe_callback(void *cb_arg, librados::callback_t cb) __attribute__ ((deprecated));
     void wait_for_complete();
-    void wait_for_safe();
+    void wait_for_safe() __attribute__ ((deprecated));
     void wait_for_complete_and_cb();
-    void wait_for_safe_and_cb();
+    void wait_for_safe_and_cb() __attribute__ ((deprecated));
     bool is_complete();
-    bool is_safe();
+    bool is_safe() __attribute__ ((deprecated));
     bool is_complete_and_cb();
-    bool is_safe_and_cb();
+    bool is_safe_and_cb() __attribute__ ((deprecated));
     int get_return_value();
     void release();
     MultiAioCompletionImpl *pc;

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -52,7 +52,7 @@ struct C_GetClient : public Context {
     client::get_client_start(&op, client_id);
 
     librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      this, nullptr, &utils::rados_state_callback<
+      this, &utils::rados_state_callback<
         C_GetClient, &C_GetClient::handle_get_client>);
 
     int r = ioctx.aio_operate(oid, comp, &op, &out_bl);
@@ -110,7 +110,7 @@ struct C_AllocateTag : public Context {
     client::get_next_tag_tid_start(&op);
 
     librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      this, nullptr, &utils::rados_state_callback<
+      this, &utils::rados_state_callback<
         C_AllocateTag, &C_AllocateTag::handle_get_next_tag_tid>);
 
     out_bl.clear();
@@ -140,7 +140,7 @@ struct C_AllocateTag : public Context {
     client::tag_create(&op, tag->tid, tag_class, tag->data);
 
     librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      this, nullptr, &utils::rados_state_callback<
+      this, &utils::rados_state_callback<
         C_AllocateTag, &C_AllocateTag::handle_tag_create>);
 
     int r = ioctx.aio_operate(oid, comp, &op);
@@ -169,7 +169,7 @@ struct C_AllocateTag : public Context {
     client::get_tag_start(&op, tag->tid);
 
     librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      this, nullptr, &utils::rados_state_callback<
+      this, &utils::rados_state_callback<
         C_AllocateTag, &C_AllocateTag::handle_get_tag>);
 
     out_bl.clear();
@@ -229,7 +229,7 @@ struct C_GetTag : public Context {
     client::get_tag_start(&op, tag_tid);
 
     librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      this, nullptr, &utils::rados_state_callback<
+      this, &utils::rados_state_callback<
         C_GetTag, &C_GetTag::handle_get_tag>);
 
     int r = ioctx.aio_operate(oid, comp, &op, &out_bl);
@@ -289,7 +289,7 @@ struct C_GetTags : public Context {
                            tag_class);
 
     librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      this, nullptr, &utils::rados_state_callback<
+      this, &utils::rados_state_callback<
         C_GetTags, &C_GetTags::handle_tag_list>);
 
     out_bl.clear();
@@ -368,7 +368,7 @@ struct C_AssertActiveTag : public Context {
     client::tag_list_start(&op, tag_tid, 2, client_id, boost::none);
 
     librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      this, nullptr, &utils::rados_state_callback<
+      this, &utils::rados_state_callback<
         C_AssertActiveTag, &C_AssertActiveTag::handle_send>);
 
     int r = ioctx.aio_operate(oid, comp, &op, &out_bl);
@@ -444,7 +444,7 @@ void JournalMetadata::init(Context *on_finish) {
     });
 
   librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-    on_finish, nullptr, utils::rados_ctx_callback);
+    on_finish, utils::rados_ctx_callback);
   int r = m_ioctx.aio_watch(m_oid, comp, &m_watch_handle, &m_watch_ctx);
   ceph_assert(r == 0);
   comp->release();
@@ -472,7 +472,7 @@ void JournalMetadata::shut_down(Context *on_finish) {
       ldout(m_cct, 20) << "shut_down: flushing watch" << dendl;
       librados::Rados rados(m_ioctx);
       librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-        on_finish, nullptr, utils::rados_ctx_callback);
+        on_finish, utils::rados_ctx_callback);
       r = rados.aio_watch_flush(comp);
       ceph_assert(r == 0);
       comp->release();
@@ -482,7 +482,7 @@ void JournalMetadata::shut_down(Context *on_finish) {
     });
   if (watch_handle != 0) {
     librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-      on_finish, nullptr, utils::rados_ctx_callback);
+      on_finish, utils::rados_ctx_callback);
     int r = m_ioctx.aio_unwatch(watch_handle, comp);
     ceph_assert(r == 0);
     comp->release();
@@ -516,7 +516,7 @@ void JournalMetadata::register_client(const bufferlist &data,
   C_NotifyUpdate *ctx = new C_NotifyUpdate(this, on_finish);
 
   librados::AioCompletion *comp =
-    librados::Rados::aio_create_completion(ctx, NULL,
+    librados::Rados::aio_create_completion(ctx, 
                                            utils::rados_ctx_callback);
   int r = m_ioctx.aio_operate(m_oid, comp, &op);
   ceph_assert(r == 0);
@@ -532,8 +532,7 @@ void JournalMetadata::update_client(const bufferlist &data,
   C_NotifyUpdate *ctx = new C_NotifyUpdate(this, on_finish);
 
   librados::AioCompletion *comp =
-    librados::Rados::aio_create_completion(ctx, NULL,
-                                           utils::rados_ctx_callback);
+    librados::Rados::aio_create_completion(ctx, utils::rados_ctx_callback);
   int r = m_ioctx.aio_operate(m_oid, comp, &op);
   ceph_assert(r == 0);
   comp->release();
@@ -549,8 +548,7 @@ void JournalMetadata::unregister_client(Context *on_finish) {
   C_NotifyUpdate *ctx = new C_NotifyUpdate(this, on_finish);
 
   librados::AioCompletion *comp =
-    librados::Rados::aio_create_completion(ctx, NULL,
-                                           utils::rados_ctx_callback);
+    librados::Rados::aio_create_completion(ctx, utils::rados_ctx_callback);
   int r = m_ioctx.aio_operate(m_oid, comp, &op);
   ceph_assert(r == 0);
   comp->release();
@@ -618,8 +616,7 @@ void JournalMetadata::set_minimum_set(uint64_t object_set) {
 
   C_NotifyUpdate *ctx = new C_NotifyUpdate(this);
   librados::AioCompletion *comp =
-    librados::Rados::aio_create_completion(ctx, NULL,
-                                           utils::rados_ctx_callback);
+    librados::Rados::aio_create_completion(ctx, utils::rados_ctx_callback);
   int r = m_ioctx.aio_operate(m_oid, comp, &op);
   ceph_assert(r == 0);
   comp->release();
@@ -648,8 +645,7 @@ void JournalMetadata::set_active_set(uint64_t object_set, Context *on_finish) {
 
   C_NotifyUpdate *ctx = new C_NotifyUpdate(this, on_finish);
   librados::AioCompletion *comp =
-    librados::Rados::aio_create_completion(ctx, NULL,
-                                           utils::rados_ctx_callback);
+    librados::Rados::aio_create_completion(ctx, utils::rados_ctx_callback);
   int r = m_ioctx.aio_operate(m_oid, comp, &op);
   ceph_assert(r == 0);
   comp->release();
@@ -865,8 +861,7 @@ void JournalMetadata::handle_commit_position_task() {
   librados::ObjectWriteOperation op;
   client::client_commit(&op, m_client_id, m_commit_position);
 
-  auto comp = librados::Rados::aio_create_completion(ctx, nullptr,
-                                                     utils::rados_ctx_callback);
+  auto comp = librados::Rados::aio_create_completion(ctx,                                                     utils::rados_ctx_callback);
   int r = m_ioctx.aio_operate(m_oid, comp, &op);
   ceph_assert(r == 0);
   comp->release();
@@ -1068,8 +1063,7 @@ void JournalMetadata::async_notify_update(Context *on_safe) {
 
   C_AioNotify *ctx = new C_AioNotify(this, on_safe);
   librados::AioCompletion *comp =
-    librados::Rados::aio_create_completion(ctx, NULL,
-                                           utils::rados_ctx_callback);
+    librados::Rados::aio_create_completion(ctx, utils::rados_ctx_callback);
 
   bufferlist bl;
   int r = m_ioctx.aio_notify(m_oid, comp, bl, 5000, NULL);
@@ -1124,7 +1118,7 @@ void JournalMetadata::schedule_laggy_clients_disconnect(Context *on_finish) {
               &op, client_id, cls::journal::CLIENT_STATE_DISCONNECTED);
 
             auto comp = librados::Rados::aio_create_completion(
-              ctx, nullptr, utils::rados_ctx_callback);
+              ctx, utils::rados_ctx_callback);
             int r = m_ioctx.aio_operate(m_oid, comp, &op);
             ceph_assert(r == 0);
             comp->release();

--- a/src/journal/Journaler.cc
+++ b/src/journal/Journaler.cc
@@ -128,7 +128,7 @@ void Journaler::exists(Context *on_finish) const {
   op.stat(nullptr, nullptr, nullptr);
 
   librados::AioCompletion *comp =
-    librados::Rados::aio_create_completion(on_finish, nullptr, rados_ctx_callback);
+    librados::Rados::aio_create_completion(on_finish, rados_ctx_callback);
   int r = m_header_ioctx.aio_operate(m_header_oid, comp, &op, nullptr);
   ceph_assert(r == 0);
   comp->release();
@@ -228,7 +228,7 @@ void Journaler::create(uint8_t order, uint8_t splay_width,
   client::create(&op, order, splay_width, pool_id);
 
   librados::AioCompletion *comp =
-    librados::Rados::aio_create_completion(on_finish, nullptr, rados_ctx_callback);
+    librados::Rados::aio_create_completion(on_finish, rados_ctx_callback);
   int r = m_header_ioctx.aio_operate(m_header_oid, comp, &op);
   ceph_assert(r == 0);
   comp->release();
@@ -238,7 +238,7 @@ void Journaler::remove(bool force, Context *on_finish) {
   // chain journal removal (reverse order)
   on_finish = new LambdaContext([this, on_finish](int r) {
       librados::AioCompletion *comp = librados::Rados::aio_create_completion(
-        on_finish, nullptr, utils::rados_ctx_callback);
+        on_finish, utils::rados_ctx_callback);
       r = m_header_ioctx.aio_remove(m_header_oid, comp);
       ceph_assert(r == 0);
       comp->release();

--- a/src/librados/librados_asio.h
+++ b/src/librados/librados_asio.h
@@ -85,7 +85,7 @@ struct AsyncOp : Invoker<Result> {
   static auto create(const Executor1& ex1, CompletionHandler&& handler) {
     auto p = Completion::create(ex1, std::move(handler));
     p->user_data.aio_completion.reset(
-        Rados::aio_create_completion(p.get(), nullptr, aio_dispatch));
+        Rados::aio_create_completion(p.get(), aio_dispatch));
     return p;
   }
 };

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -2266,7 +2266,7 @@ LIBRADOS_C_API_BASE_DEFAULT(rados_aio_wait_for_complete);
 extern "C" int _rados_aio_wait_for_safe(rados_completion_t c)
 {
   tracepoint(librados, rados_aio_wait_for_safe_enter, c);
-  int retval = ((librados::AioCompletionImpl*)c)->wait_for_safe();
+  int retval = ((librados::AioCompletionImpl*)c)->wait_for_complete();
   tracepoint(librados, rados_aio_wait_for_safe_exit, retval);
   return retval;
 }

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -2240,6 +2240,20 @@ extern "C" int _rados_aio_create_completion(void *cb_arg,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_aio_create_completion);
 
+extern "C" int _rados_aio_create_completion2(void *cb_arg,
+					     rados_callback_t cb_complete,
+					     rados_completion_t *pc)
+{
+  tracepoint(librados, rados_aio_create_completion2_enter, cb_arg, cb_complete);
+  librados::AioCompletionImpl *c = new librados::AioCompletionImpl;
+  if (cb_complete)
+    c->set_complete_callback(cb_arg, cb_complete);
+  *pc = c;
+  tracepoint(librados, rados_aio_create_completion2_exit, 0, *pc);
+  return 0;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_aio_create_completion2);
+
 extern "C" int _rados_aio_wait_for_complete(rados_completion_t c)
 {
   tracepoint(librados, rados_aio_wait_for_complete_enter, c);

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2798,6 +2798,15 @@ librados::AioCompletion *librados::Rados::aio_create_completion(void *cb_arg,
   return new AioCompletion(c);
 }
 
+librados::AioCompletion *librados::Rados::aio_create_completion(void *cb_arg,
+								callback_t cb_complete)
+{
+  AioCompletionImpl *c;
+  int r = rados_aio_create_completion(cb_arg, cb_complete, (void**)&c);
+  ceph_assert(r == 0);
+  return new AioCompletion(c);
+}
+
 librados::ObjectOperation::ObjectOperation() : impl(new ObjectOperationImpl) {}
 
 librados::ObjectOperation::ObjectOperation(ObjectOperation&& rhs)

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1014,7 +1014,7 @@ int librados::AioCompletion::AioCompletion::wait_for_complete()
 int librados::AioCompletion::AioCompletion::wait_for_safe()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
-  return c->wait_for_safe();
+  return c->wait_for_complete();
 }
 
 bool librados::AioCompletion::AioCompletion::is_complete()

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2802,7 +2802,7 @@ librados::AioCompletion *librados::Rados::aio_create_completion(void *cb_arg,
 								callback_t cb_complete)
 {
   AioCompletionImpl *c;
-  int r = rados_aio_create_completion(cb_arg, cb_complete, (void**)&c);
+  int r = rados_aio_create_completion2(cb_arg, cb_complete, (void**)&c);
   ceph_assert(r == 0);
   return new AioCompletion(c);
 }

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -131,19 +131,19 @@ librados::AioCompletion *create_rados_callback(Context *on_finish);
 template <typename T>
 librados::AioCompletion *create_rados_callback(T *obj) {
   return librados::Rados::aio_create_completion(
-    obj, &detail::rados_callback<T>, nullptr);
+    obj, &detail::rados_callback<T>);
 }
 
 template <typename T, void(T::*MF)(int)>
 librados::AioCompletion *create_rados_callback(T *obj) {
   return librados::Rados::aio_create_completion(
-    obj, &detail::rados_callback<T, MF>, nullptr);
+    obj, &detail::rados_callback<T, MF>);
 }
 
 template <typename T, Context*(T::*MF)(int*), bool destroy=true>
 librados::AioCompletion *create_rados_callback(T *obj) {
   return librados::Rados::aio_create_completion(
-    obj, &detail::rados_state_callback<T, MF, destroy>, nullptr);
+    obj, &detail::rados_state_callback<T, MF, destroy>);
 }
 
 template <typename T, void(T::*MF)(int) = &T::complete>

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -31,7 +31,7 @@ struct state {
 
   state(Aio* aio, AioResult& r)
     : aio(aio),
-      c(librados::Rados::aio_create_completion(&r, nullptr, &cb)) {}
+      c(librados::Rados::aio_create_completion(&r, &cb)) {}
 };
 
 void cb(librados::completion_t, void* arg) {

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -409,7 +409,7 @@ static int rgw_remove_bucket(RGWRadosStore *store, rgw_bucket& bucket, bool dele
 static int aio_wait(librados::AioCompletion *handle)
 {
   librados::AioCompletion *c = (librados::AioCompletion *)handle;
-  c->wait_for_safe();
+  c->wait_for_complete();
   int ret = c->get_return_value();
   c->release();
   return ret;

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -439,8 +439,7 @@ static void _aio_completion_notifier_cb(librados::completion_t cb, void *arg)
 RGWAioCompletionNotifier::RGWAioCompletionNotifier(RGWCompletionManager *_mgr, const rgw_io_id& _io_id, void *_user_data) : completion_mgr(_mgr),
                                                                          io_id(_io_id),
                                                                          user_data(_user_data), registered(true) {
-  c = librados::Rados::aio_create_completion((void *)this, NULL,
-					     _aio_completion_notifier_cb);
+  c = librados::Rados::aio_create_completion(this, _aio_completion_notifier_cb);
 }
 
 RGWAioCompletionNotifier *RGWCoroutinesStack::create_completion_notifier()

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -336,7 +336,7 @@ public:
   int handle_next_completion() {
     ceph_assert(!ios.empty());
     IO& io = ios.front();
-    io.c->wait_for_safe();
+    io.c->wait_for_complete();
     int ret = io.c->get_return_value();
     io.c->release();
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5272,7 +5272,7 @@ int RGWRados::Object::Stat::wait()
     return state.ret;
   }
 
-  state.completion->wait_for_safe();
+  state.completion->wait_for_complete();
   state.ret = state.completion->get_return_value();
   state.completion->release();
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -971,7 +971,7 @@ void RGWIndexCompletionManager::create_completion(const rgw_obj& obj,
 
   *result = entry;
 
-  entry->rados_completion = librados::Rados::aio_create_completion(entry, NULL, obj_complete_cb);
+  entry->rados_completion = librados::Rados::aio_create_completion(entry, obj_complete_cb);
 
   std::lock_guard l{locks[shard_id]};
   completions[shard_id].insert(entry);
@@ -5252,7 +5252,7 @@ int RGWRados::Object::Stat::stat_async()
   librados::ObjectReadOperation op;
   op.stat2(&result.size, &result.mtime, NULL);
   op.getxattrs(&result.attrs, NULL);
-  state.completion = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+  state.completion = librados::Rados::aio_create_completion(nullptr, nullptr);
   state.io_ctx.locator_set_key(loc);
   r = state.io_ctx.aio_operate(oid, state.completion, &op, NULL);
   if (r < 0) {
@@ -7497,7 +7497,7 @@ int RGWRados::append_async(rgw_raw_obj& obj, size_t size, bufferlist& bl)
     return r;
   }
   librados::Rados *rad = get_rados_handle();
-  librados::AioCompletion *completion = rad->aio_create_completion(NULL, NULL, NULL);
+  librados::AioCompletion *completion = rad->aio_create_completion(nullptr, nullptr);
 
   r = ref.pool.ioctx().aio_append(ref.obj.oid, completion, bl, size);
   completion->release();
@@ -8050,7 +8050,7 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
       ObjectWriteOperation o;
       cls_rgw_suggest_changes(o, miter->second);
       // we don't care if we lose suggested updates, send them off blindly
-      AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      AioCompletion *c = librados::Rados::aio_create_completion(nullptr, nullptr);
       ioctx.aio_operate(miter->first, c, &o);
       c->release();
     }
@@ -8211,7 +8211,7 @@ check_updates:
       ObjectWriteOperation o;
       cls_rgw_suggest_changes(o, miter->second);
       // we don't care if we lose suggested updates, send them off blindly
-      AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+      AioCompletion *c = librados::Rados::aio_create_completion(nullptr, nullptr);
       ioctx.aio_operate(miter->first, c, &o);
       c->release();
     }
@@ -8628,7 +8628,7 @@ int RGWRados::delete_raw_obj_aio(const rgw_raw_obj& obj, list<librados::AioCompl
   list<string> prefixes;
   cls_rgw_remove_obj(op, prefixes);
 
-  AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+  AioCompletion *c = librados::Rados::aio_create_completion(nullptr, nullptr);
   ret = ref.pool.ioctx().aio_operate(ref.obj.oid, c, &op);
   if (ret < 0) {
     lderr(cct) << "ERROR: AioOperate failed with ret=" << ret << dendl;
@@ -8668,7 +8668,7 @@ int RGWRados::delete_obj_aio(const rgw_obj& obj,
   list<string> prefixes;
   cls_rgw_remove_obj(op, prefixes);
 
-  AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+  AioCompletion *c = librados::Rados::aio_create_completion(nullptr, nullptr);
   ret = ref.pool.ioctx().aio_operate(ref.obj.oid, c, &op);
   if (ret < 0) {
     lderr(cct) << "ERROR: AioOperate failed with ret=" << ret << dendl;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -93,7 +93,7 @@ class BucketReshardShard {
       }
     }
 
-    *c = librados::Rados::aio_create_completion(nullptr, nullptr, nullptr);
+    *c = librados::Rados::aio_create_completion(nullptr, nullptr);
     aio_completions.push_back(*c);
 
     return 0;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -72,7 +72,7 @@ class BucketReshardShard {
     librados::AioCompletion *c = aio_completions.front();
     aio_completions.pop_front();
 
-    c->wait_for_safe();
+    c->wait_for_complete();
 
     int ret = c->get_return_value();
     c->release();

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -111,7 +111,7 @@ public:
     if (!register_completion) {
       return -EINVAL;
     }
-    register_completion->wait_for_safe();
+    register_completion->wait_for_complete();
     int r = register_completion->get_return_value();
     register_completion->release();
     register_completion = nullptr;

--- a/src/test/cls_hello/test_cls_hello.cc
+++ b/src/test/cls_hello/test_cls_hello.cc
@@ -106,7 +106,7 @@ TEST(ClsHello, WriteReturnData) {
   librados::AioCompletion *completion = cluster.aio_create_completion();
   ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &o,
 				 librados::OPERATION_RETURNVEC));
-  completion->wait_for_safe();
+  completion->wait_for_complete();
   ASSERT_EQ(42, completion->get_return_value());
   ASSERT_EQ(42, rval);
   out.hexdump(std::cout);
@@ -122,7 +122,7 @@ TEST(ClsHello, WriteReturnData) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &o,
 				   librados::OPERATION_RETURNVEC));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EOVERFLOW, completion->get_return_value());
     ASSERT_EQ(-EOVERFLOW, rval);
     ASSERT_EQ("", std::string(out.c_str(), out.length()));

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -68,8 +68,8 @@ TEST(LibRadosAio, TooBig) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(-E2BIG, rados_aio_write(test_data.m_ioctx, "foo",
@@ -85,8 +85,8 @@ TEST(LibRadosAio, SimpleWrite) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   auto sg = make_scope_guard([&] { rados_aio_release(my_completion); });
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
@@ -100,8 +100,8 @@ TEST(LibRadosAio, SimpleWrite) {
 
   rados_ioctx_set_namespace(test_data.m_ioctx, "nspace");
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   auto sg2 = make_scope_guard([&] { rados_aio_release(my_completion2); });
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
 			       my_completion2, buf, sizeof(buf), 0));
@@ -116,14 +116,14 @@ TEST(LibRadosAio, WaitForSafe) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
 			       my_completion, buf, sizeof(buf), 0));
   TestAlarm alarm;
-  ASSERT_EQ(0, rados_aio_wait_for_safe(my_completion));
+  ASSERT_EQ(0, rados_aio_wait_for_complete(my_completion));
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   rados_aio_release(my_completion);
 }
@@ -132,8 +132,8 @@ TEST(LibRadosAio, RoundTrip) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -146,8 +146,8 @@ TEST(LibRadosAio, RoundTrip) {
   char buf2[256];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -164,8 +164,8 @@ TEST(LibRadosAio, RoundTrip2) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -178,8 +178,8 @@ TEST(LibRadosAio, RoundTrip2) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -196,8 +196,8 @@ TEST(LibRadosAio, RoundTrip3) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
 
@@ -219,8 +219,8 @@ TEST(LibRadosAio, RoundTrip3) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
 
   rados_read_op_t op2 = rados_create_read_op();
   rados_read_op_read(op2, 0, sizeof(buf2), buf2, NULL, NULL);
@@ -255,8 +255,8 @@ TEST(LibRadosAio, RoundTripAppend) {
   AioTestData test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_append(test_data.m_ioctx, "foo",
@@ -268,8 +268,8 @@ TEST(LibRadosAio, RoundTripAppend) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   char buf2[128];
   memset(buf2, 0xdd, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_append(test_data.m_ioctx, "foo",
 			       my_completion2, buf2, sizeof(buf2)));
   {
@@ -279,8 +279,8 @@ TEST(LibRadosAio, RoundTripAppend) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
   char buf3[sizeof(buf) + sizeof(buf2)];
   memset(buf3, 0, sizeof(buf3));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion3, buf3, sizeof(buf3), 0));
   {
@@ -301,8 +301,8 @@ TEST(LibRadosAio, RemoveTest) {
   rados_completion_t my_completion;
   AioTestData test_data;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   memset(buf, 0xaa, sizeof(buf));
   ASSERT_EQ(0, rados_append(test_data.m_ioctx, "foo", buf, sizeof(buf)));
   ASSERT_EQ(0, rados_aio_remove(test_data.m_ioctx, "foo", my_completion));
@@ -327,8 +327,8 @@ TEST(LibRadosAio, XattrsRoundTrip) {
   ASSERT_EQ(0, rados_append(test_data.m_ioctx, "foo", buf, sizeof(buf)));
   // async getxattr
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   ASSERT_EQ(0, rados_aio_getxattr(test_data.m_ioctx, "foo", my_completion, attr1, buf, sizeof(buf)));
   {
     TestAlarm alarm;
@@ -338,8 +338,8 @@ TEST(LibRadosAio, XattrsRoundTrip) {
   rados_aio_release(my_completion);
   // async setxattr
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_setxattr(test_data.m_ioctx, "foo", my_completion2, attr1, attr1_buf, sizeof(attr1_buf)));
   {
     TestAlarm alarm;
@@ -349,8 +349,8 @@ TEST(LibRadosAio, XattrsRoundTrip) {
   rados_aio_release(my_completion2);
   // async getxattr
   rados_completion_t my_completion3;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_getxattr(test_data.m_ioctx, "foo", my_completion3, attr1, buf, sizeof(buf)));
   {
     TestAlarm alarm;
@@ -373,8 +373,8 @@ TEST(LibRadosAio, RmXattr) {
   ASSERT_EQ(0, rados_append(test_data.m_ioctx, "foo", buf, sizeof(buf)));  
   // async setxattr
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   ASSERT_EQ(0, rados_aio_setxattr(test_data.m_ioctx, "foo", my_completion, attr1, attr1_buf, sizeof(attr1_buf)));
   {
     TestAlarm alarm;
@@ -384,8 +384,8 @@ TEST(LibRadosAio, RmXattr) {
   rados_aio_release(my_completion);
   // async rmxattr
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-            nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+            nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_rmxattr(test_data.m_ioctx, "foo", my_completion2, attr1));
   {
     TestAlarm alarm;
@@ -395,8 +395,8 @@ TEST(LibRadosAio, RmXattr) {
   rados_aio_release(my_completion2);
   // async getxattr after deletion
   rados_completion_t my_completion3;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-            nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+            nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_getxattr(test_data.m_ioctx, "foo", my_completion3, attr1, buf, sizeof(buf)));
   {
     TestAlarm alarm;
@@ -412,8 +412,8 @@ TEST(LibRadosAio, RmXattr) {
   ASSERT_EQ(0, rados_write(test_data.m_ioctx, "foo_rmxattr", buf2, sizeof(buf2), 0));
   // asynx setxattr
   rados_completion_t my_completion4;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-            nullptr, nullptr, &my_completion4));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+            nullptr, &my_completion4));
   ASSERT_EQ(0, rados_aio_setxattr(test_data.m_ioctx, "foo_rmxattr", my_completion4, attr2, attr2_buf, sizeof(attr2_buf)));
   {
     TestAlarm alarm;
@@ -425,8 +425,8 @@ TEST(LibRadosAio, RmXattr) {
   ASSERT_EQ(0, rados_remove(test_data.m_ioctx, "foo_rmxattr"));
   // async rmxattr on non existing object
   rados_completion_t my_completion5;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-            nullptr, nullptr, &my_completion5));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+            nullptr, &my_completion5));
   ASSERT_EQ(0, rados_aio_rmxattr(test_data.m_ioctx, "foo_rmxattr", my_completion5, attr2));
   {
     TestAlarm alarm;
@@ -454,8 +454,8 @@ TEST(LibRadosAio, XattrIter) {
   ASSERT_EQ(0, rados_setxattr(test_data.m_ioctx, "foo", attr2, attr2_buf, sizeof(attr2_buf)));
   // call async version of getxattrs and wait for completion
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion((void*)&test_data,
-            nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2((void*)&test_data,
+            nullptr, &my_completion));
   rados_xattrs_iter_t iter;
   ASSERT_EQ(0, rados_aio_getxattrs(test_data.m_ioctx, "foo", my_completion, &iter));
   {
@@ -493,8 +493,8 @@ TEST(LibRadosAio, IsComplete) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -507,8 +507,8 @@ TEST(LibRadosAio, IsComplete) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -532,8 +532,8 @@ TEST(LibRadosAio, IsSafe) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -553,8 +553,8 @@ TEST(LibRadosAio, IsSafe) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -571,8 +571,8 @@ TEST(LibRadosAio, ReturnValue) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0, sizeof(buf));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "nonexistent",
@@ -589,8 +589,8 @@ TEST(LibRadosAio, Flush) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xee, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -600,8 +600,8 @@ TEST(LibRadosAio, Flush) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -618,10 +618,10 @@ TEST(LibRadosAio, FlushAsync) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   rados_completion_t flush_completion;
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &flush_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &flush_completion));
   char buf[128];
   memset(buf, 0xee, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -630,18 +630,15 @@ TEST(LibRadosAio, FlushAsync) {
   {
     TestAlarm alarm;
     ASSERT_EQ(0, rados_aio_wait_for_complete(flush_completion));
-    ASSERT_EQ(0, rados_aio_wait_for_safe(flush_completion));
   }
   ASSERT_EQ(1, rados_aio_is_complete(my_completion));
-  ASSERT_EQ(1, rados_aio_is_safe(my_completion));
   ASSERT_EQ(1, rados_aio_is_complete(flush_completion));
-  ASSERT_EQ(1, rados_aio_is_safe(flush_completion));
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -659,8 +656,8 @@ TEST(LibRadosAio, RoundTripWriteFull) {
   AioTestData test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -672,8 +669,8 @@ TEST(LibRadosAio, RoundTripWriteFull) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   char buf2[64];
   memset(buf2, 0xdd, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_write_full(test_data.m_ioctx, "foo",
 			       my_completion2, buf2, sizeof(buf2)));
   {
@@ -683,8 +680,8 @@ TEST(LibRadosAio, RoundTripWriteFull) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
   char buf3[sizeof(buf) + sizeof(buf2)];
   memset(buf3, 0, sizeof(buf3));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion3, buf3, sizeof(buf3), 0));
   {
@@ -702,8 +699,8 @@ TEST(LibRadosAio, RoundTripWriteSame) {
   AioTestData test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char full[128];
   memset(full, 0xcc, sizeof(full));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -717,8 +714,8 @@ TEST(LibRadosAio, RoundTripWriteSame) {
   char buf[32];
   size_t ws_write_len = sizeof(full);
   memset(buf, 0xdd, sizeof(buf));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_writesame(test_data.m_ioctx, "foo",
 				   my_completion2, buf, sizeof(buf),
 				   ws_write_len, 0));
@@ -727,8 +724,8 @@ TEST(LibRadosAio, RoundTripWriteSame) {
     ASSERT_EQ(0, rados_aio_wait_for_complete(my_completion2));
   }
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion3, full, sizeof(full), 0));
   {
@@ -748,8 +745,8 @@ TEST(LibRadosAio, SimpleStat) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -762,8 +759,8 @@ TEST(LibRadosAio, SimpleStat) {
   uint64_t psize;
   time_t pmtime;
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion2, &psize, &pmtime));
   {
@@ -780,8 +777,8 @@ TEST(LibRadosAio, SimpleStatNS) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -794,8 +791,8 @@ TEST(LibRadosAio, SimpleStatNS) {
   rados_ioctx_set_namespace(test_data.m_ioctx, "nspace");
   char buf2[64];
   memset(buf2, 0xbb, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
 			       my_completion, buf2, sizeof(buf2), 0));
   {
@@ -807,8 +804,8 @@ TEST(LibRadosAio, SimpleStatNS) {
   time_t pmtime;
   rados_completion_t my_completion2;
   rados_ioctx_set_namespace(test_data.m_ioctx, "");
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion2, &psize, &pmtime));
   {
@@ -820,8 +817,8 @@ TEST(LibRadosAio, SimpleStatNS) {
 
   rados_ioctx_set_namespace(test_data.m_ioctx, "nspace");
   rados_completion_t my_completion3;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion3, &psize, &pmtime));
   {
@@ -840,8 +837,8 @@ TEST(LibRadosAio, StatRemove) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -854,8 +851,8 @@ TEST(LibRadosAio, StatRemove) {
   uint64_t psize;
   time_t pmtime;
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion2, &psize, &pmtime));
   {
@@ -865,8 +862,8 @@ TEST(LibRadosAio, StatRemove) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
   ASSERT_EQ(sizeof(buf), psize);
   rados_completion_t my_completion3;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_remove(test_data.m_ioctx, "foo", my_completion3));
   {
     TestAlarm alarm;
@@ -876,8 +873,8 @@ TEST(LibRadosAio, StatRemove) {
   uint64_t psize2;
   time_t pmtime2;
   rados_completion_t my_completion4;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion4));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion4));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion4, &psize2, &pmtime2));
   {
@@ -895,8 +892,8 @@ TEST(LibRadosAio, ExecuteClass) {
   AioTestData test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -906,8 +903,8 @@ TEST(LibRadosAio, ExecuteClass) {
     ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   }
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   char out[128];
   ASSERT_EQ(0, rados_aio_exec(test_data.m_ioctx, "foo", my_completion2,
 			      "hello", "say_hello", NULL, 0, out, sizeof(out)));
@@ -929,8 +926,8 @@ TEST(LibRadosAio, MultiWrite) {
   AioTestData test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -943,8 +940,8 @@ TEST(LibRadosAio, MultiWrite) {
 
   char buf2[64];
   memset(buf2, 0xdd, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
 			       my_completion2, buf2, sizeof(buf2), sizeof(buf)));
   {
@@ -955,8 +952,8 @@ TEST(LibRadosAio, MultiWrite) {
 
   char buf3[(sizeof(buf) + sizeof(buf2)) * 3];
   memset(buf3, 0, sizeof(buf3));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion3, buf3, sizeof(buf3), 0));
   {
@@ -976,8 +973,8 @@ TEST(LibRadosAio, AioUnlock) {
   ASSERT_EQ("", test_data.init());
   ASSERT_EQ(0, rados_lock_exclusive(test_data.m_ioctx, "foo", "TestLock", "Cookie", "", NULL, 0));
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-            nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+            nullptr, &my_completion));
   ASSERT_EQ(0, rados_aio_unlock(test_data.m_ioctx, "foo", "TestLock", "Cookie", my_completion));
   {
     TestAlarm alarm;
@@ -1037,8 +1034,8 @@ TEST(LibRadosAioEC, SimpleWrite) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   auto sg = make_scope_guard([&] { rados_aio_release(my_completion); });
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
@@ -1052,8 +1049,8 @@ TEST(LibRadosAioEC, SimpleWrite) {
 
   rados_ioctx_set_namespace(test_data.m_ioctx, "nspace");
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   auto sg2 = make_scope_guard([&] { rados_aio_release(my_completion2); });
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
 			       my_completion2, buf, sizeof(buf), 0));
@@ -1064,18 +1061,18 @@ TEST(LibRadosAioEC, SimpleWrite) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
 }
 
-TEST(LibRadosAioEC, WaitForSafe) {
+TEST(LibRadosAioEC, WaitForComplete) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
 			       my_completion, buf, sizeof(buf), 0));
   TestAlarm alarm;
-  ASSERT_EQ(0, rados_aio_wait_for_safe(my_completion));
+  ASSERT_EQ(0, rados_aio_wait_for_complete(my_completion));
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   rados_aio_release(my_completion);
 }
@@ -1084,8 +1081,8 @@ TEST(LibRadosAioEC, RoundTrip) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1098,8 +1095,8 @@ TEST(LibRadosAioEC, RoundTrip) {
   char buf2[256];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -1116,8 +1113,8 @@ TEST(LibRadosAioEC, RoundTrip2) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1130,8 +1127,8 @@ TEST(LibRadosAioEC, RoundTrip2) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -1148,8 +1145,8 @@ TEST(LibRadosAioEC, RoundTripAppend) {
   AioTestDataEC test_data;
   rados_completion_t my_completion, my_completion2, my_completion3, my_completion4;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   int requires;
   ASSERT_EQ(0, rados_ioctx_pool_requires_alignment2(test_data.m_ioctx, &requires));
   ASSERT_NE(0, requires);
@@ -1171,8 +1168,8 @@ TEST(LibRadosAioEC, RoundTripAppend) {
   int hbsize = bsize / 2;
   char *buf2 = (char *)new char[hbsize];
   memset(buf2, 0xdd, hbsize);
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_append(test_data.m_ioctx, "foo",
 			       my_completion2, buf2, hbsize));
   {
@@ -1181,8 +1178,8 @@ TEST(LibRadosAioEC, RoundTripAppend) {
   }
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
 
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_append(test_data.m_ioctx, "foo",
 			       my_completion3, buf2, hbsize));
   {
@@ -1194,8 +1191,8 @@ TEST(LibRadosAioEC, RoundTripAppend) {
   int tbsize = bsize + hbsize;
   char *buf3 = (char *)new char[tbsize];
   memset(buf3, 0, tbsize);
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion4));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion4));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion4, buf3, bsize * 3, 0));
   {
@@ -1218,8 +1215,8 @@ TEST(LibRadosAioEC, IsComplete) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1232,8 +1229,8 @@ TEST(LibRadosAioEC, IsComplete) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -1257,8 +1254,8 @@ TEST(LibRadosAioEC, IsSafe) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1278,8 +1275,8 @@ TEST(LibRadosAioEC, IsSafe) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -1296,8 +1293,8 @@ TEST(LibRadosAioEC, ReturnValue) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0, sizeof(buf));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "nonexistent",
@@ -1314,8 +1311,8 @@ TEST(LibRadosAioEC, Flush) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xee, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1325,8 +1322,8 @@ TEST(LibRadosAioEC, Flush) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -1343,10 +1340,10 @@ TEST(LibRadosAioEC, FlushAsync) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   rados_completion_t flush_completion;
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &flush_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &flush_completion));
   char buf[128];
   memset(buf, 0xee, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1355,18 +1352,15 @@ TEST(LibRadosAioEC, FlushAsync) {
   {
     TestAlarm alarm;
     ASSERT_EQ(0, rados_aio_wait_for_complete(flush_completion));
-    ASSERT_EQ(0, rados_aio_wait_for_safe(flush_completion));
   }
   ASSERT_EQ(1, rados_aio_is_complete(my_completion));
-  ASSERT_EQ(1, rados_aio_is_safe(my_completion));
   ASSERT_EQ(1, rados_aio_is_complete(flush_completion));
-  ASSERT_EQ(1, rados_aio_is_safe(flush_completion));
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion2, buf2, sizeof(buf2), 0));
   {
@@ -1384,8 +1378,8 @@ TEST(LibRadosAioEC, RoundTripWriteFull) {
   AioTestDataEC test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1397,8 +1391,8 @@ TEST(LibRadosAioEC, RoundTripWriteFull) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   char buf2[64];
   memset(buf2, 0xdd, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_write_full(test_data.m_ioctx, "foo",
 			       my_completion2, buf2, sizeof(buf2)));
   {
@@ -1408,8 +1402,8 @@ TEST(LibRadosAioEC, RoundTripWriteFull) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
   char buf3[sizeof(buf) + sizeof(buf2)];
   memset(buf3, 0, sizeof(buf3));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion3, buf3, sizeof(buf3), 0));
   {
@@ -1427,8 +1421,8 @@ TEST(LibRadosAioEC, SimpleStat) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1441,8 +1435,8 @@ TEST(LibRadosAioEC, SimpleStat) {
   uint64_t psize;
   time_t pmtime;
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion2, &psize, &pmtime));
   {
@@ -1460,8 +1454,8 @@ TEST(LibRadosAioEC, SimpleStatNS) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1474,8 +1468,8 @@ TEST(LibRadosAioEC, SimpleStatNS) {
   rados_ioctx_set_namespace(test_data.m_ioctx, "nspace");
   char buf2[64];
   memset(buf2, 0xbb, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
 			       my_completion, buf2, sizeof(buf2), 0));
   {
@@ -1487,8 +1481,8 @@ TEST(LibRadosAioEC, SimpleStatNS) {
   time_t pmtime;
   rados_completion_t my_completion2;
   rados_ioctx_set_namespace(test_data.m_ioctx, "");
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion2, &psize, &pmtime));
   {
@@ -1500,8 +1494,8 @@ TEST(LibRadosAioEC, SimpleStatNS) {
 
   rados_ioctx_set_namespace(test_data.m_ioctx, "nspace");
   rados_completion_t my_completion3;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion3, &psize, &pmtime));
   {
@@ -1520,8 +1514,8 @@ TEST(LibRadosAioEC, StatRemove) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1534,8 +1528,8 @@ TEST(LibRadosAioEC, StatRemove) {
   uint64_t psize;
   time_t pmtime;
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion2, &psize, &pmtime));
   {
@@ -1545,8 +1539,8 @@ TEST(LibRadosAioEC, StatRemove) {
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion2));
   ASSERT_EQ(sizeof(buf), psize);
   rados_completion_t my_completion3;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_remove(test_data.m_ioctx, "foo", my_completion3));
   {
     TestAlarm alarm;
@@ -1556,8 +1550,8 @@ TEST(LibRadosAioEC, StatRemove) {
   uint64_t psize2;
   time_t pmtime2;
   rados_completion_t my_completion4;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion4));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion4));
   ASSERT_EQ(0, rados_aio_stat(test_data.m_ioctx, "foo",
 			      my_completion4, &psize2, &pmtime2));
   {
@@ -1575,8 +1569,8 @@ TEST(LibRadosAioEC, ExecuteClass) {
   AioTestDataEC test_data;
   rados_completion_t my_completion;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1587,8 +1581,8 @@ TEST(LibRadosAioEC, ExecuteClass) {
   }
   ASSERT_EQ(0, rados_aio_get_return_value(my_completion));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   char out[128];
   ASSERT_EQ(0, rados_aio_exec(test_data.m_ioctx, "foo", my_completion2,
 			      "hello", "say_hello", NULL, 0, out, sizeof(out)));
@@ -1606,8 +1600,8 @@ TEST(LibRadosAioEC, MultiWrite) {
   AioTestDataEC test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
   ASSERT_EQ("", test_data.init());
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
@@ -1620,8 +1614,8 @@ TEST(LibRadosAioEC, MultiWrite) {
 
   char buf2[64];
   memset(buf2, 0xdd, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion2));
   ASSERT_EQ(0, rados_aio_write(test_data.m_ioctx, "foo",
 			       my_completion2, buf2, sizeof(buf2), sizeof(buf)));
   {
@@ -1632,8 +1626,8 @@ TEST(LibRadosAioEC, MultiWrite) {
 
   char buf3[(sizeof(buf) + sizeof(buf2)) * 3];
   memset(buf3, 0, sizeof(buf3));
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr,
-	      nullptr, nullptr, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr,
+	      nullptr, &my_completion3));
   ASSERT_EQ(0, rados_aio_read(test_data.m_ioctx, "foo",
 			      my_completion3, buf3, sizeof(buf3), 0));
   {

--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -108,7 +108,7 @@ TEST(LibRadosAio, PoolQuotaPP) {
     ASSERT_EQ(0, ioctx.aio_operate(
 	"foo" + stringify(n), completion, &op,
 	librados::OPERATION_FULL_TRY));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     int r = completion->get_return_value();
     completion->release();
     if (r == -EDQUOT)
@@ -190,7 +190,7 @@ TEST(LibRadosAio, WaitForSafePP) {
   ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo",
 			       my_completion, bl1, sizeof(buf), 0));
   TestAlarm alarm;
-  ASSERT_EQ(0, my_completion->wait_for_safe());
+  ASSERT_EQ(0, my_completion->wait_for_complete());
   ASSERT_EQ(0, my_completion->get_return_value());
   delete my_completion;
 }
@@ -256,7 +256,6 @@ TEST(LibRadosAio, RoundTripPP2) {
 			      my_completion2, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
-    ASSERT_EQ(0, my_completion2->wait_for_safe());
     ASSERT_EQ(0, my_completion2->wait_for_complete());
   }
   ASSERT_EQ((int)sizeof(buf), my_completion2->get_return_value());
@@ -736,7 +735,6 @@ TEST(LibRadosAio, FlushAsyncPP) {
   {
       TestAlarm alarm;
       ASSERT_EQ(0, flush_completion->wait_for_complete());
-      ASSERT_EQ(0, flush_completion->wait_for_safe());
   }
   ASSERT_EQ(1, my_completion->is_complete());
   ASSERT_EQ(1, my_completion->is_safe());
@@ -1490,7 +1488,7 @@ TEST(LibRadosAioEC, WaitForSafePP) {
   ASSERT_EQ(0, test_data.m_ioctx.aio_write("foo",
 			       my_completion, bl1, sizeof(buf), 0));
   TestAlarm alarm;
-  ASSERT_EQ(0, my_completion->wait_for_safe());
+  ASSERT_EQ(0, my_completion->wait_for_complete());
   ASSERT_EQ(0, my_completion->get_return_value());
   delete my_completion;
 }
@@ -1556,7 +1554,6 @@ TEST(LibRadosAioEC, RoundTripPP2) {
 			      my_completion2, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
-    ASSERT_EQ(0, my_completion2->wait_for_safe());
     ASSERT_EQ(0, my_completion2->wait_for_complete());
   }
   ASSERT_EQ((int)sizeof(buf), my_completion2->get_return_value());
@@ -1943,7 +1940,6 @@ TEST(LibRadosAioEC, FlushAsyncPP) {
   {
       TestAlarm alarm;
       ASSERT_EQ(0, flush_completion->wait_for_complete());
-      ASSERT_EQ(0, flush_completion->wait_for_safe());
   }
   ASSERT_EQ(1, my_completion->is_complete());
   ASSERT_EQ(1, my_completion->is_safe());

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -119,7 +119,7 @@ TEST(LibRadosMiscPool, PoolCreationRace) {
   while (max--) {
     char buf[100];
     rados_completion_t c;
-    rados_aio_create_completion(0, 0, 0, &c);
+    rados_aio_create_completion2(nullptr, nullptr, &c);
     cls.push_back(c);
     rados_aio_read(a, "PoolCreationRaceObj", c, buf, 100, 0);
     cout << "started " << (void*)c << std::endl;

--- a/src/test/librados/snapshots.cc
+++ b/src/test/librados/snapshots.cc
@@ -88,7 +88,7 @@ TEST_F(LibRadosSnapshotsSelfManaged, Snap) {
 
   my_snaps.push_back(-2);
   rados_completion_t completion;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr, nullptr, nullptr,
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr,
                                            &completion));
   rados_aio_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back(), completion);
   ASSERT_EQ(0, rados_aio_wait_for_complete(completion));
@@ -108,7 +108,7 @@ TEST_F(LibRadosSnapshotsSelfManaged, Snap) {
   ASSERT_EQ((int)sizeof(buf3), rados_read(ioctx, "foo", buf3, sizeof(buf3), 0));
   ASSERT_EQ(0, memcmp(buf3, buf, sizeof(buf)));
 
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr, nullptr, nullptr,
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr,
                                            &completion));
   rados_aio_ioctx_selfmanaged_snap_remove(ioctx, my_snaps.back(), completion);
   ASSERT_EQ(0, rados_aio_wait_for_complete(completion));
@@ -227,7 +227,7 @@ TEST_F(LibRadosSnapshotsSelfManagedEC, Snap) {
 
   my_snaps.push_back(-2);
   rados_completion_t completion;
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr, nullptr, nullptr,
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr,
                                            &completion));
   rados_aio_ioctx_selfmanaged_snap_create(ioctx, &my_snaps.back(), completion);
   ASSERT_EQ(0, rados_aio_wait_for_complete(completion));
@@ -247,7 +247,7 @@ TEST_F(LibRadosSnapshotsSelfManagedEC, Snap) {
   ASSERT_EQ(bsize, rados_read(ioctx, "foo", buf3, bsize*2, 0));
   ASSERT_EQ(0, memcmp(buf3, buf, bsize));
 
-  ASSERT_EQ(0, rados_aio_create_completion(nullptr, nullptr, nullptr,
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr,
                                            &completion));
   rados_aio_ioctx_selfmanaged_snap_remove(ioctx, my_snaps.back(), completion);
   ASSERT_EQ(0, rados_aio_wait_for_complete(completion));

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -238,7 +238,7 @@ void RadosTestPP::cleanup_namespace(librados::IoCtx ioctx, std::string ns)
       auto sg = make_scope_guard([&] { completion->release(); });
       ASSERT_EQ(0, ioctx.aio_operate(it->get_oid(), completion, &op,
 				     librados::OPERATION_IGNORE_CACHE));
-      completion->wait_for_safe();
+      completion->wait_for_complete();
       if (completion->get_return_value() == -ENOENT) {
 	++got_enoent;
 	std::cout << " got ENOENT removing " << it->get_oid()

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -45,7 +45,7 @@ void flush_evict_all(librados::Rados& cluster, librados::IoCtx& cache_ioctx)
       cache_ioctx.aio_operate(
         it->get_oid(), completion, &op,
 	librados::OPERATION_IGNORE_OVERLAY, NULL);
-      completion->wait_for_safe();
+      completion->wait_for_complete();
       completion->get_return_value();
       completion->release();
     }
@@ -56,7 +56,7 @@ void flush_evict_all(librados::Rados& cluster, librados::IoCtx& cache_ioctx)
       cache_ioctx.aio_operate(
         it->get_oid(), completion, &op,
 	librados::OPERATION_IGNORE_OVERLAY, NULL);
-      completion->wait_for_safe();
+      completion->wait_for_complete();
       completion->get_return_value();
       completion->release();
     }
@@ -274,7 +274,7 @@ TEST_F(LibRadosTwoPoolsPP, Overlay) {
     ASSERT_EQ(0, ioctx.aio_operate(
 	"foo", completion, &op,
 	librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
     ASSERT_EQ('b', bl[0]);
@@ -714,7 +714,7 @@ TEST_F(LibRadosTwoPoolsPP, Whiteout) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("bar", completion, &op,
 				   librados::OPERATION_IGNORE_CACHE));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
 
@@ -845,7 +845,7 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -858,7 +858,7 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op,
 					 librados::OPERATION_IGNORE_CACHE,
 					 NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EPERM, completion->get_return_value());
     completion->release();
   }
@@ -869,7 +869,7 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
     op.cache_unpin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -882,7 +882,7 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -906,7 +906,7 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op,
 					 librados::OPERATION_IGNORE_CACHE,
 					 NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -917,7 +917,7 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -928,7 +928,7 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EBUSY, completion->get_return_value());
     completion->release();
   }
@@ -1036,7 +1036,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "bam", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1048,7 +1048,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "bam", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-ENOENT, completion->get_return_value());
     completion->release();
   }
@@ -1069,7 +1069,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1082,7 +1082,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-ENOENT, completion->get_return_value());
     completion->release();
   }
@@ -1096,7 +1096,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1124,7 +1124,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EBUSY, completion->get_return_value());
     completion->release();
   }
@@ -1138,7 +1138,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1152,7 +1152,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1163,7 +1163,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1228,7 +1228,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap2) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1242,7 +1242,7 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap2) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op,
 				   librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-ENOENT, completion->get_return_value());
     completion->release();
   }
@@ -1354,7 +1354,7 @@ TEST_F(LibRadosTwoPoolsPP, ListSnap){
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1367,7 +1367,7 @@ TEST_F(LibRadosTwoPoolsPP, ListSnap){
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-ENOENT, completion->get_return_value());
     completion->release();
   }
@@ -1383,7 +1383,7 @@ TEST_F(LibRadosTwoPoolsPP, ListSnap){
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       0, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, snap_ret);
     ASSERT_LT(0u, snap_set.clones.size());
     for (vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
@@ -1460,7 +1460,7 @@ TEST_F(LibRadosTwoPoolsPP, TryFlush) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1474,7 +1474,7 @@ TEST_F(LibRadosTwoPoolsPP, TryFlush) {
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EPERM, completion->get_return_value());
     completion->release();
   }
@@ -1485,7 +1485,7 @@ TEST_F(LibRadosTwoPoolsPP, TryFlush) {
     op.cache_unpin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1499,7 +1499,7 @@ TEST_F(LibRadosTwoPoolsPP, TryFlush) {
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1531,7 +1531,7 @@ TEST_F(LibRadosTwoPoolsPP, TryFlush) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
 	 "foo", completion, &op, librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1607,7 +1607,7 @@ TEST_F(LibRadosTwoPoolsPP, Flush) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1621,7 +1621,7 @@ TEST_F(LibRadosTwoPoolsPP, Flush) {
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EPERM, completion->get_return_value());
     completion->release();
   }
@@ -1632,7 +1632,7 @@ TEST_F(LibRadosTwoPoolsPP, Flush) {
     op.cache_unpin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1645,7 +1645,7 @@ TEST_F(LibRadosTwoPoolsPP, Flush) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1677,7 +1677,7 @@ TEST_F(LibRadosTwoPoolsPP, Flush) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
 	 "foo", completion, &op, librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1710,7 +1710,7 @@ TEST_F(LibRadosTwoPoolsPP, Flush) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1722,7 +1722,7 @@ TEST_F(LibRadosTwoPoolsPP, Flush) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
 	 "foo", completion, &op, librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1819,7 +1819,7 @@ TEST_F(LibRadosTwoPoolsPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EBUSY, completion->get_return_value());
     completion->release();
   }
@@ -1832,7 +1832,7 @@ TEST_F(LibRadosTwoPoolsPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EBUSY, completion->get_return_value());
     completion->release();
   }
@@ -1845,7 +1845,7 @@ TEST_F(LibRadosTwoPoolsPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1858,7 +1858,7 @@ TEST_F(LibRadosTwoPoolsPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1871,7 +1871,7 @@ TEST_F(LibRadosTwoPoolsPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -1988,8 +1988,8 @@ TEST_F(LibRadosTierPP, FlushWriteRaces) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion2, &op2, 0));
 
-    completion->wait_for_safe();
-    completion2->wait_for_safe();
+    completion->wait_for_complete();
+    completion2->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     ASSERT_EQ(0, completion2->get_return_value());
     completion->release();
@@ -2022,8 +2022,8 @@ TEST_F(LibRadosTierPP, FlushWriteRaces) {
       librados::AioCompletion *completion2 = cluster.aio_create_completion();
       ASSERT_EQ(0, ioctx.aio_operate("foo", completion2, &op2, 0));
 
-      completion->wait_for_safe();
-      completion2->wait_for_safe();
+      completion->wait_for_complete();
+      completion2->wait_for_complete();
       int r = completion->get_return_value();
       ASSERT_TRUE(r == -EBUSY || r == 0);
       ASSERT_EQ(0, completion2->get_return_value());
@@ -2098,8 +2098,8 @@ TEST_F(LibRadosTwoPoolsPP, FlushTryFlushRaces) {
       "foo", completion2, &op2,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
 
-    completion->wait_for_safe();
-    completion2->wait_for_safe();
+    completion->wait_for_complete();
+    completion2->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     ASSERT_EQ(0, completion2->get_return_value());
     completion->release();
@@ -2132,8 +2132,8 @@ TEST_F(LibRadosTwoPoolsPP, FlushTryFlushRaces) {
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
 
-    completion->wait_for_safe();
-    completion2->wait_for_safe();
+    completion->wait_for_complete();
+    completion2->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     ASSERT_EQ(0, completion2->get_return_value());
     completion->release();
@@ -2169,8 +2169,8 @@ TEST_F(LibRadosTwoPoolsPP, FlushTryFlushRaces) {
         "foo", completion2, &op2,
 	librados::OPERATION_IGNORE_OVERLAY, NULL));
 
-      completion->wait_for_safe();
-      completion2->wait_for_safe();
+      completion->wait_for_complete();
+      completion2->wait_for_complete();
       int r = completion->get_return_value();
       ASSERT_TRUE(r == -EBUSY || r == 0);
       ASSERT_EQ(0, completion2->get_return_value());
@@ -2210,8 +2210,8 @@ TEST_F(LibRadosTwoPoolsPP, FlushTryFlushRaces) {
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
 
-    completion->wait_for_safe();
-    completion2->wait_for_safe();
+    completion->wait_for_complete();
+    completion2->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     ASSERT_EQ(0, completion2->get_return_value());
     completion->release();
@@ -2300,7 +2300,7 @@ TEST_F(LibRadosTwoPoolsPP, TryFlushReadRace) {
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
 
-  completion->wait_for_safe();
+  completion->wait_for_complete();
   ASSERT_EQ(0, completion->get_return_value());
   completion->release();
 
@@ -2851,7 +2851,7 @@ TEST_F(LibRadosTwoPoolsPP, CachePin) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -2860,7 +2860,7 @@ TEST_F(LibRadosTwoPoolsPP, CachePin) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("baz", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -2956,7 +2956,7 @@ TEST_F(LibRadosTwoPoolsPP, SetRedirectRead) {
     op.set_redirect("bar", cache_ioctx, 0);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3017,7 +3017,7 @@ TEST_F(LibRadosTwoPoolsPP, SetChunkRead) {
     }
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3101,7 +3101,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestPromoteRead) {
     op.set_redirect("bar", cache_ioctx, 0);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3111,7 +3111,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestPromoteRead) {
     op.set_chunk(0, 2, cache_ioctx, "bar-chunk", 0);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3121,7 +3121,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestPromoteRead) {
     op.tier_promote();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3137,7 +3137,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestPromoteRead) {
     op.tier_promote();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3199,7 +3199,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestRefRead) {
     op.set_redirect("bar", cache_ioctx, 0, CEPH_OSD_OP_FLAG_WITH_REFERENCE);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3209,7 +3209,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestRefRead) {
     op.set_chunk(0, 2, cache_ioctx, "bar-chunk", 0, CEPH_OSD_OP_FLAG_WITH_REFERENCE);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3290,7 +3290,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestUnset) {
     op.set_redirect("bar", cache_ioctx, 0, CEPH_OSD_OP_FLAG_WITH_REFERENCE);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3300,7 +3300,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestUnset) {
     op.set_chunk(0, 2, cache_ioctx, "bar-chunk", 0, CEPH_OSD_OP_FLAG_WITH_REFERENCE);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3337,7 +3337,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestUnset) {
     op.unset_manifest();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3348,7 +3348,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestUnset) {
     op.unset_manifest();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3361,7 +3361,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestUnset) {
       op.unset_manifest();
       librados::AioCompletion *completion = cluster.aio_create_completion();
       ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-      completion->wait_for_safe();
+      completion->wait_for_complete();
       ASSERT_EQ(-EOPNOTSUPP, completion->get_return_value());
       completion->release();
     }
@@ -3375,7 +3375,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestUnset) {
       op.unset_manifest();
       librados::AioCompletion *completion = cluster.aio_create_completion();
       ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-      completion->wait_for_safe();
+      completion->wait_for_complete();
       ASSERT_EQ(-EOPNOTSUPP, completion->get_return_value());
       completion->release();
     }
@@ -3442,7 +3442,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestDedupRefRead) {
 		CEPH_OSD_OP_FLAG_WITH_REFERENCE);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-dedup", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3454,7 +3454,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestDedupRefRead) {
 		CEPH_OSD_OP_FLAG_WITH_REFERENCE);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3556,7 +3556,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushRead) {
     op.set_chunk(0, 2, cache_ioctx, "bar-chunk", 0);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3566,7 +3566,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushRead) {
     op.set_chunk(2, 2, cache_ioctx, "bar-chunk", 2);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3584,7 +3584,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushRead) {
     op.tier_flush();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -3768,7 +3768,7 @@ TEST_F(LibRadosTwoPoolsECPP, Overlay) {
     ASSERT_EQ(0, ioctx.aio_operate(
 	"foo", completion, &op,
 	librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
     ASSERT_EQ('b', bl[0]);
@@ -4129,7 +4129,7 @@ TEST_F(LibRadosTwoPoolsECPP, Whiteout) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("bar", completion, &op,
 				   librados::OPERATION_IGNORE_CACHE));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
 
@@ -4215,7 +4215,7 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4228,7 +4228,7 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op,
 					 librados::OPERATION_IGNORE_CACHE,
 					 NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EPERM, completion->get_return_value());
     completion->release();
   }
@@ -4239,7 +4239,7 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
     op.cache_unpin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4252,7 +4252,7 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4276,7 +4276,7 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op,
 					 librados::OPERATION_IGNORE_CACHE,
 					 NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4287,7 +4287,7 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4298,7 +4298,7 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EBUSY, completion->get_return_value());
     completion->release();
   }
@@ -4406,7 +4406,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "bam", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4418,7 +4418,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "bam", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-ENOENT, completion->get_return_value());
     completion->release();
   }
@@ -4439,7 +4439,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4452,7 +4452,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-ENOENT, completion->get_return_value());
     completion->release();
   }
@@ -4466,7 +4466,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4494,7 +4494,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EBUSY, completion->get_return_value());
     completion->release();
   }
@@ -4508,7 +4508,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4522,7 +4522,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4533,7 +4533,7 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "bar", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4603,7 +4603,7 @@ TEST_F(LibRadosTwoPoolsECPP, TryFlush) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4617,7 +4617,7 @@ TEST_F(LibRadosTwoPoolsECPP, TryFlush) {
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EPERM, completion->get_return_value());
     completion->release();
   }
@@ -4628,7 +4628,7 @@ TEST_F(LibRadosTwoPoolsECPP, TryFlush) {
     op.cache_unpin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4642,7 +4642,7 @@ TEST_F(LibRadosTwoPoolsECPP, TryFlush) {
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4674,7 +4674,7 @@ TEST_F(LibRadosTwoPoolsECPP, TryFlush) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
 	 "foo", completion, &op, librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4738,7 +4738,7 @@ TEST_F(LibRadosTwoPoolsECPP, FailedFlush) {
     op.omap_set(omap);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4751,7 +4751,7 @@ TEST_F(LibRadosTwoPoolsECPP, FailedFlush) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_NE(0, completion->get_return_value());
     completion->release();
   }
@@ -4795,7 +4795,7 @@ TEST_F(LibRadosTwoPoolsECPP, FailedFlush) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4806,7 +4806,7 @@ TEST_F(LibRadosTwoPoolsECPP, FailedFlush) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op, librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4887,7 +4887,7 @@ TEST_F(LibRadosTwoPoolsECPP, Flush) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4901,7 +4901,7 @@ TEST_F(LibRadosTwoPoolsECPP, Flush) {
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EPERM, completion->get_return_value());
     completion->release();
   }
@@ -4912,7 +4912,7 @@ TEST_F(LibRadosTwoPoolsECPP, Flush) {
     op.cache_unpin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4925,7 +4925,7 @@ TEST_F(LibRadosTwoPoolsECPP, Flush) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4957,7 +4957,7 @@ TEST_F(LibRadosTwoPoolsECPP, Flush) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
 	 "foo", completion, &op, librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -4990,7 +4990,7 @@ TEST_F(LibRadosTwoPoolsECPP, Flush) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -5002,7 +5002,7 @@ TEST_F(LibRadosTwoPoolsECPP, Flush) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate(
 	 "foo", completion, &op, librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -5099,7 +5099,7 @@ TEST_F(LibRadosTwoPoolsECPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EBUSY, completion->get_return_value());
     completion->release();
   }
@@ -5112,7 +5112,7 @@ TEST_F(LibRadosTwoPoolsECPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EBUSY, completion->get_return_value());
     completion->release();
   }
@@ -5125,7 +5125,7 @@ TEST_F(LibRadosTwoPoolsECPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -5138,7 +5138,7 @@ TEST_F(LibRadosTwoPoolsECPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -5151,7 +5151,7 @@ TEST_F(LibRadosTwoPoolsECPP, FlushSnap) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_CACHE, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -5269,8 +5269,8 @@ TEST_F(LibRadosTierECPP, FlushWriteRaces) {
     ASSERT_EQ(0, ioctx.aio_operate(
       "foo", completion2, &op2, 0));
 
-    completion->wait_for_safe();
-    completion2->wait_for_safe();
+    completion->wait_for_complete();
+    completion2->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     ASSERT_EQ(0, completion2->get_return_value());
     completion->release();
@@ -5303,8 +5303,8 @@ TEST_F(LibRadosTierECPP, FlushWriteRaces) {
       librados::AioCompletion *completion2 = cluster.aio_create_completion();
       ASSERT_EQ(0, ioctx.aio_operate("foo", completion2, &op2, 0));
 
-      completion->wait_for_safe();
-      completion2->wait_for_safe();
+      completion->wait_for_complete();
+      completion2->wait_for_complete();
       int r = completion->get_return_value();
       ASSERT_TRUE(r == -EBUSY || r == 0);
       ASSERT_EQ(0, completion2->get_return_value());
@@ -5379,8 +5379,8 @@ TEST_F(LibRadosTwoPoolsECPP, FlushTryFlushRaces) {
       "foo", completion2, &op2,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
 
-    completion->wait_for_safe();
-    completion2->wait_for_safe();
+    completion->wait_for_complete();
+    completion2->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     ASSERT_EQ(0, completion2->get_return_value());
     completion->release();
@@ -5413,8 +5413,8 @@ TEST_F(LibRadosTwoPoolsECPP, FlushTryFlushRaces) {
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
 
-    completion->wait_for_safe();
-    completion2->wait_for_safe();
+    completion->wait_for_complete();
+    completion2->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     ASSERT_EQ(0, completion2->get_return_value());
     completion->release();
@@ -5450,8 +5450,8 @@ TEST_F(LibRadosTwoPoolsECPP, FlushTryFlushRaces) {
         "foo", completion2, &op2,
 	librados::OPERATION_IGNORE_OVERLAY, NULL));
 
-      completion->wait_for_safe();
-      completion2->wait_for_safe();
+      completion->wait_for_complete();
+      completion2->wait_for_complete();
       int r = completion->get_return_value();
       ASSERT_TRUE(r == -EBUSY || r == 0);
       ASSERT_EQ(0, completion2->get_return_value());
@@ -5491,8 +5491,8 @@ TEST_F(LibRadosTwoPoolsECPP, FlushTryFlushRaces) {
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
 
-    completion->wait_for_safe();
-    completion2->wait_for_safe();
+    completion->wait_for_complete();
+    completion2->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     ASSERT_EQ(0, completion2->get_return_value());
     completion->release();
@@ -5550,7 +5550,7 @@ TEST_F(LibRadosTwoPoolsECPP, TryFlushReadRace) {
       librados::OPERATION_IGNORE_OVERLAY |
       librados::OPERATION_SKIPRWLOCKS, NULL));
 
-  completion->wait_for_safe();
+  completion->wait_for_complete();
   ASSERT_EQ(0, completion->get_return_value());
   completion->release();
 
@@ -5623,7 +5623,7 @@ TEST_F(LibRadosTierECPP, CallForcesPromote) {
     ASSERT_EQ(0, cache_ioctx.aio_operate(
       "foo", completion, &op,
       librados::OPERATION_IGNORE_OVERLAY, NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -5636,7 +5636,7 @@ TEST_F(LibRadosTierECPP, CallForcesPromote) {
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op,
 					 librados::OPERATION_IGNORE_CACHE,
 					 NULL));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6170,7 +6170,7 @@ TEST_F(LibRadosTwoPoolsECPP, CachePin) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6179,7 +6179,7 @@ TEST_F(LibRadosTwoPoolsECPP, CachePin) {
     op.cache_pin();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, cache_ioctx.aio_operate("baz", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6274,7 +6274,7 @@ TEST_F(LibRadosTwoPoolsECPP, SetRedirectRead) {
     op.set_redirect("bar", cache_ioctx, 0);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6328,7 +6328,7 @@ TEST_F(LibRadosTwoPoolsECPP, SetChunkRead) {
     op.set_chunk(0, 8, cache_ioctx, "bar", 0);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6406,7 +6406,7 @@ TEST_F(LibRadosTwoPoolsECPP, ManifestPromoteRead) {
     op.set_redirect("bar", cache_ioctx, 0);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6416,7 +6416,7 @@ TEST_F(LibRadosTwoPoolsECPP, ManifestPromoteRead) {
     op.set_chunk(0, 10, cache_ioctx, "bar-chunk", 0);
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6426,7 +6426,7 @@ TEST_F(LibRadosTwoPoolsECPP, ManifestPromoteRead) {
     op.tier_promote();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6442,7 +6442,7 @@ TEST_F(LibRadosTwoPoolsECPP, ManifestPromoteRead) {
     op.tier_promote();
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(0, completion->get_return_value());
     completion->release();
   }
@@ -6559,7 +6559,7 @@ TEST_F(LibRadosTwoPoolsPP, HelloWriteReturn) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &o,
 				   librados::OPERATION_RETURNVEC));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(42, completion->get_return_value());
     ASSERT_EQ(42, rval);
     out.hexdump(std::cout);
@@ -6575,7 +6575,7 @@ TEST_F(LibRadosTwoPoolsPP, HelloWriteReturn) {
     librados::AioCompletion *completion = cluster.aio_create_completion();
     ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &o,
 				   librados::OPERATION_RETURNVEC));
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ASSERT_EQ(-EOVERFLOW, completion->get_return_value());
     ASSERT_EQ(-EOVERFLOW, rval);
     ASSERT_EQ("", std::string(out.c_str(), out.length()));

--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -162,7 +162,7 @@ TEST_F(LibRadosWatchNotify, AioWatchDelete) {
 
   rados_completion_t comp;
   uint64_t handle;
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_watch(ioctx, notify_oid, comp, &handle,
                   watch_notify2_test_cb, watch_notify2_test_errcb, this);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
@@ -178,7 +178,7 @@ TEST_F(LibRadosWatchNotify, AioWatchDelete) {
   ASSERT_TRUE(left > 0);
   ASSERT_EQ(-ENOTCONN, notify_err);
   ASSERT_EQ(-ENOTCONN, rados_watch_check(ioctx, handle));
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_unwatch(ioctx, handle, comp);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
   ASSERT_EQ(-ENOENT, rados_aio_get_return_value(comp));
@@ -243,7 +243,7 @@ TEST_F(LibRadosWatchNotify, AioWatchNotify2) {
 
   rados_completion_t comp;
   uint64_t handle;
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_watch(ioctx, notify_oid, comp, &handle,
                   watch_notify2_test_cb, watch_notify2_test_errcb, this);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
@@ -280,7 +280,7 @@ TEST_F(LibRadosWatchNotify, AioWatchNotify2) {
   ASSERT_EQ((char*)0, reply_buf);
   ASSERT_EQ(0u, reply_buf_len);
 
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_unwatch(ioctx, handle, comp);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
   ASSERT_EQ(0, rados_aio_get_return_value(comp));
@@ -303,7 +303,7 @@ TEST_F(LibRadosWatchNotify, AioNotify) {
   char *reply_buf = 0;
   size_t reply_buf_len;
   rados_completion_t comp;
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   ASSERT_EQ(0, rados_aio_notify(ioctx, "foo", comp, "notify", 6, 300000,
                                 &reply_buf, &reply_buf_len));
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
@@ -328,7 +328,7 @@ TEST_F(LibRadosWatchNotify, AioNotify) {
 
   // try it on a non-existent object ... our buffer pointers
   // should get zeroed.
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   ASSERT_EQ(0, rados_aio_notify(ioctx, "doesnotexist", comp, "notify", 6,
                                 300000, &reply_buf, &reply_buf_len));
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
@@ -436,7 +436,7 @@ TEST_F(LibRadosWatchNotify, WatchNotify2Timeout) {
   rados_unwatch2(ioctx, handle);
 
   rados_completion_t comp;
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_watch_flush(cluster, comp);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
   ASSERT_EQ(0, rados_aio_get_return_value(comp));
@@ -559,7 +559,7 @@ TEST_F(LibRadosWatchNotify, AioWatchDelete2) {
 
   rados_completion_t comp;
   uint64_t handle;
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_watch2(ioctx, notify_oid, comp, &handle,
                   watch_notify2_test_cb, watch_notify2_test_errcb, timeout, this);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
@@ -575,7 +575,7 @@ TEST_F(LibRadosWatchNotify, AioWatchDelete2) {
   ASSERT_TRUE(left > 0);
   ASSERT_EQ(-ENOTCONN, notify_err);
   ASSERT_EQ(-ENOTCONN, rados_watch_check(ioctx, handle));
-  ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
+  ASSERT_EQ(0, rados_aio_create_completion2(nullptr, nullptr, &comp));
   rados_aio_unwatch(ioctx, handle, comp);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));
   ASSERT_EQ(-ENOENT, rados_aio_get_return_value(comp));

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -116,17 +116,13 @@ librados::TestRadosClient *create_rados_client() {
 
 } // anonymous namespace
 
-extern "C" int rados_aio_create_completion(void *cb_arg,
-                                           rados_callback_t cb_complete,
-                                           rados_callback_t cb_safe,
-                                           rados_completion_t *pc)
+extern "C" int rados_aio_create_completion2(void *cb_arg,
+					    rados_callback_t cb_complete,
+					    rados_completion_t *pc)
 {
   librados::AioCompletionImpl *c = new librados::AioCompletionImpl;
   if (cb_complete) {
     c->set_complete_callback(cb_arg, cb_complete);
-  }
-  if (cb_safe) {
-    c->set_safe_callback(cb_arg, cb_safe);
   }
   *pc = c;
   return 0;
@@ -1005,10 +1001,9 @@ void Rados::from_rados_t(rados_t p, Rados &rados) {
 }
 
 AioCompletion *Rados::aio_create_completion(void *cb_arg,
-                                            callback_t cb_complete,
-                                            callback_t cb_safe) {
+                                            callback_t cb_complete) {
   AioCompletionImpl *c;
-  int r = rados_aio_create_completion(cb_arg, cb_complete, cb_safe,
+  int r = rados_aio_create_completion2(cb_arg, cb_complete,
       reinterpret_cast<void**>(&c));
   ceph_assert(r == 0);
   return new AioCompletion(c);

--- a/src/test/librados_test_stub/TestIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestIoCtxImpl.cc
@@ -210,7 +210,7 @@ int TestIoCtxImpl::operate(const std::string& oid, TestObjectOperationImpl &ops)
     &TestIoCtxImpl::execute_aio_operations, this, oid, &ops,
     reinterpret_cast<bufferlist*>(0), m_snapc), comp);
 
-  comp->wait_for_safe();
+  comp->wait_for_complete();
   int ret = comp->get_return_value();
   comp->put();
   return ret;

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -218,7 +218,7 @@ struct WaitForFlush {
 void TestRadosClient::flush_aio_operations() {
   AioCompletionImpl *comp = new AioCompletionImpl();
   flush_aio_operations(comp);
-  comp->wait_for_safe();
+  comp->wait_for_complete();
   comp->put();
 }
 

--- a/src/test/libradosstriper/aio.cc
+++ b/src/test/libradosstriper/aio.cc
@@ -40,8 +40,9 @@ void set_completion_complete(rados_completion_t cb, void *arg)
 TEST_F(StriperTest, SimpleWrite) {
   AioTestData test_data;
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_write(striper, "StriperTest", my_completion, buf, sizeof(buf), 0));
@@ -67,21 +68,23 @@ TEST_F(StriperTestPP, SimpleWritePP) {
 TEST_F(StriperTest, WaitForSafe) {
   AioTestData test_data;
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_write(striper, "WaitForSafe", my_completion, buf, sizeof(buf), 0));
   TestAlarm alarm;
-  rados_aio_wait_for_safe(my_completion);
+  rados_aio_wait_for_complete(my_completion);
   sem_wait(test_data.m_sem);
   rados_aio_release(my_completion);
 }
 
 TEST_F(StriperTestPP, WaitForSafePP) {
   AioTestData test_data;
-  AioCompletion *my_completion = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion =
+    librados::Rados::aio_create_completion(&test_data,
+                                           set_completion_complete);
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -96,8 +99,9 @@ TEST_F(StriperTestPP, WaitForSafePP) {
 TEST_F(StriperTest, RoundTrip) {
   AioTestData test_data;
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_write(striper, "RoundTrip", my_completion, buf, sizeof(buf), 0));
@@ -108,8 +112,9 @@ TEST_F(StriperTest, RoundTrip) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion2));
   ASSERT_EQ(0, rados_striper_aio_read(striper, "RoundTrip", my_completion2, buf2, sizeof(buf2), 0));
   {
     TestAlarm alarm;
@@ -124,8 +129,9 @@ TEST_F(StriperTest, RoundTrip) {
 TEST_F(StriperTest, RoundTrip2) {
   AioTestData test_data;
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_write(striper, "RoundTrip2", my_completion, buf, sizeof(buf), 0));
@@ -136,8 +142,9 @@ TEST_F(StriperTest, RoundTrip2) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion2));
   ASSERT_EQ(0, rados_striper_aio_read(striper, "RoundTrip2", my_completion2, buf2, sizeof(buf2), 0));
   {
     TestAlarm alarm;
@@ -151,8 +158,8 @@ TEST_F(StriperTest, RoundTrip2) {
 
 TEST_F(StriperTestPP, RoundTripPP) {
   AioTestData test_data;
-  AioCompletion *my_completion = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -163,8 +170,8 @@ TEST_F(StriperTestPP, RoundTripPP) {
     sem_wait(test_data.m_sem);
   }
   bufferlist bl2;
-  AioCompletion *my_completion2 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion2 =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   ASSERT_EQ(0, striper.aio_read("RoundTripPP", my_completion2, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -178,8 +185,8 @@ TEST_F(StriperTestPP, RoundTripPP) {
 
 TEST_F(StriperTestPP, RoundTripPP2) {
   AioTestData test_data;
-  AioCompletion *my_completion = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -190,8 +197,8 @@ TEST_F(StriperTestPP, RoundTripPP2) {
     sem_wait(test_data.m_sem);
   }
   bufferlist bl2;
-  AioCompletion *my_completion2 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion2 =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   ASSERT_EQ(0, striper.aio_read("RoundTripPP2", my_completion2, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -206,8 +213,9 @@ TEST_F(StriperTestPP, RoundTripPP2) {
 TEST_F(StriperTest, IsComplete) {
   AioTestData test_data;
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_write(striper, "IsComplete", my_completion, buf, sizeof(buf), 0));
@@ -218,8 +226,9 @@ TEST_F(StriperTest, IsComplete) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion2));
   ASSERT_EQ(0, rados_striper_aio_read(striper, "IsComplete", my_completion2, buf2, sizeof(buf2), 0));
   {
     TestAlarm alarm;
@@ -239,8 +248,8 @@ TEST_F(StriperTest, IsComplete) {
 
 TEST_F(StriperTestPP, IsCompletePP) {
   AioTestData test_data;
-  AioCompletion *my_completion = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -251,8 +260,8 @@ TEST_F(StriperTestPP, IsCompletePP) {
     sem_wait(test_data.m_sem);
   }
   bufferlist bl2;
-  AioCompletion *my_completion2 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion2 =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   ASSERT_EQ(0, striper.aio_read("IsCompletePP", my_completion2, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -273,8 +282,9 @@ TEST_F(StriperTestPP, IsCompletePP) {
 TEST_F(StriperTest, IsSafe) {
   AioTestData test_data;
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_write(striper, "IsSafe", my_completion, buf, sizeof(buf), 0));
@@ -291,8 +301,9 @@ TEST_F(StriperTest, IsSafe) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion2));
   ASSERT_EQ(0, rados_striper_aio_read(striper, "IsSafe", my_completion2, buf2, sizeof(buf2), 0));
   {
     TestAlarm alarm;
@@ -304,45 +315,12 @@ TEST_F(StriperTest, IsSafe) {
   rados_aio_release(my_completion2);
 }
 
-TEST_F(StriperTestPP, IsSafePP) {
-  AioTestData test_data;
-  AioCompletion *my_completion = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
-  char buf[128];
-  memset(buf, 0xcc, sizeof(buf));
-  bufferlist bl1;
-  bl1.append(buf, sizeof(buf));
-  ASSERT_EQ(0, striper.aio_write("IsSafePP", my_completion, bl1, sizeof(buf), 0));
-  {
-    TestAlarm alarm;
-    // Busy-wait until the AIO completes.
-    // Normally we wouldn't do this, but we want to test rados_aio_is_safe.
-    while (true) {
-      int is_safe = my_completion->is_safe();
-      if (is_safe)
-	break;
-    }
-  }
-  bufferlist bl2;
-  AioCompletion *my_completion2 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
-  ASSERT_EQ(0, striper.aio_read("IsSafePP", my_completion2, &bl2, sizeof(buf), 0));
-  {
-    TestAlarm alarm;
-    my_completion2->wait_for_complete();
-  }
-  ASSERT_EQ(0, memcmp(buf, bl2.c_str(), sizeof(buf)));
-  sem_wait(test_data.m_sem);
-  sem_wait(test_data.m_sem);
-  my_completion->release();
-  my_completion2->release();
-}
-
 TEST_F(StriperTest, RoundTripAppend) {
   AioTestData test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                           set_completion_complete,
+                                           &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_append(striper, "RoundTripAppend", my_completion, buf, sizeof(buf)));
@@ -352,8 +330,9 @@ TEST_F(StriperTest, RoundTripAppend) {
   }
   char buf2[128];
   memset(buf2, 0xdd, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion2));
   ASSERT_EQ(0, rados_striper_aio_append(striper, "RoundTripAppend", my_completion2, buf2, sizeof(buf)));
   {
     TestAlarm alarm;
@@ -361,8 +340,9 @@ TEST_F(StriperTest, RoundTripAppend) {
   }
   char buf3[sizeof(buf) + sizeof(buf2)];
   memset(buf3, 0, sizeof(buf3));
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion3));
   ASSERT_EQ(0, rados_striper_aio_read(striper, "RoundTripAppend", my_completion3, buf3, sizeof(buf3), 0));
   {
     TestAlarm alarm;
@@ -379,8 +359,8 @@ TEST_F(StriperTest, RoundTripAppend) {
 
 TEST_F(StriperTestPP, RoundTripAppendPP) {
   AioTestData test_data;
-  AioCompletion *my_completion = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -394,16 +374,16 @@ TEST_F(StriperTestPP, RoundTripAppendPP) {
   memset(buf2, 0xdd, sizeof(buf2));
   bufferlist bl2;
   bl2.append(buf2, sizeof(buf2));
-  AioCompletion *my_completion2 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion2 =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   ASSERT_EQ(0, striper.aio_append("RoundTripAppendPP", my_completion2, bl2, sizeof(buf2)));
   {
     TestAlarm alarm;
     my_completion2->wait_for_complete();
   }
   bufferlist bl3;
-  AioCompletion *my_completion3 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion3 =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   ASSERT_EQ(0, striper.aio_read("RoundTripAppendPP", my_completion3, &bl3, 2 * sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -421,8 +401,9 @@ TEST_F(StriperTestPP, RoundTripAppendPP) {
 TEST_F(StriperTest, Flush) {
   AioTestData test_data;
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   char buf[128];
   memset(buf, 0xee, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_write(striper, "Flush", my_completion, buf, sizeof(buf), 0));
@@ -430,8 +411,9 @@ TEST_F(StriperTest, Flush) {
   char buf2[128];
   memset(buf2, 0, sizeof(buf2));
   rados_completion_t my_completion2;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion2));
   ASSERT_EQ(0, rados_striper_aio_read(striper, "Flush", my_completion2, buf2, sizeof(buf2), 0));
   {
     TestAlarm alarm;
@@ -445,8 +427,8 @@ TEST_F(StriperTest, Flush) {
 
 TEST_F(StriperTestPP, FlushPP) {
   AioTestData test_data;
-  AioCompletion *my_completion = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   char buf[128];
   memset(buf, 0xee, sizeof(buf));
   bufferlist bl1;
@@ -454,8 +436,8 @@ TEST_F(StriperTestPP, FlushPP) {
   ASSERT_EQ(0, striper.aio_write("FlushPP", my_completion, bl1, sizeof(buf), 0));
   striper.aio_flush();
   bufferlist bl2;
-  AioCompletion *my_completion2 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion2 =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   ASSERT_EQ(0, striper.aio_read("FlushPP", my_completion2, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -470,8 +452,9 @@ TEST_F(StriperTestPP, FlushPP) {
 TEST_F(StriperTest, RoundTripWriteFull) {
   AioTestData test_data;
   rados_completion_t my_completion, my_completion2, my_completion3;
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_striper_aio_write(striper, "RoundTripWriteFull", my_completion, buf, sizeof(buf), 0));
@@ -481,8 +464,9 @@ TEST_F(StriperTest, RoundTripWriteFull) {
   }
   char buf2[64];
   memset(buf2, 0xdd, sizeof(buf2));
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion2));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion2));
   ASSERT_EQ(0, rados_striper_aio_write_full(striper, "RoundTripWriteFull", my_completion2, buf2, sizeof(buf2)));
   {
     TestAlarm alarm;
@@ -490,8 +474,9 @@ TEST_F(StriperTest, RoundTripWriteFull) {
   }
   char buf3[sizeof(buf) + sizeof(buf2)];
   memset(buf3, 0, sizeof(buf3));
-  ASSERT_EQ(0, rados_aio_create_completion
-            ((void*)&test_data, set_completion_complete, set_completion_safe, &my_completion3));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion3));
   ASSERT_EQ(0, rados_striper_aio_read(striper, "RoundTripWriteFull", my_completion3, buf3, sizeof(buf3), 0));
   {
     TestAlarm alarm;
@@ -507,8 +492,8 @@ TEST_F(StriperTest, RoundTripWriteFull) {
 
 TEST_F(StriperTestPP, RoundTripWriteFullPP) {
   AioTestData test_data;
-  AioCompletion *my_completion = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -522,16 +507,16 @@ TEST_F(StriperTestPP, RoundTripWriteFullPP) {
   memset(buf2, 0xdd, sizeof(buf2));
   bufferlist bl2;
   bl2.append(buf2, sizeof(buf2));
-  AioCompletion *my_completion2 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion2 =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   ASSERT_EQ(0, striper.aio_write_full("RoundTripWriteFullPP", my_completion2, bl2));
   {
     TestAlarm alarm;
     my_completion2->wait_for_complete();
   }
   bufferlist bl3;
-  AioCompletion *my_completion3 = librados::Rados::aio_create_completion
-    ((void*)&test_data, set_completion_complete, set_completion_safe);
+  AioCompletion *my_completion3 =
+    librados::Rados::aio_create_completion(&test_data, set_completion_complete);
   ASSERT_EQ(0, striper.aio_read("RoundTripWriteFullPP", my_completion3, &bl3, sizeof(buf), 0));
   {
     TestAlarm alarm;
@@ -554,8 +539,9 @@ TEST_F(StriperTest, RemoveTest) {
   // async remove it
   AioTestData test_data;
   rados_completion_t my_completion;
-  ASSERT_EQ(0, rados_aio_create_completion2((void*)&test_data,
-	      set_completion_complete, set_completion_safe, &my_completion));
+  ASSERT_EQ(0, rados_aio_create_completion2(&test_data,
+                                            set_completion_complete,
+                                            &my_completion));
   ASSERT_EQ(0, rados_striper_aio_remove(striper, "RemoveTest", my_completion));
   {
     TestAlarm alarm;
@@ -573,7 +559,7 @@ TEST_F(StriperTestPP, RemoveTestPP) {
   bufferlist bl;
   bl.append(buf, sizeof(buf));
   ASSERT_EQ(0, striper.write("RemoveTestPP", bl, sizeof(buf), 0));
-  AioCompletion *my_completion = cluster.aio_create_completion(0, 0, 0);
+  AioCompletion *my_completion = cluster.aio_create_completion(nullptr, nullptr);
   ASSERT_EQ(0, striper.aio_remove("RemoveTestPP", my_completion));
   {
     TestAlarm alarm;

--- a/src/test/libradosstriper/aio.cc
+++ b/src/test/libradosstriper/aio.cc
@@ -99,7 +99,7 @@ TEST_F(StriperTestPP, WaitForSafePP) {
   bl1.append(buf, sizeof(buf));
   ASSERT_EQ(0, striper.aio_write("WaitForSafePP", my_completion, bl1, sizeof(buf), 0));
   TestAlarm alarm;
-  my_completion->wait_for_safe();
+  my_completion->wait_for_complete();
   sem_wait(test_data.m_sem);
   sem_wait(test_data.m_sem);
   my_completion->release();
@@ -156,7 +156,7 @@ TEST_F(StriperTest, RoundTrip2) {
   ASSERT_EQ(0, rados_striper_aio_read(striper, "RoundTrip2", my_completion2, buf2, sizeof(buf2), 0));
   {
     TestAlarm alarm;
-    rados_aio_wait_for_safe(my_completion2);
+    rados_aio_wait_for_complete(my_completion2);
   }
   ASSERT_EQ(0, memcmp(buf, buf2, sizeof(buf)));
   sem_wait(test_data.m_sem);
@@ -214,7 +214,7 @@ TEST_F(StriperTestPP, RoundTripPP2) {
   ASSERT_EQ(0, striper.aio_read("RoundTripPP2", my_completion2, &bl2, sizeof(buf), 0));
   {
     TestAlarm alarm;
-    my_completion2->wait_for_safe();
+    my_completion2->wait_for_complete();
   }
   ASSERT_EQ(0, memcmp(buf, bl2.c_str(), sizeof(buf)));
   sem_wait(test_data.m_sem);

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2446,7 +2446,7 @@ public:
       op.copy_from(src.c_str(), context->io_ctx, src_value.version, 0);
       context->low_tier_io_ctx.aio_operate(context->prefix+oid_tgt, comp, &op,
 					   librados::OPERATION_ORDER_READS_WRITES);
-      comp->wait_for_safe();
+      comp->wait_for_complete();
       if ((r = comp->get_return_value())) {
 	cerr << "Error: oid " << oid << " copy_from " << oid_tgt << " returned error code "
 	     << r << std::endl;
@@ -2462,7 +2462,7 @@ public:
       context->io_ctx.aio_operate(context->prefix+oid, comp, &op,
 				  librados::OPERATION_ORDER_READS_WRITES |
 				  librados::OPERATION_IGNORE_REDIRECT);
-      comp->wait_for_safe();
+      comp->wait_for_complete();
       if ((r = comp->get_return_value())) {
 	if (!(r == -ENOENT && !present)) {
 	  cerr << "r is " << r << " while deleting " << oid << " and present is " << present << std::endl;
@@ -2481,7 +2481,7 @@ public:
      			  librados::OPERATION_ORDER_READS_WRITES |
      			  librados::OPERATION_IGNORE_REDIRECT,
      			  NULL);
-    comp->wait_for_safe();
+    comp->wait_for_complete();
     if ((r = comp->get_return_value()) && !src_value.deleted()) {
       cerr << "Error: oid " << oid << " stat returned error code "
 	   << r << std::endl;
@@ -2496,7 +2496,7 @@ public:
      			  librados::OPERATION_ORDER_READS_WRITES |
      			  librados::OPERATION_IGNORE_REDIRECT,
      			  NULL);
-    comp->wait_for_safe();
+    comp->wait_for_complete();
     if ((r = comp->get_return_value())) {
       cerr << "Error: oid " << oid_tgt << " stat returned error code "
 	   << r << std::endl;
@@ -2598,7 +2598,7 @@ public:
     context->io_ctx.aio_operate(context->prefix+oid, comp, &op,
 				librados::OPERATION_ORDER_READS_WRITES |
 				librados::OPERATION_IGNORE_REDIRECT);
-    comp->wait_for_safe();
+    comp->wait_for_complete();
     int r = comp->get_return_value();
     if (r && !(r == -ENOENT && !present)) {
       cerr << "r is " << r << " while deleting " << oid << " and present is " << present << std::endl;

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -485,7 +485,6 @@ class TestIoctx(object):
             self.ioctx.set_omap(write_op, keys, values)
             comp = self.ioctx.operate_aio_write_op(write_op, "hw", cb, cb)
             comp.wait_for_complete()
-            comp.wait_for_safe()
             with lock:
                 while count[0] < 2:
                     lock.wait()
@@ -496,7 +495,6 @@ class TestIoctx(object):
             eq(ret, 0)
             comp = self.ioctx.operate_aio_read_op(read_op, "hw", cb, cb)
             comp.wait_for_complete()
-            comp.wait_for_safe()
             with lock:
                 while count[0] < 4:
                     lock.wait()
@@ -608,7 +606,6 @@ class TestIoctx(object):
             return 0
         comp = self.ioctx.aio_write("foo", b"bar", 0, cb, cb)
         comp.wait_for_complete()
-        comp.wait_for_safe()
         with lock:
             while count[0] < 2:
                 lock.wait()
@@ -666,7 +663,6 @@ class TestIoctx(object):
         self.ioctx.aio_write("foo", b"barbaz", 0, cb, cb)
         comp = self.ioctx.aio_write_full("foo", b"bar", cb, cb)
         comp.wait_for_complete()
-        comp.wait_for_safe()
         with lock:
             while count[0] < 2:
                 lock.wait()

--- a/src/tools/immutable_object_cache/Utils.h
+++ b/src/tools/immutable_object_cache/Utils.h
@@ -23,7 +23,7 @@ void rados_callback(rados_completion_t c, void *arg) {
 template <typename T, void(T::*MF)(int)=&T::complete>
 librados::AioCompletion *create_rados_callback(T *obj) {
   return librados::Rados::aio_create_completion(
-    obj, &detail::rados_callback<T, MF>, nullptr);
+    obj, &detail::rados_callback<T, MF>);
 }
 
 }  // namespace immutable_obj_cache

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -863,7 +863,7 @@ int LoadGen::bootstrap(const char *pool)
       }
     }
 
-    librados::AioCompletion *c = rados->aio_create_completion(NULL, NULL, NULL);
+    librados::AioCompletion *c = rados->aio_create_completion(nullptr, nullptr);
     completions.push_back(c);
     // generate object
     ret = io_ctx.aio_write(info.name, c, bl, buf_len, info.len - buf_len);
@@ -890,7 +890,7 @@ int LoadGen::bootstrap(const char *pool)
 
 void LoadGen::run_op(LoadGenOp *op)
 {
-  op->completion = rados->aio_create_completion(op, _load_gen_cb, NULL);
+  op->completion = rados->aio_create_completion(op, _load_gen_cb);
 
   switch (op->type) {
   case OP_READ:
@@ -1053,7 +1053,7 @@ protected:
     completions = NULL;
   }
   int create_completion(int slot, void (*cb)(void *, void*), void *arg) override {
-    completions[slot] = rados.aio_create_completion((void *) arg, 0, cb);
+    completions[slot] = rados.aio_create_completion((void *) arg, cb);
 
     if (!completions[slot])
       return -EINVAL;
@@ -1115,11 +1115,11 @@ protected:
   }
 
   bool completion_is_done(int slot) override {
-    return completions[slot]->is_safe();
+    return completions[slot]->is_complete();
   }
 
   int completion_wait(int slot) override {
-    return completions[slot]->wait_for_safe_and_cb();
+    return completions[slot]->wait_for_complete_and_cb();
   }
   int completion_ret(int slot) override {
     return completions[slot]->get_return_value();
@@ -1330,7 +1330,7 @@ static int do_cache_flush(IoCtx& io_ctx, string oid)
 		     librados::OPERATION_IGNORE_CACHE |
 		     librados::OPERATION_IGNORE_OVERLAY,
 		     NULL);
-  completion->wait_for_safe();
+  completion->wait_for_complete();
   int r = completion->get_return_value();
   completion->release();
   return r;
@@ -1347,7 +1347,7 @@ static int do_cache_try_flush(IoCtx& io_ctx, string oid)
 		     librados::OPERATION_IGNORE_OVERLAY |
 		     librados::OPERATION_SKIPRWLOCKS,
 		     NULL);
-  completion->wait_for_safe();
+  completion->wait_for_complete();
   int r = completion->get_return_value();
   completion->release();
   return r;
@@ -1364,7 +1364,7 @@ static int do_cache_evict(IoCtx& io_ctx, string oid)
 		     librados::OPERATION_IGNORE_OVERLAY |
 		     librados::OPERATION_SKIPRWLOCKS,
 		     NULL);
-  completion->wait_for_safe();
+  completion->wait_for_complete();
   int r = completion->get_return_value();
   completion->release();
   return r;
@@ -1789,7 +1789,7 @@ static int do_get_inconsistent_cmd(const std::vector<const char*> &nargs,
     auto completion = librados::Rados::aio_create_completion();
     ret = do_get_inconsistent(rados, pg, start, max_item_num, completion,
 			      &items, &interval);
-    completion->wait_for_safe();
+    completion->wait_for_complete();
     ret = completion->get_return_value();
     completion->release();
     if (ret < 0) {

--- a/src/tools/scratchtool.c
+++ b/src/tools/scratchtool.c
@@ -259,8 +259,8 @@ static int testrados(void)
 
 	/* aio */
 	rados_completion_t a, b;
-	rados_aio_create_completion(0, 0, 0, &a);
-	rados_aio_create_completion(0, 0, 0, &b);
+	rados_aio_create_completion2(NULL, NULL, &a);
+	rados_aio_create_completion2(NULL, NULL, &b);
 	rados_aio_write(io_ctx, "a", a, buf, 100, 0);
 	rados_aio_write(io_ctx, "../b/bb_bb_bb\\foo\\bar", b, buf, 100, 0);
 	rados_aio_wait_for_complete(a);
@@ -273,7 +273,7 @@ static int testrados(void)
 	/* test flush */
 	printf("testing aio flush\n");
 	rados_completion_t c;
-	rados_aio_create_completion(0, 0, 0, &c);
+	rados_aio_create_completion2(NULL, NULL,  &c);
 	rados_aio_write(io_ctx, "c", c, buf, 100, 0);
 	safe = rados_aio_is_safe(c);
 	printf("a should not yet be safe and ... %s\n", safe ? "is":"is not");

--- a/src/tools/scratchtool.c
+++ b/src/tools/scratchtool.c
@@ -263,9 +263,9 @@ static int testrados(void)
 	rados_aio_create_completion(0, 0, 0, &b);
 	rados_aio_write(io_ctx, "a", a, buf, 100, 0);
 	rados_aio_write(io_ctx, "../b/bb_bb_bb\\foo\\bar", b, buf, 100, 0);
-	rados_aio_wait_for_safe(a);
+	rados_aio_wait_for_complete(a);
 	printf("a safe\n");
-	rados_aio_wait_for_safe(b);
+	rados_aio_wait_for_complete(b);
 	printf("b safe\n");
 	rados_aio_release(a);
 	rados_aio_release(b);

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -1991,6 +1991,26 @@ TRACEPOINT_EVENT(librados, rados_aio_create_completion_exit,
     )
 )
 
+TRACEPOINT_EVENT(librados, rados_aio_create_completion2_enter,
+    TP_ARGS(
+        void*, cb_arg,
+        rados_callback_t, cb_complete),
+    TP_FIELDS(
+        ctf_integer_hex(void*, cb_arg, cb_arg)
+        ctf_integer_hex(rados_callback_t, cb_complete, cb_complete)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_aio_create_completion2_exit,
+    TP_ARGS(
+        int, retval,
+        rados_completion_t, completion),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+        ctf_integer_hex(rados_completion_t, completion, completion)
+    )
+)
+
 TRACEPOINT_EVENT(librados, rados_aio_wait_for_complete_enter,
     TP_ARGS(
         rados_completion_t, completion),


### PR DESCRIPTION
it's a follow-up of #12607 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
