### PR TITLE
mgr/MgrClient: fix open condition

### DIFF
--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -183,7 +183,7 @@ void MgrClient::reconnect()
 
   // Don't send an open if we're just a client (i.e. doing
   // command-sending, not stats etc)
-  if (!cct->_conf->name.is_client() || service_daemon) {
+  if (msgr->get_mytype() != CEPH_ENTITY_TYPE_CLIENT || service_daemon) {
     _send_open();
   }
 
@@ -574,7 +574,7 @@ int MgrClient::service_daemon_register(
   daemon_dirty_status = true;
 
   // late register?
-  if (cct->_conf->name.is_client() && session && session->con) {
+  if (msgr->get_mytype() != CEPH_ENTITY_TYPE_CLIENT && session && session->con) {
     _send_open();
   }
 


### PR DESCRIPTION
Do not open a mgr daemon session if we are a client using a non-client
key to authenticate.  This is a bit of a corner case, but it can
happen when using the mon. key do bootstrap functions.

This aligns the MgrClient condition with the mgr/DaemonServer.cc
handle_report condition, which rejects non-daemon client connections
based on the connection entity type, not the auth identity.

Fixes: https://tracker.ceph.com/issues/42566
Signed-off-by: Sage Weil <sage@redhat.com>