### PR TITLE
mimic: ceph-volume: api/lvm: check if list of LVs is empty

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -274,7 +274,9 @@ def is_lv(dev, lvs=None):
     splitname = dmsetup_splitname(dev)
     # Allowing to optionally pass `lvs` can help reduce repetitive checks for
     # multiple devices at once.
-    lvs = lvs if lvs is not None else Volumes()
+    if lvs is None or len(lvs) == 0:
+        lvs = Volumes()
+
     if splitname.get('LV_NAME'):
         lvs.filter(lv_name=splitname['LV_NAME'], vg_name=splitname['VG_NAME'])
         return len(lvs) > 0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42541

---

backport of https://github.com/ceph/ceph/pull/30101
parent tracker: https://tracker.ceph.com/issues/41649

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh