### PR TITLE
osd: recover head firstly

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6195,7 +6195,7 @@ void Client::tick()
   ldout(cct, 21) << "tick" << dendl;
   tick_event = timer.add_event_after(
     cct->_conf->client_tick_interval,
-    new FunctionContext([this](int) {
+    new LambdaContext([this](int) {
 	// Called back via Timer, which takes client_lock for us
 	ceph_assert(ceph_mutex_is_locked_by_me(client_lock));
 	tick();

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -9,6 +9,7 @@
 #include "cls_rgw_ops.h"
 #include "cls_rgw_const.h"
 #include "common/RefCountedObj.h"
+#include "common/strtol.h"
 #include "include/compat.h"
 #include "common/ceph_time.h"
 #include "common/ceph_mutex.h"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -24,6 +24,7 @@ set(common_srcs
   OutputDataSocket.cc
   PluginRegistry.cc
   Readahead.cc
+  RefCountedObj.cc
   SloppyCRCMap.cc
   SubProcess.cc
   Thread.cc

--- a/src/common/RefCountedObj.cc
+++ b/src/common/RefCountedObj.cc
@@ -1,0 +1,40 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+//
+#include "include/ceph_assert.h"
+
+#include "common/RefCountedObj.h"
+#include "common/ceph_context.h"
+#include "common/dout.h"
+#include "common/valgrind.h"
+
+RefCountedObject::~RefCountedObject()
+{
+  ceph_assert(nref == 0);
+}
+
+void RefCountedObject::put() const {
+  CephContext *local_cct = cct;
+  auto v = --nref;
+  if (local_cct) {
+    lsubdout(local_cct, refs, 1) << "RefCountedObject::put " << this << " "
+		   << (v + 1) << " -> " << v
+		   << dendl;
+  }
+  if (v == 0) {
+    ANNOTATE_HAPPENS_AFTER(&nref);
+    ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(&nref);
+    delete this;
+  } else {
+    ANNOTATE_HAPPENS_BEFORE(&nref);
+  }
+}
+
+void RefCountedObject::_get() const {
+  auto v = ++nref;
+  ceph_assert(v > 1); /* it should never happen that _get() sees nref == 0 */
+  if (cct) {
+    lsubdout(cct, refs, 1) << "RefCountedObject::get " << this << " "
+	     << (v - 1) << " -> " << v << dendl;
+  }
+}

--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -829,7 +829,7 @@ void TokenBucketThrottle::add_tokens() {
 }
 
 void TokenBucketThrottle::schedule_timer() {
-  m_token_ctx = new FunctionContext(
+  m_token_ctx = new LambdaContext(
       [this](int r) {
         schedule_timer();
       });

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -363,7 +363,7 @@ class TokenBucketThrottle {
   uint64_t m_burst = 0;
   SafeTimer *m_timer;
   ceph::mutex *m_timer_lock;
-  FunctionContext *m_token_ctx = nullptr;
+  Context *m_token_ctx = nullptr;
   std::list<Blocker> m_blockers;
   ceph::mutex m_lock;
 
@@ -419,7 +419,7 @@ public:
 
   template <typename T, typename I, void(T::*MF)(int, I*, uint64_t)>
   void add_blocker(uint64_t c, T *handler, I *item, uint64_t flag) {
-    Context *ctx = new FunctionContext([handler, item, flag](int r) {
+    Context *ctx = new LambdaContext([handler, item, flag](int r) {
       (handler->*MF)(r, item, flag);
       });
     m_blockers.emplace_back(c, ctx);

--- a/src/common/ref.h
+++ b/src/common/ref.h
@@ -10,17 +10,25 @@ namespace ceph {
 template<typename T> using ref_t = boost::intrusive_ptr<T>;
 template<typename T> using cref_t = boost::intrusive_ptr<const T>;
 template<class T, class U>
-boost::intrusive_ptr<T> ref_cast(const boost::intrusive_ptr<U>& r) noexcept {
+ref_t<T> ref_cast(const ref_t<U>& r) noexcept {
   return static_cast<T*>(r.get());
 }
 template<class T, class U>
-boost::intrusive_ptr<T> ref_cast(boost::intrusive_ptr<U>&& r) noexcept {
+ref_t<T> ref_cast(ref_t<U>&& r) noexcept {
   return {static_cast<T*>(r.detach()), false};
 }
 template<class T, class U>
-boost::intrusive_ptr<const T> ref_cast(const boost::intrusive_ptr<const U>& r) noexcept {
+cref_t<T> ref_cast(const cref_t<U>& r) noexcept {
   return static_cast<const T*>(r.get());
 }
+template<class T, typename... Args>
+ceph::ref_t<T> make_ref(Args&&... args) {
+  return {new T(std::forward<Args>(args)...), false};
 }
+}
+
+// Friends cannot be partial specializations: https://en.cppreference.com/w/cpp/language/friend
+#define FRIEND_MAKE_REF(C) \
+template<class T, typename... Args> friend ceph::ref_t<T> ceph::make_ref(Args&&... args)
 
 #endif

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/Thread.cc
   ${PROJECT_SOURCE_DIR}/src/common/HeartbeatMap.cc
   ${PROJECT_SOURCE_DIR}/src/common/PluginRegistry.cc
+  ${PROJECT_SOURCE_DIR}/src/common/RefCountedObj.cc
   ${PROJECT_SOURCE_DIR}/src/global/pidfile.cc
   ${PROJECT_SOURCE_DIR}/src/librbd/Features.cc
   ${PROJECT_SOURCE_DIR}/src/log/Log.cc

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -170,7 +170,7 @@ public:
   void start_flush_on_transaction(
     ObjectStore::Transaction &t) final {
     t.register_on_commit(
-      new LambdaContext([this](){
+      new LambdaContext([this](int r){
 	peering_state.complete_flush();
     }));
   }
@@ -217,7 +217,7 @@ public:
     PGPeeringEventRef on_commit) final {
     t.register_on_commit(
       new LambdaContext(
-	[this, on_commit=std::move(on_commit)] {
+	[this, on_commit=std::move(on_commit)](int r){
 	  shard_services.start_operation<LocalPeeringEvent>(
 	    this,
 	    shard_services,

--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -122,13 +122,16 @@ struct RunOnDelete {
 typedef std::shared_ptr<RunOnDelete> RunOnDeleteRef;
 
 template <typename T>
-struct LambdaContext : public Context {
-  T t;
+class LambdaContext : public Context {
+public:
   LambdaContext(T &&t) : t(std::forward<T>(t)) {}
-  void finish(int) override {
-    t();
+  void finish(int r) override {
+    t(r);
   }
+private:
+  T t;
 };
+
 template <typename T>
 LambdaContext<T> *make_lambda_context(T &&t) {
   return new LambdaContext<T>(std::move(t));
@@ -472,20 +475,6 @@ private:
 
 typedef C_GatherBase<Context, Context> C_Gather;
 typedef C_GatherBuilderBase<Context, C_Gather > C_GatherBuilder;
-
-class FunctionContext : public Context {
-public:
-  FunctionContext(boost::function<void(int)> &&callback)
-    : m_callback(std::move(callback))
-  {
-  }
-
-  void finish(int r) override {
-    m_callback(r);
-  }
-private:
-  boost::function<void(int)> m_callback;
-};
 
 template <class ContextType>
 class ContextFactory {

--- a/src/journal/Future.cc
+++ b/src/journal/Future.cc
@@ -7,6 +7,14 @@
 
 namespace journal {
 
+Future::Future() = default;
+Future::Future(const Future& o) = default;
+Future& Future::operator=(const Future& o) = default;
+Future::Future(Future&& o) = default;
+Future& Future::operator=(Future&& o) = default;
+Future::Future(ceph::ref_t<FutureImpl> future_impl) : m_future_impl(std::move(future_impl)) {}
+Future::~Future() = default;
+
 void Future::flush(Context *on_safe) {
   m_future_impl->flush(on_safe);
 }
@@ -24,16 +32,8 @@ int Future::get_return_value() const {
   return m_future_impl->get_return_value();
 }
 
-void intrusive_ptr_add_ref(FutureImpl *p) {
-  p->get();
-}
-
-void intrusive_ptr_release(FutureImpl *p) {
-  p->put();
-}
-
 std::ostream &operator<<(std::ostream &os, const Future &future) {
-  return os << *future.m_future_impl.get();
+  return os << *future.m_future_impl;
 }
 
 } // namespace journal

--- a/src/journal/Future.h
+++ b/src/journal/Future.h
@@ -4,11 +4,12 @@
 #ifndef CEPH_JOURNAL_FUTURE_H
 #define CEPH_JOURNAL_FUTURE_H
 
-#include "include/int_types.h"
-#include <string>
 #include <iosfwd>
-#include <boost/intrusive_ptr.hpp>
+#include <string>
+
 #include "include/ceph_assert.h"
+#include "include/int_types.h"
+#include "common/ref.h"
 
 class Context;
 
@@ -18,13 +19,16 @@ class FutureImpl;
 
 class Future {
 public:
-  typedef boost::intrusive_ptr<FutureImpl> FutureImplPtr;
+  Future();
+  Future(const Future&);
+  Future& operator=(const Future&);
+  Future(Future&&);
+  Future& operator=(Future&&);
+  Future(ceph::ref_t<FutureImpl> future_impl);
+  ~Future();
 
-  Future() {}
-  Future(const FutureImplPtr &future_impl) : m_future_impl(future_impl) {}
-
-  inline bool is_valid() const {
-    return m_future_impl.get() != nullptr;
+  bool is_valid() const {
+    return bool(m_future_impl);
   }
 
   void flush(Context *on_safe);
@@ -37,22 +41,17 @@ private:
   friend class Journaler;
   friend std::ostream& operator<<(std::ostream&, const Future&);
 
-  inline FutureImplPtr get_future_impl() const {
+  const auto& get_future_impl() const {
     return m_future_impl;
   }
 
-  FutureImplPtr m_future_impl;
+  ceph::ref_t<FutureImpl> m_future_impl;
 };
-
-void intrusive_ptr_add_ref(FutureImpl *p);
-void intrusive_ptr_release(FutureImpl *p);
 
 std::ostream &operator<<(std::ostream &os, const Future &future);
 
 } // namespace journal
 
-using journal::intrusive_ptr_add_ref;
-using journal::intrusive_ptr_release;
 using journal::operator<<;
 
 #endif // CEPH_JOURNAL_FUTURE_H

--- a/src/journal/FutureImpl.cc
+++ b/src/journal/FutureImpl.cc
@@ -8,14 +8,14 @@ namespace journal {
 
 FutureImpl::FutureImpl(uint64_t tag_tid, uint64_t entry_tid,
                        uint64_t commit_tid)
-  : RefCountedObject(NULL, 0), m_tag_tid(tag_tid), m_entry_tid(entry_tid),
+  : m_tag_tid(tag_tid),
+    m_entry_tid(entry_tid),
     m_commit_tid(commit_tid),
-    m_safe(false),
-    m_consistent(false), m_return_value(0), m_flush_state(FLUSH_STATE_NONE),
-    m_consistent_ack(this) {
+    m_consistent_ack(this)
+{
 }
 
-void FutureImpl::init(const FutureImplPtr &prev_future) {
+void FutureImpl::init(const ceph::ref_t<FutureImpl> &prev_future) {
   // chain ourself to the prior future (if any) to that we known when the
   // journal is consistent
   if (prev_future) {
@@ -30,7 +30,7 @@ void FutureImpl::flush(Context *on_safe) {
 
   bool complete;
   FlushHandlers flush_handlers;
-  FutureImplPtr prev_future;
+  ceph::ref_t<FutureImpl> prev_future;
   {
     std::lock_guard locker{m_lock};
     complete = (m_safe && m_consistent);
@@ -60,20 +60,21 @@ void FutureImpl::flush(Context *on_safe) {
   }
 }
 
-FutureImplPtr FutureImpl::prepare_flush(FlushHandlers *flush_handlers) {
+ceph::ref_t<FutureImpl> FutureImpl::prepare_flush(FlushHandlers *flush_handlers) {
   std::lock_guard locker{m_lock};
   return prepare_flush(flush_handlers, m_lock);
 }
 
-FutureImplPtr FutureImpl::prepare_flush(FlushHandlers *flush_handlers,
+ceph::ref_t<FutureImpl> FutureImpl::prepare_flush(FlushHandlers *flush_handlers,
                                         ceph::mutex &lock) {
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
   if (m_flush_state == FLUSH_STATE_NONE) {
     m_flush_state = FLUSH_STATE_REQUESTED;
 
-    if (m_flush_handler && flush_handlers->count(m_flush_handler) == 0) {
-      flush_handlers->insert({m_flush_handler, this});
+    auto h = m_flush_handler;
+    if (h) {
+      flush_handlers->try_emplace(std::move(h), this);
     }
   }
   return m_prev_future;
@@ -103,10 +104,10 @@ int FutureImpl::get_return_value() const {
   return m_return_value;
 }
 
-bool FutureImpl::attach(const FlushHandlerPtr &flush_handler) {
+bool FutureImpl::attach(FlushHandler::ref flush_handler) {
   std::lock_guard locker{m_lock};
   ceph_assert(!m_flush_handler);
-  m_flush_handler = flush_handler;
+  m_flush_handler = std::move(flush_handler);
   return m_flush_state != FLUSH_STATE_NONE;
 }
 
@@ -161,14 +162,6 @@ std::ostream &operator<<(std::ostream &os, const FutureImpl &future) {
      << "entry_tid=" << future.m_entry_tid << ", "
      << "commit_tid=" << future.m_commit_tid << "]";
   return os;
-}
-
-void intrusive_ptr_add_ref(FutureImpl::FlushHandler *p) {
-  p->get();
-}
-
-void intrusive_ptr_release(FutureImpl::FlushHandler *p) {
-  p->put();
 }
 
 } // namespace journal

--- a/src/journal/FutureImpl.h
+++ b/src/journal/FutureImpl.h
@@ -11,29 +11,21 @@
 #include <list>
 #include <map>
 #include <boost/noncopyable.hpp>
-#include <boost/intrusive_ptr.hpp>
 #include "include/ceph_assert.h"
 
 class Context;
 
 namespace journal {
 
-class FutureImpl;
-typedef boost::intrusive_ptr<FutureImpl> FutureImplPtr;
-
 class FutureImpl : public RefCountedObject, boost::noncopyable {
 public:
   struct FlushHandler {
-    virtual ~FlushHandler() {}
-    virtual void flush(const FutureImplPtr &future) = 0;
-    virtual void get() = 0;
-    virtual void put() = 0;
+    using ref = std::shared_ptr<FlushHandler>;
+    virtual void flush(const ceph::ref_t<FutureImpl> &future) = 0;
+    virtual ~FlushHandler() = default;
   };
-  typedef boost::intrusive_ptr<FlushHandler> FlushHandlerPtr;
 
-  FutureImpl(uint64_t tag_tid, uint64_t entry_tid, uint64_t commit_tid);
-
-  void init(const FutureImplPtr &prev_future);
+  void init(const ceph::ref_t<FutureImpl> &prev_future);
 
   inline uint64_t get_tag_tid() const {
     return m_tag_tid;
@@ -56,19 +48,17 @@ public:
     return (m_flush_state == FLUSH_STATE_IN_PROGRESS);
   }
   inline void set_flush_in_progress() {
+    auto h = std::move(m_flush_handler);
+    ceph_assert(h);
     std::lock_guard locker{m_lock};
-    ceph_assert(m_flush_handler);
-    m_flush_handler.reset();
     m_flush_state = FLUSH_STATE_IN_PROGRESS;
   }
 
-  bool attach(const FlushHandlerPtr &flush_handler);
+  bool attach(FlushHandler::ref flush_handler);
   inline void detach() {
-    std::lock_guard locker{m_lock};
     m_flush_handler.reset();
   }
-  inline FlushHandlerPtr get_flush_handler() const {
-    std::lock_guard locker{m_lock};
+  inline FlushHandler::ref get_flush_handler() const {
     return m_flush_handler;
   }
 
@@ -77,7 +67,7 @@ public:
 private:
   friend std::ostream &operator<<(std::ostream &, const FutureImpl &);
 
-  typedef std::map<FlushHandlerPtr, FutureImplPtr> FlushHandlers;
+  typedef std::map<FlushHandler::ref, ceph::ref_t<FutureImpl>> FlushHandlers;
   typedef std::list<Context *> Contexts;
 
   enum FlushState {
@@ -87,8 +77,8 @@ private:
   };
 
   struct C_ConsistentAck : public Context {
-    FutureImplPtr future;
-    C_ConsistentAck(FutureImpl *_future) : future(_future) {}
+    ceph::ref_t<FutureImpl> future;
+    C_ConsistentAck(ceph::ref_t<FutureImpl> _future) : future(std::move(_future)) {}
     void complete(int r) override {
       future->consistent(r);
       future.reset();
@@ -96,31 +86,32 @@ private:
     void finish(int r) override {}
   };
 
+  FRIEND_MAKE_REF(FutureImpl);
+  FutureImpl(uint64_t tag_tid, uint64_t entry_tid, uint64_t commit_tid);
+  ~FutureImpl() override = default;
+
   uint64_t m_tag_tid;
   uint64_t m_entry_tid;
   uint64_t m_commit_tid;
 
   mutable ceph::mutex m_lock = ceph::make_mutex("FutureImpl::m_lock", false);
-  FutureImplPtr m_prev_future;
-  bool m_safe;
-  bool m_consistent;
-  int m_return_value;
+  ceph::ref_t<FutureImpl> m_prev_future;
+  bool m_safe = false;
+  bool m_consistent = false;
+  int m_return_value = 0;
 
-  FlushHandlerPtr m_flush_handler;
-  FlushState m_flush_state;
+  FlushHandler::ref m_flush_handler;
+  FlushState m_flush_state = FLUSH_STATE_NONE;
 
   C_ConsistentAck m_consistent_ack;
   Contexts m_contexts;
 
-  FutureImplPtr prepare_flush(FlushHandlers *flush_handlers);
-  FutureImplPtr prepare_flush(FlushHandlers *flush_handlers, ceph::mutex &lock);
+  ceph::ref_t<FutureImpl> prepare_flush(FlushHandlers *flush_handlers);
+  ceph::ref_t<FutureImpl> prepare_flush(FlushHandlers *flush_handlers, ceph::mutex &lock);
 
   void consistent(int r);
   void finish_unlock();
 };
-
-void intrusive_ptr_add_ref(FutureImpl::FlushHandler *p);
-void intrusive_ptr_release(FutureImpl::FlushHandler *p);
 
 std::ostream &operator<<(std::ostream &os, const FutureImpl &future);
 

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -405,14 +405,11 @@ JournalMetadata::JournalMetadata(ContextWQ *work_queue, SafeTimer *timer,
                                  const std::string &oid,
                                  const std::string &client_id,
                                  const Settings &settings)
-    : RefCountedObject(NULL, 0), m_cct(NULL), m_oid(oid),
-      m_client_id(client_id), m_settings(settings), m_order(0),
-      m_splay_width(0), m_pool_id(-1), m_initialized(false),
+    : m_oid(oid),
+      m_client_id(client_id), m_settings(settings),
       m_work_queue(work_queue), m_timer(timer), m_timer_lock(timer_lock),
-      m_commit_tid(0), m_watch_ctx(this),
-      m_watch_handle(0), m_minimum_set(0), m_active_set(0),
-      m_update_notifications(0), m_commit_position_ctx(NULL),
-      m_commit_position_task_ctx(NULL) {
+      m_watch_ctx(this)
+{
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext*>(m_ioctx.cct());
 }

--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -716,7 +716,7 @@ void JournalPlayer::schedule_watch(bool immediate) {
                      << *m_active_tag_tid << dendl;
 
     m_async_op_tracker.start_op();
-    FunctionContext *ctx = new FunctionContext([this](int r) {
+    auto ctx = new LambdaContext([this](int r) {
         handle_watch_assert_active(r);
       });
     m_journal_metadata->assert_active_tag(*m_active_tag_tid, ctx);
@@ -856,7 +856,7 @@ void JournalPlayer::handle_cache_rebalanced(uint64_t new_cache_bytes) {
     m_state = STATE_INIT;
     if (m_max_fetch_bytes >= min_bytes) {
       m_async_op_tracker.start_op();
-      auto ctx = new FunctionContext(
+      auto ctx = new LambdaContext(
         [this](int r) {
           prefetch();
           m_async_op_tracker.finish_op();

--- a/src/journal/JournalPlayer.cc
+++ b/src/journal/JournalPlayer.cc
@@ -20,30 +20,20 @@ namespace {
 static const uint64_t MIN_FETCH_BYTES = 32768;
 
 struct C_HandleComplete : public Context {
-  ReplayHandler *replay_handler;
+  ReplayHandler* replay_handler;
 
-  explicit C_HandleComplete(ReplayHandler *_replay_handler)
-    : replay_handler(_replay_handler) {
-    replay_handler->get();
-  }
-  ~C_HandleComplete() override {
-    replay_handler->put();
-  }
+  explicit C_HandleComplete(ReplayHandler* r) : replay_handler(std::move(r)) {}
+  ~C_HandleComplete() override {}
   void finish(int r) override {
     replay_handler->handle_complete(r);
   }
 };
 
 struct C_HandleEntriesAvailable : public Context {
-  ReplayHandler *replay_handler;
+  ReplayHandler* replay_handler;
 
-  explicit C_HandleEntriesAvailable(ReplayHandler *_replay_handler)
-      : replay_handler(_replay_handler) {
-    replay_handler->get();
-  }
-  ~C_HandleEntriesAvailable() override {
-    replay_handler->put();
-  }
+  explicit C_HandleEntriesAvailable(ReplayHandler* r) : replay_handler(std::move(r)) {}
+  ~C_HandleEntriesAvailable() override {}
   void finish(int r) override {
     replay_handler->handle_entries_available();
   }
@@ -52,17 +42,16 @@ struct C_HandleEntriesAvailable : public Context {
 } // anonymous namespace
 
 JournalPlayer::JournalPlayer(librados::IoCtx &ioctx,
-                             const std::string &object_oid_prefix,
-                             const JournalMetadataPtr& journal_metadata,
-                             ReplayHandler *replay_handler,
+                             std::string_view object_oid_prefix,
+                             ceph::ref_t<JournalMetadata> journal_metadata,
+                             ReplayHandler* replay_handler,
                              CacheManagerHandler *cache_manager_handler)
-  : m_cct(NULL), m_object_oid_prefix(object_oid_prefix),
-    m_journal_metadata(journal_metadata), m_replay_handler(replay_handler),
+  : m_object_oid_prefix(object_oid_prefix),
+    m_journal_metadata(std::move(journal_metadata)),
+    m_replay_handler(std::move(replay_handler)),
     m_cache_manager_handler(cache_manager_handler),
-    m_cache_rebalance_handler(this),
-    m_state(STATE_INIT), m_splay_offset(0), m_watch_enabled(false),
-    m_watch_scheduled(false), m_watch_interval(0) {
-  m_replay_handler->get();
+    m_cache_rebalance_handler(this)
+{
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext *>(m_ioctx.cct());
 
@@ -109,7 +98,6 @@ JournalPlayer::~JournalPlayer() {
     ceph_assert(m_fetch_object_numbers.empty());
     ceph_assert(!m_watch_scheduled);
   }
-  m_replay_handler->put();
 
   if (m_cache_manager_handler != nullptr) {
     m_cache_manager_handler->unregister_cache(m_cache_name);
@@ -186,7 +174,7 @@ void JournalPlayer::shut_down(Context *on_finish) {
       m_journal_metadata, on_finish);
 
   if (m_watch_scheduled) {
-    ObjectPlayerPtr object_player = get_object_player();
+    auto object_player = get_object_player();
     switch (m_watch_step) {
     case WATCH_STEP_FETCH_FIRST:
       object_player = m_object_players.begin()->second;
@@ -220,7 +208,7 @@ bool JournalPlayer::try_pop_front(Entry *entry, uint64_t *commit_tid) {
     return false;
   }
 
-  ObjectPlayerPtr object_player = get_object_player();
+  auto object_player = get_object_player();
   ceph_assert(object_player && !object_player->empty());
 
   object_player->front(entry);
@@ -294,7 +282,7 @@ int JournalPlayer::process_prefetch(uint64_t object_number) {
 
   bool prefetch_complete = false;
   ceph_assert(m_object_players.count(splay_offset) == 1);
-  ObjectPlayerPtr object_player = m_object_players[splay_offset];
+  auto object_player = m_object_players[splay_offset];
 
   // prefetch in-order since a newer splay object could prefetch first
   if (m_fetch_object_numbers.count(object_player->get_object_number()) == 0) {
@@ -415,7 +403,7 @@ bool JournalPlayer::verify_playback_ready() {
       return false;
     }
 
-    ObjectPlayerPtr object_player = get_object_player();
+    auto object_player = get_object_player();
     ceph_assert(object_player);
     uint64_t object_num = object_player->get_object_number();
 
@@ -520,8 +508,8 @@ void JournalPlayer::prune_tag(uint64_t tag_tid) {
   }
 
   bool pruned = false;
-  for (auto &player_pair : m_object_players) {
-    ObjectPlayerPtr object_player(player_pair.second);
+  for (const auto &player_pair : m_object_players) {
+    auto& object_player = player_pair.second;
     ldout(m_cct, 15) << __func__ << ": checking " << object_player->get_oid()
                      << dendl;
     while (!object_player->empty()) {
@@ -541,14 +529,14 @@ void JournalPlayer::prune_tag(uint64_t tag_tid) {
   if (pruned) {
     ldout(m_cct, 15) << __func__ << ": resetting refetch state to immediate"
                      << dendl;
-    for (auto &player_pair : m_object_players) {
-      ObjectPlayerPtr object_player(player_pair.second);
+    for (const auto &player_pair : m_object_players) {
+      auto& object_player = player_pair.second;
       object_player->set_refetch_state(ObjectPlayer::REFETCH_STATE_IMMEDIATE);
     }
   }
 
   // trim empty player to prefetch the next available object
-  for (auto &player_pair : m_object_players) {
+  for (const auto &player_pair : m_object_players) {
     remove_empty_object_player(player_pair.second);
   }
 }
@@ -567,7 +555,7 @@ void JournalPlayer::prune_active_tag(const boost::optional<uint64_t>& tag_tid) {
   prune_tag(active_tag_tid);
 }
 
-ObjectPlayerPtr JournalPlayer::get_object_player() const {
+ceph::ref_t<ObjectPlayer> JournalPlayer::get_object_player() const {
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
   SplayedObjectPlayers::const_iterator it = m_object_players.find(
@@ -576,7 +564,7 @@ ObjectPlayerPtr JournalPlayer::get_object_player() const {
   return it->second;
 }
 
-ObjectPlayerPtr JournalPlayer::get_object_player(uint64_t object_number) const {
+ceph::ref_t<ObjectPlayer> JournalPlayer::get_object_player(uint64_t object_number) const {
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
   uint8_t splay_width = m_journal_metadata->get_splay_width();
@@ -584,7 +572,7 @@ ObjectPlayerPtr JournalPlayer::get_object_player(uint64_t object_number) const {
   auto splay_it = m_object_players.find(splay_offset);
   ceph_assert(splay_it != m_object_players.end());
 
-  ObjectPlayerPtr object_player = splay_it->second;
+  auto object_player = splay_it->second;
   ceph_assert(object_player->get_object_number() == object_number);
   return object_player;
 }
@@ -598,7 +586,7 @@ void JournalPlayer::advance_splay_object() {
                    << static_cast<uint32_t>(m_splay_offset) << dendl;
 }
 
-bool JournalPlayer::remove_empty_object_player(const ObjectPlayerPtr &player) {
+bool JournalPlayer::remove_empty_object_player(const ceph::ref_t<ObjectPlayer> &player) {
   ceph_assert(ceph_mutex_is_locked(m_lock));
   ceph_assert(!m_watch_scheduled);
 
@@ -615,7 +603,7 @@ bool JournalPlayer::remove_empty_object_player(const ObjectPlayerPtr &player) {
     ldout(m_cct, 20) << __func__ << ": new active set detected, all players "
                      << "require refetch" << dendl;
     m_active_set = active_set;
-    for (auto &pair : m_object_players) {
+    for (const auto& pair : m_object_players) {
       pair.second->set_refetch_state(ObjectPlayer::REFETCH_STATE_IMMEDIATE);
     }
     return false;
@@ -635,17 +623,17 @@ bool JournalPlayer::remove_empty_object_player(const ObjectPlayerPtr &player) {
 void JournalPlayer::fetch(uint64_t object_num) {
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
-  ObjectPlayerPtr object_player(new ObjectPlayer(
+  auto object_player = ceph::make_ref<ObjectPlayer>(
     m_ioctx, m_object_oid_prefix, object_num, m_journal_metadata->get_timer(),
     m_journal_metadata->get_timer_lock(), m_journal_metadata->get_order(),
-    m_max_fetch_bytes));
+    m_max_fetch_bytes);
 
   auto splay_width = m_journal_metadata->get_splay_width();
   m_object_players[object_num % splay_width] = object_player;
   fetch(object_player);
 }
 
-void JournalPlayer::fetch(const ObjectPlayerPtr &object_player) {
+void JournalPlayer::fetch(const ceph::ref_t<ObjectPlayer> &object_player) {
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
   uint64_t object_num = object_player->get_object_number();
@@ -673,7 +661,7 @@ void JournalPlayer::handle_fetched(uint64_t object_num, int r) {
   }
 
   if (r == 0) {
-    ObjectPlayerPtr object_player = get_object_player(object_num);
+    auto object_player = get_object_player(object_num);
     remove_empty_object_player(object_player);
   }
   process_state(object_num, r);
@@ -690,7 +678,7 @@ void JournalPlayer::refetch(bool immediate) {
     return;
   }
 
-  ObjectPlayerPtr object_player = get_object_player();
+  auto object_player = get_object_player();
   if (object_player->refetch_required()) {
     object_player->set_refetch_state(ObjectPlayer::REFETCH_STATE_NONE);
     fetch(object_player);
@@ -723,7 +711,7 @@ void JournalPlayer::schedule_watch(bool immediate) {
     return;
   }
 
-  ObjectPlayerPtr object_player;
+  ceph::ref_t<ObjectPlayer> object_player;
   double watch_interval = m_watch_interval;
 
   switch (m_watch_step) {
@@ -772,7 +760,7 @@ void JournalPlayer::handle_watch(uint64_t object_num, int r) {
     return;
   }
 
-  ObjectPlayerPtr object_player = get_object_player(object_num);
+  auto object_player = get_object_player(object_num);
   if (r == 0 && object_player->empty()) {
     // possibly need to prune this empty object player if we've
     // already fetched it after the active set was advanced with no
@@ -824,8 +812,7 @@ void JournalPlayer::notify_entries_available() {
   m_handler_notified = true;
 
   ldout(m_cct, 10) << __func__ << ": entries available" << dendl;
-  m_journal_metadata->queue(new C_HandleEntriesAvailable(
-    m_replay_handler), 0);
+  m_journal_metadata->queue(new C_HandleEntriesAvailable(m_replay_handler), 0);
 }
 
 void JournalPlayer::notify_complete(int r) {
@@ -833,8 +820,7 @@ void JournalPlayer::notify_complete(int r) {
   m_handler_notified = true;
 
   ldout(m_cct, 10) << __func__ << ": replay complete: r=" << r << dendl;
-  m_journal_metadata->queue(new C_HandleComplete(
-    m_replay_handler), r);
+  m_journal_metadata->queue(new C_HandleComplete(m_replay_handler), r);
 }
 
 void JournalPlayer::handle_cache_rebalanced(uint64_t new_cache_bytes) {

--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -88,14 +88,14 @@ JournalRecorder::~JournalRecorder() {
 }
 
 void JournalRecorder::shut_down(Context *on_safe) {
-  on_safe = new FunctionContext(
+  on_safe = new LambdaContext(
     [this, on_safe](int r) {
       Context *ctx = nullptr;
       {
 	std::lock_guard locker{m_lock};
         if (m_in_flight_advance_sets != 0) {
           ceph_assert(m_on_object_set_advanced == nullptr);
-          m_on_object_set_advanced = new FunctionContext(
+          m_on_object_set_advanced = new LambdaContext(
             [on_safe, r](int) {
               on_safe->complete(r);
             });

--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -20,15 +20,16 @@ namespace journal {
 namespace {
 
 struct C_Flush : public Context {
-  JournalMetadataPtr journal_metadata;
+  ceph::ref_t<JournalMetadata> journal_metadata;
   Context *on_finish;
-  std::atomic<int64_t> pending_flushes = { 0 };
-  int ret_val;
+  std::atomic<int64_t> pending_flushes{0};
+  int ret_val = 0;
 
-  C_Flush(JournalMetadataPtr _journal_metadata, Context *_on_finish,
+  C_Flush(ceph::ref_t<JournalMetadata> _journal_metadata, Context *_on_finish,
           size_t _pending_flushes)
-    : journal_metadata(_journal_metadata), on_finish(_on_finish),
-      pending_flushes(_pending_flushes), ret_val(0) {
+    : journal_metadata(std::move(_journal_metadata)),
+      on_finish(_on_finish),
+      pending_flushes(_pending_flushes) {
   }
 
   void complete(int r) override {
@@ -48,22 +49,21 @@ struct C_Flush : public Context {
 } // anonymous namespace
 
 JournalRecorder::JournalRecorder(librados::IoCtx &ioctx,
-                                 const std::string &object_oid_prefix,
-                                 const JournalMetadataPtr& journal_metadata,
+                                 std::string_view object_oid_prefix,
+                                 ceph::ref_t<JournalMetadata> journal_metadata,
                                  uint64_t max_in_flight_appends)
-  : m_cct(NULL), m_object_oid_prefix(object_oid_prefix),
-    m_journal_metadata(journal_metadata),
-    m_max_in_flight_appends(max_in_flight_appends), m_listener(this),
+  : m_object_oid_prefix(object_oid_prefix),
+    m_journal_metadata(std::move(journal_metadata)),
+    m_max_in_flight_appends(max_in_flight_appends),
+    m_listener(this),
     m_object_handler(this),
-    m_lock(ceph::make_mutex("JournalerRecorder::m_lock")),
     m_current_set(m_journal_metadata->get_active_set()),
     m_object_locks{ceph::make_lock_container<ceph::mutex>(
-      journal_metadata->get_splay_width(), [](const size_t splay_offset) {
+      m_journal_metadata->get_splay_width(), [](const size_t splay_offset) {
       return ceph::make_mutex("ObjectRecorder::m_lock::" +
 			      std::to_string(splay_offset));
     })}
 {
-
   std::lock_guard locker{m_lock};
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext*>(m_ioctx.cct());
@@ -141,10 +141,10 @@ Future JournalRecorder::append(uint64_t tag_tid,
   uint8_t splay_width = m_journal_metadata->get_splay_width();
   uint8_t splay_offset = entry_tid % splay_width;
 
-  ObjectRecorderPtr object_ptr = get_object(splay_offset);
+  auto object_ptr = get_object(splay_offset);
   uint64_t commit_tid = m_journal_metadata->allocate_commit_tid(
     object_ptr->get_object_number(), tag_tid, entry_tid);
-  FutureImplPtr future(new FutureImpl(tag_tid, entry_tid, commit_tid));
+  auto future = ceph::make_ref<FutureImpl>(tag_tid, entry_tid, commit_tid);
   future->init(m_prev_future);
   m_prev_future = future;
 
@@ -176,9 +176,8 @@ void JournalRecorder::flush(Context *on_safe) {
     std::lock_guard locker{m_lock};
 
     ctx = new C_Flush(m_journal_metadata, on_safe, m_object_ptrs.size() + 1);
-    for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
-         it != m_object_ptrs.end(); ++it) {
-      it->second->flush(ctx);
+    for (const auto& p : m_object_ptrs) {
+      p.second->flush(ctx);
     }
 
   }
@@ -187,11 +186,11 @@ void JournalRecorder::flush(Context *on_safe) {
   ctx->complete(0);
 }
 
-ObjectRecorderPtr JournalRecorder::get_object(uint8_t splay_offset) {
+ceph::ref_t<ObjectRecorder> JournalRecorder::get_object(uint8_t splay_offset) {
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
-  ObjectRecorderPtr object_recoder = m_object_ptrs[splay_offset];
-  ceph_assert(object_recoder != NULL);
+  const auto& object_recoder = m_object_ptrs.at(splay_offset);
+  ceph_assert(object_recoder);
   return object_recoder;
 }
 
@@ -261,9 +260,8 @@ void JournalRecorder::open_object_set() {
   uint8_t splay_width = m_journal_metadata->get_splay_width();
 
   lock_object_recorders();
-  for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
-       it != m_object_ptrs.end(); ++it) {
-    ObjectRecorderPtr object_recorder = it->second;
+  for (const auto& p : m_object_ptrs) {
+    const auto& object_recorder = p.second;
     uint64_t object_number = object_recorder->get_object_number();
     if (object_number / splay_width != m_current_set) {
       ceph_assert(object_recorder->is_closed());
@@ -283,9 +281,8 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
   // closing the object to ensure correct order of future appends
   uint8_t splay_width = m_journal_metadata->get_splay_width();
   lock_object_recorders();
-  for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
-       it != m_object_ptrs.end(); ++it) {
-    ObjectRecorderPtr object_recorder = it->second;
+  for (const auto& p : m_object_ptrs) {
+    const auto& object_recorder = p.second;
     if (object_recorder->get_object_number() / splay_width != active_set) {
       ldout(m_cct, 10) << "closing object " << object_recorder->get_oid()
                        << dendl;
@@ -302,21 +299,21 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
   return (m_in_flight_object_closes == 0);
 }
 
-ObjectRecorderPtr JournalRecorder::create_object_recorder(
+ceph::ref_t<ObjectRecorder> JournalRecorder::create_object_recorder(
     uint64_t object_number, ceph::mutex* lock) {
   ldout(m_cct, 10) << "object_number=" << object_number << dendl;
-  ObjectRecorderPtr object_recorder(new ObjectRecorder(
+  auto object_recorder = ceph::make_ref<ObjectRecorder>(
     m_ioctx, utils::get_object_name(m_object_oid_prefix, object_number),
     object_number, lock, m_journal_metadata->get_work_queue(),
     &m_object_handler, m_journal_metadata->get_order(),
-    m_max_in_flight_appends));
+    m_max_in_flight_appends);
   object_recorder->set_append_batch_options(m_flush_interval, m_flush_bytes,
                                             m_flush_age);
   return object_recorder;
 }
 
 void JournalRecorder::create_next_object_recorder(
-    ObjectRecorderPtr object_recorder) {
+    ceph::ref_t<ObjectRecorder> object_recorder) {
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
   uint64_t object_number = object_recorder->get_object_number();
@@ -326,7 +323,7 @@ void JournalRecorder::create_next_object_recorder(
 
   ceph_assert(ceph_mutex_is_locked(m_object_locks[splay_offset]));
 
-  ObjectRecorderPtr new_object_recorder = create_object_recorder(
+  auto new_object_recorder = create_object_recorder(
      (m_current_set * splay_width) + splay_offset, &m_object_locks[splay_offset]);
 
   ldout(m_cct, 10) << "old oid=" << object_recorder->get_oid() << ", "
@@ -342,7 +339,7 @@ void JournalRecorder::create_next_object_recorder(
   }
 
   new_object_recorder->append(std::move(append_buffers));
-  m_object_ptrs[splay_offset] = new_object_recorder;
+  m_object_ptrs[splay_offset] = std::move(new_object_recorder);
 }
 
 void JournalRecorder::handle_update() {
@@ -373,7 +370,7 @@ void JournalRecorder::handle_closed(ObjectRecorder *object_recorder) {
   uint64_t object_number = object_recorder->get_object_number();
   uint8_t splay_width = m_journal_metadata->get_splay_width();
   uint8_t splay_offset = object_number % splay_width;
-  ObjectRecorderPtr active_object_recorder = m_object_ptrs[splay_offset];
+  auto& active_object_recorder = m_object_ptrs.at(splay_offset);
   ceph_assert(active_object_recorder->get_object_number() == object_number);
 
   ceph_assert(m_in_flight_object_closes > 0);
@@ -401,7 +398,7 @@ void JournalRecorder::handle_overflow(ObjectRecorder *object_recorder) {
   uint64_t object_number = object_recorder->get_object_number();
   uint8_t splay_width = m_journal_metadata->get_splay_width();
   uint8_t splay_offset = object_number % splay_width;
-  ObjectRecorderPtr active_object_recorder = m_object_ptrs[splay_offset];
+  auto& active_object_recorder = m_object_ptrs.at(splay_offset);
   ceph_assert(active_object_recorder->get_object_number() == object_number);
 
   ldout(m_cct, 10) << "object " << active_object_recorder->get_oid()

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -22,8 +22,8 @@ namespace journal {
 
 class JournalRecorder {
 public:
-  JournalRecorder(librados::IoCtx &ioctx, const std::string &object_oid_prefix,
-                  const JournalMetadataPtr &journal_metadata,
+  JournalRecorder(librados::IoCtx &ioctx, std::string_view object_oid_prefix,
+                  ceph::ref_t<JournalMetadata> journal_metadata,
                   uint64_t max_in_flight_appends);
   ~JournalRecorder();
 
@@ -35,10 +35,10 @@ public:
   Future append(uint64_t tag_tid, const bufferlist &bl);
   void flush(Context *on_safe);
 
-  ObjectRecorderPtr get_object(uint8_t splay_offset);
+  ceph::ref_t<ObjectRecorder> get_object(uint8_t splay_offset);
 
 private:
-  typedef std::map<uint8_t, ObjectRecorderPtr> ObjectRecorderPtrs;
+  typedef std::map<uint8_t, ceph::ref_t<ObjectRecorder>> ObjectRecorderPtrs;
 
   struct Listener : public JournalMetadataListener {
     JournalRecorder *journal_recorder;
@@ -78,10 +78,10 @@ private:
   };
 
   librados::IoCtx m_ioctx;
-  CephContext *m_cct;
+  CephContext *m_cct = nullptr;
   std::string m_object_oid_prefix;
 
-  JournalMetadataPtr m_journal_metadata;
+  ceph::ref_t<JournalMetadata> m_journal_metadata;
 
   uint32_t m_flush_interval = 0;
   uint64_t m_flush_bytes = 0;
@@ -91,7 +91,7 @@ private:
   Listener m_listener;
   ObjectHandler m_object_handler;
 
-  ceph::mutex m_lock;
+  ceph::mutex m_lock = ceph::make_mutex("JournalerRecorder::m_lock");
 
   uint32_t m_in_flight_advance_sets = 0;
   uint32_t m_in_flight_object_closes = 0;
@@ -99,7 +99,7 @@ private:
   ObjectRecorderPtrs m_object_ptrs;
   ceph::containers::tiny_vector<ceph::mutex> m_object_locks;
 
-  FutureImplPtr m_prev_future;
+  ceph::ref_t<FutureImpl> m_prev_future;
 
   Context *m_on_object_set_advanced = nullptr;
 
@@ -111,9 +111,9 @@ private:
 
   void close_and_advance_object_set(uint64_t object_set);
 
-  ObjectRecorderPtr create_object_recorder(uint64_t object_number,
+  ceph::ref_t<ObjectRecorder> create_object_recorder(uint64_t object_number,
                                            ceph::mutex* lock);
-  void create_next_object_recorder(ObjectRecorderPtr object_recorder);
+  void create_next_object_recorder(ceph::ref_t<ObjectRecorder> object_recorder);
 
   void handle_update();
 

--- a/src/journal/JournalTrimmer.cc
+++ b/src/journal/JournalTrimmer.cc
@@ -57,7 +57,7 @@ void JournalTrimmer::shut_down(Context *on_finish) {
   m_journal_metadata->remove_listener(&m_metadata_listener);
 
   // chain the shut down sequence (reverse order)
-  on_finish = new FunctionContext([this, on_finish](int r) {
+  on_finish = new LambdaContext([this, on_finish](int r) {
       m_async_op_tracker.wait_for_ops(on_finish);
     });
   m_journal_metadata->flush_commit_position(on_finish);
@@ -66,7 +66,7 @@ void JournalTrimmer::shut_down(Context *on_finish) {
 void JournalTrimmer::remove_objects(bool force, Context *on_finish) {
   ldout(m_cct, 20) << __func__ << dendl;
 
-  on_finish = new FunctionContext([this, force, on_finish](int r) {
+  on_finish = new LambdaContext([this, force, on_finish](int r) {
 				    std::lock_guard locker{m_lock};
 
       if (m_remove_set_pending) {

--- a/src/journal/JournalTrimmer.cc
+++ b/src/journal/JournalTrimmer.cc
@@ -31,7 +31,7 @@ struct JournalTrimmer::C_RemoveSet : public Context {
 
 JournalTrimmer::JournalTrimmer(librados::IoCtx &ioctx,
                                const std::string &object_oid_prefix,
-                               const JournalMetadataPtr &journal_metadata)
+                               const ceph::ref_t<JournalMetadata>& journal_metadata)
     : m_cct(NULL), m_object_oid_prefix(object_oid_prefix),
       m_journal_metadata(journal_metadata), m_metadata_listener(this),
       m_remove_set_pending(false),

--- a/src/journal/JournalTrimmer.h
+++ b/src/journal/JournalTrimmer.h
@@ -21,7 +21,7 @@ public:
   typedef cls::journal::ObjectSetPosition ObjectSetPosition;
 
   JournalTrimmer(librados::IoCtx &ioctx, const std::string &object_oid_prefix,
-                 const JournalMetadataPtr &journal_metadata);
+                 const ceph::ref_t<JournalMetadata> &journal_metadata);
   ~JournalTrimmer();
 
   void shut_down(Context *on_finish);
@@ -64,7 +64,7 @@ private:
   CephContext *m_cct;
   std::string m_object_oid_prefix;
 
-  JournalMetadataPtr m_journal_metadata;
+  ceph::ref_t<JournalMetadata> m_journal_metadata;
   MetadataListener m_metadata_listener;
 
   AsyncOpTracker m_async_op_tracker;

--- a/src/journal/Journaler.cc
+++ b/src/journal/Journaler.cc
@@ -100,10 +100,9 @@ void Journaler::set_up(ContextWQ *work_queue, SafeTimer *timer,
   m_header_oid = header_oid(journal_id);
   m_object_oid_prefix = object_oid_prefix(m_header_ioctx.get_id(), journal_id);
 
-  m_metadata = new JournalMetadata(work_queue, timer, timer_lock,
+  m_metadata = ceph::make_ref<JournalMetadata>(work_queue, timer, timer_lock,
                                    m_header_ioctx, m_header_oid, m_client_id,
                                    settings);
-  m_metadata->get();
 }
 
 Journaler::~Journaler() {
@@ -114,8 +113,7 @@ Journaler::~Journaler() {
       // since we wouldn't expect shut_down to be invoked
       m_metadata->wait_for_ops();
     }
-    m_metadata->put();
-    m_metadata = nullptr;
+    m_metadata.reset();
   }
   ceph_assert(m_trimmer == nullptr);
   ceph_assert(m_player == nullptr);
@@ -175,13 +173,10 @@ void Journaler::shut_down(Context *on_finish) {
   ceph_assert(m_player == nullptr);
   ceph_assert(m_recorder == nullptr);
 
-  JournalMetadata *metadata = nullptr;
-  ceph_assert(m_metadata != nullptr);
-  std::swap(metadata, m_metadata);
-  ceph_assert(metadata != nullptr);
+  auto metadata = std::move(m_metadata);
+  ceph_assert(metadata);
 
   on_finish = new LambdaContext([metadata, on_finish](int r) {
-      metadata->put();
       on_finish->complete(0);
     });
 
@@ -336,12 +331,12 @@ void Journaler::get_tags(uint64_t start_after_tag_tid, uint64_t tag_class,
   m_metadata->get_tags(start_after_tag_tid, tag_class, tags, on_finish);
 }
 
-void Journaler::start_replay(ReplayHandler *replay_handler) {
+void Journaler::start_replay(ReplayHandler* replay_handler) {
   create_player(replay_handler);
   m_player->prefetch();
 }
 
-void Journaler::start_live_replay(ReplayHandler *replay_handler,
+void Journaler::start_live_replay(ReplayHandler* replay_handler,
                                   double interval) {
   create_player(replay_handler);
   m_player->prefetch_and_watch(interval);
@@ -371,17 +366,14 @@ void Journaler::stop_replay() {
 }
 
 void Journaler::stop_replay(Context *on_finish) {
-  JournalPlayer *player = nullptr;
-  ceph_assert(m_player != nullptr);
-  std::swap(player, m_player);
-  ceph_assert(player != nullptr);
+  auto player = std::move(m_player);
+  auto* playerp = player.get();
 
-  auto f = [player, on_finish](int r) {
-      delete player;
+  auto f = [player=std::move(player), on_finish](int r) {
       on_finish->complete(r);
     };
   on_finish = new LambdaContext(std::move(f));
-  player->shut_down(on_finish);
+  playerp->shut_down(on_finish);
 }
 
 void Journaler::committed(const ReplayEntry &replay_entry) {
@@ -389,7 +381,7 @@ void Journaler::committed(const ReplayEntry &replay_entry) {
 }
 
 void Journaler::committed(const Future &future) {
-  FutureImplPtr future_impl = future.get_future_impl();
+  auto& future_impl = future.get_future_impl();
   m_trimmer->committed(future_impl->get_commit_tid());
 }
 
@@ -398,7 +390,7 @@ void Journaler::start_append(uint64_t max_in_flight_appends) {
 
   // TODO verify active object set >= current replay object set
 
-  m_recorder = new JournalRecorder(m_data_ioctx, m_object_oid_prefix,
+  m_recorder = std::make_unique<JournalRecorder>(m_data_ioctx, m_object_oid_prefix,
 				   m_metadata, max_in_flight_appends);
 }
 
@@ -410,16 +402,14 @@ void Journaler::set_append_batch_options(int flush_interval,
 }
 
 void Journaler::stop_append(Context *on_safe) {
-  JournalRecorder *recorder = nullptr;
-  ceph_assert(m_recorder != nullptr);
-  std::swap(recorder, m_recorder);
-  ceph_assert(recorder != nullptr);
+  auto recorder = std::move(m_recorder);
+  ceph_assert(recorder);
 
-  on_safe = new LambdaContext([recorder, on_safe](int r) {
-      delete recorder;
+  auto* recorderp = recorder.get();
+  on_safe = new LambdaContext([recorder=std::move(recorder), on_safe](int r) {
       on_safe->complete(r);
     });
-  recorder->shut_down(on_safe);
+  recorderp->shut_down(on_safe);
 }
 
 uint64_t Journaler::get_max_append_size() const {
@@ -440,9 +430,9 @@ void Journaler::flush_append(Context *on_safe) {
   m_recorder->flush(on_safe);
 }
 
-void Journaler::create_player(ReplayHandler *replay_handler) {
+void Journaler::create_player(ReplayHandler* replay_handler) {
   ceph_assert(m_player == nullptr);
-  m_player = new JournalPlayer(m_data_ioctx, m_object_oid_prefix, m_metadata,
+  m_player = std::make_unique<JournalPlayer>(m_data_ioctx, m_object_oid_prefix, m_metadata,
                                replay_handler, m_cache_manager_handler);
 }
 

--- a/src/journal/Journaler.h
+++ b/src/journal/Journaler.h
@@ -24,9 +24,6 @@ namespace journal {
 
 struct CacheManagerHandler;
 
-class JournalMetadata;
-class JournalPlayer;
-class JournalRecorder;
 class JournalTrimmer;
 class ReplayEntry;
 class ReplayHandler;
@@ -103,8 +100,8 @@ public:
   void get_tags(uint64_t start_after_tag_tid, uint64_t tag_class, Tags *tags,
                 Context *on_finish);
 
-  void start_replay(ReplayHandler *replay_handler);
-  void start_live_replay(ReplayHandler *replay_handler, double interval);
+  void start_replay(ReplayHandler* replay_handler);
+  void start_live_replay(ReplayHandler* replay_handler, double interval);
   bool try_pop_front(ReplayEntry *replay_entry, uint64_t *tag_tid = nullptr);
   void stop_replay();
   void stop_replay(Context *on_finish);
@@ -149,9 +146,9 @@ private:
   std::string m_object_oid_prefix;
 
   bool m_initialized = false;
-  JournalMetadata *m_metadata = nullptr;
-  JournalPlayer *m_player = nullptr;
-  JournalRecorder *m_recorder = nullptr;
+  ceph::ref_t<class JournalMetadata> m_metadata;
+  std::unique_ptr<class JournalPlayer> m_player;
+  std::unique_ptr<class JournalRecorder> m_recorder;
   JournalTrimmer *m_trimmer = nullptr;
 
   void set_up(ContextWQ *work_queue, SafeTimer *timer, ceph::mutex *timer_lock,
@@ -159,7 +156,7 @@ private:
               const Settings &settings);
 
   int init_complete();
-  void create_player(ReplayHandler *replay_handler);
+  void create_player(ReplayHandler* replay_handler);
 
   friend std::ostream &operator<<(std::ostream &os,
 				  const Journaler &journaler);

--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -43,17 +43,16 @@ bool advance_to_last_pad_byte(uint32_t off, bufferlist::const_iterator *iter,
 } // anonymous namespace
 
 ObjectPlayer::ObjectPlayer(librados::IoCtx &ioctx,
-                           const std::string &object_oid_prefix,
+                           const std::string& object_oid_prefix,
                            uint64_t object_num, SafeTimer &timer,
                            ceph::mutex &timer_lock, uint8_t order,
                            uint64_t max_fetch_bytes)
-  : RefCountedObject(NULL, 0), m_object_num(object_num),
+  : m_object_num(object_num),
     m_oid(utils::get_object_name(object_oid_prefix, m_object_num)),
-    m_cct(NULL), m_timer(timer), m_timer_lock(timer_lock), m_order(order),
+    m_timer(timer), m_timer_lock(timer_lock), m_order(order),
     m_max_fetch_bytes(max_fetch_bytes > 0 ? max_fetch_bytes : 2 << order),
-    m_watch_interval(0), m_watch_task(NULL),
-    m_lock(ceph::make_mutex(utils::unique_lock_name("ObjectPlayer::m_lock", this))),
-    m_fetch_in_progress(false) {
+    m_lock(ceph::make_mutex(utils::unique_lock_name("ObjectPlayer::m_lock", this)))
+{
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext*>(m_ioctx.cct());
 }

--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -283,7 +283,7 @@ void ObjectPlayer::schedule_watch() {
   ceph_assert(m_watch_task == nullptr);
   m_watch_task = m_timer.add_event_after(
     m_watch_interval,
-    new FunctionContext([this](int) {
+    new LambdaContext([this](int) {
 	handle_watch_task();
       }));
 }

--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -19,16 +19,16 @@ using std::shared_ptr;
 
 namespace journal {
 
-ObjectRecorder::ObjectRecorder(librados::IoCtx &ioctx, const std::string &oid,
+ObjectRecorder::ObjectRecorder(librados::IoCtx &ioctx, std::string_view oid,
                                uint64_t object_number, ceph::mutex* lock,
                                ContextWQ *work_queue, Handler *handler,
                                uint8_t order, int32_t max_in_flight_appends)
-  : RefCountedObject(NULL, 0), m_oid(oid), m_object_number(object_number),
-    m_cct(NULL), m_op_work_queue(work_queue), m_handler(handler),
+  : m_oid(oid), m_object_number(object_number),
+    m_op_work_queue(work_queue), m_handler(handler),
     m_order(order), m_soft_max_size(1 << m_order),
-    m_max_in_flight_appends(max_in_flight_appends), m_flush_handler(this),
-    m_lock(lock), m_last_flush_time(ceph_clock_now()), m_append_tid(0),
-    m_overflowed(false), m_object_closed(false), m_in_flight_flushes(false) {
+    m_max_in_flight_appends(max_in_flight_appends),
+    m_lock(lock), m_last_flush_time(ceph_clock_now())
+{
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext*>(m_ioctx.cct());
   ceph_assert(m_handler != NULL);
@@ -70,11 +70,12 @@ bool ObjectRecorder::append(AppendBuffers &&append_buffers) {
 
   ceph_assert(ceph_mutex_is_locked(*m_lock));
 
-  FutureImplPtr last_flushed_future;
+  ceph::ref_t<FutureImpl> last_flushed_future;
+  auto flush_handler = get_flush_handler();
   for (auto& append_buffer : append_buffers) {
     ldout(m_cct, 20) << *append_buffer.first << ", "
                      << "size=" << append_buffer.second.length() << dendl;
-    bool flush_requested = append_buffer.first->attach(&m_flush_handler);
+    bool flush_requested = append_buffer.first->attach(flush_handler);
     if (flush_requested) {
       last_flushed_future = append_buffer.first;
     }
@@ -121,19 +122,23 @@ void ObjectRecorder::flush(Context *on_safe) {
   }
 }
 
-void ObjectRecorder::flush(const FutureImplPtr &future) {
+void ObjectRecorder::flush(const ceph::ref_t<FutureImpl>& future) {
   ldout(m_cct, 20) << "flushing " << *future << dendl;
 
   m_lock->lock();
-  if (future->get_flush_handler().get() != &m_flush_handler) {
-    // if we don't own this future, re-issue the flush so that it hits the
-    // correct journal object owner
-    future->flush();
-    m_lock->unlock();
-    return;
-  } else if (future->is_flush_in_progress()) {
-    m_lock->unlock();
-    return;
+  {
+    auto flush_handler = future->get_flush_handler();
+    auto my_handler = get_flush_handler();
+    if (flush_handler != my_handler) {
+      // if we don't own this future, re-issue the flush so that it hits the
+      // correct journal object owner
+      future->flush();
+      m_lock->unlock();
+      return;
+    } else if (future->is_flush_in_progress()) {
+      m_lock->unlock();
+      return;
+    }
   }
 
   bool overflowed = send_appends(true, future);
@@ -258,7 +263,7 @@ void ObjectRecorder::append_overflowed() {
   restart_append_buffers.swap(m_pending_buffers);
 }
 
-bool ObjectRecorder::send_appends(bool force, FutureImplPtr flush_future) {
+bool ObjectRecorder::send_appends(bool force, ceph::ref_t<FutureImpl> flush_future) {
   ldout(m_cct, 20) << dendl;
 
   ceph_assert(ceph_mutex_is_locked(*m_lock));

--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -112,7 +112,7 @@ void ObjectRecorder::flush(Context *on_safe) {
 
   if (future.is_valid()) {
     // cannot be invoked while the same lock context
-    m_op_work_queue->queue(new FunctionContext(
+    m_op_work_queue->queue(new LambdaContext(
       [future, on_safe] (int r) mutable {
         future.flush(on_safe);
       }));

--- a/src/journal/ObjectRecorder.h
+++ b/src/journal/ObjectRecorder.h
@@ -14,7 +14,6 @@
 #include <list>
 #include <map>
 #include <set>
-#include <boost/intrusive_ptr.hpp>
 #include <boost/noncopyable.hpp>
 #include "include/ceph_assert.h"
 
@@ -23,9 +22,8 @@ class SafeTimer;
 namespace journal {
 
 class ObjectRecorder;
-typedef boost::intrusive_ptr<ObjectRecorder> ObjectRecorderPtr;
 
-typedef std::pair<FutureImplPtr, bufferlist> AppendBuffer;
+typedef std::pair<ceph::ref_t<FutureImpl>, bufferlist> AppendBuffer;
 typedef std::list<AppendBuffer> AppendBuffers;
 
 class ObjectRecorder : public RefCountedObject, boost::noncopyable {
@@ -36,12 +34,6 @@ public:
     virtual void closed(ObjectRecorder *object_recorder) = 0;
     virtual void overflow(ObjectRecorder *object_recorder) = 0;
   };
-
-  ObjectRecorder(librados::IoCtx &ioctx, const std::string &oid,
-                 uint64_t object_number, ceph::mutex* lock,
-                 ContextWQ *work_queue, Handler *handler, uint8_t order,
-                 int32_t max_in_flight_appends);
-  ~ObjectRecorder() override;
 
   void set_append_batch_options(int flush_interval, uint64_t flush_bytes,
                                 double flush_age);
@@ -55,7 +47,7 @@ public:
 
   bool append(AppendBuffers &&append_buffers);
   void flush(Context *on_safe);
-  void flush(const FutureImplPtr &future);
+  void flush(const ceph::ref_t<FutureImpl> &future);
 
   void claim_append_buffers(AppendBuffers *append_buffers);
 
@@ -75,39 +67,38 @@ public:
   }
 
 private:
+  FRIEND_MAKE_REF(ObjectRecorder);
+  ObjectRecorder(librados::IoCtx &ioctx, std::string_view oid,
+                 uint64_t object_number, ceph::mutex* lock,
+                 ContextWQ *work_queue, Handler *handler, uint8_t order,
+                 int32_t max_in_flight_appends);
+  ~ObjectRecorder() override;
+
   typedef std::set<uint64_t> InFlightTids;
   typedef std::map<uint64_t, AppendBuffers> InFlightAppends;
 
   struct FlushHandler : public FutureImpl::FlushHandler {
-    ObjectRecorder *object_recorder;
-    FlushHandler(ObjectRecorder *o) : object_recorder(o) {}
-    void get() override {
-      object_recorder->get();
-    }
-    void put() override {
-      object_recorder->put();
-    }
-    void flush(const FutureImplPtr &future) override {
+    ceph::ref_t<ObjectRecorder> object_recorder;
+    virtual void flush(const ceph::ref_t<FutureImpl> &future) override {
       object_recorder->flush(future);
     }
+    FlushHandler(ceph::ref_t<ObjectRecorder> o) : object_recorder(std::move(o)) {}
   };
   struct C_AppendFlush : public Context {
-    ObjectRecorder *object_recorder;
+    ceph::ref_t<ObjectRecorder> object_recorder;
     uint64_t tid;
-    C_AppendFlush(ObjectRecorder *o, uint64_t _tid)
-        : object_recorder(o), tid(_tid) {
-      object_recorder->get();
+    C_AppendFlush(ceph::ref_t<ObjectRecorder> o, uint64_t _tid)
+        : object_recorder(std::move(o)), tid(_tid) {
     }
     void finish(int r) override {
       object_recorder->handle_append_flushed(tid, r);
-      object_recorder->put();
     }
   };
 
   librados::IoCtx m_ioctx;
   std::string m_oid;
   uint64_t m_object_number;
-  CephContext *m_cct;
+  CephContext *m_cct = nullptr;
 
   ContextWQ *m_op_work_queue;
 
@@ -123,28 +114,37 @@ private:
 
   bool m_compat_mode;
 
-  FlushHandler m_flush_handler;
+  /* So that ObjectRecorder::FlushHandler doesn't create a circular reference: */
+  std::weak_ptr<FlushHandler> m_flush_handler;
+  auto get_flush_handler() {
+    auto h = m_flush_handler.lock();
+    if (!h) {
+      h = std::make_shared<FlushHandler>(this);
+      m_flush_handler = h;
+    }
+    return h;
+  }
 
   mutable ceph::mutex* m_lock;
   AppendBuffers m_pending_buffers;
   uint64_t m_pending_bytes = 0;
   utime_t m_last_flush_time;
 
-  uint64_t m_append_tid;
+  uint64_t m_append_tid = 0;
 
   InFlightTids m_in_flight_tids;
   InFlightAppends m_in_flight_appends;
   uint64_t m_object_bytes = 0;
-  bool m_overflowed;
-  bool m_object_closed;
+  bool m_overflowed = false;
+  bool m_object_closed = false;
 
   bufferlist m_prefetch_bl;
 
-  bool m_in_flight_flushes;
+  bool m_in_flight_flushes = false;
   ceph::condition_variable m_in_flight_flushes_cond;
   uint64_t m_in_flight_bytes = 0;
 
-  bool send_appends(bool force, FutureImplPtr flush_sentinal);
+  bool send_appends(bool force, ceph::ref_t<FutureImpl> flush_sentinal);
   void handle_append_flushed(uint64_t tid, int r);
   void append_overflowed();
 

--- a/src/journal/ReplayHandler.h
+++ b/src/journal/ReplayHandler.h
@@ -6,14 +6,10 @@
 
 namespace journal {
 
-struct ReplayHandler  {
-  virtual ~ReplayHandler() {}
-
-  virtual void get() = 0;
-  virtual void put() = 0;
-
+struct ReplayHandler {
   virtual void handle_entries_available() = 0;
   virtual void handle_complete(int r) = 0;
+  virtual ~ReplayHandler() {}
 };
 
 } // namespace journal

--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -27,6 +27,7 @@
 #include "include/ceph_fs.h"
 #include "common/dout.h"
 #include "common/strtol.h"
+#include "common/RefCountedObj.h"
 #include "osdc/Striper.h"
 #include "librados/AioCompletionImpl.h"
 #include <cls/lock/cls_lock_client.h>
@@ -124,14 +125,6 @@ namespace {
  * function in asynchronous operations
  */
 struct CompletionData : RefCountedObject {
-  /// constructor
-  CompletionData(libradosstriper::RadosStriperImpl * striper,
-		 const std::string& soid,
-		 const std::string& lockCookie,
-		 librados::AioCompletionImpl *userCompletion = 0,
-		 int n = 1);
-  /// destructor
-  ~CompletionData() override;
   /// complete method
   void complete(int r);
   /// striper to be used to handle the write completion
@@ -142,15 +135,21 @@ struct CompletionData : RefCountedObject {
   std::string m_lockCookie;
   /// completion handler
   librados::IoCtxImpl::C_aio_Complete *m_ack;
+protected:
+  CompletionData(libradosstriper::RadosStriperImpl * striper,
+		 const std::string& soid,
+		 const std::string& lockCookie,
+		 librados::AioCompletionImpl *userCompletion = 0);
+  ~CompletionData() override;
+
 };
 
 CompletionData::CompletionData
 (libradosstriper::RadosStriperImpl* striper,
  const std::string& soid,
  const std::string& lockCookie,
- librados::AioCompletionImpl *userCompletion,
- int n) :
-  RefCountedObject(striper->cct(), n),
+ librados::AioCompletionImpl *userCompletion) :
+  RefCountedObject(striper->cct()),
   m_striper(striper), m_soid(soid), m_lockCookie(lockCookie), m_ack(0) {
   m_striper->get();
   if (userCompletion) {
@@ -183,21 +182,21 @@ struct ReadCompletionData : CompletionData {
   int m_readRc;
   /// completion object for the unlocking of the striped object at the end of the read
   librados::AioCompletion *m_unlockCompletion;
-  /// constructor
+  /// complete method for when reading is over
+  void complete_read(int r);
+  /// complete method for when object is unlocked
+  void complete_unlock(int r);
+
+private:
+  FRIEND_MAKE_REF(ReadCompletionData);
   ReadCompletionData(libradosstriper::RadosStriperImpl * striper,
 		     const std::string& soid,
 		     const std::string& lockCookie,
 		     librados::AioCompletionImpl *userCompletion,
 		     bufferlist* bl,
 		     std::vector<ObjectExtent>* extents,
-		     std::vector<bufferlist>* resultbl,
-		     int n);
-  /// destructor
+		     std::vector<bufferlist>* resultbl);
   ~ReadCompletionData() override;
-  /// complete method for when reading is over
-  void complete_read(int r);
-  /// complete method for when object is unlocked
-  void complete_unlock(int r);
 };
 
 ReadCompletionData::ReadCompletionData
@@ -207,9 +206,8 @@ ReadCompletionData::ReadCompletionData
  librados::AioCompletionImpl *userCompletion,
  bufferlist* bl,
  std::vector<ObjectExtent>* extents,
- std::vector<bufferlist>* resultbl,
- int n) :
-  CompletionData(striper, soid, lockCookie, userCompletion, n),
+ std::vector<bufferlist>* resultbl) :
+  CompletionData(striper, soid, lockCookie, userCompletion),
   m_bl(bl), m_extents(extents), m_resultbl(resultbl), m_readRc(0),
   m_unlockCompletion(0) {}
 
@@ -251,30 +249,30 @@ struct WriteCompletionData : CompletionData {
   librados::AioCompletion *m_unlockCompletion;
   /// return code of write completion, to be remembered until unlocking happened
   int m_writeRc;
-  /// constructor
-  WriteCompletionData(libradosstriper::RadosStriperImpl * striper,
-		      const std::string& soid,
-		      const std::string& lockCookie,
-		      librados::AioCompletionImpl *userCompletion,
-		      int n);
-  /// destructor
-  ~WriteCompletionData() override;
   /// complete method for when writing is over
   void complete_write(int r);
   /// complete method for when object is unlocked
   void complete_unlock(int r);
   /// safe method
   void safe(int r);
+private:
+  FRIEND_MAKE_REF(WriteCompletionData);
+  /// constructor
+  WriteCompletionData(libradosstriper::RadosStriperImpl * striper,
+		      const std::string& soid,
+		      const std::string& lockCookie,
+		      librados::AioCompletionImpl *userCompletion);
+  /// destructor
+  ~WriteCompletionData() override;
 };
 
 WriteCompletionData::WriteCompletionData
 (libradosstriper::RadosStriperImpl* striper,
  const std::string& soid,
  const std::string& lockCookie,
- librados::AioCompletionImpl *userCompletion,
- int n) :
-  CompletionData(striper, soid, lockCookie, userCompletion, n), m_safe(0),
-  m_unlockCompletion(0), m_writeRc(0) {
+ librados::AioCompletionImpl *userCompletion) :
+  CompletionData(striper, soid, lockCookie, userCompletion),
+  m_safe(0), m_unlockCompletion(0), m_writeRc(0) {
   if (userCompletion) {
     m_safe = new librados::IoCtxImpl::C_aio_Complete(userCompletion);
   }
@@ -303,6 +301,9 @@ void WriteCompletionData::safe(int r) {
 struct RemoveCompletionData : CompletionData {
   /// removal flags
   int flags;
+
+private:
+  FRIEND_MAKE_REF(RemoveCompletionData);
   /**
    * constructor
    * note that the constructed object will take ownership of the lock
@@ -320,6 +321,15 @@ struct RemoveCompletionData : CompletionData {
  * function in asynchronous truncate operations
  */
 struct TruncateCompletionData : RefCountedObject {
+  /// striper to be used
+  libradosstriper::RadosStriperImpl *m_striper;
+  /// striped object concerned by the truncate operation
+  std::string m_soid;
+  /// the final size of the truncated object
+  uint64_t m_size;
+
+private:
+  FRIEND_MAKE_REF(TruncateCompletionData);
   /// constructor
   TruncateCompletionData(libradosstriper::RadosStriperImpl* striper,
 			 const std::string& soid,
@@ -332,12 +342,6 @@ struct TruncateCompletionData : RefCountedObject {
   ~TruncateCompletionData() override {
     m_striper->put();
   }
-  /// striper to be used
-  libradosstriper::RadosStriperImpl *m_striper;
-  /// striped object concerned by the truncate operation
-  std::string m_soid;
-  /// the final size of the truncated object
-  uint64_t m_size;
 };
 
 /**
@@ -345,20 +349,22 @@ struct TruncateCompletionData : RefCountedObject {
  * function in asynchronous read operations of a Rados File
  */
 struct RadosReadCompletionData : RefCountedObject {
-  /// constructor
-  RadosReadCompletionData(MultiAioCompletionImplPtr multiAioCompl,
-			  uint64_t expectedBytes,
-			  bufferlist *bl,
-			  CephContext *context,
-			  int n = 1) :
-    RefCountedObject(context, n),
-    m_multiAioCompl(multiAioCompl), m_expectedBytes(expectedBytes), m_bl(bl) {}
   /// the multi asynch io completion object to be used
   MultiAioCompletionImplPtr m_multiAioCompl;
   /// the expected number of bytes
   uint64_t m_expectedBytes;
   /// the bufferlist object where data have been written
   bufferlist *m_bl;
+
+private:
+  FRIEND_MAKE_REF(RadosReadCompletionData);
+  /// constructor
+  RadosReadCompletionData(MultiAioCompletionImplPtr multiAioCompl,
+			  uint64_t expectedBytes,
+			  bufferlist *bl,
+			  CephContext *context) :
+    RefCountedObject(context),
+    m_multiAioCompl(multiAioCompl), m_expectedBytes(expectedBytes), m_bl(bl) {}
 };
 
 /**
@@ -368,16 +374,6 @@ struct RadosReadCompletionData : RefCountedObject {
  * versions (time_t or struct timespec)
  */
 struct BasicStatCompletionData : CompletionData {
-  /// constructor
-  BasicStatCompletionData(libradosstriper::RadosStriperImpl* striper,
-			  const std::string& soid,
-			  librados::AioCompletionImpl *userCompletion,
-			  libradosstriper::MultiAioCompletionImpl *multiCompletion,
-			  uint64_t *psize,
-			  int n = 1) :
-    CompletionData(striper, soid, "", userCompletion, n),
-    m_multiCompletion(multiCompletion), m_psize(psize),
-    m_statRC(0), m_getxattrRC(0) {};
   // MultiAioCompletionImpl used to handle the double aysnc
   // call in the back (stat + getxattr)
   libradosstriper::MultiAioCompletionImpl *m_multiCompletion;
@@ -393,6 +389,18 @@ struct BasicStatCompletionData : CompletionData {
   int m_statRC;
   /// return code of the getxattr
   int m_getxattrRC;
+
+protected:
+  /// constructor
+  BasicStatCompletionData(libradosstriper::RadosStriperImpl* striper,
+			  const std::string& soid,
+			  librados::AioCompletionImpl *userCompletion,
+			  libradosstriper::MultiAioCompletionImpl *multiCompletion,
+			  uint64_t *psize) :
+    CompletionData(striper, soid, "", userCompletion),
+    m_multiCompletion(multiCompletion), m_psize(psize),
+    m_statRC(0), m_getxattrRC(0) {};
+
 };
 
 /**
@@ -404,18 +412,19 @@ struct BasicStatCompletionData : CompletionData {
  */
 template<class TimeType>
 struct StatCompletionData : BasicStatCompletionData {
+  // where to store the file time
+  TimeType *m_pmtime;
+private:
+  FRIEND_MAKE_REF(StatCompletionData);
   /// constructor
-  StatCompletionData(libradosstriper::RadosStriperImpl* striper,
+  StatCompletionData<TimeType>(libradosstriper::RadosStriperImpl* striper,
 		     const std::string& soid,
 		     librados::AioCompletionImpl *userCompletion,
 		     libradosstriper::MultiAioCompletionImpl *multiCompletion,
 		     uint64_t *psize,
-		     TimeType *pmtime,
-		     int n = 1) :
-    BasicStatCompletionData(striper, soid, userCompletion, multiCompletion, psize, n),
+		     TimeType *pmtime) :
+    BasicStatCompletionData(striper, soid, userCompletion, multiCompletion, psize),
     m_pmtime(pmtime) {};
-  // where to store the file time
-  TimeType *m_pmtime;
 };
 
 /**
@@ -423,13 +432,15 @@ struct StatCompletionData : BasicStatCompletionData {
  * function in asynchronous remove operations of a Rados File
  */
 struct RadosRemoveCompletionData : RefCountedObject {
+  /// the multi asynch io completion object to be used
+  MultiAioCompletionImplPtr m_multiAioCompl;
+private:
+  FRIEND_MAKE_REF(RadosRemoveCompletionData);
   /// constructor
   RadosRemoveCompletionData(MultiAioCompletionImplPtr multiAioCompl,
 			    CephContext *context) :
-    RefCountedObject(context, 2),
+    RefCountedObject(context),
     m_multiAioCompl(multiAioCompl) {};
-  /// the multi asynch io completion object to be used
-  MultiAioCompletionImplPtr m_multiAioCompl;
 };
 
 
@@ -614,16 +625,15 @@ int libradosstriper::RadosStriperImpl::aio_write_full(const std::string& soid,
 
 static void rados_read_aio_unlock_complete(rados_striper_multi_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<ReadCompletionData*>(arg);
+  auto cdata = ceph::ref_t<ReadCompletionData>(static_cast<ReadCompletionData*>(arg), false);
   libradosstriper::MultiAioCompletionImpl *comp =
     reinterpret_cast<libradosstriper::MultiAioCompletionImpl*>(c);
   cdata->complete_unlock(comp->rval);
-  cdata->put();
 }
 
 static void striper_read_aio_req_complete(rados_striper_multi_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<ReadCompletionData*>(arg);
+  auto cdata = static_cast<ReadCompletionData*>(arg);
   // launch the async unlocking of the object
   cdata->m_striper->aio_unlockObject(cdata->m_soid, cdata->m_lockCookie, cdata->m_unlockCompletion);
   // complete the read part in parallel
@@ -634,19 +644,18 @@ static void striper_read_aio_req_complete(rados_striper_multi_completion_t c, vo
 
 static void rados_req_read_safe(rados_completion_t c, void *arg)
 {
-  auto data = reinterpret_cast<RadosReadCompletionData*>(arg);
+  auto data = ceph::ref_t<RadosReadCompletionData>(static_cast<RadosReadCompletionData*>(arg), false);
   int rc = rados_aio_get_return_value(c);
   // ENOENT means that we are dealing with a sparse file. This is fine,
   // data (0s) will be created on the fly by the rados_req_read_complete method
   if (rc == -ENOENT) rc = 0;
   auto multiAioComp = data->m_multiAioCompl;
   multiAioComp->safe_request(rc);
-  data->put();
 }
 
 static void rados_req_read_complete(rados_completion_t c, void *arg)
 {
-  auto data = reinterpret_cast<RadosReadCompletionData*>(arg);
+  auto data = static_cast<RadosReadCompletionData*>(arg);
   int rc = rados_aio_get_return_value(c);
   // We need to handle the case of sparse files here
   if (rc == -ENOENT) {
@@ -672,7 +681,6 @@ static void rados_req_read_complete(rados_completion_t c, void *arg)
   }
   auto multiAioComp = data->m_multiAioCompl;
   multiAioComp->complete_request(rc);
-  data->put();
 }
 
 int libradosstriper::RadosStriperImpl::aio_read(const std::string& soid,
@@ -710,18 +718,17 @@ int libradosstriper::RadosStriperImpl::aio_read(const std::string& soid,
 
   // create a completion object and transfer ownership of extents and resultbl
   vector<bufferlist> *resultbl = new vector<bufferlist>(extents->size());
-  ReadCompletionData *cdata = new ReadCompletionData(this, soid, lockCookie, c,
-						     bl, extents, resultbl, 1);
+  auto cdata = ceph::make_ref<ReadCompletionData>(this, soid, lockCookie, c, bl, extents, resultbl);
   c->is_read = true;
   c->io = m_ioCtxImpl;
   // create a completion for the unlocking of the striped object at the end of the read
   librados::AioCompletion *unlock_completion =
-    librados::Rados::aio_create_completion(cdata, rados_read_aio_unlock_complete, 0);
+    librados::Rados::aio_create_completion(cdata->get() /* create ref! */, rados_read_aio_unlock_complete, 0);
   cdata->m_unlockCompletion = unlock_completion;
   // create the multiCompletion object handling the reads
   MultiAioCompletionImplPtr nc{new libradosstriper::MultiAioCompletionImpl,
 			       false};
-  nc->set_complete_callback(cdata, striper_read_aio_req_complete);
+  nc->set_complete_callback(cdata.get(), striper_read_aio_req_complete);
   // go through the extents
   int r = 0, i = 0;
   for (vector<ObjectExtent>::iterator p = extents->begin(); p != extents->end(); ++p) {
@@ -738,9 +745,9 @@ int libradosstriper::RadosStriperImpl::aio_read(const std::string& soid,
     nc->add_request();
     // we need 2 references on data as both rados_req_read_safe and rados_req_read_complete
     // will release one
-    RadosReadCompletionData *data = new RadosReadCompletionData(nc, p->length, oid_bl, cct(), 2);
+    auto data = ceph::make_ref<RadosReadCompletionData>(nc, p->length, oid_bl, cct());
     librados::AioCompletion *rados_completion =
-      librados::Rados::aio_create_completion(data, rados_req_read_complete, rados_req_read_safe);
+      librados::Rados::aio_create_completion(data.detach(), rados_req_read_complete, rados_req_read_safe);
     r = m_ioCtx.aio_read(p->oid.name, rados_completion, oid_bl, p->length, p->offset);
     rados_completion->release();
     if (r < 0)
@@ -794,18 +801,17 @@ int libradosstriper::RadosStriperImpl::stat(const std::string& soid, uint64_t *p
 }
 
 static void striper_stat_aio_stat_complete(rados_completion_t c, void *arg) {
-  auto data = reinterpret_cast<BasicStatCompletionData*>(arg);
+  auto data = ceph::ref_t<BasicStatCompletionData>(static_cast<BasicStatCompletionData*>(arg), false);
   int rc = rados_aio_get_return_value(c);
   if (rc == -ENOENT) {
     // remember this has failed
     data->m_statRC = rc;
   }
   data->m_multiCompletion->complete_request(rc);
-  data->put();
 }
 
 static void striper_stat_aio_getxattr_complete(rados_completion_t c, void *arg) {
-  auto data = reinterpret_cast<BasicStatCompletionData*>(arg);
+  auto data = ceph::ref_t<BasicStatCompletionData>(static_cast<BasicStatCompletionData*>(arg), false);
   int rc = rados_aio_get_return_value(c);
   // We need to handle the case of sparse files here
   if (rc < 0) {
@@ -823,12 +829,11 @@ static void striper_stat_aio_getxattr_complete(rados_completion_t c, void *arg) 
     rc = 0;
   }
   data->m_multiCompletion->complete_request(rc);
-  data->put();
 }
 
 static void striper_stat_aio_req_complete(rados_striper_multi_completion_t c,
 					  void *arg) {
-  auto data = reinterpret_cast<BasicStatCompletionData*>(arg);
+  auto data = ceph::ref_t<BasicStatCompletionData>(static_cast<BasicStatCompletionData*>(arg), false);
   if (data->m_statRC) {
     data->complete(data->m_statRC);
   } else {
@@ -838,7 +843,6 @@ static void striper_stat_aio_req_complete(rados_striper_multi_completion_t c,
       data->complete(0);
     }
   }
-  data->put();
 }
 
 template<class TimeType>
@@ -855,13 +859,11 @@ int libradosstriper::RadosStriperImpl::aio_generic_stat
     new libradosstriper::MultiAioCompletionImpl, false};
   // Data object used for passing context to asynchronous calls
   std::string firstObjOid = getObjectId(soid, 0);
-  StatCompletionData<TimeType> *cdata =
-    new StatCompletionData<TimeType>(this, firstObjOid, c,
-				     multi_completion.get(), psize, pmtime, 4);
-  multi_completion->set_complete_callback(cdata, striper_stat_aio_req_complete);
+  auto cdata = ceph::make_ref<StatCompletionData<TimeType>>(this, firstObjOid, c, multi_completion.get(), psize, pmtime);
+  multi_completion->set_complete_callback(cdata->get() /* create ref! */, striper_stat_aio_req_complete);
   // use a regular AioCompletion for the stat async call
   librados::AioCompletion *stat_completion =
-    librados::Rados::aio_create_completion(cdata, striper_stat_aio_stat_complete, 0);
+    librados::Rados::aio_create_completion(cdata->get() /* create ref! */, striper_stat_aio_stat_complete, 0);
   multi_completion->add_safe_request();
   object_t obj(firstObjOid);
   int rc = (m_ioCtxImpl->*statFunction)(obj, stat_completion->pc,
@@ -869,12 +871,12 @@ int libradosstriper::RadosStriperImpl::aio_generic_stat
   stat_completion->release();
   if (rc < 0) {
     // nothing is really started so cancel everything
-    delete cdata;
+    delete cdata.detach();
     return rc;
   }
   // use a regular AioCompletion for the getxattr async call
   librados::AioCompletion *getxattr_completion =
-    librados::Rados::aio_create_completion(cdata, striper_stat_aio_getxattr_complete, 0);
+    librados::Rados::aio_create_completion(cdata->get() /* create ref! */, striper_stat_aio_getxattr_complete, 0);
   multi_completion->add_safe_request();
   // in parallel, get the pmsize from the first object asynchronously
   rc = m_ioCtxImpl->aio_getxattr(obj, getxattr_completion->pc,
@@ -888,7 +890,6 @@ int libradosstriper::RadosStriperImpl::aio_generic_stat
     multi_completion->complete_request(rc);
     return rc;
   }
-  cdata->put();
   return 0;
 }
 
@@ -925,31 +926,29 @@ int libradosstriper::RadosStriperImpl::aio_stat2(const std::string& soid,
 
 static void rados_req_remove_complete(rados_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<RadosRemoveCompletionData*>(arg);
+  auto cdata = static_cast<RadosRemoveCompletionData*>(arg);
   int rc = rados_aio_get_return_value(c);
   // in case the object did not exist, it means we had a sparse file, all is fine
   if (rc == -ENOENT) {
     rc = 0;
   }
   cdata->m_multiAioCompl->complete_request(rc);
-  cdata->put();
 }
 
 static void rados_req_remove_safe(rados_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<RadosRemoveCompletionData*>(arg);
+  auto cdata = ceph::ref_t<RadosRemoveCompletionData>(static_cast<RadosRemoveCompletionData*>(arg), false);
   int rc = rados_aio_get_return_value(c);
   // in case the object did not exist, it means we had a sparse file, all is fine
   if (rc == -ENOENT) {
     rc = 0;
   }
   cdata->m_multiAioCompl->safe_request(rc);
-  cdata->put();
 }
 
 static void striper_remove_aio_req_complete(rados_striper_multi_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<RemoveCompletionData*>(arg);
+  auto cdata = ceph::ref_t<RemoveCompletionData>(static_cast<RemoveCompletionData*>(arg), false);
   libradosstriper::MultiAioCompletionImpl *comp =
     reinterpret_cast<libradosstriper::MultiAioCompletionImpl*>(c);
   ldout(cdata->m_striper->cct(), 10)
@@ -968,7 +967,6 @@ static void striper_remove_aio_req_complete(rados_striper_multi_completion_t c, 
       << dendl;
   }
   cdata->complete(rc);
-  cdata->put();
 }
 
 int libradosstriper::RadosStriperImpl::remove(const std::string& soid, int flags)
@@ -996,10 +994,10 @@ int libradosstriper::RadosStriperImpl::aio_remove(const std::string& soid,
   int rc = m_ioCtx.lock_exclusive(getObjectId(soid, 0), RADOS_LOCK_NAME, lockCookie, "", 0, 0);
   if (rc) return rc;
   // create CompletionData for the async remove call
-  RemoveCompletionData *cdata = new RemoveCompletionData(this, soid, lockCookie, c, flags);
+  auto cdata = ceph::make_ref<RemoveCompletionData>(this, soid, lockCookie, c, flags);
   MultiAioCompletionImplPtr multi_completion{
     new libradosstriper::MultiAioCompletionImpl, false};
-  multi_completion->set_complete_callback(cdata, striper_remove_aio_req_complete);
+  multi_completion->set_complete_callback(cdata->get() /* create ref! */, striper_remove_aio_req_complete);
   // call asynchronous internal version of remove
   ldout(cct(), 10)
     << "RadosStriperImpl : Aio_remove starting for "
@@ -1054,10 +1052,9 @@ int libradosstriper::RadosStriperImpl::internal_aio_remove(
     int rcr = 0;
     for (int i = nb_objects-1; i >= 1; i--) {
       multi_completion->add_request();
-      RadosRemoveCompletionData *data =
-	new RadosRemoveCompletionData(multi_completion, cct());
+      auto data = ceph::make_ref<RadosRemoveCompletionData>(multi_completion, cct());
       librados::AioCompletion *rados_completion =
-	librados::Rados::aio_create_completion(data,
+	librados::Rados::aio_create_completion(data->get() /* create ref! */,
 					       rados_req_remove_complete,
 					       rados_req_remove_safe);
       if (flags == 0) {
@@ -1142,32 +1139,29 @@ void libradosstriper::RadosStriperImpl::aio_unlockObject(const std::string& soid
 
 static void rados_write_aio_unlock_complete(rados_striper_multi_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<WriteCompletionData*>(arg);
+  auto cdata = ceph::ref_t<WriteCompletionData>(static_cast<WriteCompletionData*>(arg), false);
   libradosstriper::MultiAioCompletionImpl *comp =
     reinterpret_cast<libradosstriper::MultiAioCompletionImpl*>(c);
   cdata->complete_unlock(comp->rval);
-  cdata->put();
 }
 
 static void striper_write_aio_req_complete(rados_striper_multi_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<WriteCompletionData*>(arg);
+  auto cdata = ceph::ref_t<WriteCompletionData>(static_cast<WriteCompletionData*>(arg), false);
   // launch the async unlocking of the object
   cdata->m_striper->aio_unlockObject(cdata->m_soid, cdata->m_lockCookie, cdata->m_unlockCompletion);
   // complete the write part in parallel
   libradosstriper::MultiAioCompletionImpl *comp =
     reinterpret_cast<libradosstriper::MultiAioCompletionImpl*>(c);
   cdata->complete_write(comp->rval);
-  cdata->put();
 }
 
 static void striper_write_aio_req_safe(rados_striper_multi_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<WriteCompletionData*>(arg);
+  auto cdata = ceph::ref_t<WriteCompletionData>(static_cast<WriteCompletionData*>(arg), false);
   libradosstriper::MultiAioCompletionImpl *comp =
     reinterpret_cast<libradosstriper::MultiAioCompletionImpl*>(c);
   cdata->safe(comp->rval);
-  cdata->put();
 }
 
 int libradosstriper::RadosStriperImpl::write_in_open_object(const std::string& soid,
@@ -1179,17 +1173,16 @@ int libradosstriper::RadosStriperImpl::write_in_open_object(const std::string& s
   // create a completion object to be passed to the callbacks of the multicompletion
   // we need 3 references as striper_write_aio_req_complete will release two and
   // striper_write_aio_req_safe will release one
-  WriteCompletionData *cdata = new WriteCompletionData(this, soid, lockCookie, 0, 3);
-  cdata->get(); // local ref
+  auto cdata = ceph::make_ref<WriteCompletionData>(this, soid, lockCookie, nullptr);
   // create a completion object for the unlocking of the striped object at the end of the write
   librados::AioCompletion *unlock_completion =
-    librados::Rados::aio_create_completion(cdata, rados_write_aio_unlock_complete, 0);
+    librados::Rados::aio_create_completion(cdata->get() /* create ref! */, rados_write_aio_unlock_complete, 0);
   cdata->m_unlockCompletion = unlock_completion;
   // create the multicompletion that will handle the write completion
   MultiAioCompletionImplPtr c{new libradosstriper::MultiAioCompletionImpl,
                               false};
-  c->set_complete_callback(cdata, striper_write_aio_req_complete);
-  c->set_safe_callback(cdata, striper_write_aio_req_safe);
+  c->set_complete_callback(cdata->get() /* create ref! */, striper_write_aio_req_complete);
+  c->set_safe_callback(cdata->get() /* create ref! */, striper_write_aio_req_safe);
   // call the asynchronous API
   int rc = internal_aio_write(soid, c, bl, len, off, layout);
   if (!rc) {
@@ -1201,7 +1194,6 @@ int libradosstriper::RadosStriperImpl::write_in_open_object(const std::string& s
     // return result
     rc = c->get_return_value();
   }
-  cdata->put();
   return rc;
 }
 
@@ -1215,22 +1207,20 @@ int libradosstriper::RadosStriperImpl::aio_write_in_open_object(const std::strin
   // create a completion object to be passed to the callbacks of the multicompletion
   // we need 3 references as striper_write_aio_req_complete will release two and
   // striper_write_aio_req_safe will release one
-  WriteCompletionData *cdata = new WriteCompletionData(this, soid, lockCookie, c, 3);
-  cdata->get(); // local ref
+  auto cdata = ceph::make_ref<WriteCompletionData>(this, soid, lockCookie, c);
   m_ioCtxImpl->get();
   c->io = m_ioCtxImpl;
   // create a completion object for the unlocking of the striped object at the end of the write
   librados::AioCompletion *unlock_completion =
-    librados::Rados::aio_create_completion(cdata, rados_write_aio_unlock_complete, 0);
+    librados::Rados::aio_create_completion(cdata->get() /* create ref! */, rados_write_aio_unlock_complete, 0);
   cdata->m_unlockCompletion = unlock_completion;
   // create the multicompletion that will handle the write completion
   libradosstriper::MultiAioCompletionImplPtr nc{
     new libradosstriper::MultiAioCompletionImpl, false};
-  nc->set_complete_callback(cdata, striper_write_aio_req_complete);
-  nc->set_safe_callback(cdata, striper_write_aio_req_safe);
+  nc->set_complete_callback(cdata->get() /* create ref! */, striper_write_aio_req_complete);
+  nc->set_safe_callback(cdata->get() /* create ref! */, striper_write_aio_req_safe);
   // internal asynchronous API
   int rc = internal_aio_write(soid, nc, bl, len, off, layout);
-  cdata->put();
   return rc;
 }
 
@@ -1503,7 +1493,7 @@ int libradosstriper::RadosStriperImpl::createAndOpenStripedObject(const std::str
 
 static void striper_truncate_aio_req_complete(rados_striper_multi_completion_t c, void *arg)
 {
-  auto cdata = reinterpret_cast<TruncateCompletionData*>(arg);
+  auto cdata = ceph::ref_t<TruncateCompletionData>(static_cast<TruncateCompletionData*>(arg), false);
   libradosstriper::MultiAioCompletionImpl *comp =
     reinterpret_cast<libradosstriper::MultiAioCompletionImpl*>(c);
   if (0 == comp->rval) {
@@ -1514,7 +1504,6 @@ static void striper_truncate_aio_req_complete(rados_striper_multi_completion_t c
     bl.append(oss.str());
     cdata->m_striper->setxattr(cdata->m_soid, XATTR_SIZE, bl);
   }
-  cdata->put();
 }
 
 int libradosstriper::RadosStriperImpl::truncate(const std::string& soid,
@@ -1522,10 +1511,10 @@ int libradosstriper::RadosStriperImpl::truncate(const std::string& soid,
 						uint64_t size,
 						ceph_file_layout &layout) 
 {
-  TruncateCompletionData *cdata = new TruncateCompletionData(this, soid, size);
+  auto cdata = ceph::make_ref<TruncateCompletionData>(this, soid, size);
   libradosstriper::MultiAioCompletionImplPtr multi_completion{
     new libradosstriper::MultiAioCompletionImpl, false};
-  multi_completion->set_complete_callback(cdata, striper_truncate_aio_req_complete);
+  multi_completion->set_complete_callback(cdata->get() /* create ref! */, striper_truncate_aio_req_complete);
   // call asynchrous version of truncate
   int rc = aio_truncate(soid, multi_completion, original_size, size, layout);
   // wait for completion of the truncation
@@ -1573,10 +1562,9 @@ int libradosstriper::RadosStriperImpl::aio_truncate
     if (exists) {
       // remove asynchronously
       multi_completion->add_request();
-      RadosRemoveCompletionData *data =
-	new RadosRemoveCompletionData(multi_completion, cct());
+      auto data = ceph::make_ref<RadosRemoveCompletionData>(multi_completion, cct());
       librados::AioCompletion *rados_completion =
-	librados::Rados::aio_create_completion(data,
+	librados::Rados::aio_create_completion(data->get() /* create ref! */,
 					       rados_req_remove_complete,
 					       rados_req_remove_safe);
       int rc = m_ioCtx.aio_remove(getObjectId(soid, objectno), rados_completion);
@@ -1608,10 +1596,9 @@ int libradosstriper::RadosStriperImpl::aio_truncate
       } else {
 	// removes are asynchronous in order to speed up truncations of big files
 	multi_completion->add_request();
-	RadosRemoveCompletionData *data =
-	  new RadosRemoveCompletionData(multi_completion, cct());
+	auto data = ceph::make_ref<RadosRemoveCompletionData>(multi_completion, cct());
 	librados::AioCompletion *rados_completion =
-	  librados::Rados::aio_create_completion(data,
+	  librados::Rados::aio_create_completion(data->get() /* create ref! */,
 						 rados_req_remove_complete,
 						 rados_req_remove_safe);
 	rc = m_ioCtx.aio_remove(getObjectId(soid, objectno), rados_completion);

--- a/src/librbd/DeepCopyRequest.cc
+++ b/src/librbd/DeepCopyRequest.cc
@@ -33,7 +33,7 @@ DeepCopyRequest<I>::DeepCopyRequest(I *src_image_ctx, I *dst_image_ctx,
                                     ContextWQ *work_queue, SnapSeqs *snap_seqs,
                                     ProgressContext *prog_ctx,
                                     Context *on_finish)
-  : RefCountedObject(dst_image_ctx->cct, 1), m_src_image_ctx(src_image_ctx),
+  : RefCountedObject(dst_image_ctx->cct), m_src_image_ctx(src_image_ctx),
     m_dst_image_ctx(dst_image_ctx), m_snap_id_start(snap_id_start),
     m_snap_id_end(snap_id_end), m_flatten(flatten),
     m_object_number(object_number), m_work_queue(work_queue),

--- a/src/librbd/DeepCopyRequest.cc
+++ b/src/librbd/DeepCopyRequest.cc
@@ -226,7 +226,7 @@ void DeepCopyRequest<I>::send_copy_object_map() {
   }
 
   // rollback the object map (copy snapshot object map to HEAD)
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_copy_object_map(r);
       finish_op_ctx->complete(0);
     });
@@ -269,7 +269,7 @@ void DeepCopyRequest<I>::send_refresh_object_map() {
 
   ldout(m_cct, 20) << dendl;
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_refresh_object_map(r);
       finish_op_ctx->complete(0);
     });

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -147,7 +147,7 @@ Context *ExclusiveLock<I>::start_op(int* ret_val) {
   }
 
   m_async_op_tracker.start_op();
-  return new FunctionContext([this](int r) {
+  return new LambdaContext([this](int r) {
       m_async_op_tracker.finish_op();
     });
 }
@@ -202,7 +202,7 @@ void ExclusiveLock<I>::pre_acquire_lock_handler(Context *on_finish) {
 
   PreAcquireRequest<I> *req = PreAcquireRequest<I>::create(m_image_ctx,
                                                            on_finish);
-  m_image_ctx.op_work_queue->queue(new FunctionContext([req](int r) {
+  m_image_ctx.op_work_queue->queue(new LambdaContext([req](int r) {
     req->send();
   }));
 }
@@ -252,7 +252,7 @@ void ExclusiveLock<I>::post_acquire_lock_handler(int r, Context *on_finish) {
       util::create_context_callback<EL, &EL::handle_post_acquiring_lock>(this),
       util::create_context_callback<EL, &EL::handle_post_acquired_lock>(this));
 
-  m_image_ctx.op_work_queue->queue(new FunctionContext([req](int r) {
+  m_image_ctx.op_work_queue->queue(new LambdaContext([req](int r) {
     req->send();
   }));
 }
@@ -301,7 +301,7 @@ void ExclusiveLock<I>::pre_release_lock_handler(bool shutting_down,
 
   PreReleaseRequest<I> *req = PreReleaseRequest<I>::create(
     m_image_ctx, shutting_down, m_async_op_tracker, on_finish);
-  m_image_ctx.op_work_queue->queue(new FunctionContext([req](int r) {
+  m_image_ctx.op_work_queue->queue(new LambdaContext([req](int r) {
     req->send();
   }));
 }

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -44,7 +44,7 @@ public:
     {
       std::lock_guard locker{m_lock};
       if (!m_in_flight.empty()) {
-	Context *ctx = new FunctionContext(
+	Context *ctx = new LambdaContext(
 	  [this, on_finish](int r) {
 	    ldout(m_cct, 20) << "ImageUpdateWatchers::" << __func__
 	                     << ": completing flush" << dendl;
@@ -130,7 +130,7 @@ public:
 
     m_in_flight.insert(handle);
 
-    Context *ctx = new FunctionContext(
+    Context *ctx = new LambdaContext(
       [this, handle, watcher](int r) {
 	handle_notify(handle, watcher);
       });

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -310,7 +310,7 @@ private:
     MetadataListener(Journal<ImageCtxT> *journal) : journal(journal) { }
 
     void handle_update(::journal::JournalMetadata *) override {
-      FunctionContext *ctx = new FunctionContext([this](int r) {
+      auto ctx = new LambdaContext([this](int r) {
         journal->handle_metadata_updated();
       });
       journal->m_work_queue->queue(ctx, 0);

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -254,13 +254,6 @@ private:
     ReplayHandler(Journal *_journal) : journal(_journal) {
     }
 
-    void get() override {
-      // TODO
-    }
-    void put() override {
-      // TODO
-    }
-
     void handle_entries_available() override {
       journal->handle_replay_ready();
     }

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -273,7 +273,7 @@ void ObjectMap<I>::detained_aio_update(UpdateOperation &&op) {
 
   ldout(cct, 20) << "in-flight update cell: " << cell << dendl;
   Context *on_finish = op.on_finish;
-  Context *ctx = new FunctionContext([this, cell, on_finish](int r) {
+  Context *ctx = new LambdaContext([this, cell, on_finish](int r) {
       handle_detained_aio_update(cell, r, on_finish);
     });
   aio_update(CEPH_NOSNAP, op.start_object_no, op.end_object_no, op.new_state,

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -588,13 +588,13 @@ void Operations<I>::execute_rename(const std::string &dest_name,
   if (m_image_ctx.old_format) {
     // unregister watch before and register back after rename
     on_finish = new C_NotifyUpdate<I>(m_image_ctx, on_finish);
-    on_finish = new FunctionContext([this, on_finish](int r) {
+    on_finish = new LambdaContext([this, on_finish](int r) {
         if (m_image_ctx.old_format) {
           m_image_ctx.image_watcher->set_oid(m_image_ctx.header_oid);
         }
 	m_image_ctx.image_watcher->register_watch(on_finish);
       });
-    on_finish = new FunctionContext([this, dest_name, on_finish](int r) {
+    on_finish = new LambdaContext([this, dest_name, on_finish](int r) {
         std::shared_lock owner_locker{m_image_ctx.owner_lock};
 	operation::RenameRequest<I> *req = new operation::RenameRequest<I>(
 	  m_image_ctx, on_finish, dest_name);

--- a/src/librbd/Watcher.cc
+++ b/src/librbd/Watcher.cc
@@ -162,7 +162,7 @@ void Watcher::unregister_watch(Context *on_finish) {
                        << dendl;
 
       ceph_assert(m_unregister_watch_ctx == nullptr);
-      m_unregister_watch_ctx = new FunctionContext([this, on_finish](int r) {
+      m_unregister_watch_ctx = new LambdaContext([this, on_finish](int r) {
           unregister_watch(on_finish);
         });
       return;
@@ -234,7 +234,7 @@ void Watcher::handle_error(uint64_t handle, int err) {
       m_watch_blacklisted = true;
     }
 
-    FunctionContext *ctx = new FunctionContext(
+    auto ctx = new LambdaContext(
         boost::bind(&Watcher::rewatch, this));
     m_work_queue->queue(ctx);
   }

--- a/src/librbd/cache/ObjectCacherObjectDispatch.cc
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.cc
@@ -162,7 +162,7 @@ void ObjectCacherObjectDispatch<I>::shut_down(Context* on_finish) {
   // chain shut down in reverse order
 
   // shut down the cache
-  on_finish = new FunctionContext([this, on_finish](int r) {
+  on_finish = new LambdaContext([this, on_finish](int r) {
       m_object_cacher->stop();
       on_finish->complete(r);
     });
@@ -235,7 +235,7 @@ bool ObjectCacherObjectDispatch<I>::discard(
   // discard the cache state after changes are committed to disk (and to
   // prevent races w/ readahead)
   auto ctx = *on_finish;
-  *on_finish = new FunctionContext(
+  *on_finish = new LambdaContext(
     [this, object_extents, ctx](int r) {
       m_cache_lock.lock();
       m_object_cacher->discard_set(m_object_set, object_extents);

--- a/src/librbd/cache/ParentCacheObjectDispatch.cc
+++ b/src/librbd/cache/ParentCacheObjectDispatch.cc
@@ -50,7 +50,7 @@ void ParentCacheObjectDispatch<I>::init(Context* on_finish) {
     return;
   }
 
-  Context* create_session_ctx = new FunctionContext([this, on_finish](int ret) {
+  Context* create_session_ctx = new LambdaContext([this, on_finish](int ret) {
     m_connecting.store(false);
     if (on_finish != nullptr) {
       on_finish->complete(ret);
@@ -90,7 +90,7 @@ bool ParentCacheObjectDispatch<I>::read(
        * So, we need to check if session is normal again. If session work,
        * we need set m_connecting to false. */
       if (!m_cache_client->is_session_work()) {
-        Context* on_finish = new FunctionContext([this](int ret) {
+        Context* on_finish = new LambdaContext([this](int ret) {
           m_connecting.store(false);
         });
         create_cache_session(on_finish, true);
@@ -167,7 +167,7 @@ int ParentCacheObjectDispatch<I>::create_cache_session(Context* on_finish, bool 
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << dendl;
 
-  Context* register_ctx = new FunctionContext([this, cct, on_finish](int ret) {
+  Context* register_ctx = new LambdaContext([this, cct, on_finish](int ret) {
     if (ret < 0) {
       lderr(cct) << "Parent cache fail to register client." << dendl;
     } else {
@@ -177,7 +177,7 @@ int ParentCacheObjectDispatch<I>::create_cache_session(Context* on_finish, bool 
     on_finish->complete(ret);
   });
 
-  Context* connect_ctx = new FunctionContext(
+  Context* connect_ctx = new LambdaContext(
     [this, cct, register_ctx](int ret) {
     if (ret < 0) {
       lderr(cct) << "Parent cache fail to connect RO daeomn." << dendl;

--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -150,7 +150,7 @@ bool WriteAroundObjectDispatch<I>::flush(
   auto ctx = util::create_async_context_callback(*m_image_ctx, *on_finish);
 
   *dispatch_result = io::DISPATCH_RESULT_CONTINUE;
-  *on_finish = new FunctionContext([this, tid](int r) {
+  *on_finish = new LambdaContext([this, tid](int r) {
       handle_in_flight_flush_complete(r, tid);
     });
 
@@ -219,7 +219,7 @@ bool WriteAroundObjectDispatch<I>::dispatch_io(
   auto ctx = util::create_async_context_callback(*m_image_ctx, *on_finish);
 
   *dispatch_result = io::DISPATCH_RESULT_CONTINUE;
-  *on_finish = new FunctionContext(
+  *on_finish = new LambdaContext(
     [this, tid, object_no, object_off, object_len](int r) {
       handle_in_flight_io_complete(r, tid, object_no, object_off, object_len);
     });

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -30,7 +30,7 @@ ImageCopyRequest<I>::ImageCopyRequest(I *src_image_ctx, I *dst_image_ctx,
                                       const SnapSeqs &snap_seqs,
                                       ProgressContext *prog_ctx,
                                       Context *on_finish)
-  : RefCountedObject(dst_image_ctx->cct, 1), m_src_image_ctx(src_image_ctx),
+  : RefCountedObject(dst_image_ctx->cct), m_src_image_ctx(src_image_ctx),
     m_dst_image_ctx(dst_image_ctx), m_snap_id_start(snap_id_start),
     m_snap_id_end(snap_id_end), m_flatten(flatten),
     m_object_number(object_number), m_snap_seqs(snap_seqs),

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -117,7 +117,7 @@ void ImageCopyRequest<I>::send_next_object_copy() {
 
   ++m_current_ops;
 
-  Context *ctx = new FunctionContext(
+  Context *ctx = new LambdaContext(
     [this, ono](int r) {
       handle_object_copy(ono, r);
     });

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -391,7 +391,7 @@ void ObjectCopyRequest<I>::send_write_object() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_write_object(r);
       finish_op_ctx->complete(0);
     });
@@ -468,7 +468,7 @@ void ObjectCopyRequest<I>::send_update_object_map() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_update_object_map(r);
       finish_op_ctx->complete(0);
     });
@@ -509,7 +509,7 @@ Context *ObjectCopyRequest<I>::start_lock_op(ceph::shared_mutex &owner_lock,
 					     int* r) {
   ceph_assert(ceph_mutex_is_locked(m_dst_image_ctx->owner_lock));
   if (m_dst_image_ctx->exclusive_lock == nullptr) {
-    return new FunctionContext([](int r) {});
+    return new LambdaContext([](int r) {});
   }
   return m_dst_image_ctx->exclusive_lock->start_op(r);
 }

--- a/src/librbd/deep_copy/SetHeadRequest.cc
+++ b/src/librbd/deep_copy/SetHeadRequest.cc
@@ -65,7 +65,7 @@ void SetHeadRequest<I>::send_set_size() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_set_size(r);
       finish_op_ctx->complete(0);
     });
@@ -122,7 +122,7 @@ void SetHeadRequest<I>::send_detach_parent() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_detach_parent(r);
       finish_op_ctx->complete(0);
     });
@@ -171,7 +171,7 @@ void SetHeadRequest<I>::send_attach_parent() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_attach_parent(r);
       finish_op_ctx->complete(0);
     });
@@ -204,7 +204,7 @@ template <typename I>
 Context *SetHeadRequest<I>::start_lock_op(int* r) {
   std::shared_lock owner_locker{m_image_ctx->owner_lock};
   if (m_image_ctx->exclusive_lock == nullptr) {
-    return new FunctionContext([](int r) {});
+    return new LambdaContext([](int r) {});
   }
   return m_image_ctx->exclusive_lock->start_op(r);
 }

--- a/src/librbd/deep_copy/SnapshotCopyRequest.cc
+++ b/src/librbd/deep_copy/SnapshotCopyRequest.cc
@@ -49,7 +49,7 @@ SnapshotCopyRequest<I>::SnapshotCopyRequest(I *src_image_ctx,
                                             bool flatten, ContextWQ *work_queue,
                                             SnapSeqs *snap_seqs,
                                             Context *on_finish)
-  : RefCountedObject(dst_image_ctx->cct, 1), m_src_image_ctx(src_image_ctx),
+  : RefCountedObject(dst_image_ctx->cct), m_src_image_ctx(src_image_ctx),
     m_dst_image_ctx(dst_image_ctx), m_snap_id_end(snap_id_end),
     m_flatten(flatten), m_work_queue(work_queue), m_snap_seqs_result(snap_seqs),
     m_snap_seqs(*snap_seqs), m_on_finish(on_finish), m_cct(dst_image_ctx->cct),

--- a/src/librbd/deep_copy/SnapshotCopyRequest.cc
+++ b/src/librbd/deep_copy/SnapshotCopyRequest.cc
@@ -182,7 +182,7 @@ void SnapshotCopyRequest<I>::send_snap_unprotect() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_snap_unprotect(r);
       finish_op_ctx->complete(0);
     });
@@ -279,7 +279,7 @@ void SnapshotCopyRequest<I>::send_snap_remove() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_snap_remove(r);
       finish_op_ctx->complete(0);
     });
@@ -380,7 +380,7 @@ void SnapshotCopyRequest<I>::send_snap_create() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_snap_create(r);
       finish_op_ctx->complete(0);
     });
@@ -488,7 +488,7 @@ void SnapshotCopyRequest<I>::send_snap_protect() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_snap_protect(r);
       finish_op_ctx->complete(0);
     });
@@ -577,7 +577,7 @@ void SnapshotCopyRequest<I>::send_resize_object_map() {
 
       auto finish_op_ctx = start_lock_op(m_dst_image_ctx->owner_lock, &r);
       if (finish_op_ctx != nullptr) {
-        auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+        auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
             handle_resize_object_map(r);
             finish_op_ctx->complete(0);
           });
@@ -625,7 +625,7 @@ template <typename I>
 void SnapshotCopyRequest<I>::error(int r) {
   ldout(m_cct, 20) << "r=" << r << dendl;
 
-  m_work_queue->queue(new FunctionContext([this, r](int r1) { finish(r); }));
+  m_work_queue->queue(new LambdaContext([this, r](int r1) { finish(r); }));
 }
 
 template <typename I>
@@ -662,7 +662,7 @@ template <typename I>
 Context *SnapshotCopyRequest<I>::start_lock_op(ceph::shared_mutex &owner_lock, int* r) {
   ceph_assert(ceph_mutex_is_locked(m_dst_image_ctx->owner_lock));
   if (m_dst_image_ctx->exclusive_lock == nullptr) {
-    return new FunctionContext([](int r) {});
+    return new LambdaContext([](int r) {});
   }
   return m_dst_image_ctx->exclusive_lock->start_op(r);
 }

--- a/src/librbd/deep_copy/SnapshotCreateRequest.cc
+++ b/src/librbd/deep_copy/SnapshotCreateRequest.cc
@@ -76,7 +76,7 @@ void SnapshotCreateRequest<I>::send_create_snap() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_create_snap(r);
       finish_op_ctx->complete(0);
     });
@@ -140,7 +140,7 @@ void SnapshotCreateRequest<I>::send_create_object_map() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_create_object_map(r);
       finish_op_ctx->complete(0);
     });
@@ -168,7 +168,7 @@ template <typename I>
 Context *SnapshotCreateRequest<I>::start_lock_op(int* r) {
   std::shared_lock owner_locker{m_dst_image_ctx->owner_lock};
   if (m_dst_image_ctx->exclusive_lock == nullptr) {
-    return new FunctionContext([](int r) {});
+    return new LambdaContext([](int r) {});
   }
   return m_dst_image_ctx->exclusive_lock->start_op(r);
 }

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -418,7 +418,7 @@ template<typename I>
 void RemoveRequest<I>::remove_v1_image() {
   ldout(m_cct, 20) << dendl;
 
-  Context *ctx = new FunctionContext([this] (int r) {
+  Context *ctx = new LambdaContext([this] (int r) {
       r = tmap_rm(m_ioctx, m_image_name);
       handle_remove_v1_image(r);
     });

--- a/src/librbd/image/ValidatePoolRequest.cc
+++ b/src/librbd/image/ValidatePoolRequest.cc
@@ -97,7 +97,7 @@ void ValidatePoolRequest<I>::create_snapshot() {
 
   // allocate a self-managed snapshot id if this a new pool to force
   // self-managed snapshot mode
-  auto ctx = new FunctionContext([this](int r) {
+  auto ctx = new LambdaContext([this](int r) {
       r = m_io_ctx.selfmanaged_snap_create(&m_snap_id);
       handle_create_snapshot(r);
     });
@@ -161,7 +161,7 @@ template <typename I>
 void ValidatePoolRequest<I>::remove_snapshot() {
   ldout(m_cct, 5) << dendl;
 
-  auto ctx = new FunctionContext([this](int r) {
+  auto ctx = new LambdaContext([this](int r) {
       r = m_io_ctx.selfmanaged_snap_remove(m_snap_id);
       handle_remove_snapshot(r);
     });

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1420,7 +1420,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       }
 
       auto *throttle = m_throttle;
-      auto *end_op_ctx = new FunctionContext([throttle](int r) {
+      auto *end_op_ctx = new LambdaContext([throttle](int r) {
 	throttle->end_op(r);
       });
       auto gather_ctx = new C_Gather(m_dest->cct, end_op_ctx);

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -692,7 +692,7 @@ void ImageFlushRequest<I>::send_request() {
   auto object_dispatch_spec = ObjectDispatchSpec::create_flush(
     &image_ctx, OBJECT_DISPATCH_LAYER_NONE, m_flush_source, journal_tid,
     this->m_trace, ctx);
-  ctx = new FunctionContext([object_dispatch_spec](int r) {
+  ctx = new LambdaContext([object_dispatch_spec](int r) {
       object_dispatch_spec->send();
     });
 

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -249,17 +249,17 @@ void ObjectDispatcher<I>::shut_down_object_dispatch(
   auto async_op_tracker = object_dispatch_meta.async_op_tracker;
 
   Context* ctx = *on_finish;
-  ctx = new FunctionContext(
+  ctx = new LambdaContext(
     [object_dispatch, async_op_tracker, ctx](int r) {
       delete object_dispatch;
       delete async_op_tracker;
 
       ctx->complete(r);
     });
-  ctx = new FunctionContext([object_dispatch, ctx](int r) {
+  ctx = new LambdaContext([object_dispatch, ctx](int r) {
       object_dispatch->shut_down(ctx);
     });
-  *on_finish = new FunctionContext([async_op_tracker, ctx](int r) {
+  *on_finish = new LambdaContext([async_op_tracker, ctx](int r) {
       async_op_tracker->wait_for_ops(ctx);
     });
 }

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -200,7 +200,7 @@ void ObjectReadRequest<I>::read_object() {
     std::shared_lock image_locker{image_ctx->image_lock};
     if (image_ctx->object_map != nullptr &&
         !image_ctx->object_map->object_may_exist(this->m_object_no)) {
-      image_ctx->op_work_queue->queue(new FunctionContext([this](int r) {
+      image_ctx->op_work_queue->queue(new LambdaContext([this](int r) {
           read_parent();
         }), 0);
       return;

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -145,7 +145,7 @@ void SimpleSchedulerObjectDispatch<I>::ObjectRequests::dispatch_delayed_requests
     auto offset = it.first;
     auto &merged_requests = it.second;
 
-    auto ctx = new FunctionContext(
+    auto ctx = new LambdaContext(
         [requests=std::move(merged_requests.requests), latency_stats,
          latency_stats_lock, start_time=ceph_clock_now()](int r) {
           if (latency_stats) {
@@ -404,7 +404,7 @@ void SimpleSchedulerObjectDispatch<I>::register_in_flight_request(
 
   auto dispatch_seq = ++m_dispatch_seq;
   it->second->set_dispatch_seq(dispatch_seq);
-  *on_finish = new FunctionContext(
+  *on_finish = new LambdaContext(
     [this, object_no, dispatch_seq, start_time, ctx=*on_finish](int r) {
       ctx->complete(r);
 
@@ -498,7 +498,7 @@ void SimpleSchedulerObjectDispatch<I>::schedule_dispatch_delayed_requests() {
     object_requests = m_dispatch_queue.front().get();
   }
 
-  m_timer_task = new FunctionContext(
+  m_timer_task = new LambdaContext(
     [this, object_no=object_requests->get_object_no()](int r) {
       ceph_assert(ceph_mutex_is_locked(*m_timer_lock));
       auto cct = m_image_ctx->cct;
@@ -506,7 +506,7 @@ void SimpleSchedulerObjectDispatch<I>::schedule_dispatch_delayed_requests() {
 
       m_timer_task = nullptr;
       m_image_ctx->op_work_queue->queue(
-          new FunctionContext(
+          new LambdaContext(
             [this, object_no](int r) {
 	      std::lock_guard locker{m_lock};
               dispatch_delayed_requests(object_no);

--- a/src/librbd/journal/ObjectDispatch.cc
+++ b/src/librbd/journal/ObjectDispatch.cc
@@ -194,7 +194,7 @@ bool ObjectDispatch<I>::flush(
   ldout(cct, 20) << dendl;
 
   auto ctx = *on_finish;
-  *on_finish = new FunctionContext(
+  *on_finish = new LambdaContext(
     [image_ctx=m_image_ctx, ctx, journal_tid=*journal_tid](int r) {
       image_ctx->journal->commit_io_event(journal_tid, r);
       ctx->complete(r);

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -324,7 +324,7 @@ void Replay<I>::replay_op_ready(uint64_t op_tid, Context *on_resume) {
 
   // resume the op state machine once the associated OpFinishEvent
   // is processed
-  op_event.on_op_finish_event = new FunctionContext(
+  op_event.on_op_finish_event = new LambdaContext(
     [on_resume](int r) {
       on_resume->complete(r);
     });

--- a/src/librbd/mirror/DisableRequest.cc
+++ b/src/librbd/mirror/DisableRequest.cc
@@ -313,7 +313,7 @@ void DisableRequest<I>::send_remove_snap(const std::string &client_id,
   Context *ctx = create_context_callback(
     &DisableRequest<I>::handle_remove_snap, client_id);
 
-  ctx = new FunctionContext([this, snap_namespace, snap_name, ctx](int r) {
+  ctx = new LambdaContext([this, snap_namespace, snap_name, ctx](int r) {
       m_image_ctx->operations->snap_remove(snap_namespace,
                                            snap_name.c_str(),
                                            ctx);
@@ -477,7 +477,7 @@ Context *DisableRequest<I>::create_context_callback(
   Context*(DisableRequest<I>::*handle)(int*, const std::string &client_id),
   const std::string &client_id) {
 
-  return new FunctionContext([this, handle, client_id](int r) {
+  return new LambdaContext([this, handle, client_id](int r) {
       Context *on_finish = (this->*handle)(&r, client_id);
       if (on_finish != nullptr) {
         on_finish->complete(r);

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -548,13 +548,13 @@ void MDBalancer::queue_split(const CDir *dir, bool fast)
     // Do the split ASAP: enqueue it in the MDSRank waiters which are
     // run at the end of dispatching the current request
     mds->queue_waiter(new MDSInternalContextWrapper(mds, 
-          new FunctionContext(callback)));
+          new LambdaContext(std::move(callback))));
   } else if (is_new) {
     // Set a timer to really do the split: we don't do it immediately
     // so that bursts of ops on a directory have a chance to go through
     // before we freeze it.
     mds->timer.add_event_after(bal_fragment_interval,
-                               new FunctionContext(callback));
+                               new LambdaContext(std::move(callback)));
   }
 }
 
@@ -616,7 +616,7 @@ void MDBalancer::queue_merge(CDir *dir)
     dout(20) << __func__ << " enqueued dir " << *dir << dendl;
     merge_pending.insert(frag);
     mds->timer.add_event_after(bal_fragment_interval,
-        new FunctionContext(callback));
+        new LambdaContext(std::move(callback)));
   } else {
     dout(20) << __func__ << " dir already in queue " << *dir << dendl;
   }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -620,7 +620,7 @@ void MDCache::open_mydir_frag(MDSContext *c)
 {
   open_mydir_inode(
       new MDSInternalContextWrapper(mds,
-	new FunctionContext([this, c](int r) {
+	new LambdaContext([this, c](int r) {
 	    if (r < 0) {
 	      c->complete(r);
 	      return;
@@ -2671,7 +2671,7 @@ void MDCache::send_resolves()
     // I'm survivor: refresh snap cache
     mds->snapclient->sync(
 	new MDSInternalContextWrapper(mds,
-	  new FunctionContext([this](int r) {
+	  new LambdaContext([this](int r) {
 	    maybe_finish_slave_resolve();
 	    })
 	  )
@@ -5327,7 +5327,7 @@ bool MDCache::process_imported_caps()
       open_file_table.prefetch_inodes()) {
     open_file_table.wait_for_prefetch(
 	new MDSInternalContextWrapper(mds,
-	  new FunctionContext([this](int r) {
+	  new LambdaContext([this](int r) {
 	    ceph_assert(rejoin_gather.count(mds->get_nodeid()));
 	    process_imported_caps();
 	    })
@@ -5928,7 +5928,7 @@ bool MDCache::open_undef_inodes_dirfrags()
 
   MDSGatherBuilder gather(g_ceph_context,
       new MDSInternalContextWrapper(mds,
-	new FunctionContext([this](int r) {
+	new LambdaContext([this](int r) {
 	    if (rejoin_gather.empty())
 	      rejoin_gather_finish();
 	  })
@@ -7904,7 +7904,7 @@ again:
 	MDSContext *fin = nullptr;
 	if (shutdown_exporting_strays.empty()) {
 	  fin = new MDSInternalContextWrapper(mds,
-		  new FunctionContext([this](int r) {
+		  new LambdaContext([this](int r) {
 		    shutdown_export_strays();
 		  })
 		);
@@ -12573,7 +12573,7 @@ void MDCache::enqueue_scrub_work(MDRequestRef& mdr)
   if (header->get_recursive()) {
     header->get_origin()->get(CInode::PIN_SCRUBQUEUE);
     fin = new MDSInternalContextWrapper(mds,
-	    new FunctionContext([this, header](int r) {
+	    new LambdaContext([this, header](int r) {
 	      recursive_scrub_finish(header);
 	      header->get_origin()->put(CInode::PIN_SCRUBQUEUE);
 	    })
@@ -12585,14 +12585,14 @@ void MDCache::enqueue_scrub_work(MDRequestRef& mdr)
   // If the scrub did some repair, then flush the journal at the end of
   // the scrub.  Otherwise in the case of e.g. rewriting a backtrace
   // the on disk state will still look damaged.
-  auto scrub_finish = new FunctionContext([this, header, fin](int r){
+  auto scrub_finish = new LambdaContext([this, header, fin](int r){
     if (!header->get_repaired()) {
       if (fin)
         fin->complete(r);
       return;
     }
 
-    auto flush_finish = new FunctionContext([this, fin](int r){
+    auto flush_finish = new LambdaContext([this, fin](int r){
       dout(4) << "Expiring log segments because scrub did some repairs" << dendl;
       mds->mdlog->trim_all();
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -459,7 +459,7 @@ void MDSDaemon::reset_tick()
   // schedule
   tick_event = timer.add_event_after(
     g_conf()->mds_tick_interval,
-    new FunctionContext([this](int) {
+    new LambdaContext([this](int) {
 	ceph_assert(ceph_mutex_is_locked_by_me(mds_lock));
 	tick();
       }));
@@ -872,8 +872,8 @@ void MDSDaemon::handle_mds_map(const cref_t<MMDSMap> &m)
     if (mds_rank == NULL) {
       mds_rank = new MDSRankDispatcher(whoami, mds_lock, clog,
           timer, beacon, mdsmap, messenger, monc, &mgrc,
-          new FunctionContext([this](int r){respawn();}),
-          new FunctionContext([this](int r){suicide();}));
+          new LambdaContext([this](int r){respawn();}),
+          new LambdaContext([this](int r){suicide();}));
       dout(10) <<  __func__ << ": initializing MDS rank "
                << mds_rank->get_nodeid() << dendl;
       mds_rank->init();

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -1074,7 +1074,7 @@ void OpenFileTable::_prefetch_dirfrags()
   if (gather.has_subs()) {
     gather.set_finisher(
 	new MDSInternalContextWrapper(mds,
-	  new FunctionContext(finish_func)));
+	  new LambdaContext(std::move(finish_func))));
     gather.activate();
   } else {
     finish_func(0);
@@ -1144,7 +1144,7 @@ bool OpenFileTable::prefetch_inodes()
   if (!load_done) {
     wait_for_load(
 	new MDSInternalContextWrapper(mds,
-	  new FunctionContext([this](int r) {
+	  new LambdaContext([this](int r) {
 	    _prefetch_inodes();
 	    })
 	  )

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -420,7 +420,7 @@ void Server::finish_reclaim_session(Session *session, const ref_t<MClientReclaim
     Context *send_reply;
     if (reply) {
       int64_t session_id = session->get_client().v;
-      send_reply = new FunctionContext([this, session_id, reply](int r) {
+      send_reply = new LambdaContext([this, session_id, reply](int r) {
 	    assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
 	    Session *session = mds->sessionmap.get_session(entity_name_t::CLIENT(session_id));
 	    if (!session) {
@@ -632,7 +632,7 @@ void Server::handle_client_session(const cref_t<MClientSession> &m)
       pv = mds->sessionmap.mark_projected(session);
       sseq = mds->sessionmap.set_state(session, Session::STATE_OPENING);
       mds->sessionmap.touch_session(session);
-      auto fin = new FunctionContext([log_session_status = std::move(log_session_status)](int r){
+      auto fin = new LambdaContext([log_session_status = std::move(log_session_status)](int r){
         ceph_assert(r == 0);
         log_session_status("ACCEPTED", "");
       });
@@ -1577,7 +1577,7 @@ void Server::reconnect_tick()
 
   if (gather.has_subs()) {
     dout(1) << "reconnect will complete once clients are evicted" << dendl;
-    gather.set_finisher(new MDSInternalContextWrapper(mds, new FunctionContext(
+    gather.set_finisher(new MDSInternalContextWrapper(mds, new LambdaContext(
 	    [this](int r){reconnect_gather_finish();})));
     gather.activate();
     reconnect_evicting = true;

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -411,7 +411,7 @@ void ActivePyModules::start_one(PyModuleRef py_module)
 
   // Send all python calls down a Finisher to avoid blocking
   // C++ code, and avoid any potential lock cycles.
-  finisher.queue(new FunctionContext([this, active_module, name](int) {
+  finisher.queue(new LambdaContext([this, active_module, name](int) {
     int r = active_module->load(this);
     if (r != 0) {
       derr << "Failed to run module in active mode ('" << name << "')"
@@ -467,7 +467,7 @@ void ActivePyModules::notify_all(const std::string &notify_type,
     auto module = i.second.get();
     // Send all python calls down a Finisher to avoid blocking
     // C++ code, and avoid any potential lock cycles.
-    finisher.queue(new FunctionContext([module, notify_type, notify_id](int r){
+    finisher.queue(new LambdaContext([module, notify_type, notify_id](int r){
       module->notify(notify_type, notify_id);
     }));
   }
@@ -486,7 +486,7 @@ void ActivePyModules::notify_all(const LogEntry &log_entry)
     // Note intentional use of non-reference lambda binding on
     // log_entry: we take a copy because caller's instance is
     // probably ephemeral.
-    finisher.queue(new FunctionContext([module, log_entry](int r){
+    finisher.queue(new LambdaContext([module, log_entry](int r){
       module->notify_clog(log_entry);
     }));
   }
@@ -981,7 +981,7 @@ void ActivePyModules::config_notify()
     auto module = i.second.get();
     // Send all python calls down a Finisher to avoid blocking
     // C++ code, and avoid any potential lock cycles.
-    finisher.queue(new FunctionContext([module](int r){
+    finisher.queue(new LambdaContext([module](int r){
 					 module->config_notify();
 				       }));
   }

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -152,9 +152,9 @@ ceph_send_command(BaseMgrModule *self, PyObject *args)
     // TODO: enhance MCommand interface so that it returns
     // latest cluster map versions on completion, and callers
     // can wait for those.
-    auto c = new FunctionContext([command_c, self](int command_r){
+    auto c = new LambdaContext([command_c, self](int command_r){
       self->py_modules->get_objecter().wait_for_latest_osdmap(
-          new FunctionContext([command_c, command_r](int wait_r){
+          new LambdaContext([command_c, command_r](int wait_r){
             command_c->complete(command_r);
           })
       );

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -331,7 +331,7 @@ void DaemonServer::schedule_tick_locked(double delay_sec)
     return;
 
   tick_event = timer.add_event_after(delay_sec,
-    new FunctionContext([this](int r) {
+    new LambdaContext([this](int r) {
       tick();
   }));
 }
@@ -348,7 +348,7 @@ void DaemonServer::handle_osd_perf_metric_query_updated()
 
   // Send a fresh MMgrConfigure to all clients, so that they can follow
   // the new policy for transmitting stats
-  finisher.queue(new FunctionContext([this](int r) {
+  finisher.queue(new LambdaContext([this](int r) {
         std::lock_guard l(lock);
         for (auto &c : daemon_connections) {
           if (c->peer_is_osd()) {
@@ -2245,7 +2245,7 @@ bool DaemonServer::_handle_command(
   }
 
   dout(10) << "passing through " << cmdctx->cmdmap.size() << dendl;
-  finisher.queue(new FunctionContext([this, cmdctx, handler_name, prefix](int r_) {
+  finisher.queue(new LambdaContext([this, cmdctx, handler_name, prefix](int r_) {
     std::stringstream ss;
 
     // Validate that the module is enabled
@@ -2810,7 +2810,7 @@ void DaemonServer::handle_conf_change(const ConfigProxy& conf,
             << daemon_connections.size() << " clients" << dendl;
     // Send a fresh MMgrConfigure to all clients, so that they can follow
     // the new policy for transmitting stats
-    finisher.queue(new FunctionContext([this](int r) {
+    finisher.queue(new LambdaContext([this](int r) {
       std::lock_guard l(lock);
       for (auto &c : daemon_connections) {
         _send_configure(c);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -168,7 +168,7 @@ entity_addrvec_t DaemonServer::get_myaddrs() const
 
 int DaemonServer::ms_handle_authentication(Connection *con)
 {
-  MgrSession *s = new MgrSession(cct);
+  auto s = ceph::make_ref<MgrSession>(cct);
   con->set_priv(s);
   s->inst.addr = con->get_peer_addr();
   s->entity_name = con->peer_name;

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -158,7 +158,7 @@ void Mgr::background_init(Context *completion)
 
   finisher.start();
 
-  finisher.queue(new FunctionContext([this, completion](int r){
+  finisher.queue(new LambdaContext([this, completion](int r){
     init();
     completion->complete(0);
   }));
@@ -400,7 +400,7 @@ void Mgr::load_all_metadata()
 
 void Mgr::shutdown()
 {
-  finisher.queue(new FunctionContext([&](int) {
+  finisher.queue(new LambdaContext([&](int) {
     {
       std::lock_guard l(lock);
       // First stop the server so that we're not taking any more incoming

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -150,7 +150,7 @@ void MgrClient::reconnect()
       if (!connect_retry_callback) {
 	connect_retry_callback = timer.add_event_at(
 	  when,
-	  new FunctionContext([this](int r){
+	  new LambdaContext([this](int r){
 	      connect_retry_callback = nullptr;
 	      reconnect();
 	    }));
@@ -258,7 +258,7 @@ void MgrClient::_send_stats()
   if (stats_period != 0) {
     report_callback = timer.add_event_after(
       stats_period,
-      new FunctionContext([this](int) {
+      new LambdaContext([this](int) {
 	  _send_stats();
 	}));
   }

--- a/src/mgr/MgrSession.h
+++ b/src/mgr/MgrSession.h
@@ -25,15 +25,17 @@ struct MgrSession : public RefCountedObject {
 
   std::set<std::string> declared_types;
 
-  explicit MgrSession(CephContext *cct) : RefCountedObject(cct, 0) {}
-  ~MgrSession() override {}
-
   const entity_addr_t& get_peer_addr() {
     return inst.addr;
   }
+
+private:
+  FRIEND_MAKE_REF(MgrSession);
+  explicit MgrSession(CephContext *cct) : RefCountedObject(cct) {}
+  ~MgrSession() override = default;
 };
 
-typedef boost::intrusive_ptr<MgrSession> MgrSessionRef;
+using MgrSessionRef = ceph::ref_t<MgrSession>;
 
 
 #endif

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -253,7 +253,7 @@ void MgrStandby::tick()
 
   timer.add_event_after(
       g_conf().get_val<std::chrono::seconds>("mgr_tick_period").count(),
-      new FunctionContext([this](int r){
+      new LambdaContext([this](int r){
           tick();
       }
   )); 
@@ -269,7 +269,7 @@ void MgrStandby::handle_signal(int signum)
 
 void MgrStandby::shutdown()
 {
-  finisher.queue(new FunctionContext([&](int) {
+  finisher.queue(new LambdaContext([&](int) {
     std::lock_guard l(lock);
 
     dout(4) << "Shutting down" << dendl;
@@ -395,7 +395,7 @@ void MgrStandby::handle_mgr_map(ref_t<MMgrMap> mmap)
       active_mgr.reset(new Mgr(&monc, map, &py_module_registry,
                                client_messenger.get(), &objecter,
 			       &client, clog, audit_clog));
-      active_mgr->background_init(new FunctionContext(
+      active_mgr->background_init(new LambdaContext(
             [this](int r){
               // Advertise our active-ness ASAP instead of waiting for
               // next tick.

--- a/src/mgr/StandbyPyModules.cc
+++ b/src/mgr/StandbyPyModules.cc
@@ -87,7 +87,7 @@ void StandbyPyModules::start_one(PyModuleRef py_module)
 
   // Send all python calls down a Finisher to avoid blocking
   // C++ code, and avoid any potential lock cycles.
-  finisher.queue(new FunctionContext([this, standby_module, name](int) {
+  finisher.queue(new LambdaContext([this, standby_module, name](int) {
     int r = standby_module->load();
     if (r != 0) {
       derr << "Failed to run module in standby mode ('" << name << "')"

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -151,9 +151,9 @@ void Elector::reset_timer(double plus)
    */
   expire_event = mon->timer.add_event_after(
     g_conf()->mon_election_timeout + plus,
-    new C_MonContext(mon, [this](int) {
+    new C_MonContext{mon, [this](int) {
 	logic.end_election_period();
-      }));
+      }});
 }
 
 

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -640,7 +640,7 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
        * know which FS it was part of. Nor does this matter. Sending an empty
        * MDSMap is sufficient for getting the MDS to respawn.
        */
-      wait_for_finished_proposal(op, new FunctionContext([op, this](int r){
+      wait_for_finished_proposal(op, new LambdaContext([op, this](int r){
         if (r >= 0) {
           const auto& fsmap = get_fsmap();
           MDSMap null_map;
@@ -778,7 +778,7 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
   dout(5) << "prepare_beacon pending map now:" << dendl;
   print_map(pending);
   
-  wait_for_finished_proposal(op, new FunctionContext([op, this](int r){
+  wait_for_finished_proposal(op, new LambdaContext([op, this](int r){
     if (r >= 0)
       _updated(op);   // success
     else if (r == -ECANCELED) {

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -291,9 +291,9 @@ void MgrMonitor::post_paxos_update()
         send_digests();
       } else {
         cancel_timer();
-        wait_for_active_ctx(new C_MonContext(mon, [this](int) {
+        wait_for_active_ctx(new C_MonContext{mon, [this](int) {
           send_digests();
-        }));
+        }});
       }
     }
   }
@@ -651,9 +651,9 @@ void MgrMonitor::send_digests()
 timer:
   digest_event = mon->timer.add_event_after(
     g_conf().get_val<int64_t>("mon_mgr_digest_period"),
-    new C_MonContext(mon, [this](int) {
+    new C_MonContext{mon, [this](int) {
       send_digests();
-  }));
+  }});
 }
 
 void MgrMonitor::cancel_timer()

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -415,7 +415,7 @@ void MonClient::handle_monmap(MMonMap *m)
 void MonClient::handle_config(MConfig *m)
 {
   ldout(cct,10) << __func__ << " " << *m << dendl;
-  finisher.queue(new FunctionContext([this, m](int r) {
+  finisher.queue(new LambdaContext([this, m](int r) {
 	cct->_conf.set_mon_vals(cct, m->config, config_cb);
 	if (config_notify_cb) {
 	  config_notify_cb();
@@ -895,7 +895,7 @@ void MonClient::_un_backoff()
 
 void MonClient::schedule_tick()
 {
-  auto do_tick = make_lambda_context([this]() { tick(); });
+  auto do_tick = make_lambda_context([this](int) { tick(); });
   if (_hunting()) {
     const auto hunt_interval = (cct->_conf->mon_client_hunt_interval *
 				reopen_interval_multiplier);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -120,14 +120,6 @@ MonCommand mon_commands[] = {
 #undef COMMAND
 #undef COMMAND_WITH_FLAG
 
-
-
-void C_MonContext::finish(int r) {
-  if (mon->is_shutdown())
-    return;
-  FunctionContext::finish(r);
-}
-
 Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
 		 Messenger *m, Messenger *mgr_m, MonMap *map) :
   Dispatcher(cct_),
@@ -549,18 +541,18 @@ void Monitor::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("mon_health_to_clog") ||
       changed.count("mon_health_to_clog_interval") ||
       changed.count("mon_health_to_clog_tick_interval")) {
-    finisher.queue(new C_MonContext(this, [this, changed](int) {
+    finisher.queue(new C_MonContext{this, [this, changed](int) {
       std::lock_guard l{lock};
       health_to_clog_update_conf(changed);
-    }));
+    }});
   }
 
   if (changed.count("mon_scrub_interval")) {
     int scrub_interval = conf->mon_scrub_interval;
-    finisher.queue(new C_MonContext(this, [this, scrub_interval](int) {
+    finisher.queue(new C_MonContext{this, [this, scrub_interval](int) {
       std::lock_guard l{lock};
       scrub_update_interval(scrub_interval);
-    }));
+    }});
   }
 }
 
@@ -1449,9 +1441,9 @@ void Monitor::sync_reset_timeout()
     timer.cancel_event(sync_timeout_event);
   sync_timeout_event = timer.add_event_after(
     g_conf()->mon_sync_timeout,
-    new C_MonContext(this, [this](int) {
+    new C_MonContext{this, [this](int) {
 	sync_timeout();
-      }));
+      }});
 }
 
 void Monitor::sync_finish(version_t last_committed)
@@ -1791,9 +1783,9 @@ void Monitor::cancel_probe_timeout()
 void Monitor::reset_probe_timeout()
 {
   cancel_probe_timeout();
-  probe_timeout_event = new C_MonContext(this, [this](int r) {
+  probe_timeout_event = new C_MonContext{this, [this](int r) {
       probe_timeout(r);
-    });
+    }};
   double t = g_conf()->mon_probe_timeout;
   if (timer.add_event_after(t, probe_timeout_event)) {
     dout(10) << "reset_probe_timeout " << probe_timeout_event
@@ -2202,16 +2194,16 @@ void Monitor::win_election(epoch_t epoch, const set<int>& active, uint64_t featu
 
     // Freshen the health status before doing health_to_clog in case
     // our just-completed election changed the health
-    healthmon()->wait_for_active_ctx(new FunctionContext([this](int r){
+    healthmon()->wait_for_active_ctx(new LambdaContext([this](int r){
       dout(20) << "healthmon now active" << dendl;
       healthmon()->tick();
       if (healthmon()->is_proposing()) {
         dout(20) << __func__ << " healthmon proposing, waiting" << dendl;
-        healthmon()->wait_for_finished_proposal(nullptr, new C_MonContext(this,
+        healthmon()->wait_for_finished_proposal(nullptr, new C_MonContext{this,
               [this](int r){
                 ceph_assert(ceph_mutex_is_locked_by_me(lock));
                 do_health_to_clog_interval();
-              }));
+              }});
 
       } else {
         do_health_to_clog_interval();
@@ -2631,11 +2623,11 @@ void Monitor::health_tick_start()
   health_tick_stop();
   health_tick_event = timer.add_event_after(
     cct->_conf->mon_health_to_clog_tick_interval,
-    new C_MonContext(this, [this](int r) {
+    new C_MonContext{this, [this](int r) {
 	if (r < 0)
 	  return;
 	health_tick_start();
-      }));
+      }});
 }
 
 void Monitor::health_tick_stop()
@@ -2677,11 +2669,11 @@ void Monitor::health_interval_start()
 
   health_interval_stop();
   auto next = health_interval_calc_next_update();
-  health_interval_event = new C_MonContext(this, [this](int r) {
+  health_interval_event = new C_MonContext{this, [this](int r) {
       if (r < 0)
         return;
       do_health_to_clog_interval();
-    });
+    }};
   if (!timer.add_event_at(next, health_interval_event)) {
     health_interval_event = nullptr;
   }
@@ -4771,9 +4763,9 @@ void Monitor::timecheck_reset_event()
 
   timecheck_event = timer.add_event_after(
     delay,
-    new C_MonContext(this, [this](int) {
+    new C_MonContext{this, [this](int) {
 	timecheck_start_round();
-      }));
+      }});
 }
 
 void Monitor::timecheck_check_skews()
@@ -5628,9 +5620,9 @@ void Monitor::scrub_event_start()
 
   scrub_event = timer.add_event_after(
     cct->_conf->mon_scrub_interval,
-    new C_MonContext(this, [this](int) {
+    new C_MonContext{this, [this](int) {
       scrub_start();
-      }));
+      }});
 }
 
 void Monitor::scrub_event_cancel()
@@ -5656,17 +5648,17 @@ void Monitor::scrub_reset_timeout()
   scrub_cancel_timeout();
   scrub_timeout_event = timer.add_event_after(
     g_conf()->mon_scrub_timeout,
-    new C_MonContext(this, [this](int) {
+    new C_MonContext{this, [this](int) {
       scrub_timeout();
-    }));
+    }});
 }
 
 /************ TICK ***************/
 void Monitor::new_tick()
 {
-  timer.add_event_after(g_conf()->mon_tick_interval, new C_MonContext(this, [this](int) {
+  timer.add_event_after(g_conf()->mon_tick_interval, new C_MonContext{this, [this](int) {
 	tick();
-      }));
+      }});
 }
 
 void Monitor::tick()

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2992,7 +2992,7 @@ bool OSDMonitor::prepare_mark_me_dead(MonOpRequestRef op)
   pending_inc.new_xinfo[target_osd].dead_epoch = m->get_epoch();
   wait_for_finished_proposal(
     op,
-    new FunctionContext(
+    new LambdaContext(
       [op, this] (int r) {
 	if (r >= 0) {
 	  mon->no_reply(op);	  // ignore on success

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -203,11 +203,11 @@ void Paxos::collect(version_t oldpn)
   collect_timeout_event = mon->timer.add_event_after(
     g_conf()->mon_accept_timeout_factor *
     g_conf()->mon_lease,
-    new C_MonContext(mon, [this](int r) {
+    new C_MonContext{mon, [this](int r) {
 	if (r == -ECANCELED)
 	  return;
 	collect_timeout();
-    }));
+    }});
 }
 
 
@@ -694,11 +694,11 @@ void Paxos::begin(bufferlist& v)
   // set timeout event
   accept_timeout_event = mon->timer.add_event_after(
     g_conf()->mon_accept_timeout_factor * g_conf()->mon_lease,
-    new C_MonContext(mon, [this](int r) {
+    new C_MonContext{mon, [this](int r) {
 	if (r == -ECANCELED)
 	  return;
 	accept_timeout();
-      }));
+      }});
 }
 
 // peon
@@ -995,11 +995,11 @@ void Paxos::extend_lease()
   if (!lease_ack_timeout_event) {
     lease_ack_timeout_event = mon->timer.add_event_after(
       g_conf()->mon_lease_ack_timeout_factor * g_conf()->mon_lease,
-      new C_MonContext(mon, [this](int r) {
+      new C_MonContext{mon, [this](int r) {
 	  if (r == -ECANCELED)
 	    return;
 	  lease_ack_timeout();
-	}));
+	}});
   }
 
   // set renew event
@@ -1008,11 +1008,11 @@ void Paxos::extend_lease()
   at += ceph::make_timespan(g_conf()->mon_lease_renew_interval_factor *
 			    g_conf()->mon_lease);
   lease_renew_event = mon->timer.add_event_at(
-    at, new C_MonContext(mon, [this](int r) {
+    at, new C_MonContext{mon, [this](int r) {
 	if (r == -ECANCELED)
 	  return;
 	lease_renew_timeout();
-    }));
+    }});
 }
 
 void Paxos::warn_on_future_time(utime_t t, entity_name_t from)
@@ -1198,11 +1198,11 @@ void Paxos::reset_lease_timeout()
     mon->timer.cancel_event(lease_timeout_event);
   lease_timeout_event = mon->timer.add_event_after(
     g_conf()->mon_lease_ack_timeout_factor * g_conf()->mon_lease,
-    new C_MonContext(mon, [this](int r) {
+    new C_MonContext{mon, [this](int r) {
 	if (r == -ECANCELED)
 	  return;
 	lease_timeout();
-      }));
+      }});
 }
 
 void Paxos::lease_timeout()

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -117,7 +117,7 @@ bool PaxosService::dispatch(MonOpRequestRef op)
        * Callback class used to propose the pending value once the proposal_timer
        * fires up.
        */
-    auto do_propose = new C_MonContext(mon, [this](int r) {
+    auto do_propose = new C_MonContext{mon, [this](int r) {
         proposal_timer = 0;
         if (r >= 0) {
           propose_pending();
@@ -126,7 +126,7 @@ bool PaxosService::dispatch(MonOpRequestRef op)
         } else {
           ceph_abort_msg("bad return value for proposal_timer");
         }
-    });
+    }};
     dout(10) << " setting proposal_timer " << do_propose
              << " with delay of " << delay << dendl;
     proposal_timer = mon->timer.add_event_after(delay, do_propose);

--- a/src/mon/QuorumService.h
+++ b/src/mon/QuorumService.h
@@ -59,11 +59,11 @@ protected:
     if (tick_period <= 0)
       return;
 
-    tick_event = new C_MonContext(mon, [this](int r) {
+    tick_event = new C_MonContext{mon, [this](int r) {
 	if (r < 0)
 	  return;
 	tick();
-      });
+      }};
     mon->timer.add_event_after(tick_period, tick_event);
   }
 

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -18,12 +18,11 @@
 #include <stdlib.h>
 #include <ostream>
 
-#include <boost/intrusive_ptr.hpp>
-
 #include "auth/Auth.h"
 #include "common/RefCountedObj.h"
 #include "common/config.h"
 #include "common/debug.h"
+#include "common/ref.h"
 #include "common/ceph_mutex.h"
 #include "include/ceph_assert.h" // Because intusive_ptr clobbers our assert...
 #include "include/buffer.h"
@@ -41,21 +40,21 @@ class Messenger;
 class Interceptor;
 #endif
 
-struct Connection : public RefCountedObject {
+struct Connection : public RefCountedObjectSafe {
   mutable ceph::mutex lock = ceph::make_mutex("Connection::lock");
   Messenger *msgr;
   RefCountedPtr priv;
-  int peer_type;
+  int peer_type = -1;
   int64_t peer_id = -1;  // [msgr2 only] the 0 of osd.0, 4567 or client.4567
   safe_item_history<entity_addrvec_t> peer_addrs;
   utime_t last_keepalive, last_keepalive_ack;
 private:
-  uint64_t features;
+  uint64_t features = 0;
 public:
-  bool is_loopback;
-  bool failed; // true if we are a lossy connection that has failed.
+  bool is_loopback = false;
+  bool failed = false; // true if we are a lossy connection that has failed.
 
-  int rx_buffers_version;
+  int rx_buffers_version = 0;
   std::map<ceph_tid_t,std::pair<ceph::buffer::list, int>> rx_buffers;
 
   // authentication state
@@ -69,26 +68,9 @@ public:
   Interceptor *interceptor;
 #endif
 
-  friend class boost::intrusive_ptr<Connection>;
   friend class PipeConnection;
 
 public:
-  Connection(CephContext *cct, Messenger *m)
-    // we are managed exclusively by ConnectionRef; make it so you can
-    //   ConnectionRef foo = new Connection;
-    : RefCountedObject(cct, 0),
-      msgr(m),
-      peer_type(-1),
-      features(0),
-      is_loopback(false),
-      failed(false),
-      rx_buffers_version(0) {
-  }
-
-  ~Connection() override {
-    //generic_dout(0) << "~Connection " << this << dendl;
-  }
-
   void set_priv(const RefCountedPtr& o) {
     std::lock_guard l{lock};
     priv = o;
@@ -254,9 +236,18 @@ public:
     last_keepalive_ack = t;
   }
   bool is_blackhole() const;
+
+protected:
+  Connection(CephContext *cct, Messenger *m)
+    : RefCountedObjectSafe(cct),
+      msgr(m)
+  {}
+
+  ~Connection() override {
+    //generic_dout(0) << "~Connection " << this << dendl;
+  }
 };
 
-typedef boost::intrusive_ptr<Connection> ConnectionRef;
-
+using ConnectionRef = ceph::ref_t<Connection>;
 
 #endif /* CEPH_CONNECTION_H */

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -113,7 +113,8 @@ class C_tick_wakeup : public EventCallback {
 
 AsyncConnection::AsyncConnection(CephContext *cct, AsyncMessenger *m, DispatchQueue *q,
                                  Worker *w, bool m2, bool local)
-  : Connection(cct, m), delay_state(NULL), async_msgr(m), conn_id(q->get_id()),
+  : Connection(cct, m),
+    delay_state(NULL), async_msgr(m), conn_id(q->get_id()),
     logger(w->get_perf_counter()),
     state(STATE_NONE), port(-1),
     dispatch_queue(q), recv_buf(NULL),

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -51,7 +51,6 @@ static const int ASYNC_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
  * sequence, try to reconnect peer endpoint.
  */
 class AsyncConnection : public Connection {
-
   ssize_t read(unsigned len, char *buffer,
                std::function<void(char *, ssize_t)> callback);
   ssize_t read_until(unsigned needed, char *p);
@@ -106,10 +105,12 @@ class AsyncConnection : public Connection {
     void flush();
   } *delay_state;
 
- public:
+private:
+  FRIEND_MAKE_REF(AsyncConnection);
   AsyncConnection(CephContext *cct, AsyncMessenger *m, DispatchQueue *q,
 		  Worker *w, bool is_msgr2, bool local);
   ~AsyncConnection() override;
+public:
   void maybe_start_delay_thread();
 
   ostream& _conn_prefix(std::ostream *_dout);
@@ -235,6 +236,6 @@ class AsyncConnection : public Connection {
   friend class ProtocolV2;
 }; /* AsyncConnection */
 
-typedef boost::intrusive_ptr<AsyncConnection> AsyncConnectionRef;
+using AsyncConnectionRef = ceph::ref_t<AsyncConnection>;
 
 #endif

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -292,7 +292,7 @@ AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
   stack = single->stack.get();
   stack->start();
   local_worker = stack->get_worker();
-  local_connection = new AsyncConnection(cct, this, &dispatch_queue,
+  local_connection = ceph::make_ref<AsyncConnection>(cct, this, &dispatch_queue,
 					 local_worker, true, true);
   init_local_connection();
   reap_handler = new C_handle_reap(this);
@@ -556,7 +556,7 @@ void AsyncMessenger::add_accept(Worker *w, ConnectedSocket cli_socket,
 				const entity_addr_t &peer_addr)
 {
   std::lock_guard l{lock};
-  AsyncConnectionRef conn = new AsyncConnection(cct, this, &dispatch_queue, w,
+  auto conn = ceph::make_ref<AsyncConnection>(cct, this, &dispatch_queue, w,
 						listen_addr.is_msgr2(), false);
   conn->accept(std::move(cli_socket), listen_addr, peer_addr);
   accepting_conns.insert(conn);
@@ -585,7 +585,7 @@ AsyncConnectionRef AsyncMessenger::create_connect(
 
   // create connection
   Worker *w = stack->get_worker();
-  AsyncConnectionRef conn = new AsyncConnection(cct, this, &dispatch_queue, w,
+  auto conn = ceph::make_ref<AsyncConnection>(cct, this, &dispatch_queue, w,
 						target.is_msgr2(), false);
   conn->connect(addrs, type, target);
   ceph_assert(!conns.count(addrs));

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -124,10 +124,6 @@ public:
   struct CollectionImpl : public RefCountedObject {
     const coll_t cid;
 
-    CollectionImpl(const coll_t& c)
-      : RefCountedObject(NULL, 0),
-	cid(c) {}
-
     /// wait for any queued transactions to apply
     // block until any previous transactions are visible.  specifically,
     // collection_list and collection_empty need to reflect prior operations.
@@ -149,8 +145,12 @@ public:
     const coll_t &get_cid() {
       return cid;
     }
+  protected:
+    CollectionImpl() = delete;
+    CollectionImpl(CephContext* cct, const coll_t& c) : RefCountedObject(cct), cid(c) {}
+    ~CollectionImpl() = default;
   };
-  typedef boost::intrusive_ptr<CollectionImpl> CollectionHandle;
+  using CollectionHandle = ceph::ref_t<CollectionImpl>;
 
 
   /*********************************

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -463,7 +463,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   dout(1) << __func__ << " uuid " << super.uuid << dendl;
 
   // init log
-  FileRef log_file = new File;
+  FileRef log_file = ceph::make_ref<File>();
   log_file->fnode.ino = 1;
   log_file->fnode.prefer_bdev = BDEV_WAL;
   int r = _allocate(
@@ -1060,7 +1060,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	  if (!noop) {
 	    map<string,DirRef>::iterator q = dir_map.find(dirname);
 	    ceph_assert(q == dir_map.end());
-	    dir_map[dirname] = new Dir;
+	    dir_map[dirname] = ceph::make_ref<Dir>();
 	  }
 	}
 	break;
@@ -1465,7 +1465,7 @@ BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
 {
   auto p = file_map.find(ino);
   if (p == file_map.end()) {
-    FileRef f = new File;
+    FileRef f = ceph::make_ref<File>();
     file_map[ino] = f;
     dout(30) << __func__ << " ino " << ino << " = " << f
 	     << " (new)" << dendl;
@@ -1959,7 +1959,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 
   // create a new log [writer] so that we know compaction is in progress
   // (see _should_compact_log)
-  new_log = new File;
+  new_log = ceph::make_ref<File>();
   new_log->fnode.ino = 0;   // so that _flush_range won't try to log the fnode
 
   // 0. wait for any racing flushes to complete.  (We do not want to block
@@ -2833,7 +2833,7 @@ int BlueFS::open_for_write(
 	       << " does not exist" << dendl;
       return -ENOENT;
     }
-    file = new File;
+    file = ceph::make_ref<File>();
     file->fnode.ino = ++ino_last;
     file_map[ino_last] = file;
     dir->file_map[filename] = file;
@@ -3012,7 +3012,7 @@ int BlueFS::mkdir(const string& dirname)
     dout(20) << __func__ << " dir " << dirname << " exists" << dendl;
     return -EEXIST;
   }
-  dir_map[dirname] = new Dir;
+  dir_map[dirname] = ceph::make_ref<Dir>();
   log_t.op_dir_create(dirname);
   return 0;
 }
@@ -3085,12 +3085,12 @@ int BlueFS::lock_file(const string& dirname, const string& filename,
   }
   DirRef dir = p->second;
   map<string,FileRef>::iterator q = dir->file_map.find(filename);
-  File *file;
+  FileRef file;
   if (q == dir->file_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " (" << dir
 	     << ") file " << filename
 	     << " not found, creating" << dendl;
-    file = new File;
+    file = ceph::make_ref<File>();
     file->fnode.ino = ++ino_last;
     file->fnode.mtime = ceph_clock_now();
     file_map[ino_last] = file;
@@ -3099,7 +3099,7 @@ int BlueFS::lock_file(const string& dirname, const string& filename,
     log_t.op_file_update(file->fnode);
     log_t.op_dir_link(dirname, filename, file->fnode.ino);
   } else {
-    file = q->second.get();
+    file = q->second;
     if (file->locked) {
       dout(10) << __func__ << " already locked" << dendl;
       return -ENOLCK;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -7,11 +7,13 @@
 #include <mutex>
 
 #include "bluefs_types.h"
-#include "common/RefCountedObj.h"
 #include "BlockDevice.h"
 
+#include "common/RefCountedObj.h"
+#include "common/ceph_context.h"
+#include "global/global_context.h"
+
 #include "boost/intrusive/list.hpp"
-#include <boost/intrusive_ptr.hpp>
 
 class PerfCounters;
 
@@ -101,8 +103,10 @@ public:
     std::atomic_int num_readers, num_writers;
     std::atomic_int num_reading;
 
+  private:
+    FRIEND_MAKE_REF(File);
     File()
-      : RefCountedObject(NULL, 0),
+      :
 	refs(0),
 	dirty_seq(0),
 	locked(false),
@@ -117,15 +121,8 @@ public:
       ceph_assert(num_reading.load() == 0);
       ceph_assert(!locked);
     }
-
-    friend void intrusive_ptr_add_ref(File *f) {
-      f->get();
-    }
-    friend void intrusive_ptr_release(File *f) {
-      f->put();
-    }
   };
-  typedef boost::intrusive_ptr<File> FileRef;
+  using FileRef = ceph::ref_t<File>;
 
   typedef boost::intrusive::list<
       File,
@@ -139,22 +136,17 @@ public:
 
     mempool::bluefs::map<string,FileRef> file_map;
 
-    Dir() : RefCountedObject(NULL, 0) {}
-
-    friend void intrusive_ptr_add_ref(Dir *d) {
-      d->get();
-    }
-    friend void intrusive_ptr_release(Dir *d) {
-      d->put();
-    }
+  private:
+    FRIEND_MAKE_REF(Dir);
+    Dir() = default;
   };
-  typedef boost::intrusive_ptr<Dir> DirRef;
+  using DirRef = ceph::ref_t<Dir>;
 
   struct FileWriter {
     MEMPOOL_CLASS_HELPERS();
 
     FileRef file;
-    uint64_t pos;           ///< start offset for buffer
+    uint64_t pos = 0;       ///< start offset for buffer
     bufferlist buffer;      ///< new data to write (at end of file)
     bufferlist tail_block;  ///< existing partial block at end of file, if any
     bufferlist::page_aligned_appender buffer_appender;  //< for const char* only
@@ -167,7 +159,6 @@ public:
 
     FileWriter(FileRef f)
       : file(f),
-	pos(0),
 	buffer_appender(buffer.get_page_aligned_appender(
 			  g_conf()->bluefs_alloc_size / CEPH_PAGE_SIZE)) {
       ++file->num_writers;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2016,7 +2016,7 @@ void FileStore::init_temp_collections()
   for (vector<coll_t>::iterator p = ls.begin(); p != ls.end(); ++p) {
     if (p->is_temp())
       continue;
-    coll_map[*p] = new OpSequencer(cct, ++next_osr_id, *p);
+    coll_map[*p] = ceph::make_ref<OpSequencer>(cct, ++next_osr_id, *p);
     if (p->is_meta())
       continue;
     coll_t temp = p->get_temp();
@@ -2130,7 +2130,7 @@ ObjectStore::CollectionHandle FileStore::create_new_collection(const coll_t& c)
   std::lock_guard l{coll_lock};
   auto p = coll_map.find(c);
   if (p == coll_map.end()) {
-    auto *r = new OpSequencer(cct, ++next_osr_id, c);
+    auto r = ceph::make_ref<OpSequencer>(cct, ++next_osr_id, c);
     coll_map[c] = r;
     return r;
   } else {

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -359,8 +359,10 @@ private:
       }
     }
 
+  private:
+    FRIEND_MAKE_REF(OpSequencer);
     OpSequencer(CephContext* cct, int i, coll_t cid)
-      : CollectionImpl(cid),
+      : CollectionImpl(cct, cid),
 	cct(cct),
 	osr_name_str(stringify(cid)),
         id(i),

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -565,7 +565,7 @@ int KStore::OnodeHashLRU::trim(int max)
 #define dout_prefix *_dout << "kstore(" << store->path << ").collection(" << cid << ") "
 
 KStore::Collection::Collection(KStore *ns, coll_t cid)
-  : CollectionImpl(cid),
+  : CollectionImpl(ns->cct, cid),
     store(ns),
     osr(new OpSequencer()),
     onode_map(store->cct)
@@ -895,7 +895,7 @@ int KStore::_open_collections(int *errors)
        it->next()) {
     coll_t cid;
     if (cid.parse(it->key())) {
-      CollectionRef c(new Collection(this, cid));
+      auto c = ceph::make_ref<Collection>(this, cid);
       bufferlist bl = it->value();
       auto p = bl.cbegin();
       try {
@@ -1107,7 +1107,7 @@ ObjectStore::CollectionHandle KStore::open_collection(const coll_t& cid)
 
 ObjectStore::CollectionHandle KStore::create_new_collection(const coll_t& cid)
 {
-  auto *c = new Collection(this, cid);
+  auto c = ceph::make_ref<Collection>(this, cid);
   std::unique_lock l{coll_lock};
   new_coll_map[cid] = c;
   return c;

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -161,9 +161,11 @@ public:
     void flush() override;
     bool flush_commit(Context *c) override;
 
+  private:
+    FRIEND_MAKE_REF(Collection);
     Collection(KStore *ns, coll_t c);
   };
-  typedef boost::intrusive_ptr<Collection> CollectionRef;
+  using CollectionRef = ceph::ref_t<Collection>;
 
   class OmapIteratorImpl : public ObjectMap::ObjectMapIteratorImpl {
     CollectionRef c;

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -36,11 +36,8 @@ public:
     bufferlist omap_header;
     map<string,bufferlist> omap;
 
-    typedef boost::intrusive_ptr<Object> Ref;
-    friend void intrusive_ptr_add_ref(Object *o) { o->get(); }
-    friend void intrusive_ptr_release(Object *o) { o->put(); }
+    using Ref = ceph::ref_t<Object>;
 
-    Object() : RefCountedObject(nullptr, 0) {}
     // interface for object data
     virtual size_t get_size() const = 0;
     virtual int read(uint64_t offset, uint64_t len, bufferlist &bl) = 0;
@@ -90,8 +87,10 @@ public:
       }
       f->close_section();
     }
+  protected:
+    Object() = default;
   };
-  typedef Object::Ref ObjectRef;
+  using ObjectRef = Object::Ref;
 
   struct PageSetObject;
   struct Collection : public CollectionImpl {
@@ -110,8 +109,6 @@ public:
       ceph::make_mutex("MemStore::Collection::sequencer_mutex")};
 
     typedef boost::intrusive_ptr<Collection> Ref;
-    friend void intrusive_ptr_add_ref(Collection *c) { c->get(); }
-    friend void intrusive_ptr_release(Collection *c) { c->put(); }
 
     ObjectRef create_object() const;
 
@@ -184,8 +181,10 @@ public:
       return true;
     }
 
+  private:
+    FRIEND_MAKE_REF(Collection);
     explicit Collection(CephContext *cct, coll_t c)
-      : CollectionImpl(c),
+      : CollectionImpl(cct, c),
 	cct(cct),
 	use_page_set(cct->_conf->memstore_page_set) {}
   };

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -450,7 +450,7 @@ HeartbeatStampsRef OSDService::get_hb_stamps(unsigned peer)
     hb_stamps.resize(peer + 1);
   }
   if (!hb_stamps[peer]) {
-    hb_stamps[peer].reset(new HeartbeatStamps(peer));
+    hb_stamps[peer] = ceph::make_ref<HeartbeatStamps>(peer);
   }
   return hb_stamps[peer];
 }
@@ -4539,20 +4539,18 @@ void OSD::_add_heartbeat_peer(int p)
 
     auto stamps = service.get_hb_stamps(p);
 
-    Session *sb = new Session(cct, cons.first.get());
+    auto sb = ceph::make_ref<Session>(cct, cons.first.get());
     sb->peer = p;
     sb->stamps = stamps;
-    RefCountedPtr sbref{sb, false};
     hi->hb_interval_start = ceph_clock_now();
     hi->con_back = cons.first.get();
-    hi->con_back->set_priv(sbref);
+    hi->con_back->set_priv(sb);
 
-    Session *sf = new Session(cct, cons.second.get());
+    auto sf = ceph::make_ref<Session>(cct, cons.second.get());
     sf->peer = p;
     sf->stamps = stamps;
-    RefCountedPtr sfref{sf, false};
     hi->con_front = cons.second.get();
-    hi->con_front->set_priv(sfref);
+    hi->con_front->set_priv(sf);
 
     dout(10) << "_add_heartbeat_peer: new peer osd." << p
 	     << " " << hi->con_back->get_peer_addr()
@@ -5691,11 +5689,9 @@ void OSD::ms_handle_fast_connect(Connection *con)
 {
   if (con->get_peer_type() != CEPH_ENTITY_TYPE_MON &&
       con->get_peer_type() != CEPH_ENTITY_TYPE_MGR) {
-    auto priv = con->get_priv();
-    auto s = static_cast<Session*>(priv.get());
-    if (!s) {
-      s = new Session{cct, con};
-      con->set_priv(RefCountedPtr{s, false});
+    if (auto s = ceph::ref_cast<Session>(con->get_priv()); !s) {
+      s = ceph::make_ref<Session>(cct, con);
+      con->set_priv(s);
       dout(10) << " new session (outgoing) " << s << " con=" << s->con
           << " addr=" << s->con->get_peer_addr() << dendl;
       // we don't connect to clients
@@ -5709,11 +5705,9 @@ void OSD::ms_handle_fast_accept(Connection *con)
 {
   if (con->get_peer_type() != CEPH_ENTITY_TYPE_MON &&
       con->get_peer_type() != CEPH_ENTITY_TYPE_MGR) {
-    auto priv = con->get_priv();
-    auto s = static_cast<Session*>(priv.get());
-    if (!s) {
-      s = new Session{cct, con};
-      con->set_priv(RefCountedPtr{s, false});
+    if (auto s = ceph::ref_cast<Session>(con->get_priv()); !s) {
+      s = ceph::make_ref<Session>(cct, con);
+      con->set_priv(s);
       dout(10) << "new session (incoming)" << s << " con=" << con
           << " addr=" << con->get_peer_addr()
           << " must have raced with connect" << dendl;
@@ -5725,9 +5719,8 @@ void OSD::ms_handle_fast_accept(Connection *con)
 
 bool OSD::ms_handle_reset(Connection *con)
 {
-  auto s = con->get_priv();
-  auto session = static_cast<Session*>(s.get());
-  dout(2) << "ms_handle_reset con " << con << " session " << session << dendl;
+  auto session = ceph::ref_cast<Session>(con->get_priv());
+  dout(2) << "ms_handle_reset con " << con << " session " << session.get() << dendl;
   if (!session)
     return false;
   session->wstate.reset(con);
@@ -5736,7 +5729,7 @@ bool OSD::ms_handle_reset(Connection *con)
   // note that we break session->con *before* the session_handle_reset
   // cleanup below.  this avoids a race between us and
   // PG::add_backoff, Session::check_backoff, etc.
-  session_handle_reset(SessionRef{session});
+  session_handle_reset(session);
   return true;
 }
 
@@ -5745,9 +5738,8 @@ bool OSD::ms_handle_refused(Connection *con)
   if (!cct->_conf->osd_fast_fail_on_connection_refused)
     return false;
 
-  auto priv = con->get_priv();
-  auto session = static_cast<Session*>(priv.get());
-  dout(2) << "ms_handle_refused con " << con << " session " << session << dendl;
+  auto session = ceph::ref_cast<Session>(con->get_priv());
+  dout(2) << "ms_handle_refused con " << con << " session " << session.get() << dendl;
   if (!session)
     return false;
   int type = con->get_peer_type();
@@ -6320,8 +6312,7 @@ void OSD::handle_command(MMonCommand *m)
 void OSD::handle_command(MCommand *m)
 {
   ConnectionRef con = m->get_connection();
-  auto priv = con->get_priv();
-  auto session = static_cast<Session *>(priv.get());
+  auto session = ceph::ref_cast<Session>(con->get_priv());
   if (!session) {
     con->send_message(new MCommandReply(m, -EPERM));
     m->put();
@@ -6329,7 +6320,6 @@ void OSD::handle_command(MCommand *m)
   }
 
   OSDCap& caps = session->caps;
-  priv.reset();
 
   if (!caps.allow_all() || m->get_source().is_mon()) {
     con->send_message(new MCommandReply(m, -EPERM));
@@ -7154,8 +7144,7 @@ void OSDService::maybe_share_map(
 {
   // NOTE: we assume caller hold something that keeps the Connection itself
   // pinned (e.g., an OpRequest's MessageRef).
-  auto priv = con->get_priv();
-  auto session = static_cast<Session*>(priv.get());
+  auto session = ceph::ref_cast<Session>(con->get_priv());
   if (!session) {
     return;
   }
@@ -7191,7 +7180,7 @@ void OSDService::maybe_share_map(
   session->sent_epoch_lock.unlock();
 }
 
-void OSD::dispatch_session_waiting(SessionRef session, OSDMapRef osdmap)
+void OSD::dispatch_session_waiting(const ceph::ref_t<Session>& session, OSDMapRef osdmap)
 {
   ceph_assert(ceph_mutex_is_locked(session->session_dispatch_lock));
 
@@ -7327,11 +7316,10 @@ void OSD::ms_fast_dispatch(Message *m)
 int OSD::ms_handle_authentication(Connection *con)
 {
   int ret = 0;
-  auto priv = con->get_priv();
-  Session *s = static_cast<Session*>(priv.get());
+  auto s = ceph::ref_cast<Session>(con->get_priv());
   if (!s) {
-    s = new Session(cct, con);
-    con->set_priv(RefCountedPtr{s, false});
+    s = ceph::make_ref<Session>(cct, con);
+    con->set_priv(s);
     s->entity_name = con->get_peer_entity_name();
     dout(10) << __func__ << " new session " << s << " con " << s->con
 	     << " entity " << s->entity_name
@@ -8017,9 +8005,8 @@ void OSD::handle_osd_map(MOSDMap *m)
     return;
   }
 
-  auto priv = m->get_connection()->get_priv();
-  if (auto session = static_cast<Session *>(priv.get());
-      session && !(session->entity_name.is_mon() ||
+  auto session = ceph::ref_cast<Session>(m->get_connection()->get_priv());
+  if (session && !(session->entity_name.is_mon() ||
 		   session->entity_name.is_osd())) {
     //not enough perms!
     dout(10) << "got osd map from Session " << session
@@ -9055,8 +9042,7 @@ bool OSD::require_same_peer_instance(const Message *m, OSDMapRef& map,
 	    << dendl;
     ConnectionRef con = m->get_connection();
     con->mark_down();
-    auto priv = con->get_priv();
-    if (auto s = static_cast<Session*>(priv.get()); s) {
+    if (auto s = ceph::ref_cast<Session>(con->get_priv()); s) {
       if (!is_fast_dispatch)
 	s->session_dispatch_lock.lock();
       clear_session_waiting_on_map(s);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5858,7 +5858,7 @@ void OSD::_preboot(epoch_t oldest, epoch_t newest)
     // this thread might be required for splitting and merging PGs to
     // make progress.
     boot_finisher.queue(
-      new FunctionContext(
+      new LambdaContext(
 	[this](int r) {
 	  std::unique_lock l(osd_lock);
 	  if (is_preboot()) {
@@ -9628,7 +9628,7 @@ void OSD::do_recovery(
     std::lock_guard l(service.sleep_lock);
     if (recovery_sleep > 0 && service.recovery_needs_sleep) {
       PGRef pgref(pg);
-      auto recovery_requeue_callback = new FunctionContext([this, pgref, queued, reserved_pushes](int r) {
+      auto recovery_requeue_callback = new LambdaContext([this, pgref, queued, reserved_pushes](int r) {
         dout(20) << "do_recovery wake up at "
                  << ceph_clock_now()
 	         << ", re-queuing recovery" << dendl;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2459,7 +2459,7 @@ void PG::scrub(epoch_t queued, ThreadPool::TPHandle &handle)
     spg_t pgid = get_pgid();
     int state = scrubber.state;
     auto scrub_requeue_callback =
-        new FunctionContext([osds, pgid, state](int r) {
+        new LambdaContext([osds, pgid, state](int r) {
           PGRef pg = osds->osd->lookup_lock_pg(pgid);
           if (pg == nullptr) {
             lgeneric_dout(osds->osd->cct, 20)
@@ -3743,7 +3743,7 @@ void PG::do_delete_work(ObjectStore::Transaction &t)
     if (osd_delete_sleep > 0 && delete_needs_sleep) {
       epoch_t e = get_osdmap()->get_epoch();
       PGRef pgref(this);
-      auto delete_requeue_callback = new FunctionContext([this, pgref, e](int r) {
+      auto delete_requeue_callback = new LambdaContext([this, pgref, e](int r) {
         dout(20) << __func__ << " wake up at "
                  << ceph_clock_now()
 	         << ", re-queuing delete" << dendl;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -356,7 +356,7 @@ public:
     __u8 &);
   static bool _has_removal_flag(ObjectStore *store, spg_t pgid);
 
-  void rm_backoff(BackoffRef b);
+  void rm_backoff(const ceph::ref_t<Backoff>& b);
 
   void update_snap_mapper_bits(uint32_t bits) {
     snap_mapper.update_bits(bits);
@@ -1063,16 +1063,16 @@ protected:
   // -- backoff --
   ceph::mutex backoff_lock = // orders inside Backoff::lock
     ceph::make_mutex("PG::backoff_lock");
-  map<hobject_t,set<BackoffRef>> backoffs;
+  map<hobject_t,set<ceph::ref_t<Backoff>>> backoffs;
 
-  void add_backoff(SessionRef s, const hobject_t& begin, const hobject_t& end);
+  void add_backoff(const ceph::ref_t<Session>& s, const hobject_t& begin, const hobject_t& end);
   void release_backoffs(const hobject_t& begin, const hobject_t& end);
   void release_backoffs(const hobject_t& o) {
     release_backoffs(o, o);
   }
   void clear_backoffs();
 
-  void add_pg_backoff(SessionRef s) {
+  void add_pg_backoff(const ceph::ref_t<Session>& s) {
     hobject_t begin = info.pgid.pgid.get_hobj_start();
     hobject_t end = info.pgid.pgid.get_hobj_end(pool.info.get_pg_num());
     add_backoff(s, begin, end);

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -136,7 +136,7 @@ void PGBackend::handle_recovery_delete(OpRequestRef op)
   reply->objects = m->objects;
   ConnectionRef conn = m->get_connection();
 
-  gather.set_finisher(new FunctionContext(
+  gather.set_finisher(new LambdaContext(
     [=](int r) {
       if (r != -EAGAIN) {
 	get_parent()->send_message_osd_cluster(reply, conn.get());

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -109,10 +109,6 @@ struct HeartbeatStamps : public RefCountedObject {
   /// highest up_from we've seen from this rank
   epoch_t up_from = 0;
 
-  HeartbeatStamps(int o)
-    : RefCountedObject(NULL, 0),
-      osd(o) {}
-
   void print(ostream& out) const {
     std::lock_guard l(lock);
     out << "hbstamp(osd." << osd << " up_from " << up_from
@@ -163,8 +159,13 @@ struct HeartbeatStamps : public RefCountedObject {
     peer_clock_delta_ub = delta_ub;
   }
 
+private:
+  FRIEND_MAKE_REF(HeartbeatStamps);
+  HeartbeatStamps(int o)
+    : RefCountedObject(NULL),
+      osd(o) {}
 };
-typedef boost::intrusive_ptr<HeartbeatStamps> HeartbeatStampsRef;
+using HeartbeatStampsRef = ceph::ref_t<HeartbeatStamps>;
 
 inline ostream& operator<<(ostream& out, const HeartbeatStamps& hb)
 {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11275,7 +11275,7 @@ int PrimaryLogPG::recover_missing(
     ceph_assert(!recovering.count(soid));
     recovering.insert(make_pair(soid, ObjectContextRef()));
     epoch_t cur_epoch = get_osdmap_epoch();
-    remove_missing_object(soid, v, new FunctionContext(
+    remove_missing_object(soid, v, new LambdaContext(
      [=](int) {
        std::scoped_lock locker{*this};
        if (!pg_has_reset_since(cur_epoch)) {
@@ -11358,7 +11358,7 @@ void PrimaryLogPG::remove_missing_object(const hobject_t &soid,
   recovery_info.version = v;
 
   epoch_t cur_epoch = get_osdmap_epoch();
-  t.register_on_complete(new FunctionContext(
+  t.register_on_complete(new LambdaContext(
      [=](int) {
        std::unique_lock locker{*this};
        if (!pg_has_reset_since(cur_epoch)) {
@@ -11529,7 +11529,7 @@ void PrimaryLogPG::do_update_log_missing(OpRequestRef &op)
     m->entries, t, op_trim_to, op_roll_forward_to);
   eversion_t new_lcod = info.last_complete;
 
-  Context *complete = new FunctionContext(
+  Context *complete = new LambdaContext(
     [=](int) {
       const MOSDPGUpdateLogMissing *msg = static_cast<const MOSDPGUpdateLogMissing*>(
 	op->get_req());

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1439,7 +1439,7 @@ void PrimaryLogPG::get_src_oloc(const object_t& oid, const object_locator_t& olo
 void PrimaryLogPG::handle_backoff(OpRequestRef& op)
 {
   auto m = op->get_req<MOSDBackoff>();
-  SessionRef session{static_cast<Session*>(m->get_connection()->get_priv().get())};
+  auto session = ceph::ref_cast<Session>(m->get_connection()->get_priv());
   if (!session)
     return;  // drop it.
   hobject_t begin = info.pgid.pgid.get_hobj_start();
@@ -1490,7 +1490,7 @@ void PrimaryLogPG::do_request(
   const Message *m = op->get_req();
   int msg_type = m->get_type();
   if (m->get_connection()->has_feature(CEPH_FEATURE_RADOS_BACKOFF)) {
-    SessionRef session{static_cast<Session*>(m->get_connection()->get_priv().get())};
+    auto session = ceph::ref_cast<Session>(m->get_connection()->get_priv());
     if (!session)
       return;  // drop it.
 
@@ -1674,7 +1674,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 
   bool can_backoff =
     m->get_connection()->has_feature(CEPH_FEATURE_RADOS_BACKOFF);
-  SessionRef session;
+  ceph::ref_t<Session> session;
   if (can_backoff) {
     session = static_cast<Session*>(m->get_connection()->get_priv().get());
     if (!session.get()) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -747,6 +747,12 @@ void PrimaryLogPG::maybe_force_recovery()
     }
   }
 
+  hobject_t head = soid.get_head();
+  if (soid.is_snap() && pg_log.get_missing().is_missing(head)) {
+    dout(10) << __func__ << " the oldest object is snap, recover head firstly, " << soid << dendl;
+    soid = head; // recover head firstly
+  }
+
   // recover it
   if (soid != hobject_t())
     maybe_kick_recovery(soid);

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -339,18 +339,17 @@ private:
     Context *on_commit;
     OpRequestRef op;
     eversion_t v;
-    InProgressOp(
-      ceph_tid_t tid, Context *on_commit,
-      OpRequestRef op, eversion_t v)
-      : RefCountedObject(nullptr, 0),
-        tid(tid), on_commit(on_commit),
-        op(op), v(v) {}
     bool done() const {
       return waiting_for_commit.empty();
     }
+  private:
+    FRIEND_MAKE_REF(InProgressOp);
+    InProgressOp(ceph_tid_t tid, Context *on_commit, OpRequestRef op, eversion_t v)
+      :
+	tid(tid), on_commit(on_commit),
+	op(op), v(v) {}
   };
-  typedef boost::intrusive_ptr<InProgressOp> InProgressOpRef;
-  map<ceph_tid_t, InProgressOpRef> in_progress_ops;
+  map<ceph_tid_t, ceph::ref_t<InProgressOp>> in_progress_ops;
 public:
   friend class C_OSD_OnOpCommit;
 
@@ -403,7 +402,7 @@ private:
     std::optional<pg_hit_set_history_t> &hset_history,
     InProgressOp *op,
     ObjectStore::Transaction &op_t);
-  void op_commit(InProgressOpRef& op);
+  void op_commit(const ceph::ref_t<InProgressOp>& op);
   void do_repop_reply(OpRequestRef op);
   void do_repop(OpRequestRef op);
 

--- a/src/osd/Session.cc
+++ b/src/osd/Session.cc
@@ -11,7 +11,7 @@
 
 void Session::clear_backoffs()
 {
-  map<spg_t,map<hobject_t,set<BackoffRef>>> ls;
+  map<spg_t,map<hobject_t,set<ceph::ref_t<Backoff>>>> ls;
   {
     std::lock_guard l(backoff_lock);
     ls.swap(backoffs);
@@ -85,7 +85,7 @@ void Session::ack_backoff(
 bool Session::check_backoff(
   CephContext *cct, spg_t pgid, const hobject_t& oid, const Message *m)
 {
-  BackoffRef b(have_backoff(pgid, oid));
+  auto b = have_backoff(pgid, oid);
   if (b) {
     dout(10) << __func__ << " session " << this << " has backoff " << *b
 	     << " for " << *m << dendl;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -36,6 +36,7 @@
 #include "include/types.h"
 #include "include/utime.h"
 #include "include/CompatSet.h"
+#include "common/ceph_context.h"
 #include "common/histogram.h"
 #include "include/interval_set.h"
 #include "include/inline_memory.h"

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -2514,7 +2514,7 @@ void ObjectCacher::discard_writeback(ObjectSet *oset,
 
   if (gather.has_subs()) {
     bool flushed = was_dirty && oset->dirty_or_tx == 0;
-    gather.set_finisher(new FunctionContext(
+    gather.set_finisher(new LambdaContext(
       [this, oset, flushed, on_finish](int) {
 	ceph_assert(ceph_mutex_is_locked(lock));
 	if (flushed && flush_set_callback)

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.po.ts
@@ -16,23 +16,27 @@ export class HostsPageHelper extends PageHelper {
     await this.navigateTo();
     let links_tested = 0;
 
-    // grab services column for first host
-    const services = element.all(by.css('.datatable-body-cell')).get(1);
-    // check is any services links are present
-    const txt = await services.getText();
+    const services = element.all(by.css('cd-hosts a.service-link'));
     // check that text (links) is present in services box
-    await expect(txt.length).toBeGreaterThan(0, 'No services links exist on first host');
-    if (txt.length === 0) {
-      return;
-    }
-    const links = services.all(by.css('a.service-link'));
-    const num_links = await links.count();
+    await expect(services.count()).toBeGreaterThan(0, 'No services links exist on first host');
+
+    /**
+     * Currently there is an issue [1] in ceph that it's causing
+     * a random appearance of a mds service in the hosts service listing.
+     * Decreasing the number of service by 1 temporarily fixes the e2e failure.
+     *
+     * TODO: Revert this change when the issue has been fixed.
+     *
+     * [1] https://tracker.ceph.com/issues/41538
+     */
+    const num_links = (await services.count()) - 1;
+
     for (let i = 0; i < num_links; i++) {
       // click link, check it worked by looking for changed breadcrumb,
       // navigate back to hosts page, repeat until all links checked
-      await links.get(i).click();
+      await services.get(i).click();
       await this.waitTextToBePresent(this.getBreadcrumb(), 'Performance Counters');
-      await this.navigateTo();
+      await this.navigateBack();
       await this.waitTextToBePresent(this.getBreadcrumb(), 'Hosts');
       links_tested++;
     }

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 #include "test/librados/test_cxx.h"
 #include "global/global_context.h"
+#include "common/ceph_context.h"
 
 #include <errno.h>
 #include <string>

--- a/src/test/direct_messenger/DirectMessenger.cc
+++ b/src/test/direct_messenger/DirectMessenger.cc
@@ -28,13 +28,15 @@ class DirectConnection : public Connection {
   /// clear this pointer) before dropping its own reference
   std::atomic<Connection*> reply_connection{nullptr};
 
- public:
+ private:
+  FRIEND_MAKE_REF(DirectConnection);
   DirectConnection(CephContext *cct, DirectMessenger *m,
                    DispatchStrategy *dispatchers)
     : Connection(cct, m),
       dispatchers(dispatchers)
   {}
 
+ public:
   /// sets the Connection that will receive replies to outgoing messages
   void set_direct_reply_connection(ConnectionRef conn);
 
@@ -100,8 +102,7 @@ static ConnectionRef create_loopback(DirectMessenger *m,
                                      entity_name_t name,
                                      DispatchStrategy *dispatchers)
 {
-  auto loopback = boost::intrusive_ptr<DirectConnection>(
-      new DirectConnection(m->cct, m, dispatchers));
+  auto loopback = ceph::make_ref<DirectConnection>(m->cct, m, dispatchers);
   // loopback replies go to itself
   loopback->set_direct_reply_connection(loopback);
   loopback->set_peer_type(name.type());
@@ -131,8 +132,7 @@ int DirectMessenger::set_direct_peer(DirectMessenger *peer)
   peer_inst = peer->get_myinst();
 
   // allocate a Connection that dispatches to the peer messenger
-  auto direct_connection = boost::intrusive_ptr<DirectConnection>(
-      new DirectConnection(cct, peer, peer->dispatchers.get()));
+  auto direct_connection = ceph::make_ref<DirectConnection>(cct, peer, peer->dispatchers.get());
 
   direct_connection->set_peer_addr(peer_inst.addr);
   direct_connection->set_peer_type(peer_inst.name.type());

--- a/src/test/immutable_object_cache/test_DomainSocket.cc
+++ b/src/test/immutable_object_cache/test_DomainSocket.cc
@@ -58,7 +58,7 @@ public:
       }
     }
 
-    auto ctx = new FunctionContext([](int reg) {
+    auto ctx = new LambdaContext([](int reg) {
       ASSERT_TRUE(reg == 0);
     });
     m_cache_client->register_client(ctx);

--- a/src/test/immutable_object_cache/test_multi_session.cc
+++ b/src/test/immutable_object_cache/test_multi_session.cc
@@ -106,7 +106,7 @@ public:
   void test_register_client(uint64_t random_index) {
     ASSERT_TRUE(m_cache_client_vec[random_index] == nullptr);
 
-    auto ctx = new FunctionContext([](int ret){
+    auto ctx = new LambdaContext([](int ret){
        ASSERT_TRUE(ret == 0);
     });
     auto session = create_session(random_index);

--- a/src/test/journal/RadosTestFixture.cc
+++ b/src/test/journal/RadosTestFixture.cc
@@ -68,15 +68,15 @@ int RadosTestFixture::create(const std::string &oid, uint8_t order,
   return cls::journal::client::create(m_ioctx, oid, order, splay_width, -1);
 }
 
-journal::JournalMetadataPtr RadosTestFixture::create_metadata(
+ceph::ref_t<journal::JournalMetadata> RadosTestFixture::create_metadata(
     const std::string &oid, const std::string &client_id,
     double commit_interval, int max_concurrent_object_sets) {
   journal::Settings settings;
   settings.commit_interval = commit_interval;
   settings.max_concurrent_object_sets = max_concurrent_object_sets;
 
-  journal::JournalMetadataPtr metadata(new journal::JournalMetadata(
-    m_work_queue, m_timer, &m_timer_lock, m_ioctx, oid, client_id, settings));
+  auto metadata = ceph::make_ref<journal::JournalMetadata>(
+    m_work_queue, m_timer, &m_timer_lock, m_ioctx, oid, client_id, settings);
   m_metadatas.push_back(metadata);
   return metadata;
 }
@@ -109,13 +109,13 @@ bufferlist RadosTestFixture::create_payload(const std::string &payload) {
   return bl;
 }
 
-int RadosTestFixture::init_metadata(journal::JournalMetadataPtr metadata) {
+int RadosTestFixture::init_metadata(const ceph::ref_t<journal::JournalMetadata>& metadata) {
   C_SaferCond cond;
   metadata->init(&cond);
   return cond.wait();
 }
 
-bool RadosTestFixture::wait_for_update(journal::JournalMetadataPtr metadata) {
+bool RadosTestFixture::wait_for_update(const ceph::ref_t<journal::JournalMetadata>& metadata) {
   std::unique_lock locker{m_listener.mutex};
   while (m_listener.updates[metadata.get()] == 0) {
     if (m_listener.cond.wait_for(locker, 10s) == std::cv_status::timeout) {

--- a/src/test/journal/RadosTestFixture.h
+++ b/src/test/journal/RadosTestFixture.h
@@ -23,7 +23,7 @@ public:
 
   int create(const std::string &oid, uint8_t order = 14,
              uint8_t splay_width = 2);
-  journal::JournalMetadataPtr create_metadata(const std::string &oid,
+  ceph::ref_t<journal::JournalMetadata> create_metadata(const std::string &oid,
                                               const std::string &client_id = "client",
                                               double commit_internal = 0.1,
                                               int max_concurrent_object_sets = 0);
@@ -52,9 +52,9 @@ public:
     }
   };
 
-  int init_metadata(journal::JournalMetadataPtr metadata);
+  int init_metadata(const ceph::ref_t<journal::JournalMetadata>& metadata);
 
-  bool wait_for_update(journal::JournalMetadataPtr metadata);
+  bool wait_for_update(const ceph::ref_t<journal::JournalMetadata>& metadata);
 
   static std::string _pool_name;
   static librados::Rados _rados;
@@ -70,5 +70,5 @@ public:
 
   Listener m_listener;
 
-  std::list<journal::JournalMetadataPtr> m_metadatas;
+  std::list<ceph::ref_t<journal::JournalMetadata>> m_metadatas;
 };

--- a/src/test/journal/test_FutureImpl.cc
+++ b/src/test/journal/test_FutureImpl.cc
@@ -9,46 +9,39 @@
 class TestFutureImpl : public RadosTestFixture {
 public:
   struct FlushHandler : public journal::FutureImpl::FlushHandler {
-    uint64_t refs;
-    uint64_t flushes;
-    FlushHandler() : refs(0), flushes(0) {}
-    void get() override {
-      ++refs;
-    }
-    void put() override {
-      ceph_assert(refs > 0);
-      --refs;
-    }
-    void flush(const journal::FutureImplPtr &future) override {
+    uint64_t flushes = 0;
+    void flush(const ceph::ref_t<journal::FutureImpl>& future) override {
       ++flushes;
     }
+    FlushHandler() = default;
   };
 
-  journal::FutureImplPtr create_future(uint64_t tag_tid, uint64_t entry_tid,
-                                       uint64_t commit_tid,
-                                       const journal::FutureImplPtr &prev =
-                                         journal::FutureImplPtr()) {
-    journal::FutureImplPtr future(new journal::FutureImpl(tag_tid,
-                                                          entry_tid,
-                                                          commit_tid));
+  TestFutureImpl() {
+    m_flush_handler = std::make_shared<FlushHandler>();
+  }
+
+  auto create_future(uint64_t tag_tid, uint64_t entry_tid,
+                     uint64_t commit_tid,
+                     ceph::ref_t<journal::FutureImpl> prev = nullptr) {
+    auto future = ceph::make_ref<journal::FutureImpl>(tag_tid, entry_tid, commit_tid);
     future->init(prev);
     return future;
   }
 
-  void flush(const journal::FutureImplPtr &future) {
+  void flush(const ceph::ref_t<journal::FutureImpl>& future) {
   }
 
-  FlushHandler m_flush_handler;
+  std::shared_ptr<FlushHandler> m_flush_handler;
 };
 
 TEST_F(TestFutureImpl, Getters) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 123, 456);
+  auto future = create_future(234, 123, 456);
   ASSERT_EQ(234U, future->get_tag_tid());
   ASSERT_EQ(123U, future->get_entry_tid());
   ASSERT_EQ(456U, future->get_commit_tid());
@@ -58,68 +51,68 @@ TEST_F(TestFutureImpl, Attach) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 123, 456);
-  ASSERT_FALSE(future->attach(&m_flush_handler));
-  ASSERT_EQ(1U, m_flush_handler.refs);
+  auto future = create_future(234, 123, 456);
+  ASSERT_FALSE(future->attach(m_flush_handler));
+  ASSERT_EQ(2U, m_flush_handler.use_count());
 }
 
 TEST_F(TestFutureImpl, AttachWithPendingFlush) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 123, 456);
+  auto future = create_future(234, 123, 456);
   future->flush(NULL);
 
-  ASSERT_TRUE(future->attach(&m_flush_handler));
-  ASSERT_EQ(1U, m_flush_handler.refs);
+  ASSERT_TRUE(future->attach(m_flush_handler));
+  ASSERT_EQ(2U, m_flush_handler.use_count());
 }
 
 TEST_F(TestFutureImpl, Detach) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 123, 456);
-  ASSERT_FALSE(future->attach(&m_flush_handler));
+  auto future = create_future(234, 123, 456);
+  ASSERT_FALSE(future->attach(m_flush_handler));
   future->detach();
-  ASSERT_EQ(0U, m_flush_handler.refs);
+  ASSERT_EQ(1U, m_flush_handler.use_count());
 }
 
 TEST_F(TestFutureImpl, DetachImplicit) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 123, 456);
-  ASSERT_FALSE(future->attach(&m_flush_handler));
+  auto future = create_future(234, 123, 456);
+  ASSERT_FALSE(future->attach(m_flush_handler));
   future.reset();
-  ASSERT_EQ(0U, m_flush_handler.refs);
+  ASSERT_EQ(1U, m_flush_handler.use_count());
 }
 
 TEST_F(TestFutureImpl, Flush) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 123, 456);
-  ASSERT_FALSE(future->attach(&m_flush_handler));
+  auto future = create_future(234, 123, 456);
+  ASSERT_FALSE(future->attach(m_flush_handler));
 
   C_SaferCond cond;
   future->flush(&cond);
 
-  ASSERT_EQ(1U, m_flush_handler.flushes);
+  ASSERT_EQ(1U, m_flush_handler->flushes);
   future->safe(-EIO);
   ASSERT_EQ(-EIO, cond.wait());
 }
@@ -128,14 +121,14 @@ TEST_F(TestFutureImpl, FlushWithoutContext) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 123, 456);
-  ASSERT_FALSE(future->attach(&m_flush_handler));
+  auto future = create_future(234, 123, 456);
+  ASSERT_FALSE(future->attach(m_flush_handler));
 
   future->flush(NULL);
-  ASSERT_EQ(1U, m_flush_handler.flushes);
+  ASSERT_EQ(1U, m_flush_handler->flushes);
   future->safe(-EIO);
   ASSERT_TRUE(future->is_complete());
   ASSERT_EQ(-EIO, future->get_return_value());
@@ -145,25 +138,23 @@ TEST_F(TestFutureImpl, FlushChain) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future1 = create_future(234, 123, 456);
-  journal::FutureImplPtr future2 = create_future(234, 124, 457,
-                                                 future1);
-  journal::FutureImplPtr future3 = create_future(235, 1, 458,
-                                                 future2);
+  auto future1 = create_future(234, 123, 456);
+  auto future2 = create_future(234, 124, 457, future1);
+  auto future3 = create_future(235, 1, 458, future2);
 
-  FlushHandler flush_handler;
-  ASSERT_FALSE(future1->attach(&m_flush_handler));
-  ASSERT_FALSE(future2->attach(&flush_handler));
-  ASSERT_FALSE(future3->attach(&m_flush_handler));
+  auto flush_handler = std::make_shared<FlushHandler>();
+  ASSERT_FALSE(future1->attach(m_flush_handler));
+  ASSERT_FALSE(future2->attach(flush_handler));
+  ASSERT_FALSE(future3->attach(m_flush_handler));
 
   C_SaferCond cond;
   future3->flush(&cond);
 
-  ASSERT_EQ(1U, m_flush_handler.flushes);
-  ASSERT_EQ(1U, flush_handler.flushes);
+  ASSERT_EQ(1U, m_flush_handler->flushes);
+  ASSERT_EQ(1U, flush_handler->flushes);
 
   future3->safe(0);
   ASSERT_FALSE(future3->is_complete());
@@ -182,20 +173,19 @@ TEST_F(TestFutureImpl, FlushInProgress) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future1 = create_future(234, 123, 456);
-  journal::FutureImplPtr future2 = create_future(234, 124, 457,
-                                                 future1);
-  ASSERT_FALSE(future1->attach(&m_flush_handler));
-  ASSERT_FALSE(future2->attach(&m_flush_handler));
+  auto future1 = create_future(234, 123, 456);
+  auto future2 = create_future(234, 124, 457, future1);
+  ASSERT_FALSE(future1->attach(m_flush_handler));
+  ASSERT_FALSE(future2->attach(m_flush_handler));
 
   future1->set_flush_in_progress();
   ASSERT_TRUE(future1->is_flush_in_progress());
 
   future1->flush(NULL);
-  ASSERT_EQ(0U, m_flush_handler.flushes);
+  ASSERT_EQ(0U, m_flush_handler->flushes);
 
   future1->safe(0);
 }
@@ -204,10 +194,10 @@ TEST_F(TestFutureImpl, FlushAlreadyComplete) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 123, 456);
+  auto future = create_future(234, 123, 456);
   future->safe(-EIO);
 
   C_SaferCond cond;
@@ -219,10 +209,10 @@ TEST_F(TestFutureImpl, Wait) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 1, 456);
+  auto future = create_future(234, 1, 456);
 
   C_SaferCond cond;
   future->wait(&cond);
@@ -234,10 +224,10 @@ TEST_F(TestFutureImpl, WaitAlreadyComplete) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future = create_future(234, 1, 456);
+  auto future = create_future(234, 1, 456);
   future->safe(-EEXIST);
 
   C_SaferCond cond;
@@ -249,12 +239,11 @@ TEST_F(TestFutureImpl, SafePreservesError) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future1 = create_future(234, 123, 456);
-  journal::FutureImplPtr future2 = create_future(234, 124, 457,
-                                                 future1);
+  auto future1 = create_future(234, 123, 456);
+  auto future2 = create_future(234, 124, 457, future1);
 
   future1->safe(-EIO);
   future2->safe(-EEXIST);
@@ -266,12 +255,11 @@ TEST_F(TestFutureImpl, ConsistentPreservesError) {
   std::string oid = get_temp_oid();
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid));
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
-  journal::FutureImplPtr future1 = create_future(234, 123, 456);
-  journal::FutureImplPtr future2 = create_future(234, 124, 457,
-                                                 future1);
+  auto future1 = create_future(234, 123, 456);
+  auto future2 = create_future(234, 124, 457, future1);
 
   future2->safe(-EEXIST);
   future1->safe(-EIO);

--- a/src/test/journal/test_JournalMetadata.cc
+++ b/src/test/journal/test_JournalMetadata.cc
@@ -18,25 +18,25 @@ public:
     RadosTestFixture::TearDown();
   }
 
-  journal::JournalMetadataPtr create_metadata(const std::string &oid,
-                                              const std::string &client_id,
-                                              double commit_interval = 0.1,
-                                              int max_concurrent_object_sets = 0) {
-    journal::JournalMetadataPtr metadata = RadosTestFixture::create_metadata(
+  auto create_metadata(const std::string &oid,
+                       const std::string &client_id,
+                       double commit_interval = 0.1,
+                       int max_concurrent_object_sets = 0) {
+    auto metadata = RadosTestFixture::create_metadata(
       oid, client_id, commit_interval, max_concurrent_object_sets);
     m_metadata_list.push_back(metadata);
     metadata->add_listener(&m_listener);
     return metadata;
   }
 
-  typedef std::list<journal::JournalMetadataPtr> MetadataList;
+  typedef std::list<ceph::ref_t<journal::JournalMetadata>> MetadataList;
   MetadataList m_metadata_list;
 };
 
 TEST_F(TestJournalMetadata, JournalDNE) {
   std::string oid = get_temp_oid();
 
-  journal::JournalMetadataPtr metadata1 = create_metadata(oid, "client1");
+  auto metadata1 = create_metadata(oid, "client1");
   ASSERT_EQ(-ENOENT, init_metadata(metadata1));
 }
 
@@ -46,10 +46,10 @@ TEST_F(TestJournalMetadata, ClientDNE) {
   ASSERT_EQ(0, create(oid, 14, 2));
   ASSERT_EQ(0, client_register(oid, "client1", ""));
 
-  journal::JournalMetadataPtr metadata1 = create_metadata(oid, "client1");
+  auto metadata1 = create_metadata(oid, "client1");
   ASSERT_EQ(0, init_metadata(metadata1));
 
-  journal::JournalMetadataPtr metadata2 = create_metadata(oid, "client2");
+  auto metadata2 = create_metadata(oid, "client2");
   ASSERT_EQ(-ENOENT, init_metadata(metadata2));
 }
 
@@ -59,10 +59,10 @@ TEST_F(TestJournalMetadata, Committed) {
   ASSERT_EQ(0, create(oid, 14, 2));
   ASSERT_EQ(0, client_register(oid, "client1", ""));
 
-  journal::JournalMetadataPtr metadata1 = create_metadata(oid, "client1", 600);
+  auto metadata1 = create_metadata(oid, "client1", 600);
   ASSERT_EQ(0, init_metadata(metadata1));
 
-  journal::JournalMetadataPtr metadata2 = create_metadata(oid, "client1");
+  auto metadata2 = create_metadata(oid, "client1");
   ASSERT_EQ(0, init_metadata(metadata2));
   ASSERT_TRUE(wait_for_update(metadata2));
 
@@ -104,7 +104,7 @@ TEST_F(TestJournalMetadata, UpdateActiveObject) {
   ASSERT_EQ(0, create(oid, 14, 2));
   ASSERT_EQ(0, client_register(oid, "client1", ""));
 
-  journal::JournalMetadataPtr metadata1 = create_metadata(oid, "client1");
+  auto metadata1 = create_metadata(oid, "client1");
   ASSERT_EQ(0, init_metadata(metadata1));
   ASSERT_TRUE(wait_for_update(metadata1));
 
@@ -124,7 +124,7 @@ TEST_F(TestJournalMetadata, DisconnectLaggyClient) {
   ASSERT_EQ(0, client_register(oid, "client2", "laggy"));
 
   int max_concurrent_object_sets = 100;
-  journal::JournalMetadataPtr metadata =
+  auto metadata =
     create_metadata(oid, "client1", 0.1, max_concurrent_object_sets);
   ASSERT_EQ(0, init_metadata(metadata));
   ASSERT_TRUE(wait_for_update(metadata));
@@ -186,7 +186,7 @@ TEST_F(TestJournalMetadata, AssertActiveTag) {
   ASSERT_EQ(0, create(oid));
   ASSERT_EQ(0, client_register(oid, "client1", ""));
 
-  journal::JournalMetadataPtr metadata = create_metadata(oid, "client1");
+  auto metadata = create_metadata(oid, "client1");
   ASSERT_EQ(0, init_metadata(metadata));
   ASSERT_TRUE(wait_for_update(metadata));
 

--- a/src/test/journal/test_JournalPlayer.cc
+++ b/src/test/journal/test_JournalPlayer.cc
@@ -32,9 +32,6 @@ public:
       : entries_available(false), complete(false),
         complete_result(0) {}
 
-    void get() override {}
-    void put() override {}
-
     void handle_entries_available() override {
       std::lock_guard locker{lock};
       entries_available = true;
@@ -57,7 +54,7 @@ public:
     RadosTestFixture::TearDown();
   }
 
-  journal::JournalMetadataPtr create_metadata(const std::string &oid) {
+  auto create_metadata(const std::string &oid) {
     return RadosTestFixture::create_metadata(oid, "client", 0.1,
                                              max_fetch_bytes);
   }
@@ -75,7 +72,7 @@ public:
   }
 
   journal::JournalPlayer *create_player(const std::string &oid,
-                                        const journal::JournalMetadataPtr &metadata) {
+                                        const ceph::ref_t<journal::JournalMetadata>& metadata) {
     journal::JournalPlayer *player(new journal::JournalPlayer(
       m_ioctx, oid + ".", metadata, &m_replay_hander, nullptr));
     m_players.push_back(player);
@@ -156,7 +153,7 @@ TYPED_TEST(TestJournalPlayer, Prefetch) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -202,7 +199,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchSkip) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -237,7 +234,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchWithoutCommit) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -277,7 +274,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchMultipleTags) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -316,7 +313,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchCorruptSequence) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -350,7 +347,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchMissingSequence) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -400,7 +397,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchLargeMissingSequence) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -436,7 +433,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchBlockedNewTag) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -475,7 +472,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchStaleEntries) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -511,7 +508,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchUnexpectedTag) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -548,7 +545,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchAndWatch) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -586,7 +583,7 @@ TYPED_TEST(TestJournalPlayer, PrefetchSkippedObject) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
   ASSERT_EQ(0, metadata->set_active_set(2));
 
@@ -637,7 +634,7 @@ TYPED_TEST(TestJournalPlayer, ImbalancedJournal) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
   ASSERT_EQ(0, metadata->set_active_set(2));
   metadata->set_minimum_set(2);
@@ -686,7 +683,7 @@ TYPED_TEST(TestJournalPlayer, LiveReplayLaggyAppend) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -736,7 +733,7 @@ TYPED_TEST(TestJournalPlayer, LiveReplayMissingSequence) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -791,7 +788,7 @@ TYPED_TEST(TestJournalPlayer, LiveReplayLargeMissingSequence) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -827,7 +824,7 @@ TYPED_TEST(TestJournalPlayer, LiveReplayBlockedNewTag) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -886,7 +883,7 @@ TYPED_TEST(TestJournalPlayer, LiveReplayStaleEntries) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -922,7 +919,7 @@ TYPED_TEST(TestJournalPlayer, LiveReplayRefetchRemoveEmpty) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, commit_position));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -964,7 +961,7 @@ TYPED_TEST(TestJournalPlayer, PrefechShutDown) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, {}));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);
@@ -983,7 +980,7 @@ TYPED_TEST(TestJournalPlayer, LiveReplayShutDown) {
   ASSERT_EQ(0, this->client_register(oid));
   ASSERT_EQ(0, this->client_commit(oid, {}));
 
-  journal::JournalMetadataPtr metadata = this->create_metadata(oid);
+  auto metadata = this->create_metadata(oid);
   ASSERT_EQ(0, this->init_metadata(metadata));
 
   journal::JournalPlayer *player = this->create_player(oid, metadata);

--- a/src/test/journal/test_JournalRecorder.cc
+++ b/src/test/journal/test_JournalRecorder.cc
@@ -14,7 +14,7 @@ public:
   using JournalRecorderPtr = std::unique_ptr<journal::JournalRecorder,
 					     std::function<void(journal::JournalRecorder*)>>;
   JournalRecorderPtr create_recorder(
-      const std::string &oid, const journal::JournalMetadataPtr &metadata) {
+      const std::string &oid, const ceph::ref_t<journal::JournalMetadata>& metadata) {
     JournalRecorderPtr recorder{
       new journal::JournalRecorder(m_ioctx, oid + ".", metadata, 0),
       [](journal::JournalRecorder* recorder) {
@@ -34,7 +34,7 @@ TEST_F(TestJournalRecorder, Append) {
   ASSERT_EQ(0, create(oid, 12, 2));
   ASSERT_EQ(0, client_register(oid));
 
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
   JournalRecorderPtr recorder = create_recorder(oid, metadata);
@@ -51,7 +51,7 @@ TEST_F(TestJournalRecorder, AppendKnownOverflow) {
   ASSERT_EQ(0, create(oid, 12, 2));
   ASSERT_EQ(0, client_register(oid));
 
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
   ASSERT_EQ(0U, metadata->get_active_set());
 
@@ -73,7 +73,7 @@ TEST_F(TestJournalRecorder, AppendDelayedOverflow) {
   ASSERT_EQ(0, create(oid, 12, 2));
   ASSERT_EQ(0, client_register(oid));
 
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
   ASSERT_EQ(0U, metadata->get_active_set());
 
@@ -98,7 +98,7 @@ TEST_F(TestJournalRecorder, FutureFlush) {
   ASSERT_EQ(0, create(oid, 12, 2));
   ASSERT_EQ(0, client_register(oid));
 
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
   JournalRecorderPtr recorder = create_recorder(oid, metadata);
@@ -118,7 +118,7 @@ TEST_F(TestJournalRecorder, Flush) {
   ASSERT_EQ(0, create(oid, 12, 2));
   ASSERT_EQ(0, client_register(oid));
 
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
 
   JournalRecorderPtr recorder = create_recorder(oid, metadata);
@@ -142,7 +142,7 @@ TEST_F(TestJournalRecorder, OverflowCommitObjectNumber) {
   ASSERT_EQ(0, create(oid, 12, 2));
   ASSERT_EQ(0, client_register(oid));
 
-  journal::JournalMetadataPtr metadata = create_metadata(oid);
+  auto metadata = create_metadata(oid);
   ASSERT_EQ(0, init_metadata(metadata));
   ASSERT_EQ(0U, metadata->get_active_set());
 

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -71,7 +71,7 @@ public:
     int ret = m_callback();
     if (m_comp != NULL) {
       if (m_finisher != NULL) {
-        m_finisher->queue(new FunctionContext(boost::bind(
+        m_finisher->queue(new LambdaContext(boost::bind(
           &finish_aio_completion, m_comp, ret)));
       } else {
         finish_aio_completion(m_comp, ret);
@@ -203,7 +203,7 @@ void TestRadosClient::add_aio_operation(const std::string& oid,
 struct WaitForFlush {
   int flushed() {
     if (--count == 0) {
-      aio_finisher->queue(new FunctionContext(boost::bind(
+      aio_finisher->queue(new LambdaContext(boost::bind(
         &finish_aio_completion, c, 0)));
       delete this;
     }
@@ -240,7 +240,7 @@ void TestRadosClient::flush_aio_operations(AioCompletionImpl *c) {
 
 int TestRadosClient::aio_watch_flush(AioCompletionImpl *c) {
   c->get();
-  Context *ctx = new FunctionContext(boost::bind(
+  Context *ctx = new LambdaContext(boost::bind(
     &TestRadosClient::finish_aio_completion, this, c, _1));
   get_watch_notify()->aio_flush(this, ctx);
   return 0;

--- a/src/test/librbd/cache/test_mock_ParentImageCache.cc
+++ b/src/test/librbd/cache/test_mock_ParentImageCache.cc
@@ -151,12 +151,12 @@ TEST_F(TestMockParentImageCache, test_initialization_success) {
 
   expect_cache_run(*mock_parent_image_cache, 0);
   C_SaferCond cond;
-  Context* handle_connect = new FunctionContext([&cond](int ret) {
+  Context* handle_connect = new LambdaContext([&cond](int ret) {
     ASSERT_EQ(ret, 0);
     cond.complete(0);
   });
   expect_cache_async_connect(*mock_parent_image_cache, 0, handle_connect);
-  Context* ctx = new FunctionContext([](bool reg) {
+  Context* ctx = new LambdaContext([](bool reg) {
     ASSERT_EQ(reg, true);
   });
   expect_cache_register(*mock_parent_image_cache, ctx, 0);
@@ -189,7 +189,7 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_connect) {
 
   expect_cache_run(*mock_parent_image_cache, 0);
   C_SaferCond cond;
-  Context* handle_connect = new FunctionContext([&cond](int ret) {
+  Context* handle_connect = new LambdaContext([&cond](int ret) {
     ASSERT_EQ(ret, -1);
     cond.complete(0);
   });
@@ -223,12 +223,12 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_register) {
 
   expect_cache_run(*mock_parent_image_cache, 0);
   C_SaferCond cond;
-  Context* handle_connect = new FunctionContext([&cond](int ret) {
+  Context* handle_connect = new LambdaContext([&cond](int ret) {
     ASSERT_EQ(ret, 0);
     cond.complete(0);
   });
   expect_cache_async_connect(*mock_parent_image_cache, 0, handle_connect);
-  Context* ctx = new FunctionContext([](bool reg) {
+  Context* ctx = new LambdaContext([](bool reg) {
     ASSERT_EQ(reg, false);
   });
   expect_cache_register(*mock_parent_image_cache, ctx, -1);
@@ -300,12 +300,12 @@ TEST_F(TestMockParentImageCache, test_read) {
 
   expect_cache_run(*mock_parent_image_cache, 0);
   C_SaferCond conn_cond;
-  Context* handle_connect = new FunctionContext([&conn_cond](int ret) {
+  Context* handle_connect = new LambdaContext([&conn_cond](int ret) {
     ASSERT_EQ(ret, 0);
     conn_cond.complete(0);
   });
   expect_cache_async_connect(*mock_parent_image_cache, 0, handle_connect);
-  Context* ctx = new FunctionContext([](bool reg) {
+  Context* ctx = new LambdaContext([](bool reg) {
     ASSERT_EQ(reg, true);
   });
   expect_cache_register(*mock_parent_image_cache, ctx, 0);

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -167,8 +167,7 @@ public:
     if ((m_src_image_ctx->features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0) {
       return;
     }
-    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(
-      ReturnNew<FunctionContext>([](int) {}));
+    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(Return(new LambdaContext([](int){})));
   }
 
   void expect_list_snaps(librbd::MockTestImageCtx &mock_image_ctx,

--- a/src/test/librbd/deep_copy/test_mock_SetHeadRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SetHeadRequest.cc
@@ -110,8 +110,7 @@ public:
   }
 
   void expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {
-    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(
-      ReturnNew<FunctionContext>([](int) {}));
+    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(Return(new LambdaContext([](int){})));
   }
 
   void expect_test_features(librbd::MockTestImageCtx &mock_image_ctx,

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCopyRequest.cc
@@ -148,8 +148,7 @@ public:
     if ((m_src_image_ctx->features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0) {
       return;
     }
-    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(
-      ReturnNew<FunctionContext>([](int) {}));
+    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(Return(new LambdaContext([](int){})));
   }
 
   void expect_get_snap_namespace(librbd::MockTestImageCtx &mock_image_ctx,

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
@@ -89,8 +89,7 @@ public:
   }
 
   void expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {
-    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(
-      ReturnNew<FunctionContext>([](int) {}));
+    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(Return(new LambdaContext([](int){})));
   }
 
   void expect_test_features(librbd::MockTestImageCtx &mock_image_ctx,

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -277,11 +277,6 @@ struct ReplayHandler : public journal::ReplayHandler {
                   on_finish(on_finish) {
         }
 
-        void get() override {
-        }
-        void put() override {
-        }
-
         void handle_entries_available() override {
                 while (true) {
                         journal::ReplayEntry replay_entry;

--- a/src/test/librbd/journal/test_Entries.cc
+++ b/src/test/librbd/journal/test_Entries.cc
@@ -32,11 +32,6 @@ public:
       : entries_available(false), complete(false) {
     }
 
-    void get() override {
-    }
-    void put() override {
-    }
-
     void handle_entries_available() override  {
       std::lock_guard locker{lock};
       entries_available = true;

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -122,7 +122,7 @@ ACTION_P2(NotifyInvoke, lock, cond) {
 }
 
 ACTION_P2(CompleteAioCompletion, r, image_ctx) {
-  image_ctx->op_work_queue->queue(new FunctionContext([this, arg0](int r) {
+  image_ctx->op_work_queue->queue(new LambdaContext([this, arg0](int r) {
       arg0->get();
       arg0->init_time(image_ctx, librbd::io::AIO_TYPE_NONE);
       arg0->set_request_count(1);

--- a/src/test/librbd/operation/test_mock_Request.cc
+++ b/src/test/librbd/operation/test_mock_Request.cc
@@ -109,7 +109,7 @@ struct TestMockOperationRequest : public TestMockFixture {
     EXPECT_CALL(mock_request, send_op())
       .WillOnce(Invoke([&mock_image_ctx, &mock_request, r]() {
                   mock_image_ctx.image_ctx->op_work_queue->queue(
-                    new FunctionContext([&mock_request, r](int _) {
+                    new LambdaContext([&mock_request, r](int _) {
                       mock_request.send_op_impl(r);
                     }), 0);
                 }));

--- a/src/test/librbd/operation/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/operation/test_mock_ResizeRequest.cc
@@ -157,7 +157,7 @@ public:
     EXPECT_CALL(mock_io_image_dispatch_spec, send())
       .WillOnce(Invoke([&mock_image_ctx, &mock_io_image_dispatch_spec, r]() {
                   auto aio_comp = mock_io_image_dispatch_spec.s_instance->aio_comp;
-                  auto ctx = new FunctionContext([aio_comp](int r) {
+                  auto ctx = new LambdaContext([aio_comp](int r) {
                     aio_comp->fail(r);
                   });
                   mock_image_ctx.image_ctx->op_work_queue->queue(ctx, r);

--- a/src/test/librbd/test_ObjectMap.cc
+++ b/src/test/librbd/test_ObjectMap.cc
@@ -193,7 +193,7 @@ TEST_F(TestObjectMap, DISABLED_StressTest) {
 
     throttle.start_op();
     uint64_t object_no = (rand() % object_count);
-    auto ctx = new FunctionContext([&throttle, object_no](int r) {
+    auto ctx = new LambdaContext([&throttle, object_no](int r) {
         ASSERT_EQ(0, r) << "object_no=" << object_no;
         throttle.end_op(r);
       });

--- a/src/test/librbd/test_mock_DeepCopyRequest.cc
+++ b/src/test/librbd/test_mock_DeepCopyRequest.cc
@@ -170,8 +170,7 @@ public:
   }
 
   void expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {
-    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(
-      ReturnNew<FunctionContext>([](int) {}));
+    EXPECT_CALL(mock_exclusive_lock, start_op(_)).WillOnce(Return(new LambdaContext([](int){})));
   }
 
   void expect_rollback_object_map(librbd::MockObjectMap &mock_object_map, int r) {

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -492,7 +492,7 @@ public:
       mock_image_ctx.image_ctx->op_work_queue->queue(ctx, r);
     }
 
-    on_flush = new FunctionContext([on_flush](int r) {
+    on_flush = new LambdaContext([on_flush](int r) {
         derr << "FLUSH START" << dendl;
         on_flush->complete(r);
         derr << "FLUSH FINISH" << dendl;

--- a/src/test/librbd/test_mock_Watcher.cc
+++ b/src/test/librbd/test_mock_Watcher.cc
@@ -76,7 +76,7 @@ public:
           }
 
           c->get();
-          mock_image_ctx.image_ctx->op_work_queue->queue(new FunctionContext([mock_rados_client, action, c](int r) {
+          mock_image_ctx.image_ctx->op_work_queue->queue(new LambdaContext([mock_rados_client, action, c](int r) {
               if (action) {
                 action();
               }
@@ -97,7 +97,7 @@ public:
       .WillOnce(DoAll(Invoke([this, &mock_image_ctx, mock_rados_client, r, action](
               uint64_t handle, librados::AioCompletionImpl *c) {
           c->get();
-          mock_image_ctx.image_ctx->op_work_queue->queue(new FunctionContext([mock_rados_client, action, c](int r) {
+          mock_image_ctx.image_ctx->op_work_queue->queue(new LambdaContext([mock_rados_client, action, c](int r) {
               if (action) {
                 action();
               }

--- a/src/test/librbd/watcher/test_mock_RewatchRequest.cc
+++ b/src/test/librbd/watcher/test_mock_RewatchRequest.cc
@@ -34,7 +34,7 @@ struct TestMockWatcherRewatchRequest : public TestMockFixture {
       .WillOnce(DoAll(WithArgs<1, 2>(Invoke([&mock_image_ctx, &mock_io_ctx, r](librados::AioCompletionImpl *c, uint64_t *cookie) {
                                    *cookie = 234;
                                    c->get();
-                                   mock_image_ctx.image_ctx->op_work_queue->queue(new FunctionContext([&mock_io_ctx, c](int r) {
+                                   mock_image_ctx.image_ctx->op_work_queue->queue(new LambdaContext([&mock_io_ctx, c](int r) {
                                        mock_io_ctx.get_mock_rados_client()->finish_aio_completion(c, r);
                                      }), r);
                                    })),
@@ -49,7 +49,7 @@ struct TestMockWatcherRewatchRequest : public TestMockFixture {
       .WillOnce(DoAll(Invoke([&mock_image_ctx, &mock_io_ctx, r](uint64_t handle,
                                                                 librados::AioCompletionImpl *c) {
                         c->get();
-                        mock_image_ctx.image_ctx->op_work_queue->queue(new FunctionContext([&mock_io_ctx, c](int r) {
+                        mock_image_ctx.image_ctx->op_work_queue->queue(new LambdaContext([&mock_io_ctx, c](int r) {
                             mock_io_ctx.get_mock_rados_client()->finish_aio_completion(c, r);
                           }), r);
                         }),

--- a/src/test/mds/TestSessionFilter.cc
+++ b/src/test/mds/TestSessionFilter.cc
@@ -74,15 +74,13 @@ TEST(MDSSessionFilter, IdEquality)
   SessionFilter filter;
   std::stringstream ss;
   filter.parse({"id=123"}, &ss);
-  Session *a = new Session(nullptr);;
-  Session *b = new Session(nullptr);;
+  auto a = ceph::make_ref<Session>(nullptr);;
+  auto b = ceph::make_ref<Session>(nullptr);;
   a->info.inst.name.parse("client.123");
   b->info.inst.name.parse("client.456");
 
   ASSERT_TRUE(filter.match(*a, [](client_t c) -> bool {return false;}));
   ASSERT_FALSE(filter.match(*b, [](client_t c) -> bool {return false;}));
-  a->put();
-  b->put();
 }
 
 TEST(MDSSessionFilter, StateEquality)
@@ -90,15 +88,13 @@ TEST(MDSSessionFilter, StateEquality)
   SessionFilter filter;
   std::stringstream ss;
   filter.parse({"state=closing"}, &ss);
-  Session *a = new Session(nullptr);
+  auto a = ceph::make_ref<Session>(nullptr);
   a->set_state(Session::STATE_CLOSING);
-  Session *b = new Session(nullptr);
+  auto b = ceph::make_ref<Session>(nullptr);
   b->set_state(Session::STATE_OPENING);
 
   ASSERT_TRUE(filter.match(*a, [](client_t c) -> bool {return false;}));
   ASSERT_FALSE(filter.match(*b, [](client_t c) -> bool {return false;}));
-  a->put();
-  b->put();
 }
 
 TEST(MDSSessionFilter, AuthEquality)
@@ -106,15 +102,13 @@ TEST(MDSSessionFilter, AuthEquality)
   SessionFilter filter;
   std::stringstream ss;
   filter.parse({"auth_name=rhubarb"}, &ss);
-  Session *a = new Session(nullptr);
+  auto a = ceph::make_ref<Session>(nullptr);
   a->info.auth_name.set_id("rhubarb");
-  Session *b = new Session(nullptr);
+  auto b = ceph::make_ref<Session>(nullptr);
   b->info.auth_name.set_id("custard");
 
   ASSERT_TRUE(filter.match(*a, [](client_t c) -> bool {return false;}));
   ASSERT_FALSE(filter.match(*b, [](client_t c) -> bool {return false;}));
-  a->put();
-  b->put();
 }
 
 TEST(MDSSessionFilter, MetadataEquality)
@@ -124,17 +118,15 @@ TEST(MDSSessionFilter, MetadataEquality)
   int r = filter.parse({"client_metadata.root=/rhubarb"}, &ss);
   ASSERT_EQ(r, 0);
   client_metadata_t meta;
-  Session *a = new Session(nullptr);
+  auto a = ceph::make_ref<Session>(nullptr);
   meta.kv_map = {{"root", "/rhubarb"}};
   a->set_client_metadata(meta);
-  Session *b = new Session(nullptr);
+  auto b = ceph::make_ref<Session>(nullptr);
   meta.kv_map = {{"root", "/custard"}};
   b->set_client_metadata(meta);
 
   ASSERT_TRUE(filter.match(*a, [](client_t c) -> bool {return false;}));
   ASSERT_FALSE(filter.match(*b, [](client_t c) -> bool {return false;}));
-  a->put();
-  b->put();
 }
 
 TEST(MDSSessionFilter, ReconnectingEquality)
@@ -143,9 +135,8 @@ TEST(MDSSessionFilter, ReconnectingEquality)
   std::stringstream ss;
   int r = filter.parse({"reconnecting=true"}, &ss);
   ASSERT_EQ(r, 0);
-  Session *a = new Session(nullptr);
+  auto a = ceph::make_ref<Session>(nullptr);
 
   ASSERT_TRUE(filter.match(*a, [](client_t c) -> bool {return true;}));
   ASSERT_FALSE(filter.match(*a, [](client_t c) -> bool {return false;}));
-  a->put();
 }

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -341,7 +341,7 @@ TEST(Blob, put_ref)
     BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
       g_ceph_context, "lru", NULL);
 
-    BlueStore::Collection coll(&store, oc, bc, coll_t());
+    auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Blob b;
     b.shared_blob = new BlueStore::SharedBlob(nullptr);
     b.shared_blob->get();  // hack to avoid dtor from running
@@ -349,19 +349,19 @@ TEST(Blob, put_ref)
     b.dirty_blob().allocated_test(
       bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x8000));
     b.dirty_blob().allocated_test(bluestore_pextent_t(0x4071f000, 0x5000));
-    b.get_ref(&coll, 0, 0x1200);
-    b.get_ref(&coll, 0xae00, 0x4200);
+    b.get_ref(coll.get(), 0, 0x1200);
+    b.get_ref(coll.get(), 0xae00, 0x4200);
     ASSERT_EQ(0x5400u, b.get_referenced_bytes());
     cout << b << std::endl;
     PExtentVector r;
 
-    ASSERT_FALSE(b.put_ref(&coll, 0, 0x1200, &r));
+    ASSERT_FALSE(b.put_ref(coll.get(), 0, 0x1200, &r));
     ASSERT_EQ(0x4200u, b.get_referenced_bytes());
     cout << " r " << r << std::endl;
     cout << b << std::endl;
 
     r.clear();
-    ASSERT_TRUE(b.put_ref(&coll, 0xae00, 0x4200, &r));
+    ASSERT_TRUE(b.put_ref(coll.get(), 0xae00, 0x4200, &r));
     ASSERT_EQ(0u, b.get_referenced_bytes());
     cout << " r " << r << std::endl;
     cout << b << std::endl;
@@ -373,7 +373,7 @@ TEST(Blob, put_ref)
     g_ceph_context, "lru", NULL);
   BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
     g_ceph_context, "lru", NULL);
-  BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
 
   {
     BlueStore::Blob B;
@@ -822,7 +822,7 @@ TEST(Blob, put_ref)
     BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
       g_ceph_context, "lru", NULL);
 
-    BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+    auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Blob B;
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
@@ -911,7 +911,7 @@ TEST(Blob, split)
       g_ceph_context, "lru", NULL);
     BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
       g_ceph_context, "lru", NULL);
-  BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   {
     BlueStore::Blob L, R;
     L.shared_blob = new BlueStore::SharedBlob(coll.get());
@@ -969,7 +969,7 @@ TEST(Blob, legacy_decode)
     g_ceph_context, "lru", NULL);
   BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
     g_ceph_context, "lru", NULL);
-  BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   bufferlist bl, bl2;
   {
     BlueStore::Blob B;
@@ -1050,7 +1050,7 @@ TEST(ExtentMap, seek_lextent)
   BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
     g_ceph_context, "lru", NULL);
 
-  BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
   BlueStore::ExtentMap em(&onode);
   BlueStore::BlobRef br(new BlueStore::Blob);
@@ -1102,7 +1102,7 @@ TEST(ExtentMap, has_any_lextents)
     g_ceph_context, "lru", NULL);
   BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
     g_ceph_context, "lru", NULL);
-  BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
   BlueStore::ExtentMap em(&onode);
   BlueStore::BlobRef b(new BlueStore::Blob);
@@ -1153,7 +1153,7 @@ TEST(ExtentMap, compress_extent_map)
   BlueStore::BufferCacheShard *bc = BlueStore::BufferCacheShard::create(
     g_ceph_context, "lru", NULL);
   
-BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
   BlueStore::ExtentMap em(&onode);
   BlueStore::BlobRef b1(new BlueStore::Blob);
@@ -1210,7 +1210,7 @@ TEST(GarbageCollector, BasicTest)
     g_ceph_context, "lru", NULL);
 
   BlueStore store(g_ceph_context, "", 4096);
-  BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+  auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
   BlueStore::ExtentMap em(&onode);
 
@@ -1295,7 +1295,7 @@ TEST(GarbageCollector, BasicTest)
   */  
   {
     BlueStore store(g_ceph_context, "", 0x10000);
-    BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+    auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Onode onode(coll.get(), ghobject_t(), "");
     BlueStore::ExtentMap em(&onode);
 
@@ -1411,7 +1411,7 @@ TEST(GarbageCollector, BasicTest)
   */  
   {
     BlueStore store(g_ceph_context, "", 0x10000);
-    BlueStore::CollectionRef coll(new BlueStore::Collection(&store, oc, bc, coll_t()));
+    auto coll = ceph::make_ref<BlueStore::Collection>(&store, oc, bc, coll_t());
     BlueStore::Onode onode(coll.get(), ghobject_t(), "");
     BlueStore::ExtentMap em(&onode);
 

--- a/src/test/rbd_mirror/image_deleter/test_mock_SnapshotPurgeRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_SnapshotPurgeRequest.cc
@@ -141,11 +141,12 @@ public:
   void expect_start_op(librbd::MockTestImageCtx &mock_image_ctx, bool success) {
     EXPECT_CALL(*mock_image_ctx.exclusive_lock, start_op(_))
       .WillOnce(Invoke([success](int* r) {
+                  auto f = [](int r) {};
                   if (!success) {
                     *r = -EROFS;
-                    return static_cast<FunctionContext*>(nullptr);
+                    return static_cast<LambdaContext<decltype(f)>*>(nullptr);
                   }
-                  return new FunctionContext([](int r) {});
+                  return new LambdaContext(std::move(f));
                 }));
   }
 

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashWatcher.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashWatcher.cc
@@ -180,7 +180,7 @@ public:
     EXPECT_CALL(*mock_threads.timer, add_event_after(_, _))
       .WillOnce(DoAll(WithArg<1>(Invoke([this](Context *ctx) {
                         auto wrapped_ctx =
-			  new FunctionContext([this, ctx](int r) {
+			  new LambdaContext([this, ctx](int r) {
 			      std::lock_guard timer_locker{m_threads->timer_lock};
 			      ctx->complete(r);
 			    });

--- a/src/test/rbd_mirror/test_mock_ImageMap.cc
+++ b/src/test/rbd_mirror/test_mock_ImageMap.cc
@@ -188,7 +188,7 @@ public:
   void expect_add_event(MockThreads &mock_threads) {
     EXPECT_CALL(*mock_threads.timer, add_event_after(_,_))
       .WillOnce(DoAll(WithArg<1>(Invoke([this](Context *ctx) {
-             auto wrapped_ctx = new FunctionContext([this, ctx](int r) {
+             auto wrapped_ctx = new LambdaContext([this, ctx](int r) {
                     std::lock_guard timer_locker{m_threads->timer_lock};
                     ctx->complete(r);
                   });
@@ -203,7 +203,7 @@ public:
                 CephContext *cct = reinterpret_cast<CephContext *>(m_local_io_ctx.cct());
                 cct->_conf.set_val("rbd_mirror_image_policy_rebalance_timeout", "0");
 
-                auto wrapped_ctx = new FunctionContext([this, ctx](int r) {
+                auto wrapped_ctx = new LambdaContext([this, ctx](int r) {
                     std::lock_guard timer_locker{m_threads->timer_lock};
                     ctx->complete(r);
                   });

--- a/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
@@ -150,7 +150,7 @@ public:
             mock_threads.timer_cond.notify_one();
           } else {
             m_threads->work_queue->queue(
-              new FunctionContext([&mock_threads, ctx](int) {
+              new LambdaContext([&mock_threads, ctx](int) {
                 std::lock_guard timer_lock{mock_threads.timer_lock};
                 ctx->complete(0);
               }), 0);

--- a/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
@@ -500,7 +500,7 @@ TEST_F(TestMockInstanceWatcher, ImageAcquireReleaseCancel) {
                     const std::string& o, librados::AioCompletionImpl *c,
                     bufferlist& bl, uint64_t timeout_ms, bufferlist *pbl) {
                     c->get();
-                    auto ctx = new FunctionContext(
+                    auto ctx = new LambdaContext(
                       [instance_watcher, &mock_io_ctx, c, pbl](int r) {
                         instance_watcher->cancel_notify_requests("other");
                         encode(librbd::watcher::NotifyResponse(), *pbl);
@@ -521,7 +521,7 @@ TEST_F(TestMockInstanceWatcher, ImageAcquireReleaseCancel) {
                     const std::string& o, librados::AioCompletionImpl *c,
                     bufferlist& bl, uint64_t timeout_ms, bufferlist *pbl) {
                     c->get();
-                    auto ctx = new FunctionContext(
+                    auto ctx = new LambdaContext(
                       [instance_watcher, &mock_io_ctx, c, pbl](int r) {
                         instance_watcher->cancel_notify_requests("other");
                         encode(librbd::watcher::NotifyResponse(), *pbl);
@@ -631,7 +631,7 @@ TEST_F(TestMockInstanceWatcher, PeerImageRemovedCancel) {
                     const std::string& o, librados::AioCompletionImpl *c,
                     bufferlist& bl, uint64_t timeout_ms, bufferlist *pbl) {
                     c->get();
-                    auto ctx = new FunctionContext(
+                    auto ctx = new LambdaContext(
                       [instance_watcher, &mock_io_ctx, c, pbl](int r) {
                         instance_watcher->cancel_notify_requests("other");
                         encode(librbd::watcher::NotifyResponse(), *pbl);

--- a/src/test/rbd_mirror/test_mock_PoolReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_PoolReplayer.cc
@@ -724,7 +724,7 @@ TEST_F(TestMockPoolReplayer, NamespacesError) {
   // test namespace replayer init fails for non leader
 
   C_SaferCond on_ns1_init;
-  auto ctx = new FunctionContext(
+  Context* ctx = new LambdaContext(
       [&mock_namespace, &on_ns1_init](int r) {
         mock_namespace.remove("ns1");
         on_ns1_init.complete(r);
@@ -760,7 +760,7 @@ TEST_F(TestMockPoolReplayer, NamespacesError) {
 
   expect_namespace_replayer_handle_acquire_leader(*mock_ns2_namespace_replayer,
                                                   -EINVAL);
-  ctx = new FunctionContext(
+  ctx = new LambdaContext(
       [&mock_namespace](int) {
         mock_namespace.remove("ns2");
       });
@@ -774,7 +774,7 @@ TEST_F(TestMockPoolReplayer, NamespacesError) {
   // test namespace replayer init fails on acquire leader
 
   C_SaferCond on_ns3_shut_down;
-  ctx = new FunctionContext(
+  ctx = new LambdaContext(
       [&mock_namespace, &on_ns3_shut_down](int) {
         mock_namespace.remove("ns3");
         on_ns3_shut_down.complete(0);

--- a/src/test/rbd_mirror/test_mock_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_PoolWatcher.cc
@@ -240,7 +240,7 @@ public:
     EXPECT_CALL(*mock_threads.timer, add_event_after(_, _))
       .WillOnce(DoAll(WithArg<1>(Invoke([this](Context *ctx) {
                         auto wrapped_ctx =
-			  new FunctionContext([this, ctx](int r) {
+			  new LambdaContext([this, ctx](int r) {
 			      std::lock_guard timer_locker{m_threads->timer_lock};
 			      ctx->complete(r);
 			    });

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -539,7 +539,7 @@ void wait_until_done(ObjectStore::Transaction* txn, Func&& func)
   bool finished = false;
   std::condition_variable cond;
   std::mutex m;
-  txn->register_on_complete(make_lambda_context([&]() {
+  txn->register_on_complete(make_lambda_context([&](int) {
     std::unique_lock lock{m};
     finished = true;
     cond.notify_one();

--- a/src/tools/immutable_object_cache/CacheClient.cc
+++ b/src/tools/immutable_object_cache/CacheClient.cc
@@ -77,7 +77,7 @@ namespace immutable_obj_cache {
   int CacheClient::connect() {
     int ret = -1;
     C_SaferCond cond;
-    Context* on_finish = new FunctionContext([&cond, &ret](int err) {
+    Context* on_finish = new LambdaContext([&cond, &ret](int err) {
       ret = err;
       cond.complete(err);
     });
@@ -280,7 +280,7 @@ namespace immutable_obj_cache {
     }
 
     ceph_assert(current_request != nullptr);
-    auto process_reply = new FunctionContext([current_request, reply]
+    auto process_reply = new LambdaContext([current_request, reply]
       (bool dedicated) {
        if (dedicated) {
          // dedicated thrad to execute this context.

--- a/src/tools/immutable_object_cache/ObjectCacheStore.cc
+++ b/src/tools/immutable_object_cache/ObjectCacheStore.cc
@@ -120,7 +120,7 @@ int ObjectCacheStore::do_promote(std::string pool_nspace,
 
   librados::bufferlist* read_buf = new librados::bufferlist();
 
-  auto ctx = new FunctionContext([this, read_buf, cache_file_name](int ret) {
+  auto ctx = new LambdaContext([this, read_buf, cache_file_name](int ret) {
     handle_promote_callback(ret, read_buf, cache_file_name);
   });
 

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -461,9 +461,6 @@ protected:
     JournalPlayer *journal;
     explicit ReplayHandler(JournalPlayer *_journal) : journal(_journal) {}
 
-    void get() override {}
-    void put() override {}
-
     void handle_entries_available() override {
       journal->handle_replay_ready();
     }

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -272,7 +272,7 @@ public:
     dout(20) << this << " " << __func__ << ": image_name=" << m_image_name
              << dendl;
 
-    auto ctx = new FunctionContext([this](int r) {
+    auto ctx = new LambdaContext([this](int r) {
         handle_finalize(r);
       });
 

--- a/src/tools/rbd_mirror/BaseRequest.h
+++ b/src/tools/rbd_mirror/BaseRequest.h
@@ -13,7 +13,7 @@ namespace mirror {
 class BaseRequest : public RefCountedObject {
 public:
   BaseRequest(const std::string& name, CephContext *cct, Context *on_finish)
-    : RefCountedObject(cct, 1), m_name(name), m_cct(cct),
+    : RefCountedObject(cct), m_name(name), m_cct(cct),
       m_on_finish(on_finish) {
   }
 

--- a/src/tools/rbd_mirror/ImageMap.cc
+++ b/src/tools/rbd_mirror/ImageMap.cc
@@ -118,7 +118,7 @@ void ImageMap<I>::update_image_mapping(Updates&& map_updates,
   dout(5) << "updates=[" << map_updates << "], "
           << "removes=[" << map_removals << "]" << dendl;
 
-  Context *on_finish = new FunctionContext(
+  Context *on_finish = new LambdaContext(
     [this, map_updates, map_removals](int r) {
       handle_update_request(map_updates, map_removals, r);
       finish_async_op();
@@ -221,7 +221,7 @@ void ImageMap<I>::schedule_update_task(const ceph::mutex &timer_lock) {
     }
   }
 
-  m_timer_task = new FunctionContext([this](int r) {
+  m_timer_task = new LambdaContext([this](int r) {
       ceph_assert(ceph_mutex_is_locked(m_threads->timer_lock));
       m_timer_task = nullptr;
 
@@ -275,7 +275,7 @@ void ImageMap<I>::schedule_rebalance_task() {
     m_threads->timer->cancel_event(m_rebalance_task);
   }
 
-  m_rebalance_task = new FunctionContext([this](int _) {
+  m_rebalance_task = new LambdaContext([this](int _) {
       ceph_assert(ceph_mutex_is_locked(m_threads->timer_lock));
       m_rebalance_task = nullptr;
 

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -62,8 +62,6 @@ template <typename I>
 struct ReplayHandler : public ::journal::ReplayHandler {
   ImageReplayer<I> *replayer;
   ReplayHandler(ImageReplayer<I> *replayer) : replayer(replayer) {}
-  void get() override {}
-  void put() override {}
 
   void handle_entries_available() override {
     replayer->handle_replay_ready();

--- a/src/tools/rbd_mirror/ImageSync.cc
+++ b/src/tools/rbd_mirror/ImageSync.cc
@@ -364,7 +364,7 @@ void ImageSync<I>::handle_update_sync_point(int r) {
     m_updating_sync_point = false;
 
     if (m_image_copy_request != nullptr) {
-      m_update_sync_ctx = new FunctionContext(
+      m_update_sync_ctx = new LambdaContext(
         [this](int r) {
 	  std::lock_guard locker{m_lock};
           this->send_update_sync_point();

--- a/src/tools/rbd_mirror/InstanceWatcher.cc
+++ b/src/tools/rbd_mirror/InstanceWatcher.cc
@@ -513,7 +513,7 @@ void InstanceWatcher<I>::notify_sync_start(const std::string &instance_id,
   bufferlist bl;
   encode(NotifyMessage{SyncStartPayload{request_id, sync_id}}, bl);
 
-  auto ctx = new FunctionContext(
+  auto ctx = new LambdaContext(
     [this, sync_id] (int r) {
       dout(10) << "finish: sync_id=" << sync_id << ", r=" << r << dendl;
       std::lock_guard locker{m_lock};
@@ -1040,7 +1040,7 @@ Context *InstanceWatcher<I>::prepare_request(const std::string &instance_id,
     m_requests.erase(it);
   } else {
     ctx = create_async_context_callback(
-        m_work_queue, new FunctionContext(
+        m_work_queue, new LambdaContext(
             [this, instance_id, request_id] (int r) {
               complete_request(instance_id, request_id, r);
             }));
@@ -1098,7 +1098,7 @@ void InstanceWatcher<I>::handle_image_acquire(
     const std::string &global_image_id, Context *on_finish) {
   dout(10) << "global_image_id=" << global_image_id << dendl;
 
-  auto ctx = new FunctionContext(
+  auto ctx = new LambdaContext(
       [this, global_image_id, on_finish] (int r) {
         m_instance_replayer->acquire_image(this, global_image_id, on_finish);
         m_notify_op_tracker.finish_op();
@@ -1113,7 +1113,7 @@ void InstanceWatcher<I>::handle_image_release(
     const std::string &global_image_id, Context *on_finish) {
   dout(10) << "global_image_id=" << global_image_id << dendl;
 
-  auto ctx = new FunctionContext(
+  auto ctx = new LambdaContext(
       [this, global_image_id, on_finish] (int r) {
         m_instance_replayer->release_image(global_image_id, on_finish);
         m_notify_op_tracker.finish_op();
@@ -1130,7 +1130,7 @@ void InstanceWatcher<I>::handle_peer_image_removed(
   dout(10) << "global_image_id=" << global_image_id << ", "
            << "peer_mirror_uuid=" << peer_mirror_uuid << dendl;
 
-  auto ctx = new FunctionContext(
+  auto ctx = new LambdaContext(
       [this, peer_mirror_uuid, global_image_id, on_finish] (int r) {
         m_instance_replayer->remove_peer_image(global_image_id,
                                                peer_mirror_uuid, on_finish);
@@ -1156,7 +1156,7 @@ void InstanceWatcher<I>::handle_sync_request(const std::string &instance_id,
   }
 
   Context *on_start = create_async_context_callback(
-    m_work_queue, new FunctionContext(
+    m_work_queue, new LambdaContext(
       [this, instance_id, sync_id, on_finish] (int r) {
         dout(10) << "handle_sync_request: finish: instance_id=" << instance_id
                  << ", sync_id=" << sync_id << ", r=" << r << dendl;

--- a/src/tools/rbd_mirror/Instances.cc
+++ b/src/tools/rbd_mirror/Instances.cc
@@ -55,7 +55,7 @@ void Instances<I>::shut_down(Context *on_finish) {
   ceph_assert(m_on_finish == nullptr);
   m_on_finish = on_finish;
 
-  Context *ctx = new FunctionContext(
+  Context *ctx = new LambdaContext(
     [this](int r) {
       std::scoped_lock locker{m_threads->timer_lock, m_lock};
       cancel_remove_task();
@@ -255,7 +255,7 @@ void Instances<I>::remove_instances(const Instances<I>::clock_t::time_point& tim
   ceph_assert(!instance_ids.empty());
 
   dout(10) << "instance_ids=" << instance_ids << dendl;
-  Context* ctx = new FunctionContext([this, instance_ids](int r) {
+  Context* ctx = new LambdaContext([this, instance_ids](int r) {
       handle_remove_instances(r, instance_ids);
     });
   ctx = create_async_context_callback(m_threads->work_queue, ctx);
@@ -337,7 +337,7 @@ void Instances<I>::schedule_remove_task(const Instances<I>::clock_t::time_point&
   dout(10) << dendl;
 
   // schedule a time to fire when the oldest instance should be removed
-  m_timer_task = new FunctionContext(
+  m_timer_task = new LambdaContext(
     [this, oldest_time](int r) {
       ceph_assert(ceph_mutex_is_locked(m_threads->timer_lock));
       std::lock_guard locker{m_lock};

--- a/src/tools/rbd_mirror/LeaderWatcher.cc
+++ b/src/tools/rbd_mirror/LeaderWatcher.cc
@@ -235,7 +235,7 @@ void LeaderWatcher<I>::handle_wait_for_tasks() {
   ceph_assert(!m_timer_op_tracker.empty());
   m_timer_op_tracker.finish_op();
 
-  auto ctx = new FunctionContext([this](int r) {
+  auto ctx = new LambdaContext([this](int r) {
       Context *on_finish;
       {
         // ensure lock isn't held when completing shut down
@@ -350,7 +350,7 @@ void LeaderWatcher<I>::schedule_timer_task(const std::string &name,
 
   cancel_timer_task();
 
-  m_timer_task = new FunctionContext(
+  m_timer_task = new LambdaContext(
     [this, leader, timer_callback](int r) {
       ceph_assert(ceph_mutex_is_locked(m_threads->timer_lock));
       m_timer_task = nullptr;
@@ -582,7 +582,7 @@ void LeaderWatcher<I>::handle_get_locker(int r,
     return;
   }
 
-  auto ctx = new FunctionContext(
+  auto ctx = new LambdaContext(
     [this](int r) {
       std::string instance_id;
       if (get_leader_instance_id(&instance_id)) {
@@ -767,12 +767,12 @@ void LeaderWatcher<I>::notify_listener() {
       LeaderWatcher<I>, &LeaderWatcher<I>::handle_notify_listener>(this));
 
   if (is_leader(m_lock)) {
-    ctx = new FunctionContext(
+    ctx = new LambdaContext(
       [this, ctx](int r) {
         m_listener->post_acquire_handler(ctx);
       });
   } else {
-    ctx = new FunctionContext(
+    ctx = new LambdaContext(
       [this, ctx](int r) {
         m_listener->pre_release_handler(ctx);
       });

--- a/src/tools/rbd_mirror/MirrorStatusWatcher.cc
+++ b/src/tools/rbd_mirror/MirrorStatusWatcher.cc
@@ -32,7 +32,7 @@ template <typename I>
 void MirrorStatusWatcher<I>::init(Context *on_finish) {
   dout(20) << dendl;
 
-  on_finish = new FunctionContext(
+  on_finish = new LambdaContext(
     [this, on_finish] (int r) {
       if (r < 0) {
         derr << "error removing down statuses: " << cpp_strerror(r) << dendl;

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -582,7 +582,7 @@ void PoolReplayer<I>::update_namespace_replayers() {
     auto iter = mirroring_namespaces.find(it->first);
     if (iter == mirroring_namespaces.end()) {
       auto namespace_replayer = it->second;
-      auto on_shut_down = new FunctionContext(
+      auto on_shut_down = new LambdaContext(
         [this, namespace_replayer, ctx=gather_ctx->new_sub()](int r) {
           delete namespace_replayer;
           ctx->complete(r);
@@ -601,7 +601,7 @@ void PoolReplayer<I>::update_namespace_replayers() {
         m_threads, m_image_sync_throttler.get(),
         m_image_deletion_throttler.get(), m_service_daemon,
         m_cache_manager_handler);
-    auto on_init = new FunctionContext(
+    auto on_init = new LambdaContext(
         [this, namespace_replayer, name, &mirroring_namespaces,
          ctx=gather_ctx->new_sub()](int r) {
           if (r < 0) {
@@ -699,7 +699,7 @@ void PoolReplayer<I>::namespace_replayer_acquire_leader(const std::string &name,
   auto it = m_namespace_replayers.find(name);
   ceph_assert(it != m_namespace_replayers.end());
 
-  on_finish = new FunctionContext(
+  on_finish = new LambdaContext(
       [this, name, on_finish](int r) {
         if (r < 0) {
           derr << "failed to handle acquire leader for namespace: "
@@ -712,7 +712,7 @@ void PoolReplayer<I>::namespace_replayer_acquire_leader(const std::string &name,
 
           auto namespace_replayer = m_namespace_replayers[name];
           m_namespace_replayers.erase(name);
-          auto on_shut_down = new FunctionContext(
+          auto on_shut_down = new LambdaContext(
               [this, namespace_replayer, on_finish](int r) {
                 delete namespace_replayer;
                 on_finish->complete(r);
@@ -896,7 +896,7 @@ void PoolReplayer<I>::handle_post_acquire_leader(Context *on_finish) {
         m_service_daemon->add_or_update_attribute(m_local_pool_id,
                                                   SERVICE_DAEMON_LEADER_KEY,
                                                   true);
-        auto ctx = new FunctionContext(
+        auto ctx = new LambdaContext(
             [this, on_finish](int r) {
               if (r == 0) {
                 std::lock_guard locker{m_lock};

--- a/src/tools/rbd_mirror/PoolReplayer.h
+++ b/src/tools/rbd_mirror/PoolReplayer.h
@@ -146,7 +146,7 @@ private:
     std::lock_guard locker{m_lock};
 
     on_finish = librbd::util::create_async_context_callback(
-      m_threads->work_queue, new FunctionContext(
+      m_threads->work_queue, new LambdaContext(
           [this, on_finish](int r) {
             {
               std::lock_guard locker{m_lock};
@@ -163,7 +163,7 @@ private:
             on_finish->complete(r);
           }));
 
-    auto on_lock = new FunctionContext(
+    auto on_lock = new LambdaContext(
         [this, callback, on_finish](int) {
           std::lock_guard locker{m_lock};
           ceph_assert(m_namespace_replayers_locked);

--- a/src/tools/rbd_mirror/PoolWatcher.cc
+++ b/src/tools/rbd_mirror/PoolWatcher.cc
@@ -193,7 +193,7 @@ void PoolWatcher<I>::unregister_watcher() {
   dout(5) << dendl;
 
   m_async_op_tracker.start_op();
-  Context *ctx = new FunctionContext([this](int r) {
+  Context *ctx = new LambdaContext([this](int r) {
       dout(5) << "unregister_watcher: r=" << r << dendl;
       if (r < 0) {
         derr << "error unregistering watcher for "
@@ -365,7 +365,7 @@ void PoolWatcher<I>::schedule_refresh_images(double interval) {
   m_image_ids_invalid = true;
   m_timer_ctx = m_threads->timer->add_event_after(
     interval,
-    new FunctionContext([this](int r) {
+    new LambdaContext([this](int r) {
 	process_refresh_images();
       }));
 }
@@ -427,7 +427,7 @@ void PoolWatcher<I>::process_refresh_images() {
 
   // execute outside of the timer's lock
   m_async_op_tracker.start_op();
-  Context *ctx = new FunctionContext([this](int r) {
+  Context *ctx = new LambdaContext([this](int r) {
       register_watcher();
       m_async_op_tracker.finish_op();
     });
@@ -445,7 +445,7 @@ void PoolWatcher<I>::schedule_listener() {
   dout(20) << dendl;
 
   m_async_op_tracker.start_op();
-  Context *ctx = new FunctionContext([this](int r) {
+  Context *ctx = new LambdaContext([this](int r) {
       notify_listener();
       m_async_op_tracker.finish_op();
     });

--- a/src/tools/rbd_mirror/ServiceDaemon.cc
+++ b/src/tools/rbd_mirror/ServiceDaemon.cc
@@ -197,7 +197,7 @@ void ServiceDaemon<I>::schedule_update_status() {
     return;
   }
 
-  m_timer_ctx = new FunctionContext([this](int) {
+  m_timer_ctx = new LambdaContext([this](int) {
       m_timer_ctx = nullptr;
       update_status();
     });

--- a/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
@@ -159,7 +159,7 @@ void SnapshotPurgeRequest<I>::snap_unprotect() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_snap_unprotect(r);
       finish_op_ctx->complete(0);
     });
@@ -214,7 +214,7 @@ void SnapshotPurgeRequest<I>::snap_remove() {
     return;
   }
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
       handle_snap_remove(r);
       finish_op_ctx->complete(0);
     });

--- a/src/tools/rbd_mirror/image_deleter/TrashWatcher.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashWatcher.cc
@@ -70,7 +70,7 @@ void TrashWatcher<I>::shut_down(Context *on_finish) {
     }
   }
 
-  auto ctx = new FunctionContext([this, on_finish](int r) {
+  auto ctx = new LambdaContext([this, on_finish](int r) {
       unregister_watcher(on_finish);
     });
   m_async_op_tracker.wait_for_ops(ctx);
@@ -222,7 +222,7 @@ void TrashWatcher<I>::unregister_watcher(Context* on_finish) {
   dout(5) << dendl;
 
   m_async_op_tracker.start_op();
-  Context *ctx = new FunctionContext([this, on_finish](int r) {
+  Context *ctx = new LambdaContext([this, on_finish](int r) {
       handle_unregister_watcher(r, on_finish);
     });
   this->unregister_watch(ctx);
@@ -327,7 +327,7 @@ void TrashWatcher<I>::schedule_trash_list(double interval) {
   dout(5) << dendl;
   m_timer_ctx = m_threads->timer->add_event_after(
     interval,
-    new FunctionContext([this](int r) {
+    new LambdaContext([this](int r) {
 	process_trash_list();
       }));
 }
@@ -348,7 +348,7 @@ void TrashWatcher<I>::process_trash_list() {
 
   // execute outside of the timer's lock
   m_async_op_tracker.start_op();
-  Context *ctx = new FunctionContext([this](int r) {
+  Context *ctx = new LambdaContext([this](int r) {
       create_trash();
       m_async_op_tracker.finish_op();
     });
@@ -368,7 +368,7 @@ void TrashWatcher<I>::add_image(const std::string& image_id,
            << "deferment_end_time=" << deferment_end_time << dendl;
 
   m_async_op_tracker.start_op();
-  auto ctx = new FunctionContext([this, image_id, deferment_end_time](int r) {
+  auto ctx = new LambdaContext([this, image_id, deferment_end_time](int r) {
       m_trash_listener.handle_trash_image(image_id,
 					  deferment_end_time.to_real_time());
       m_async_op_tracker.finish_op();

--- a/src/tools/rbd_mirror/image_replayer/ReplayStatusFormatter.cc
+++ b/src/tools/rbd_mirror/image_replayer/ReplayStatusFormatter.cc
@@ -170,7 +170,7 @@ void ReplayStatusFormatter<I>::send_update_tag_cache(uint64_t master_tag_tid,
   dout(20) << "master_tag_tid=" << master_tag_tid << ", mirror_tag_tid="
 	   << mirror_tag_tid << dendl;
 
-  FunctionContext *ctx = new FunctionContext(
+  auto ctx = new LambdaContext(
     [this, master_tag_tid, mirror_tag_tid](int r) {
       handle_update_tag_cache(master_tag_tid, mirror_tag_tid, r);
     });


### PR DESCRIPTION
When an IO triggers a forced recovery, if the selected object is a snapshot object, and the object's head object is missing on local, which causes the assertion to fail  in function PrimaryLogPG::on_local_recover(). Therefore, the head object should be recovered first.