### PR TITLE
jaegertracing build/ops integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,15 @@
 [submodule "s3select"]
 	path = src/s3select
 	url = https://github.com/ceph/s3select.git
+[submodule "src/jaegertracing/opentracing-cpp"]
+	path = src/jaegertracing/opentracing-cpp
+	url = https://github.com/opentracing/opentracing-cpp.git
+	branch = v1.6.0
+[submodule "src/jaegertracing/jaeger-client-cpp"]
+	path = src/jaegertracing/jaeger-client-cpp
+	url = https://github.com/ceph/jaeger-client-cpp.git
+	branch = hunter-disabled
+[submodule "src/jaegertracing/thrift"]
+	path = src/jaegertracing/thrift
+	url = https://github.com/apache/thrift.git
+	branch = 0.13.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,11 @@ if(WITH_BLKIN)
   include_directories(SYSTEM src/blkin/blkin-lib)
 endif(WITH_BLKIN)
 
+option(WITH_JAEGER "Enable jaegertracing and it's dependent libraries" ON)
+if(WITH_JAEGER)
+  set(HAVE_JAEGER TRUE)
+endif()
+
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
 option(WITH_RADOSGW_FCGI_FRONTEND "Rados Gateway's FCGI frontend is enabled" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,7 +364,7 @@ if(WITH_BLKIN)
   include_directories(SYSTEM src/blkin/blkin-lib)
 endif(WITH_BLKIN)
 
-option(WITH_JAEGER "Enable jaegertracing and it's dependent libraries" ON)
+option(WITH_JAEGER "Enable jaegertracing and it's dependent libraries" OFF)
 if(WITH_JAEGER)
   set(HAVE_JAEGER TRUE)
 endif()

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -61,7 +61,7 @@
 %endif
 %endif
 %bcond_with seastar
-%bcond_without jaeger
+%bcond_with jaeger
 %if 0%{?fedora} || 0%{?suse_version} >= 1500
 # distros that ship cmd2 and/or colorama
 %bcond_without cephfs_shell

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -61,6 +61,7 @@
 %endif
 %endif
 %bcond_with seastar
+%bcond_without jaeger
 %if 0%{?fedora} || 0%{?suse_version} >= 1500
 # distros that ship cmd2 and/or colorama
 %bcond_without cephfs_shell
@@ -201,6 +202,18 @@ BuildRequires:	socat
 %endif
 %if 0%{with zbd}
 BuildRequires:  libzbd-devel
+%endif
+%if 0%{with jaeger}
+BuildRequires:  bison
+BuildRequires:  flex
+%if 0%{?fedora} || 0%{?rhel}
+BuildRequires:  json-devel
+%endif
+%if 0%{?suse_version}
+BuildRequires:  nlohmann_json-devel
+%endif
+BuildRequires:  libevent-devel
+BuildRequires:  yaml-cpp-devel
 %endif
 %if 0%{with seastar}
 BuildRequires:  c-ares-devel
@@ -409,6 +422,9 @@ Requires:	python%{python3_pkgversion}-cephfs = %{_epoch_prefix}%{version}-%{rele
 Requires:	python%{python3_pkgversion}-rgw = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
+%if 0%{with jaeger}
+Requires:	libjaeger = %{_epoch_prefix}%{version}-%{release}
+%endif
 %if 0%{?fedora} || 0%{?rhel}
 Requires:	python%{python3_pkgversion}-prettytable
 %endif
@@ -447,6 +463,9 @@ Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
 Recommends:	nvme-cli
 Recommends:	smartmontools
+%endif
+%if 0%{with jaeger}
+Requires:	libjaeger = %{_epoch_prefix}%{version}-%{release}
 %endif
 %description mon
 ceph-mon is the cluster monitor daemon for the Ceph distributed file
@@ -917,6 +936,19 @@ Obsoletes:	libcephfs2-devel < %{_epoch_prefix}%{version}-%{release}
 %description -n libcephfs-devel
 This package contains libraries and headers needed to develop programs
 that use Cephs distributed file system.
+
+%if 0%{with jaeger}
+%package -n libjaeger
+Summary:	Ceph distributed file system tracing library
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
+Provides: 	libjaegertracing.so.0()(64bit)
+Provides:	libopentracing.so.1()(64bit)
+Provides:	libthrift.so.0.13.0()(64bit)
+%description -n libjaeger
+This package contains libraries needed to provide distributed
+tracing for Ceph.
 
 %package -n python%{python3_pkgversion}-cephfs
 Summary:	Python 3 libraries for Ceph distributed file system
@@ -2080,6 +2112,15 @@ fi
 %dir %{_includedir}/cephfs/metrics
 %{_includedir}/cephfs/metrics/Types.h
 %{_libdir}/libcephfs.so
+
+%if %{with jaeger}
+%files -n libjaeger
+%{_libdir}/libopentracing.so.*
+%{_libdir}/libthrift.so.*
+%{_libdir}/libjaegertracing.so.*
+%post -n libjaeger -p /sbin/ldconfig
+%postun -n libjaeger -p /sbin/ldconfig
+%endif
 
 %files -n python%{python3_pkgversion}-cephfs
 %{python3_sitearch}/cephfs.cpython*.so

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -815,7 +815,7 @@ Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{relea
 Provides:	python-rgw = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rgw < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rgw
-This package contains Python 3 libraries for interacting with Cephs RADOS
+This package contains Python 3 libraries for interacting with Ceph RADOS
 gateway.
 
 %package -n python%{python3_pkgversion}-rados
@@ -829,7 +829,7 @@ Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 Provides:	python-rados = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rados < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rados
-This package contains Python 3 libraries for interacting with Cephs RADOS
+This package contains Python 3 libraries for interacting with Ceph RADOS
 object store.
 
 %if 0%{with libradosstriper}
@@ -904,7 +904,7 @@ Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{relea
 Provides:	python-rbd = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rbd < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rbd
-This package contains Python 3 libraries for interacting with Cephs RADOS
+This package contains Python 3 libraries for interacting with Ceph RADOS
 block device.
 
 %package -n libcephfs2
@@ -935,7 +935,7 @@ Provides:	libcephfs2-devel = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	libcephfs2-devel < %{_epoch_prefix}%{version}-%{release}
 %description -n libcephfs-devel
 This package contains libraries and headers needed to develop programs
-that use Cephs distributed file system.
+that use Ceph distributed file system.
 
 %if 0%{with jaeger}
 %package -n libjaeger
@@ -949,6 +949,7 @@ Provides:	libthrift.so.0.13.0()(64bit)
 %description -n libjaeger
 This package contains libraries needed to provide distributed
 tracing for Ceph.
+%endif
 
 %package -n python%{python3_pkgversion}-cephfs
 Summary:	Python 3 libraries for Ceph distributed file system
@@ -962,7 +963,7 @@ Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}
 Provides:	python-cephfs = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-cephfs < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-cephfs
-This package contains Python 3 libraries for interacting with Cephs distributed
+This package contains Python 3 libraries for interacting with Ceph distributed
 file system.
 
 %package -n python%{python3_pkgversion}-ceph-argparse
@@ -1107,7 +1108,7 @@ Summary:        Prometheus alerts for a Ceph deployment
 BuildArch:      noarch
 Group:          System/Monitoring
 %description prometheus-alerts
-This package provides Ceph’s default alerts for Prometheus.
+This package provides Ceph default alerts for Prometheus.
 
 #################################################################################
 # common

--- a/cmake/modules/BuildJaeger.cmake
+++ b/cmake/modules/BuildJaeger.cmake
@@ -1,0 +1,65 @@
+# This module builds Jaeger after it's dependencies are installed and discovered
+# opentracing: is built using cmake/modules/Buildopentracing.cmake
+# Thrift: build using cmake/modules/Buildthrift.cmake
+# yaml-cpp, nlhomann-json: are installed locally and then discovered using
+# Find<package>.cmake
+# Boost Libraries used for building thrift are build and provided by
+# cmake/modules/BuildBoost.cmake
+
+function(build_jaeger)
+  set(Jaeger_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing/jaeger-client-cpp")
+  set(Jaeger_INSTALL_DIR "${CMAKE_BINARY_DIR}/external")
+  set(Jaeger_BINARY_DIR "${Jaeger_INSTALL_DIR}/Jaeger")
+
+  file(MAKE_DIRECTORY "${Jaeger_INSTALL_DIR}")
+  set(Jaeger_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+			-DBUILD_SHARED_LIBS=ON
+			-DHUNTER_ENABLED=OFF
+			-DBUILD_TESTING=OFF
+			-DJAEGERTRACING_BUILD_EXAMPLES=OFF
+			-DCMAKE_PREFIX_PATH="${CMAKE_BINARY_DIR}/external;${CMAKE_BINARY_DIR}/boost"
+			-DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/external
+			-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+			-DOpenTracing_DIR=${CMAKE_SOURCE_DIR}/src/jaegertracing/opentracing-cpp
+			-Dnlohmann_json_DIR=/usr/lib
+			-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/boost\;${CMAKE_BINARY_DIR}/boost/include\;${CMAKE_BINARY_DIR}/external
+                       -DCMAKE_FIND_ROOT_PATH=${CMAKE_BINARY_DIR}/boost\;${CMAKE_BINARY_DIR}/boost/include\;${CMAKE_BINARY_DIR}/external
+			-DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/external/lib
+			-Dthrift_HOME=${CMAKE_BINARY_DIR}/external
+			-DOpenTracing_HOME=${CMAKE_BINARY_DIR}/external)
+
+  set(dependencies opentracing thrift)
+  include(BuildOpenTracing)
+  build_opentracing()
+  include(Buildthrift)
+  build_thrift()
+  if(NOT yaml-cpp_FOUND)
+    include(Buildyaml-cpp)
+    build_yamlcpp()
+    add_library(yaml-cpp::yaml-cpp SHARED IMPORTED)
+    add_dependencies(yaml-cpp::yaml-cpp yaml-cpp)
+    set_library_properties_for_external_project(yaml-cpp::yaml-cpp yaml-cpp)
+    list(APPEND dependencies "yaml-cpp")
+  endif()
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "make")
+    # try to inherit command line arguments passed by parent "make" job
+    set(make_cmd $(MAKE))
+  else()
+    set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> --target Jaeger)
+  endif()
+  set(install_cmd $(MAKE) install DESTDIR=)
+
+  include(ExternalProject)
+  ExternalProject_Add(Jaeger
+    SOURCE_DIR ${Jaeger_SOURCE_DIR}
+    UPDATE_COMMAND ""
+    INSTALL_DIR "external"
+    PREFIX ${Jaeger_INSTALL_DIR}
+    CMAKE_ARGS ${Jaeger_CMAKE_ARGS}
+    BINARY_DIR ${Jaeger_BINARY_DIR}
+    BUILD_COMMAND ${make_cmd}
+    INSTALL_COMMAND ${install_cmd}
+    DEPENDS "${dependencies}"
+    )
+endfunction()

--- a/cmake/modules/BuildOpenTracing.cmake
+++ b/cmake/modules/BuildOpenTracing.cmake
@@ -1,0 +1,35 @@
+function(build_opentracing)
+  set(opentracing_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing/opentracing-cpp")
+  set(opentracing_BINARY_DIR "${CMAKE_BINARY_DIR}/external/opentracing-cpp")
+
+  set(opentracing_CMAKE_ARGS  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                              -DBUILD_MOCKTRACER=OFF
+                              -DENABLE_LINTING=OFF
+                              -DBUILD_STATIC_LIBS=OFF
+                              -DBUILD_TESTING=OFF
+                              -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external
+                              -DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/external
+                              -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+                              -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/external/lib
+                              -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/external)
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "make")
+    # try to inherit command line arguments passed by parent "make" job
+    set(make_cmd $(MAKE) )
+  else()
+    set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --target opentracing)
+  endif()
+  set(install_cmd $(MAKE) install DESTDIR=)
+
+  include(ExternalProject)
+  ExternalProject_Add(opentracing
+    SOURCE_DIR ${opentracing_SOURCE_DIR}
+    UPDATE_COMMAND ""
+    INSTALL_DIR "external"
+    PREFIX "external/opentracing-cpp"
+    CMAKE_ARGS ${opentracing_CMAKE_ARGS}
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ${make_cmd}
+    INSTALL_COMMAND ${install_cmd}
+    )
+endfunction()

--- a/cmake/modules/Buildthrift.cmake
+++ b/cmake/modules/Buildthrift.cmake
@@ -1,0 +1,54 @@
+function(build_thrift)
+  set(thrift_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing/thrift")
+  set(thrift_BINARY_DIR "${CMAKE_BINARY_DIR}/external/thrift")
+
+  set(thrift_CMAKE_ARGS  -DCMAKE_BUILD_TYPE=Release
+			 -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+			 -DBUILD_JAVA=OFF
+			 -DBUILD_PYTHON=OFF
+			 -DBUILD_TESTING=OFF
+			 -DBUILD_TUTORIALS=OFF
+			 -DBUILD_C_GLIB=OFF
+			 -DBUILD_HASKELL=OFF
+			 -DWITH_LIBEVENT=OFF
+			 -DWITH_ZLIB=OFF
+			 -DBoost_INCLUDE_DIRS=${CMAKE_BINARY_DIR}/boost/include
+			 -DCMAKE_INSTALL_PREFIX="${CMAKE_BINARY_DIR}/boost;${CMAKE_BINARY_DIR}/boost/include;${CMAKE_BINARY_DIR}/external"
+			 -DCMAKE_FIND_ROOT_PATH="${CMAKE_BINARY_DIR}/boost;${CMAKE_BINARY_DIR}/boost/include;${CMAKE_BINARY_DIR}/external"
+			 -DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/external/lib
+			 -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+			 -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external
+			 -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/external/lib)
+
+  if(WITH_SYSTEM_BOOST)
+    message(STATUS "thrift will be using system boost")
+    set(dependencies "")
+    list(APPEND thrift_CMAKE_ARGS -DBOOST_ROOT=/opt/ceph)
+    list(APPEND thrift_CMAKE_ARGS -DCMAKE_FIND_ROOT_PATH=/opt/ceph)
+  else()
+    message(STATUS "thrift will be using external build boost")
+    set(dependencies Boost)
+    list(APPEND thrift_CMAKE_ARGS  -DCMAKE_FIND_ROOT_PATH=${CMAKE_BINARY_DIR}/boost)
+    list(APPEND thrift_CMAKE_ARGS  -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/external)
+  endif()
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "make")
+    # try to inherit command line arguments passed by parent "make" job
+    set(make_cmd $(MAKE))
+  else()
+    set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --target thrift)
+  endif()
+
+  set(install_cmd $(MAKE) install DESTDIR=)
+
+  include(ExternalProject)
+  ExternalProject_Add(thrift
+    SOURCE_DIR ${thrift_SOURCE_DIR}
+    PREFIX "${CMAKE_BINARY_DIR}/external/thrift"
+    CMAKE_ARGS ${thrift_CMAKE_ARGS}
+    BINARY_DIR ${thrift_BINARY_DIR}
+    BUILD_COMMAND ${make_cmd}
+    INSTALL_COMMAND ${install_cmd}
+    DEPENDS ${dependencies}
+    )
+endfunction()

--- a/cmake/modules/Buildyaml-cpp.cmake
+++ b/cmake/modules/Buildyaml-cpp.cmake
@@ -1,0 +1,36 @@
+function(build_yamlcpp)
+  set(yaml-cpp_DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing")
+  set(yaml-cpp_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing/yaml-cpp")
+  set(yaml-cpp_BINARY_DIR "${CMAKE_BINARY_DIR}/external/yaml-cpp")
+
+  set(yaml-cpp_CMAKE_ARGS -DBUILD_SHARED_LIBS=ON
+			  -DYAML_CPP_BUILD_TESTS=OFF
+			  -DYAML_CPP_BUILD_CONTRIB=OFF
+			  -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external
+			  -DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/external/lib
+			  -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+			  -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/external/lib
+			  -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/external)
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "make")
+    # try to inherit command line arguments passed by parent "make" job
+    set(make_cmd "$(MAKE)")
+  else()
+    set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --target yaml-cpp)
+  endif()
+set(install_cmd $(MAKE) install DESTDIR=)
+
+  include(ExternalProject)
+  ExternalProject_Add(yaml-cpp
+    GIT_REPOSITORY "https://github.com/jbeder/yaml-cpp.git"
+    GIT_TAG "yaml-cpp-0.6.2"
+    UPDATE_COMMAND ""
+    INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+    DOWNLOAD_DIR ${yaml-cpp_DOWNLOAD_DIR}
+    SOURCE_DIR ${yaml-cpp_SOURCE_DIR}
+    PREFIX "${CMAKE_BINARY_DIR}/external/yaml-cpp"
+    CMAKE_ARGS ${yaml-cpp_CMAKE_ARGS}
+    BUILD_COMMAND ${make_cmd}
+    INSTALL_COMMAND ${install_cmd}
+    )
+endfunction()

