### PR TITLE
mgr/dashboard: Refactor Python unittests and controller

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -588,6 +588,7 @@ class BaseController(object):
     def __init__(self):
         logger.info('Initializing controller: %s -> %s',
                     self.__class__.__name__, self._cp_path_)
+        super(BaseController, self).__init__()
 
     def _has_permissions(self, permissions, scope=None):
         if not self._cp_config['tools.authenticate.on']:

--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -16,29 +16,38 @@ from . import Controller, UiApiController, BaseController, Proxy, Endpoint
 from .. import mgr, logger
 
 
-LANGUAGES = {f for f in os.listdir(mgr.get_frontend_path())
-             if os.path.isdir(os.path.join(mgr.get_frontend_path(), f))}
-LANGUAGES_PATH_MAP = {f.lower(): {'lang': f, 'path': os.path.join(mgr.get_frontend_path(), f)}
-                      for f in LANGUAGES}
-# pre-populating with the primary language subtag
-for _lang in list(LANGUAGES_PATH_MAP.keys()):
-    if '-' in _lang:
-        LANGUAGES_PATH_MAP[_lang.split('-')[0]] = {
-            'lang': LANGUAGES_PATH_MAP[_lang]['lang'], 'path': LANGUAGES_PATH_MAP[_lang]['path']}
-
-
-def _get_default_language():
-    with open("{}/../package.json".format(mgr.get_frontend_path()), "r") as f:
-        config = json.load(f)
-    return config['config']['locale']
-
-
-DEFAULT_LANGUAGE = _get_default_language()
-DEFAULT_LANGUAGE_PATH = os.path.join(mgr.get_frontend_path(), DEFAULT_LANGUAGE)
+class LanguageMixin(object):
+    def __init__(self):
+        self.LANGUAGES = {
+            f
+            for f in os.listdir(mgr.get_frontend_path())
+            if os.path.isdir(os.path.join(mgr.get_frontend_path(), f))
+        }
+        self.LANGUAGES_PATH_MAP = {
+            f.lower(): {
+                'lang': f,
+                'path': os.path.join(mgr.get_frontend_path(), f)
+            }
+            for f in self.LANGUAGES
+        }
+        # pre-populating with the primary language subtag.
+        for lang in list(self.LANGUAGES_PATH_MAP.keys()):
+            if '-' in lang:
+                self.LANGUAGES_PATH_MAP[lang.split('-')[0]] = {
+                    'lang': self.LANGUAGES_PATH_MAP[lang]['lang'],
+                    'path': self.LANGUAGES_PATH_MAP[lang]['path']
+                }
+        with open("{}/../package.json".format(mgr.get_frontend_path()),
+                  "r") as f:
+            config = json.load(f)
+        self.DEFAULT_LANGUAGE = config['config']['locale']
+        self.DEFAULT_LANGUAGE_PATH = os.path.join(mgr.get_frontend_path(),
+                                                  self.DEFAULT_LANGUAGE)
+        super(LanguageMixin, self).__init__()
 
 
 @Controller("/", secure=False)
-class HomeController(BaseController):
+class HomeController(BaseController, LanguageMixin):
     LANG_TAG_SEQ_RE = re.compile(r'\s*([^,]+)\s*,?\s*')
     LANG_TAG_RE = re.compile(
         r'^(?P<locale>[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})?)(;q=(?P<weight>[01]\.\d{0,3}))?$')
@@ -73,14 +82,16 @@ class HomeController(BaseController):
 
     def _language_dir(self, langs):
         for lang in langs:
-            if lang in LANGUAGES_PATH_MAP:
+            if lang in self.LANGUAGES_PATH_MAP:
                 logger.debug("found directory for language '%s'", lang)
-                cherrypy.response.headers['Content-Language'] = LANGUAGES_PATH_MAP[lang]['lang']
-                return LANGUAGES_PATH_MAP[lang]['path']
+                cherrypy.response.headers[
+                    'Content-Language'] = self.LANGUAGES_PATH_MAP[lang]['lang']
+                return self.LANGUAGES_PATH_MAP[lang]['path']
 
-        logger.debug("Languages '%s' not available, falling back to %s", langs, DEFAULT_LANGUAGE)
-        cherrypy.response.headers['Content-Language'] = DEFAULT_LANGUAGE
-        return DEFAULT_LANGUAGE_PATH
+        logger.debug("Languages '%s' not available, falling back to %s",
+                     langs, self.DEFAULT_LANGUAGE)
+        cherrypy.response.headers['Content-Language'] = self.DEFAULT_LANGUAGE
+        return self.DEFAULT_LANGUAGE_PATH
 
     @Proxy()
     def __call__(self, path, **params):
@@ -95,7 +106,7 @@ class HomeController(BaseController):
                 accept_lang_header = cherrypy.request.headers['Accept-Language']
                 langs = self._parse_accept_language(accept_lang_header)
             else:
-                langs = [DEFAULT_LANGUAGE.lower()]
+                langs = [self.DEFAULT_LANGUAGE.lower()]
             logger.debug("frontend language from headers: %s", langs)
 
         base_dir = self._language_dir(langs)
@@ -109,7 +120,7 @@ class HomeController(BaseController):
 
 
 @UiApiController("/langs", secure=False)
-class LangsController(BaseController):
+class LangsController(BaseController, LanguageMixin):
     @Endpoint('GET')
     def __call__(self):
