### PR TITLE
ceph-daemon: Use `shutil.move` to move log files

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -44,19 +44,21 @@ import json
 import logging
 import os
 import select
+import shutil
 import socket
 import subprocess
 import sys
 import tempfile
 import time
 import uuid
+
 from distutils.spawn import find_executable
+from glob import glob
 
 try:
     from tempfile import TemporaryDirectory # py3
 except ImportError:
     # define a minimal (but sufficient) equivalent for <= py 3.2
-    import shutil
     class TemporaryDirectory(object):
         def __init__(self):
             self.name = tempfile.mkdtemp()
@@ -1360,32 +1362,29 @@ def command_adopt():
             logger.info('Disabling old systemd unit %s...' % unit_name)
             call_throws(['systemctl', 'disable', unit_name])
 
+        # data
         logger.info('Moving data...')
-        make_data_dir_base(fsid, uid, gid)
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
-        call_throws([
-            'mv',
-            '/var/lib/ceph/%s/%s-%s' % (daemon_type, args.cluster, daemon_id),
-            data_dir])
-        call_throws([
-            'cp',
-            '/etc/ceph/%s.conf' % args.cluster,
-            os.path.join(data_dir, 'config')])
-        os.chmod(data_dir, DATA_DIR_MODE)
-        os.chown(data_dir, uid, gid)
+        data_dir_src = ('/var/lib/ceph/%s/%s-%s/*' %
+                        (daemon_type, args.cluster, daemon_id))
+        data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id)
+        for data_file in glob(data_dir_src):
+            logger.debug('Move \'%s\' -> \'%s\'' % (data_file, data_dir_dst))
+            shutil.move(data_file, data_dir_dst)
 
+        # config
+        config_src = '/etc/ceph/%s.conf' % (args.cluster)
+        config_dst = os.path.join(data_dir_dst, 'config')
+        logger.debug('Copy \'%s\' -> \'%s\'' % (config_src, config_dst))
+        shutil.copy(config_src, config_dst)
+
+        # logs
         logger.info('Moving logs...')
-        log_dir = make_log_dir(fsid, uid=uid, gid=gid)
-        try:
-            call_throws(
-                ['mv',
-                 '/var/log/ceph/%s-%s.%s.log*' % (args.cluster,
-                                                  daemon_type, daemon_id),
-                 os.path.join(log_dir)],
-                shell=True)
-        except Exception as e:
-            logger.warning('unable to move log file: %s' % e)
-            pass
+        log_dir_src = ('/var/log/ceph/%s-%s.%s.log*' %
+                        (args.cluster, daemon_type, daemon_id))
+        log_dir_dst = make_log_dir(fsid, uid=uid, gid=gid)
+        for log_file in glob(log_dir_src):
+            logger.debug('Move \'%s\' -> \'%s\'' % (log_file, log_dir_dst))
+            shutil.move(log_file, log_dir_dst)
 
         logger.info('Creating new units...')
         c = get_container(fsid, daemon_type, daemon_id)


### PR DESCRIPTION
When using `ceph-daemon` to adopt an existing mon, mds, etc., the existing log files are not relocated --

```
DEBUG:ceph-daemon:Running command: mv /var/log/ceph/ceph-mon.mon2.log* /var/log/ceph/d9a8bcba-e6b6-41ad-90c7-a73850336dfa
DEBUG:ceph-daemon:mv:stderr mv:
DEBUG:ceph-daemon:mv:stderr missing file operand
DEBUG:ceph-daemon:mv:stderr
DEBUG:ceph-daemon:mv:stderr Try 'mv --help' for more information.
INFO:ceph-daemon:Non-zero exit code 1 from mv /var/log/ceph/ceph-mon.mon2.log* /var/log/ceph/d9a8bcba-e6b6-41ad-90c7-a73850336dfa
INFO:ceph-daemon:mv:stderr mv: missing file operand
INFO:ceph-daemon:mv:stderr Try 'mv --help' for more information.
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>
