### PR TITLE
mimic: ceph-volume: add Ceph's device id to inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -25,7 +25,8 @@ def device_report_keys(device_info):
                      'sectorsize': '512',
                      'size': 1999844147200.0,
                      'support_discard': '',
-                     'vendor': 'DELL'}
+                     'vendor': 'DELL',
+                     'device_id': 'Vendor-Model-Serial'}
     }
  )
     report = Devices().json_report()[0]
@@ -67,6 +68,7 @@ class TestInventory(object):
         'sys_api',
         'available',
         'lvs',
+        'device_id',
     ]
 
     expected_sys_api_keys = [

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -62,6 +62,7 @@ class Device(object):
         'available',
         'path',
         'sys_api',
+        'device_id',
     ]
     pretty_report_sys_fields = [
         'human_readable_size',


### PR DESCRIPTION
Backport of #31072

This will benefit the orchestrator and dashboard to show a unified view of devices with SMART data

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
(cherry picked from commit e70d6041c1a093ed5c2b77abe17e1ede533d9659)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
