### PR TITLE
osd/OSD: enhance osd numa affinity compatibility

### DIFF
--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -25,6 +25,9 @@
 #include "common/numa.h"
 
 #include <netdb.h>
+#include <string>
+#include <string.h>
+#include <vector>
 
 #define dout_subsys ceph_subsys_
 
@@ -508,15 +511,29 @@ int get_iface_numa_node(
   const std::string& iface,
   int *node)
 {
-  string fn = std::string("/sys/class/net/") + iface + "/device/numa_node";
+  int ifatype = IFACE_DEFAULT;
+  string ifa = iface;
+  int pos = ifa.find(":");
+  if (pos != string::npos) {
+    ifa.erase(pos);
+  }
+  string fn = std::string("/sys/class/net/") + ifa + "/device/numa_node";
+  int fd = ::open(fn.c_str(), O_RDONLY);
+  if (fd < 0) {
+    fn = std::string("/sys/class/net/") + ifa + "/bonding/slaves";
+    fd = ::open(fn.c_str(), O_RDONLY);
+    if (fd < 0) {
+      return -errno;
+    }
+    ifatype = IFACE_BOND_PORT;
+  } else {
+    ifatype = IFACE_PHY_PORT;
+  }
 
   int r = 0;
   char buf[1024];
   char *endptr = 0;
-  int fd = ::open(fn.c_str(), O_RDONLY);
-  if (fd < 0) {
-    return -errno;
-  }
+  int bond_node = -1;
   r = safe_read(fd, &buf, sizeof(buf));
   if (r < 0) {
     goto out;
@@ -525,13 +542,43 @@ int get_iface_numa_node(
   while (r > 0 && ::isspace(buf[--r])) {
     buf[r] = 0;
   }
-  *node = strtoll(buf, &endptr, 10);
-  if (endptr != buf + strlen(buf)) {
-    r = -EINVAL;
-    goto out;
+
+  switch (ifatype) {
+  case IFACE_PHY_PORT:
+    *node = strtoll(buf, &endptr, 10);
+    if (endptr != buf + strlen(buf)) {
+      r = -EINVAL;
+      goto out;
+    }
+    r = 0;
+    break;
+  case IFACE_BOND_PORT:
+    std::vector<std::string> sv;
+    char *q, *p = strtok_r(buf, " ", &q);
+    while (p != NULL) {
+      sv.push_back(p);
+      p = strtok_r(NULL, " ", &q);
+    }
+    for (auto& iter : sv) {
+      int bn = -1;
+      r = get_iface_numa_node(iter, &bn);
+      if (r >= 0) {
+        if (bond_node == -1 || bn == bond_node) {
+          bond_node = bn;
+        } else {
+          *node = -2;
+          goto out;
+        }
+      } else {
+        goto out;
+      }
+    }
+    *node = bond_node;
+    break;
   }
-  r = 0;
- out:
+
+  out:
   ::close(fd);
   return r;
 }
+

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -20,6 +20,12 @@ class entity_addrvec_t;
 #define CEPH_PICK_ADDRESS_PREFER_IPV4 0x40
 #define CEPH_PICK_ADDRESS_DEFAULT_MON_PORTS  0x80
 
+enum IfaceType {
+  IFACE_DEFAULT = 0,
+  IFACE_PHY_PORT = 1,
+  IFACE_BOND_PORT = 2
+};
+
 #ifndef WITH_SEASTAR
 /*
   Pick addresses based on subnets if needed.

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2269,11 +2269,11 @@ int OSD::set_numa_affinity()
     cct,
     cluster_messenger->get_myaddrs().front().get_sockaddr_storage());
   int r = get_iface_numa_node(front_iface, &front_node);
-  if (r >= 0) {
+  if (r >= 0 && front_node >= 0) {
     dout(1) << __func__ << " public network " << front_iface << " numa node "
-	      << front_node << dendl;
+            << front_node << dendl;
     r = get_iface_numa_node(back_iface, &back_node);
-    if (r >= 0) {
+    if (r >= 0 && back_node >= 0) {
       dout(1) << __func__ << " cluster network " << back_iface << " numa node "
 	      << back_node << dendl;
       if (front_node == back_node &&
@@ -2282,14 +2282,23 @@ int OSD::set_numa_affinity()
 	if (g_conf().get_val<bool>("osd_numa_auto_affinity")) {
 	  numa_node = front_node;
 	}
+      } else if (front_node != back_node) {
+        dout(1) << __func__ << " public and cluster network numa nodes do not match"
+                << dendl;
       } else {
 	dout(1) << __func__ << " objectstore and network numa nodes do not match"
 		<< dendl;
       }
+    } else if (back_node == -2) {
+      dout(1) << __func__ << " cluster network " << back_iface
+              << " ports numa nodes do not match" << dendl;
     } else {
       derr << __func__ << " unable to identify cluster interface '" << back_iface
            << "' numa node: " << cpp_strerror(r) << dendl;
     }
+  } else if (front_node == -2) {
+    dout(1) << __func__ << " public network " << front_iface
+            << " ports numa nodes do not match" << dendl;
   } else {
     derr << __func__ << " unable to identify public interface '" << front_iface
 	 << "' numa node: " << cpp_strerror(r) << dendl;


### PR DESCRIPTION
add bond network numa affinity compatibility support
add subnet compatibility support
add public and cluster network numa nodes not matching log

Fixes: https://tracker.ceph.com/issues/42411

Signed-off-by: Dai zhiwei <daizhiwei3@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
