### PR TITLE
nautilus: core: mon/MonCommands: "smart" only needs read permission

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1232,4 +1232,4 @@ COMMAND("config generate-minimal-conf",
 
 COMMAND_WITH_FLAG("smart name=devid,type=CephString,req=false",
 		  "Query health metrics for underlying device",
-		  "mon", "rw", FLAG(HIDDEN))
+		  "mon", "r", FLAG(HIDDEN))


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42455
Signed-off-by: Kefu Chai <kchai@redhat.com>

Conflicts: this change is not cherry-picked from master, because in
master, we had a massive refactor in asok. see
https://github.com/ceph/ceph/pull/30859. and #30859 is not backported
to nautilus.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
