### PR TITLE
mimic: tools/cephfs: make 'cephfs-data-scan scan_links' reconstruct snaptable

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -59,5 +59,6 @@
   crush requires 1 replica on each of 3 racks, but there are fewer OSDs in 1 of
   the racks.  In those cases, the configuration value can be increased.
 
-* The 'cephfs-data-scan scan_links' now automatically repair inotables.
+* The 'cephfs-data-scan scan_links' now automatically repair inotables and
+  snaptable.
 

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -46,6 +46,9 @@
   New admin command ``ceph daemon osd.# dump_osd_network [threshold]`` will
   do the same but only including heartbeats initiated by the specified OSD.
 
+13.2.9
+======
+
 * The configuration value ``osd_calc_pg_upmaps_max_stddev`` used for upmap
   balancing has been removed. Instead use the mgr balancer config
   ``upmap_max_deviation`` which now is an integer number of PGs of deviation
@@ -55,3 +58,6 @@
   would not allow a pool to ever have completely balanced PGs.  For example, if
   crush requires 1 replica on each of 3 racks, but there are fewer OSDs in 1 of
   the racks.  In those cases, the configuration value can be increased.
+
+* The 'cephfs-data-scan scan_links' now automatically repair inotables.
+

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -6,6 +6,7 @@ import json
 
 import logging
 import os
+import time
 from textwrap import dedent
 import traceback
 from collections import namedtuple, defaultdict
@@ -541,7 +542,7 @@ class TestDataScan(CephFSTestCase):
             log.info("{0}: {1}".format(pg_str, lines))
             self.assertSetEqual(set(lines), set(pgs_to_files[pg_str]))
 
-    def test_scan_links(self):
+    def test_rebuild_linkage(self):
         """
         The scan_links command fixes linkage errors
         """
@@ -596,3 +597,48 @@ class TestDataScan(CephFSTestCase):
         # link count was adjusted?
         file1_nlink = self.mount_a.path_to_nlink("testdir1/file1")
         self.assertEqual(file1_nlink, 2)
+
+    def test_rebuild_inotable(self):
+        """
+        The scan_links command repair inotables
+        """
+        self.fs.set_max_mds(2)
+        self.fs.wait_for_daemons()
+
+        active_mds_names = self.fs.get_active_names()
+        mds0_id = active_mds_names[0]
+        mds1_id = active_mds_names[1]
+
+        self.mount_a.run_shell(["mkdir", "dir1"])
+        dir_ino = self.mount_a.path_to_ino("dir1")
+        self.mount_a.setfattr("dir1", "ceph.dir.pin", "1")
+        # wait for subtree migration
+
+        file_ino = 0;
+        while True:
+            time.sleep(1)
+            # allocate an inode from mds.1
+            self.mount_a.run_shell(["touch", "dir1/file1"])
+            file_ino = self.mount_a.path_to_ino("dir1/file1")
+            if file_ino >= (2 << 40):
+                break
+            self.mount_a.run_shell(["rm", "-f", "dir1/file1"])
+
+        self.mount_a.umount_wait()
+
+        self.fs.mds_asok(["flush", "journal"], mds0_id)
+        self.fs.mds_asok(["flush", "journal"], mds1_id)
+        self.mds_cluster.mds_stop()
+
+        self.fs.rados(["rm", "mds0_inotable"])
+        self.fs.rados(["rm", "mds1_inotable"])
+
+        self.fs.data_scan(["scan_links", "--filesystem", self.fs.name])
+
+        mds0_inotable = json.loads(self.fs.table_tool([self.fs.name + ":0", "show", "inode"]))
+        self.assertGreaterEqual(
+            mds0_inotable['0']['data']['inotable']['free'][0]['start'], dir_ino)
+
+        mds1_inotable = json.loads(self.fs.table_tool([self.fs.name + ":1", "show", "inode"]))
+        self.assertGreaterEqual(
+            mds1_inotable['1']['data']['inotable']['free'][0]['start'], file_ino)

--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -223,3 +223,18 @@ bool InoTable::repair(inodeno_t id)
   dout(10) << "repair: after status. ino = " << id << " pver =" << projected_version << " ver= " << version << dendl;
   return true;
 }
+
+bool InoTable::force_consume_to(inodeno_t ino)
+{
+  auto it = free.begin();
+  if (it != free.end() && it.get_start() <= ino) {
+    inodeno_t min = it.get_start();
+    derr << "erasing " << min << " to " << ino << dendl;
+    free.erase(min, ino - min + 1);
+    projected_free = free;
+    projected_version = ++version;
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -96,19 +96,7 @@ class InoTable : public MDSTable {
    *
    * @return true if the table was modified
    */
-  bool force_consume_to(inodeno_t ino)
-  {
-    if (free.contains(ino)) {
-      inodeno_t min = free.begin().get_start();
-      std::cerr << "Erasing " << min << " to " << ino << std::endl;
-      free.erase(min, ino - min + 1);
-      projected_free = free;
-      projected_version = ++version;
-      return true;
-    } else {
-      return false;
-    }
-  }
+  bool force_consume_to(inodeno_t ino);
 };
 WRITE_CLASS_ENCODER(InoTable)
 

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -142,7 +142,7 @@ object_t MDSTable::get_object_name() const
 {
   char n[50];
   if (per_mds)
-    snprintf(n, sizeof(n), "mds%d_%s", int(mds->get_nodeid()), table_name);
+    snprintf(n, sizeof(n), "mds%d_%s", int(rank), table_name);
   else
     snprintf(n, sizeof(n), "mds_%s", table_name);
   return object_t(n);

--- a/src/mds/MDSTable.h
+++ b/src/mds/MDSTable.h
@@ -31,7 +31,6 @@ protected:
   bool per_mds;
   mds_rank_t rank;
 
-  object_t get_object_name() const;
   
   static const int STATE_UNDEF   = 0;
   static const int STATE_OPENING = 1;
@@ -80,6 +79,7 @@ public:
     if (is_active()) save(0);
   }
 
+  object_t get_object_name() const;
   void load(MDSInternalContextBase *onfinish);
   void load_2(int, bufferlist&, Context *onfinish);
 

--- a/src/mds/MDSTableServer.h
+++ b/src/mds/MDSTableServer.h
@@ -93,6 +93,11 @@ public:
     MDSTable(m, get_mdstable_name(tab), false), table(tab), recovered(false) {}
   ~MDSTableServer() override {}
 
+  void reset_state() override {
+    pending_for_mds.clear();
+    ++version;
+  }
+
   void handle_request(MMDSTableRequest *m);
   void do_server_update(bufferlist& bl);
 

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -38,6 +38,9 @@ void SnapServer::reset_state()
   last_snap = 1;  /* snapid 1 reserved for initial root snaprealm */
   snaps.clear();
   need_to_purge.clear();
+  pending_update.clear();
+  pending_destroy.clear();
+  pending_noop.clear();
 
   // find any removed snapshot in data pools
   if (mds) {  // only if I'm running in a live MDS
@@ -61,7 +64,8 @@ void SnapServer::reset_state()
   last_created = last_snap;
   last_destroyed = last_snap;
   snaprealm_v2_since = last_snap + 1;
-  version++;
+
+  MDSTableServer::reset_state();
 }
 
 
@@ -440,4 +444,37 @@ void SnapServer::generate_test_instances(list<SnapServer*>& ls)
   populated->pending_noop.insert(890);
 
   ls.push_back(populated);
+}
+
+bool SnapServer::force_update(snapid_t last, snapid_t v2_since,
+			      map<snapid_t, SnapInfo>& _snaps)
+{
+  bool modified = false;
+  if (last > last_snap) {
+    derr << " updating last_snap " << last_snap << " -> " << last << dendl;
+    last_snap = last;
+    last_created = last;
+    last_destroyed = last;
+    modified = true;
+  }
+  if (v2_since > snaprealm_v2_since) {
+    derr << " updating snaprealm_v2_since " << snaprealm_v2_since
+	 << " -> " << v2_since << dendl;
+    snaprealm_v2_since = v2_since;
+    modified = true;
+  }
+  if (snaps != _snaps) {
+    derr << " updating snaps {" << snaps << "} -> {" << _snaps << "}" << dendl;
+    snaps = _snaps;
+    modified = true;
+  }
+
+  if (modified) {
+    need_to_purge.clear();
+    pending_update.clear();
+    pending_destroy.clear();
+    pending_noop.clear();
+    MDSTableServer::reset_state();
+  }
+  return modified;
 }

--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -140,6 +140,9 @@ public:
 
   void dump(Formatter *f) const;
   static void generate_test_instances(list<SnapServer*>& ls);
+
+  bool force_update(snapid_t last, snapid_t v2_since,
+		    map<snapid_t, SnapInfo>& _snaps);
 };
 WRITE_CLASS_ENCODER(SnapServer)
 

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -40,6 +40,12 @@ struct SnapInfo {
 };
 WRITE_CLASS_ENCODER(SnapInfo)
 
