### PR TITLE
crush: ftotal needn't to be set to 0 again in every replicas loop

### DIFF
--- a/src/crush/mapper.c
+++ b/src/crush/mapper.c
@@ -494,9 +494,9 @@ parent_r %d stable %d\n",
 		tries, recurse_tries, local_retries, local_fallback_retries,
 		parent_r, stable);
 
+	ftotal = 0;
 	for (rep = stable ? 0 : outpos; rep < numrep && count > 0 ; rep++) {
 		/* keep trying until we get a non-out, non-colliding item */
-		ftotal = 0;
 		skip_rep = 0;
 		do {
 			retry_descent = 0;


### PR DESCRIPTION
If we set ftotal to 0 in every loop begins, r may has the same value
as previous iteration, which is meaningless. The previous iteration
may has already reject this r due to collision or item out, so in
this iteration the same r will be reject again.
We should keep r' always increasing to avoid redudant calculation.

In Sage Weil's paper "CRUSH: Controlled, Scalable, Decentralized
Placement of Replicated Data", ftotal is set to 0 only once before
loop begins. (Algorithm 1 CRUSH placement for object x, line 7).
So I think this should be a mistake.

Signed-off-by: Gao Mingfei <mingfei.gao@ucloud.cn>