### PR TITLE
ceph-daemon: Fix `ls` cmd for legacy confs

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -270,7 +270,7 @@ def get_legacy_config_fsid(cluster):
         return None
     return None
 
-def get_legacy_daemon_fsid(cluster_name, daemon_type, daemon_id):
+def get_legacy_daemon_fsid(cluster, daemon_type, daemon_id):
     fsid = None
     if daemon_type == 'osd':
         try:


### PR DESCRIPTION
Running `ceph-daemon ls` on an existing system with legacy ceph services (mon, mgr, etc) was failing with two tracebacks -- 

```
# python3 ./ceph-daemon ls
Traceback (most recent call last):
  File "./ceph-daemon", line 1721, in <module>
    r = args.func()
  File "./ceph-daemon", line 1268, in command_ls
    daemon_id) or 'unknown'
  File "./ceph-daemon", line 283, in get_legacy_daemon_fsid
    fsid = get_legacy_config_fsid(cluster)
NameError: name 'cluster' is not defined
```

```
# python3 ./ceph-daemon ls
Traceback (most recent call last):
  File "./ceph-daemon", line 1721, in <module>
    r = args.func()
  File "./ceph-daemon", line 1272, in command_ls
    out, err, code = call(['ceph', '-v'])
TypeError: call() missing 1 required positional argument: 'desc'
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
