### PR TITLE
luminous: mgr/prometheus: replace whitespaces in metrics' names

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -142,7 +142,8 @@ class Metric(object):
 
         def promethize(path):
             ''' replace illegal metric name characters '''
-            result = path.replace('.', '_').replace('+', '_plus').replace('::', '_')
+            result = path.replace('.', '_').replace(
+                '+', '_plus').replace('::', '_').replace(' ', '_')
 
             # Hyphens usually turn into underscores, unless they are
             # trailing


### PR DESCRIPTION
tracker: https://tracker.ceph.com/issues/39457
backport of: #27722