### PR TITLE
mgr/dashboard: Remove convertion to seconds

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -77,16 +77,12 @@ class CephFS(RESTController):
         result = {}
         mds_names = self._get_mds_names(fs_id)
 
-        def _to_second(point):
-            return (point[0] // 1000000000, point[1])
-
         for mds_name in mds_names:
             result[mds_name] = {}
             for counter in counters:
                 data = mgr.get_counter("mds", mds_name, counter)
                 if data is not None:
-                    result[mds_name][counter] = list(
-                        map(_to_second, data[counter]))
+                    result[mds_name][counter] = data[counter]
                 else:
                     result[mds_name][counter] = []
 


### PR DESCRIPTION
This is no longer need since the values are already in seconds.

Fixes: https://tracker.ceph.com/issues/42567

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
