### PR TITLE
ceph-daemon: only set up crash dir mount if it exists

### DIFF
--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -30,6 +30,10 @@ $SUDO $CEPH_DAEMON --image $IMAGE version | grep 'ceph version'
 # try force docker; this won't work if docker isn't installed
 which docker && ( $SUDO $CEPH_DAEMON --docker version | grep 'ceph version' )
 
+## test shell before bootstrap, when crash dir isn't (yet) present on this host
+$SUDO $CEPH_DAEMON shell -- ceph -v | grep 'ceph version'
+$SUDO $CEPH_DAEMON shell --fsid $FSID -- ceph -v | grep 'ceph version'
+
 ## bootstrap
 ORIG_CONFIG=`mktemp -p $TMPDIR`
 CONFIG=`mktemp -p $TMPDIR`

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -339,7 +339,9 @@ def get_container_mounts(fsid, daemon_type, daemon_id):
     if fsid:
         log_dir = get_log_dir(fsid)
         mounts[log_dir] = '/var/log/ceph:z'
-        mounts['/var/lib/ceph/%s/crash' % fsid] = '/var/lib/ceph/crash:z'
+        crash_dir = '/var/lib/ceph/%s/crash' % fsid
+        if os.path.exists(crash_dir):
+            mounts[crash_dir] = '/var/lib/ceph/crash:z'
 
     if daemon_id:
         data_dir = get_data_dir(fsid, daemon_type, daemon_id)


### PR DESCRIPTION
Sometimes we run containers on a host that doesn't have a crash dir set
up (becuase no daemon has been deployed).  Examples include shell and
ceph-volume.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>