### PR TITLE
doc/bootstrap.rst: fix github's url

### DIFF
--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -19,7 +19,7 @@ your Linux distribution::
 
 or by simply downloading the standalone script manually::
 
-  curl https://github.com/ceph/ceph/tree/master/src/ceph-daemon > ceph-daemon
+  curl --silent --remote-name --location https://github.com/ceph/ceph/raw/master/src/ceph-daemon
   chmod +x ceph-daemon
   sudo install -m 0755 ceph-daemon /usr/sbin    # optional!
 


### PR DESCRIPTION
The previous URL leads to github's html page, which is not suitable for scripting

Signed-off-by: Alexandre Bruyelles <jack@jack.fr.eu.org>