### PR TITLE
luminous: krbd: avoid udev netlink socket overrun and retry on transient errors from udev_enumerate_scan_devices()

### DIFF
--- a/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_enumerate.yaml
+++ b/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_enumerate.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/krbd_udev_enumerate.sh

--- a/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_netlink_enobufs.yaml
+++ b/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_netlink_enobufs.yaml
@@ -1,0 +1,10 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - pauserd,pausewr flag\(s\) set
+
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/krbd_udev_netlink_enobufs.sh

--- a/qa/workunits/rbd/krbd_udev_enumerate.sh
+++ b/qa/workunits/rbd/krbd_udev_enumerate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This is a test for https://tracker.ceph.com/issues/41036, but it also
+# triggers https://tracker.ceph.com/issues/41404 in some environments.
+
+set -ex
+
+function assert_exit_codes() {
+    declare -a pids=($@)
+
+    for pid in ${pids[@]}; do
+       wait $pid
+    done
+}
+
+function run_map() {
+    declare -a pids
+
+    for i in {1..300}; do
+        sudo rbd map img$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 301 ]]
+}
+
+function run_unmap_by_dev() {
+    declare -a pids
+
+    run_map
+    for i in {0..299}; do
+        sudo rbd unmap /dev/rbd$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 0 ]]
+}
+
+function run_unmap_by_spec() {
+    declare -a pids
+
+    run_map
+    for i in {1..300}; do
+        sudo rbd unmap img$i &
+        pids+=($!)
+    done
+
+    assert_exit_codes ${pids[@]}
+    [[ $(rbd showmapped | wc -l) -eq 0 ]]
+}
+
+# Can't test with exclusive-lock, don't bother enabling deep-flatten.
+# See https://tracker.ceph.com/issues/42492.
+for i in {1..300}; do
+    rbd create --size 1 --image-feature '' img$i
+done
+
+for i in {1..30}; do
+    echo Iteration $i
+    run_unmap_by_dev
+    run_unmap_by_spec
+done
+
+echo OK

--- a/qa/workunits/rbd/krbd_udev_netlink_enobufs.sh
+++ b/qa/workunits/rbd/krbd_udev_netlink_enobufs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This is a test for https://tracker.ceph.com/issues/41404, verifying that udev
+# events are properly reaped while the image is being (un)mapped in the kernel.
+# UDEV_BUF_SIZE is 1M (giving us a 2M socket receive buffer), but modprobe +
+# modprobe -r generate ~28M worth of "block" events.
+
+set -ex
+
+rbd create --size 1 img
+
+ceph osd pause
+sudo rbd map img &
+PID=$!
+sudo modprobe scsi_debug max_luns=16 add_host=16 num_parts=1 num_tgts=16
+sudo udevadm settle
+sudo modprobe -r scsi_debug
+[[ $(rbd showmapped | wc -l) -eq 0 ]]
+ceph osd unpause
+wait $PID
+[[ $(rbd showmapped | wc -l) -eq 2 ]]
+sudo rbd unmap img
+
+echo OK

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -434,6 +434,7 @@ static int devno_to_krbd_id(struct udev *udev, dev_t devno, string *pid)
   struct udev_device *dev;
   int r;
 
+retry:
   enm = udev_enumerate_new(udev);
   if (!enm)
     return -ENOMEM;
@@ -455,8 +456,14 @@ static int devno_to_krbd_id(struct udev *udev, dev_t devno, string *pid)
   }
 
   r = udev_enumerate_scan_devices(enm);
-  if (r < 0)
+  if (r < 0) {
+    if (r == -ENOENT || r == -ENODEV) {
+      std::cerr << "rbd: udev enumerate failed, retrying" << std::endl;
+      udev_enumerate_unref(enm);
+      goto retry;
+    }
     goto out_enm;
+  }
 
   l = udev_enumerate_get_list_entry(enm);
   if (!l) {
@@ -492,6 +499,7 @@ static int spec_to_devno_and_krbd_id(struct udev *udev, const char *pool,
   string err;
   int r;
 
+retry:
   enm = udev_enumerate_new(udev);
   if (!enm)
     return -ENOMEM;
@@ -513,8 +521,14 @@ static int spec_to_devno_and_krbd_id(struct udev *udev, const char *pool,
     goto out_enm;
 
   r = udev_enumerate_scan_devices(enm);
-  if (r < 0)
+  if (r < 0) {
+    if (r == -ENOENT || r == -ENODEV) {
+      std::cerr << "rbd: udev enumerate failed, retrying" << std::endl;
+      udev_enumerate_unref(enm);
+      goto retry;
+    }
     goto out_enm;
+  }
 
   l = udev_enumerate_get_list_entry(enm);
   if (!l) {
@@ -771,6 +785,7 @@ static int do_dump(struct udev *udev, Formatter *f, TextTable *tbl)
   bool have_output = false;
   int r;
 
+retry:
   enm = udev_enumerate_new(udev);
   if (!enm)
     return -ENOMEM;
@@ -780,8 +795,14 @@ static int do_dump(struct udev *udev, Formatter *f, TextTable *tbl)
     goto out_enm;
 
   r = udev_enumerate_scan_devices(enm);
-  if (r < 0)
+  if (r < 0) {
+    if (r == -ENOENT || r == -ENODEV) {
+      std::cerr << "rbd: udev enumerate failed, retrying" << std::endl;
+      udev_enumerate_unref(enm);
+      goto retry;
+    }
     goto out_enm;
+  }
 
   udev_list_entry_foreach(l, udev_enumerate_get_list_entry(enm)) {
     struct udev_device *dev;

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -22,7 +22,10 @@
 #include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <thread>
+#include <tuple>
 #include <unistd.h>
+#include <utility>
 
 #include "auth/KeyRing.h"
 #include "common/errno.h"
@@ -33,6 +36,7 @@
 #include "common/secret.h"
 #include "common/TextTable.h"
 #include "include/assert.h"
+#include "include/compat.h"
 #include "include/stringify.h"
 #include "include/krbd.h"
 #include "mon/MonMap.h"
@@ -174,31 +178,69 @@ static int build_map_buf(CephContext *cct, const char *pool, const char *image,
   return 0;
 }
 
+/*
+ * Return:
+ *   <kernel error, false> - didn't map
+ *   <0 or udev error, true> - mapped
+ */
 template <typename F>
-static int wait_for_mapping(udev_monitor *mon, F udev_device_handler)
+static std::pair<int, bool> wait_for_mapping(int sysfs_r_fd, udev_monitor *mon,
+                                             F udev_device_handler)
 {
-  struct pollfd fds[1];
+  struct pollfd fds[2];
+  int sysfs_r = INT_MAX, udev_r = INT_MAX;
+  int r;
 
-  fds[0].fd = udev_monitor_get_fd(mon);
+  fds[0].fd = sysfs_r_fd;
   fds[0].events = POLLIN;
+  fds[1].fd = udev_monitor_get_fd(mon);
+  fds[1].events = POLLIN;
 
   for (;;) {
-    if (poll(fds, 1, -1) < 0) {
+    if (poll(fds, 2, -1) < 0) {
       ceph_abort();
     }
 
-    for (;;) {
-      struct udev_device *dev;
-
-      dev = udev_monitor_receive_device(mon);
-      if (!dev) {
-        if (errno != EINTR && errno != EAGAIN) {
-          return -errno;
-        }
-        break;
+    if (fds[0].revents) {
+      r = safe_read_exact(sysfs_r_fd, &sysfs_r, sizeof(sysfs_r));
+      if (r < 0) {
+        ceph_abort();
       }
-      if (udev_device_handler(dev)) {
-        return 0;
+      if (sysfs_r < 0) {
+        return std::make_pair(sysfs_r, false);
+      }
+      if (udev_r != INT_MAX) {
+        assert(!sysfs_r);
+        return std::make_pair(udev_r, true);
+      }
+      fds[0].fd = -1;
+    }
+
+    if (fds[1].revents) {
+      for (;;) {
+        struct udev_device *dev;
+
+        dev = udev_monitor_receive_device(mon);
+        if (!dev) {
+          if (errno != EINTR && errno != EAGAIN) {
+            udev_r = -errno;
+            if (sysfs_r != INT_MAX) {
+              assert(!sysfs_r);
+              return std::make_pair(udev_r, true);
+            }
+            fds[1].fd = -1;
+          }
+          break;
+        }
+        if (udev_device_handler(dev)) {
+          udev_r = 0;
+          if (sysfs_r != INT_MAX) {
+            assert(!sysfs_r);
+            return std::make_pair(udev_r, true);
+          }
+          fds[1].fd = -1;
+          break;
+        }
       }
     }
   }
@@ -285,6 +327,9 @@ static int do_map(struct udev *udev, const char *pool, const char *image,
                   const char *snap, const string& buf, string *pname)
 {
   struct udev_monitor *mon;
+  std::thread mapper;
+  bool mapped;
+  int fds[2];
   int r;
 
   mon = udev_monitor_new_from_netlink(udev, "udev");
@@ -303,17 +348,34 @@ static int do_map(struct udev *udev, const char *pool, const char *image,
   if (r < 0)
     goto out_mon;
 
-  r = sysfs_write_rbd_add(buf);
-  if (r < 0) {
-    cerr << "rbd: sysfs write failed" << std::endl;
+  if (pipe2(fds, O_NONBLOCK) < 0) {
+    r = -errno;
     goto out_mon;
   }
 
-  r = wait_for_mapping(mon, UdevMapHandler(pool, image, snap, pname));
+  mapper = std::thread([&buf, &fds]() {
+    ceph_pthread_setname(pthread_self(), "mapper");
+    int sysfs_r = sysfs_write_rbd_add(buf);
+    int r = safe_write(fds[1], &sysfs_r, sizeof(sysfs_r));
+    if (r < 0) {
+      ceph_abort();
+    }
+  });
+
+  std::tie(r, mapped) = wait_for_mapping(
+      fds[0], mon, UdevMapHandler(pool, image, snap, pname));
   if (r < 0) {
-    cerr << "rbd: wait failed" << std::endl;
-    goto out_mon;
+    if (!mapped) {
+      std::cerr << "rbd: sysfs write failed" << std::endl;
+    } else {
+      std::cerr << "rbd: udev wait failed" << std::endl;
+      /* TODO: fall back to enumeration */
+    }
   }
+
+  mapper.join();
+  close(fds[0]);
+  close(fds[1]);
 
 out_mon:
   udev_monitor_unref(mon);
@@ -525,6 +587,9 @@ private:
 static int do_unmap(struct udev *udev, dev_t devno, const string& buf)
 {
   struct udev_monitor *mon;
+  std::thread unmapper;
+  bool unmapped;
+  int fds[2];
   int r;
 
   mon = udev_monitor_new_from_netlink(udev, "udev");
@@ -539,39 +604,58 @@ static int do_unmap(struct udev *udev, dev_t devno, const string& buf)
   if (r < 0)
     goto out_mon;
 
-  /*
-   * On final device close(), kernel sends a block change event, in
-   * response to which udev apparently runs blkid on the device.  This
-   * makes unmap fail with EBUSY, if issued right after final close().
-   * Try to circumvent this with a retry before turning to udev.
-   */
-  for (int tries = 0; ; tries++) {
-    r = sysfs_write_rbd_remove(buf);
-    if (r >= 0) {
-      break;
-    } else if (r == -EBUSY && tries < 2) {
-      if (!tries) {
-        usleep(250 * 1000);
+  if (pipe2(fds, O_NONBLOCK) < 0) {
+    r = -errno;
+    goto out_mon;
+  }
+
+  unmapper = std::thread([&buf, &fds]() {
+    ceph_pthread_setname(pthread_self(), "unmapper");
+    /*
+     * On final device close(), kernel sends a block change event, in
+     * response to which udev apparently runs blkid on the device.  This
+     * makes unmap fail with EBUSY, if issued right after final close().
+     * Try to circumvent this with a retry before turning to udev.
+     */
+    for (int tries = 0; ; tries++) {
+      int sysfs_r = sysfs_write_rbd_remove(buf);
+      if (sysfs_r == -EBUSY && tries < 2) {
+        if (!tries) {
+          usleep(250 * 1000);
+        } else {
+          /*
+           * libudev does not provide the "wait until the queue is empty"
+           * API or the sufficient amount of primitives to build it from.
+           */
+          std::string err = run_cmd("udevadm", "settle", "--timeout", "10",
+                                    (char *)NULL);
+          if (!err.empty())
+            std::cerr << "rbd: " << err << std::endl;
+        }
       } else {
-        /*
-         * libudev does not provide the "wait until the queue is empty"
-         * API or the sufficient amount of primitives to build it from.
-         */
-        string err = run_cmd("udevadm", "settle", "--timeout", "10", NULL);
-        if (!err.empty())
-          cerr << "rbd: " << err << std::endl;
+        int r = safe_write(fds[1], &sysfs_r, sizeof(sysfs_r));
+        if (r < 0) {
+          ceph_abort();
+        }
+        break;
       }
+    }
+  });
+
+  std::tie(r, unmapped) = wait_for_mapping(fds[0], mon,
+                                           UdevUnmapHandler(devno));
+  if (r < 0) {
+    if (!unmapped) {
+      std::cerr << "rbd: sysfs write failed" << std::endl;
     } else {
-      cerr << "rbd: sysfs write failed" << std::endl;
-      goto out_mon;
+      std::cerr << "rbd: udev wait failed: " << cpp_strerror(r) << std::endl;
+      r = 0;
     }
   }
 
-  r = wait_for_mapping(mon, UdevUnmapHandler(devno));
-  if (r < 0) {
-    cerr << "rbd: wait failed" << std::endl;
-    goto out_mon;
-  }
+  unmapper.join();
+  close(fds[0]);
+  close(fds[1]);
 
 out_mon:
   udev_monitor_unref(mon);

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -46,6 +46,8 @@
 
 using namespace std;
 
+static const int UDEV_BUF_SIZE = 1 << 20;  /* doubled to 2M (SO_RCVBUFFORCE) */
+
 struct krbd_ctx {
   CephContext *cct;
   struct udev *udev;
@@ -344,6 +346,13 @@ static int do_map(struct udev *udev, const char *pool, const char *image,
   if (r < 0)
     goto out_mon;
 
+  r = udev_monitor_set_receive_buffer_size(mon, UDEV_BUF_SIZE);
+  if (r < 0) {
+    std::cerr << "rbd: failed to set udev buffer size: " << cpp_strerror(r)
+              << std::endl;
+    /* not fatal */
+  }
+
   r = udev_monitor_enable_receiving(mon);
   if (r < 0)
     goto out_mon;
@@ -599,6 +608,13 @@ static int do_unmap(struct udev *udev, dev_t devno, const string& buf)
   r = udev_monitor_filter_add_match_subsystem_devtype(mon, "block", "disk");
   if (r < 0)
     goto out_mon;
+
+  r = udev_monitor_set_receive_buffer_size(mon, UDEV_BUF_SIZE);
+  if (r < 0) {
+    std::cerr << "rbd: failed to set udev buffer size: " << cpp_strerror(r)
+              << std::endl;
+    /* not fatal */
+  }
 
   r = udev_monitor_enable_receiving(mon);
   if (r < 0)

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -42,8 +42,6 @@
 
 using namespace std;
 
-const static int POLL_TIMEOUT=120000;
-
 struct krbd_ctx {
   CephContext *cct;
   struct udev *udev;
@@ -182,7 +180,6 @@ static int wait_for_udev_add(struct udev_monitor *mon, const char *pool,
 {
   struct udev_device *bus_dev = NULL;
   std::vector<struct udev_device*> block_dev_vec;
-  int r;
 
   /*
    * Catch /sys/devices/rbd/<id>/ and wait for the corresponding
@@ -195,12 +192,8 @@ static int wait_for_udev_add(struct udev_monitor *mon, const char *pool,
 
     fds[0].fd = udev_monitor_get_fd(mon);
     fds[0].events = POLLIN;
-    r = poll(fds, 1, POLL_TIMEOUT);
-    if (r > 0) {
-      r = 0;
-    } else {
-      r = (r == 0) ? -ETIMEDOUT : -errno;
-      break;
+    if (poll(fds, 1, -1) < 0) {
+      ceph_abort();
     }
 
     dev = udev_monitor_receive_device(mon);
@@ -264,7 +257,7 @@ done:
     udev_device_unref(p);
   }
 
-  return r;
+  return 0;
 }
 
 static int do_map(struct udev *udev, const char *pool, const char *image,
@@ -494,16 +487,12 @@ static int wait_for_udev_remove(struct udev_monitor *mon, dev_t devno)
   for (;;) {
     struct pollfd fds[1];
     struct udev_device *dev;
-    int r;
 
     fds[0].fd = udev_monitor_get_fd(mon);
     fds[0].events = POLLIN;
-    r = poll(fds, 1, POLL_TIMEOUT);
-    if (r < 0)
-      return -errno;
-
-    if (r == 0)
-      return -ETIMEDOUT;
+    if (poll(fds, 1, -1) < 0) {
+      ceph_abort();
+    }
 
     dev = udev_monitor_receive_device(mon);
     if (!dev)

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -181,6 +181,8 @@ static int wait_for_udev_add(struct udev_monitor *mon, const char *pool,
                              string *pname)
 {
   struct udev_device *bus_dev = NULL;
+  std::vector<struct udev_device*> block_dev_vec;
+  int r;
 
   /*
    * Catch /sys/devices/rbd/<id>/ and wait for the corresponding
@@ -190,16 +192,16 @@ static int wait_for_udev_add(struct udev_monitor *mon, const char *pool,
   for (;;) {
     struct pollfd fds[1];
     struct udev_device *dev;
-    int r;
 
     fds[0].fd = udev_monitor_get_fd(mon);
     fds[0].events = POLLIN;
     r = poll(fds, 1, POLL_TIMEOUT);
-    if (r < 0)
-      return -errno;
-
-    if (r == 0)
-      return -ETIMEDOUT;
+    if (r > 0) {
+      r = 0;
+    } else {
+      r = (r == 0) ? -ETIMEDOUT : -errno;
+      break;
+    }
 
     dev = udev_monitor_receive_device(mon);
     if (!dev)
@@ -208,8 +210,8 @@ static int wait_for_udev_add(struct udev_monitor *mon, const char *pool,
     if (strcmp(udev_device_get_action(dev), "add") != 0)
       goto next;
 
-    if (!bus_dev) {
-      if (strcmp(udev_device_get_subsystem(dev), "rbd") == 0) {
+    if (strcmp(udev_device_get_subsystem(dev), "rbd") == 0) {
+      if (!bus_dev) {
         const char *this_pool = udev_device_get_sysattr_value(dev, "pool");
         const char *this_image = udev_device_get_sysattr_value(dev, "name");
         const char *this_snap = udev_device_get_sysattr_value(dev,
@@ -219,37 +221,50 @@ static int wait_for_udev_add(struct udev_monitor *mon, const char *pool,
             this_image && strcmp(this_image, image) == 0 &&
             this_snap && strcmp(this_snap, snap) == 0) {
           bus_dev = dev;
-          continue;
+          goto check;
         }
       }
-    } else {
-      if (strcmp(udev_device_get_subsystem(dev), "block") == 0) {
-        const char *major = udev_device_get_sysattr_value(bus_dev, "major");
-        const char *minor = udev_device_get_sysattr_value(bus_dev, "minor");
-        const char *this_major = udev_device_get_property_value(dev, "MAJOR");
-        const char *this_minor = udev_device_get_property_value(dev, "MINOR");
+    } else if (strcmp(udev_device_get_subsystem(dev), "block") == 0) {
+      block_dev_vec.push_back(dev);
+      goto check;
+    }
 
-        assert(!minor ^ have_minor_attr());
+next:
+    udev_device_unref(dev);
+    continue;
+
+check:
+    if (bus_dev && !block_dev_vec.empty()) {
+      const char *major = udev_device_get_sysattr_value(bus_dev, "major");
+      const char *minor = udev_device_get_sysattr_value(bus_dev, "minor");
+      assert(!minor ^ have_minor_attr());
+
+      for (auto p : block_dev_vec) {
+        const char *this_major = udev_device_get_property_value(p, "MAJOR");
+        const char *this_minor = udev_device_get_property_value(p, "MINOR");
 
         if (strcmp(this_major, major) == 0 &&
             (!minor || strcmp(this_minor, minor) == 0)) {
           string name = get_kernel_rbd_name(udev_device_get_sysname(bus_dev));
 
-          assert(strcmp(udev_device_get_devnode(dev), name.c_str()) == 0);
+          assert(strcmp(udev_device_get_devnode(p), name.c_str()) == 0);
           *pname = name;
-
-          udev_device_unref(dev);
-          udev_device_unref(bus_dev);
-          break;
+          goto done;
         }
       }
     }
-
-  next:
-    udev_device_unref(dev);
   }
 
-  return 0;
+done:
+  if (bus_dev) {
+    udev_device_unref(bus_dev);
+  }
+  
+  for (auto p : block_dev_vec) {
+    udev_device_unref(p);
+  }
+
+  return r;
 }
 
 static int do_map(struct udev *udev, const char *pool, const char *image,


### PR DESCRIPTION
Pulled in #27339 to reduce conflicts, resolutions are similar to #31322:

https://tracker.ceph.com/issues/39314
https://tracker.ceph.com/issues/42425
https://tracker.ceph.com/issues/42527