### PR TITLE
doc: Fixed cephfs name in example

### DIFF
--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -46,7 +46,7 @@ For example, to restrict client ``foo`` to writing only in the ``bar`` directory
    key: *key*
    caps: [mds] allow r, allow rw path=/bar
    caps: [mon] allow r
-   caps: [osd] allow rw tag cephfs data=cephfs_a
+   caps: [osd] allow rw tag cephfs data=cephfs
 
 To completely restrict the client to the ``bar`` directory, omit the
 root directory ::


### PR DESCRIPTION
Was the wrong cephfs name in the example - it should be 'cephfs' instead 'cephfs_a'

Signed-off-by: Michel Raabe <raabe@b1-systems.de>