+inline bool operator==(const SnapInfo &l, const SnapInfo &r)
+{
+  return l.snapid == r.snapid && l.ino == r.ino &&
+	 l.stamp == r.stamp && l.name == r.name;
+}
+
 ostream& operator<<(ostream& out, const SnapInfo &sn);
 
 

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -20,6 +20,7 @@
 
 #include "mds/CInode.h"
 #include "mds/InoTable.h"
+#include "mds/SnapServer.h"
 #include "cls/cephfs/cls_cephfs_client.h"
 
 #include "PgFiles.h"
@@ -298,6 +299,8 @@ int DataScan::main(const std::vector<const char*> &args)
     if (r != 0) {
       return r;
     }
+
+    data_pools = fs->mds_map.get_data_pools();
   }
 
   // Finally, dispatch command
@@ -906,6 +909,9 @@ int DataScan::scan_links()
 
   interval_set<uint64_t> used_inos;
   map<inodeno_t, int> remote_links;
+  map<snapid_t, SnapInfo> snaps;
+  snapid_t last_snap = 1;
+  snapid_t snaprealm_v2_since = 2;
 
   struct link_info_t {
     inodeno_t dirino;
@@ -914,6 +920,7 @@ int DataScan::scan_links()
     version_t version;
     int nlink;
     bool is_dir;
+    map<snapid_t, SnapInfo> snaps;
     link_info_t() : version(0), nlink(0), is_dir(false) {}
     link_info_t(inodeno_t di, frag_t df, const string& n, const CInode::mempool_inode& i) :
       dirino(di), frag(df), name(n),
@@ -972,6 +979,10 @@ int DataScan::scan_links()
 	try {
 	  snapid_t dnfirst;
 	  decode(dnfirst, q);
+	  if (dnfirst <= CEPH_MAXSNAP) {
+	    if (dnfirst - 1 > last_snap)
+	      last_snap = dnfirst - 1;
+	  }
 	  char dentry_type;
 	  decode(dentry_type, q);
 	  if (dentry_type == 'I') {
@@ -986,9 +997,33 @@ int DataScan::scan_links()
 		used_inos.insert(ino);
 	      }
 	    } else if (step == CHECK_LINK) {
+	      sr_t srnode;
+	      if (inode.snap_blob.length()) {
+		auto p = inode.snap_blob.begin();
+		decode(srnode, p);
+		for (auto it = srnode.snaps.begin();
+		     it != srnode.snaps.end(); ) {
+		  if (it->second.ino != ino ||
+		      it->second.snapid != it->first) {
+		    srnode.snaps.erase(it++);
+		  } else {
+		    ++it;
+		  }
+		}
+		if (!srnode.past_parents.empty()) {
+		  snapid_t last = srnode.past_parents.rbegin()->first;
+		  if (last + 1 > snaprealm_v2_since)
+		    snaprealm_v2_since = last + 1;
+		}
+	      }
+	      if (!inode.old_inodes.empty()) {
+		if (inode.old_inodes.rbegin()->first > last_snap)
+		  last_snap = inode.old_inodes.rbegin()->first;
+	      }
 	      auto q = dup_primaries.find(ino);
 	      if (q != dup_primaries.end()) {
 		q->second.push_back(link_info_t(dir_ino, frag_id, dname, inode.inode));
+		q->second.back().snaps.swap(srnode.snaps);
 	      } else {
 		int nlink = 0;
 		auto r = remote_links.find(ino);
@@ -1002,6 +1037,8 @@ int DataScan::scan_links()
 		  bad_nlink_inos[ino] = link_info_t(dir_ino, frag_id, dname, inode.inode);
 		  bad_nlink_inos[ino].nlink = nlink;
 		}
+		snaps.insert(make_move_iterator(begin(srnode.snaps)),
+			     make_move_iterator(end(srnode.snaps)));
 	      }
 	    }
 	  } else if (dentry_type == 'L') {
@@ -1074,8 +1111,11 @@ int DataScan::scan_links()
 
     for (auto& q : p.second) {
       // in the middle of dir fragmentation?
-      if (newest.dirino == q.dirino && newest.name == q.name)
+      if (newest.dirino == q.dirino && newest.name == q.name) {
+	snaps.insert(make_move_iterator(begin(q.snaps)),
+		     make_move_iterator(end(q.snaps)));
 	continue;
+      }
 
       std::string key;
       dentry_key_t dn_key(CEPH_NOSNAP, q.name.c_str());
@@ -1150,6 +1190,38 @@ int DataScan::scan_links()
     }
   }
 
