### PR TITLE
mimic: qa/tasks/cbt: run stop-all.sh while shutting down

### DIFF
--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -240,6 +240,21 @@ class CBT(Task):
                 cosbench_version = 'cosbench-0.4.2.c3.1'
             else:
                 cosbench_version = '0.4.2.c3'
+            # note: stop-all requires 'nc'
+            self.first_mon.run(
+                args=[
+                    'cd', testdir, run.Raw('&&'),
+                    'cd', 'cos', run.Raw('&&'),
+                    'sh', 'stop-all.sh',
+                    run.Raw('||'), 'true'
+                ]
+            )
+            self.first_mon.run(
+                args=[
+                    'sudo', 'killall', '-9', 'java',
+                    run.Raw('||'), 'true'
+                ]
+            )
             self.first_mon.run(
                 args=[
                     'rm', '--one-file-system', '-rf', '--',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42544

---

backport of https://github.com/ceph/ceph/pull/31171
parent tracker: https://tracker.ceph.com/issues/42496

this backport was staged using ceph-backport.sh version 15.0.0.6612
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh