### PR TITLE
mgr/dashboard: AttributeError: 'NoneType' object has no attrib…

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -57,6 +57,7 @@ class Osd(RESTController):
         def add_id(osd):
             osd['id'] = osd['osd']
             return osd
+
         resp = {
             osd['osd']: add_id(osd)
             for osd in mgr.get('osd_map')['osds'] if svc_id is None or osd['osd'] == int(svc_id)
@@ -77,11 +78,13 @@ class Osd(RESTController):
             if dev_id not in smart_data:
                 dev_smart_data = mgr.remote('devicehealth', 'do_scrape_daemon', 'osd', svc_id,
                                             dev_id)
-                for _, dev_data in dev_smart_data.items():
-                    if 'error' in dev_data:
-                        logger.warning('[OSD] Error retrieving smartctl data for device ID %s: %s',
-                                       dev_id, dev_smart_data)
-                smart_data.update(dev_smart_data)
+                if dev_smart_data:
+                    for _, dev_data in dev_smart_data.items():
+                        if 'error' in dev_data:
+                            logger.warning(
+                                '[OSD] Error retrieving smartctl data for device ID %s: %s', dev_id,
+                                dev_smart_data)
+                    smart_data.update(dev_smart_data)
         return smart_data
 
     @RESTController.Resource('GET')


### PR DESCRIPTION
Fixes a bug in the smart data integration where the back-end throws an error if no smart data is returned.

Fixes: https://tracker.ceph.com/issues/42443

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
