### PR TITLE
mgr/dashboard: display OSD IDs on inventory page

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -5,9 +5,44 @@ import cherrypy
 
 from . import ApiController, Endpoint, ReadPermission
 from . import RESTController, Task
+from .. import mgr
 from ..security import Scope
 from ..services.orchestrator import OrchClient
 from ..tools import wraps
+
+
+def get_device_osd_map():
+    """Get mappings from inventory devices to OSD IDs.
+
+    :return: Returns a dictionary containing mappings. Note one device might
+        shared between multiple OSDs.
+        e.g. {
+                 'node1': {
+                     'nvme0n1': [0, 1],
+                     'vdc': [0],
+                     'vdb': [1]
+                 },
+                 'node2': {
+                     'vdc': [2]
+                 }
+             }
+    :rtype: dict
+    """
+    result = {}
+    for osd_id, osd_metadata in mgr.get('osd_metadata').items():
+        hostname = osd_metadata.get('hostname')
+        devices = osd_metadata.get('devices')
+        if not hostname or not devices:
+            continue
+        if hostname not in result:
+            result[hostname] = {}
+        # for OSD contains multiple devices, devices is in `sda,sdb`
+        for device in devices.split(','):
+            if device not in result[hostname]:
+                result[hostname][device] = [int(osd_id)]
+            else:
+                result[hostname][device].append(int(osd_id))
+    return result
 
 
 def orchestrator_task(name, metadata, wait_for=2.0):
@@ -40,8 +75,16 @@ class OrchestratorInventory(RESTController):
     def list(self, hostname=None):
         orch = OrchClient.instance()
         hosts = [hostname] if hostname else None
-        inventory_nodes = orch.inventory.list(hosts)
-        return [node.to_json() for node in inventory_nodes]
+        inventory_nodes = [node.to_json() for node in orch.inventory.list(hosts)]
+        device_osd_map = get_device_osd_map()
+        for inventory_node in inventory_nodes:
+            node_osds = device_osd_map.get(inventory_node['name'])
+            for device in inventory_node['devices']:
+                if node_osds:
+                    device['osd_ids'] = sorted(node_osds.get(device['id'], []))
+                else:
+                    device['osd_ids'] = []
+        return inventory_nodes
 
 
 @ApiController('/orchestrator/service', Scope.HOSTS)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.html
@@ -20,3 +20,11 @@
     </div>
   </div>
 </ng-container>
+
+<ng-template #osds
+             let-value="value">
+  <span *ngFor="let osdId of value; last as last">
+    <span class="badge badge-dark">osd.{{ osdId }}</span>
+    <span *ngIf="!last">&nbsp;</span>
+  </span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@angular/core';
+
 import { I18n } from '@ngx-translate/i18n-polyfill';
 
 import { OrchestratorService } from '../../../shared/api/orchestrator.service';
@@ -18,6 +19,8 @@ import { Device, InventoryNode } from './inventory.model';
 export class InventoryComponent implements OnChanges, OnInit {
   @ViewChild(TableComponent, { static: false })
   table: TableComponent;
+  @ViewChild('osds', { static: true })
+  osds: TemplateRef<any>;
 
   @Input() hostname = '';
 
@@ -69,6 +72,12 @@ export class InventoryComponent implements OnChanges, OnInit {
         name: this.i18n('Model'),
         prop: 'model',
         flexGrow: 1
+      },
+      {
+        name: this.i18n('OSDs'),
+        prop: 'osd_ids',
+        flexGrow: 1,
+        cellTemplate: this.osds
       }
     ];
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.model.ts
@@ -1,6 +1,7 @@
 export class Device {
   hostname: string;
   uid: string;
+  osd_ids: number[];
 
   blank: boolean;
   type: string;

--- a/src/pybind/mgr/dashboard/tests/test_orchestrator.py
+++ b/src/pybind/mgr/dashboard/tests/test_orchestrator.py
@@ -1,3 +1,4 @@
+import unittest
 try:
     import mock
 except ImportError:
@@ -6,9 +7,11 @@ except ImportError:
 from orchestrator import InventoryNode, ServiceDescription
 
 from . import ControllerTestCase
+from .. import mgr
 from ..controllers.orchestrator import Orchestrator
 from ..controllers.orchestrator import OrchestratorInventory
 from ..controllers.orchestrator import OrchestratorService
+from ..controllers.orchestrator import get_device_osd_map
 
 
 class OrchestratorControllerTest(ControllerTestCase):
@@ -42,14 +45,40 @@ class OrchestratorControllerTest(ControllerTestCase):
             nodes = []
             for node in inventory:
                 if hosts is None or node['name'] in hosts:
-                    nodes.append(InventoryNode(node['name'], node['devices']))
+                    nodes.append(InventoryNode.from_json(node))
             return nodes
         mock_instance.inventory.list.side_effect = _list_inventory
 
+    @mock.patch('dashboard.controllers.orchestrator.get_device_osd_map')
     @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
-    def test_inventory_list(self, instance):
-        inventory = [dict(name='host-{}'.format(i), devices=[]) for i in range(3)]
-
+    def test_inventory_list(self, instance, get_dev_osd_map):
+        get_dev_osd_map.return_value = {
+            'host-0': {
+                'nvme0n1': [1, 2],
+                'sdb': [1],
+                'sdc': [2]
+            },
+            'host-1': {
+                'sdb': [3]
+            }
+        }
+        inventory = [
+            {
+                'name': 'host-0',
+                'devices': [
+                    {'id': 'nvme0n1'},
+                    {'id': 'sdb'},
+                    {'id': 'sdc'},
+                ]
+            },
+            {
+                'name': 'host-1',
+                'devices': [
+                    {'id': 'sda'},
+                    {'id': 'sdb'},
+                ]
+            }
+        ]
         fake_client = mock.Mock()
         fake_client.available.return_value = True
         self._set_inventory(fake_client, inventory)
@@ -58,12 +87,22 @@ class OrchestratorControllerTest(ControllerTestCase):
         # list
         self._get(self.URL_INVENTORY)
         self.assertStatus(200)
-        self.assertJsonBody(inventory)
+        resp = self.json_body()
+        self.assertEqual(len(resp), 2)
+        host0 = resp[0]
+        self.assertEqual(host0['name'], 'host-0')
+        self.assertEqual(host0['devices'][0]['osd_ids'], [1, 2])
+        self.assertEqual(host0['devices'][1]['osd_ids'], [1])
+        self.assertEqual(host0['devices'][2]['osd_ids'], [2])
+        host1 = resp[1]
+        self.assertEqual(host1['name'], 'host-1')
+        self.assertEqual(host1['devices'][0]['osd_ids'], [])
+        self.assertEqual(host1['devices'][1]['osd_ids'], [3])
 
         # list with existent hostname
         self._get('{}?hostname=host-0'.format(self.URL_INVENTORY))
         self.assertStatus(200)
-        self.assertJsonBody([inventory[0]])
+        self.assertEqual(self.json_body()[0]['name'], 'host-0')
 
         # list with non-existent inventory
         self._get('{}?hostname=host-10'.format(self.URL_INVENTORY))
@@ -125,3 +164,44 @@ class OrchestratorControllerTest(ControllerTestCase):
         fake_client.available.return_value = False
         self._get(self.URL_SERVICE)
         self.assertStatus(503)
+
+
+class TestOrchestrator(unittest.TestCase):
+    def test_get_device_osd_map(self):
+        mgr.get.side_effect = lambda key: {
+            'osd_metadata': {
+                '0': {
+                    'hostname': 'node0',
+                    'devices': 'nvme0n1,sdb',
+                },
+                '1': {
+                    'hostname': 'node0',
+                    'devices': 'nvme0n1,sdc',
+                },
+                '2': {
+                    'hostname': 'node1',
+                    'devices': 'sda',
+                },
+                '3': {
+                    'hostname': 'node2',
+                    'devices': '',
+                }
+            }
+        }[key]
+
+        device_osd_map = get_device_osd_map()
+        mgr.get.assert_called_with('osd_metadata')
+        # sort OSD IDs to make assertDictEqual work
+        for devices in device_osd_map.values():
+            for node in devices.keys():
+                devices[node] = sorted(devices[node])
+        self.assertDictEqual(device_osd_map, {
+            'node0': {
+                'nvme0n1': [0, 1],
+                'sdb': [0],
+                'sdc': [1],
+            },
+            'node1': {
+                'sda': [2]
+            }
+        })


### PR DESCRIPTION
- Return OSD IDs when querying inventory nodes
- Display OSD ID column on inventory page

Fixes: https://tracker.ceph.com/issues/42075

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
