### PR TITLE
cmake: update FindBoost.cmake for 1.71

### DIFF
--- a/cmake/modules/FindBoost.cmake
+++ b/cmake/modules/FindBoost.cmake
@@ -30,12 +30,18 @@ case results are reported in variables::
   Boost_<C>_FOUND        - True if component <C> was found (<C> is upper-case)
   Boost_<C>_LIBRARY      - Libraries to link for component <C> (may include
                            target_link_libraries debug/optimized keywords)
-  Boost_VERSION          - BOOST_VERSION value from boost/version.hpp
-  Boost_LIB_VERSION      - Version string appended to library filenames
-  Boost_MAJOR_VERSION    - Boost major version number (X in X.y.z)
-  Boost_MINOR_VERSION    - Boost minor version number (Y in x.Y.z)
-  Boost_SUBMINOR_VERSION - Boost subminor version number (Z in x.y.Z)
+  Boost_VERSION_MACRO    - BOOST_VERSION value from boost/version.hpp
   Boost_VERSION_STRING   - Boost version number in x.y.z format
+  Boost_VERSION          - if CMP0093 NEW => same as Boost_VERSION_STRING
+                           if CMP0093 OLD or unset => same as Boost_VERSION_MACRO
+  Boost_LIB_VERSION      - Version string appended to library filenames
+  Boost_VERSION_MAJOR    - Boost major version number (X in X.y.z)
+                           alias: Boost_MAJOR_VERSION
+  Boost_VERSION_MINOR    - Boost minor version number (Y in x.Y.z)
+                           alias: Boost_MINOR_VERSION
+  Boost_VERSION_PATCH    - Boost subminor version number (Z in x.y.Z)
+                           alias: Boost_SUBMINOR_VERSION
+  Boost_VERSION_COUNT    - Amount of version components (3)
   Boost_LIB_DIAGNOSTIC_DEFINITIONS (Windows)
                          - Pass to add_definitions() to have diagnostic
                            information about Boost's automatic linking
@@ -74,8 +80,9 @@ and saves search results persistently in CMake cache entries::
 
 The following :prop_tgt:`IMPORTED` targets are also defined::
 
-  Boost::boost                  - Target for header-only dependencies
+  Boost::headers                - Target for header-only dependencies
                                   (Boost include directory)
+                                  alias: Boost::boost
   Boost::<C>                    - Target for specific component dependency
                                   (shared or static library); <C> is lower-
                                   case
@@ -87,33 +94,33 @@ The following :prop_tgt:`IMPORTED` targets are also defined::
   Boost::dynamic_linking        - interface target to enable dynamic linking
                                   linking with MSVC (adds BOOST_ALL_DYN_LINK)
 
-Implicit dependencies such as Boost::filesystem requiring
-Boost::system will be automatically detected and satisfied, even
-if system is not specified when using find_package and if
-Boost::system is not added to target_link_libraries.  If using
-Boost::thread, then Threads::Threads will also be added automatically.
+Implicit dependencies such as ``Boost::filesystem`` requiring
+``Boost::system`` will be automatically detected and satisfied, even
+if system is not specified when using :command:`find_package` and if
+``Boost::system`` is not added to :command:`target_link_libraries`.  If using
+``Boost::thread``, then ``Threads::Threads`` will also be added automatically.
 
 It is important to note that the imported targets behave differently
 than variables created by this module: multiple calls to
-find_package(Boost) in the same directory or sub-directories with
+:command:`find_package(Boost)` in the same directory or sub-directories with
 different options (e.g. static or shared) will not override the
 values of the targets created by the first call.
 
-Users may set these hints or results as cache entries.  Projects
+Users may set these hints or results as ``CACHE`` entries.  Projects
 should not read these entries directly but instead use the above
 result variables.  Note that some hint names start in upper-case
 "BOOST".  One may specify these as environment variables if they are
 not specified as CMake variables or cache entries.
 
-This module first searches for the Boost header files using the above
-hint variables (excluding BOOST_LIBRARYDIR) and saves the result in
-Boost_INCLUDE_DIR.  Then it searches for requested component libraries
-using the above hints (excluding BOOST_INCLUDEDIR and
-Boost_ADDITIONAL_VERSIONS), "lib" directories near Boost_INCLUDE_DIR,
+This module first searches for the ``Boost`` header files using the above
+hint variables (excluding ``BOOST_LIBRARYDIR``) and saves the result in
+``Boost_INCLUDE_DIR``.  Then it searches for requested component libraries
+using the above hints (excluding ``BOOST_INCLUDEDIR`` and
+``Boost_ADDITIONAL_VERSIONS``), "lib" directories near ``Boost_INCLUDE_DIR``,
 and the library name configuration settings below.  It saves the
-library directories in Boost_LIBRARY_DIR_DEBUG and
-Boost_LIBRARY_DIR_RELEASE and individual library
-locations in Boost_<C>_LIBRARY_DEBUG and Boost_<C>_LIBRARY_RELEASE.
+library directories in ``Boost_LIBRARY_DIR_DEBUG`` and
+``Boost_LIBRARY_DIR_RELEASE`` and individual library
+locations in ``Boost_<C>_LIBRARY_DEBUG`` and ``Boost_<C>_LIBRARY_RELEASE``.
 When one changes settings used by previous searches in the same build
 tree (excluding environment variables) this module discards previous
 search results affected by the changes and searches again.
@@ -164,10 +171,6 @@ Other variables one may set to control this module are::
 
   Boost_DEBUG              - Set to ON to enable debug output from FindBoost.
                              Please enable this before filing any bug report.
-  Boost_DETAILED_FAILURE_MSG
-                           - Set to ON to add detailed information to the
-                             failure message even when the REQUIRED option
-                             is not given to the find_package call.
   Boost_REALPATH           - Set to ON to resolve symlinks for discovered
                              libraries to assist with packaging.  For example,
                              the "system" component library may be resolved to
@@ -181,9 +184,9 @@ Other variables one may set to control this module are::
 On Visual Studio and Borland compilers Boost headers request automatic
 linking to corresponding libraries.  This requires matching libraries
 to be linked explicitly or available in the link library search path.
-In this case setting Boost_USE_STATIC_LIBS to OFF may not achieve
+In this case setting ``Boost_USE_STATIC_LIBS`` to ``OFF`` may not achieve
 dynamic linking.  Boost automatic linking typically requests static
-libraries with a few exceptions (such as Boost.Python).  Use::
+libraries with a few exceptions (such as ``Boost.Python``).  Use::
 
   add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
 
@@ -229,27 +232,201 @@ Example to find Boost headers and some *static* (release only) libraries::
 Boost CMake
 ^^^^^^^^^^^
 
-If Boost was built using the boost-cmake project it provides a package
-configuration file for use with find_package's Config mode.  This
-module looks for the package configuration file called
-BoostConfig.cmake or boost-config.cmake and stores the result in cache
-entry "Boost_DIR".  If found, the package configuration file is loaded
+If Boost was built using the boost-cmake project or from Boost 1.70.0 on
+it provides a package configuration file for use with find_package's config mode.
+This module looks for the package configuration file called
+``BoostConfig.cmake`` or ``boost-config.cmake`` and stores the result in
+``CACHE`` entry "Boost_DIR".  If found, the package configuration file is loaded
 and this module returns with no further action.  See documentation of
 the Boost CMake package configuration for details on what it provides.
 
-Set Boost_NO_BOOST_CMAKE to ON to disable the search for boost-cmake.
+Set ``Boost_NO_BOOST_CMAKE`` to ``ON``, to disable the search for boost-cmake.
 #]=======================================================================]
+
+# The FPHSA helper provides standard way of reporting final search results to
+# the user including the version and component checks.
+include(FindPackageHandleStandardArgs)
 
 # Save project's policies
 cmake_policy(PUSH)
 cmake_policy(SET CMP0057 NEW) # if IN_LIST
 
+function(_boost_get_existing_target component target_var)
+  set(names "${component}")
+  if(component MATCHES "^([a-z_]*)(python|numpy)([1-9])\\.?([0-9])?$")
+    # handle pythonXY and numpyXY versioned components and also python X.Y, mpi_python etc.
+    list(APPEND names
+      "${CMAKE_MATCH_1}${CMAKE_MATCH_2}" # python
+      "${CMAKE_MATCH_1}${CMAKE_MATCH_2}${CMAKE_MATCH_3}" # pythonX
+      "${CMAKE_MATCH_1}${CMAKE_MATCH_2}${CMAKE_MATCH_3}${CMAKE_MATCH_4}" #pythonXY
+    )
+  endif()
+  # https://github.com/boost-cmake/boost-cmake uses boost::file_system etc.
+  # So handle similar constructions of target names
+  string(TOLOWER "${component}" lower_component)
+  list(APPEND names "${lower_component}")
+  foreach(prefix Boost boost)
+    foreach(name IN LISTS names)
+      if(TARGET "${prefix}::${name}")
+        # The target may be an INTERFACE library that wraps around a single other
+        # target for compatibility.  Unwrap this layer so we can extract real info.
+        if("${name}" MATCHES "^(python|numpy|mpi_python)([1-9])([0-9])$")
+          set(name_nv "${CMAKE_MATCH_1}")
+          if(TARGET "${prefix}::${name_nv}")
+            get_property(type TARGET "${prefix}::${name}" PROPERTY TYPE)
+            if(type STREQUAL "INTERFACE_LIBRARY")
+              get_property(lib TARGET "${prefix}::${name}" PROPERTY INTERFACE_LINK_LIBRARIES)
+              if("${lib}" STREQUAL "${prefix}::${name_nv}")
+                set(${target_var} "${prefix}::${name_nv}" PARENT_SCOPE)
+                return()
+              endif()
+            endif()
+          endif()
+        endif()
+        set(${target_var} "${prefix}::${name}" PARENT_SCOPE)
+        return()
+      endif()
+    endforeach()
+  endforeach()
+  set(${target_var} "" PARENT_SCOPE)
+endfunction()
+
+function(_boost_get_canonical_target_name component target_var)
+  string(TOLOWER "${component}" component)
+  if(component MATCHES "^([a-z_]*)(python|numpy)([1-9])\\.?([0-9])?$")
+    # handle pythonXY and numpyXY versioned components and also python X.Y, mpi_python etc.
+    set(${target_var} "Boost::${CMAKE_MATCH_1}${CMAKE_MATCH_2}" PARENT_SCOPE)
+  else()
+    set(${target_var} "Boost::${component}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+macro(_boost_set_in_parent_scope name value)
+  # Set a variable in parent scope and make it visibile in current scope
+  set(${name} "${value}" PARENT_SCOPE)
+  set(${name} "${value}")
+endmacro()
+
+macro(_boost_set_if_unset name value)
+  if(NOT ${name})
+    _boost_set_in_parent_scope(${name} "${value}")
+  endif()
+endmacro()
+
+macro(_boost_set_cache_if_unset name value)
+  if(NOT ${name})
+    set(${name} "${value}" CACHE STRING "" FORCE)
+  endif()
+endmacro()
+
+macro(_boost_append_include_dir target)
+  get_target_property(inc "${target}" INTERFACE_INCLUDE_DIRECTORIES)
+  if(inc)
+    list(APPEND include_dirs "${inc}")
+  endif()
+endmacro()
+
+function(_boost_set_legacy_variables_from_config)
+  # Set legacy variables for compatibility if not set
+  set(include_dirs "")
+  set(library_dirs "")
+  set(libraries "")
+  # Header targets Boost::headers or Boost::boost
+  foreach(comp headers boost)
+    _boost_get_existing_target(${comp} target)
+    if(target)
+      _boost_append_include_dir("${target}")
+    endif()
+  endforeach()
+  # Library targets
+  foreach(comp IN LISTS Boost_FIND_COMPONENTS)
+    string(TOUPPER ${comp} uppercomp)
+    # Overwrite if set
+    _boost_set_in_parent_scope(Boost_${uppercomp}_FOUND "${Boost_${comp}_FOUND}")
+    if(Boost_${comp}_FOUND)
+      _boost_get_existing_target(${comp} target)
+      if(NOT target)
+        if(Boost_DEBUG OR Boost_VERBOSE)
+          message(WARNING "Could not find imported target for required component '${comp}'. Legacy variables for this component might be missing. Refer to the documentation of your Boost installation for help on variables to use.")
+        endif()
+        continue()
+      endif()
+      _boost_append_include_dir("${target}")
+      _boost_set_if_unset(Boost_${uppercomp}_LIBRARY "${target}")
+      _boost_set_if_unset(Boost_${uppercomp}_LIBRARIES "${target}") # Very old legacy variable
+      list(APPEND libraries "${target}")
+      get_property(type TARGET "${target}" PROPERTY TYPE)
+      if(NOT type STREQUAL "INTERFACE_LIBRARY")
+        foreach(cfg RELEASE DEBUG)
+          get_target_property(lib ${target} IMPORTED_LOCATION_${cfg})
+          if(lib)
+            get_filename_component(lib_dir "${lib}" DIRECTORY)
+            list(APPEND library_dirs ${lib_dir})
+            _boost_set_cache_if_unset(Boost_${uppercomp}_LIBRARY_${cfg} "${lib}")
+          endif()
+        endforeach()
+      elseif(Boost_DEBUG OR Boost_VERBOSE)
+        # For projects using only the Boost::* targets this warning can be safely ignored.
+        message(WARNING "Imported target '${target}' for required component '${comp}' has no artifact. Legacy variables for this component might be missing. Refer to the documentation of your Boost installation for help on variables to use.")
+      endif()
+      _boost_get_canonical_target_name("${comp}" canonical_target)
+      if(NOT TARGET "${canonical_target}")
+        add_library("${canonical_target}" INTERFACE IMPORTED)
+        target_link_libraries("${canonical_target}" INTERFACE "${target}")
+      endif()
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES include_dirs)
+  list(REMOVE_DUPLICATES library_dirs)
+  _boost_set_if_unset(Boost_INCLUDE_DIRS "${include_dirs}")
+  _boost_set_if_unset(Boost_LIBRARY_DIRS "${library_dirs}")
+  _boost_set_if_unset(Boost_LIBRARIES "${libraries}")
+  _boost_set_if_unset(Boost_VERSION_STRING "${Boost_VERSION_MAJOR}.${Boost_VERSION_MINOR}.${Boost_VERSION_PATCH}")
+  find_path(Boost_INCLUDE_DIR
+    NAMES boost/version.hpp boost/config.hpp
+    HINTS ${Boost_INCLUDE_DIRS}
+    NO_DEFAULT_PATH
+  )
+  if(NOT Boost_VERSION_MACRO OR NOT Boost_LIB_VERSION)
+    set(version_file ${Boost_INCLUDE_DIR}/boost/version.hpp)
+    if(EXISTS "${version_file}")
+      file(STRINGS "${version_file}" contents REGEX "#define BOOST_(LIB_)?VERSION ")
+      if(contents MATCHES "#define BOOST_VERSION ([0-9]+)")
+        _boost_set_if_unset(Boost_VERSION_MACRO "${CMAKE_MATCH_1}")
+      endif()
+      if(contents MATCHES "#define BOOST_LIB_VERSION \"([0-9_]+)\"")
+        _boost_set_if_unset(Boost_LIB_VERSION "${CMAKE_MATCH_1}")
+      endif()
+    endif()
+  endif()
+  _boost_set_if_unset(Boost_MAJOR_VERSION ${Boost_VERSION_MAJOR})
+  _boost_set_if_unset(Boost_MINOR_VERSION ${Boost_VERSION_MINOR})
+  _boost_set_if_unset(Boost_SUBMINOR_VERSION ${Boost_VERSION_PATCH})
+  if(WIN32)
+    _boost_set_if_unset(Boost_LIB_DIAGNOSTIC_DEFINITIONS "-DBOOST_LIB_DIAGNOSTIC")
+  endif()
+  if(NOT TARGET Boost::headers)
+    add_library(Boost::headers INTERFACE IMPORTED)
+    target_include_directories(Boost::headers INTERFACE ${Boost_INCLUDE_DIRS})
+  endif()
+  # Legacy targets w/o functionality as all handled by defined targets
+  foreach(lib diagnostic_definitions disable_autolinking dynamic_linking)
+    if(NOT TARGET Boost::${lib})
+      add_library(Boost::${lib} INTERFACE IMPORTED)
+    endif()
+  endforeach()
+  if(NOT TARGET Boost::boost)
+    add_library(Boost::boost INTERFACE IMPORTED)
+    target_link_libraries(Boost::boost INTERFACE Boost::headers)
+  endif()
+endfunction()
+
 # https://gitlab.kitware.com/cmake/cmake/issues/18865
 set(Boost_NO_BOOST_CMAKE ON CACHE BOOL "Disable the search for boost-cmake")
 
 #-------------------------------------------------------------------------------
-# Before we go searching, check whether boost-cmake is available, unless the
-# user specifically asked NOT to search for boost-cmake.
+# Before we go searching, check whether a boost cmake package is available, unless
+# the user specifically asked NOT to search for one.
 #
 # If Boost_DIR is set, this behaves as any find_package call would. If not,
 # it looks at BOOST_ROOT and BOOSTROOT to find Boost.
@@ -271,13 +448,28 @@ if (NOT Boost_NO_BOOST_CMAKE)
   find_package(Boost QUIET NO_MODULE)
   mark_as_advanced(Boost_DIR)
 
-  # If we found boost-cmake, then we're done.  Print out what we found.
+  # If we found a boost cmake package, then we're done. Print out what we found.
   # Otherwise let the rest of the module try to find it.
-  if (Boost_FOUND)
-    message(STATUS "Boost ${Boost_FIND_VERSION} found.")
-    if (Boost_FIND_COMPONENTS)
-      message(STATUS "Found Boost components:\n   ${Boost_FIND_COMPONENTS}")
+  if(Boost_FOUND)
+    # Convert component found variables to standard variables if required
+    # Necessary for legacy boost-cmake and 1.70 builtin BoostConfig
+    if(Boost_FIND_COMPONENTS)
+      foreach(_comp IN LISTS Boost_FIND_COMPONENTS)
+        if(DEFINED Boost_${_comp}_FOUND)
+          continue()
+        endif()
+        string(TOUPPER ${_comp} _uppercomp)
+        if(DEFINED Boost${_comp}_FOUND) # legacy boost-cmake project
+          set(Boost_${_comp}_FOUND ${Boost${_comp}_FOUND})
+        elseif(DEFINED Boost_${_uppercomp}_FOUND) # Boost 1.70
+          set(Boost_${_comp}_FOUND ${Boost_${_uppercomp}_FOUND})
+        endif()
+      endforeach()
     endif()
+
+    find_package_handle_standard_args(Boost HANDLE_COMPONENTS CONFIG_MODE)
+    _boost_set_legacy_variables_from_config()
+
     # Restore project's policies
     cmake_policy(POP)
     return()
@@ -288,6 +480,56 @@ endif()
 #-------------------------------------------------------------------------------
 #  FindBoost functions & macros
 #
+
+#
+# Print debug text if Boost_DEBUG is set.
+# Call example:
+# _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "debug message")
+#
+function(_Boost_DEBUG_PRINT file line text)
+  if(Boost_DEBUG)
+    message(STATUS "[ ${file}:${line} ] ${text}")
+  endif()
+endfunction()
+
+#
+# _Boost_DEBUG_PRINT_VAR(file line variable_name [ENVIRONMENT]
+#                        [SOURCE "short explanation of origin of var value"])
+#
+#   ENVIRONMENT - look up environment variable instead of CMake variable
+#
+# Print variable name and its value if Boost_DEBUG is set.
+# Call example:
+# _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" BOOST_ROOT)
+#
+function(_Boost_DEBUG_PRINT_VAR file line name)
+  if(Boost_DEBUG)
+    cmake_parse_arguments(_args "ENVIRONMENT" "SOURCE" "" ${ARGN})
+
+    unset(source)
+    if(_args_SOURCE)
+      set(source " (${_args_SOURCE})")
+    endif()
+
+    if(_args_ENVIRONMENT)
+      if(DEFINED ENV{${name}})
+        set(value "\"$ENV{${name}}\"")
+      else()
+        set(value "<unset>")
+      endif()
+      set(_name "ENV{${name}}")
+    else()
+      if(DEFINED "${name}")
+        set(value "\"${${name}}\"")
+      else()
+        set(value "<unset>")
+      endif()
+      set(_name "${name}")
+    endif()
+
+    _Boost_DEBUG_PRINT("${file}" "${line}" "${_name} = ${value}${source}")
+  endif()
+endfunction()
 
 ############################################
 #
@@ -406,11 +648,10 @@ macro(_Boost_FIND_LIBRARY var build_type)
   # If Boost_LIBRARY_DIR_[RELEASE,DEBUG] is known then search only there.
   if(Boost_LIBRARY_DIR_${build_type})
     set(_boost_LIBRARY_SEARCH_DIRS_${build_type} ${Boost_LIBRARY_DIR_${build_type}} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
-    if(Boost_DEBUG)
-      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-        " Boost_LIBRARY_DIR_${build_type} = ${Boost_LIBRARY_DIR_${build_type}}"
-        " _boost_LIBRARY_SEARCH_DIRS_${build_type} = ${_boost_LIBRARY_SEARCH_DIRS_${build_type}}")
-    endif()
+    _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                           "Boost_LIBRARY_DIR_${build_type}")
+    _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                           "_boost_LIBRARY_SEARCH_DIRS_${build_type}")
   endif()
 endmacro()
 
@@ -470,7 +711,7 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
     endif()
   elseif (GHSMULTI)
     set(_boost_COMPILER "-ghs")
-  elseif("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
+  elseif("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC" OR "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC")
     if(MSVC_TOOLSET_VERSION GREATER_EQUAL 150)
       # Not yet known.
       set(_boost_COMPILER "")
@@ -491,6 +732,12 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
     else() # VS 6.0 Good luck!
       set(_boost_COMPILER "-vc6") # yes, this is correct
     endif()
+
+    if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
+      string(REPLACE "." ";" VERSION_LIST "${CMAKE_CXX_COMPILER_VERSION}")
+      list(GET VERSION_LIST 0 CLANG_VERSION_MAJOR)
+      set(_boost_COMPILER "-clangw${CLANG_VERSION_MAJOR};${_boost_COMPILER}")
+    endif()
   elseif (BORLAND)
     set(_boost_COMPILER "-bcb")
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
@@ -498,7 +745,7 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "XL")
     set(_boost_COMPILER "-xlc")
   elseif (MINGW)
