### PR TITLE
RFC DNM: mon: elector: enable new leader election strategies, like best-connected

### DIFF
--- a/src/messages/MMonPing.h
+++ b/src/messages/MMonPing.h
@@ -16,7 +16,7 @@
 #include "common/Clock.h"
 
 #include "msg/Message.h"
-#include "mon/Elector.h"
+#include "mon/ConnectionTracker.h"
 
 class MMonPing : public Message {
 private:

--- a/src/messages/MMonPing.h
+++ b/src/messages/MMonPing.h
@@ -1,0 +1,109 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/**
+ * This is used to send pings between monitors for
+ * heartbeat purposes. We include a timestamp and distinguish between
+ * outgoing pings and responses to those. If you set the
+ * min_message in the constructor, the message will inflate itself
+ * to the specified size -- this is good for dealing with network
+ * issues with jumbo frames. See http://tracker.ceph.com/issues/20087
+ *
+ */
+
+#ifndef CEPH_MMONPING_H
+#define CEPH_MMONPING_H
+
+#include "common/Clock.h"
+
+#include "msg/Message.h"
+#include "mon/Elector.h"
+
+class MMonPing : public Message {
+private:
+  static constexpr int HEAD_VERSION = 1;
+  static constexpr int COMPAT_VERSION = 1;
+
+ public:
+  enum {
+    PING = 1,
+    PING_REPLY = 2,
+  };
+  const char *get_op_name(int op) const {
+    switch (op) {
+    case PING: return "ping";
+    case PING_REPLY: return "ping_reply";
+    default: return "???";
+    }
+  }
+
+  __u8 op = 0;
+  utime_t stamp;
+  map<string,ConnectionReport> peer_reports;
+  uint32_t min_message_size = 0;
+
+  MMonPing(__u8 o, utime_t s, const map<string,ConnectionReport>& reports,
+	   uint32_t min_message)
+    : Message{MSG_MON_PING, HEAD_VERSION, COMPAT_VERSION},
+      op(o), stamp(s), peer_reports(reports), min_message_size(min_message)
+  {}
+  MMonPing(__u8 o, utime_t s, const map<string,ConnectionReport>& reports)
+    : Message{MSG_MON_PING, HEAD_VERSION, COMPAT_VERSION},
+      op(o), stamp(s), peer_reports(reports) {}
+  MMonPing()
+    : Message{MSG_MON_PING, HEAD_VERSION, COMPAT_VERSION}
+  {}
+private:
+  ~MMonPing() override {}
+
+public:
+  void decode_payload() override {
+    auto p = payload.cbegin();
+    decode(op, p);
+    decode(stamp, p);
+    decode(peer_reports, p);
+
+    int payload_mid_length = p.get_off();
+    uint32_t size;
+    decode(size, p);
+    p.advance(size);
+    min_message_size = size + payload_mid_length;
+  }
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(op, payload);
+    encode(stamp, payload);
+    encode(peer_reports, payload);
+
+    size_t s = 0;
+    if (min_message_size > payload.length()) {
+      s = min_message_size - payload.length();
+    }
+    encode((uint32_t)s, payload);
+    if (s) {
+      // this should be big enough for normal min_message padding sizes. since
+      // we are targeting jumbo ethernet frames around 9000 bytes, 16k should
+      // be more than sufficient!  the compiler will statically zero this so
+      // that at runtime we are only adding a bufferptr reference to it.
+      static char zeros[16384] = {};
+      while (s > sizeof(zeros)) {
+        payload.append(buffer::create_static(sizeof(zeros), zeros));
+        s -= sizeof(zeros);
+      }
+      if (s) {
+        payload.append(buffer::create_static(s, zeros));
+      }
+    }
+  }
+
+  std::string_view get_type_name() const override { return "mon_ping"; }
+  void print(ostream& out) const override {
+    out << "mon_ping(" << get_op_name(op)
+	<< " stamp " << stamp
+	<< ")";
+  }
+private:
+  template<class T, typename... Args>
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+};
+
+#endif

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -19,6 +19,7 @@ set(lib_mon_srcs
   ConfigMonitor.cc
   Elector.cc
   ElectionLogic.cc
+  ConnectionTracker.cc
   HealthMonitor.cc
   ConfigKeyService.cc
   ../mds/MDSAuthCaps.cc

--- a/src/mon/ConnectionTracker.cc
+++ b/src/mon/ConnectionTracker.cc
@@ -33,13 +33,12 @@ bool ConnectionTracker::increase_epoch(epoch_t e)
   return false;
 }
 
-bool ConnectionTracker::increase_version(uint64_t v)
+void ConnectionTracker::increase_version()
 {
-  if (v > version) {
-    version = v;
-    return true;
+  ++version;
+  if ((version % 10) == 0 ) { // TODO: make this configurable?
+    owner->persist_connectivity_scores();
   }
-  return false;
 }
 
 void ConnectionTracker::generate_report_of_peers(ConnectionReport *report) const
@@ -77,7 +76,7 @@ void ConnectionTracker::report_live_connection(int rank, double units_alive)
     ( units_alive / (2*half_life) );
   conn.score = std::max(conn.score, 1.0);
   conn.alive = true;
-  ++version;
+  increase_version();
 }
 
 void ConnectionTracker::report_dead_connection(int rank, double units_dead)
@@ -87,7 +86,7 @@ void ConnectionTracker::report_dead_connection(int rank, double units_dead)
     ( units_dead / (2*half_life) );
   conn.score = std::min(conn.score, 0.0);
   conn.alive = false;
-  ++version;
+  increase_version();
 }
 
 void ConnectionTracker::get_connection_score(int rank, double *rating, bool *alive) const

--- a/src/mon/ConnectionTracker.cc
+++ b/src/mon/ConnectionTracker.cc
@@ -1,0 +1,168 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "ConnectionTracker.h"
+
+void ConnectionTracker::receive_peer_report(const ConnectionReport& report)
+{
+  ConnectionReport& existing = peer_reports[report.rank];
+  if (report.epoch > existing.epoch ||
+      (report.epoch == existing.epoch && report.epoch_version > existing.epoch_version)) {
+    existing = report;
+  }
+}
+
+bool ConnectionTracker::increase_epoch(epoch_t e)
+{
+  if (e > epoch) {
+    version = 0;
+    epoch = e;
+    return true;
+  }
+  return false;
+}
+
+bool ConnectionTracker::increase_version(uint64_t v)
+{
+  if (v > version) {
+    version = v;
+    return true;
+  }
+  return false;
+}
+
+void ConnectionTracker::generate_report_of_peers(ConnectionReport *report) const
+{
+  assert(report != NULL);
+  report->rank = get_my_rank();
+  report->epoch = epoch;
+  report->epoch_version = version;
+  for (const auto i : conn_tracker.peers) {
+    get_connection_score(i.first, &report->history[i.first], &report->current[i.first]);
+  }
+}
+
+const ConnectionReport *ConnectionTracker::get_peer_view(int peer) const
+{
+  if (peer == get_my_rank()) {
+    ceph_assert(0);
+  }
+  const auto& i = peer_reports.find(peer);
+  if (i != peer_reports.end()) {
+    return &(i->second);
+  }
+  return NULL;
+}
+
+void ConnectionTracker::forget_peer(int peer)
+{
+  conn_tracker.peers.erase(peer);
+}
+
+void ConnectionTracker::report_live_connection(int rank, double units_alive)
+{
+  PeerReportTracker::PeerConnection& conn = conn_tracker.peers[rank];
+  conn.score = conn.score * ( 1 - units_alive / (2*half_life)) +
+    ( units_alive / (2*half_life) );
+  conn.score = std::max(conn.score, 1.0);
+  conn.alive = true;
+  ++version;
+}
+
+void ConnectionTracker::report_dead_connection(int rank, double units_dead)
+{
+  PeerReportTracker::PeerConnection& conn = conn_tracker.peers[rank];
+  conn.score = conn.score * ( 1 - units_dead / (2*half_life)) -
+    ( units_dead / (2*half_life) );
+  conn.score = std::min(conn.score, 0.0);
+  conn.alive = false;
+  ++version;
+}
+
+void ConnectionTracker::get_connection_score(int rank, double *rating, bool *alive) const
+{
+  *rating = 0;
+  *alive = false;
+  const auto& i = conn_tracker.peers.find(rank);
+  if (i == conn_tracker.peers.end()) {
+    return;
+  }
+  const PeerReportTracker::PeerConnection& conn = i->second;
+  *rating = conn.score;
+  *alive = conn.alive;
+}
+
+void ConnectionTracker::get_total_connection_score(int rank, double *rating, int *live_count) const
+{
+  *rating = 0;
+  *live_count = 0;
+  double rate = 0;
+  int live = 0;
+
+  bool alive;
+  get_connection_score(rank, &rate, &alive); // check my scores for the rank
+  if (!alive) {
+    rate = 0;
+  } else {
+    ++live;
+  }
+  for (const auto i : peer_reports) { // and then add everyone else's scores on
+    if (i.first == get_my_rank() ||
+	i.first == rank) {
+      continue;
+    }
+    const auto& report = i.second;
+    auto score_i = report.history.find(rank);
+    auto live_i = report.current.find(rank);
+    if (score_i != report.history.end()) {
+      if (live_i->second) {
+	rate += score_i->second;
+	++live;
+      }
+    }
+  }
+  *rating = rate;
+  *live_count = live;
+}
+
+void ConnectionTracker::encode(bufferlist &bl) const
+{
+  map<int,ConnectionReport> peer_copy = peer_reports;
+  generate_report_of_peers(&peer_copy[get_my_rank()]);
+
+  ENCODE_START(1, 1, bl);
+  encode(epoch, bl);
+  encode(version, bl);
+  encode(half_life, bl);
+  encode(peer_copy, bl);
+  ENCODE_FINISH(bl);
+}
+
+void ConnectionTracker::decode(bufferlist::const_iterator& bl) {
+  peer_reports.clear();
+  DECODE_START(1, bl);
+  decode(epoch, bl);
+  decode(version, bl);
+  decode(half_life, bl);
+  decode(peer_reports, bl);
+  DECODE_FINISH(bl);
+
+  ConnectionReport& my_report = peer_reports[get_my_rank()];
+  // TODO should we validate epoch/version matches here?
+  for (auto &i : my_report.history) {
+    auto& peer_con = conn_tracker.peers[i.first];
+    peer_con.alive = my_report.current[i.first];
+    peer_con.score = i.second;
+  }
+}

--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -1,0 +1,159 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef CEPH_MON_CONNECTIONTRACKER_H
+#define CEPH_MON_CONNECTIONTRACKER_H
+
+#include "include/types.h"
+
+struct ConnectionReport {
+  int rank = -1; // mon rank this state belongs to
+  std::map<int, bool> current; // true if connected to the other mon
+  std::map<int, double> history; // [0-1]; the connection reliability
+  epoch_t epoch = 0; // the (local) election epoch the ConnectionReport came from
+  uint64_t epoch_version = 0; // version of the ConnectionReport within the epoch
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(rank, bl);
+    encode(current, bl);
+    encode(history, bl);
+    encode(epoch, bl);
+    encode(epoch_version, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(rank, bl);
+    decode(current, bl);
+    decode(history, bl);
+    decode(epoch, bl);
+    decode(epoch_version, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(ConnectionReport);
+
+class RankProvider {
+ public:
+  /**
+   * Get the rank of the running daemon.
+   * It can be -1, meaning unknown/invalid, or it
+   * can be >1.
+   * You should not invoke the functions generate_report_of_peers()
+   * or get_total_connection_score() with an unknown rank.
+   */
+  virtual int get_my_rank() const = 0;
+  virtual ~RankProvider() {}
+};
+
+class ConnectionTracker {
+ public:
+  /**
+   * Receive a report from a peer and update our internal state
+   * if the peer has newer data.
+   */
+  void receive_peer_report(const ConnectionReport& report);
+  /**
+   * Bump up the epoch to the specified number.
+   * Validates that it is > current epoch and resets
+   * version to 0; returns false if not.
+   */
+  bool increase_epoch(epoch_t e);
+  /**
+   * Bump up the version within our epoch.
+   * Validates that it is > current version; returns false if not.
+   */
+  bool increase_version(uint64_t v);
+  /**
+   * Fill in the report with our liveness and reliability
+   * scores for all peers.
+   */
+  void generate_report_of_peers(ConnectionReport *report) const;
+  /**
+   * Get our current report from a peer of what it sees.
+   */
+  const ConnectionReport *get_peer_view(int peer) const;
+  /**
+   * Remove the scores for a given peer. Use this
+   * when it gets removed from the cluster.
+   */
+  // TODO: This isn't used anywhere yet and needs to be
+  void forget_peer(int peer);
+  
+  /**
+   * Report a connection to a peer rank has been considered alive for
+   * the given time duration. We assume the units_alive is <= the time
+   * since the previous reporting call.
+   * (Or, more precisely, we assume that the total amount of time
+   * passed in is less than or equal to the time which has actually
+   * passed -- you can report a 10-second death immediately followed
+   * by reporting 5 seconds of liveness if your metrics are delayed.)
+   */
+  void report_live_connection(int rank, double units_alive);
+  /**
+   * Report a connection to a peer rank has been considered dead for
+   * the given time duration, analogous to that above.
+   */
+  void report_dead_connection(int rank, double units_dead);
+  /**
+   * Set the half-life for dropping connection state
+   * out of the ongoing score.
+   * Whenever you add a new data point:
+   * new_score = old_score * ( 1 - units / (2d)) + (units/(2d))
+   * where units is the units reported alive (for dead, you subtract them).
+   */
+  void set_half_life(double d) {
+    half_life = d;
+  }
+  /**
+   * Get the connection score and whether it has most recently
+   * been reported alive for a peer rank.
+   */
+  void get_connection_score(int rank, double *rating, bool *alive) const;
+  /**
+   * Get the total connection score of a rank across
+   * all peers, and the count of how many electors think it's alive.
+   * For this summation, if a rank reports a peer as down its score is zero.
+   */
+  void get_total_connection_score(int rank, double *rating, int *live_count) const;
+  
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::const_iterator& bl);
+
+ private:
+  struct PeerReportTracker {
+    struct PeerConnection {
+      double score;
+      bool alive;
+      PeerConnection() : score(1), alive(false) {}
+    };
+    map<int, PeerConnection> peers;
+  };
+
+  epoch_t epoch;
+  uint64_t version;
+  PeerReportTracker conn_tracker; // track my view of peer reliability
+  map<int,ConnectionReport> peer_reports; // keep latest reports of peers
+  double half_life;
+  RankProvider *owner;
+  int get_my_rank() const { return owner->get_my_rank(); }
+
+ public:
+  ConnectionTracker(RankProvider *o, double hl) : epoch(0), version(0),
+						  half_life(hl), owner(o) {}
+};
+
+WRITE_CLASS_ENCODER(ConnectionTracker);
+
+#endif

--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -54,6 +54,11 @@ class RankProvider {
    * or get_total_connection_score() with an unknown rank.
    */
   virtual int get_my_rank() const = 0;
+  /**
+   * Asks our owner to encode us and persist it to disk.
+   * Presently we do this every tenth update.
+   */
+  virtual void persist_connectivity_scores() = 0;
   virtual ~RankProvider() {}
 };
 
@@ -72,9 +77,9 @@ class ConnectionTracker {
   bool increase_epoch(epoch_t e);
   /**
    * Bump up the version within our epoch.
-   * Validates that it is > current version; returns false if not.
+   * If the new version is a multiple of ten, we also persist it.
    */
-  bool increase_version(uint64_t v);
+  void increase_version();
   /**
    * Fill in the report with our liveness and reliability
    * scores for all peers.

--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -83,6 +83,14 @@ class ConnectionTracker {
   /**
    * Fill in the report with our liveness and reliability
    * scores for all peers.
+   *
+   * NOTE: This only shares what the *local* node has seen directly;
+   * it does not include the shared data from other peers. Use
+   * get_peer_view to grab those and bundle them up when sharing it.
+   * This interface isn't great and would be better if you got a single
+   * struct for sharing, encode/decode, and import back into another
+   * ConnectionTracker, so look at existing implementations carefully
+   * if you're messing around here.
    */
   void generate_report_of_peers(ConnectionReport *report) const;
   /**

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -45,6 +45,7 @@ void ElectionLogic::bump_epoch(epoch_t e)
   ldout(cct, 10) << __func__ << epoch << " to " << e << dendl;
   ceph_assert(epoch <= e);
   epoch = e;
+  peer_tracker->increase_epoch(e);
   elector->persist_epoch(epoch);
   // clear up some state
   electing_me = false;

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -141,7 +141,7 @@ void ElectionLogic::declare_victory()
   elector->message_victory(new_quorum);
 }
 
-void ElectionLogic::receive_propose(int from, epoch_t mepoch)
+bool ElectionLogic::propose_classic_prefix(int from, epoch_t mepoch)
 {
   if (mepoch > epoch) {
     bump_epoch(mepoch);
@@ -156,27 +156,34 @@ void ElectionLogic::receive_propose(int from, epoch_t mepoch)
       elector->trigger_new_election();
     } else {
       ldout(cct, 5) << " ignoring old propose" << dendl;
-      return;
+      return true;
     }
   }
+  return false;
+}
 
+void ElectionLogic::receive_propose(int from, epoch_t mepoch)
+{
   switch (strategy) {
   case CLASSIC:
-    propose_classic_handler(from);
+    propose_classic_handler(from, mepoch);
     break;
   case DISALLOW:
-    propose_disallow_handler(from);
+    propose_disallow_handler(from, mepoch);
     break;
   case CONNECTIVITY:
-    propose_connectivity_handler(from);
+    propose_connectivity_handler(from, mepoch);
     break;
   default:
     ceph_assert(0 == "how did election strategy become an invalid value?");
   }
 }
 
-void ElectionLogic::propose_disallow_handler(int from)
+void ElectionLogic::propose_disallow_handler(int from, epoch_t mepoch)
 {
+  if (propose_classic_prefix(from, mepoch)) {
+    return;
+  }
   const set<int>& disallowed_leaders = elector->get_disallowed_leaders();
   int my_rank = elector->get_my_rank();
   bool me_disallowed = disallowed_leaders.count(my_rank);
@@ -210,8 +217,11 @@ void ElectionLogic::propose_disallow_handler(int from)
   }
 }
 
-void ElectionLogic::propose_classic_handler(int from)
+void ElectionLogic::propose_classic_handler(int from, epoch_t mepoch)
 {
+  if (propose_classic_prefix(from, mepoch)) {
+    return;
+  }
   if (elector->get_my_rank() < from) {
     // i would win over them.
     if (leader_acked >= 0) {        // we already acked someone
@@ -236,8 +246,25 @@ void ElectionLogic::propose_classic_handler(int from)
   }
 }
 
-void ElectionLogic::propose_connectivity_handler(int from)
+void ElectionLogic::propose_connectivity_handler(int from, epoch_t mepoch)
 {
+  if (mepoch > epoch) {
+    bump_epoch(mepoch);
+  } else if (mepoch < epoch) {
+    // got an "old" propose,
+    if (epoch % 2 == 0 &&    // in a non-election cycle
+	!elector->is_current_member(from)) {  // from someone outside the quorum
+      // a mon just started up, call a new election so they can rejoin!
+      ldout(cct, 5) << " got propose from old epoch, "
+	      << from << " must have just started" << dendl;
+      // we may be active; make sure we reset things in the monitor appropriately.
+      elector->trigger_new_election();
+    } else {
+      ldout(cct, 5) << " ignoring old propose" << dendl;
+      return;
+    }
+  }
+
   const set<int>& disallowed_leaders = elector->get_disallowed_leaders();
   int my_rank = elector->get_my_rank();
   bool me_disallowed = disallowed_leaders.count(my_rank);

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -87,7 +87,13 @@ void ElectionLogic::start()
 
 void ElectionLogic::defer(int who)
 {
-  ldout(cct, 5) << "defer to " << who << dendl;
+  if (strategy == CLASSIC) {
+      ldout(cct, 5) << "defer to " << who << dendl;
+      ceph_assert(who < elector->get_my_rank());
+  } else {
+    ldout(cct, 5) << "defer to " << who << ", disallowed_leaders=" << elector->get_disallowed_leaders() << dendl;
+    ceph_assert(!elector->get_disallowed_leaders().count(who));
+  }
 
   if (electing_me) {
     // drop out
@@ -121,6 +127,7 @@ void ElectionLogic::end_election_period()
 
 void ElectionLogic::declare_victory()
 {
+  ldout(cct, 5) << "I win! acked_me=" << acked_me << dendl;
   leader_acked = -1;
   electing_me = false;
 
@@ -152,10 +159,21 @@ void ElectionLogic::receive_propose(int from, epoch_t mepoch)
     }
   }
 
-  if (elector->get_my_rank() < from) {
+  const set<int>& disallowed_leaders = elector->get_disallowed_leaders();
+  int my_rank = elector->get_my_rank();
+  bool me_disallowed = disallowed_leaders.count(my_rank);
+  bool from_disallowed = disallowed_leaders.count(from);
+  bool my_win = !me_disallowed && // we are allowed to lead
+    (my_rank < from || from_disallowed); // we are a better choice than them
+  bool their_win = !from_disallowed && // they are allowed to lead
+    (my_rank > from || me_disallowed) && // they are a better choice than us
+    (leader_acked < 0 || leader_acked >= from); // they are a better choice than our previously-acked choice
+    
+  
+  if (my_win) {
     // i would win over them.
     if (leader_acked >= 0) {        // we already acked someone
-      ceph_assert(leader_acked < from);  // and they still win, of course
+      ceph_assert(leader_acked < from || from_disallowed);  // and they still win, of course
       ldout(cct, 5) << "no, we already acked " << leader_acked << dendl;
     } else {
       // wait, i should win!
@@ -165,9 +183,7 @@ void ElectionLogic::receive_propose(int from, epoch_t mepoch)
     }
   } else {
     // they would win over me
-    if (leader_acked < 0 ||      // haven't acked anyone yet, or
-	leader_acked > from ||   // they would win over who you did ack, or
-	leader_acked == from) {  // this is the guy we're already deferring to
+    if (their_win) {
       defer(from);
     } else {
       // ignore them!
@@ -200,7 +216,7 @@ void ElectionLogic::receive_ack(int from, epoch_t from_epoch)
 
 bool ElectionLogic::receive_victory_claim(int from, epoch_t from_epoch)
 {
-  ceph_assert(from < elector->get_my_rank());
+  ceph_assert(from < elector->get_my_rank() || elector->get_disallowed_leaders().count(elector->get_my_rank()));
   ceph_assert(from_epoch % 2 == 0);  
 
   leader_acked = -1;

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -159,6 +159,23 @@ void ElectionLogic::receive_propose(int from, epoch_t mepoch)
     }
   }
 
+  switch (strategy) {
+  case CLASSIC:
+    propose_classic_handler(from);
+    break;
+  case DISALLOW:
+    propose_disallow_handler(from);
+    break;
+  case CONNECTIVITY:
+    propose_connectivity_handler(from);
+    break;
+  default:
+    ceph_assert(0 == "how did election strategy become an invalid value?");
+  }
+}
+
+void ElectionLogic::propose_disallow_handler(int from)
+{
   const set<int>& disallowed_leaders = elector->get_disallowed_leaders();
   int my_rank = elector->get_my_rank();
   bool me_disallowed = disallowed_leaders.count(my_rank);
@@ -192,6 +209,37 @@ void ElectionLogic::receive_propose(int from, epoch_t mepoch)
   }
 }
 
+void ElectionLogic::propose_classic_handler(int from)
+{
+  if (elector->get_my_rank() < from) {
+    // i would win over them.
+    if (leader_acked >= 0) {        // we already acked someone
+      ceph_assert(leader_acked < from);  // and they still win, of course
+      ldout(cct, 5) << "no, we already acked " << leader_acked << dendl;
+    } else {
+      // wait, i should win!
+      if (!electing_me) {
+	elector->trigger_new_election();
+      }
+    }
+  } else {
+    // they would win over me
+    if (leader_acked < 0 || // haven't acked anyone yet, or
+	leader_acked > from ||   // they would win over who you did ack, or
+	leader_acked == from) {  // this is the guy we're already deferring to
+      defer(from);
+    } else {
+      // ignore them!
+      ldout(cct, 5) << "no, we already acked " << leader_acked << dendl;
+    }
+  }
+}
+
+void ElectionLogic::propose_connectivity_handler(int from)
+{
+  ceph_assert(0);
+}
+
 void ElectionLogic::receive_ack(int from, epoch_t from_epoch)
 {
   ceph_assert(from_epoch % 2 == 1); // sender in an election epoch
@@ -214,10 +262,28 @@ void ElectionLogic::receive_ack(int from, epoch_t from_epoch)
   }
 }
 
+bool ElectionLogic::victory_makes_sense(int from)
+{
+  bool makes_sense = false;
+  switch(strategy) {
+  case CLASSIC:
+    makes_sense = (from < elector->get_my_rank());
+  case DISALLOW:
+    makes_sense = (from < elector->get_my_rank()) ||
+      elector->get_disallowed_leaders().count(elector->get_my_rank());
+    break;
+  case CONNECTIVITY:
+    // TODO: actually do soemthing here!
+    makes_sense = true;
+  default:
+    ceph_assert(0 == "how did you get a nonsense election strategy assigned?");
+  }
+  return makes_sense;
+}
+
 bool ElectionLogic::receive_victory_claim(int from, epoch_t from_epoch)
 {
-  ceph_assert(from < elector->get_my_rank() || elector->get_disallowed_leaders().count(elector->get_my_rank()));
-  ceph_assert(from_epoch % 2 == 0);  
+  ceph_assert(victory_makes_sense(from));
 
   leader_acked = -1;
 

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -129,6 +129,7 @@ void ElectionLogic::declare_victory()
 {
   ldout(cct, 5) << "I win! acked_me=" << acked_me << dendl;
   last_election_winner = elector->get_my_rank();
+  last_voted_for = last_election_winner;
   leader_acked = -1;
   electing_me = false;
 
@@ -259,6 +260,25 @@ double ElectionLogic::connectivity_election_score(int rank)
 
 void ElectionLogic::propose_connectivity_handler(int from, epoch_t mepoch)
 {
+  if ((epoch % 2 == 0) &&
+      last_election_winner != elector->get_my_rank() &&
+      !elector->is_current_member(from)) {
+    // To prevent election flapping, peons ignore proposals from out-of-quorum
+    // peers unless their vote would change from the last election
+    int best_scorer = 0;
+    double best_score = 0;
+    for (unsigned i = 0; i < elector->paxos_size(); ++i) {
+      double score = connectivity_election_score(i);
+      if (score > best_score) {
+	best_scorer = i;
+	best_score = score;
+      }
+    }
+    if (best_scorer == last_voted_for) {
+      // drop this message; it won't change our vote so we defer to leader
+      return;
+    }
+  }
   if (mepoch > epoch) {
     bump_epoch(mepoch);
   } else if (mepoch < epoch) {
@@ -375,6 +395,7 @@ bool ElectionLogic::receive_victory_claim(int from, epoch_t from_epoch)
   ceph_assert(victory_makes_sense(from));
 
   last_election_winner = from;
+  last_voted_for = leader_acked;
   leader_acked = -1;
 
   // i should have seen this election if i'm getting the victory.

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -128,6 +128,7 @@ void ElectionLogic::end_election_period()
 void ElectionLogic::declare_victory()
 {
   ldout(cct, 5) << "I win! acked_me=" << acked_me << dendl;
+  last_election_winner = elector->get_my_rank();
   leader_acked = -1;
   electing_me = false;
 
@@ -285,6 +286,7 @@ bool ElectionLogic::receive_victory_claim(int from, epoch_t from_epoch)
 {
   ceph_assert(victory_makes_sense(from));
 
+  last_election_winner = from;
   leader_acked = -1;
 
   // i should have seen this election if i'm getting the victory.

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -238,7 +238,58 @@ void ElectionLogic::propose_classic_handler(int from)
 
 void ElectionLogic::propose_connectivity_handler(int from)
 {
-  ceph_assert(0);
+  const set<int>& disallowed_leaders = elector->get_disallowed_leaders();
+  int my_rank = elector->get_my_rank();
+  bool me_disallowed = disallowed_leaders.count(my_rank);
+  bool from_disallowed = disallowed_leaders.count(from);
+  double my_score, from_score, leader_score = 0;
+  int my_liveness, from_liveness, leader_liveness = 0;
+  peer_tracker->get_total_connection_score(my_rank, &my_score, &my_liveness);
+  peer_tracker->get_total_connection_score(from, &from_score, &from_liveness);
+  if (leader_acked >= 0) {
+    peer_tracker->get_total_connection_score(leader_acked, &leader_score, &leader_liveness);
+  }
+
+  ldout(cct, 10) << "propose from rank=" << from << ",disallowed="
+		 << from_disallowed << ",score=" << from_score
+		 << "; my score=" << my_score << ",disallowed=" << me_disallowed
+		 << "; currently acked " << leader_acked
+		 << ",score=" << leader_score << dendl;
+
+
+  bool my_win = !me_disallowed && // I am allowed to lead
+    (from_disallowed || // either they're disallowed or
+     ((my_rank < from && (my_score >= from_score)) || // we have same scores and my rank is lower
+      my_score > from_score)); // my score is higher
+  
+  bool their_win = !from_disallowed && // they are allowed to lead
+    (me_disallowed || // either I'm disallowed or
+     ((from < my_rank && (from_score >= my_score)) || // they have lower rank and same scores
+      (from_score > my_score))) && // or they score more connectivity points than me
+    // and they are a better choice than our previously-acked choice
+    ((from < leader_acked && leader_score <= from_score) ||
+     (leader_score <= from_score));
+
+  if (my_win) {
+    // i would win over them.
+    if (leader_acked >= 0) {        // we already acked someone
+      ceph_assert(leader_score >= from_score || from_disallowed);  // and they still win, of course
+      ldout(cct, 5) << "no, we already acked " << leader_acked << dendl;
+    } else {
+      // wait, i should win!
+      if (!electing_me) {
+	elector->trigger_new_election();
+      }
+    }
+  } else {
+    // they would win over me
+    if (their_win) {
+      defer(from);
+    } else {
+      // ignore them!
+      ldout(cct, 5) << "no, we already acked " << leader_acked << dendl;
+    }
+  }
 }
 
 void ElectionLogic::receive_ack(int from, epoch_t from_epoch)
@@ -274,8 +325,19 @@ bool ElectionLogic::victory_makes_sense(int from)
       elector->get_disallowed_leaders().count(elector->get_my_rank());
     break;
   case CONNECTIVITY:
-    // TODO: actually do soemthing here!
-    makes_sense = true;
+    double my_score, leader_score;
+    int my_liveness, leader_liveness;
+    peer_tracker->get_total_connection_score(elector->get_my_rank(),
+					     &my_score, &my_liveness);
+    peer_tracker->get_total_connection_score(from,
+					     &leader_score, &leader_liveness);
+    ldout(cct, 5) << "victory from " << from << " makes sense? lscore:"
+		  << leader_score << ",llive:" << leader_liveness
+		  << "; my score:" << my_score << ",liveness:" << my_liveness << dendl;
+
+    // TODO: this probably isn't safe because we may be behind on score states?
+    makes_sense = (leader_score >= my_score);
+    break;
   default:
     ceph_assert(0 == "how did you get a nonsense election strategy assigned?");
   }

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -246,6 +246,17 @@ void ElectionLogic::propose_classic_handler(int from, epoch_t mepoch)
   }
 }
 
+double ElectionLogic::connectivity_election_score(int rank)
+{
+  if (elector->get_disallowed_leaders().count(rank)) {
+    return 0;
+  }
+  double score;
+  int liveness;
+  peer_tracker->get_total_connection_score(rank, &score, &liveness);
+  return score;
+}
+
 void ElectionLogic::propose_connectivity_handler(int from, epoch_t mepoch)
 {
   if (mepoch > epoch) {
@@ -265,42 +276,33 @@ void ElectionLogic::propose_connectivity_handler(int from, epoch_t mepoch)
     }
   }
 
-  const set<int>& disallowed_leaders = elector->get_disallowed_leaders();
   int my_rank = elector->get_my_rank();
-  bool me_disallowed = disallowed_leaders.count(my_rank);
-  bool from_disallowed = disallowed_leaders.count(from);
-  double my_score, from_score, leader_score = 0;
-  int my_liveness, from_liveness, leader_liveness = 0;
-  peer_tracker->get_total_connection_score(my_rank, &my_score, &my_liveness);
-  peer_tracker->get_total_connection_score(from, &from_score, &from_liveness);
+  double my_score = connectivity_election_score(my_rank);
+  double from_score = connectivity_election_score(from);
+  double leader_score = 0;
   if (leader_acked >= 0) {
-    peer_tracker->get_total_connection_score(leader_acked, &leader_score, &leader_liveness);
+    leader_score = connectivity_election_score(leader_acked);
   }
 
-  ldout(cct, 10) << "propose from rank=" << from << ",disallowed="
-		 << from_disallowed << ",score=" << from_score
-		 << "; my score=" << my_score << ",disallowed=" << me_disallowed
+  ldout(cct, 10) << "propose from rank=" << from << ",score=" << from_score
+		 << "; my score=" << my_score
 		 << "; currently acked " << leader_acked
 		 << ",score=" << leader_score << dendl;
 
-
-  bool my_win = !me_disallowed && // I am allowed to lead
-    (from_disallowed || // either they're disallowed or
-     ((my_rank < from && (my_score >= from_score)) || // we have same scores and my rank is lower
-      my_score > from_score)); // my score is higher
+  bool my_win = (my_score > 0) && // My score is non-zero; I am allowed to lead
+    ((my_rank < from && my_score >= from_score) || // We have same scores and I have lower rank, or
+     (my_score > from_score)); // my score is higher
   
-  bool their_win = !from_disallowed && // they are allowed to lead
-    (me_disallowed || // either I'm disallowed or
-     ((from < my_rank && (from_score >= my_score)) || // they have lower rank and same scores
-      (from_score > my_score))) && // or they score more connectivity points than me
-    // and they are a better choice than our previously-acked choice
-    ((from < leader_acked && leader_score <= from_score) ||
-     (leader_score <= from_score));
+  bool their_win = (from_score > 0) && // Their score is non-zero; they're allowed to lead, AND
+    ((from < my_rank && from_score >= my_score) || // Either they have lower rank and same score, or
+     (from_score > my_score)) && // their score is higher, AND
+    ((from <= leader_acked && from_score >= leader_score) || // same conditions compared to leader, or IS leader
+     (from_score > leader_score));
 
   if (my_win) {
     // i would win over them.
     if (leader_acked >= 0) {        // we already acked someone
-      ceph_assert(leader_score >= from_score || from_disallowed);  // and they still win, of course
+      ceph_assert(leader_score >= from_score);  // and they still win, of course
       ldout(cct, 5) << "no, we already acked " << leader_acked << dendl;
     } else {
       // wait, i should win!
@@ -353,14 +355,11 @@ bool ElectionLogic::victory_makes_sense(int from)
     break;
   case CONNECTIVITY:
     double my_score, leader_score;
-    int my_liveness, leader_liveness;
-    peer_tracker->get_total_connection_score(elector->get_my_rank(),
-					     &my_score, &my_liveness);
-    peer_tracker->get_total_connection_score(from,
-					     &leader_score, &leader_liveness);
+    my_score = connectivity_election_score(elector->get_my_rank());
+    leader_score = connectivity_election_score(from);
     ldout(cct, 5) << "victory from " << from << " makes sense? lscore:"
-		  << leader_score << ",llive:" << leader_liveness
-		  << "; my score:" << my_score << ",liveness:" << my_liveness << dendl;
+		  << leader_score
+		  << "; my score:" << my_score << dendl;
 
     // TODO: this probably isn't safe because we may be behind on score states?
     makes_sense = (leader_score >= my_score);

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -60,6 +60,14 @@ void ElectionLogic::declare_standalone_victory()
   bump_epoch(epoch+1);
 }
 
+void ElectionLogic::clear_live_election_state()
+{
+  leader_acked = -1;
+  electing_me = false;
+  delete stable_peer_tracker;
+  stable_peer_tracker = new ConnectionTracker(*peer_tracker);
+}
+
 void ElectionLogic::start()
 {
   if (!participating) {
@@ -77,9 +85,9 @@ void ElectionLogic::start()
   } else {
     elector->validate_store();
   }
-  electing_me = true;
   acked_me.insert(elector->get_my_rank());
-  leader_acked = -1;
+  clear_live_election_state();
+  electing_me = true;
 
   elector->propose_to_peers(epoch);
   elector->_start();
@@ -130,8 +138,7 @@ void ElectionLogic::declare_victory()
   ldout(cct, 5) << "I win! acked_me=" << acked_me << dendl;
   last_election_winner = elector->get_my_rank();
   last_voted_for = last_election_winner;
-  leader_acked = -1;
-  electing_me = false;
+  clear_live_election_state();
 
   set<int> new_quorum;
   new_quorum.swap(acked_me);
@@ -254,7 +261,11 @@ double ElectionLogic::connectivity_election_score(int rank)
   }
   double score;
   int liveness;
-  peer_tracker->get_total_connection_score(rank, &score, &liveness);
+  if (stable_peer_tracker) {
+    stable_peer_tracker->get_total_connection_score(rank, &score, &liveness);
+  } else {
+    peer_tracker->get_total_connection_score(rank, &score, &liveness);
+  }
   return score;
 }
 
@@ -381,7 +392,6 @@ bool ElectionLogic::victory_makes_sense(int from)
 		  << leader_score
 		  << "; my score:" << my_score << dendl;
 
-    // TODO: this probably isn't safe because we may be behind on score states?
     makes_sense = (leader_score >= my_score);
     break;
   default:
@@ -396,7 +406,7 @@ bool ElectionLogic::receive_victory_claim(int from, epoch_t from_epoch)
 
   last_election_winner = from;
   last_voted_for = leader_acked;
-  leader_acked = -1;
+  clear_live_election_state();
 
   // i should have seen this election if i'm getting the victory.
   if (from_epoch != epoch + 1) { 

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -149,6 +149,10 @@ class ElectionLogic {
    */
   epoch_t epoch = 0;
   /**
+   * The last rank which won an election we participated in
+   */
+  int last_election_winner = -1;
+  /**
    * Indicates who we have acked
    */
   int leader_acked;
@@ -189,6 +193,7 @@ public:
 
   ElectionLogic(ElectionOwner *e, ConnectionTracker *t,
 		CephContext *c) : elector(e), peer_tracker(t), cct(c),
+				  last_election_winner(-1),
 				  leader_acked(-1),
 				  strategy(CLASSIC),
 				  participating(true),
@@ -305,8 +310,8 @@ public:
    * @returns Our current epoch number
    */
   epoch_t get_epoch() const { return epoch; }
-  int get_acked_leader() { return leader_acked; }
-  
+  int get_election_winner() { return last_election_winner; }
+
 private:
   /**
    * Initiate the ElectionLogic class.

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include "include/types.h"
+#include "ConnectionTracker.h"
 
 class ElectionOwner {
 public:
@@ -127,6 +128,8 @@ public:
 
 class ElectionLogic {
   ElectionOwner *elector;
+  ConnectionTracker *peer_tracker;
+  
   CephContext *cct;
   /**
    * Latest epoch we've seen.
@@ -167,10 +170,11 @@ public:
    */
   std::set<int> acked_me;
 
-  ElectionLogic(ElectionOwner *e, CephContext *c) : elector(e), cct(c),
-						    leader_acked(-1),
-						    participating(true),
-						    electing_me(false) {}
+  ElectionLogic(ElectionOwner *e, ConnectionTracker *t,
+		CephContext *c) : elector(e), peer_tracker(t), cct(c),
+				  leader_acked(-1),
+				  participating(true),
+				  electing_me(false) {}
   /**
    * If there are no other peers in this Paxos group, ElectionOwner
    * can simply declare victory and we will make it so.

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -83,8 +83,18 @@ public:
   /**
    * Ask the ElectionOwner for the size of the Paxos set. This includes
    * those monitors which may not be in the current quorum!
+   * The value returned by this function can change between elections,
+   * but not during them. (In practical terms, it can be updated
+   * by making a paxos commit, but not by injecting values while
+   * an election is ongoing.)
    */
   virtual unsigned paxos_size() const = 0;
+  /**
+   * Retrieve a set of ranks which are not allowed to become the leader.
+   * Like paxos_size(), This set can change between elections, but not
+   * during them.
+   */
+  virtual const set<int>& get_disallowed_leaders() const = 0;
   /**
    * Tell the ElectionOwner we have started a new election.
    *

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -336,6 +336,12 @@ private:
    */
   void bump_epoch(epoch_t e);
   /**
+   * If the incoming proposal is newer, bump our own epoch; if
+   * it comes from an out-of-quorum peer, trigger a new eleciton.
+   * @returns true if you should drop this proposal, false otherwise.
+   */
+  bool propose_classic_prefix(int from, epoch_t mepoch);
+  /**
    * Handle a proposal from another rank using the classic strategy.
    * We will take one of the following actions:
    *
@@ -344,13 +350,13 @@ private:
    *  @li Defer to it because it outranks us and the node we previously
    *	  acked, if any
    */
-  void propose_classic_handler(int from);
+  void propose_classic_handler(int from, epoch_t mepoch);
   /**
    * Handle a proposal from another rank using our disallow strategy.
    * This is the same as the classic strategy except we also disallow
    * certain ranks from becoming the leader.
    */
-  void propose_disallow_handler(int from);
+  void propose_disallow_handler(int from, epoch_t mepoch);
   /**
    * Handle a proposal from another rank using the connectivity strategy.
    * We will choose to defer or not based on the ordered criteria:
@@ -359,7 +365,7 @@ private:
    * @li Whether the other monitor or ourself has the most connectivity to peers
    * @li Whether the other monitor or ourself has the lower rank
    */
-  void propose_connectivity_handler(int from);
+  void propose_connectivity_handler(int from, epoch_t mepoch);
   /**
    * Defer the current election to some other monitor.
    *

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -367,6 +367,11 @@ private:
    */
   void propose_connectivity_handler(int from, epoch_t mepoch);
   /**
+   * Helper function for connectivity handler. Combines the disallowed list
+   * with ConnectionTracker scores.
+   */
+  double connectivity_election_score(int rank);
+  /**
    * Defer the current election to some other monitor.
    *
    * This means that we will ack some other monitor and drop out from the run

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -191,11 +191,11 @@ public:
    */
   std::set<int> acked_me;
 
-  ElectionLogic(ElectionOwner *e, ConnectionTracker *t,
+  ElectionLogic(ElectionOwner *e, election_strategy es, ConnectionTracker *t,
 		CephContext *c) : elector(e), peer_tracker(t), cct(c),
 				  last_election_winner(-1),
 				  leader_acked(-1),
-				  strategy(CLASSIC),
+				  strategy(es),
 				  participating(true),
 				  electing_me(false) {}
   /**

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -153,9 +153,15 @@ class ElectionLogic {
    */
   int last_election_winner = -1;
   /**
+   * Only used in the connectivity handler.
+   * The rank we voted for in the last election we voted in.
+   */
+  int last_voted_for = -1;
+  /**
    * Indicates who we have acked
    */
   int leader_acked;
+  
 public:
   enum election_strategy {
     CLASSIC = 1, // the original rank-based one
@@ -193,7 +199,7 @@ public:
 
   ElectionLogic(ElectionOwner *e, election_strategy es, ConnectionTracker *t,
 		CephContext *c) : elector(e), peer_tracker(t), cct(c),
-				  last_election_winner(-1),
+				  last_election_winner(-1), last_voted_for(-1),
 				  leader_acked(-1),
 				  strategy(es),
 				  participating(true),

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -161,6 +161,11 @@ class ElectionLogic {
    * Only used in the connectivity handler.
    * Points at a stable copy of the peer_tracker we use to keep scores
    * throughout an election period.
+   * TODO: hmm, this might not be strong enough since the scores
+   * may not match across all ranks. It's possible we need to do
+   * some kind of vector clock and use only the newest version of a report
+   * all up peers have seen? I haven't managed to break it yet in unit
+   * tests though so leave that as a possibility for later.
    */
   const ConnectionTracker *stable_peer_tracker;
   /**

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -158,6 +158,12 @@ class ElectionLogic {
    */
   int last_voted_for = -1;
   /**
+   * Only used in the connectivity handler.
+   * Points at a stable copy of the peer_tracker we use to keep scores
+   * throughout an election period.
+   */
+  const ConnectionTracker *stable_peer_tracker;
+  /**
    * Indicates who we have acked
    */
   int leader_acked;
@@ -200,6 +206,7 @@ public:
   ElectionLogic(ElectionOwner *e, election_strategy es, ConnectionTracker *t,
 		CephContext *c) : elector(e), peer_tracker(t), cct(c),
 				  last_election_winner(-1), last_voted_for(-1),
+				  stable_peer_tracker(NULL),
 				  leader_acked(-1),
 				  strategy(es),
 				  participating(true),
@@ -420,6 +427,11 @@ private:
    * get from another rank makes any sense.
    */
   bool victory_makes_sense(int from);
+  /**
+   * Reset some data members which we only care about while we are in an election
+   * or need to be set consistently during stable states.
+   */
+  void clear_live_election_state();
 };
 
 #endif

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -32,7 +32,7 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon, epoch_t epoch) {
 		<< ").elector(" << epoch << ") ";
 }
 
-Elector::Elector(Monitor *m) : logic(this,
+Elector::Elector(Monitor *m) : logic(this, ElectionLogic::CLASSIC,
 				     &peer_tracker, m->cct),
 			       peer_tracker(this, 12*60*60), // TODO: make configurable
 			       ping_timeout(2),

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -36,13 +36,32 @@ Elector::Elector(Monitor *m) : logic(this,
 				     &peer_tracker, m->cct),
 			       peer_tracker(this, 12*60*60), // TODO: make configurable
 			       ping_timeout(2),
-			       mon(m), elector(this) {}
+			       mon(m), elector(this) {
+  bufferlist bl;
+  mon->store->get(Monitor::MONITOR_NAME, "connectivity_scores", bl);
+  if (bl.length()) {
+    bufferlist::const_iterator bi = bl.begin();
+    peer_tracker.decode(bi);
+  }
+}
 
 
 void Elector::persist_epoch(epoch_t e)
 {
   auto t(std::make_shared<MonitorDBStore::Transaction>());
   t->put(Monitor::MONITOR_NAME, "election_epoch", e);
+  bufferlist bl;
+  encode(peer_tracker, bl);
+  t->put(Monitor::MONITOR_NAME, "connectivity_scores", e);
+  mon->store->apply_transaction(t);
+}
+
+void Elector::persist_connectivity_scores()
+{
+  auto t(std::make_shared<MonitorDBStore::Transaction>());
+  bufferlist bl;
+  encode(peer_tracker, bl);
+  t->put(Monitor::MONITOR_NAME, "connectivity_scores", bl);
   mon->store->apply_transaction(t);
 }
 
@@ -504,7 +523,6 @@ void Elector::handle_ping(MonOpRequestRef op)
     }
     break;
   }
-  // TODO: Really need to persist the ConnectionTracker at some point (note early return statements above)
 }
 
 void Elector::dispatch(MonOpRequestRef op)

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -18,6 +18,7 @@
 #include "common/Timer.h"
 #include "MonitorDBStore.h"
 #include "messages/MMonElection.h"
+#include "messages/MMonPing.h"
 
 #include "common/config.h"
 #include "include/ceph_assert.h"
@@ -31,8 +32,11 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon, epoch_t epoch) {
 		<< ").elector(" << epoch << ") ";
 }
 
-Elector::Elector(Monitor *m) : logic(this, m->cct),
-					mon(m), elector(this) {}
+Elector::Elector(Monitor *m) : logic(this,
+				     &peer_tracker, m->cct),
+			       peer_tracker(this, 12*60*60), // TODO: make configurable
+			       ping_timeout(2),
+			       mon(m), elector(this) {}
 
 
 void Elector::persist_epoch(epoch_t e)
@@ -163,6 +167,14 @@ void Elector::cancel_timer()
     mon->timer.cancel_event(expire_event);
     expire_event = 0;
   }
+}
+
+void Elector::assimilate_connection_reports(const map<string,ConnectionReport>& reports)
+{
+  for (auto i : reports) {
+    peer_tracker.receive_peer_report(i.second);
+  }
+  return;
 }
 
 void Elector::message_victory(const std::set<int>& quorum)
@@ -381,10 +393,124 @@ void Elector::handle_nak(MonOpRequestRef op)
   // the end!
 }
 
+void Elector::begin_peer_ping(int peer)
+{
+  if (live_pinging.count(peer)) {
+    return;
+  }
+
+  dout(5) << __func__ << " against " << peer << dendl;
+
+  live_pinging.insert(peer);
+  peer_acked_ping[peer] = ceph_clock_now();
+  send_peer_ping(peer);
+  mon->timer.add_event_after(ping_timeout / PING_DIVISOR,
+			     new C_MonContext{mon, [this, peer](int) {
+				 ping_check(peer);
+			       }});
+}
+
+void Elector::send_peer_ping(int peer, const utime_t *n)
+{
+  dout(10) << __func__ << " to peer " << peer << dendl;
+  map<string, ConnectionReport> reports;
+  
+  for (int i = 0; i < static_cast<int>(mon->monmap->size()); ++i) {
+    if (i == get_my_rank()) {
+      continue;
+    }
+    const ConnectionReport *view = peer_tracker.get_peer_view(i);
+    if (view != NULL) {
+      reports[mon->monmap->get_name(i)] = *view;
+    }
+  }
+  peer_tracker.generate_report_of_peers(&reports[mon->monmap->get_name(get_my_rank())]);
+
+  utime_t now;
+  if (n != NULL) {
+    now = *n;
+  } else {
+    now = ceph_clock_now();
+  }
+  MMonPing *ping = new MMonPing(MMonPing::PING, now, reports);
+  mon->messenger->send_to_mon(ping, mon->monmap->get_addrs(peer)); // TODO: this is deprecated, figure out using Connection
+  peer_sent_ping[peer] = now;
+}
+
+void Elector::ping_check(int peer) {
+  dout(20) << __func__ << " to peer " << peer << dendl;
+  utime_t now = ceph_clock_now();
+  utime_t& acked_ping = peer_acked_ping[peer];
+  utime_t& newest_ping = peer_sent_ping[peer];
+  if (!acked_ping.is_zero() && acked_ping < now - ping_timeout) {
+    peer_tracker.report_dead_connection(peer, now - acked_ping);
+    acked_ping = now;
+    live_pinging.erase(peer);
+    return;
+  }
+
+  if (acked_ping == newest_ping) {
+    send_peer_ping(peer, &now);
+  }
+
+  mon->timer.add_event_after(ping_timeout / PING_DIVISOR,
+			     new C_MonContext{mon, [this, peer](int) {
+				 ping_check(peer);
+			       }});
+}
+
+void Elector::handle_ping(MonOpRequestRef op)
+{
+  MMonPing *m = static_cast<MMonPing*>(op->get_req());
+  dout(10) << __func__ << " " << *m << dendl;
+
+  int prank = mon->monmap->get_rank(m->get_source_addr());
+  begin_peer_ping(prank);
+  assimilate_connection_reports(m->peer_reports);
+  switch(m->op) {
+  case MMonPing::PING:
+    {
+      map<string, ConnectionReport> reports;
+      for (int i = 0; i < static_cast<int>(mon->monmap->size()); ++i) {
+	if (i == get_my_rank()) {
+	  continue;
+	}
+	const ConnectionReport *r = peer_tracker.get_peer_view(i);
+	if (r != NULL) {
+	  reports[mon->monmap->get_name(i)] = *r;
+	}
+      }
+      peer_tracker.generate_report_of_peers(&reports[mon->monmap->get_name(get_my_rank())]);
+      MMonPing *reply = new MMonPing(MMonPing::PING_REPLY, m->stamp, reports);
+      m->get_connection()->send_message(reply);
+    }
+    break;
+
+  case MMonPing::PING_REPLY:
+    const utime_t& previous_acked = peer_acked_ping[prank];
+    const utime_t& newest = peer_sent_ping[prank];
+    if (m->stamp > newest && !newest.is_zero()) {
+      derr << "dropping PING_REPLY stamp " << m->stamp
+	   << " as it is newer than newest sent " << newest << dendl;
+      return;
+    }
+    if (m->stamp > previous_acked) {
+      peer_tracker.report_live_connection(prank, m->stamp - previous_acked);
+      peer_acked_ping[prank] = m->stamp;
+    }
+    utime_t now = ceph_clock_now();
+    if (now - m->stamp > ping_timeout / PING_DIVISOR) {
+      send_peer_ping(prank, &now);
+    }
+    break;
+  }
+  // TODO: Really need to persist the ConnectionTracker at some point (note early return statements above)
+}
+
 void Elector::dispatch(MonOpRequestRef op)
 {
   op->mark_event("elector:dispatch");
-  ceph_assert(op->is_type_election());
+  ceph_assert(op->is_type_election_or_ping());
 
   switch (op->get_req()->get_type()) {
     
@@ -437,6 +563,7 @@ void Elector::dispatch(MonOpRequestRef op)
 		<< dendl;
       } 
 
+      begin_peer_ping(mon->monmap->get_rank(em->get_source_addr()));
       switch (em->op) {
       case MMonElection::OP_PROPOSE:
 	handle_propose(op);
@@ -462,6 +589,10 @@ void Elector::dispatch(MonOpRequestRef op)
 	ceph_abort();
       }
     }
+    break;
+
+  case MSG_MON_PING:
+    handle_ping(op);
     break;
     
   default: 

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -208,7 +208,9 @@ class Elector : public ElectionOwner, RankProvider {
    * @defgroup Elector_h_ElectionOwner Functions from the ElectionOwner interface
    * @{
    */
-  /* Commit the given epoch to our MonStore */
+  /* Commit the given epoch to our MonStore.
+   * We also take the opportunity to persist our peer_tracker.
+   */
   void persist_epoch(epoch_t e);
   /* Read the epoch out of our MonStore */
   epoch_t read_persisted_epoch() const;
@@ -256,6 +258,10 @@ class Elector : public ElectionOwner, RankProvider {
   /*
    * @}
    */
+  /**
+   * Persist our peer_tracker to disk.
+   */
+  void persist_connectivity_scores();
 
   Elector *elector;
   

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -230,6 +230,9 @@ class Elector : public ElectionOwner, RankProvider {
   bool ever_participated() const;
   /* Retrieve monmap->size() */
   unsigned paxos_size() const;
+  /* Right now we don't disallow anybody */
+  set<int> disallowed_leaders;
+  const set<int>& get_disallowed_leaders() const { return disallowed_leaders; }
   /**
    * Reset the expire_event timer so we can limit the amount of time we 
    * will be electing. Clean up our peer_info.

--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -167,7 +167,7 @@ public:
   void set_type_paxos() {
     set_op_type(OP_TYPE_PAXOS);
   }
-  void set_type_election() {
+  void set_type_election_or_ping() {
     set_op_type(OP_TYPE_ELECTION);
   }
   void set_type_command() {
@@ -187,7 +187,7 @@ public:
   bool is_type_paxos() {
     return (get_op_type() == OP_TYPE_PAXOS);
   }
-  bool is_type_election() {
+  bool is_type_election_or_ping() {
     return (get_op_type() == OP_TYPE_ELECTION);
   }
   bool is_type_command() {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1948,6 +1948,8 @@ void Monitor::handle_probe_probe(MonOpRequestRef op)
     dout(1) << " adding peer " << m->get_source_addrs()
 	    << " to list of hints" << dendl;
     extra_probe_peers.insert(m->get_source_addrs());
+  } else {
+    elector.begin_peer_ping(monmap->get_rank(m->get_source_addr()));
   }
 
  out:
@@ -4569,7 +4571,7 @@ void Monitor::dispatch_op(MonOpRequestRef op)
 
     // elector messages
     case MSG_MON_ELECTION:
-      op->set_type_election();
+      op->set_type_election_or_ping();
       //check privileges here for simplicity
       if (!op->get_session()->is_capable("mon", MON_CAP_X)) {
         dout(0) << "MMonElection received from entity without enough caps!"
@@ -4579,6 +4581,11 @@ void Monitor::dispatch_op(MonOpRequestRef op)
       if (!is_probing() && !is_synchronizing()) {
         elector.dispatch(op);
       }
+      return;
+
+    case MSG_MON_PING:
+      op->set_type_election_or_ping();
+      elector.dispatch(op);
       return;
 
     case MSG_FORWARD:

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -41,6 +41,7 @@
 #include "messages/MMonJoin.h"
 #include "messages/MMonElection.h"
 #include "messages/MMonSync.h"
+#include "messages/MMonPing.h"
 #include "messages/MMonScrub.h"
 
 #include "messages/MLog.h"
@@ -405,6 +406,9 @@ Message *decode_message(CephContext *cct,
     break;
   case MSG_MON_SYNC:
     m = make_message<MMonSync>();
+    break;
+  case MSG_MON_PING:
+    m = make_message<MMonPing>();
     break;
   case MSG_MON_SCRUB:
     m = make_message<MMonScrub>();

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -46,6 +46,7 @@
 #define MSG_MON_PROBE              67
 #define MSG_MON_JOIN               68
 #define MSG_MON_SYNC		   69
+#define MSG_MON_PING               140 // FIXME: This is a dumb number
 
 /* monitor <-> mon admin tool */
 #define MSG_MON_COMMAND            50

--- a/src/test/mon/test_election.cc
+++ b/src/test/mon/test_election.cc
@@ -63,6 +63,8 @@ struct Election {
   void start_one(int who);
   void start_all();
   bool election_stable();
+  bool check_leader_agreement();
+  bool check_epoch_agreement();
   void block_messages(int from, int to);
   void block_bidirectional_messages(int a, int b);
   void unblock_messages(int from, int to);
@@ -299,6 +301,31 @@ bool Election::election_stable()
   return true;
 }
 
+bool Election::check_leader_agreement()
+{
+  int leader = electors[0]->logic.get_acked_leader();
+  for (auto i: electors) {
+    if (leader != i.second->logic.get_acked_leader()) {
+      return false;
+    }
+  }
+  if (disallowed_leaders.count(leader)) {
+    return false;
+  }
+  return true;
+}
+
+bool Election::check_epoch_agreement()
+{
+  epoch_t epoch = electors[0]->logic.get_epoch();
+  for (auto i : electors) {
+    if (epoch != i.second->logic.get_epoch()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void Election::block_messages(int from, int to)
 {
   blocked_messages[from].insert(to);
@@ -329,14 +356,8 @@ TEST(election, single_startup_election_completes)
     int steps = election.run_timesteps(0);
     ldout(g_ceph_context, 1) << "ran in " << steps << " timesteps" << dendl;
     ASSERT_TRUE(election.election_stable());
-    Owner *first_o = election.electors[0];
-    int leader = first_o->logic.get_acked_leader();
-    int epoch = first_o->logic.get_epoch();
-    for (auto i : election.electors) {
-      Owner *o = i.second;
-      ASSERT_EQ(leader, o->logic.get_acked_leader());
-      ASSERT_EQ(epoch, o->logic.get_epoch());
-    }
+    ASSERT_TRUE(election.check_leader_agreement());
+    ASSERT_TRUE(election.check_epoch_agreement());
   }
 }
 
@@ -347,14 +368,8 @@ TEST(election, everybody_starts_completes)
   int steps = election.run_timesteps(0);
   ldout(g_ceph_context, 1) << "ran in " << steps << " timesteps" << dendl;
   ASSERT_TRUE(election.election_stable());
-  Owner *first_o = election.electors[0];
-  int leader = first_o->logic.get_acked_leader();
-  int epoch = first_o->logic.get_epoch();
-  for (auto i : election.electors) {
-    Owner *o = i.second;
-    ASSERT_EQ(leader, o->logic.get_acked_leader());
-    ASSERT_EQ(epoch, o->logic.get_epoch());
-  }
+  ASSERT_TRUE(election.check_leader_agreement());
+  ASSERT_TRUE(election.check_epoch_agreement());
 }
 
 TEST(election, blocked_connection_continues_election)
@@ -370,6 +385,8 @@ TEST(election, blocked_connection_continues_election)
   steps = election.run_timesteps(100);
   ldout(g_ceph_context, 1) << "ran in " << steps << " timesteps" << dendl;
   ASSERT_TRUE(election.election_stable());
+  ASSERT_TRUE(election.check_leader_agreement());
+  ASSERT_TRUE(election.check_epoch_agreement());
 }
 
 TEST(election, disallowed_doesnt_win)
@@ -384,17 +401,29 @@ TEST(election, disallowed_doesnt_win)
     int steps = election.run_timesteps(0);
     ldout(g_ceph_context, 1) << "ran in " << steps << " timesteps" << dendl;
     ASSERT_TRUE(election.election_stable());
-    Owner *first_o = election.electors[0];
-    int leader = first_o->logic.get_acked_leader();
-    int epoch = first_o->logic.get_epoch();
-    for (auto i : election.electors) {
-      Owner *o = i.second;
-      ASSERT_EQ(leader, o->logic.get_acked_leader());
-      ASSERT_EQ(epoch, o->logic.get_epoch());
-    }
+    ASSERT_TRUE(election.check_leader_agreement());
+    ASSERT_TRUE(election.check_epoch_agreement());
+    int leader = election.electors[0]->logic.get_acked_leader();
     for (int j = 0; j <= i; ++j) {
+      ASSERT_NE(j, leader);
+    }
+  }
+  for (int i = MON_COUNT - 1; i > 0; --i) {
+    Election election(MON_COUNT);
+    for (int j = i; j <= MON_COUNT - 1; ++j) {
+      election.add_disallowed_leader(j);
+    }
+    election.start_all();
+    int steps = election.run_timesteps(0);
+    ldout(g_ceph_context, 1) << "ran in " << steps << " timesteps" << dendl;
+    ASSERT_TRUE(election.election_stable());
+    ASSERT_TRUE(election.check_leader_agreement());
+    ASSERT_TRUE(election.check_epoch_agreement());
+    int leader = election.electors[0]->logic.get_acked_leader();
+    for (int j = i; j < MON_COUNT; ++j) {
       ASSERT_NE(j, leader);
     }
   }
 }
 
+// TODO: Write a test that disallowing and disconnecting 0 is otherwise stable?

--- a/src/test/mon/test_election.cc
+++ b/src/test/mon/test_election.cc
@@ -95,6 +95,8 @@ struct Owner : public ElectionOwner {
   // pass back to ElectionLogic; we don't need this redirect ourselves
   void trigger_new_election() { logic.start(); }
   int get_my_rank() const { return rank; }
+  // we don't need to persist scores as we don't reset and lose memory state
+  void persist_connectivity_scores() {}
   void propose_to_peers(epoch_t e) {
     for (int i = 0; i < parent->get_paxos_size(); ++i) {
       if (i == rank) continue;


### PR DESCRIPTION
test: elector: make macros to run test scenarios against each ElectionStrategy

This PR sets up pinging between monitors, uses them to track the quality of
connections, and passes those scores to a new election_strategy that votes
based on the best-connected monitor. There are several parts:

* Builds a new ConnectionTracker and MMonPing, which monitors send to
   each other following bootstrap.
* Extends the ElectionLogic interface and implementation to support multiple
   election strategies.
* Adds a pretty basic DISALLOW strategy, which lets you ban one monitor
   from being a leader -- eg, a tiebreaker with high latency in a 3-site stretch cluster.
* Adds a much more involved CONNECTIVITY strategy, which takes the
   ConnectionTracker scores as inputs and elects the monitor with the best
   aggregate scores.
   This mode also works much better in net split scenarios than our existing
   strategy, as peons can ignore out-of-quorum peers who can't connect
   to enough others to form a useful quorum.
* Adds a bunch of new unit tests and capabilities to cover these cases in ElectionLogic

There are several TODOs noted in the source code, and I have a list of a few others. In particular:
- [ ] Make the election stuff configurable in real clusters (you can't poke it yet)
- [ ] Usefully expose the ConnectionTracker state via admin socket
- [ ] Write teuthology tests too so we can check the full stack

Also, while the scores each rank uses when voting in an election are stable until that election ends, the scores each rank uses can differ even when they're fully-connected. So far I haven't broken anything with this, but I'm worried it might break in some cases. So I need to either prove that's okay, or else strengthen the ConnectionTracker interfaces and guarantees so we can make everybody in an election work from the same set of scores.