### PR TITLE
do_cmake: Warn user about slow debug performance only for not set

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -64,7 +64,9 @@ erasure code dir = lib
 EOF
 
 echo done.
-cat <<EOF
+
+if [[ ! $ARGS =~ "-DCMAKE_BUILD_TYPE" ]]; then
+  cat <<EOF
 
 ****
 WARNING: do_cmake.sh now creates debug builds by default. Performance
@@ -72,3 +74,5 @@ may be severely affected. Please use -DCMAKE_BUILD_TYPE=RelWithDebInfo
 if a performance sensitive build is required.
 ****
 EOF
+fi
+

--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -55,6 +55,7 @@ else
     CMAKE=cmake
 fi
 ${CMAKE} $ARGS "$@" .. || exit 1
+set +x
 
 # minimal config to find plugins
 cat <<EOF > ceph.conf


### PR DESCRIPTION
do_cmake: Warn user about slow debug performance only for not set 

If user pass `-DCMAKE_BUILD_TYPE=RelWithDebInfo`, The warning message have to be gone. It makes users confused if warning message is remained even if user pass correct arguments. I was confused, too.

Fixes: None
Signed-off-by: Junyoung, Sung <junyoung.sung@navercorp.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