-    if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.34)
+    if(Boost_VERSION_STRING VERSION_LESS 1.34)
         set(_boost_COMPILER "-mgw") # no GCC version encoding prior to 1.34
     else()
       _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION _boost_COMPILER_VERSION_MAJOR _boost_COMPILER_VERSION_MINOR)
@@ -506,7 +753,7 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
     endif()
   elseif (UNIX)
     _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION _boost_COMPILER_VERSION_MAJOR _boost_COMPILER_VERSION_MINOR)
-    if(NOT Boost_VERSION VERSION_LESS 106900)
+    if(NOT Boost_VERSION_STRING VERSION_LESS 1.69.0)
       # From GCC 5 and clang 4, versioning changes and minor becomes patch.
       # For those compilers, patch is exclude from compiler tag in Boost 1.69+ library naming.
       if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND _boost_COMPILER_VERSION_MAJOR VERSION_GREATER 4)
@@ -517,25 +764,19 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
     endif()
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.34)
+      if(Boost_VERSION_STRING VERSION_LESS 1.34)
         set(_boost_COMPILER "-gcc") # no GCC version encoding prior to 1.34
       else()
         # Determine which version of GCC we have.
         if(APPLE)
-          if(Boost_MINOR_VERSION)
-            if(${Boost_MINOR_VERSION} GREATER 35)
-              # In Boost 1.36.0 and newer, the mangled compiler name used
-              # on macOS/Darwin is "xgcc".
-              set(_boost_COMPILER "-xgcc${_boost_COMPILER_VERSION}")
-            else()
-              # In Boost <= 1.35.0, there is no mangled compiler name for
-              # the macOS/Darwin version of GCC.
-              set(_boost_COMPILER "")
-            endif()
-          else()
-            # We don't know the Boost version, so assume it's
-            # pre-1.36.0.
+          if(Boost_VERSION_STRING VERSION_LESS 1.36.0)
+            # In Boost <= 1.35.0, there is no mangled compiler name for
+            # the macOS/Darwin version of GCC.
             set(_boost_COMPILER "")
+          else()
+            # In Boost 1.36.0 and newer, the mangled compiler name used
+            # on macOS/Darwin is "xgcc".
+            set(_boost_COMPILER "-xgcc${_boost_COMPILER_VERSION}")
           endif()
         else()
           set(_boost_COMPILER "-gcc${_boost_COMPILER_VERSION}")
@@ -546,9 +787,10 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
       set(_boost_COMPILER "-clang${_boost_COMPILER_VERSION}")
     endif()
   else()
-    # TODO at least Boost_DEBUG here?
     set(_boost_COMPILER "")
   endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                         "_boost_COMPILER" SOURCE "guessed")
   set(${_ret} ${_boost_COMPILER} PARENT_SCOPE)
 endfunction()
 
@@ -586,15 +828,14 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
   # - Indent
   #   s;^set(;    set(;;
   # - Add conditionals
-  #   s;Scanning /path/to/boost/sources/boost_\(.*\)_\(.*\)_\(.*);  elseif(NOT Boost_VERSION VERSION_LESS \10\20\3 AND Boost_VERSION VERSION_LESS xxxx);
+  #   s;Scanning /path/to/boost/sources/boost_\(.*\)_\(.*\)_\(.*);  elseif(NOT Boost_VERSION_STRING VERSION_LESS \1\.\2\.\3 AND Boost_VERSION_STRING VERSION_LESS xxxx);
   #
   # This results in the logic seen below, but will require the xxxx
   # replacing with the following Boost release version (or the next
   # minor version to be released, e.g. 1.59 was the latest at the time
-  # of writing, making 1.60 the next, so 106000 is the needed version
-  # number).  Identical consecutive releases were then merged together
-  # by updating the end range of the first block and removing the
-  # following redundant blocks.
+  # of writing, making 1.60 the next. Identical consecutive releases
+  # were then merged together by updating the end range of the first
+  # block and removing the following redundant blocks.
   #
   # Running the script against all historical releases should be
   # required only if the BoostScanDeps.cmake script logic is changed.
@@ -608,22 +849,22 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
   endif()
 
   set(_Boost_IMPORTED_TARGETS TRUE)
-  if(Boost_VERSION AND Boost_VERSION VERSION_LESS 103300)
-    message(WARNING "Imported targets and dependency information not available for Boost version ${Boost_VERSION} (all versions older than 1.33)")
+  if(Boost_VERSION_STRING AND Boost_VERSION_STRING VERSION_LESS 1.33.0)
+    message(WARNING "Imported targets and dependency information not available for Boost version ${Boost_VERSION_STRING} (all versions older than 1.33)")
     set(_Boost_IMPORTED_TARGETS FALSE)
-  elseif(NOT Boost_VERSION VERSION_LESS 103300 AND Boost_VERSION VERSION_LESS 103500)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.33.0 AND Boost_VERSION_STRING VERSION_LESS 1.35.0)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex thread)
     set(_Boost_REGEX_DEPENDENCIES thread)
     set(_Boost_WAVE_DEPENDENCIES filesystem thread)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 103500 AND Boost_VERSION VERSION_LESS 103600)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.35.0 AND Boost_VERSION_STRING VERSION_LESS 1.36.0)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
     set(_Boost_MPI_DEPENDENCIES serialization)
     set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
     set(_Boost_WAVE_DEPENDENCIES filesystem system thread)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 103600 AND Boost_VERSION VERSION_LESS 103800)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.36.0 AND Boost_VERSION_STRING VERSION_LESS 1.38.0)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
     set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
@@ -631,7 +872,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
     set(_Boost_WAVE_DEPENDENCIES filesystem system thread)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 103800 AND Boost_VERSION VERSION_LESS 104300)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.38.0 AND Boost_VERSION_STRING VERSION_LESS 1.43.0)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
     set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
@@ -640,7 +881,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_THREAD_DEPENDENCIES date_time)
     set(_Boost_WAVE_DEPENDENCIES filesystem system thread date_time)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104300 AND Boost_VERSION VERSION_LESS 104400)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.43.0 AND Boost_VERSION_STRING VERSION_LESS 1.44.0)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
     set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
@@ -649,7 +890,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_THREAD_DEPENDENCIES date_time)
     set(_Boost_WAVE_DEPENDENCIES filesystem system thread date_time)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104400 AND Boost_VERSION VERSION_LESS 104500)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.44.0 AND Boost_VERSION_STRING VERSION_LESS 1.45.0)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
     set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random serialization)
@@ -658,7 +899,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_THREAD_DEPENDENCIES date_time)
     set(_Boost_WAVE_DEPENDENCIES serialization filesystem system thread date_time)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104500 AND Boost_VERSION VERSION_LESS 104700)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.45.0 AND Boost_VERSION_STRING VERSION_LESS 1.47.0)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
     set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
@@ -667,7 +908,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_THREAD_DEPENDENCIES date_time)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104700 AND Boost_VERSION VERSION_LESS 104800)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.47.0 AND Boost_VERSION_STRING VERSION_LESS 1.48.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
@@ -677,7 +918,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_THREAD_DEPENDENCIES date_time)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104800 AND Boost_VERSION VERSION_LESS 105000)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.48.0 AND Boost_VERSION_STRING VERSION_LESS 1.50.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
@@ -688,7 +929,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105000 AND Boost_VERSION VERSION_LESS 105300)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.50.0 AND Boost_VERSION_STRING VERSION_LESS 1.53.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
     set(_Boost_IOSTREAMS_DEPENDENCIES regex)
@@ -699,7 +940,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105300 AND Boost_VERSION VERSION_LESS 105400)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.53.0 AND Boost_VERSION_STRING VERSION_LESS 1.54.0)
     set(_Boost_ATOMIC_DEPENDENCIES thread chrono system date_time)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
@@ -711,7 +952,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105400 AND Boost_VERSION VERSION_LESS 105500)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.54.0 AND Boost_VERSION_STRING VERSION_LESS 1.55.0)
     set(_Boost_ATOMIC_DEPENDENCIES thread chrono system date_time)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
@@ -724,7 +965,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105500 AND Boost_VERSION VERSION_LESS 105600)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.55.0 AND Boost_VERSION_STRING VERSION_LESS 1.56.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
@@ -737,7 +978,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105600 AND Boost_VERSION VERSION_LESS 105900)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.56.0 AND Boost_VERSION_STRING VERSION_LESS 1.59.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
@@ -751,7 +992,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105900 AND Boost_VERSION VERSION_LESS 106000)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.59.0 AND Boost_VERSION_STRING VERSION_LESS 1.60.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
@@ -765,7 +1006,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106000 AND Boost_VERSION VERSION_LESS 106100)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.60.0 AND Boost_VERSION_STRING VERSION_LESS 1.61.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
     set(_Boost_FILESYSTEM_DEPENDENCIES system)
@@ -779,7 +1020,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106100 AND Boost_VERSION VERSION_LESS 106200)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.61.0 AND Boost_VERSION_STRING VERSION_LESS 1.62.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
@@ -793,7 +1034,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106200 AND Boost_VERSION VERSION_LESS 106300)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.62.0 AND Boost_VERSION_STRING VERSION_LESS 1.63.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
@@ -808,7 +1049,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106300 AND Boost_VERSION VERSION_LESS 106500)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.63.0 AND Boost_VERSION_STRING VERSION_LESS 1.65.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
@@ -824,7 +1065,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106500 AND Boost_VERSION VERSION_LESS 106700)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.65.0 AND Boost_VERSION_STRING VERSION_LESS 1.67.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
@@ -841,7 +1082,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106700 AND Boost_VERSION VERSION_LESS 106800)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.67.0 AND Boost_VERSION_STRING VERSION_LESS 1.68.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
     set(_Boost_COROUTINE_DEPENDENCIES context system)
@@ -858,7 +1099,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106800 AND Boost_VERSION VERSION_LESS 106900)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.68.0 AND Boost_VERSION_STRING VERSION_LESS 1.69.0)
     set(_Boost_CHRONO_DEPENDENCIES system)
     set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
     set(_Boost_CONTRACT_DEPENDENCIES thread chrono system date_time)
@@ -876,7 +1117,7 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106900 AND Boost_VERSION VERSION_LESS 107000)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.69.0 AND Boost_VERSION_STRING VERSION_LESS 1.70.0)
     set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
     set(_Boost_COROUTINE_DEPENDENCIES context)
     set(_Boost_FIBER_DEPENDENCIES context)
@@ -890,23 +1131,21 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
     set(_Boost_TIMER_DEPENDENCIES chrono system)
     set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
     set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  else()
-    if(NOT Boost_VERSION VERSION_LESS 107000)
-      set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
-      set(_Boost_COROUTINE_DEPENDENCIES context)
-      set(_Boost_FIBER_DEPENDENCIES context)
-      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-      set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
-      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
-      set(_Boost_MPI_DEPENDENCIES serialization)
-      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
-      set(_Boost_THREAD_DEPENDENCIES chrono date_time atomic)
-      set(_Boost_TIMER_DEPENDENCIES chrono system)
-      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
-      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-    endif()
-    if(NOT Boost_VERSION VERSION_LESS 107100)
+  elseif(NOT Boost_VERSION_STRING VERSION_LESS 1.70.0)
+    set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
+    set(_Boost_COROUTINE_DEPENDENCIES context)
+    set(_Boost_FIBER_DEPENDENCIES context)
+    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+    set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
+    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+    set(_Boost_MPI_DEPENDENCIES serialization)
+    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+    set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+    set(_Boost_THREAD_DEPENDENCIES chrono date_time atomic)
+    set(_Boost_TIMER_DEPENDENCIES chrono)
+    set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
+    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    if(NOT Boost_VERSION_STRING VERSION_LESS 1.72.0)
       message(WARNING "New Boost version may have incorrect or missing dependencies and imported targets")
     endif()
   endif()
@@ -944,7 +1183,7 @@ function(_Boost_COMPONENT_HEADERS component _hdrs)
   set(_Boost_CHRONO_HEADERS              "boost/chrono.hpp")
   set(_Boost_CONTAINER_HEADERS           "boost/container/container_fwd.hpp")
   set(_Boost_CONTRACT_HEADERS            "boost/contract.hpp")
-  if(Boost_VERSION VERSION_LESS 106100)
+  if(Boost_VERSION_STRING VERSION_LESS 1.61.0)
     set(_Boost_CONTEXT_HEADERS           "boost/context/all.hpp")
   else()
     set(_Boost_CONTEXT_HEADERS           "boost/context/detail/fcontext.hpp")
@@ -1063,7 +1302,7 @@ endfunction()
 #
 function(_Boost_COMPILER_FEATURES component _ret)
   # Boost >= 1.62
-  if(NOT Boost_VERSION VERSION_LESS 106200)
+  if(NOT Boost_VERSION_STRING VERSION_LESS 1.62.0)
     set(_Boost_FIBER_COMPILER_FEATURES
         cxx_alias_templates
         cxx_auto_type
@@ -1178,7 +1417,7 @@ else()
   # _Boost_COMPONENT_HEADERS.  See the instructions at the top of
   # _Boost_COMPONENT_DEPENDENCIES.
   set(_Boost_KNOWN_VERSIONS ${Boost_ADDITIONAL_VERSIONS}
-    "1.70.0" "1.70" "1.69.0" "1.69"
+    "1.71.0" "1.71" "1.70.0" "1.70" "1.69.0" "1.69"
     "1.68.0" "1.68" "1.67.0" "1.67" "1.66.0" "1.66" "1.65.1" "1.65.0" "1.65"
     "1.64.0" "1.64" "1.63.0" "1.63" "1.62.0" "1.62" "1.61.0" "1.61" "1.60.0" "1.60"
     "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55"
@@ -1209,26 +1448,12 @@ else()
   endif()
 endif()
 
-# The reason that we failed to find Boost. This will be set to a
-# user-friendly message when we fail to find some necessary piece of
-# Boost.
-set(Boost_ERROR_REASON)
-
-if(Boost_DEBUG)
-  # Output some of their choices
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "_boost_TEST_VERSIONS = ${_boost_TEST_VERSIONS}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_USE_MULTITHREADED = ${Boost_USE_MULTITHREADED}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_USE_STATIC_LIBS = ${Boost_USE_STATIC_LIBS}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_USE_STATIC_RUNTIME = ${Boost_USE_STATIC_RUNTIME}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_ADDITIONAL_VERSIONS = ${Boost_ADDITIONAL_VERSIONS}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_NO_SYSTEM_PATHS = ${Boost_NO_SYSTEM_PATHS}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_TEST_VERSIONS")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_USE_MULTITHREADED")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_USE_STATIC_LIBS")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_USE_STATIC_RUNTIME")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_ADDITIONAL_VERSIONS")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_NO_SYSTEM_PATHS")
 
 # Supply Boost_LIB_DIAGNOSTIC_DEFINITIONS as a convenience target. It
 # will only contain any interface definitions on WIN32, but is created
@@ -1239,6 +1464,8 @@ if(NOT TARGET Boost::diagnostic_definitions)
   add_library(Boost::diagnostic_definitions INTERFACE IMPORTED)
   add_library(Boost::disable_autolinking INTERFACE IMPORTED)
   add_library(Boost::dynamic_linking INTERFACE IMPORTED)
+  set_target_properties(Boost::dynamic_linking PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_DYN_LINK")
 endif()
 if(WIN32)
   # In windows, automatic linking is performed, so you do not have
@@ -1263,11 +1490,13 @@ if(WIN32)
     INTERFACE_COMPILE_DEFINITIONS "BOOST_LIB_DIAGNOSTIC")
   set_target_properties(Boost::disable_autolinking PROPERTIES
     INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_NO_LIB")
-  set_target_properties(Boost::dynamic_linking PROPERTIES
-    INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_DYN_LINK")
 endif()
 
-_Boost_CHECK_SPELLING(Boost_ROOT)
+cmake_policy(GET CMP0074 _Boost_CMP0074)
+if(NOT "x${_Boost_CMP0074}x" STREQUAL "xNEWx")
+  _Boost_CHECK_SPELLING(Boost_ROOT)
+endif()
+unset(_Boost_CMP0074)
 _Boost_CHECK_SPELLING(Boost_LIBRARYDIR)
 _Boost_CHECK_SPELLING(Boost_INCLUDEDIR)
 
@@ -1293,18 +1522,12 @@ set(_Boost_VARS_DIR
   Boost_NO_SYSTEM_PATHS
   )
 
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Declared as CMake or Environmental Variables:")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "  BOOST_ROOT = ${BOOST_ROOT}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "  BOOST_INCLUDEDIR = ${BOOST_INCLUDEDIR}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "  BOOST_LIBRARYDIR = ${BOOST_LIBRARYDIR}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "_boost_TEST_VERSIONS = ${_boost_TEST_VERSIONS}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_ROOT")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_ROOT" ENVIRONMENT)
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_INCLUDEDIR")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_INCLUDEDIR" ENVIRONMENT)
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_LIBRARYDIR")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_LIBRARYDIR" ENVIRONMENT)
 
 # ------------------------------------------------------------------------
 #  Search for Boost include DIR
@@ -1376,14 +1599,8 @@ if(NOT Boost_INCLUDE_DIR)
 
   endforeach()
 
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "Include debugging info:")
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "  _boost_INCLUDE_SEARCH_DIRS = ${_boost_INCLUDE_SEARCH_DIRS}")
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "  _boost_PATH_SUFFIXES = ${_boost_PATH_SUFFIXES}")
-  endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_INCLUDE_SEARCH_DIRS")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_PATH_SUFFIXES")
 
   # Look for a standard boost header file.
   find_path(Boost_INCLUDE_DIR
@@ -1397,74 +1614,54 @@ endif()
 #  Extract version information from version.hpp
 # ------------------------------------------------------------------------
 
-# Set Boost_FOUND based only on header location and version.
-# It will be updated below for component libraries.
 if(Boost_INCLUDE_DIR)
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "location of version.hpp: ${Boost_INCLUDE_DIR}/boost/version.hpp")
-  endif()
+  _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                     "location of version.hpp: ${Boost_INCLUDE_DIR}/boost/version.hpp")
 
-  # Extract Boost_VERSION and Boost_LIB_VERSION from version.hpp
-  set(Boost_VERSION 0)
+  # Extract Boost_VERSION_MACRO and Boost_LIB_VERSION from version.hpp
+  set(Boost_VERSION_MACRO 0)
   set(Boost_LIB_VERSION "")
   file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_VERSION_HPP_CONTENTS REGEX "#define BOOST_(LIB_)?VERSION ")
-  set(_Boost_VERSION_REGEX "([0-9]+)")
-  set(_Boost_LIB_VERSION_REGEX "\"([0-9_]+)\"")
-  foreach(v VERSION LIB_VERSION)
-    if("${_boost_VERSION_HPP_CONTENTS}" MATCHES "#define BOOST_${v} ${_Boost_${v}_REGEX}")
-      set(Boost_${v} "${CMAKE_MATCH_1}")
-    endif()
-  endforeach()
+  if("${_boost_VERSION_HPP_CONTENTS}" MATCHES "#define BOOST_VERSION ([0-9]+)")
+    set(Boost_VERSION_MACRO "${CMAKE_MATCH_1}")
+  endif()
+  if("${_boost_VERSION_HPP_CONTENTS}" MATCHES "#define BOOST_LIB_VERSION \"([0-9_]+)\"")
+    set(Boost_LIB_VERSION "${CMAKE_MATCH_1}")
+  endif()
   unset(_boost_VERSION_HPP_CONTENTS)
 
-  math(EXPR Boost_MAJOR_VERSION "${Boost_VERSION} / 100000")
-  math(EXPR Boost_MINOR_VERSION "${Boost_VERSION} / 100 % 1000")
-  math(EXPR Boost_SUBMINOR_VERSION "${Boost_VERSION} % 100")
-  set(Boost_VERSION_STRING "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+  # Calculate version components
+  math(EXPR Boost_VERSION_MAJOR "${Boost_VERSION_MACRO} / 100000")
+  math(EXPR Boost_VERSION_MINOR "${Boost_VERSION_MACRO} / 100 % 1000")
+  math(EXPR Boost_VERSION_PATCH "${Boost_VERSION_MACRO} % 100")
+  set(Boost_VERSION_COUNT 3)
 
-  string(APPEND Boost_ERROR_REASON
-    "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}\nBoost include path: ${Boost_INCLUDE_DIR}")
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "version.hpp reveals boost "
-                   "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-  endif()
+  # Define alias variables for backwards compat.
+  set(Boost_MAJOR_VERSION ${Boost_VERSION_MAJOR})
+  set(Boost_MINOR_VERSION ${Boost_VERSION_MINOR})
+  set(Boost_SUBMINOR_VERSION ${Boost_VERSION_PATCH})
 
-  if(Boost_FIND_VERSION)
-    # Set Boost_FOUND based on requested version.
-    set(_Boost_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-    if("${_Boost_VERSION}" VERSION_LESS "${Boost_FIND_VERSION}")
-      set(Boost_FOUND 0)
-      set(_Boost_VERSION_AGE "old")
-    elseif(Boost_FIND_VERSION_EXACT AND
-        NOT "${_Boost_VERSION}" VERSION_EQUAL "${Boost_FIND_VERSION}")
-      set(Boost_FOUND 0)
-      set(_Boost_VERSION_AGE "new")
-    else()
-      set(Boost_FOUND 1)
-    endif()
-    if(NOT Boost_FOUND)
-      # State that we found a version of Boost that is too new or too old.
-      string(APPEND Boost_ERROR_REASON
-        "\nDetected version of Boost is too ${_Boost_VERSION_AGE}. Requested version was ${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}")
-      if (Boost_FIND_VERSION_PATCH)
-        string(APPEND Boost_ERROR_REASON
-          ".${Boost_FIND_VERSION_PATCH}")
-      endif ()
-      if (NOT Boost_FIND_VERSION_EXACT)
-        string(APPEND Boost_ERROR_REASON " (or newer)")
-      endif ()
-      string(APPEND Boost_ERROR_REASON ".")
-    endif ()
+  # Define Boost version in x.y.z format
+  set(Boost_VERSION_STRING "${Boost_VERSION_MAJOR}.${Boost_VERSION_MINOR}.${Boost_VERSION_PATCH}")
+
+  # Define final Boost_VERSION
+  cmake_policy(GET CMP0093 _Boost_CMP0093
+    PARENT_SCOPE # undocumented, do not use outside of CMake
+  )
+  if("x${_Boost_CMP0093}x" STREQUAL "xNEWx")
+    set(Boost_VERSION ${Boost_VERSION_STRING})
   else()
-    # Caller will accept any Boost version.
-    set(Boost_FOUND 1)
+    set(Boost_VERSION ${Boost_VERSION_MACRO})
   endif()
-else()
-  set(Boost_FOUND 0)
-  string(APPEND Boost_ERROR_REASON
-    "Unable to find the Boost header files. Please set BOOST_ROOT to the root directory containing Boost or BOOST_INCLUDEDIR to the directory containing Boost's headers.")
+  unset(_Boost_CMP0093)
+
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_STRING")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_MACRO")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_MAJOR")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_MINOR")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_PATCH")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_COUNT")
 endif()
 
 # ------------------------------------------------------------------------
