### PR TITLE
os/bluestore: do not mark per_pool_omap updated unless we fixed it

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8203,9 +8203,6 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     }
     derr << "fsck " << w << ": store not yet converted to per-pool omap"
 	 << dendl;
-    if (repair) {
-      repairer.fix_per_pool_omap(db);
-    }
   }
 
   // get expected statfs; reset unaffected fields to be able to compare
@@ -8737,6 +8734,12 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     }
   }
   if (repair) {
+    if (!per_pool_omap &&
+	depth != FSCK_SHALLOW) {
+      dout(5) << __func__ << " marking per_pool_omap=1" << dendl;
+      repairer.fix_per_pool_omap(db);
+    }
+
     dout(5) << __func__ << " applying repair results" << dendl;
     repaired = repairer.apply(db);
     dout(5) << __func__ << " repair applied" << dendl;


### PR DESCRIPTION
We only fix the per-pool-omap issues if we do a non-shallow fsck.

Fixes: https://tracker.ceph.com/issues/42490
Signed-off-by: Sage Weil <sage@redhat.com>