### PR TITLE
rgw: one log shard fails shouldn't block other shards process when reshard buckets

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -1054,9 +1054,8 @@ int RGWReshard::process_all_logshards()
     ldout(store->ctx(), 20) << "processing logshard = " << logshard << dendl;
 
     ret = process_single_logshard(i);
-    if (ret <0) {
-      return ret;
-    }
+
+    ldout(store->ctx(), 20) << "finish processing logshard = " << logshard << " , ret = " << ret << dendl;
   }
 
   return 0;


### PR DESCRIPTION
Signed-off-by: zhangshaowen <zhangshaowen@cmss.chinamobile.com>

