### PR TITLE
qa/standalone/test_ceph_daemon: fix multi-version python test

### DIFF
--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -1,32 +1,37 @@
 #!/bin/bash -ex
 
-# respawn ourselves with a modified path with both python2 and python3
+FSID='00000000-0000-0000-0000-0000deadbeef'
+IMAGE='ceph/daemon-base:latest-master-devel'
+
+[ -z "$SUDO" ] && SUDO=sudo
+
+if [ -z "$CEPH_DAEMON" ]; then
+    [ -x ../src/ceph-daemon ] && CEPH_DAEMON=../src/ceph-daemon
+    [ -x ./ceph-daemon ] && CEPH_DAEMON=.ceph-daemon
+    which ceph-daemon && CEPH_DAEMON=$(which ceph-daemon)
+fi
+
+# respawn ourselves with a shebang
 PYTHONS="python3 python2"  # which pythons we test
 if [ -z "$PYTHON_KLUDGE" ]; then
    TMPBINDIR=`mktemp -d $TMPDIR`
    trap "rm -rf $TMPBINDIR" TERM HUP INT
-
+   ORIG_CEPH_DAEMON="$CEPH_DAEMON"
+   CEPH_DAEMON="$TMPBINDIR/ceph-daemon"
    for p in $PYTHONS; do
-       ln -s `which $p` $TMPBINDIR/python
        echo "=== re-running with $p ==="
-       PYTHON_KLUDGE=1 PATH=$TMPBINDIR:$PATH $0
+       ln -s `which $p` $TMPBINDIR/python
+       echo "#!$TMPBINDIR/python" > $CEPH_DAEMON
+       cat $ORIG_CEPH_DAEMON >> $CEPH_DAEMON
+       chmod 700 $CEPH_DAEMON
+       $TMPBINDIR/python --version
+       PYTHON_KLUDGE=1 CEPH_DAEMON=$CEPH_DAEMON $0
        rm $TMPBINDIR/python
    done
    rm -rf $TMPBINDIR
    echo "PASS with all of: $PYTHONS"
    exit 0
 fi
-
-echo "path is $PATH"
-ls -al `which python`
-
-[ -z "$SUDO" ] && SUDO=sudo
-[ -x ../src/ceph-daemon ] && CEPH_DAEMON=../src/ceph-daemon
-[ -x ./ceph-daemon ] && CEPH_DAEMON=.ceph-daemon
-which ceph-daemon && CEPH_DAEMON=$(which ceph-daemon)
-
-FSID='00000000-0000-0000-0000-0000deadbeef'
-IMAGE='ceph/daemon-base:latest-master-devel'
 
 # clean up previous run(s)?
 $SUDO $CEPH_DAEMON rm-cluster --fsid $FSID --force


### PR DESCRIPTION
We have to rewrite the shebang line, since it is no longer just
'#/usr/bin/env python' (as of e12ad1b016db818fe20062e4373218890c6f4cbd).

Signed-off-by: Sage Weil <sage@redhat.com>