--- a/cmake/modules/ExternalProjectHelper.cmake
+++ b/cmake/modules/ExternalProjectHelper.cmake
@@ -1,0 +1,17 @@
+function (set_library_properties_for_external_project _target _lib)
+  # Manually create the directory, it will be created as part of the build,
+  # but this runs in the configuration phase, and CMake generates an error if
+  # we add an include directory that does not exist yet.
+  set(_libfullname "${CMAKE_SHARED_LIBRARY_PREFIX}${_lib}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  set(_libpath "${CMAKE_BINARY_DIR}/external/lib/${_libfullname}")
+  set(_includepath "${CMAKE_BINARY_DIR}/external/include")
+  message(STATUS "Configuring ${_target} with ${_libpath}")
+
+  file(MAKE_DIRECTORY "${_includepath}")
+  set_target_properties(${_target} PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${_libpath}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+    IMPORTED_LOCATION "${_libpath}"
+    INTERFACE_INCLUDE_DIRECTORIES "${_includepath}")
+  #  set_property(TARGET ${_target} APPEND PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES "CXX")
+endfunction ()

--- a/cmake/modules/Findyaml-cpp.cmake
+++ b/cmake/modules/Findyaml-cpp.cmake
@@ -1,0 +1,62 @@
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Copyright (C) 2018 Scylladb, Ltd.
+#
+
+find_package (PkgConfig REQUIRED)
+
+pkg_search_module (yaml-cpp_PC yaml-cpp)
+
+find_library (yaml-cpp_LIBRARY
+  NAMES yaml-cpp
+  HINTS
+    ${yaml-cpp_PC_LIBDIR}
+    ${yaml-cpp_PC_LIBRARY_DIRS})
+
+find_path (yaml-cpp_INCLUDE_DIR
+  NAMES yaml-cpp/yaml.h
+  PATH_SUFFIXES yaml-cpp
+  HINTS
+    ${yaml-cpp_PC_INCLUDEDIR}
+    ${yaml-cpp_PC_INCLUDE_DIRS})
+
+mark_as_advanced (
+  yaml-cpp_LIBRARY
+  yaml-cpp_INCLUDE_DIR)
+
+include (FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args (yaml-cpp
+  REQUIRED_VARS
+    yaml-cpp_LIBRARY
+    yaml-cpp_INCLUDE_DIR
+  VERSION_VAR yaml-cpp_PC_VERSION)
+
+set (yaml-cpp_LIBRARIES ${yaml-cpp_LIBRARY})
+set (yaml-cpp_INCLUDE_DIRS ${yaml-cpp_INCLUDE_DIR})
+
+if (yaml-cpp_FOUND AND NOT (TARGET yaml-cpp::yaml-cpp))
+  add_library (yaml-cpp::yaml-cpp UNKNOWN IMPORTED)
+
+  set_target_properties (yaml-cpp::yaml-cpp
+    PROPERTIES
+      IMPORTED_LOCATION ${yaml-cpp_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES ${yaml-cpp_INCLUDE_DIRS})
+endif ()

--- a/cmake/modules/IncludeJaeger.cmake
+++ b/cmake/modules/IncludeJaeger.cmake
@@ -1,0 +1,21 @@
+include(BuildJaeger)
+include(BuildOpenTracing)
+
+include(ExternalProjectHelper)
+
+build_jaeger()
+
+add_library(opentracing::libopentracing SHARED IMPORTED)
+add_dependencies(opentracing::libopentracing opentracing)
+add_library(jaegertracing::libjaegertracing SHARED IMPORTED)
+add_dependencies(jaegertracing::libjaegertracing Jaeger)
+add_library(thrift::libthrift SHARED IMPORTED)
+add_dependencies(thrift::libthrift thrift)
+
+#(set_library_properties_for_external_project _target _lib)
+set_library_properties_for_external_project(opentracing::libopentracing
+  opentracing)
+set_library_properties_for_external_project(jaegertracing::libjaegertracing
+  jaegertracing)
+set_library_properties_for_external_project(thrift::libthrift
+  thrift)

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,9 @@ Vcs-Browser: https://github.com/ceph/ceph
 Maintainer: Ceph Maintainers <ceph-maintainers@lists.ceph.com>
 Uploaders: Ken Dreyer <kdreyer@redhat.com>,
            Alfredo Deza <adeza@redhat.com>,
-Build-Depends: cmake (>= 3.10.2),
+Build-Depends: automake,
+               bison,
+               cmake (>= 3.10.2),
                cpio,
                cryptsetup-bin | cryptsetup,
                cython,
@@ -17,6 +19,7 @@ Build-Depends: cmake (>= 3.10.2),
                dh-exec,
                dh-python,
                dh-systemd,
+               flex,
                git,
                gperf,
                g++ (>= 7),
@@ -32,6 +35,7 @@ Build-Depends: cmake (>= 3.10.2),
                libcap-ng-dev,
                libcunit1-dev,
                libcurl4-openssl-dev,
+               libevent-dev,
                libexpat1-dev,
                libfuse-dev,
                libgoogle-perftools-dev [i386 amd64 arm64],
@@ -58,7 +62,7 @@ Build-Depends: cmake (>= 3.10.2),
                libudev-dev,
                libnl-genl-3-dev,
                libxml2-dev,
-# Crimson      libyaml-cpp-dev,
+               libyaml-cpp-dev,
                librabbitmq-dev,
                librdkafka-dev,
 # Make-Check   libxmlsec1,
@@ -66,6 +70,7 @@ Build-Depends: cmake (>= 3.10.2),
 # Make-Check   libxmlsec1-openssl,
 # Make-Check   libxmlsec1-dev,
                lsb-release,
+               nlohmann-json-dev | nlohmann-json3-dev,
                parted,
                patch,
                pkg-config,
@@ -362,6 +367,7 @@ Description: debugging symbols for ceph-mgr
 Package: ceph-mon
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
+         libjaeger,
          ${misc:Depends},
          ${shlibs:Depends},
 Replaces: ceph (<< 10), ceph-test (<< 12.2.2-14)
@@ -594,7 +600,8 @@ Description: debugging symbols for rbd-nbd
 
 Package: ceph-common
 Architecture: linux-any
-Depends: librbd1 (= ${binary:Version}),
+Depends: libjaeger (= ${binary:Version}),
+         librbd1 (= ${binary:Version}),
          python3-cephfs (= ${binary:Version}),
          python3-ceph-argparse (= ${binary:Version}),
          python3-ceph-common (= ${binary:Version}),
@@ -930,6 +937,13 @@ Description: debugging symbols for radosgw
  service as well as the OpenStack Object Storage ("Swift") API.
  .
  This package contains debugging symbols for radosgw.
+
+Package: libjaeger
+Architecture: linux-any
+Section: libs
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+Description: This package provides libraries needed for distributed tracing for Ceph.
 
 Package: ceph-test
 Architecture: linux-any

--- a/debian/control
+++ b/debian/control
@@ -62,7 +62,6 @@ Build-Depends: automake,
                libudev-dev,
                libnl-genl-3-dev,
                libxml2-dev,
-               libyaml-cpp-dev,
                librabbitmq-dev,
                librdkafka-dev,
 # Make-Check   libxmlsec1,
@@ -104,6 +103,7 @@ Build-Depends: automake,
 # Make-Check   xmlstarlet,
                nasm [amd64],
                zlib1g-dev,
+Built-Using:   libyaml-cpp-dev (>= 0.6),
 Standards-Version: 4.4.0
 
 Package: ceph

--- a/debian/libjaeger.install
+++ b/debian/libjaeger.install
@@ -1,0 +1,3 @@
+usr/lib/libopentracing.so.*
+usr/lib/libjaegertracing.so.*
+usr/lib/libthrift.so.*

--- a/debian/libjaeger.install
+++ b/debian/libjaeger.install
@@ -1,3 +1,3 @@
-usr/lib/libopentracing.so.*
-usr/lib/libjaegertracing.so.*
-usr/lib/libthrift.so.*
+#usr/lib/libopentracing.so.*
+#usr/lib/libjaegertracing.so.*
+#usr/lib/libthrift.so.*

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -284,9 +284,15 @@ else
             *Bionic*)
                 ensure_decent_gcc_on_ubuntu 9 bionic
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu bionic
+                $SUDO apt-get install -y nlohmann-json-dev
                 ;;
             *Disco*)
                 [ ! $NO_BOOST_PKGS ] && apt-get install -y libboost1.67-all-dev
+                $SUDO apt-get install -y nlohmann-json-dev
+                ;;
+	    *Focal*)
+                [ ! $NO_BOOST_PKGS ] && apt-get install -y libboost1.71-all-dev
+                $SUDO apt-get install -y nlohmann-json3-dev
                 ;;
             *)
                 $SUDO apt-get install -y gcc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -393,7 +393,9 @@ add_library(common-objs OBJECT ${libcommon_files})
 if(WITH_JAEGER)
   find_package(yaml-cpp 0.6.0)
   if(NOT yaml-cpp_FOUND)
-    set(jaeger_libs ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so.0.6.2)
+    set(jaeger_libs ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so
+		    ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so.0.6
+		    ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so.0.6.2)
     execute_process(COMMAND bash -c "grep -q 'yaml-cpp' debian/libjaeger.install || echo 'usr/lib/libyaml-cpp.so.*' >> debian/libjaeger.install"
 		    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,6 +387,38 @@ set_source_files_properties(ceph_ver.c
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h)
 add_library(common-objs OBJECT ${libcommon_files})
 
+if(WITH_JAEGER)
+  find_package(yaml-cpp 0.6.0)
+  if(NOT yaml-cpp_FOUND)
+    set(jaeger_libs ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so.0.6.2)
+    execute_process(COMMAND bash -c "grep -q 'yaml-cpp' debian/libjaeger.install || echo 'usr/lib/libyaml-cpp.so.*' >> debian/libjaeger.install"
+		    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  endif()
+  include(IncludeJaeger)
+  add_library(jaeger-base INTERFACE)
+  add_dependencies(common-objs
+  yaml-cpp::yaml-cpp
+  opentracing::libopentracing
+  thrift::libthrift
+  jaegertracing::libjaegertracing)
+  target_link_libraries(jaeger-base INTERFACE
+  yaml-cpp::yaml-cpp
+  opentracing::libopentracing
+  thrift::libthrift
+  jaegertracing::libjaegertracing)
+  include_directories(SYSTEM ${CMAKE_BINARY_DIR}/external/include)
+  #with CMake 3.12+ the following can be replaced by:
+  #target_link_libraries(common-objs jaeger-base)
+   list(APPEND jaeger_libs
+    ${CMAKE_BINARY_DIR}/external/lib/libjaegertracing.so.0
+    ${CMAKE_BINARY_DIR}/external/lib/libjaegertracing.so.0.6.1
+    ${CMAKE_BINARY_DIR}/external/lib/libopentracing.so.1
+    ${CMAKE_BINARY_DIR}/external/lib/libopentracing.so.1.6.0
+    ${CMAKE_BINARY_DIR}/external/lib/libthrift.so.0.13.0)
+  install(FILES ${jaeger_libs}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
 CHECK_C_COMPILER_FLAG("-fvar-tracking-assignments" HAS_VTA)
 add_subdirectory(auth)
 add_subdirectory(common)
@@ -445,6 +477,10 @@ endif()
 
 if(WITH_DPDK)
   list(APPEND ceph_common_deps common_async_dpdk)
+endif()
+
+if(WITH_JAEGER)
+  list(APPEND ceph_common_deps jaeger-base)
 endif()
 
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -396,6 +396,9 @@ if(WITH_JAEGER)
     set(jaeger_libs ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so
 		    ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so.0.6
 		    ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so.0.6.2)
+    #customize libjaeger.install
+    execute_process(COMMAND bash -c "sed -i 's/#//' debian/libjaeger.install"
+		    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
     execute_process(COMMAND bash -c "grep -q 'yaml-cpp' debian/libjaeger.install || echo 'usr/lib/libyaml-cpp.so.*' >> debian/libjaeger.install"
 		    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -383,6 +383,9 @@ set(libcommon_files
   osdc/error_code.cc
   librbd/Features.cc
   ${mds_files})
+if(WITH_JAEGER)
+  list(APPEND libcommon_files common/tracer.cc)
+endif()
 set_source_files_properties(ceph_ver.c
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h)
 add_library(common-objs OBJECT ${libcommon_files})
@@ -628,6 +631,9 @@ set(ceph_osd_srcs
   osd/objclass.cc
   objclass/class_api.cc
   ceph_osd.cc)
+if(WITH_JAEGER)
+  list(APPEND ceph_osd_srcs common/tracer.cc)
+endif()
 add_executable(ceph-osd ${ceph_osd_srcs})
 add_dependencies(ceph-osd erasure_code_plugins)
 target_link_libraries(ceph-osd osd os global-static common

--- a/src/common/tracer.cc
+++ b/src/common/tracer.cc
@@ -1,0 +1,86 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tracer.h"
+#include <arpa/inet.h>
+#include <yaml-cpp/yaml.h>
+#ifdef __linux__
+#include <linux/types.h>
+#else
+typedef int64_t __s64;
+#endif
+
+#include "common/debug.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_osd
+#undef dout_prefix
+#define dout_prefix *_dout << "jaeger_tracing "
+
+namespace jaeger_tracing {
+
+  std::shared_ptr<opentracing::v3::Tracer> tracer = nullptr;
+
+  void init_tracer(const char* tracer_name) {
+    if (!tracer) {
+	YAML::Node yaml;
+	try{
+	  yaml = YAML::LoadFile("../src/jaegertracing/config.yml");
+	dout(3) << "yaml loaded" << yaml << dendl;
+	}
+	catch(std::exception &e) {
+	  dout(3) << "failed to load yaml file using default config" << dendl;
+	  auto yaml_config = R"cfg(
+disabled: false
+reporter:
+    logSpans: false
+    queueSize: 100
+    bufferFlushInterval: 10
+sampler:
+    type: const
+    param: 1
+headers:
+    jaegerDebugHeader: debug-id
+    jaegerBaggageHeader: baggage
+    TraceContextHeaderName: trace-id
+baggage_restrictions:
+    denyBaggageOnInitializationFailure: false
+    refreshInterval: 60
+)cfg";
+	yaml = YAML::Load(yaml_config);
+	dout(3) << "yaml loaded" << yaml << dendl;
+      }
+      static auto configuration = jaegertracing::Config::parse(yaml);
+      tracer = jaegertracing::Tracer::make( tracer_name, configuration,
+	    jaegertracing::logging::consoleLogger());
+      dout(3) << "tracer_jaeger init successful" << dendl;
+    }
+    //incase of stale tracer, configure with a new global tracer
+    if (opentracing::Tracer::Global() != tracer) {
+      opentracing::Tracer::InitGlobal(
+	  std::static_pointer_cast<opentracing::Tracer>(tracer));
+    }
+  }
+
+  jspan new_span(const char* span_name) {
+    return opentracing::Tracer::Global()->StartSpan(span_name);
+ }
+
+  jspan child_span(const char* span_name, const jspan& parent_span) {
+    //no parent check if parent not found span will still be constructed
+    return opentracing::Tracer::Global()->StartSpan(span_name,
+	{opentracing::ChildOf(&parent_span->context())});
+ }
+
+  void finish_span(const jspan& span) {
+    if (span) {
+      span->Finish();
+    }
+  }
+
+  void set_span_tag(const jspan& span, const char* key, const char* value) {
+    if (span) {
+      span->SetTag(key, value);
+    }
+  }
+}

--- a/src/common/tracer.h
+++ b/src/common/tracer.h
@@ -1,0 +1,32 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef TRACER_H_
+#define TRACER_H_
+
+#define SIGNED_RIGHT_SHIFT_IS 1
+#define ARITHMETIC_RIGHT_SHIFT 1
+
+#include <jaegertracing/Tracer.h>
+
+typedef std::unique_ptr<opentracing::Span> jspan;
+
+namespace jaeger_tracing {
+
+  extern std::shared_ptr<opentracing::v3::Tracer> tracer;
+
+  void init_tracer(const char* tracer_name);
+
+  //create a root jspan
+  jspan new_span(const char*);
+
+  //create a child_span used given parent_span
+  jspan child_span(const char*, const jspan&);
+
+  //finish tracing of a single jspan
+  void finish_span(const jspan&);
+
+  //setting tags in sundefined reference topans
+  void set_span_tag(const jspan&, const char*, const char*);
+}
+#endif // TRACER_H_

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -124,7 +124,13 @@ target_compile_definitions(crimson-common PRIVATE
 
 set(crimson_common_deps
   Boost::iostreams
-  Boost::random)
+  Boost::random
+  json_spirit)
+
+if(WITH_JAEGER)
+  include_directories(SYSTEM ${CMAKE_BINARY_DIR}/external/include)
+  list(APPEND crimson_common_deps jaeger-base)
+endif()
 
 if(NOT WITH_SYSTEM_BOOST)
   list(APPEND crimson_common_deps ${ZLIB_LIBRARIES})
@@ -132,7 +138,6 @@ endif()
 
 target_link_libraries(crimson-common
   PUBLIC
-    json_spirit
     crimson::cflags
   PRIVATE
     crc32

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -166,6 +166,9 @@
 /* Define if you want to use LTTng */
 #cmakedefine WITH_LTTNG
 
+/* Define if you want to use Jaeger */
+#cmakedefine HAVE_JAEGER
+
 /* Define if you want to use EVENTTRACE */
 #cmakedefine WITH_EVENTTRACE
 

--- a/src/include/int_types.h
+++ b/src/include/int_types.h
@@ -5,7 +5,7 @@
 
 #include <inttypes.h>
 
-#ifdef HAVE_LINUX_TYPES_H
+#ifdef __linux__
 #include <linux/types.h>
 #else
 #ifndef HAVE___U8

--- a/src/jaegertracing/config.yml
+++ b/src/jaegertracing/config.yml
@@ -1,0 +1,6 @@
+disabled: false
+reporter:
+    logSpans: true
+sampler:
+  type: const
+  param: 1

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -34,3 +34,6 @@ endif()
 add_library(mon STATIC
   ${lib_mon_srcs})
 target_link_libraries(mon kv heap_profiler)
+if(WITH_JAEGER)
+  target_link_libraries(mon jaeger-base)
+endif()

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -91,6 +91,10 @@ if(WITH_LTTNG)
   add_dependencies(os bluestore-tp)
 endif()
 
+if(WITH_JAEGER)
+  target_link_libraries(os jaeger-base)
+endif()
+
 target_link_libraries(os kv)
 
 add_dependencies(os compressor_plugins)

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -940,6 +940,11 @@ void ECBackend::handle_sub_write(
   if (msg)
     msg->mark_event("sub_op_started");
   trace.event("handle_sub_write");
+#ifdef HAVE_JAEGER
+  if (msg->osd_parent_span) {
+    auto ec_sub_trans = jaeger_tracing::child_span(__func__, msg->osd_parent_span);
+  }
+#endif
   if (!get_parent()->pgb_is_primary())
     get_parent()->update_stats(op.stats);
   ObjectStore::Transaction localt;
@@ -1529,7 +1534,12 @@ void ECBackend::submit_transaction(
   op->client_op = client_op;
   if (client_op)
     op->trace = client_op->pg_trace;
-  
+
+#ifdef HAVE_JAEGER
+  if (client_op->osd_parent_span) {
+    auto ec_sub_trans = jaeger_tracing::child_span("ECBackend::submit_transaction", client_op->osd_parent_span);
+  }
+#endif
   dout(10) << __func__ << ": op " << *op << " starting" << dendl;
   start_rmw(op, std::move(t));
 }
@@ -2098,6 +2108,12 @@ bool ECBackend::try_reads_to_commit()
       messages.push_back(std::make_pair(i->osd, r));
     }
   }
+
+#ifdef HAVE_JAEGER
+   if (op->client_op->osd_parent_span) {
+      auto sub_write_span = jaeger_tracing::child_span("EC sub write", op->client_op->osd_parent_span);
+    }
+#endif
   if (!messages.empty()) {
     get_parent()->send_message_osd_cluster(messages, get_osdmap_epoch());
   }

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -297,7 +297,7 @@ struct RecoveryMessages {
   map<pg_shard_t, vector<PushReplyOp> > push_replies;
   ObjectStore::Transaction t;
   RecoveryMessages() {}
-  ~RecoveryMessages(){}
+  ~RecoveryMessages() {}
 };
 
 void ECBackend::handle_recovery_push(

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -314,7 +314,7 @@ OSDService::OSDService(OSD *osd, ceph::async::io_context_pool& poolctx) :
 }
 
 #ifdef PG_DEBUG_REFS
-void OSDService::add_pgid(spg_t pgid, PG *pg){
+void OSDService::add_pgid(spg_t pgid, PG *pg) {
   std::lock_guard l(pgid_lock);
   if (!pgid_tracker.count(pgid)) {
     live_pgs[pgid] = pg;
@@ -3539,7 +3539,7 @@ int OSD::init()
   if (r < 0)
     goto out;
 
-  mgrc.set_pgstats_cb([this](){ return collect_pg_stats(); });
+  mgrc.set_pgstats_cb([this]() { return collect_pg_stats(); });
   mgrc.set_perf_metric_query_cb(
     [this](const ConfigPayload &config_payload) {
         set_perf_queries(config_payload);

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -17,6 +17,9 @@
 #include "osd/osd_op_util.h"
 #include "osd/osd_types.h"
 #include "common/TrackedOp.h"
+#ifdef HAVE_JAEGER
+#include "common/tracer.h"
+#endif
 
 /**
  * The OpRequest takes in a Message* and takes over a single reference
@@ -88,7 +91,17 @@ public:
   epoch_t min_epoch = 0;      ///< min epoch needed to handle this msg
 
   bool hitset_inserted;
-
+#ifdef HAVE_JAEGER
+  jspan osd_parent_span = nullptr;
+  void set_osd_parent_span(jspan& span) {
+    if(osd_parent_span){
+      jaeger_tracing::finish_span(osd_parent_span);
+    }
+    osd_parent_span = move(span);
+  }
+#else
+  void set_osd_parent_span(...) {}
+#endif
   template<class T>
   const T* get_req() const { return static_cast<const T*>(request); }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -70,6 +70,9 @@
 #include <utility>
 
 #include <errno.h>
+#ifdef HAVE_JAEGER
+#include "common/tracer.h"
+#endif
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(PrimaryLogPG, replicatedpg, osd);
 
@@ -1660,7 +1663,12 @@ void PrimaryLogPG::do_request(
     op->pg_trace.init("pg op", &trace_endpoint, &op->osd_trace);
     op->pg_trace.event("do request");
   }
-  // make sure we have a new enough map
+#ifdef HAVE_JAEGER
+  if (op->osd_parent_span) {
+    auto do_req_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+  }
+#endif
+// make sure we have a new enough map
   auto p = waiting_for_map.find(op->get_source());
   if (p != waiting_for_map.end()) {
     // preserve ordering
@@ -1690,7 +1698,6 @@ void PrimaryLogPG::do_request(
     auto session = ceph::ref_cast<Session>(m->get_connection()->get_priv());
     if (!session)
       return;  // drop it.
-
     if (msg_type == CEPH_MSG_OSD_OP) {
       if (session->check_backoff(cct, info.pgid,
 				 info.pgid.pgid.get_hobj_start(), m)) {
@@ -2019,6 +2026,11 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 	   << " flags " << ceph_osd_flag_string(m->get_flags())
 	   << dendl;
 
+#ifdef HAVE_JAEGER
+  if (op->osd_parent_span) {
+    auto do_op_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+  }
+#endif
   // missing object?
   if (is_unreadable_object(head)) {
     if (!is_primary()) {
@@ -3849,6 +3861,11 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
     tracepoint(osd, prepare_tx_enter, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
   }
+#ifdef HAVE_JAEGER
+  if (ctx->op->osd_parent_span) {
+    auto execute_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+  }
+#endif
 
   int result = prepare_transaction(ctx);
 
@@ -5615,6 +5632,11 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   PGTransaction* t = ctx->op_t.get();
 
   dout(10) << "do_osd_op " << soid << " " << ops << dendl;
+#ifdef HAVE_JAEGER
+  if (ctx->op->osd_parent_span) {
+    auto do_osd_op_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+  }
+#endif
 
   ctx->current_osd_subop_num = 0;
   for (auto p = ops.begin(); p != ops.end(); ++p, ctx->current_osd_subop_num++, ctx->processed_subop_count++) {
@@ -8496,6 +8518,11 @@ void PrimaryLogPG::finish_ctx(OpContext *ctx, int log_op_type, int result)
 	   << dendl;
   utime_t now = ceph_clock_now();
 
+#ifdef HAVE_JAEGER
+  if (ctx->op->osd_parent_span) {
+    auto finish_ctx_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+  }
+#endif
   // Drop the reference if deduped chunk is modified
   if (ctx->new_obs.oi.is_dirty() &&
     (ctx->obs->oi.has_manifest() && ctx->obs->oi.manifest.is_chunked()) &&
@@ -10498,6 +10525,11 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
 
 void PrimaryLogPG::eval_repop(RepGather *repop)
 {
+  #ifdef HAVE_JAEGER
+  if (repop->op->osd_parent_span) {
+    auto eval_span = jaeger_tracing::child_span(__func__, repop->op->osd_parent_span);
+  }
+ #endif
   dout(10) << "eval_repop " << *repop
     << (repop->op && repop->op->get_req<MOSDOp>() ? "" : " (no op)") << dendl;
 
@@ -10552,6 +10584,11 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
   dout(7) << "issue_repop rep_tid " << repop->rep_tid
           << " o " << soid
           << dendl;
+#ifdef HAVE_JAEGER
+  if (ctx->op->osd_parent_span) {
+    auto issue_repop_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+  }
+#endif
 
   repop->v = ctx->at_version;
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1864,7 +1864,7 @@ bool ReplicatedBackend::handle_pull_response(
   interval_set<uint64_t> data_zeros;
   uint64_t z_offset = pop.before_progress.data_recovered_to;
   uint64_t z_length = pop.after_progress.data_recovered_to - pop.before_progress.data_recovered_to;
-  if(z_length)
+  if (z_length)
     data_zeros.insert(z_offset, z_length);
   bool complete = pi.is_complete();
   bool clear_omap = !pop.before_progress.omap_complete;
@@ -1923,7 +1923,7 @@ void ReplicatedBackend::handle_push(
   interval_set<uint64_t> data_zeros;
   uint64_t z_offset = pop.before_progress.data_recovered_to;
   uint64_t z_length = pop.after_progress.data_recovered_to - pop.before_progress.data_recovered_to;
-  if(z_length)
+  if (z_length)
     data_zeros.insert(z_offset, z_length);
   response->soid = pop.recovery_info.soid;
 
@@ -2039,12 +2039,12 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
   object_info_t oi;
   if (progress.first) {
     int r = store->omap_get_header(ch, ghobject_t(recovery_info.soid), &out_op->omap_header);
-    if(r < 0) {
-      dout(1) << __func__ << " get omap header failed: " << cpp_strerror(-r) << dendl; 
+    if (r < 0) {
+      dout(1) << __func__ << " get omap header failed: " << cpp_strerror(-r) << dendl;
       return r;
     }
     r = store->getattrs(ch, ghobject_t(recovery_info.soid), out_op->attrset);
-    if(r < 0) {
+    if (r < 0) {
       dout(1) << __func__ << " getattrs failed: " << cpp_strerror(-r) << dendl;
       return r;
     }

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -502,6 +502,9 @@ void ReplicatedBackend::submit_transaction(
   ceph_assert(insert_res.second);
   InProgressOp &op = *insert_res.first->second;
 
+#ifdef HAVE_JAEGER
+  auto rep_sub_trans = jaeger_tracing::child_span("ReplicatedBackend::submit_transaction", orig_op->osd_parent_span);
+#endif
   op.waiting_for_commit.insert(
     parent->get_acting_recovery_backfill_shards().begin(),
     parent->get_acting_recovery_backfill_shards().end());
@@ -1056,6 +1059,10 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
 	   << (m->logbl.length() ? " (transaction)" : " (parallel exec")
 	   << " " << m->logbl.length()
 	   << dendl;
+
+#ifdef HAVE_JAEGER
+  auto do_repop_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+#endif
 
   // sanity checks
   ceph_assert(m->map_epoch >= get_info().history.same_interval_since);

--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -14,6 +14,9 @@
 
 #include "osd/scheduler/OpSchedulerItem.h"
 #include "osd/OSD.h"
+#ifdef HAVE_JAEGER
+#include "common/tracer.h"
+#endif
 
 namespace ceph::osd::scheduler {
 
@@ -23,6 +26,9 @@ void PGOpItem::run(
   PGRef& pg,
   ThreadPool::TPHandle &handle)
 {
+#ifdef HAVE_JAEGER
+  auto PGOpItem_span = jaeger_tracing::child_span("PGOpItem::run", op->osd_parent_span);
+#endif
   osd->dequeue_op(pg, op, handle);
   pg->unlock();
 }

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -185,6 +185,10 @@ if(WITH_LTTNG)
   add_dependencies(rgw_common rgw_op-tp rgw_rados-tp)
 endif()
 
+if(WITH_JAEGER)
+  add_dependencies(rgw_common jaegertracing::libjaegertracing)
+endif()
+
 set(rgw_a_srcs
   rgw_auth_keystone.cc
   rgw_client_io.cc

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -62,6 +62,7 @@ fi
 if [ -n "$CEPH_BUILD_ROOT" ]; then
     [ -z "$CEPH_BIN" ] && CEPH_BIN=$CEPH_BUILD_ROOT/bin
     [ -z "$CEPH_LIB" ] && CEPH_LIB=$CEPH_BUILD_ROOT/lib
+    [ -z "$CEPH_EXT_LIB" ] && CEPH_EXT_LIB=$CEPH_BUILD_ROOT/external/lib
     [ -z "$EC_PATH" ] && EC_PATH=$CEPH_LIB/erasure-code
     [ -z "$OBJCLASS_PATH" ] && OBJCLASS_PATH=$CEPH_LIB/rados-classes
     # make install should install python extensions into PYTHONPATH
@@ -72,6 +73,7 @@ elif [ -n "$CEPH_ROOT" ]; then
     [ -z "$CEPH_ADM" ] && CEPH_ADM=$CEPH_BIN/ceph
     [ -z "$INIT_CEPH" ] && INIT_CEPH=$CEPH_BIN/init-ceph
     [ -z "$CEPH_LIB" ] && CEPH_LIB=$CEPH_BUILD_DIR/lib
+    [ -z "$CEPH_EXT_LIB" ] && CEPH_EXT_LIB=$CEPH_BUILD_DIR/external/lib
     [ -z "$OBJCLASS_PATH" ] && OBJCLASS_PATH=$CEPH_LIB
     [ -z "$EC_PATH" ] && EC_PATH=$CEPH_LIB
     [ -z "$CEPH_PYTHON_COMMON" ] && CEPH_PYTHON_COMMON=$CEPH_ROOT/src/python-common
@@ -87,8 +89,8 @@ fi
 CYTHON_PYTHONPATH="$CEPH_LIB/cython_modules/lib.3"
 export PYTHONPATH=$PYBIND:$CYTHON_PYTHONPATH:$CEPH_PYTHON_COMMON$PYTHONPATH
 
-export LD_LIBRARY_PATH=$CEPH_LIB:$LD_LIBRARY_PATH
-export DYLD_LIBRARY_PATH=$CEPH_LIB:$DYLD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$CEPH_LIB:$CEPH_EXT_LIB:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=$CEPH_LIB:$CEPH_EXT_LIB:$DYLD_LIBRARY_PATH
 # Suppress logging for regular use that indicated that we are using a
 # development version. vstart.sh is only used during testing and
 # development

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -166,6 +166,7 @@ lockdep=${LOCKDEP:-1}
 spdk_enabled=0 #disable SPDK by default
 zoned_enabled=0
 io_uring_enabled=0
+with_jaeger=0
 
 with_mgr_dashboard=true
 if [[ "$(get_cmake_variable WITH_MGR_DASHBOARD_FRONTEND)" != "ON" ]] ||
@@ -236,6 +237,7 @@ usage=$usage"\t--bluestore-io-uring: enable io_uring backend\n"
 usage=$usage"\t--inc-osd: append some more osds into existing vcluster\n"
 usage=$usage"\t--cephadm: enable cephadm orchestrator with ~/.ssh/id_rsa[.pub]\n"
 usage=$usage"\t--no-parallel: dont start all OSDs in parallel\n"
+usage=$usage"\t--jaeger: use jaegertracing for tracing\n"
 
 usage_exit() {
     printf "$usage"
@@ -244,27 +246,27 @@ usage_exit() {
 
 while [ $# -ge 1 ]; do
 case $1 in
-    -d | --debug )
+    -d | --debug)
         debug=1
         ;;
     -s | --standby_mds)
         standby=1
         ;;
-    -l | --localhost )
+    -l | --localhost)
         ip="127.0.0.1"
         ;;
-    -i )
+    -i)
         [ -z "$2" ] && usage_exit
         ip="$2"
         shift
         ;;
-    -e )
+    -e)
         ec=1
         ;;
-    --new | -n )
+    --new | -n)
         new=1
         ;;
-    --inc-osd )
+    --inc-osd)
         new=0
         kill_all=0
         inc_osd_num=$2
@@ -274,103 +276,103 @@ case $1 in
             shift
         fi
         ;;
-    --short )
+    --short)
         short=1
         ;;
-    --crimson )
+    --crimson)
         ceph_osd=crimson-osd
         ;;
-    --osd-args )
+    --osd-args)
         extra_osd_args="$2"
         shift
         ;;
-    --msgr1 )
+    --msgr1)
         msgr="1"
         ;;
-    --msgr2 )
+    --msgr2)
         msgr="2"
         ;;
-    --msgr21 )
+    --msgr21)
         msgr="21"
         ;;
-    --cephadm )
+    --cephadm)
         cephadm=1
         ;;
-    --no-parallel )
+    --no-parallel)
         parallel=false
         ;;
-    --valgrind )
+    --valgrind)
         [ -z "$2" ] && usage_exit
         valgrind=$2
         shift
         ;;
-    --valgrind_args )
+    --valgrind_args)
         valgrind_args="$2"
         shift
         ;;
-    --valgrind_mds )
+    --valgrind_mds)
         [ -z "$2" ] && usage_exit
         valgrind_mds=$2
         shift
         ;;
-    --valgrind_osd )
+    --valgrind_osd)
         [ -z "$2" ] && usage_exit
         valgrind_osd=$2
         shift
         ;;
-    --valgrind_mon )
+    --valgrind_mon)
         [ -z "$2" ] && usage_exit
         valgrind_mon=$2
         shift
         ;;
-    --valgrind_mgr )
+    --valgrind_mgr)
         [ -z "$2" ] && usage_exit
         valgrind_mgr=$2
         shift
         ;;
-    --valgrind_rgw )
+    --valgrind_rgw)
         [ -z "$2" ] && usage_exit
         valgrind_rgw=$2
         shift
         ;;
-    --nodaemon )
+    --nodaemon)
         nodaemon=1
         ;;
     --redirect-output)
         redirect=1
         ;;
-    --smallmds )
+    --smallmds)
         smallmds=1
         ;;
-    --rgw_port )
+    --rgw_port)
         CEPH_RGW_PORT=$2
         shift
         ;;
-    --rgw_frontend )
+    --rgw_frontend)
         rgw_frontend=$2
         shift
         ;;
-    --rgw_compression )
+    --rgw_compression)
         rgw_compression=$2
         shift
         ;;
-    --kstore_path )
+    --kstore_path)
         kstore_path=$2
         shift
         ;;
-    --filestore_path )
+    --filestore_path)
         filestore_path=$2
         shift
         ;;
-    -m )
+    -m)
         [ -z "$2" ] && usage_exit
         MON_ADDR=$2
         shift
         ;;
-    -x )
+    -x)
         cephx=1 # this is on be default, flag exists for historical consistency
         ;;
-    -X )
+    -X)
         cephx=0
         ;;
 
@@ -381,36 +383,35 @@ case $1 in
         gssapi_authx=0
         ;;
 
-    -k )
+    -k)
         if [ ! -r $conf_fn ]; then
             echo "cannot use old configuration: $conf_fn not readable." >&2
             exit
         fi
         new=0
         ;;
-    --memstore )
+    --memstore)
         objectstore="memstore"
         ;;
-    -b | --bluestore )
+    -b | --bluestore)
         objectstore="bluestore"
         ;;
-    -f | --filestore )
+    -f | --filestore)
         objectstore="filestore"
         ;;
-    -K | --kstore )
+    -K | --kstore)
         objectstore="kstore"
         ;;
-    --hitset )
+    --hitset)
         hitset="$hitset $2 $3"
         shift
         shift
         ;;
-    -o )
-        extra_conf="$extra_conf	$2
-"
+    -o)
+        extra_conf="$extra_conf	$2"
         shift
         ;;
-    --cache )
+    --cache)
         if [ -z "$cache" ]; then
             cache="$2"
         else
@@ -418,7 +419,7 @@ case $1 in
         fi
         shift
         ;;
-    --nolockdep )
+    --nolockdep)
         lockdep=0
         ;;
     --multimds)
@@ -449,8 +450,13 @@ case $1 in
         ;;
     --bluestore-io-uring)
         io_uring_enabled=1
+        shift
         ;;
-    * )
+    --jaeger)
+        with_jaeger=1
+        echo "with_jaeger $with_jaeger"
+        ;;
+    *)
         usage_exit
 esac
 shift
@@ -1551,6 +1557,44 @@ do_rgw()
 if [ "$CEPH_NUM_RGW" -gt 0 ]; then
     do_rgw
 fi
+
+
+ docker_service(){
+     local service=''
+     #prefer podman
+     if pgrep -f podman > /dev/null; then
+	 service="podman"
+     elif pgrep -f docker > /dev/null; then
+	 service="docker"
+     fi
+     if [ -n "$service" ]; then
+       echo "using $service for deploying jaeger..."
+       #check for exited container, remove them and restart container
+       if [ "$($service ps -aq -f status=exited -f name=jaeger)" ]; then
+	 $service rm jaeger
+       fi
+       if [ ! "$(podman ps -aq -f name=jaeger)" ]; then
+         $service "$@"
+       fi
+     else
+         echo "cannot find docker or podman, please restart service and rerun."
+     fi
+ }
+
+echo ""
+if [ $with_jaeger -eq 1 ]; then
+    debug echo "Enabling jaegertracing..."
+    docker_service run -d --name jaeger \
+  -p 5775:5775/udp \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 14268:14268 \
+  -p 14250:14250 \
+  jaegertracing/all-in-one:1.20
+fi
+
 
 debug echo "vstart cluster complete. Use stop.sh to stop. See out/* (e.g. 'tail -f out/????') for debug output."
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Milestones
- [x] Build Jaeger as External Project ( all cmake at scalable level)
- [x] OSD trace using marker spans
- [ ] Off the wire context transfer configuration
- [ ] Documentation
- [ ]  RGW path trace
- [ ] Use Case Documentation 
- [ ] Reviews, Cleanups and Documentation update
- [ ] Code Coverage and Tests 

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
