### PR TITLE
osd:if the oldest object that should be force recovered is snap and is missi…

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -749,6 +749,12 @@ void PrimaryLogPG::maybe_force_recovery()
     }
   }
 
+  hobject_t head = soid.get_head();
+  if (soid.is_snap() && pg_log.get_missing().is_missing(head)) {
+    dout(10) << __func__ << " the oldest object is snap, recover head firstly, " << soid << dendl;
+    soid = head; // recover head firstly
+  }
+
   // recover it
   if (soid != hobject_t())
     maybe_kick_recovery(soid);


### PR DESCRIPTION
When an IO triggers a forced recovery, if the selected object is a snapshot object, and the object's head object is missing on local, which causes the assertion to fail in function PrimaryLogPG::on_local_recover(). Therefore, the head object should be recovered first.