-        return list(LANGUAGES)
+        return list(self.LANGUAGES)

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -8,3 +8,4 @@ flake8-colors==0.1.6; python_version >= '3'
 #pep8-naming
 rstcheck==3.3.1; python_version >= '3'
 autopep8; python_version >= '3'
+pyfakefs; python_version >= '3'

--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -2,3 +2,4 @@ mock; python_version <= '3.3'
 pytest<4
 pytest-cov
 pytest-instafail
+pyfakefs

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -4,11 +4,13 @@ from __future__ import absolute_import
 
 import json
 import threading
+import sys
 import time
 
 import cherrypy
 from cherrypy._cptools import HandlerWrapperTool
 from cherrypy.test import helper
+from pyfakefs import fake_filesystem
 
 from mgr_module import CLICommand
 
@@ -82,6 +84,17 @@ class CLICommandTestMixin(KVStoreMockMixin):
     @classmethod
     def exec_cmd(cls, cmd, **kwargs):
         return exec_dashboard_cmd(None, cmd, **kwargs)
+
+
+class FakeFsMixin(object):
+    fs = fake_filesystem.FakeFilesystem()
+    f_open = fake_filesystem.FakeFileOpen(fs)
+    f_os = fake_filesystem.FakeOsModule(fs)
+
+    if sys.version_info > (3, 0):
+        builtins_open = 'builtins.open'
+    else:
+        builtins_open = '__builtin__.open'
 
 
 class ControllerTestCase(helper.CPWebCase):

--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -1,31 +1,59 @@
 from __future__ import absolute_import
 
 import logging
+import os
 
-from . import ControllerTestCase
-from ..controllers.home import HomeController
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 
+from . import ControllerTestCase, FakeFsMixin
+from .. import mgr
+
+from ..controllers.home import HomeController, LanguageMixin
 
 logger = logging.getLogger()
 
 
-class HomeTest(ControllerTestCase):
+class HomeTest(ControllerTestCase, FakeFsMixin):
     @classmethod
     def setup_server(cls):
+        frontend_path = mgr.get_frontend_path()
+        cls.fs.reset()
+        cls.fs.create_dir(frontend_path)
+        cls.fs.create_file(
+            os.path.join(frontend_path, '..', 'package.json'),
+            contents='{"config":{"locale": "en-US"}}')
+        with mock.patch(cls.builtins_open, new=cls.f_open),\
+                mock.patch('os.listdir', new=cls.f_os.listdir):
+            lang = LanguageMixin()
+            cls.fs.create_file(
+                os.path.join(lang.DEFAULT_LANGUAGE_PATH, 'index.html'),
+                contents='<!doctype html><html lang="en"><body></body></html>')
         cls.setup_controllers([HomeController])
 
+    @mock.patch(FakeFsMixin.builtins_open, new=FakeFsMixin.f_open)
+    @mock.patch('os.stat', new=FakeFsMixin.f_os.stat)
+    @mock.patch('os.listdir', new=FakeFsMixin.f_os.listdir)
     def test_home_default_lang(self):
         self._get('/')
         self.assertStatus(200)
         logger.info(self.body)
         self.assertIn('<html lang="en">', self.body.decode('utf-8'))
 
+    @mock.patch(FakeFsMixin.builtins_open, new=FakeFsMixin.f_open)
+    @mock.patch('os.stat', new=FakeFsMixin.f_os.stat)
+    @mock.patch('os.listdir', new=FakeFsMixin.f_os.listdir)
     def test_home_en_us(self):
         self._get('/', headers=[('Accept-Language', 'en-US')])
         self.assertStatus(200)
         logger.info(self.body)
         self.assertIn('<html lang="en">', self.body.decode('utf-8'))
 
+    @mock.patch(FakeFsMixin.builtins_open, new=FakeFsMixin.f_open)
+    @mock.patch('os.stat', new=FakeFsMixin.f_os.stat)
+    @mock.patch('os.listdir', new=FakeFsMixin.f_os.listdir)
     def test_home_non_supported_lang(self):
         self._get('/', headers=[('Accept-Language', 'NO-NO')])
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/tests/test_rgw_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw_client.py
@@ -6,8 +6,8 @@ try:
 except ImportError:
     from unittest.mock import patch
 
-from .. import mgr
 from ..services.rgw_client import RgwClient
+from ..settings import Settings
 from . import KVStoreMockMixin
 
 
@@ -23,12 +23,12 @@ class RgwClientTest(unittest.TestCase, KVStoreMockMixin):
         })
 
     def test_ssl_verify(self):
-        mgr.set_module_option('RGW_API_SSL_VERIFY', True)
+        Settings.RGW_API_SSL_VERIFY = True
         instance = RgwClient.admin_instance()
         self.assertTrue(instance.session.verify)
 
     def test_no_ssl_verify(self):
-        mgr.set_module_option('RGW_API_SSL_VERIFY', False)
+        Settings.RGW_API_SSL_VERIFY = False
         instance = RgwClient.admin_instance()
         self.assertFalse(instance.session.verify)
 


### PR DESCRIPTION
* Make use of the KVStoreMockMixin class to get rid off duplicate code.
* Fake the index.html file to be able to run tests/test_home.py locally without building the frontend in production mode.
* Encapsulate helper functions in controllers/home.py, otherwise tests/test_feature_toggles.py need to fake the filesystem because load_controllers() will load the home.py controller and fail due missing files in the filesystem.

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
