### PR TITLE
mgr/dashboard: add missing test_orchestrator suite

### DIFF
--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -39,6 +39,7 @@ tasks:
         - tasks.mgr.dashboard.test_logs
         - tasks.mgr.dashboard.test_mgr_module
         - tasks.mgr.dashboard.test_monitor
+        - tasks.mgr.dashboard.test_orchestrator
         - tasks.mgr.dashboard.test_osd
         # - tasks.mgr.dashboard.test_perf_counters
         - tasks.mgr.dashboard.test_pool

--- a/qa/tasks/mgr/dashboard/test_orchestrator.py
+++ b/qa/tasks/mgr/dashboard/test_orchestrator.py
@@ -121,7 +121,7 @@ class OrchestratorControllerTest(DashboardTestCase):
         data = self._get(self.URL_STATUS)
         self.assertTrue(data['available'])
 
-    def test_iventory_list(self):
+    def test_inventory_list(self):
         # get all inventory
         data = self._get(self.URL_INVENTORY)
         self.assertStatus(200)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42244
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
