### PR TITLE
log: just return if t is empty

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -209,7 +209,7 @@ void Log::flush()
     m_queue_mutex_holder = 0;
   }
 
-  _flush(m_flush, true, false);
+  _flush(m_flush, false);
   m_flush_mutex_holder = 0;
 }
 
@@ -235,14 +235,15 @@ void Log::_flush_logbuf()
   }
 }
 
-void Log::_flush(EntryVector& t, bool requeue, bool crash)
+void Log::_flush(EntryVector& t, bool crash)
 {
   long len = 0;
+  if (t.empty()) {
+    assert(m_log_buf.empty());
+    return;
+  }
   if (crash) {
     len = t.size();
-  }
-  if (!requeue && t.empty()) {
-    return;
   }
   for (auto& e : t) {
     auto prio = e.m_prio;
@@ -302,9 +303,7 @@ void Log::_flush(EntryVector& t, bool requeue, bool crash)
       m_graylog->log_entry(e);
     }
 
-    if (requeue) {
-      m_recent.push_back(std::move(e));
-    }
+    m_recent.push_back(std::move(e));
   }
   t.clear();
 
@@ -345,7 +344,7 @@ void Log::dump_recent()
     m_queue_mutex_holder = 0;
   }
 
-  _flush(m_flush, true, false);
+  _flush(m_flush, false);
   _flush_logbuf();
 
   _log_message("--- begin dump of recent events ---", true);
@@ -353,7 +352,7 @@ void Log::dump_recent()
     EntryVector t;
     t.insert(t.end(), std::make_move_iterator(m_recent.begin()), std::make_move_iterator(m_recent.end()));
     m_recent.clear();
-    _flush(t, true, true);
+    _flush(t, true);
   }
 
   char buf[4096];

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -345,7 +345,6 @@ void Log::dump_recent()
   }
 
   _flush(m_flush, false);
-  _flush_logbuf();
 
   _log_message("--- begin dump of recent events ---", true);
   {
@@ -375,7 +374,7 @@ void Log::dump_recent()
 
   _log_message("--- end dump of recent events ---", true);
 
-  _flush_logbuf();
+  assert(m_log_buf.empty());
 
   m_flush_mutex_holder = 0;
 }

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -77,7 +77,7 @@ class Log : private Thread
 
   void _log_safe_write(std::string_view sv);
   void _flush_logbuf();
-  void _flush(EntryVector& q, bool requeue, bool crash);
+  void _flush(EntryVector& q, bool crash);
 
   void _log_message(const char *s, bool crash);
 


### PR DESCRIPTION
Whenever the t is empty, there is no need to do the followed t.clear
or the m_log_buf flush. This will also remove the requeue pararmeter
since in all the cases we should requeue the new entry.

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
