### PR TITLE
rgw: set correct storage class for append

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -561,6 +561,11 @@ int AppendObjectProcessor::prepare(optional_yield y)
       size_t pos = s.find("-");
       cur_etag = s.substr(0, pos);
     }
+
+    iter = astate->attrset.find(RGW_ATTR_STORAGE_CLASS);
+    if (iter != astate->attrset.end()) {
+      tail_placement_rule.storage_class = iter->second.to_str();
+    }
     cur_manifest = &(*astate->manifest);
     manifest.set_prefix(cur_manifest->get_prefix());
   }


### PR DESCRIPTION
fix https://tracker.ceph.com/issues/42444

when append upload first  5M object and then append 3M, the 3M data should be in the same pool as the first 5M, just like the multipart upload, the storage can be get from head object state

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>

```
    default.rgw.meta                 3     5.2 KiB          28     5.2 KiB         0        87 GiB
    default.rgw.log                  4        87 B         210        87 B         0        87 GiB
    default.rgw.buckets.index        6       227 B           4       227 B         0        87 GiB
    default.rgw.buckets.data         7       3 MiB           2       3 MiB         0        87 GiB
    default.rgw.buckets.non-ec      10         0 B           0         0 B         0        87 GiB
    default.rgw.buckets.data-ia     12       5 MiB           2       5 MiB         0        87 GiB

```

pythpn script 
```
import boto.s3.connection
boto.set_stream_logger('boto')
host = '127.0.0.1'
access_key = 'yly2'
secret_key = 'yly2'
conn = boto.connect_s3(
                access_key,
                secret_key,
                host = host,
                is_secure = False,
                port=7480,
                calling_format = boto.s3.connection.OrdinaryCallingFormat(),
                )

bucketname = 'yly2b1'
bucket = conn.get_bucket(bucketname)
obj = "obj6"
headers = {"x-amz-storage-class":"STANDARD_IA"}
data = open('/root/5M', 'rb').read()
# req = bucket.connection.make_request("PUT", bucket.name , obj, None, "abc", query_args='append&position=0' )
req = bucket.connection.make_request("PUT", bucket.name , obj, headers, data, query_args='append&position=0')
print req.read()
print req.status
data2 = open('/root/3M', 'rb').read()
req = bucket.connection.make_request("PUT", bucket.name , obj, None, data2, query_args='append&position=%s' % (len(data),) )
```


```
    default.rgw.buckets.index        6       227 B           4       227 B         0        87 GiB
    default.rgw.buckets.data         7         0 B           1         0 B         0        87 GiB
    default.rgw.buckets.non-ec      10         0 B           0         0 B         0        87 GiB
    default.rgw.buckets.data-ia     12       8 MiB           3       8 MiB         0        87 GiB

```