### PR TITLE
nautilus: ceph.in: check ceph-conf returncode

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -520,7 +520,7 @@ def ceph_conf(parsed_args, field, name):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
     outdata, errdata = p.communicate()
-    if len(errdata):
+    if p.returncode != 0:
         raise RuntimeError('unable to get conf option %s for %s: %s' % (field, name, errdata))
     return outdata.rstrip()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42400

---

backport of https://github.com/ceph/ceph/pull/30695
parent tracker: https://tracker.ceph.com/issues/37664

this backport was staged using ceph-backport.sh version 15.0.0.6612
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh