### PR TITLE
mgr/dashboard: Dashboard can't handle self-signed cert on Graf…

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -425,6 +425,12 @@ The format of url is : `<protocol>:<IP-address>:<port>`
   above, check your browser's documentation on how to unblock mixed content.
   Alternatively, consider enabling SSL/TLS support in Grafana.
 
+If you are using a self-signed certificate in your Grafana setup, then you should
+disable certificate verification in the dashboard to avoid refused connections,
+e.g. caused by certificates signed by unknown CA or not matching the host name::
+
+  $ ceph dashboard set-grafana-api-ssl-verify False
+
 You can directly access Grafana Instance as well to monitor your cluster.
 
 .. _dashboard-sso-support:

--- a/src/pybind/mgr/dashboard/grafana.py
+++ b/src/pybind/mgr/dashboard/grafana.py
@@ -17,8 +17,8 @@ class GrafanaRestClient(object):
     def url_validation(method, path):
         response = requests.request(
             method,
-            path)
-
+            path,
+            verify=Settings.GRAFANA_API_SSL_VERIFY)
         return response.status_code
 
     @staticmethod
@@ -48,6 +48,7 @@ class GrafanaRestClient(object):
                 data=json.dumps(payload),
                 auth=(Settings.GRAFANA_API_USERNAME,
                       Settings.GRAFANA_API_PASSWORD),
+                verify=Settings.GRAFANA_API_SSL_VERIFY
             )
         except requests.ConnectionError:
             raise GrafanaError("Could not connect to Grafana server")

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -39,6 +39,7 @@ class Options(object):
     GRAFANA_API_URL = ('', str)
     GRAFANA_API_USERNAME = ('admin', str)
     GRAFANA_API_PASSWORD = ('admin', str)
+    GRAFANA_API_SSL_VERIFY = (True, bool)
     GRAFANA_UPDATE_DASHBOARDS = (False, bool)
 
     # NFS Ganesha settings

--- a/src/pybind/mgr/dashboard/tests/test_grafana.py
+++ b/src/pybind/mgr/dashboard/tests/test_grafana.py
@@ -1,5 +1,15 @@
-from . import ControllerTestCase
+import json
+import unittest
+
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
+
+from . import ControllerTestCase, KVStoreMockMixin
 from ..controllers.grafana import Grafana
+from ..grafana import GrafanaRestClient
+from ..settings import Settings
 from .. import mgr
 
 
@@ -48,3 +58,57 @@ class GrafanaTest(ControllerTestCase):
         self.server_settings(password=None)
         self._post('/api/grafana/dashboards')
         self.assertStatus(500)
+
+
+class GrafanaRestClientTest(unittest.TestCase, KVStoreMockMixin):
+    headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+    payload = json.dumps({
+        'dashboard': 'foo',
+        'overwrite': True
+    })
+
+    def setUp(self):
+        self.mock_kv_store()
+        Settings.GRAFANA_API_URL = 'https://foo/bar'
+        Settings.GRAFANA_API_USERNAME = 'xyz'
+        Settings.GRAFANA_API_PASSWORD = 'abc'
+        Settings.GRAFANA_API_SSL_VERIFY = True
+
+    def test_ssl_verify_url_validation(self):
+        with patch('requests.request') as mock_request:
+            rest_client = GrafanaRestClient()
+            rest_client.url_validation('FOO', Settings.GRAFANA_API_URL)
+            mock_request.assert_called_with('FOO', Settings.GRAFANA_API_URL,
+                                            verify=True)
+
+    def test_no_ssl_verify_url_validation(self):
+        Settings.GRAFANA_API_SSL_VERIFY = False
+        with patch('requests.request') as mock_request:
+            rest_client = GrafanaRestClient()
+            rest_client.url_validation('BAR', Settings.GRAFANA_API_URL)
+            mock_request.assert_called_with('BAR', Settings.GRAFANA_API_URL,
+                                            verify=False)
+
+    def test_ssl_verify_push_dashboard(self):
+        with patch('requests.post') as mock_request:
+            rest_client = GrafanaRestClient()
+            rest_client.push_dashboard('foo')
+            mock_request.assert_called_with(
+                Settings.GRAFANA_API_URL + '/api/dashboards/db',
+                auth=(Settings.GRAFANA_API_USERNAME,
+                      Settings.GRAFANA_API_PASSWORD),
+                data=self.payload, headers=self.headers, verify=True)
+
+    def test_no_ssl_verify_push_dashboard(self):
+        Settings.GRAFANA_API_SSL_VERIFY = False
+        with patch('requests.post') as mock_request:
+            rest_client = GrafanaRestClient()
+            rest_client.push_dashboard('foo')
+            mock_request.assert_called_with(
+                Settings.GRAFANA_API_URL + '/api/dashboards/db',
+                auth=(Settings.GRAFANA_API_USERNAME,
+                      Settings.GRAFANA_API_PASSWORD),
+                data=self.payload, headers=self.headers, verify=False)


### PR DESCRIPTION
To configure SSL certificate verification use the following command:
`$ ceph dashboard set-grafana-api-ssl-verify true|false`

Fixes: https://tracker.ceph.com/issues/42445

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
