### PR TITLE
python-common: enable lint in tox tests

### DIFF
--- a/src/python-common/CMakeLists.txt
+++ b/src/python-common/CMakeLists.txt
@@ -13,5 +13,5 @@ endforeach()
 
 if(WITH_TESTS)
   include(AddCephTest)
-  add_tox_test(python-common)
+  add_tox_test(python-common TOX_ENVS lint)
 endif()

--- a/src/python-common/README.rst
+++ b/src/python-common/README.rst
@@ -6,15 +6,15 @@ functions usable throughout the Ceph project.
 
 Like for example:
 
--  All different Cython bindings
--  MGR modules
--  ``ceph`` command line interface and other Ceph tools.
--  Also external tools
+- All different Cython bindings.
+- MGR modules.
+- ``ceph`` command line interface and other Ceph tools.
+- Also external tools.
 
 Requirements
 ============
 
--  ``python-six``
+- ``python-six``
 
 Usage
 =====

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -3,7 +3,6 @@ try:
     from typing import Optional, List, Dict
 except ImportError:
     pass
-
 import six
 
 
@@ -45,7 +44,8 @@ class DeviceSelection(object):
     def validate(self):
         props = [self.id_model, self.size, self.rotates, self.count]
         if self.paths and any(p is not None for p in props):
-            raise DriveGroupValidationError('DeviceSelection: `paths` and other parameters are mutually exclusive')
+            raise DriveGroupValidationError(
+                'DeviceSelection: `paths` and other parameters are mutually exclusive')
         if not any(p is not None for p in [self.paths] + props):
             raise DriveGroupValidationError('DeviceSelection cannot be empty')
 
@@ -57,6 +57,7 @@ class DeviceSelection(object):
 class DriveGroupValidationError(Exception):
     def __init__(self, msg):
         super(DriveGroupValidationError, self).__init__('Failed to validate Drive Group: ' + msg)
+
 
 class DriveGroupSpec(object):
     """

--- a/src/python-common/ceph/deployment/ssh_orchestrator.py
+++ b/src/python-common/ceph/deployment/ssh_orchestrator.py
@@ -1,10 +1,11 @@
-
 def bootstrap_cluster():
     create_mon()
     create_mgr()
 
+
 def create_mon():
     pass
+
 
 def create_mgr():
     pass

--- a/src/python-common/ceph/exceptions.py
+++ b/src/python-common/ceph/exceptions.py
@@ -10,12 +10,15 @@ class Error(Exception):
             return msg
         return '[errno {0}] {1}'.format(self.errno, msg)
 
+
 class InvalidArgumentError(Error):
     pass
+
 
 class OSError(Error):
     """ `OSError` class, derived from `Error` """
     pass
+
 
 class InterruptedOrTimeoutError(OSError):
     """ `InterruptedOrTimeoutError` class, derived from `OSError` """

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -2,6 +2,7 @@ import pytest
 
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, DriveGroupValidationError
 
+
 def test_DriveGroup():
     dg_json = {
         'host_pattern': 'hostname',

--- a/src/python-common/requirements-lint.txt
+++ b/src/python-common/requirements-lint.txt
@@ -1,0 +1,2 @@
+flake8==3.7.8
+rstcheck==3.3.1

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, flake8
+envlist = py27, py3, lint
 skip_missing_interpreters = true
 
 [testenv]
@@ -7,12 +7,18 @@ deps=
   pytest
 commands=py.test -v {posargs:ceph/tests}
 
-[testenv:flake8]
-deps=flake8
-commands=flake8 {posargs:ceph}
-
 [tool:pytest]
 norecursedirs = .* _* virtualenv
 
 [flake8]
-select=F,E9
+max-line-length = 100
+exclude =
+    __pycache__
+
+[testenv:lint]
+deps = 
+    -rrequirements-lint.txt
+commands =
+    flake8 {posargs:ceph}
+    rstcheck --report info --debug README.rst
+


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
Since we are adding more codes to python-common, it's a good time to make sure the code look nice.

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