@@ -1481,12 +1678,8 @@ if ( NOT Boost_NAMESPACE )
   set(Boost_NAMESPACE "boost")
 endif()
 
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "Boost_LIB_PREFIX = ${Boost_LIB_PREFIX}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "Boost_NAMESPACE = ${Boost_NAMESPACE}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_LIB_PREFIX")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_NAMESPACE")
 
 # ------------------------------------------------------------------------
 #  Suffix initialization and compiler suffix detection.
@@ -1508,30 +1701,21 @@ _Boost_CHANGE_DETECT(_Boost_CHANGE_LIBNAME ${_Boost_VARS_NAME})
 # Setting some more suffixes for the library
 if (Boost_COMPILER)
   set(_boost_COMPILER ${Boost_COMPILER})
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "using user-specified Boost_COMPILER = ${_boost_COMPILER}")
-  endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                         "_boost_COMPILER" SOURCE "user-specified via Boost_COMPILER")
 else()
   # Attempt to guess the compiler suffix
   # NOTE: this is not perfect yet, if you experience any issues
   # please report them and use the Boost_COMPILER variable
   # to work around the problems.
   _Boost_GUESS_COMPILER_PREFIX(_boost_COMPILER)
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-      "guessed _boost_COMPILER = ${_boost_COMPILER}")
-  endif()
 endif()
 
 set (_boost_MULTITHREADED "-mt")
 if( NOT Boost_USE_MULTITHREADED )
   set (_boost_MULTITHREADED "")
 endif()
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "_boost_MULTITHREADED = ${_boost_MULTITHREADED}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_MULTITHREADED")
 
 #======================
 # Systematically build up the Boost ABI tag for the 'tagged' and 'versioned' layouts
@@ -1582,14 +1766,12 @@ endif()
 #           Only used in 'versioned' layout, added in Boost 1.66.0
 if(DEFINED Boost_ARCHITECTURE)
   set(_boost_ARCHITECTURE_TAG "${Boost_ARCHITECTURE}")
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-      "using user-specified Boost_ARCHITECTURE = ${_boost_ARCHITECTURE_TAG}")
-  endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                         "_boost_ARCHITECTURE_TAG" SOURCE "user-specified via Boost_ARCHITECTURE")
 else()
   set(_boost_ARCHITECTURE_TAG "")
   # {CMAKE_CXX_COMPILER_ARCHITECTURE_ID} is not currently set for all compilers
-  if(NOT "x${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "x" AND NOT Boost_VERSION VERSION_LESS 106600)
+  if(NOT "x${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "x" AND NOT Boost_VERSION_STRING VERSION_LESS 1.66.0)
     string(APPEND _boost_ARCHITECTURE_TAG "-")
     # This needs to be kept in-sync with the section of CMakePlatformId.h.in
     # inside 'defined(_WIN32) && defined(_MSC_VER)'
@@ -1610,14 +1792,12 @@ else()
       string(APPEND _boost_ARCHITECTURE_TAG "32")
     endif()
   endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                         "_boost_ARCHITECTURE_TAG" SOURCE "detected")
 endif()
 
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "_boost_RELEASE_ABI_TAG = ${_boost_RELEASE_ABI_TAG}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "_boost_DEBUG_ABI_TAG = ${_boost_DEBUG_ABI_TAG}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_RELEASE_ABI_TAG")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_DEBUG_ABI_TAG")
 
 # ------------------------------------------------------------------------
 #  Begin finding boost libraries
@@ -1677,11 +1857,8 @@ foreach(c DEBUG RELEASE)
   endif()
 endforeach()
 
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "_boost_LIBRARY_SEARCH_DIRS_RELEASE = ${_boost_LIBRARY_SEARCH_DIRS_RELEASE}"
-    "_boost_LIBRARY_SEARCH_DIRS_DEBUG   = ${_boost_LIBRARY_SEARCH_DIRS_DEBUG}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_LIBRARY_SEARCH_DIRS_RELEASE")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_LIBRARY_SEARCH_DIRS_DEBUG")
 
 # Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
 if( Boost_USE_STATIC_LIBS )
@@ -1721,10 +1898,10 @@ endif()
 
 # On versions < 1.35, remove the System library from the considered list
 # since it wasn't added until 1.35.
-if(Boost_VERSION AND Boost_FIND_COMPONENTS)
-   if(Boost_VERSION LESS 103500)
-     list(REMOVE_ITEM Boost_FIND_COMPONENTS system)
-   endif()
+if(Boost_VERSION_STRING AND Boost_FIND_COMPONENTS)
+  if(Boost_VERSION_STRING VERSION_LESS 1.35.0)
+    list(REMOVE_ITEM Boost_FIND_COMPONENTS system)
+  endif()
 endif()
 
 # Additional components may be required via component dependencies.
@@ -1806,19 +1983,13 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
   # Consolidate and report component-specific hints.
   if(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME)
     list(REMOVE_DUPLICATES _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME)
-    if(Boost_DEBUG)
-      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-        "Component-specific library search names for ${COMPONENT_NAME}: "
-        "${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME}")
-    endif()
+    _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+      "Component-specific library search names for ${COMPONENT_NAME}: ${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME}")
   endif()
   if(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
     list(REMOVE_DUPLICATES _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
-    if(Boost_DEBUG)
-      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-        "Component-specific library search paths for ${COMPONENT}: "
-        "${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT}")
-    endif()
+    _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+      "Component-specific library search paths for ${COMPONENT}: ${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT}")
   endif()
 
   #
@@ -1871,10 +2042,8 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
   if(Boost_THREADAPI AND ${COMPONENT} STREQUAL "thread")
     _Boost_PREPEND_LIST_WITH_THREADAPI(_boost_RELEASE_NAMES ${_boost_RELEASE_NAMES})
   endif()
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "Searching for ${UPPERCOMPONENT}_LIBRARY_RELEASE: ${_boost_RELEASE_NAMES}")
-  endif()
+  _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                     "Searching for ${UPPERCOMPONENT}_LIBRARY_RELEASE: ${_boost_RELEASE_NAMES}")
 
   # if Boost_LIBRARY_DIR_RELEASE is not defined,
   # but Boost_LIBRARY_DIR_DEBUG is, look there first for RELEASE libs
@@ -1928,10 +2097,8 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
   if(Boost_THREADAPI AND ${COMPONENT} STREQUAL "thread")
      _Boost_PREPEND_LIST_WITH_THREADAPI(_boost_DEBUG_NAMES ${_boost_DEBUG_NAMES})
   endif()
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "Searching for ${UPPERCOMPONENT}_LIBRARY_DEBUG: ${_boost_DEBUG_NAMES}")
-  endif()
+  _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                     "Searching for ${UPPERCOMPONENT}_LIBRARY_DEBUG: ${_boost_DEBUG_NAMES}")
 
   # if Boost_LIBRARY_DIR_DEBUG is not defined,
   # but Boost_LIBRARY_DIR_RELEASE is, look there first for DEBUG libs
@@ -1984,57 +2151,25 @@ if(Boost_LIBRARY_DIRS)
   list(REMOVE_DUPLICATES Boost_LIBRARY_DIRS)
 endif()
 
-# The above setting of Boost_FOUND was based only on the header files.
-# Update it for the requested component libraries.
+# ------------------------------------------------------------------------
+#  Call FPHSA helper, see https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html
+# ------------------------------------------------------------------------
+
+# Define aliases as needed by the component handler in the FPHSA helper below
+foreach(_comp IN LISTS Boost_FIND_COMPONENTS)
+  string(TOUPPER ${_comp} _uppercomp)
+  if(DEFINED Boost_${_uppercomp}_FOUND)
+    set(Boost_${_comp}_FOUND ${Boost_${_uppercomp}_FOUND})
+  endif()
+endforeach()
+
+find_package_handle_standard_args(Boost
+  REQUIRED_VARS Boost_INCLUDE_DIR
+  VERSION_VAR Boost_VERSION_STRING
+  HANDLE_COMPONENTS)
+
 if(Boost_FOUND)
-  # The headers were found.  Check for requested component libs.
-  set(_boost_CHECKED_COMPONENT FALSE)
-  set(_Boost_MISSING_COMPONENTS "")
-  foreach(COMPONENT ${Boost_FIND_COMPONENTS})
-    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
-    set(_boost_CHECKED_COMPONENT TRUE)
-    if(NOT Boost_${UPPERCOMPONENT}_FOUND AND Boost_FIND_REQUIRED_${COMPONENT})
-      list(APPEND _Boost_MISSING_COMPONENTS ${COMPONENT})
-    endif()
-  endforeach()
-  if(_Boost_MISSING_COMPONENTS AND _Boost_EXTRA_FIND_COMPONENTS)
-    # Optional indirect dependencies are not counted as missing.
-    list(REMOVE_ITEM _Boost_MISSING_COMPONENTS ${_Boost_EXTRA_FIND_COMPONENTS})
-  endif()
-
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] Boost_FOUND = ${Boost_FOUND}")
-  endif()
-
-  if (_Boost_MISSING_COMPONENTS)
-    set(Boost_FOUND 0)
-    # We were unable to find some libraries, so generate a sensible
-    # error message that lists the libraries we were unable to find.
-    string(APPEND Boost_ERROR_REASON
-      "\nCould not find the following")
-    if(Boost_USE_STATIC_LIBS)
-      string(APPEND Boost_ERROR_REASON " static")
-    endif()
-    string(APPEND Boost_ERROR_REASON
-      " Boost libraries:\n")
-    foreach(COMPONENT ${_Boost_MISSING_COMPONENTS})
-      string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
-      string(APPEND Boost_ERROR_REASON
-        "        ${Boost_NAMESPACE}_${COMPONENT}${Boost_ERROR_REASON_${UPPERCOMPONENT}}\n")
-    endforeach()
-
-    list(LENGTH Boost_FIND_COMPONENTS Boost_NUM_COMPONENTS_WANTED)
-    list(LENGTH _Boost_MISSING_COMPONENTS Boost_NUM_MISSING_COMPONENTS)
-    if (${Boost_NUM_COMPONENTS_WANTED} EQUAL ${Boost_NUM_MISSING_COMPONENTS})
-      string(APPEND Boost_ERROR_REASON
-        "No Boost libraries were found. You may need to set BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT to the location of Boost.")
-    else ()
-      string(APPEND Boost_ERROR_REASON
-        "Some (but not all) of the required Boost libraries were found. You may need to install these additional Boost libraries. Alternatively, set BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT to the location of Boost.")
-    endif ()
-  endif ()
-
-  if( NOT Boost_LIBRARY_DIRS AND NOT _boost_CHECKED_COMPONENT )
+  if( NOT Boost_LIBRARY_DIRS )
     # Compatibility Code for backwards compatibility with CMake
     # 2.4's FindBoost module.
 
@@ -2078,13 +2213,22 @@ endif()
 # ------------------------------------------------------------------------
 
 if(Boost_FOUND)
-  # For header-only libraries
-  if(NOT TARGET Boost::boost)
-    add_library(Boost::boost INTERFACE IMPORTED)
+  # The builtin CMake package in Boost 1.70+ introduces a new name
+  # for the header-only lib, let's provide the same UI in module mode
+  if(NOT TARGET Boost::headers)
+    add_library(Boost::headers INTERFACE IMPORTED)
     if(Boost_INCLUDE_DIRS)
-      set_target_properties(Boost::boost PROPERTIES
+      set_target_properties(Boost::headers PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
     endif()
+  endif()
+
+  # Define the old target name for header-only libraries for backwards
+  # compat.
+  if(NOT TARGET Boost::boost)
+    add_library(Boost::boost INTERFACE IMPORTED)
+    set_target_properties(Boost::boost
+      PROPERTIES INTERFACE_LINK_LIBRARIES Boost::headers)
   endif()
 
   foreach(COMPONENT ${Boost_FIND_COMPONENTS})
@@ -2142,46 +2286,20 @@ if(Boost_FOUND)
 endif()
 
 # ------------------------------------------------------------------------
-#  Notification to end user about what was found
+#  Finalize
 # ------------------------------------------------------------------------
 
+# Report Boost_LIBRARIES
 set(Boost_LIBRARIES "")
-if(Boost_FOUND)
-  if(NOT Boost_FIND_QUIETLY)
-    message(STATUS "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-    if(Boost_FIND_COMPONENTS)
-      message(STATUS "Found the following Boost libraries:")
+foreach(_comp IN LISTS Boost_FIND_COMPONENTS)
+  string(TOUPPER ${_comp} _uppercomp)
+  if(Boost_${_uppercomp}_FOUND)
+    list(APPEND Boost_LIBRARIES ${Boost_${_uppercomp}_LIBRARY})
+    if(_comp STREQUAL "thread")
+      list(APPEND Boost_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
     endif()
   endif()
-  foreach( COMPONENT  ${Boost_FIND_COMPONENTS} )
-    string( TOUPPER ${COMPONENT} UPPERCOMPONENT )
-    if( Boost_${UPPERCOMPONENT}_FOUND )
-      if(NOT Boost_FIND_QUIETLY)
-        message (STATUS "  ${COMPONENT}")
-      endif()
-      list(APPEND Boost_LIBRARIES ${Boost_${UPPERCOMPONENT}_LIBRARY})
-      if(COMPONENT STREQUAL "thread")
-        list(APPEND Boost_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-      endif()
-    endif()
-  endforeach()
-else()
-  if(Boost_FIND_REQUIRED)
-    message(SEND_ERROR "Unable to find the requested Boost libraries.\n${Boost_ERROR_REASON}")
-  else()
-    if(NOT Boost_FIND_QUIETLY)
-      # we opt not to automatically output Boost_ERROR_REASON here as
-      # it could be quite lengthy and somewhat imposing in its requests
-      # Since Boost is not always a required dependency we'll leave this
-      # up to the end-user.
-      if(Boost_DEBUG OR Boost_DETAILED_FAILURE_MSG)
-        message(STATUS "Could NOT find Boost\n${Boost_ERROR_REASON}")
-      else()
-        message(STATUS "Could NOT find Boost")
-      endif()
-    endif()
-  endif()
-endif()
+endforeach()
 
 # Configure display of cache entries in GUI.
 foreach(v BOOSTROOT BOOST_ROOT ${_Boost_VARS_INC} ${_Boost_VARS_LIB})


### PR DESCRIPTION
FreeBSD has moved to Boost 1.71.

This comes from cmake v 3.15.3
And now this update/copy contains 2 files.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>