### PR TITLE
nautilus: rgw: add num_shards to radosgw-admin bucket stats

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1444,6 +1444,7 @@ static int bucket_stats(RGWRados *store, const std::string& tenant_name, std::st
 
   formatter->open_object_section("stats");
   formatter->dump_string("bucket", bucket.name);
+  formatter->dump_int("num_shards", bucket_info.num_shards);
   formatter->dump_string("tenant", bucket.tenant);
   formatter->dump_string("zonegroup", bucket_info.zonegroup);
   formatter->dump_string("placement_rule", bucket_info.placement_rule.to_str());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42550

---

backport of https://github.com/ceph/ceph/pull/30845

parent issue: https://tracker.ceph.com/issues/42269

(don't have permissions to create properly linked backport tracker issues)