### PR TITLE
ceph-daemon: py2 compatibility

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/ceph-daemon.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-daemon.yaml
@@ -2,6 +2,9 @@ roles:
 - [mon.a, mgr.x, osd.0, client.0]
 tasks:
 - install:
+- exec:
+    mon.a:
+      - yum install -y python3 || apt install -y python3
 - workunit:
     basedir: qa/standalone
     clients:

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 DEFAULT_IMAGE='ceph/daemon-base'
 DATA_DIR='/var/lib/ceph'

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -31,8 +31,15 @@ You can invoke ceph-daemon in two ways:
 """
 
 import argparse
-import configparser
+try:
+    from configparser import ConfigParser   # py3
+except ImportError:
+    from ConfigParser import ConfigParser   # py2
 import fcntl
+try:
+    from io import StringIO                 # py3
+except:
+    from StringIO import StringIO           # py2
 import json
 import logging
 import os
@@ -45,14 +52,6 @@ import time
 import uuid
 from distutils.spawn import find_executable
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    pass
-try:
-    from io import StringIO
-except ImportError:
-    pass
 
 podman_path = None
 
@@ -228,7 +227,7 @@ def check_unit(unit_name):
 
 def get_legacy_config_fsid(cluster):
     try:
-        config = configparser.ConfigParser()
+        config = ConfigParser()
         config.read('/etc/ceph/%s.conf' % cluster)
         if 'global' in config and 'fsid' in config['global']:
             return config['global']['fsid']
@@ -739,7 +738,7 @@ def command_bootstrap():
     logging.info('Cluster fsid: %s' % fsid)
 
     # config
-    cp = configparser.ConfigParser()
+    cp = ConfigParser()
     if args.config:
         cp.read(args.config)
     if args.mon_ip:

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -164,7 +164,10 @@ def is_fsid(s):
     return True
 
 def makedirs(dir, uid, gid, mode):
-    os.makedirs(dir, exist_ok=True, mode=mode)
+    if not os.path.exists(dir):
+        os.makedirs(dir, mode=mode)
+    else:
+        os.chmod(dir, mode)
     os.chown(dir, uid, gid)
     os.chmod(dir, mode)   # the above is masked by umask...
 

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -201,7 +201,7 @@ def make_log_dir(fsid, uid=None, gid=None):
 def find_program(filename):
     name = find_executable(filename)
     if name is None:
-        raise ValueError(f'{filename} not found')
+        raise ValueError('%s not found' % filename)
     return name
 
 def get_unit_name(fsid, daemon_type, daemon_id):
@@ -668,11 +668,11 @@ class CephContainer:
 
     def run_cmd(self):
         vols = sum(
-            [['-v', f'{host_dir}:{container_dir}']
+            [['-v', '%s:%s' % (host_dir, container_dir)]
              for host_dir, container_dir in self.volume_mounts.items()], [])
         envs = [
-            '-e', f'CONTAINER_IMAGE={self.image}',
-            '-e', f'NODE_NAME={get_hostname()}',
+            '-e', 'CONTAINER_IMAGE=%s' % self.image,
+            '-e', 'NODE_NAME=%s' % get_hostname(),
         ]
         cname = ['--name', self.cname] if self.cname else []
         return [
@@ -687,11 +687,11 @@ class CephContainer:
 
     def shell_cmd(self, cmd):
         vols = sum(
-            [['-v', f'{host_dir}:{container_dir}']
+            [['-v', '%s:%s' % (host_dir, container_dir)]
              for host_dir, container_dir in self.volume_mounts.items()], [])
         envs = [
-            '-e', f'CONTAINER_IMAGE={self.image}',
-            '-e', f'NODE_NAME={get_hostname()}',
+            '-e', 'CONTAINER_IMAGE=%s' % self.image,
+            '-e', 'NODE_NAME=%s' % get_hostname(),
         ]
         cmd_args = []
         if cmd:
@@ -726,7 +726,7 @@ class CephContainer:
 
 def command_version():
     out = CephContainer(args.image, 'ceph', ['--version']).run()
-    print(out, end='')
+    print(out.strip())
     return 0
 
 ##################################

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -32,14 +32,14 @@ You can invoke ceph-daemon in two ways:
 
 import argparse
 try:
-    from configparser import ConfigParser   # py3
-except ImportError:
     from ConfigParser import ConfigParser   # py2
+except ImportError:
+    from configparser import ConfigParser   # py3
 import fcntl
 try:
-    from io import StringIO                 # py3
-except:
     from StringIO import StringIO           # py2
+except:
+    from io import StringIO                 # py3
 import json
 import logging
 import os

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -375,7 +375,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             out, err, code = remoto.process.check(
                 conn,
-                ['/usr/bin/python3', '-u'],
+                ['/usr/bin/python', '-u'],
                 stdin=script.encode('utf-8'))
             self.log.debug('exit code %s out %s err %s' % (code, out, err))
             return out, code


### PR DESCRIPTION
This allows ceph-daemon to run on hosts that don't have python3.  This notably seems to include el7.

Test both python2 and python3.  Don't specify a particular version (e.g., python2.7) since it may or may not be present on the test machine.  This *does* assume that any test machine has both (some) python2 and (some) python3 installed.  I'm not quite sure if there's a good way around that.