### PR TITLE
ceph-daemon: do not relabel system directories

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -378,12 +378,12 @@ def get_container_mounts(fsid, daemon_type, daemon_id):
         mounts[data_dir + '/config'] = '/etc/ceph/ceph.conf:z'
 
     if daemon_type in ['mon', 'osd']:
-        mounts['/dev'] = '/dev:z'  # FIXME: narrow this down?
-        mounts['/run/udev'] = '/run/udev:z'
+        mounts['/dev'] = '/dev'  # FIXME: narrow this down?
+        mounts['/run/udev'] = '/run/udev'
     if daemon_type == 'osd':
-        mounts['/sys'] = '/sys:z'  # for numa.cc, pick_address, cgroups, ...
-        mounts['/run/lvm'] = '/run/lvm:z'
-        mounts['/run/lock/lvm'] = '/run/lock/lvm:z'
+        mounts['/sys'] = '/sys'  # for numa.cc, pick_address, cgroups, ...
+        mounts['/run/lvm'] = '/run/lvm'
+        mounts['/run/lock/lvm'] = '/run/lock/lvm'
 
     return mounts
 


### PR DESCRIPTION
These are shared system directories and should not be relabled for use by
ceph containers.  (Also, trying to relabel /dev prevents the container
from starting, e.g.

Error: relabel failed "/dev": SELinux relabeling of /dev is not allowed

)

Fixes: https://tracker.ceph.com/issues/42511
Signed-off-by: Sage Weil <sage@redhat.com>