### PR TITLE
test: fix mismatch between error msg and test file

### DIFF
--- a/src/test/cli/ceph-conf/env-vs-args.t
+++ b/src/test/cli/ceph-conf/env-vs-args.t
@@ -2,9 +2,9 @@
   $ env CEPH_CONF=from-env ceph-conf -s foo bar
   did not load config file, using default settings.
   .* \-1 Errors while parsing config file! (re)
-  .* \-1 parse_file: filesystem error: .* file.size: (No such file or directory )?\[from-env\] (re)
+  .* \-1 parse_file: filesystem error: .* file.size \[from-env\] (re)
   .* \-1 Errors while parsing config file! (re)
-  .* \-1 parse_file: filesystem error: .* file.size: (No such file or directory )?\[from-env\] (re)
+  .* \-1 parse_file: filesystem error: .* file.size \[from-env\] (re)
   [1]
 
 # command-line arguments should override environment


### PR DESCRIPTION
I have no idea where or when this was broken, but all my master checks have been riddled with this error. I can only assume something was changed at some point, but I can't but wonder why this hasn't been caught so far.

`Signed-off-by: Joao Eduardo Luis <joao@suse.com>`