### PR TITLE
nautilus: cephfs: osdc/objecter: Fix last_sent in scientific format and add age to ops

### DIFF
--- a/src/client/MetaRequest.cc
+++ b/src/client/MetaRequest.cc
@@ -10,6 +10,8 @@
 
 void MetaRequest::dump(Formatter *f) const
 {
+  auto age = std::chrono::duration<double>(ceph_clock_now() - op_stamp);
+
   f->dump_unsigned("tid", tid);
   f->dump_string("op", ceph_mds_op_name(head.op));
   f->dump_stream("path") << path;
@@ -29,6 +31,7 @@ void MetaRequest::dump(Formatter *f) const
   f->dump_stream("hint_ino") << inodeno_t(head.ino);
 
   f->dump_stream("sent_stamp") << sent_stamp;
+  f->dump_float("age", age.count());
   f->dump_int("mds", mds);
   f->dump_int("resend_mds", resend_mds);
   f->dump_int("send_to_auth", send_to_auth);

--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -95,7 +95,8 @@ namespace ceph {
 	   typename std::enable_if<Clock::is_steady>::type*>
   std::ostream& operator<<(std::ostream& m,
 			   const std::chrono::time_point<Clock>& t) {
-    return m << std::chrono::duration<double>(t.time_since_epoch()).count()
+    return m << std::fixed << std::chrono::duration<double>(
+		t.time_since_epoch()).count()
 	     << "s";
   }
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -4517,10 +4517,12 @@ void Objecter::_dump_ops(const OSDSession *s, Formatter *fmt)
        p != s->ops.end();
        ++p) {
     Op *op = p->second;
+    auto age = std::chrono::duration<double>(coarse_mono_clock::now() - op->stamp);
     fmt->open_object_section("op");
     fmt->dump_unsigned("tid", op->tid);
     op->target.dump(fmt);
     fmt->dump_stream("last_sent") << op->stamp;
+    fmt->dump_float("age", age.count());
     fmt->dump_int("attempts", op->attempts);
     fmt->dump_stream("snapid") << op->snapid;
     fmt->dump_stream("snap_context") << op->snapc;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42158

---

backport of https://github.com/ceph/ceph/pull/29818
parent tracker: https://tracker.ceph.com/issues/40821

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh