### PR TITLE
luminous: rgw: return ERR_NO_SUCH_BUCKET early while evaluating bucket policy

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -482,8 +482,7 @@ int rgw_build_bucket_policies(RGWRados* store, struct req_state* s)
         s->bucket_acl->get_owner().get_display_name(),
       };
     } else {
-      s->bucket_acl->create_default(s->user->user_id, s->user->display_name);
-      ret = -ERR_NO_SUCH_BUCKET;
+      return -ERR_NO_SUCH_BUCKET;
     }
 
     s->bucket_owner = s->bucket_acl->get_owner();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/39696

---

backport of https://github.com/ceph/ceph/pull/26569
parent tracker: https://tracker.ceph.com/issues/38420

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh