### PR TITLE
restful: Query nodes_by_id for items

### DIFF
--- a/src/pybind/mgr/restful/common.py
+++ b/src/pybind/mgr/restful/common.py
@@ -96,11 +96,8 @@ def crush_rule_osds(node_buckets, rule):
             return set([node['id']])
 
         result = set()
-        for item in node['items']:
-            if item['id'] >= 0:
-                result.add(item['id'])
-            else:
-                result |= _gather_leaf_ids(nodes_by_id[item['id']])
+        for item in nodes_by_id[node['id']]['items']:
+            result |= _gather_leaf_ids(item)
 
         return result
 

--- a/src/pybind/mgr/restful/common.py
+++ b/src/pybind/mgr/restful/common.py
@@ -91,13 +91,13 @@ def pool_update_commands(pool_name, args):
 def crush_rule_osds(node_buckets, rule):
     nodes_by_id = dict((b['id'], b) for b in node_buckets)
 
-    def _gather_leaf_ids(node):
-        if node['id'] >= 0:
-            return set([node['id']])
+    def _gather_leaf_ids(node_id):
+        if node_id >= 0:
+            return set([node_id])
 
         result = set()
-        for item in nodes_by_id[node['id']]['items']:
-            result |= _gather_leaf_ids(item)
+        for item in nodes_by_id[node_id]['items']:
+            result |= _gather_leaf_ids(item['id'])
 
         return result
 
@@ -143,7 +143,7 @@ def crush_rule_osds(node_buckets, rule):
                         # Short circuit another iteration to find the emit
                         # and assume anything we've done a chooseleaf on
                         # is going to be part of the selected set of osds
-                        osds |= _gather_leaf_ids(desc_node)
+                        osds |= _gather_leaf_ids(desc_node['id'])
         elif step['op'] == 'emit':
             if root['id'] >= 0:
                 osds |= root['id']


### PR DESCRIPTION
The node dict that is passed to the _gather_leaf_ids function from the
_gather_osds function does not have 'items' in it. We also can't use
buckets at this point since those only exist for leaf nodes, not all
nodes.

We need to query the nodes_by_id dict to get 'items' for a node inside
the _gather_leaf_ids function instead.

Signed-off-by: Boris Ranto <branto@redhat.com>

This resolves https://bugzilla.redhat.com/show_bug.cgi?id=1764919


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
