### PR TITLE
luminous: tests: install python3-cephfs for fs suite

### DIFF
--- a/qa/cephfs/begin.yaml
+++ b/qa/cephfs/begin.yaml
@@ -1,3 +1,5 @@
 tasks:
   - install:
+      extra_packages:
+        - python3-cephfs
   - ceph:

--- a/qa/packages/packages.yaml
+++ b/qa/packages/packages.yaml
@@ -30,8 +30,6 @@ ceph:
   - rbd-fuse-dbg
   - rbd-mirror-dbg
   - rbd-nbd-dbg
-  - python3-cephfs
-  - python3-rados
   rpm:
   - ceph-radosgw
   - ceph-test
@@ -45,5 +43,3 @@ ceph:
   - python-ceph
   - rbd-fuse
   - ceph-debuginfo
-  - python3-cephfs
-  - python3-rados


### PR DESCRIPTION
https://tracker.ceph.com/issues/42580

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
