### PR TITLE
test: only compile ceph_test_bmap_alloc_replay WITH_BLUESTORE

### DIFF
--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -147,8 +147,10 @@ add_executable(unittest_memstore_clone
 add_ceph_unittest(unittest_memstore_clone)
 target_link_libraries(unittest_memstore_clone os global)
 
-add_executable(ceph_test_bmap_alloc_replay
-  bmap_allocator_replay_test.cc)
-target_link_libraries(ceph_test_bmap_alloc_replay os global ${UNITTEST_LIBS})
-install(TARGETS ceph_test_bmap_alloc_replay
-  DESTINATION bin)
+if(WITH_BLUESTORE)
+  add_executable(ceph_test_bmap_alloc_replay
+    bmap_allocator_replay_test.cc)
+  target_link_libraries(ceph_test_bmap_alloc_replay os global ${UNITTEST_LIBS})
+  install(TARGETS ceph_test_bmap_alloc_replay
+    DESTINATION bin)
+endif()


### PR DESCRIPTION
It uses bluestore/Allocate.cc


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>