### PR TITLE
qa/suites/rados/singleton-nomsgr/ceph-daemon: test on ubuntu only

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/ceph-daemon.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-daemon.yaml
@@ -1,3 +1,4 @@
+os_type: ubuntu
 roles:
 - [mon.a, mgr.x, osd.0, client.0]
 tasks:


### PR DESCRIPTION
Until we fix https://tracker.ceph.com/issues/42511, ceph-daemon doesn't
behave with selinux.

Signed-off-by: Sage Weil <sage@redhat.com>