### PR TITLE
nautilus: tests/ceph.py: tolerate ECONNRESET errcode during logrotate

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -174,7 +174,7 @@ def ceph_log(ctx, config):
                 except SSHException as e:
                     log.debug("Missed logrotate, SSHException")
                 except socket.error as e:
-                    if e.errno == errno.EHOSTUNREACH:
+                    if e.errno in (errno.EHOSTUNREACH, errno.ECONNRESET):
                         log.debug("Missed logrotate, host unreachable")
                     else:
                         raise


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42279

---

backport of https://github.com/ceph/ceph/pull/30809
parent tracker: https://tracker.ceph.com/issues/41800

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh