### PR TITLE
nautilus: tests/cephfs.py: allow client mount to reset fully

### DIFF
--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -187,6 +187,9 @@ class TestClientRecovery(CephFSTestCase):
         # The mount goes away while the MDS is offline
         self.mount_a.kill()
 
+        # wait for it to die
+        time.sleep(5)
+
         self.fs.mds_restart()
 
         # Enter reconnect phase


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42422

---

backport of https://github.com/ceph/ceph/pull/30986
parent tracker: https://tracker.ceph.com/issues/42213

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh