### PR TITLE
qa/rgw: remove whitelist for SLOW_OPS against ec pools

### DIFF
--- a/qa/rgw_pool_type/ec-profile.yaml
+++ b/qa/rgw_pool_type/ec-profile.yaml
@@ -1,7 +1,4 @@
 overrides:
-  ceph:
-    log-whitelist:
-    - \(SLOW_OPS\) # see https://tracker.ceph.com/issues/41834
   rgw:
     ec-data-pool: true
     erasure_code_profile:

--- a/qa/rgw_pool_type/ec.yaml
+++ b/qa/rgw_pool_type/ec.yaml
@@ -1,7 +1,4 @@
 overrides:
-  ceph:
-    log-whitelist:
-    - \(SLOW_OPS\) # see https://tracker.ceph.com/issues/41834
   rgw:
     ec-data-pool: true
   s3tests:


### PR DESCRIPTION
now that https://tracker.ceph.com/issues/41834 is resolved, we can enforce the SLOW_OPS failures again in ec pool testing