### PR TITLE
deb/rpm: move server-centric CLI tools from ceph-common to ceph-base

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1385,6 +1385,9 @@ rm -rf %{buildroot}
 %{_bindir}/osdmaptool
 %{_bindir}/ceph-kvstore-tool
 %{_bindir}/ceph-run
+%{_bindir}/cephfs-data-scan
+%{_bindir}/cephfs-journal-tool
+%{_bindir}/cephfs-table-tool
 %{_libexecdir}/systemd/system-preset/50-ceph.preset
 %{_sbindir}/ceph-create-keys
 %dir %{_libexecdir}/ceph
@@ -1492,9 +1495,6 @@ fi
 %{_bindir}/ceph-dencoder
 %{_bindir}/ceph-rbdnamer
 %{_bindir}/ceph-syn
-%{_bindir}/cephfs-data-scan
-%{_bindir}/cephfs-journal-tool
-%{_bindir}/cephfs-table-tool
 %{_bindir}/rados
 %{_bindir}/radosgw-admin
 %{_bindir}/rbd

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1389,6 +1389,7 @@ rm -rf %{buildroot}
 %{_bindir}/cephfs-data-scan
 %{_bindir}/cephfs-journal-tool
 %{_bindir}/cephfs-table-tool
+%{_bindir}/radosgw-admin
 %{_libexecdir}/systemd/system-preset/50-ceph.preset
 %{_sbindir}/ceph-create-keys
 %dir %{_libexecdir}/ceph
@@ -1432,6 +1433,8 @@ rm -rf %{buildroot}
 %{_mandir}/man8/monmaptool.8*
 %{_mandir}/man8/ceph-kvstore-tool.8*
 %{_mandir}/man8/ceph-dencoder.8*
+%{_mandir}/man8/radosgw-admin.8*
+%config %{_sysconfdir}/bash_completion.d/radosgw-admin
 #set up placeholder directories
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/crash
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/crash/posted
@@ -1497,7 +1500,6 @@ fi
 %{_bindir}/ceph-rbdnamer
 %{_bindir}/ceph-syn
 %{_bindir}/rados
-%{_bindir}/radosgw-admin
 %{_bindir}/rbd
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
@@ -1519,7 +1521,6 @@ fi
 %{_mandir}/man8/ceph.8*
 %{_mandir}/man8/mount.ceph.8*
 %{_mandir}/man8/rados.8*
-%{_mandir}/man8/radosgw-admin.8*
 %{_mandir}/man8/rbd.8*
 %{_mandir}/man8/rbdmap.8*
 %{_mandir}/man8/rbd-replay.8*
@@ -1533,7 +1534,6 @@ fi
 %config %{_sysconfdir}/bash_completion.d/ceph
 %config %{_sysconfdir}/bash_completion.d/rados
 %config %{_sysconfdir}/bash_completion.d/rbd
-%config %{_sysconfdir}/bash_completion.d/radosgw-admin
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{_unitdir}/rbdmap.service
 %dir %{_udevrulesdir}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1385,6 +1385,7 @@ rm -rf %{buildroot}
 %{_bindir}/osdmaptool
 %{_bindir}/ceph-kvstore-tool
 %{_bindir}/ceph-run
+%{_bindir}/ceph-dencoder
 %{_bindir}/cephfs-data-scan
 %{_bindir}/cephfs-journal-tool
 %{_bindir}/cephfs-table-tool
@@ -1430,6 +1431,7 @@ rm -rf %{buildroot}
 %{_mandir}/man8/osdmaptool.8*
 %{_mandir}/man8/monmaptool.8*
 %{_mandir}/man8/ceph-kvstore-tool.8*
+%{_mandir}/man8/ceph-dencoder.8*
 #set up placeholder directories
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/crash
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/crash/posted
@@ -1492,7 +1494,6 @@ fi
 %{_bindir}/ceph
 %{_bindir}/ceph-authtool
 %{_bindir}/ceph-conf
-%{_bindir}/ceph-dencoder
 %{_bindir}/ceph-rbdnamer
 %{_bindir}/ceph-syn
 %{_bindir}/rados
@@ -1512,7 +1513,6 @@ fi
 %{_tmpfilesdir}/ceph-common.conf
 %{_mandir}/man8/ceph-authtool.8*
 %{_mandir}/man8/ceph-conf.8*
-%{_mandir}/man8/ceph-dencoder.8*
 %{_mandir}/man8/ceph-rbdnamer.8*
 %{_mandir}/man8/ceph-syn.8*
 %{_mandir}/man8/ceph-post-file.8*

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -2,6 +2,7 @@ etc/init.d/ceph
 lib/systemd/system/ceph-crash.service
 usr/bin/ceph-crash
 usr/bin/ceph-debugpack
+usr/bin/ceph-dencoder
 usr/bin/ceph-run
 usr/bin/cephfs-data-scan
 usr/bin/cephfs-journal-tool
@@ -17,6 +18,7 @@ usr/sbin/ceph-create-keys
 usr/share/doc/ceph/sample.ceph.conf
 usr/share/man/man8/ceph-create-keys.8
 usr/share/man/man8/ceph-debugpack.8
+usr/share/man/man8/ceph-dencoder.8
 usr/share/man/man8/ceph-deploy.8
 usr/share/man/man8/ceph-run.8
 usr/share/man/man8/crushtool.8

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -3,6 +3,9 @@ lib/systemd/system/ceph-crash.service
 usr/bin/ceph-crash
 usr/bin/ceph-debugpack
 usr/bin/ceph-run
+usr/bin/cephfs-data-scan
+usr/bin/cephfs-journal-tool
+usr/bin/cephfs-table-tool
 usr/bin/crushtool
 usr/bin/monmaptool
 usr/bin/osdmaptool

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -1,3 +1,4 @@
+etc/bash_completion.d/radosgw-admin
 etc/init.d/ceph
 lib/systemd/system/ceph-crash.service
 usr/bin/ceph-crash
@@ -11,6 +12,7 @@ usr/bin/crushtool
 usr/bin/monmaptool
 usr/bin/osdmaptool
 usr/bin/ceph-kvstore-tool
+usr/bin/radosgw-admin
 usr/lib/ceph/ceph_common.sh
 usr/lib/ceph/erasure-code/*
 usr/lib/rados-classes/*
@@ -25,3 +27,4 @@ usr/share/man/man8/crushtool.8
 usr/share/man/man8/monmaptool.8
 usr/share/man/man8/osdmaptool.8
 usr/share/man/man8/ceph-kvstore-tool.8
+usr/share/man/man8/radosgw-admin.8

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -12,9 +12,6 @@ usr/bin/ceph-conf
 usr/bin/ceph-dencoder
 usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
-usr/bin/cephfs-data-scan
-usr/bin/cephfs-journal-tool
-usr/bin/cephfs-table-tool
 usr/bin/rados
 usr/bin/radosgw-admin
 usr/bin/rbd

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -9,7 +9,6 @@ lib/systemd/system/rbdmap.service
 usr/bin/ceph
 usr/bin/ceph-authtool
 usr/bin/ceph-conf
-usr/bin/ceph-dencoder
 usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
 usr/bin/rados
@@ -23,7 +22,6 @@ usr/lib/ceph/compressor/*
 usr/lib/ceph/crypto/* [amd64]
 usr/share/man/man8/ceph-authtool.8
 usr/share/man/man8/ceph-conf.8
-usr/share/man/man8/ceph-dencoder.8
 usr/share/man/man8/ceph-rbdnamer.8
 usr/share/man/man8/ceph-syn.8
 usr/share/man/man8/ceph-post-file.8

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -2,7 +2,6 @@
 
 etc/bash_completion.d/ceph
 etc/bash_completion.d/rados
-etc/bash_completion.d/radosgw-admin
 etc/bash_completion.d/rbd
 lib/systemd/system/ceph.target
 lib/systemd/system/rbdmap.service
@@ -12,7 +11,6 @@ usr/bin/ceph-conf
 usr/bin/ceph-rbdnamer
 usr/bin/ceph-syn
 usr/bin/rados
-usr/bin/radosgw-admin
 usr/bin/rbd
 usr/bin/rbdmap
 usr/bin/rbd-replay*
@@ -28,7 +26,6 @@ usr/share/man/man8/ceph-post-file.8
 usr/share/man/man8/ceph.8
 usr/share/man/man8/mount.ceph.8
 usr/share/man/man8/rados.8
-usr/share/man/man8/radosgw-admin.8
 usr/share/man/man8/rbd.8
 usr/share/man/man8/rbdmap.8
 usr/share/man/man8/rbd-replay*.8


### PR DESCRIPTION
Downstream, we've had the `cephfs-*` fsck tools and `ceph-dencoder` in ceph-base for a long time, with no adverse effect.

Not so sure about `radosgw-admin`, which @runsisi asked to also be moved, but it seems pretty server-centric (?)

Fixes: https://tracker.ceph.com/issues/42430