### PR TITLE
tools/rados: Unmask '-o' to restore original behaviour

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -295,3 +295,8 @@
   notably improved by heuristically -- and significantly, in many
   cases -- reducing the number of entries requested from each bucket
   index shard.
+
+* The behaviour of the ``-o`` argument to the rados tool has been reverted to
+  its orignal behaviour of indicating an output file. This reverts it to a more
+  consisten behaviour when compared to other tools. Specifying obect size is now
+  accomplished by using an upper case O ``-O``.

--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -67,6 +67,10 @@ Options
    Available for stat, stat2, get, put, append, truncate, rm, ls
    and all xattr related operation
 
+.. option:: -O object_size
+
+   Set the object size for put/get ops and for write benchmarking
+
 
 Global commands
 ===============

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -84,7 +84,7 @@ def task(ctx, config):
         if osize is 0:
             objectsize = []
         else:
-            objectsize = ['-o', str(osize)]
+            objectsize = ['-O', str(osize)]
         size = ['-b', str(config.get('size', 65536))]
         # If doing a reading run then populate data
         if runtype != "write":

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -182,7 +182,7 @@ void usage(ostream& out)
 "   --format=[--format plain|json|json-pretty]\n"
 "   -b op_size\n"
 "        set the block size for put/get ops and for write benchmarking\n"
-"   -o object_size\n"
+"   -O object_size\n"
 "        set the object size for put/get ops and for write benchmarking\n"
 "   --max-objects\n"
 "        set the max number of objects for write benchmarking\n"
@@ -3983,7 +3983,7 @@ int main(int argc, const char **argv)
       opts["max-objects"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--offset", (char*)NULL)) {
       opts["offset"] = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "-o", (char*)NULL)) {
+    } else if (ceph_argparse_witharg(args, i, &val, "-O", (char*)NULL)) {
       opts["object-size"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-s", "--snap", (char*)NULL)) {
       opts["snap"] = val;


### PR DESCRIPTION
0b369e1aff1 masked the original behaviour of '-o' which was to indicate
'outfile' as documented in the man page. Changing object-size to capital
o will restore the original behaviour.

Fixes: https://tracker.ceph.com/issues/42477

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
