### PR TITLE
mon/ConfigMap: search nested sections

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -277,3 +277,14 @@
   Accordingly, the ``osd_op_queue_mclock*`` family of config options
   has been removed in favor of the ``osd_mclock_scheduler*`` family
   of options.
+
+* The config subsystem now searches dot ('.') delineated prefixes for
+  options.  That means for an entity like ``client.foo.bar``, it's
+  overall configuration will be a combination of the global options,
+  ``client``, ``client.foo``, and ``client.foo.bar``.  Previously,
+  only global, ``client``, and ``client.foo.bar`` options would apply.
+  This change may affect the configuration for clients that include a
+  ``.`` in their name.
+
+  Note that this only applies to configuration options in the
+  monitor's database--config file parsing is not affected.

--- a/qa/workunits/mon/config.sh
+++ b/qa/workunits/mon/config.sh
@@ -50,6 +50,16 @@ ceph config rm mon.a debug_asok
 ceph config get mon.a debug_asok | grep 11
 ceph config rm mon debug_asok
 ceph config get mon.a debug_asok | grep 33
+#  nested .-prefix scoping
+ceph config set client.foo debug_asok 44
+ceph config get client.foo.bar debug_asok | grep 44
+ceph config get client.foo.bar.baz debug_asok | grep 44
+ceph config set client.foo.bar debug_asok 55
+ceph config get client.foo.bar.baz debug_asok | grep 55
+ceph config rm client.foo debug_asok
+ceph config get client.foo.bar.baz debug_asok | grep 55
+ceph config rm client.foo.bar debug_asok
+ceph config get client.foo.bar.baz debug_asok | grep 33
 ceph config rm global debug_asok
 
 # help

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -109,15 +109,26 @@ ConfigMap::generate_entity_map(
   const std::string& device_class,
   std::map<std::string,pair<std::string,const MaskedOption*>> *src)
 {
-  // global, then by type, then by full name.
+  // global, then by type, then by name prefix component(s), then name.
+  // name prefix components are .-separated,
+  // e.g. client.a.b.c -> [global, client, client.a, client.a.b, client.a.b.c]
   vector<pair<string,Section*>> sections = { make_pair("global", &global) };
   auto p = by_type.find(name.get_type_name());
   if (p != by_type.end()) {
     sections.push_back(make_pair(name.get_type_name(), &p->second));
   }
-  auto q = by_id.find(name.to_str());
-  if (q != by_id.end()) {
-    sections.push_back(make_pair(name.to_str(), &q->second));
+  vector<std::string> name_bits;
+  boost::split(name_bits, name.to_str(), [](char c){ return c == '.'; });
+  std::string tname;
+  for (unsigned p = 0; p < name_bits.size(); ++p) {
+    if (p) {
+      tname += '.';
+    }
+    tname += name_bits[p];
+    auto q = by_id.find(tname);
+    if (q != by_id.end()) {
+      sections.push_back(make_pair(tname, &q->second));
+    }
   }
   std::map<std::string,std::string,std::less<>> out;
   MaskedOption *prev = nullptr;


### PR DESCRIPTION
For an entity a.b.c.d, search all dot-delineated prefix sections.  This
enables you to establish a hierarchical set of options for clients, such
as radosgw daemons.

For example,
- client.rgw: all radosgw options
- client.rgw.myzone: all per-zone options (like, rgw_zone=myzone)
- client.rgw.myzone.id: per-daemon options

Signed-off-by: Sage Weil <sage@redhat.com>