### PR TITLE
nautilus: cephfs-shell: make compatible with cmd2 versions after 0.9.13

### DIFF
--- a/doc/cephfs/cephfs-shell.rst
+++ b/doc/cephfs/cephfs-shell.rst
@@ -226,18 +226,21 @@ Usage:
 * name - name of the alias being looked up, added, or replaced
 * value - what the alias will be resolved to (if adding or replacing) this can contain spaces and does not need to be quoted
 
-pyscript
---------
+run_pyscript
+------------
 
 Runs a python script file inside the console
 
 Usage: 
     
-    pyscript <script_path> [script_arguments]
+    run_pyscript <script_path> [script_arguments]
 
 * Console commands can be executed inside this script with cmd ("your command")
-  However, you cannot run nested "py" or "pyscript" commands from within this script
-  Paths or arguments that contain spaces must be enclosed in quotes
+  However, you cannot run nested "py" or "pyscript" commands from within this
+  script. Paths or arguments that contain spaces must be enclosed in quotes
+
+.. note:: This command is available as ``pyscript`` for cmd2 versions 0.9.13
+   or less.
 
 py
 --

--- a/doc/cephfs/cephfs-shell.rst
+++ b/doc/cephfs/cephfs-shell.rst
@@ -312,18 +312,21 @@ Usage:
 
 * file_path - path to a file to open in editor
 
-load
-----
+run_script
+----------
 
 Runs commands in script file that is encoded as either ASCII or UTF-8 text.
+Each command in the script should be separated by a newline.
 
 Usage:  
     
-    load <file_path>
+    run_script <file_path>
+
 
 * file_path - a file path pointing to a script
 
-* Script should contain one command per line, just like command would betyped in console.
+.. note:: This command is available as ``load`` for cmd2 versions 0.9.13
+   or less.
 
 shell
 -----

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -5,7 +5,6 @@ import argparse
 import os
 import os.path
 import sys
-from cmd2 import Cmd
 import cephfs as libcephfs
 import shutil
 import traceback
@@ -14,6 +13,10 @@ import fnmatch
 import math
 import re
 import shlex
+
+from cmd2 import Cmd
+from cmd2 import __version__ as cmd2_version
+from distutils.version import LooseVersion
 
 if sys.version_info.major < 3:
    raise RuntimeError("cephfs-shell is only compatible with python3")
@@ -1284,7 +1287,10 @@ if __name__ == '__main__':
     if args.config:
         config_file = args.config
     if args.batch:
-        args.commands = ['load ' + args.batch, ',quit']
+        if LooseVersion(cmd2_version) <= LooseVersion("0.9.13"):
+            args.commands = ['load ' + args.batch, ',quit']
+        else:
+            args.commands = ['run_script ' +  args.batch, ',quit']
     if args.test:
         args.commands.extend(['-t,'] + [arg+',' for arg in args.test])
     sys.argv.clear()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42327

---

backport of https://github.com/ceph/ceph/pull/30585
parent tracker: https://tracker.ceph.com/issues/42057

this backport was staged using ceph-backport.sh version 15.0.0.6814
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh