### PR TITLE
ceph-daemon: use /usr/bin/python, not /usr/bin/env python

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -344,6 +344,9 @@ BuildRequires:  libcryptopp-devel
 BuildRequires:  libnuma-devel
 %endif
 %endif
+%if 0%{?rhel} >= 8
+BuildRequires:  /usr/bin/pathfix.py
+%endif
 
 %description
 Ceph is a massively scalable, open-source, distributed storage system that runs
@@ -1342,6 +1345,11 @@ install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 
 # sudoers.d
 install -m 0600 -D sudoers.d/ceph-osd-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-osd-smartctl
+
+%if 0%{?rhel} >= 8
+pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_bindir}/*
+pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_sbindir}/*
+%endif
 
 #set up placeholder directories
 mkdir -p %{buildroot}%{_sysconfdir}/ceph

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 DEFAULT_IMAGE='ceph/daemon-base'
 DATA_DIR='/var/lib/ceph'


### PR DESCRIPTION
This works around noise from the rpm build:

*** ERROR: ambiguous python shebang in /usr/sbin/ceph-daemon: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.

Signed-off-by: Sage Weil <sage@redhat.com>