### PR TITLE
mon/MonClient: fix mon tell to older mons

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1196,7 +1196,10 @@ void MonClient::_resend_mon_commands()
   while (p != mon_commands.end()) {
     auto cmd = p->second;
     ++p;
-    if (!cmd->is_tell()) {
+    if (cmd->is_tell() && monmap.min_mon_release >= ceph_release_t::octopus) {
+      // starting with octopus, tell commands use their own connetion and need no
+      // special resend when we finish hunting.
+    } else {
       _send_command(cmd); // might remove cmd from mon_commands
     }
   }


### PR DESCRIPTION
For older mons, we need to call into send_command so that we trigger the
compat code that futzes with our mon sessions.

Signed-off-by: Sage Weil <sage@redhat.com>