### PR TITLE
nautilus: rgw: add bucket permission verify when copy obj

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4810,10 +4810,11 @@ int RGWCopyObj::verify_permission()
                                                         RGW_PERM_WRITE)){
         return -EACCES;
       }
+    } else if (! dest_bucket_policy.verify_permission(this, *s->auth.identity, s->perm_mask,
+                                                      RGW_PERM_WRITE)) {
+      return -EACCES;
     }
-  } else if (! dest_bucket_policy.verify_permission(this, *s->auth.identity, s->perm_mask,
-                                                    RGW_PERM_WRITE)) {
-    return -EACCES;
+
   }
 
   op_ret = init_dest_policy();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41634

---

backport of https://github.com/ceph/ceph/pull/29628
parent tracker: https://tracker.ceph.com/issues/41042

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh