### PR TITLE
luminous: core: osd: Fix for compatibility of encode/decode of osd_stat_t

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -390,7 +390,7 @@ void osd_stat_t::dump(Formatter *f) const
 
 void osd_stat_t::encode(bufferlist &bl) const
 {
-  ENCODE_START(9, 2, bl);
+  ENCODE_START(14, 2, bl);
   ::encode(kb, bl);
   ::encode(kb_used, bl);
   ::encode(kb_avail, bl);
@@ -406,6 +406,32 @@ void osd_stat_t::encode(bufferlist &bl) const
   ::encode(kb_used_data, bl);
   ::encode(kb_used_omap, bl);
   ::encode(kb_used_meta, bl);
+
+  // Compatibility
+  // Build statfs just like decode handles old versions (pre version 9) in later releases
+  store_statfs_t statfs;
+  statfs.total = kb << 10;
+  statfs.available = kb_avail << 10;
+  statfs.internally_reserved =
+    statfs.total > statfs.available ? statfs.total - statfs.available : 0;
+  int64_t used = kb_used << 10;
+  if ((int64_t)statfs.internally_reserved > used) {
+    statfs.internally_reserved -= used;
+  } else {
+    statfs.internally_reserved = 0;
+  }
+  statfs.allocated = kb_used_data << 10;
+  statfs.omap_allocated = kb_used_omap << 10;
+  statfs.internal_metadata = kb_used_meta << 10;
+  ::encode(statfs, bl);
+  ///////////////////////////////////
+  os_alerts_t os_alerts;
+  ::encode(os_alerts, bl);
+  ::encode((uint64_t)0, bl); // num_shards_repaired
+  ::encode((uint32_t)0, bl); // num_osds
+  ::encode((uint32_t)0, bl); // num_per_pool_osds
+  ::encode((uint32_t)0, bl); // num_per_pool_omap_osds
+
   // hb_pingtime map
   ::encode((int)hb_pingtime.size(), bl);
   for (auto i : hb_pingtime) {
@@ -437,7 +463,7 @@ void osd_stat_t::encode(bufferlist &bl) const
 
 void osd_stat_t::decode(bufferlist::iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(9, 2, 2, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(14, 2, 2, bl);
   ::decode(kb, bl);
   ::decode(kb_used, bl);
   ::decode(kb_avail, bl);
@@ -466,8 +492,29 @@ void osd_stat_t::decode(bufferlist::iterator &bl)
     kb_used_omap = 0;
     kb_used_meta = 0;
   }
-  hb_pingtime.clear();
   if (struct_v >= 9) {
+    store_statfs_t statfs;
+    ::decode(statfs, bl);
+  }
+  if (struct_v >= 10) {
+    os_alerts_t os_alerts;
+    ::decode(os_alerts, bl);
+  }
+  if (struct_v >= 11) {
+    uint64_t dummy;
+    ::decode(dummy, bl);
+  }
+  if (struct_v >= 12) {
+    uint32_t dummy;
+    ::decode(dummy, bl);
+    ::decode(dummy, bl);
+  }
+  if (struct_v >= 13) {
+    uint32_t dummy;
+    ::decode(dummy, bl);
+  }
+  hb_pingtime.clear();
+  if (struct_v >= 14) {
     int count;
     ::decode(count, bl);
     for (int i = 0 ; i < count ; i++) {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5370,6 +5370,9 @@ struct PromoteCounter {
   }
 };
 
+typedef std::map<std::string,std::string> osd_alert_list_t;
+typedef std::map<int, osd_alert_list_t> os_alerts_t;
+
 /** store_statfs_t
  * ObjectStore full statfs information
  */
@@ -5377,6 +5380,7 @@ struct store_statfs_t
 {
   uint64_t total = 0;                  ///< Total bytes
   uint64_t available = 0;              ///< Free bytes available
+  uint64_t internally_reserved = 0;    ///< Bytes reserved for internal purposes
 
   int64_t allocated = 0;               ///< Bytes allocated by the store
 
@@ -5393,7 +5397,23 @@ struct store_statfs_t
   }
   bool operator ==(const store_statfs_t& other) const;
   void dump(Formatter *f) const;
+  DENC(store_statfs_t, v, p) {
+    DENC_START(1, 1, p);
+    denc(v.total, p);
+    denc(v.available, p);
+    denc(v.internally_reserved, p);
+    denc(v.allocated, p);
+    denc(v.data_stored, p);
+    denc(v.data_compressed, p);
+    denc(v.data_compressed_allocated, p);
+    denc(v.data_compressed_original, p);
+    denc(v.omap_allocated, p);
+    denc(v.internal_metadata, p);
+    DENC_FINISH(p);
+  }
 };
+WRITE_CLASS_DENC(store_statfs_t)
+
 ostream &operator<<(ostream &lhs, const store_statfs_t &rhs);
 
 // omap specific stats


### PR DESCRIPTION
Fix for ceph/ceph#30230

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
