### PR TITLE
luminous: doc/rbd: s/guess/xml/ for codeblock lexer

### DIFF
--- a/doc/rbd/qemu-rbd.rst
+++ b/doc/rbd/qemu-rbd.rst
@@ -171,7 +171,7 @@ edit`` to include the ``xmlns:qemu`` value. Then, add a ``qemu:commandline``
 block as a child of that domain. The following example shows how to set two
 devices with ``qemu id=`` to different ``discard_granularity`` values.
 
-.. code-block:: guess
+.. code-block:: xml
 
 	<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
 		<qemu:commandline>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42415

---

backport of https://github.com/ceph/ceph/pull/30953
parent tracker: https://tracker.ceph.com/issues/42403

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh