### PR TITLE
nautilus: tests: whitelist "Error recovering journal" for cephfs-data-scan

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/data-scan.yaml
+++ b/qa/suites/fs/basic_functional/tasks/data-scan.yaml
@@ -12,6 +12,7 @@ overrides:
       - Scrub error on inode
       - Metadata damage detected
       - inconsistent rstat on inode
+      - Error recovering journal
 
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/kcephfs/recovery/tasks/data-scan.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/data-scan.yaml
@@ -11,6 +11,7 @@ overrides:
       - Scrub error on inode
       - Metadata damage detected
       - inconsistent rstat on inode
+      - Error recovering journal
 
 tasks:
   - cephfs_test_runner:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42424

---

backport of https://github.com/ceph/ceph/pull/30971
parent tracker: https://tracker.ceph.com/issues/41836

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh