### PR TITLE
mgr/ssh: add per-service operations: start, stop, restart, redeploy

### DIFF
--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -285,33 +285,33 @@ This is an overview of the current implementation status of the orchestrators.
 =================================== ========= ====== ========= =====
  Command                             Ansible   Rook   DeepSea   SSH
 =================================== ========= ====== ========= =====
- host add                            ✔️         ⚪       ⚪         ✔️
- host ls                             ✔️         ✔️       ⚪         ✔️
- host rm                             ✔️         ⚪       ⚪         ✔️
- mgr update                          ⚪         ⚪       ⚪         ✔️
- mon update                          ⚪         ✔️       ⚪         ✔️
- osd create                          ✔️         ✔️       ⚪         ✔️
+ host add                            ✔         ⚪       ⚪         ✔
+ host ls                             ✔         ✔       ⚪         ✔
+ host rm                             ✔         ⚪       ⚪         ✔
+ mgr update                          ⚪         ⚪       ⚪         ✔
+ mon update                          ⚪         ✔       ⚪         ✔
+ osd create                          ✔         ✔       ⚪         ✔
  osd device {ident,fault}-{on,off}   ⚪         ⚪       ⚪         ⚪
- osd rm                              ✔️         ⚪       ⚪         ⚪
+ osd rm                              ✔         ⚪       ⚪         ⚪
  device {ident,fault}-(on,off}       ⚪         ⚪       ⚪         ⚪
- device ls                           ✔️         ✔️       ✔️         ✔️
- service ls                          ⚪         ✔️       ✔️         ✔
+ device ls                           ✔         ✔       ✔         ✔
+ service ls                          ⚪         ✔       ✔         ✔
  service-instance status             ⚪         ⚪       ⚪         ✔
  service-instance {stop,start,...}   ⚪         ⚪       ⚪         ✔
  iscsi add                           ⚪         ⚪       ⚪         ⚪
  iscsi rm                            ⚪         ⚪       ⚪         ⚪
  iscsi update                        ⚪         ⚪       ⚪         ⚪
- mds add                             ⚪         ✔️       ⚪         ✔
- mds rm                              ⚪         ✔️       ⚪         ✔
+ mds add                             ⚪         ✔       ⚪         ✔
+ mds rm                              ⚪         ✔       ⚪         ✔
  mds update                          ⚪         ✔       ⚪         ✔
- nfs add                             ⚪         ✔️       ⚪         ⚪
- nfs rm                              ⚪         ✔️       ⚪         ⚪
- nfs update                          ⚪         ✔️       ⚪         ⚪
+ nfs add                             ⚪         ✔       ⚪         ⚪
+ nfs rm                              ⚪         ✔       ⚪         ⚪
+ nfs update                          ⚪         ✔       ⚪         ⚪
  rbd-mirror add                      ⚪         ⚪       ⚪         ⚪
  rbd-mirror rm                       ⚪         ⚪       ⚪         ⚪
  rbd-mirror update                   ⚪         ⚪       ⚪         ⚪
- rgw add                             ✔️         ✔️       ⚪         ⚪
- rgw rm                              ✔️         ✔️       ⚪         ⚪
+ rgw add                             ✔         ✔       ⚪         ⚪
+ rgw rm                              ✔         ✔       ⚪         ⚪
  rgw update                          ⚪         ⚪       ⚪         ⚪
 =================================== ========= ====== ========= =====
 

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -296,7 +296,7 @@ This is an overview of the current implementation status of the orchestrators.
  device {ident,fault}-(on,off}       ⚪         ⚪       ⚪         ⚪
  device ls                           ✔️         ✔️       ✔️         ✔️
  service ls                          ⚪         ✔️       ✔️         ✔
- service-instance status             ⚪         ⚪       ⚪         ⚪
+ service-instance status             ⚪         ⚪       ⚪         ✔
  iscsi {stop,start,reload}           ⚪         ⚪       ⚪         ⚪
  iscsi add                           ⚪         ⚪       ⚪         ⚪
  iscsi rm                            ⚪         ⚪       ⚪         ⚪

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -298,22 +298,18 @@ This is an overview of the current implementation status of the orchestrators.
  service ls                          ⚪         ✔️       ✔️         ✔
  service-instance status             ⚪         ⚪       ⚪         ✔
  service-instance {stop,start,...}   ⚪         ⚪       ⚪         ✔
- iscsi {stop,start,reload}           ⚪         ⚪       ⚪         ⚪
  iscsi add                           ⚪         ⚪       ⚪         ⚪
  iscsi rm                            ⚪         ⚪       ⚪         ⚪
  iscsi update                        ⚪         ⚪       ⚪         ⚪
  mds add                             ⚪         ✔️       ⚪         ✔
  mds rm                              ⚪         ✔️       ⚪         ✔
  mds update                          ⚪         ✔       ⚪         ✔
- nfs {stop,start,reload}             ⚪         ⚪       ⚪         ⚪
  nfs add                             ⚪         ✔️       ⚪         ⚪
  nfs rm                              ⚪         ✔️       ⚪         ⚪
  nfs update                          ⚪         ✔️       ⚪         ⚪
- rbd-mirror {stop,start,reload}      ⚪         ⚪       ⚪         ⚪
  rbd-mirror add                      ⚪         ⚪       ⚪         ⚪
  rbd-mirror rm                       ⚪         ⚪       ⚪         ⚪
  rbd-mirror update                   ⚪         ⚪       ⚪         ⚪
- rgw {stop,start,reload}             ⚪         ⚪       ⚪         ⚪
  rgw add                             ✔️         ✔️       ⚪         ⚪
  rgw rm                              ✔️         ✔️       ⚪         ⚪
  rgw update                          ⚪         ⚪       ⚪         ⚪

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -295,7 +295,7 @@ This is an overview of the current implementation status of the orchestrators.
  osd rm                              ✔️         ⚪       ⚪         ⚪
  device {ident,fault}-(on,off}       ⚪         ⚪       ⚪         ⚪
  device ls                           ✔️         ✔️       ✔️         ✔️
- service ls                          ⚪         ✔️       ✔️         ⚪
+ service ls                          ⚪         ✔️       ✔️         ✔
  service-instance status             ⚪         ⚪       ⚪         ⚪
  iscsi {stop,start,reload}           ⚪         ⚪       ⚪         ⚪
  iscsi add                           ⚪         ⚪       ⚪         ⚪

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -302,9 +302,9 @@ This is an overview of the current implementation status of the orchestrators.
  iscsi rm                            ⚪         ⚪       ⚪         ⚪
  iscsi update                        ⚪         ⚪       ⚪         ⚪
  mds {stop,start,reload}             ⚪         ⚪       ⚪         ⚪
- mds add                             ⚪         ✔️       ⚪         ⚪
- mds rm                              ⚪         ✔️       ⚪         ⚪
- mds update                          ⚪         ⚪       ⚪         ⚪
+ mds add                             ⚪         ✔️       ⚪         ✔
+ mds rm                              ⚪         ✔️       ⚪         ✔
+ mds update                          ⚪         ✔       ⚪         ✔
  nfs {stop,start,reload}             ⚪         ⚪       ⚪         ⚪
  nfs add                             ⚪         ✔️       ⚪         ⚪
  nfs rm                              ⚪         ✔️       ⚪         ⚪

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -297,11 +297,11 @@ This is an overview of the current implementation status of the orchestrators.
  device ls                           ✔️         ✔️       ✔️         ✔️
  service ls                          ⚪         ✔️       ✔️         ✔
  service-instance status             ⚪         ⚪       ⚪         ✔
+ service-instance {stop,start,...}   ⚪         ⚪       ⚪         ✔
  iscsi {stop,start,reload}           ⚪         ⚪       ⚪         ⚪
  iscsi add                           ⚪         ⚪       ⚪         ⚪
  iscsi rm                            ⚪         ⚪       ⚪         ⚪
  iscsi update                        ⚪         ⚪       ⚪         ⚪
- mds {stop,start,reload}             ⚪         ⚪       ⚪         ⚪
  mds add                             ⚪         ✔️       ⚪         ✔
  mds rm                              ⚪         ✔️       ⚪         ✔
  mds update                          ⚪         ✔       ⚪         ✔

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -503,6 +503,10 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
     call_throws(['systemctl', 'daemon-reload'])
 
     unit_name = get_unit_name(fsid, daemon_type, daemon_id)
+    call(['systemctl', 'stop', unit_name],
+         verbose_on_failure=False)
+    call(['systemctl', 'reset-failed', unit_name],
+         verbose_on_failure=False)
     if enable:
         call_throws(['systemctl', 'enable', unit_name])
     if start:

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -78,7 +78,7 @@ podman_path = None
 ##################################
 # Popen wrappers, lifted from ceph-volume
 
-def call(command, desc, verbose=False, **kw):
+def call(command, desc=None, verbose=False, **kw):
     """
     Wrap subprocess.Popen to
 
@@ -91,6 +91,8 @@ def call(command, desc, verbose=False, **kw):
     :param verbose_on_failure: On a non-zero exit status, it will forcefully set
                                logging ON for the terminal
     """
+    if not desc:
+        desc = command[0]
     verbose_on_failure = kw.pop('verbose_on_failure', True)
 
     logger.debug("Running command: %s" % ' '.join(command))
@@ -234,7 +236,7 @@ def check_unit(unit_name):
     # various exit codes based on the state of the service, but the
     # string result is more explicit (and sufficient).
     try:
-        out, err, code = call(['systemctl', 'is-enabled', unit_name], 'systemctl')
+        out, err, code = call(['systemctl', 'is-enabled', unit_name])
         enabled = out.strip() == 'enabled'
     except Exception as e:
         logger.warning('unable to run systemctl: %s' % e)
@@ -242,7 +244,7 @@ def check_unit(unit_name):
 
     state = 'unknown'
     try:
-        out, err, code = call(['systemctl', 'is-active', unit_name], 'systemctl')
+        out, err, code = call(['systemctl', 'is-active', unit_name])
         out = out.strip()
         if out in ['active']:
             state = 'running'
@@ -1305,13 +1307,11 @@ def command_ls():
                             podman_path, 'inspect',
                             '--format', '{{.Id}}',
                             'ceph-%s-%s' % (fsid, j)
-                        ],
-                        podman_path)
+                        ])
                     if not code:
                         container_id = out.strip()[0:12]
                         out, err, code = call(
-                            [podman_path, 'exec', container_id, 'ceph', '-v'],
-                            podman_path)
+                            [podman_path, 'exec', container_id, 'ceph', '-v'])
                         if not code and out.startswith('ceph version '):
                             version = out.split(' ')[2]
                     ls.append({
@@ -1410,16 +1410,16 @@ def command_rm_cluster():
     # ignore errors here
     for unit_name in ['ceph-%s.target' % args.fsid,
                       'ceph-%s-crash.service' % args.fsid]:
-        call(['systemctl', 'stop', unit_name], 'systemctl',
+        call(['systemctl', 'stop', unit_name],
              verbose_on_failure=False)
-        call(['systemctl', 'reset-failed', unit_name], 'systemctl',
+        call(['systemctl', 'reset-failed', unit_name],
              verbose_on_failure=False)
-        call(['systemctl', 'disable', unit_name], 'systemctl',
+        call(['systemctl', 'disable', unit_name],
              verbose_on_failure=False)
 
     slice_name = 'system-%s.slice' % (('ceph-%s' % args.fsid).replace('-',
                                                                       '\\x2d'))
-    call(['systemctl', 'stop', slice_name], 'systemctl',
+    call(['systemctl', 'stop', slice_name],
          verbose_on_failure=False)
 
     # FIXME: stop + disable individual daemon units, too?

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -416,7 +416,8 @@ def extract_uid_gid():
 
 def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
                   config=None, keyring=None):
-    if daemon_type == 'mon':
+    if daemon_type == 'mon' and not os.path.exists(get_data_dir(fsid, 'mon',
+                                                                daemon_id)):
         # tmp keyring file
         tmp_keyring = tempfile.NamedTemporaryFile(mode='w')
         os.fchmod(tmp_keyring.fileno(), 0o600)

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -405,7 +405,7 @@ class Orchestrator(object):
         * If using service_id, perform the action on a single specific daemon
           instance.
 
-        :param action: one of "start", "stop", "reload", "restart"
+        :param action: one of "start", "stop", "reload", "restart", "redeploy"
         :param service_type: e.g. "mds", "rgw", ...
         :param service_name: name of logical service ("cephfs", "us-east", ...)
         :param service_id: service daemon instance (usually a short hostname)

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -405,7 +405,7 @@ class Orchestrator(object):
         * If using service_id, perform the action on a single specific daemon
           instance.
 
-        :param action: one of "start", "stop", "reload"
+        :param action: one of "start", "stop", "reload", "restart"
         :param service_type: e.g. "mds", "rgw", ...
         :param service_name: name of logical service ("cephfs", "us-east", ...)
         :param service_id: service daemon instance (usually a short hostname)

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -344,7 +344,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_write_cli('orchestrator service',
-                "name=action,type=CephChoices,strings=start|stop|reload|restart "
+                "name=action,type=CephChoices,strings=start|stop|reload|restart|redeploy "
                 "name=svc_type,type=CephString "
                 "name=svc_name,type=CephString",
                 'Start, stop or reload an entire service (i.e. all daemons)')
@@ -355,7 +355,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_write_cli('orchestrator service-instance',
-                "name=action,type=CephChoices,strings=start|stop|reload|restart "
+                "name=action,type=CephChoices,strings=start|stop|reload|restart|redeploy "
                 "name=svc_type,type=CephString "
                 "name=svc_id,type=CephString",
                 'Start, stop or reload a specific service instance')

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -344,7 +344,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_write_cli('orchestrator service',
-                "name=action,type=CephChoices,strings=start|stop|reload "
+                "name=action,type=CephChoices,strings=start|stop|reload|restart "
                 "name=svc_type,type=CephString "
                 "name=svc_name,type=CephString",
                 'Start, stop or reload an entire service (i.e. all daemons)')
@@ -355,7 +355,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_write_cli('orchestrator service-instance',
-                "name=action,type=CephChoices,strings=start|stop|reload "
+                "name=action,type=CephChoices,strings=start|stop|reload|restart "
                 "name=svc_type,type=CephString "
                 "name=svc_id,type=CephString",
                 'Start, stop or reload a specific service instance')

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -869,10 +869,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         return SSHWriteCompletion(results)
 
     def update_mds(self, spec):
-        daemons = [
-            d for d in self._get_services('mds')
-            if d.service_instance.startswith(spec.name + '-')
-        ]
+        daemons = self._get_services('mds', service_name=spec.name)
         results = []
         if len(daemons) > spec.count:
             # remove some

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -529,6 +529,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         actions = {
             'start': ['reset-failed', 'start'],
             'stop': ['stop'],
+            'restart': ['reset-failed', 'restart'],
         }
         name = '%s.%s' % (service_type, service_id)
         for a in actions[action]:

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -478,7 +478,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
                 sd.status_desc = d['state']
                 sd.status = {
                     'running': 1,
-                    'inactive': 0,
+                    'stopped': 0,
                     'error': -1,
                     'unknown': -1,
                 }[d['state']]

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -958,7 +958,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
                 results.append(self._worker_pool.apply_async(
                     self._remove_mds, (d.service_instance, d.nodename)))
         if not results:
-            raise RuntimeError('Unable to find mds.%s[-*] daemon(s)' % name)
+            raise OrchestratorError('Unable to find mds.%s[-*] daemon(s)' % name)
         return SSHWriteCompletion(results)
 
     def _remove_mds(self, mds_id, host):


### PR DESCRIPTION
I skipped reload, which is a no-op for these service types.  What was the intent here?  To reopen log files?

I added:
- restart
- redeploy, which recreates the container, enabling an upgrade or downgrade