### PR TITLE
ceph-daemon: raise RuntimeError when CephContainer.run() fails

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -78,7 +78,7 @@ podman_path = None
 ##################################
 # Popen wrappers, lifted from ceph-volume
 
-def call(command, desc=None, verbose=False, **kw):
+def call(command, desc=None, verbose=False, **kwargs):
     """
     Wrap subprocess.Popen to
 
@@ -93,7 +93,7 @@ def call(command, desc=None, verbose=False, **kw):
     """
     if not desc:
         desc = command[0]
-    verbose_on_failure = kw.pop('verbose_on_failure', True)
+    verbose_on_failure = kwargs.pop('verbose_on_failure', True)
 
     logger.debug("Running command: %s" % ' '.join(command))
     process = subprocess.Popen(
@@ -101,7 +101,7 @@ def call(command, desc=None, verbose=False, **kw):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True,
-        **kw
+        **kwargs
     )
     # get current p.stdout flags, add O_NONBLOCK
     stdout_flags = fcntl.fcntl(process.stdout, fcntl.F_GETFL)
@@ -160,7 +160,7 @@ def call(command, desc=None, verbose=False, **kw):
     return out, err, returncode
 
 def call_throws(command, **kwargs):
-    out, err, ret = call(command, command[0], **kwargs)
+    out, err, ret = call(command, **kwargs)
     if ret:
         raise RuntimeError('Failed command: %s' % ' '.join(command))
     return out, err, ret
@@ -757,7 +757,7 @@ class CephContainer:
 
     def run(self):
         logger.debug(self.run_cmd())
-        out, _, _ = call(self.run_cmd(), self.entrypoint)
+        out, _, _ = call_throws(self.run_cmd(), desc=self.entrypoint)
         return out
 
 


### PR DESCRIPTION
Fix error handling when an invalid `--image` param is passed to `ceph-daemon bootstrap`

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