+  {
+    objecter->with_osdmap([&](const OSDMap& o) {
+      for (auto p : data_pools) {
+	const pg_pool_t *pi = o.get_pg_pool(p);
+	if (!pi)
+	  continue;
+	if (pi->snap_seq > last_snap)
+	  last_snap = pi->snap_seq;
+      }
+    });
+
+    if (!snaps.empty()) {
+      if (snaps.rbegin()->first > last_snap)
+	last_snap = snaps.rbegin()->first;
+    }
+
+    SnapServer snaptable;
+    snaptable.set_rank(0);
+    bool dirty = false;
+    int r = metadata_driver->load_table(&snaptable);
+    if (r < 0) {
+      snaptable.reset_state();
+      dirty = true;
+    }
+    if (snaptable.force_update(last_snap, snaprealm_v2_since, snaps))
+      dirty = true;
+    if (dirty) {
+      r = metadata_driver->save_table(&snaptable);
+      if (r < 0)
+	return r;
+    }
+  }
   return 0;
 }
 

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -17,6 +17,7 @@
 #include "include/rados/librados.hpp"
 
 class InodeStore;
+class MDSTable;
 
 class RecoveryDriver {
   protected:
@@ -232,6 +233,9 @@ class MetadataDriver : public RecoveryDriver, public MetadataTool
     int init_roots(int64_t data_pool_id) override;
 
     int check_roots(bool *result) override;
+
+    int load_table(MDSTable *table);
+    int save_table(MDSTable *table);
 };
 
 class DataScan : public MDSUtility, public MetadataTool

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -244,11 +244,13 @@ class DataScan : public MDSUtility, public MetadataTool
     RecoveryDriver *driver;
     fs_cluster_id_t fscid;
 
+    string metadata_pool_name;
+    std::vector<int64_t> data_pools;
+
     // IoCtx for data pool (where we scrape file backtraces from)
     librados::IoCtx data_io;
     // Remember the data pool ID for use in layouts
     int64_t data_pool_id;
-    string metadata_pool_name;
 
     uint32_t n;
     uint32_t m;
@@ -325,7 +327,7 @@ class DataScan : public MDSUtility, public MetadataTool
 
     DataScan()
       : driver(NULL), fscid(FS_CLUSTER_ID_NONE),
-	data_pool_id(-1), metadata_pool_name(""), n(0), m(1),
+	data_pool_id(-1), n(0), m(1),
         force_pool(false), force_corrupt(false),
         force_init(false)
     {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/37906
possibly a backport of https://github.com/ceph/ceph/pull/24556
parent tracker: https://tracker.ceph.com/issues/36413

---

original PR body:

Fixes: https://tracker.ceph.com/issues/37906


---

updated using ceph-backport.sh version 15.0.0.6814
