### PR TITLE
client: fix incomplete deletion in remove_cap

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -647,7 +647,7 @@ public:
   void add_update_cap(Inode *in, MetaSession *session, uint64_t cap_id,
 		      unsigned issued, unsigned wanted, unsigned seq, unsigned mseq,
 		      inodeno_t realm, int flags, const UserPerm& perms);
-  void remove_cap(Cap *cap, bool queue_release);
+  void remove_cap(Cap **cap, bool queue_release);
   void remove_all_caps(Inode *in);
   void remove_session_caps(MetaSession *session);
   int mark_caps_flushing(Inode *in, ceph_tid_t *ptid);


### PR DESCRIPTION
Set function parameter Cap* cap to nullptr has no effect
outside, use second rank pointer instead.

Signed-off-by: Xu Jiatong <xujiatong@cmss.chinamobile.com>


