### PR TITLE
mgr/dashboard: Add time-diff unittest and docs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/time-diff.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/time-diff.service.spec.ts
@@ -38,6 +38,11 @@ describe('TimeDiffService', () => {
     expect(service.calculateDuration(baseTime, new Date('2022-02-28T04:05:00'))).toBe('6d 4h 5m');
   });
 
+  it('should return an empty string if time diff is less then a minute', () => {
+    const ts = 1568361327000;
+    expect(service.calculateDuration(new Date(ts), new Date(ts + 120))).toBe('');
+  });
+
   describe('testing duration calculation in detail', () => {
     const minutes = 60 * 1000;
     const hours = 60 * minutes;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/time-diff.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/time-diff.service.ts
@@ -18,6 +18,12 @@ export class TimeDiffService {
     return duration;
   }
 
+  /**
+   * Get the duration in the format '[Nd] [Nh] [Nm]', e.g. '2d 1h 15m'.
+   * @param ms The time in milliseconds.
+   * @return The duration. An empty string is returned if the duration is
+   *   less than a minute.
+   */
   private getDuration(ms: number): string {
     const date = new Date(ms);
     const h = date.getUTCHours();


### PR DESCRIPTION
The method 'calculateDuration' should return an empty string if time diff is less then a minute.

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
