### PR TITLE
msg/async/rdma: fix bug event center is blocked by rdma construct connection for transport ib sync msg

### DIFF
--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -188,6 +188,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   std::vector<ibv_wc> wc;
   bool is_server;
   EventCallbackRef con_handler;
+  EventCallbackRef con_init_handler;
   int tcp_fd = -1;
   bool active;// qp is active ?
   bool pending;
@@ -217,6 +218,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   int activate();
   void fin();
   void handle_connection();
+  int handle_connection_init(bool need_set_fault = true);
   void cleanup();
   void set_accept_fd(int sd);
   int try_connect(const entity_addr_t&, const SocketOptions &opt);
@@ -235,6 +237,20 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
       active = false;
     }
   };
+  class C_handle_connection_init : public EventCallback {
+    RDMAConnectedSocketImpl *csi;
+    bool active;
+   public:
+    C_handle_connection_init(RDMAConnectedSocketImpl *w) : csi(w), active(true) {}
+    void do_request(uint64_t fd) {
+      if (active)
+        csi->handle_connection_init();
+    }
+    void close() {
+      active = false;
+    }
+  };
+
 };
 
 class RDMAServerSocketImpl : public ServerSocketImpl {


### PR DESCRIPTION
We construct a tcp connection to transport ib sync msg, if the
remote node is shutdown (shutdown by accident), the net.connect will be blocked until timeout
is reached, which cause the event center be blocked.

This bug may cause mon probe timeout and osd not reply, and so on.

Fixes: https://tracker.ceph.com/issues/42452
Signed-off-by: Peng Liu <liupeng37@baidu.com>