### PR TITLE
ceph-daemon: fixing typo in script for the output_pub_ssh_key argument

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -1028,7 +1028,7 @@ def command_bootstrap():
         tmp_pub.flush()
 
         if args.output_pub_ssh_key:
-            with open(args.output_put_ssh_key, 'w') as f:
+            with open(args.output_pub_ssh_key, 'w') as f:
                 f.write(ssh_pub)
             logger.info('Wrote public SSH key to to %s' % args.output_pub_ssh_key)
 


### PR DESCRIPTION



ceph-daemon:fixing typo in script for the output_pub_ssh_key argument

I was getting an error trying to run ceph-daemon according to the main ceph documentation.  Pretty sure this is the problem.

Signed-off-by: John McGowan <john@steakfest.com>

## Checklist
- [-] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

