### PR TITLE
nautilus: build/ops: rpm: make librados2, libcephfs2 own (create) /etc/ceph

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1907,6 +1907,7 @@ fi
 %if %{with lttng}
 %{_libdir}/librados_tp.so.*
 %endif
+%dir %{_sysconfdir}/ceph
 
 %post -n librados2 -p /sbin/ldconfig
 
@@ -2021,6 +2022,7 @@ fi
 
 %files -n libcephfs2
 %{_libdir}/libcephfs.so.*
+%dir %{_sysconfdir}/ceph
 
 %post -n libcephfs2 -p /sbin/ldconfig
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42439

---

backport of https://github.com/ceph/ceph/pull/30975
parent tracker: https://tracker.ceph.com/issues/42352

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh