### PR TITLE
nautilus: core: osd/PGLog: persist num_objects_missing for replicas when peering is done

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -485,6 +485,9 @@ void PGLog::merge_log(pg_info_t &oinfo, pg_log_t &olog, pg_shard_t fromosd,
 
     info.last_user_version = oinfo.last_user_version;
     info.purged_snaps = oinfo.purged_snaps;
+    // update num_missing too
+    // we might have appended some more missing objects above
+    info.stats.stats.sum.num_objects_missing = missing.num_missing();
 
     changed = true;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42141

---

backport of https://github.com/ceph/ceph/pull/30466
parent tracker: https://tracker.ceph.com/issues/41924

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh