### PR TITLE
mimic: rgw: fix memory growth while deleting objects with

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -725,6 +725,7 @@ int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket,
         }
         max_aio = concurrent_max;
       }
+      obj_ctx.obj.invalidate(obj);
     } // for all RGW objects
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41859

---

backport of https://github.com/ceph/ceph/pull/30174
parent tracker: https://tracker.ceph.com/issues/40700

this backport was staged using ceph-backport.sh version 15.0.0.6814
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh