### PR TITLE
common/thread: Fix race condition in make_named_thread

### DIFF
--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -16,6 +16,8 @@
 #ifndef CEPH_THREAD_H
 #define CEPH_THREAD_H
 
+#include <functional>
+#include <string_view>
 #include <system_error>
 #include <thread>
 
@@ -68,13 +70,14 @@ std::string get_thread_name(const std::thread& t);
 void kill(std::thread& t, int signal);
 
 template<typename Fun, typename... Args>
-std::thread make_named_thread(const std::string& s,
+std::thread make_named_thread(std::string_view n,
 			      Fun&& fun,
 			      Args&& ...args) {
-  auto t = std::thread(std::forward<Fun>(fun),
-		       std::forward<Args>(args)...);
-  set_thread_name(t, s);
-  return t;
-}
 
+  return std::thread([n = std::string(n)](auto&& fun, auto&& ...args) {
+		       ceph_pthread_setname(pthread_self(), n.data());
+		       std::invoke(std::forward<Fun>(fun),
+				   std::forward<Args>(args)...);
+		     }, std::forward<Fun>(fun), std::forward<Args>(args)...);
+}
 #endif


### PR DESCRIPTION
The thread may well no longer exist by the time we try to set the
name, so have the thread set its own name first thing.

Thanks to Ilya Dryomov <idryomov@gmail.com> for pointing it out.