### PR TITLE
mimic: mds: avoid calling clientreplay_done() prematurely

### DIFF
--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -277,6 +277,8 @@ class MDSRank {
 				  waiting_for_reconnect, waiting_for_resolve;
     list<MDSInternalContextBase*> waiting_for_any_client_connection;
     list<MDSInternalContextBase*> replay_queue;
+    bool replaying_requests_done = false;
+
     map<mds_rank_t, list<MDSInternalContextBase*> > waiting_for_active_peer;
     map<epoch_t, list<MDSInternalContextBase*> > waiting_for_mdsmap;
 
@@ -431,6 +433,7 @@ class MDSRank {
     }
 
     bool queue_one_replay();
+    void maybe_clientreplay_done();
 
     void set_osd_epoch_barrier(epoch_t e);
     epoch_t get_osd_epoch_barrier() const {return osd_epoch_barrier;}

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1520,8 +1520,7 @@ void Server::journal_and_reply(MDRequestRef& mdr, CInode *in, CDentry *dn, LogEv
     if (mds->queue_one_replay()) {
       dout(10) << " queued next replay op" << dendl;
     } else {
-      dout(10) << " journaled last replay op, flushing" << dendl;
-      mdlog->flush();
+      dout(10) << " journaled last replay op" << dendl;
     }
   } else if (mdr->did_early_reply)
     mds->locker->drop_rdlocks_for_early_reply(mdr.get());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/38643
possibly a backport of https://github.com/ceph/ceph/pull/26781
parent tracker: https://tracker.ceph.com/issues/38597

---

original PR body:

Fixes: https://tracker.ceph.com/issues/38643


---

updated using ceph-backport.sh version 15.0.0.6814
