### PR TITLE
mimic: mgr/prometheus: Cast collect_timeout (scrape_interval) to float

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -721,7 +721,8 @@ class Module(MgrModule):
                     raise cherrypy.HTTPError(503, 'No MON connection')
 
         # Make the cache timeout for collecting configurable
-        self.collect_timeout = self.get_localized_config('scrape_interval', 5.0)
+        self.collect_timeout = float(self.get_localized_config(
+            'scrape_interval', 5.0))
 
         server_addr = self.get_localized_config('server_addr', DEFAULT_ADDR)
         server_port = self.get_localized_config('server_port', DEFAULT_PORT)


### PR DESCRIPTION
tracker: https://tracker.ceph.com/issues/41277
backport of: #29382