### PR TITLE
luminous: mds: add reference when setting Connection::priv to existing session

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1374,7 +1374,7 @@ bool MDSDaemon::ms_verify_authorizer(Connection *con, int peer_type,
     } else {
       dout(10) << " existing session " << s << " for " << s->info.inst << " existing con " << s->connection
 	       << ", new/authorizing con " << con << dendl;
-      con->set_priv(RefCountedPtr{s, false});
+      con->set_priv(RefCountedPtr{s});
 
 
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1413,7 +1413,7 @@ void MDSRank::send_message_client_counted(Message *m, client_t client)
 void MDSRank::send_message_client_counted(Message *m, Connection *connection)
 {
   // do not carry ref
-  auto session = static_cast<Session *>(m->get_connection()->get_priv().get());
+  auto session = static_cast<Session *>(connection->get_priv().get());
   if (session) {
     send_message_client_counted(m, session);
   } else {


### PR DESCRIPTION
@smithfarm -- there's no tracker ticket for https://github.com/ceph/ceph/pull/22384. This backport is required to fix cephfs failures for luminous.