### PR TITLE
ceph-volume: allow non-physical devices for "lvm prepare"

### DIFF
--- a/doc/ceph-volume/lvm/prepare.rst
+++ b/doc/ceph-volume/lvm/prepare.rst
@@ -241,33 +241,6 @@ work for both bluestore and filestore OSDs::
     ceph-volume lvm prepare --bluestore --data vg/lv --crush-device-class foo
 
 
-.. _ceph-volume-lvm-multipath:
-
-``multipath`` support
----------------------
-Devices that come from ``multipath`` are not supported as-is. The tool will
-refuse to consume a raw multipath device and will report a message like::
-
-    -->  RuntimeError: Cannot use device (/dev/mapper/<name>). A vg/lv path or an existing device is needed
-
-The reason for not supporting multipath is that depending on the type of the
-multipath setup, if using an active/passive array as the underlying physical
-devices, filters are required in ``lvm.conf`` to exclude the disks that are part of
-those underlying devices.
-
-It is unfeasible for ceph-volume to understand what type of configuration is
-needed for LVM to be able to work in various different multipath scenarios. The
-functionality to create the LV for you is merely a (naive) convenience,
-anything that involves different settings or configuration must be provided by
-a config management system which can then provide VGs and LVs for ceph-volume
-to consume.
-
-This situation will only arise when trying to use the ceph-volume functionality
-that creates a volume group and logical volume from a device. If a multipath
-device is already a logical volume it *should* work, given that the LVM
-configuration is done correctly to avoid issues.
-
-
 Storing metadata
 ----------------
 The following tags will get applied as part of the preparation process

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -189,7 +189,7 @@ class Prepare(object):
         :param cluster_fsid: The cluster fsid/uuid
         :param osd_fsid: The OSD fsid/uuid
         """
-        if disk.is_partition(arg) or disk.is_device(arg):
+        if disk.is_block_device(arg) and not disk.is_logical_volume(arg):
             # we must create a vg, and then a single lv
             vg = api.create_vg(arg)
             lv_name = "osd-%s-%s" % (device_type, osd_fsid)

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -334,9 +334,6 @@ def is_device(dev):
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
-    if stat.S_ISBLK(os.lstat(dev)):
-        return True
-    return False
 
 
 def is_partition(dev):
@@ -360,6 +357,31 @@ def is_partition(dev):
     if os.path.exists('/sys/dev/block/%d:%d/partition' % (major, minor)):
         return True
     return False
+
+
+def is_block_device(dev):
+    """
+    Boolean to determine if a given device is a block device
+    """
+    if not os.path.exists(dev):
+        return False
+    # use lsblk first, fall back to using stat
+    TYPE = lsblk(dev).get('TYPE')
+    if TYPE:
+        return True
+
+    # fallback to stat
+    return _stat_is_device(os.lstat(dev).st_mode)
+
+
+def is_logical_volume(dev):
+    """
+    Boolean to determine if a given device is a logical volume
+    """
+    if not os.path.exists(dev):
+        return False
+    TYPE = lsblk(dev).get('TYPE')
+    return TYPE == 'lvm'
 
 
 def _map_dev_paths(_path, include_abspath=False, include_realpath=False):


### PR DESCRIPTION
Currently only physical devices and partitions can be passed to
"lvm prepare --data </path/to/device>".
This relaxes the limitation by allowing any devices except for LVs.
LVs shoud be passed as `--data <vg_name>/<lv_name>`.

Multipath devices have not been supported on purpose.
https://docs.ceph.com/docs/nautilus/ceph-volume/lvm/prepare/#multipath-support

The concern was that it's hard to work `ceph-volume` correctly with many
multipath scenarios.  However, it's up to the admin to make sure
that multipath is set up as expected.

As of other kinds of devices, there have not been prohibited explicitly.
In addition, admin is in charge of configuring these devices too.

Fixes: https://tracker.ceph.com/issues/42502
Signed-off-by: Satoru Takeuchi <sat@cybozu.co.jp>

## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
