### PR TITLE
nautilus: mgr/dashboard: qa: whitelist client eviction warning

### DIFF
--- a/qa/suites/rados/mgr/tasks/dashboard.yaml
+++ b/qa/suites/rados/mgr/tasks/dashboard.yaml
@@ -23,6 +23,7 @@ tasks:
         - \(POOL_APP_NOT_ENABLED\)
         - pauserd,pausewr flag\(s\) set
         - Monitor daemon marked osd\.[[:digit:]]+ down, but it is still running
+        - evicting unresponsive client .+
   - rgw: [client.0]
   - cephfs_test_runner:
       fail_on_skip: false


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42458

---

backport of https://github.com/ceph/ceph/pull/29114
parent tracker: https://tracker.ceph.com/issues/42457

this backport was staged using ceph-backport.sh version 15.0.0.5775
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh