### PR TITLE
ceph-volume: mokeypatch calls to lvm related binaries

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -928,6 +928,7 @@ class TestSplitNameParser(object):
 class TestIsLV(object):
 
     def test_is_not_an_lv(self, monkeypatch):
+        monkeypatch.setattr(api.process, 'call', lambda x, **kw: ('', '', 0))
         monkeypatch.setattr(api, 'dmsetup_splitname', lambda x, **kw: {})
         assert api.is_lv('/dev/sda1', lvs=[]) is False
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -1,5 +1,6 @@
 import pytest
 from ceph_volume.devices.lvm.strategies import bluestore
+from ceph_volume.api import lvm
 
 
 class TestSingleType(object):
@@ -51,7 +52,7 @@ class TestSingleType(object):
 
 class TestMixedType(object):
 
-    def test_filter_all_data_devs(self, fakedevice, factory):
+    def test_filter_all_data_devs(self, fakedevice, factory, monkeypatch):
         # in this scenario the user passed a already used device to be used for
         # data and an unused device to be used as db device.
         db_dev = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
@@ -59,6 +60,7 @@ class TestMixedType(object):
         args = factory(filtered_devices=[data_dev], osds_per_device=1,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
+        monkeypatch.setattr(lvm, 'VolumeGroup', lambda x, **kw: [])
         bluestore.MixedType(args, [], [db_dev], [])
 
 


### PR DESCRIPTION
Otherwise these tests fail occasionally when run on a system that does
not have lvm installed.

Fixes: https://tracker.ceph.com/issues/42045

Signed-off-by: Jan Fajerski <jfajerski@suse.com>