### PR TITLE
msg/DispatchQueue: Set throttle stamp for local_delivery

### DIFF
--- a/src/msg/DispatchQueue.cc
+++ b/src/msg/DispatchQueue.cc
@@ -96,7 +96,10 @@ void DispatchQueue::enqueue(const ref_t<Message>& m, int priority, uint64_t id)
 
 void DispatchQueue::local_delivery(const ref_t<Message>& m, int priority)
 {
-  m->set_recv_stamp(ceph_clock_now());
+  auto local_delivery_stamp = ceph_clock_now();
+  m->set_recv_stamp(local_delivery_stamp);
+  m->set_throttle_stamp(local_delivery_stamp);
+  m->set_recv_complete_stamp(local_delivery_stamp);
   std::lock_guard l{local_delivery_lock};
   if (local_messages.empty())
     local_delivery_cond.notify_all();


### PR DESCRIPTION
33d8efa52d changed to initialising TrackedOps with the throttle stamp.
This exposed the fact the throttle stamp was not being set for local
delivery.

Fixes: https://tracker.ceph.com/issues/41834

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
