### PR TITLE
nautilus: core: msg: fix addr2 encoding for sockaddrs

### DIFF
--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -488,16 +488,16 @@ struct entity_addr_t {
     }
     encode(nonce, bl);
     __u32 elen = get_sockaddr_len();
+#if (__FreeBSD__) || defined(__APPLE__)
+      elen -= sizeof(u.sa.sa_len);
+#endif
     encode(elen, bl);
     if (elen) {
-#if (__FreeBSD__) || defined(__APPLE__)
-      __le16 ss_family = u.sa.sa_family;
+      uint16_t ss_family = u.sa.sa_family;
+
       encode(ss_family, bl);
-      bl.append(u.sa.sa_data,
-		elen - sizeof(u.sa.sa_len) - sizeof(u.sa.sa_family));
-#else
-      bl.append((char*)get_sockaddr(), elen);
-#endif
+      elen -= sizeof(u.sa.sa_family);
+      bl.append(u.sa.sa_data, elen);
     }
     ENCODE_FINISH(bl);
   }
@@ -519,7 +519,8 @@ struct entity_addr_t {
     if (elen) {
 #if defined(__FreeBSD__) || defined(__APPLE__)
       u.sa.sa_len = 0;
-      __le16 ss_family;
+#endif
+      uint16_t ss_family;
       if (elen < sizeof(ss_family)) {
 	throw buffer::malformed_input("elen smaller than family len");
       }
@@ -530,17 +531,6 @@ struct entity_addr_t {
 	throw buffer::malformed_input("elen exceeds sockaddr len");
       }
       bl.copy(elen, u.sa.sa_data);
-#else
-      if (elen < sizeof(u.sa.sa_family)) {
-	throw buffer::malformed_input("elen smaller than family len");
-      }
-      bl.copy(sizeof(u.sa.sa_family), (char*)&u.sa.sa_family);
-      if (elen > get_sockaddr_len()) {
-	throw buffer::malformed_input("elen exceeds sockaddr len");
-      }
-      elen -= sizeof(u.sa.sa_family);
-      bl.copy(elen, u.sa.sa_data);
-#endif
     }
     DECODE_FINISH(bl);
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40227

---

backport of https://github.com/ceph/ceph/pull/28379
parent tracker: https://tracker.ceph.com/issues/40114

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh