### PR TITLE
ceph-daemon: a couple fixes

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -1289,6 +1289,8 @@ def command_rm_cluster():
                       'ceph-%s-crash.service' % args.fsid]:
         call(['systemctl', 'stop', unit_name], 'systemctl',
              verbose_on_failure=False)
+        call(['systemctl', 'reset-failed', unit_name], 'systemctl',
+             verbose_on_failure=False)
         call(['systemctl', 'disable', unit_name], 'systemctl',
              verbose_on_failure=False)
 

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -316,7 +316,7 @@ def get_config_and_both_keyrings():
             with open(args.config_and_keyrings, 'r') as f:
                 j = f.read()
         d = json.loads(j)
-        (d.get('config'), d.get('keyring'), d.get('crash_keyring'))
+        return (d.get('config'), d.get('keyring'), d.get('crash_keyring'))
     else:
         if args.key:
             keyring = '[%s]\n\tkey = %s\n' % (args.name, args.key)


### PR DESCRIPTION
- fix deploy (get_config_and_both_keyrings return value was broken)
- rm-clsuter now removes units even if they are in failed state