### PR TITLE
mon: fix tell to hybrid octopus/pre-octopus mons

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -203,10 +203,6 @@ COMMAND("log last "
         "name=channel,type=CephChoices,strings=*|cluster|audit,req=false", \
 	"print last few lines of the cluster log", \
 	"mon", "r")
-COMMAND_WITH_FLAG("injectargs " \
-	     "name=injected_args,type=CephString,n=N",			\
-	     "inject config arguments into monitor", "mon", "rw",
-	     FLAG(NOFORWARD))
 
 COMMAND("status", "show cluster status", "mon", "r")
 COMMAND("health name=detail,type=CephChoices,strings=detail,req=false", \
@@ -1233,3 +1229,28 @@ COMMAND("config generate-minimal-conf",
 	"Generate a minimal ceph.conf file",
 	"config", "r")
 
+
+
+
+// these are tell commands that were implemented as CLI commands in
+// the broken pre-octopus way that we want to allow to work when a
+// monitor has upgraded to octopus+ but the monmap min_mon_release is
+// still < octopus.  we exclude things that weren't well supported
+// before and that aren't implemented by the octopus mon anymore.
+//
+// the command set below matches the kludge in Monitor::handle_command
+// that shunts these off to the asok machinery.
+
+COMMAND_WITH_FLAG("injectargs " \
+	     "name=injected_args,type=CephString,n=N",			\
+	     "inject config arguments into monitor", "mon", "rw",
+		  FLAG(NOFORWARD)|FLAG(HIDDEN))
+COMMAND_WITH_FLAG("smart name=devid,type=CephString,req=false",
+                 "Query health metrics for underlying device",
+		  "mon", "rw", FLAG(NOFORWARD)|FLAG(HIDDEN))
+COMMAND_WITH_FLAG("mon_status", "report status of monitors", "mon", "r",
+		  FLAG(NOFORWARD)|FLAG(HIDDEN))
+COMMAND_WITH_FLAG("heap "						\
+            "name=heapcmd,type=CephChoices,strings=dump|start_profiler|stop_profiler|release|stats", \
+            "show heap usage info (available only if compiled with tcmalloc)", \
+		  "mon", "rw", FLAG(NOFORWARD)|FLAG(HIDDEN))

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3258,12 +3258,15 @@ void Monitor::handle_command(MonOpRequestRef op)
     return;
   }
 
-  // compat kludge for legacy clients trying to tell commands that are new
-  if (!HAVE_FEATURE(m->get_connection()->get_features(), SERVER_OCTOPUS) &&
+  // compat kludge for legacy clients trying to tell commands that are
+  // new.  see bottom of MonCommands.h.  we need to handle both (1)
+  // pre-octopus clients and (2) octopus clients with a mix of pre-octopus
+  // and octopus mons.
+  if ((!HAVE_FEATURE(m->get_connection()->get_features(), SERVER_OCTOPUS) ||
+       monmap->min_mon_release < ceph_release_t::octopus) &&
       (prefix == "injectargs" ||
        prefix == "smart" ||
        prefix == "mon_status" ||
-       prefix == "sync_force" ||
        prefix == "heap")) {
     dout(5) << __func__ << " passing command to tell/asok" << dendl;
     cct->get_admin_socket()->queue_tell_command(m);


### PR DESCRIPTION
We can't decide whether to use the new tell command style based on the
monmap.min_mon_release alone because some mons may be octopus even though
that hasn't updated yet.  The same goes for if we look at the combined
features for the cluster--the underlying problem is the monmap doesn't
tell us which mons are octopus and which ones aren't, so we don't know
how to behave.

Instead, allow octopus+ mons to advertise the converted tell commands
going forward, for compatibility with pre-octopus clients (who do the old
style of tell) and for octopus+ clients talking to a min_mon_release <
octopus cluster.

Signed-off-by: Sage Weil <sage@redhat.com>