### PR TITLE
qa/rgw: use 'testing' kms backend for multisite tests

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -4,6 +4,7 @@ overrides:
     conf:
       client:
         debug rgw: 20
+        rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
         rgw crypt require ssl: false
         rgw sync log trim interval: 0


### PR DESCRIPTION
a missing piece from https://github.com/ceph/ceph/pull/30940 that resolves multisite test failures in `test_encrypted_object_sync`