### PR TITLE
mimic: tests: install python3-cephfs for fs suite

### DIFF
--- a/qa/cephfs/begin.yaml
+++ b/qa/cephfs/begin.yaml
@@ -4,4 +4,6 @@ tasks:
       extra_system_packages:
         deb: ['bison', 'flex', 'libelf-dev', 'libssl-dev']
         rpm: ['bison', 'flex', 'elfutils-libelf-devel', 'openssl-devel']
+      extra_packages:
+        - python3-cephfs
   - ceph:

--- a/qa/packages/packages.yaml
+++ b/qa/packages/packages.yaml
@@ -30,8 +30,6 @@ ceph:
   - rbd-fuse-dbg
   - rbd-mirror-dbg
   - rbd-nbd-dbg
-  - python3-cephfs
-  - python3-rados
   rpm:
   - ceph-radosgw
   - ceph-test
@@ -45,5 +43,3 @@ ceph:
   - python-ceph
   - rbd-fuse
   - ceph-debuginfo
-  - python3-cephfs
-  - python3-rados


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42582

---

backport of https://github.com/ceph/ceph/pull/23411
parent tracker: https://tracker.ceph.com/issues/42579

this backport was staged using ceph-backport.sh version 15.0.0.6270
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh