### PR TITLE
mimic: doc: update bluestore cache settings and clarify data fraction

### DIFF
--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -234,12 +234,13 @@ The configured cache memory budget can be used in a few different ways:
 * BlueStore data (i.e., recently read or written object data)
 
 Cache memory usage is governed by the following options:
-``bluestore_cache_meta_ratio``, ``bluestore_cache_kv_ratio``, and
-``bluestore_cache_kv_max``.  The fraction of the cache devoted to data
-is 1.0 minus the meta and kv ratios.  The memory devoted to kv
-metadata (the RocksDB cache) is capped by ``bluestore_cache_kv_max``
-since our testing indicates there are diminishing returns beyond a
-certain point.
+``bluestore_cache_meta_ratio`` and ``bluestore_cache_kv_ratio``.
+The fraction of the cache devoted to data
+is governed by the effective bluestore cache size (depending on
+``bluestore_cache_size[_ssd|_hdd]`` settings and the device class of the primary
+device) as well as the meta and kv ratios.
+The data fraction can be calculated by
+``<effective_cache_size> * (1 - bluestore_cache_meta_ratio - bluestore_cache_kv_ratio)``
 
 ``bluestore_cache_size``
 
@@ -267,14 +268,14 @@ certain point.
 :Description: The ratio of cache devoted to metadata.
 :Type: Floating point
 :Required: Yes
-:Default: ``.01``
+:Default: ``.4``
 
 ``bluestore_cache_kv_ratio``
 
 :Description: The ratio of cache devoted to key/value data (rocksdb).
 :Type: Floating point
 :Required: Yes
-:Default: ``.99``
+:Default: ``.4``
 
 ``bluestore_cache_kv_max``
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41288

---

backport of https://github.com/ceph/ceph/pull/27859
parent tracker: https://tracker.ceph.com/issues/39522

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh