### PR TITLE
python-common: avoid using setup_requires in setup.py

### DIFF
--- a/src/python-common/setup.py
+++ b/src/python-common/setup.py
@@ -1,6 +1,7 @@
 import sys
 
 from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 
 
 if sys.version_info >= (3,0):
@@ -15,6 +16,22 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 
+class PyTest(TestCommand):
+    user_options = [('addopts=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.addopts = []
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+
+        args = self.addopts.split() if isinstance(self.addopts, str) else self.addopts
+        errno = pytest.main(args)
+        sys.exit(errno)
+
+
 setup(
     name='ceph',
     version='1.0.0',
@@ -27,10 +44,10 @@ setup(
     keywords='ceph',
     url="https://github.com/ceph/ceph",
     zip_safe = False,
+    cmdclass={'pytest': PyTest},
     install_requires=(
         'six',
     ),
-    setup_requires=['pytest-runner'],
     tests_require=[
         pytest,
         'tox',


### PR DESCRIPTION
Cause by: #31071
Fixes: https://tracker.ceph.com/issues/42528

See also: https://github.com/pytest-dev/pytest-xdist/issues/136

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
