### PR TITLE
nautilus: krbd: avoid udev netlink socket overrun and retry on transient errors from udev_enumerate_scan_devices()

### DIFF
--- a/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_enumerate.yaml
+++ b/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_enumerate.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/krbd_udev_enumerate.sh

--- a/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_netlink_enobufs.yaml
+++ b/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_netlink_enobufs.yaml
@@ -1,0 +1,10 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - pauserd,pausewr flag\(s\) set
+
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/krbd_udev_netlink_enobufs.sh

--- a/qa/workunits/rbd/krbd_udev_enumerate.sh
+++ b/qa/workunits/rbd/krbd_udev_enumerate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This is a test for https://tracker.ceph.com/issues/41036, but it also
+# triggers https://tracker.ceph.com/issues/41404 in some environments.
+
+set -ex
+
+function assert_exit_codes() {
+    declare -a pids=($@)
+
+    for pid in ${pids[@]}; do
+       wait $pid
+    done
+}
+
+function run_map() {
+    declare -a pids
+
+    for i in {1..300}; do
+        sudo rbd map img$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 301 ]]
+}
+
+function run_unmap_by_dev() {
+    declare -a pids
+
+    run_map
+    for i in {0..299}; do
+        sudo rbd unmap /dev/rbd$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 0 ]]
+}
+
+function run_unmap_by_spec() {
+    declare -a pids
+
+    run_map
+    for i in {1..300}; do
+        sudo rbd unmap img$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 0 ]]
+}
+
+# Can't test with exclusive-lock, don't bother enabling deep-flatten.
+# See https://tracker.ceph.com/issues/42492.
+for i in {1..300}; do
+    rbd create --size 1 --image-feature '' img$i
+done
+
+for i in {1..30}; do
+    echo Iteration $i
+    run_unmap_by_dev
+    run_unmap_by_spec
+done
+
+echo OK

--- a/qa/workunits/rbd/krbd_udev_netlink_enobufs.sh
+++ b/qa/workunits/rbd/krbd_udev_netlink_enobufs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This is a test for https://tracker.ceph.com/issues/41404, verifying that udev
+# events are properly reaped while the image is being (un)mapped in the kernel.
+# UDEV_BUF_SIZE is 1M (giving us a 2M socket receive buffer), but modprobe +
+# modprobe -r generate ~28M worth of "block" events.
+
+set -ex
+
+rbd create --size 1 img
+
+ceph osd pause
+sudo rbd map img &
+PID=$!
+sudo modprobe scsi_debug max_luns=16 add_host=16 num_parts=1 num_tgts=16
+sudo udevadm settle
+sudo modprobe -r scsi_debug
+[[ $(rbd showmapped | wc -l) -eq 0 ]]
+ceph osd unpause
+wait $PID
+[[ $(rbd showmapped | wc -l) -eq 2 ]]
+sudo rbd unmap img
+
+echo OK

--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -16,6 +16,8 @@
 #ifndef CEPH_THREAD_H
 #define CEPH_THREAD_H
 
+#include <functional>
+#include <string_view>
 #include <system_error>
 #include <thread>
 
@@ -68,13 +70,14 @@ std::string get_thread_name(const std::thread& t);
 void kill(std::thread& t, int signal);
 
 template<typename Fun, typename... Args>
-std::thread make_named_thread(const std::string& s,
+std::thread make_named_thread(std::string_view n,
 			      Fun&& fun,
 			      Args&& ...args) {
-  auto t = std::thread(std::forward<Fun>(fun),
-		       std::forward<Args>(args)...);
-  set_thread_name(t, s);
-  return t;
-}
 
+  return std::thread([n = std::string(n)](auto&& fun, auto&& ...args) {
+		       ceph_pthread_setname(pthread_self(), n.data());
+		       std::invoke(std::forward<Fun>(fun),
+				   std::forward<Args>(args)...);
+		     }, std::forward<Fun>(fun), std::forward<Args>(args)...);
+}
 #endif

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -44,6 +44,8 @@
 #include <blkid/blkid.h>
 #include <libudev.h>
 
+static const int UDEV_BUF_SIZE = 1 << 20;  /* doubled to 2M (SO_RCVBUFFORCE) */
+
 struct krbd_ctx {
   CephContext *cct;
   struct udev *udev;
@@ -388,6 +390,13 @@ static int do_map(struct udev *udev, const krbd_spec& spec, const string& buf,
   if (r < 0)
     goto out_mon;
 
+  r = udev_monitor_set_receive_buffer_size(mon, UDEV_BUF_SIZE);
+  if (r < 0) {
+    std::cerr << "rbd: failed to set udev buffer size: " << cpp_strerror(r)
+              << std::endl;
+    /* not fatal */
+  }
+
   r = udev_monitor_enable_receiving(mon);
   if (r < 0)
     goto out_mon;
@@ -695,6 +704,13 @@ static int do_unmap(struct udev *udev, dev_t devno, const string& buf)
   r = udev_monitor_filter_add_match_subsystem_devtype(mon, "block", "disk");
   if (r < 0)
     goto out_mon;
+
+  r = udev_monitor_set_receive_buffer_size(mon, UDEV_BUF_SIZE);
+  if (r < 0) {
+    std::cerr << "rbd: failed to set udev buffer size: " << cpp_strerror(r)
+              << std::endl;
+    /* not fatal */
+  }
 
   r = udev_monitor_enable_receiving(mon);
   if (r < 0)

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -234,18 +234,23 @@ static int wait_for_mapping(udev_monitor *mon, F udev_device_handler)
   fds[0].events = POLLIN;
 
   for (;;) {
-    struct udev_device *dev;
-
     if (poll(fds, 1, -1) < 0) {
       ceph_abort_msgf("poll failed: %d", -errno);
     }
 
-    dev = udev_monitor_receive_device(mon);
-    if (!dev) {
-      continue;
-    }
-    if (udev_device_handler(dev)) {
-      return 0;
+    for (;;) {
+      struct udev_device *dev;
+
+      dev = udev_monitor_receive_device(mon);
+      if (!dev) {
+        if (errno != EINTR && errno != EAGAIN) {
+          return -errno;
+        }
+        break;
+      }
+      if (udev_device_handler(dev)) {
+        return 0;
+      }
     }
   }
 }

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -811,13 +811,25 @@ static int unmap_image(struct krbd_ctx *ctx, const char *devnode,
     wholedevno = sb.st_rdev;
   }
 
-  r = devno_to_krbd_id(ctx->udev, wholedevno, &id);
-  if (r < 0) {
-    if (r == -ENOENT) {
-      cerr << "rbd: '" << devnode << "' is not an rbd device" << std::endl;
-      r = -EINVAL;
+  for (int tries = 0; ; tries++) {
+    r = devno_to_krbd_id(ctx->udev, wholedevno, &id);
+    if (r == -ENOENT && tries < 2) {
+      usleep(250 * 1000);
+    } else {
+      if (r < 0) {
+        if (r == -ENOENT) {
+          std::cerr << "rbd: '" << devnode << "' is not an rbd device"
+                    << std::endl;
+          r = -EINVAL;
+        }
+        return r;
+      }
+      if (tries) {
+        std::cerr << "rbd: udev enumerate missed a device, tries = " << tries
+                  << std::endl;
+      }
+      break;
     }
-    return r;
   }
 
   return do_unmap(ctx->udev, wholedevno, build_unmap_buf(id, options));
@@ -830,14 +842,25 @@ static int unmap_image(struct krbd_ctx *ctx, const krbd_spec& spec,
   string id;
   int r;
 
-  r = spec_to_devno_and_krbd_id(ctx->udev, spec, &devno, &id);
-  if (r < 0) {
-    if (r == -ENOENT) {
-      cerr << "rbd: " << spec << ": not a mapped image or snapshot"
-           << std::endl;
-      r = -EINVAL;
+  for (int tries = 0; ; tries++) {
+    r = spec_to_devno_and_krbd_id(ctx->udev, spec, &devno, &id);
+    if (r == -ENOENT && tries < 2) {
+      usleep(250 * 1000);
+    } else {
+      if (r < 0) {
+        if (r == -ENOENT) {
+          std::cerr << "rbd: " << spec << ": not a mapped image or snapshot"
+                    << std::endl;
+          r = -EINVAL;
+        }
+        return r;
+      }
+      if (tries) {
+        std::cerr << "rbd: udev enumerate missed a device, tries = " << tries
+                  << std::endl;
+      }
+      break;
     }
-    return r;
   }
 
   return do_unmap(ctx->udev, devno, build_unmap_buf(id, options));


### PR DESCRIPTION
backport trackers: 

* https://tracker.ceph.com/issues/42427
* https://tracker.ceph.com/issues/42524
* https://tracker.ceph.com/issues/42645

---

backport of

* https://github.com/ceph/ceph/pull/30965
* https://github.com/ceph/ceph/pull/31023
* https://github.com/ceph/ceph/pull/31057

parent trackers:

* https://tracker.ceph.com/issues/41036
* https://tracker.ceph.com/issues/41404
* https://tracker.ceph.com/issues/42523