### PR TITLE
qa/distros: add SLE-12-SP3 and SLE-15-SP1

### DIFF
--- a/qa/distros/all/sle_12.3.yaml
+++ b/qa/distros/all/sle_12.3.yaml
@@ -1,0 +1,2 @@
+os_type: sle
+os_version: "12.3"

--- a/qa/distros/all/sle_15.1.yaml
+++ b/qa/distros/all/sle_15.1.yaml
@@ -1,0 +1,2 @@
+os_type: sle
+os_version: "15.1"


### PR DESCRIPTION
Ceph luminous is known to run on SLE-12-SP3 and nautilus on SLE-15-SP1, so add
these two to qa/distros/all.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
