### PR TITLE
rgw: don't parse the rest of request if invalid

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -135,6 +135,7 @@ void handle_connection(boost::asio::io_context& context,
       return;
     }
 
+    int ret_code;
     {
       auto lock = pause_mutex.async_lock_shared(yield[ec]);
       if (ec == boost::asio::error::operation_aborted) {
@@ -165,8 +166,10 @@ void handle_connection(boost::asio::io_context& context,
                                     &real_client))));
       RGWRestfulIO client(cct, &real_client_io);
       auto y = optional_yield{context, yield};
-      process_request(env.store, env.rest, &req, env.uri_prefix,
-                      *env.auth_registry, &client, env.olog, y, scheduler);
+      ret_code = process_request(env.store, env.rest, &req, env.uri_prefix,
+                                 *env.auth_registry, &client, env.olog, y, scheduler);
+      if (ret_code == -ERR_INCOMPLETE_WRITE_REQ)
+	continue;
     }
 
     if (!parser.keep_alive()) {

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -168,14 +168,15 @@ void handle_connection(boost::asio::io_context& context,
       auto y = optional_yield{context, yield};
       ret_code = process_request(env.store, env.rest, &req, env.uri_prefix,
                                  *env.auth_registry, &client, env.olog, y, scheduler);
-      if (ret_code == -ERR_INCOMPLETE_WRITE_REQ)
-	continue;
     }
 
     if (!parser.keep_alive()) {
       return;
     }
 
+    if (ret_code == -ERR_INCOMPLETE_100_CONTINUE) {
+      continue;
+    }
     // if we failed before reading the entire message, discard any remaining
     // bytes before reading the next
     while (!parser.is_done()) {

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -75,7 +75,7 @@ int RGWCivetWebFrontend::process(struct mg_connection*  const conn)
     /* We don't really care about return code. */
     dout(20) << "process_request() returned " << ret << dendl;
     /* negative error code makes civetweb drop the rest of req */
-    if (ret == -ERR_INCOMPLETE_WRITE_REQ)
+    if (ret == -ERR_INCOMPLETE_100_CONTINUE)
       return ret;
   }
 

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -74,6 +74,9 @@ int RGWCivetWebFrontend::process(struct mg_connection*  const conn)
   if (ret < 0) {
     /* We don't really care about return code. */
     dout(20) << "process_request() returned " << ret << dendl;
+    /* negative error code makes civetweb drop the rest of req */
+    if (ret == -ERR_INCOMPLETE_WRITE_REQ)
+      return ret;
   }
 
   if (http_ret <= 0) {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -239,6 +239,7 @@ using ceph::crypto::MD5;
 #define ERR_POSITION_NOT_EQUAL_TO_LENGTH                 2219
 #define ERR_OBJECT_NOT_APPENDABLE                        2220
 #define ERR_INVALID_BUCKET_STATE                         2221
+#define ERR_INCOMPLETE_WRITE_REQ 2222
 
 #define ERR_BUSY_RESHARDING      2300
 #define ERR_NO_SUCH_ENTITY       2301

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -239,7 +239,7 @@ using ceph::crypto::MD5;
 #define ERR_POSITION_NOT_EQUAL_TO_LENGTH                 2219
 #define ERR_OBJECT_NOT_APPENDABLE                        2220
 #define ERR_INVALID_BUCKET_STATE                         2221
-#define ERR_INCOMPLETE_WRITE_REQ 2222
+#define ERR_INCOMPLETE_100_CONTINUE 2222
 
 #define ERR_BUSY_RESHARDING      2300
 #define ERR_NO_SUCH_ENTITY       2301

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -910,8 +910,10 @@ void rgw_build_iam_environment(rgw::sal::RGWRadosStore* store,
 
 void rgw_bucket_object_pre_exec(struct req_state *s)
 {
-  if (s->expect_cont)
+  if (s->expect_cont) {
     dump_continue(s);
+    s->expect_cont = false;
+  }
 
   dump_bucket_from_state(s);
 }

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -319,5 +319,12 @@ done:
 	  << " ======"
 	  << dendl;
 
-  return (ret < 0 ? ret : s->err.ret);
+  if (ret < 0) {
+    if (s->expect_cont && s->content_length > 0) {
+      // notify frontends not to read further content
+      return -ERR_INCOMPLETE_WRITE_REQ;
+    }
+    return ret;
+  }
+  return s->err.ret;
 } /* process_request */

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -322,7 +322,7 @@ done:
   if (ret < 0) {
     if (s->expect_cont && s->content_length > 0) {
       // notify frontends not to read further content
-      return -ERR_INCOMPLETE_WRITE_REQ;
+      return -ERR_INCOMPLETE_100_CONTINUE;
     }
     return ret;
   }


### PR DESCRIPTION
Currently for requests that contain data like PUT, even though we send a HTTP
status to the client we still read the data from the socket, which is set to
keep-alive, so we're effectively reading the next request if the client chooses
to send this and hence reading invalid data. This should fix a few cases
where requests after a expected failure continue to fail as beast would throw an
invalid method.

This is done via returning a new error code which allows for frontends to decide
on whether to read further data or not, for eg. in requests with 100-continue
headers, the client wouldn't have sent the body, so for these requests reading
further data on the socket would make the reads possibly the next requests,
whereas for PUT requests with a non 100-continue header, we'd have to read and
discard the rest of the data

Fixes: https://tracker.ceph.com/issues/42208
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
