### PR TITLE
librbd: add interface rbd_aio_compare_and_writev

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1083,7 +1083,10 @@ CEPH_RBD_API ssize_t rbd_aio_compare_and_write(rbd_image_t image,
                                                const char *cmp_buf, const char *buf,
                                                rbd_completion_t c, uint64_t *mismatch_off,
                                                int op_flags);
-
+CEPH_RBD_API int rbd_aio_compare_and_writev(rbd_image_t image, const struct iovec *iov,
+                                               int iovcnt, uint64_t off,
+                                               rbd_completion_t c, uint64_t *mismatch_off,
+                                               int op_flags);
 CEPH_RBD_API int rbd_aio_create_completion(void *cb_arg,
                                            rbd_callback_t complete_cb,
                                            rbd_completion_t *c);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2007,6 +2007,20 @@ TEST_F(TestLibRBD, TestIO)
   ASSERT_EQ(0U, mismatch_offset);
   rbd_aio_release(comp);
 
+  std::string write_buffer("This is a testThis is a test");
+  struct iovec write_iovs[] = {
+    {.iov_base = &write_buffer[0],  .iov_len = 6},
+    {.iov_base = &write_buffer[6],  .iov_len = 5},
+    {.iov_base = &write_buffer[11],  .iov_len = 7},
+    {.iov_base = &write_buffer[18], .iov_len = 2},
+    {.iov_base = &write_buffer[20], .iov_len = 8}
+  };
+  rbd_aio_create_completion(NULL, (rbd_callback_t) simple_read_cb, &comp);
+  ASSERT_EQ(0, rbd_aio_compare_and_writev(image, write_iovs, sizeof(write_iovs) / sizeof(struct iovec), 0, comp, &mismatch_offset, 0));
+  ASSERT_EQ(0, rbd_aio_wait_for_complete(comp));
+  ASSERT_EQ(0U, mismatch_offset);
+  rbd_aio_release(comp);
+
   ASSERT_PASSED(validate_object_map, image);
   ASSERT_EQ(0, rbd_close(image));
 


### PR DESCRIPTION
I convert the scatter list into the iovec，then qemu can less call the fuction to improve efficiency.
Of couse, also to enrich the interface type.

Signed-off-by: wonderpow <wangbozhao@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
