### PR TITLE
mgr/dashboard: Remove compression mode unset in pool from

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -100,9 +100,9 @@ class Pool(RESTController):
 
     def _set_pool_values(self, pool, application_metadata, flags, update_existing, kwargs):
         update_name = False
-        if update_existing:
-            current_pool = self._get(pool)
-            self._handle_update_compression_args(current_pool.get('options'), kwargs)
+        current_pool = self._get(pool)
+        if update_existing and kwargs.get('compression_mode') == 'unset':
+            self._prepare_compression_removal(current_pool.get('options'), kwargs)
         if flags and 'ec_overwrites' in flags:
             CephService.send_command('mon', 'osd pool set', pool=pool, var='allow_ec_overwrites',
                                      val='true')
@@ -146,8 +146,18 @@ class Pool(RESTController):
                 CephService.send_command('mon', 'osd pool set-quota',
                                          pool=pool, field=field, val=str(value))
 
-    def _handle_update_compression_args(self, options, kwargs):
-        if kwargs.get('compression_mode') == 'unset' and options is not None:
+    def _prepare_compression_removal(self, options, kwargs):
+        """
+        Presets payload with values to remove compression attributes in case they are not
+        needed anymore.
+
+        In case compression is not needed the dashboard will send 'compression_mode' with the
+        value 'unset'.
+
+        :param options: All set options for the current pool.
+        :param kwargs: Payload of the PUT / POST call
+        """
+        if options is not None:
             def reset_arg(arg, value):
                 if options.get(arg):
                     kwargs[arg] = value

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -175,7 +175,6 @@ export class PoolFormComponent implements OnInit {
 
   private initInfo(info: PoolFormInfo) {
     this.form.silentSet('algorithm', info.bluestore_compression_algorithm);
-    info.compression_modes.push('unset');
     this.info = info;
   }
 
@@ -602,7 +601,7 @@ export class PoolFormComponent implements OnInit {
             externalFieldName: 'compression_mode',
             formControlName: 'mode',
             editable: true,
-            replaceFn: () => 'unset'
+            replaceFn: () => 'unset' // Is used if no compression is set
           },
           {
             externalFieldName: 'srcpool',


### PR DESCRIPTION
Somehow the compression mode "unset" was shown, but "unset" is only the
key that should be send to the backend in order to know that not
compression mode is selected ("none").

I also added some comments for better understanding.

Fixes: https://tracker.ceph.com/issues/42624
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
