### PR TITLE
nautilus: os/bluestore/KernelDevice: fix RW_IO_MAX constant

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -538,7 +538,8 @@ void KernelDevice::_aio_thread()
 	      "This may suggest HW issue. Please check your dmesg!");
           }
         } else if (aio[i]->length != (uint64_t)r) {
-          derr << "aio to " << aio[i]->offset << "~" << aio[i]->length
+          derr << "aio to 0x" << std::hex << aio[i]->offset
+	       << "~" << aio[i]->length << std::dec
                << " but returned: " << r << dendl;
           ceph_abort_msg("unexpected aio return value: does not match length");
         }

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -25,9 +25,7 @@
 #include "ceph_aio.h"
 #include "BlockDevice.h"
 
-#ifndef RW_IO_MAX
-#define RW_IO_MAX 0x7FFFF000
-#endif
+#define RW_IO_MAX (INT_MAX & CEPH_PAGE_MASK)
 
 
 class KernelDevice : public BlockDevice {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41460

---

backport of https://github.com/ceph/ceph/pull/29577
parent tracker: https://tracker.ceph.com/issues/41188

this backport was staged using ceph-backport.sh version 15.0.0.6612
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh