### PR TITLE
luminous: Various whitelists for tests to pass

### DIFF
--- a/qa/suites/smoke/basic/tasks/mon_thrash.yaml
+++ b/qa/suites/smoke/basic/tasks/mon_thrash.yaml
@@ -4,6 +4,17 @@ overrides:
       - reached quota
       - \(POOL_APP_NOT_ENABLED\)
       - \(OSD_SLOW_PING_TIME
+      - mons down
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(SMALLER_PGP_NUM\)
+      - \(OBJECT_
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
     conf:
       global:
         ms inject delay max: 1

--- a/qa/suites/smoke/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_api_tests.yaml
@@ -3,6 +3,16 @@ tasks:
 - ceph:
     fs: ext4
     log-whitelist:
+    - overall HEALTH_
+    - \(OSDMAP_FLAGS\)
+    - \(OSD_
+    - \(PG_
+    - \(POOL_
+    - \(CACHE_POOL_
+    - \(SMALLER_PGP_NUM\)
+    - \(OBJECT_
+    - \(REQUEST_SLOW\)
+    - \(TOO_FEW_PGS\)
     - reached quota
     - but it is still running
     - objects unfound and apparently lost

--- a/qa/suites/smoke/basic/tasks/rados_bench.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_bench.yaml
@@ -15,6 +15,16 @@ tasks:
     - but it is still running
     - objects unfound and apparently lost
     - \(OSD_SLOW_PING_TIME
+    - overall HEALTH_
+    - \(OSDMAP_FLAGS\)
+    - \(OSD_
+    - \(PG_
+    - \(POOL_
+    - \(CACHE_POOL_
+    - \(SMALLER_PGP_NUM\)
+    - \(OBJECT_
+    - \(REQUEST_SLOW\)
+    - \(TOO_FEW_PGS\)
 - thrashosds:
     chance_pgnum_grow: 2
     chance_pgpnum_fix: 1

--- a/qa/suites/smoke/basic/tasks/rados_cache_snaps.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_cache_snaps.yaml
@@ -2,8 +2,16 @@ tasks:
 - install: null
 - ceph:
     log-whitelist:
-    - but it is still running
-    - objects unfound and apparently lost
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(SMALLER_PGP_NUM\)
+      - \(OBJECT_
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
 - thrashosds:
     chance_pgnum_grow: 2
     chance_pgpnum_fix: 1

--- a/qa/suites/smoke/basic/tasks/rados_cls_all.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_cls_all.yaml
@@ -1,3 +1,11 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd_class_load_list: "cephfs hello journal lock log numops rbd refcount
+                              replica_log rgw sdk statelog timeindex user version"
+        osd_class_default_list: "cephfs hello journal lock log numops rbd refcount
+                                 replica_log rgw sdk statelog timeindex user version"
 tasks:
 - install:
 - ceph:

--- a/qa/suites/smoke/basic/tasks/rados_ec_snaps.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_ec_snaps.yaml
@@ -3,8 +3,16 @@ tasks:
 - ceph:
     fs: xfs
     log-whitelist:
-    - but it is still running
-    - objects unfound and apparently lost
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(SMALLER_PGP_NUM\)
+      - \(OBJECT_
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
 - thrashosds:
     chance_pgnum_grow: 3
     chance_pgpnum_fix: 1

--- a/qa/suites/smoke/basic/tasks/rados_python.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_python.yaml
@@ -2,7 +2,13 @@ tasks:
 - install:
 - ceph:
     log-whitelist:
-      - but it is still running
+    - but it is still running
+    - overall HEALTH_
+    - \(OSDMAP_FLAGS\)
+    - \(PG_
+    - \(OSD_
+    - \(OBJECT_
+    - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/rados_workunit_loadgen_mix.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_workunit_loadgen_mix.yaml
@@ -2,6 +2,10 @@ tasks:
 - install:
 - ceph:
     fs: ext4
+    log-whitelist:
+    - but it is still running
+    - overall HEALTH_
+    - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/rbd_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rbd_api_tests.yaml
@@ -1,6 +1,13 @@
 tasks:
 - install:
 - ceph:
+    log-whitelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
     fs: xfs
 - ceph-fuse:
 - workunit:

--- a/qa/suites/smoke/basic/tasks/rbd_fsx.yaml
+++ b/qa/suites/smoke/basic/tasks/rbd_fsx.yaml
@@ -2,6 +2,16 @@ overrides:
   ceph:
     log-whitelist:
       - \(OSD_SLOW_PING_TIME
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(SMALLER_PGP_NUM\)
+      - \(OBJECT_
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
     conf:
       client:
         rbd cache: true


### PR DESCRIPTION
See tracker http://tracker.ceph.com/issues/21376 for details

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>
(cherry picked from commit 1f5aba674c170aae8b9e4b7d122f822eefd59f26)

Conflicts:
	qa/suites/smoke/basic/tasks/mon_thrash.yaml (trivial)
	qa/suites/smoke/basic/tasks/rados_api_tests.yaml (trivial)
	qa/suites/smoke/basic/tasks/rados_bench.yaml (trivial)
	qa/suites/smoke/basic/tasks/rbd_fsx.yaml (trivial)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
