### PR TITLE
nautilus: rgw: lifecycle days may be 0

### DIFF
--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -85,7 +85,7 @@ public:
   bool valid() const {
     if (!days.empty() && !date.empty()) {
       return false;
-    } else if (!days.empty() && get_days() <= 0) {
+    } else if (!days.empty() && get_days() < 0) {
       return false;
     }
     //We've checked date in xml parsing


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42281

---

backport of https://github.com/ceph/ceph/pull/26524
parent tracker: https://tracker.ceph.com/issues/38389

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh