### PR TITLE
mgr/dashboard: Searchable objects for table

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -7,6 +7,7 @@
           columnMode="flex"
           [columns]="columns"
           identifier="id"
+          [searchableObjects]="true"
           forceIdentifier="true"
           selectionType="single"
           (updateSelection)="updateSelection($event)">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -109,6 +109,33 @@ describe('TableComponent', () => {
       component.updateFilter(true);
     };
 
+    describe('searchableObjects', () => {
+      const testObject = {
+        obj: {
+          min: 8,
+          max: 123
+        }
+      };
+
+      beforeEach(() => {
+        component.data = [testObject];
+        component.columns = [{ prop: 'obj', name: 'Object' }];
+      });
+
+      it('should not search through objects as default case', () => {
+        expect(component.searchableObjects).toBe(false);
+        expectSearch('8', []);
+      });
+
+      it('should search through objects if searchableObjects is set to true', () => {
+        component.searchableObjects = true;
+        expectSearch('28', []);
+        expectSearch('8', [testObject]);
+        expectSearch('123', [testObject]);
+        expectSearch('max', [testObject]);
+      });
+    });
+
     it('should find a particular number', () => {
       expectSearch('5', [{ a: 5, b: 50, c: true }]);
       expectSearch('9', [{ a: 9, b: 90, c: true }]);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -106,6 +106,10 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   @Input()
   autoSave = true;
 
+  // Enable this in order to search through the JSON of any used object.
+  @Input()
+  searchableObjects = false;
+
   // Only needed to set if the classAddingTpl is used
   @Input()
   customCss?: { [css: string]: number | string | ((any) => boolean) };
@@ -561,6 +565,15 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
           } else if (_.isNumber(cellValue) || _.isBoolean(cellValue)) {
             cellValue = cellValue.toString();
           }
+
+          if (_.isObjectLike(cellValue)) {
+            if (this.searchableObjects) {
+              cellValue = JSON.stringify(cellValue);
+            } else {
+              return false;
+            }
+          }
+
           return cellValue.toLowerCase().indexOf(searchTerm) !== -1;
         }).length > 0
       );


### PR DESCRIPTION
The table can now search through objects, by default it won't search
through them, but it won't fail like before.

The RBD list page is now capable of searching through objects, which
only exist on an RBD that was cloned from a snapshot.

Fixes: https://tracker.ceph.com/issues/42480
Signed-off-by: Stephan Müller <smueller@suse.com>

---
The object in the RBD page sits under the column "Parent". Here are three screenshots for confirmation.

![rbd_list_complete](https://user-images.githubusercontent.com/16167865/67690373-0de7fd80-f99d-11e9-8378-581c5e30a828.png)
![rbd_list_search](https://user-images.githubusercontent.com/16167865/67690374-0e809400-f99d-11e9-9de9-61a7f3a1ebc3.png)
![rbd_list_search_empty](https://user-images.githubusercontent.com/16167865/67690375-0e809400-f99d-11e9-8e39-2a9b019339ad.png)

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
