### PR TITLE
nautilus: mgr/restful: requests api adds support multiple commands

### DIFF
--- a/src/pybind/mgr/restful/api/request.py
+++ b/src/pybind/mgr/restful/api/request.py
@@ -77,6 +77,14 @@ class Request(RestController):
         """
         Pass through method to create any request
         """
+        if isinstance(request.json, list):
+            if all(isinstance(element, list) for element in request.json):
+                return context.instance.submit_request(request.json, **kwargs)
+
+            # The request.json has wrong format
+            response.status = 500
+            return {'message': 'The request format should be [[{c1},{c2}]]'}
+
         return context.instance.submit_request([[request.json]], **kwargs)
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42751
possibly a backport of https://github.com/ceph/ceph/pull/31152
parent tracker: https://tracker.ceph.com/issues/42481

---

original PR body:

Add the request api to support parallel as well as sequential
 execution of commands.
 Signed-off-by: Duncan Chiang <long0709@gmail.com>
 (cherry picked from commit 87200e179601ee09db3f1219ac0df6b4c4868753)


---

updated using ceph-backport.sh version 15.0.0.6950
