### PR TITLE
rgw: clean index and remove bucket instance info when setting resharding status fails

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -681,8 +681,7 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
   ret = set_resharding_status(new_bucket_info.bucket.bucket_id,
 			      num_shards, CLS_RGW_RESHARD_IN_PROGRESS);
   if (ret < 0) {
-    reshard_lock.unlock();
-    return ret;
+    goto error_out;
   }
 
   ret = do_reshard(num_shards,


### PR DESCRIPTION

Signed-off-by: zhangshaowen <zhangshaowen@cmss.chinamobile.com>
