### PR TITLE
install-deps.sh: Use dnf for rhel/centos 8

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -343,11 +343,11 @@ else
 	if [ "$control" != "debian/control" ] ; then rm $control; fi
         ;;
     centos|fedora|rhel|ol|virtuozzo)
-        yumdnf="yum"
-        builddepcmd="yum-builddep -y --setopt=*.skip_if_unavailable=true"
-        if test "$(echo "$VERSION_ID >= 22" | bc)" -ne 0; then
-            yumdnf="dnf"
-            builddepcmd="dnf -y builddep --allowerasing"
+        yumdnf="dnf"
+        builddepcmd="dnf -y builddep --allowerasing"
+        if [[ $ID =~ centos|rhel ]] && version_lt $VERSION_ID 8; then
+            yumdnf="yum"
+            builddepcmd="yum-builddep -y --setopt=*.skip_if_unavailable=true"
         fi
         echo "Using $yumdnf to install dependencies"
 	if [ "$ID" = "centos" -a "$ARCH" = "aarch64" ]; then
@@ -357,28 +357,26 @@ else
 	fi
         case "$ID" in
             fedora)
-                if test $yumdnf = yum; then
-                    $SUDO $yumdnf install -y yum-utils
-                fi
+                $SUDO $yumdnf install -y $yumdnf-utils
                 ;;
             centos|rhel|ol|virtuozzo)
                 MAJOR_VERSION="$(echo $VERSION_ID | cut -d. -f1)"
-                $SUDO yum install -y yum-utils
+                $SUDO $yumdnf install -y $yumdnf-utils
                 if test $ID = rhel ; then
                     $SUDO yum-config-manager --enable rhel-$MAJOR_VERSION-server-optional-rpms
                 fi
                 rpm --quiet --query epel-release || \
-		    $SUDO yum -y install --nogpgcheck https://dl.fedoraproject.org/pub/epel/epel-release-latest-$MAJOR_VERSION.noarch.rpm
+		    $SUDO $yumdnf -y install --nogpgcheck https://dl.fedoraproject.org/pub/epel/epel-release-latest-$MAJOR_VERSION.noarch.rpm
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
                 if test $ID = centos -a $MAJOR_VERSION = 7 ; then
 		    case "$ARCH" in
 			x86_64)
-			    $SUDO yum -y install centos-release-scl
+			    $SUDO $yumdnf -y install centos-release-scl
 			    dts_ver=8
 			    ;;
 			aarch64)
-			    $SUDO yum -y install centos-release-scl-rh
+			    $SUDO $yumdnf -y install centos-release-scl-rh
 			    $SUDO yum-config-manager --disable centos-sclo-rh
 			    $SUDO yum-config-manager --enable centos-sclo-rh-testing
 			    dts_ver=8
@@ -520,4 +518,3 @@ if $for_make_check; then
     rm -rf $XDG_CACHE_HOME
     git --version || (echo "Dashboard uses git to pull dependencies." ; false)
 fi
-


### PR DESCRIPTION
Also install the correct dnf-utils package rather than yum-utils.

Fixes: https://tracker.ceph.com/issues/42504

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
