### PR TITLE
Clarifying which networks kube-helm doc is talking about

### DIFF
--- a/doc/start/kube-helm.rst
+++ b/doc/start/kube-helm.rst
@@ -8,7 +8,7 @@ This documentation assumes a Kubernetes environment is available.
 Current limitations
 ===================
 
- - The public and cluster networks must be the same
+ - The public and cluster networks used by ceph must be the same
  - If the storage class user id is not admin, you will have to manually create the user
    in your Ceph cluster and create its secret in Kubernetes
  - ceph-mgr can only run with 1 replica


### PR DESCRIPTION
As a noob to ceph, I was initially confused as to which networks this limtation was refering to.  I know now that public and cluster refer to ceph networks, but Initially “public and cluster” were interpreted by me as something more like the kube node and overlay networks.

Signed-off-by: John McGowan <john@steakfest.com>

## Checklist
- [ ] References tracker ticket
- [X] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug