### PR TITLE
mgr/ssh: implement 'service ls'

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -217,13 +217,23 @@ def check_unit(unit_name):
     except Exception as e:
         logger.warning('unable to run systemctl: %s' % e)
         enabled = False
+
+    state = 'unknown'
     try:
         out, err, code = call(['systemctl', 'is-active', unit_name], 'systemctl')
-        active = out.strip() == 'active'
+        out = out.strip()
+        if out in ['active']:
+            state = 'running'
+        elif out in ['inactive']:
+            state = 'stopped'
+        elif out in ['failed', 'auto-restart']:
+            state = 'error'
+        else:
+            state = 'unknown'
     except Exception as e:
         logger.warning('unable to run systemctl: %s' % e)
-        active = False
-    return (enabled, active)
+        state = 'unknown'
+    return (enabled, state)
 
 def get_legacy_config_fsid(cluster):
     try:
@@ -1204,8 +1214,8 @@ def command_ls():
                     (cluster, daemon_id) = j.split('-', 1)
                     fsid = get_legacy_daemon_fsid(cluster, daemon_type,
                                                   daemon_id) or 'unknown'
-                    (enabled, active) = check_unit('ceph-%s@%s' % (daemon_type,
-                                                                   daemon_id))
+                    (enabled, state) = check_unit('ceph-%s@%s' % (daemon_type,
+                                                                  daemon_id))
                     if not host_version:
                         out, err, code = call(['ceph', '-v'])
                         if not code and out.startswith('ceph version '):
@@ -1216,7 +1226,7 @@ def command_ls():
                         'name': '%s.%s' % (daemon_type, daemon_id),
                         'fsid': fsid,
                         'enabled': enabled,
-                        'active': active,
+                        'state': state,
                         'version': host_version,
                     })
             elif is_fsid(i):
@@ -1225,16 +1235,16 @@ def command_ls():
                     if j == 'crash':
                         name = 'crash'
                         unit_name = 'ceph-%s-crash.service' % fsid
-                        (enabled, active) = check_unit(unit_name)
+                        (enabled, state) = check_unit(unit_name)
                     else:
                         bits = j.split('.')
                         if len(bits) != 2:
                             continue
                         name = j
                         (daemon_type, daemon_id) = bits
-                        (enabled, active) = check_unit(get_unit_name(fsid,
-                                                                     daemon_type,
-                                                                     daemon_id))
+                        (enabled, state) = check_unit(get_unit_name(fsid,
+                                                                    daemon_type,
+                                                                    daemon_id))
 
                     # get container id
                     container_id = None
@@ -1258,7 +1268,7 @@ def command_ls():
                         'name': name,
                         'fsid': fsid,
                         'enabled': enabled,
-                        'active': active,
+                        'state': state,
                         'container_id': container_id,
                         'version': version,
                     })
@@ -1282,9 +1292,9 @@ def command_adopt():
         # cluster we are adopting based on the /etc/{defaults,sysconfig}/ceph
         # CLUSTER field.
         unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
-        (enabled, active) = check_unit(unit_name)
+        (enabled, state) = check_unit(unit_name)
 
-        if active:
+        if state == 'running':
             logger.info('Stopping old systemd unit %s...' % unit_name)
             call_throws(['systemctl', 'stop', unit_name])
         if enabled:
@@ -1322,7 +1332,7 @@ def command_adopt():
         c = get_container(fsid, daemon_type, daemon_id)
         deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                             enable=True,  # unconditionally enable the new unit
-                            start=active)
+                            start=(state == 'running'))
     else:
         raise RuntimeError('adoption of style %s not implemented' % args.style)
 

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -1191,6 +1191,7 @@ def command_unit():
 
 def command_ls():
     ls = []
+    host_version = None
 
     # /var/lib/ceph
     if os.path.exists(args.data_dir):
@@ -1205,12 +1206,18 @@ def command_ls():
                                                   daemon_id) or 'unknown'
                     (enabled, active) = check_unit('ceph-%s@%s' % (daemon_type,
                                                                    daemon_id))
+                    if not host_version:
+                        out, err, code = call(['ceph', '-v'])
+                        if not code and out.startswith('ceph version '):
+                            host_version = out.split(' ')[3]
+
                     ls.append({
                         'style': 'legacy',
                         'name': '%s.%s' % (daemon_type, daemon_id),
                         'fsid': fsid,
                         'enabled': enabled,
                         'active': active,
+                        'version': host_version,
                     })
             elif is_fsid(i):
                 fsid = i
@@ -1228,12 +1235,32 @@ def command_ls():
                         (enabled, active) = check_unit(get_unit_name(fsid,
                                                                      daemon_type,
                                                                      daemon_id))
+
+                    # get container id
+                    container_id = None
+                    version = None
+                    out, err, code = call(
+                        [
+                            podman_path, 'inspect',
+                            '--format', '{{.Id}}',
+                            'ceph-%s-%s' % (fsid, j)
+                        ],
+                        podman_path)
+                    if not code:
+                        container_id = out.strip()[0:12]
+                        out, err, code = call(
+                            [podman_path, 'exec', container_id, 'ceph', '-v'],
+                            podman_path)
+                        if not code and out.startswith('ceph version '):
+                            version = out.split(' ')[2]
                     ls.append({
                         'style': 'ceph-daemon:v1',
                         'name': name,
                         'fsid': fsid,
                         'enabled': enabled,
                         'active': active,
+                        'container_id': container_id,
+                        'version': version,
                     })
 
     # /var/lib/rook

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -208,18 +208,17 @@ def get_unit_name(fsid, daemon_type, daemon_id):
     return 'ceph-%s@%s.%s' % (fsid, daemon_type, daemon_id)
 
 def check_unit(unit_name):
+    # NOTE: we ignore the exit code here because systemctl outputs
+    # various exit codes based on the state of the service, but the
+    # string result is more explicit (and sufficient).
     try:
         out, err, code = call(['systemctl', 'is-enabled', unit_name], 'systemctl')
-        if code:
-            raise RuntimeError('exited with %d' % code)
         enabled = out.strip() == 'enabled'
     except Exception as e:
         logger.warning('unable to run systemctl: %s' % e)
         enabled = False
     try:
         out, err, code = call(['systemctl', 'is-active', unit_name], 'systemctl')
-        if code:
-            raise RuntimeError('exited with %d' % code)
         active = out.strip() == 'active'
     except Exception as e:
         logger.warning('unable to run systemctl: %s' % e)


### PR DESCRIPTION
This is a kind of lame synchronous implementation because I don't really understand how to use the completions.  In particular, various other mgr/ssh  methods (update_*) will want to get this same inventory (and block while we getch it), but the orchestrator_wait method is implmented in orchestrator_cli... should we just copy it here?

Anyway, this is start and it works!

```
$ bin/ceph orchestrator service ls 
  type    id     host    container     version    status  description 
 crash  glitch  glitch   <unknown>    <unknown>   error      error    
  mgr   glitch  glitch  5ca676762a01    14.2.4   running    running   
```