### PR TITLE
journal: fix flush by age and in-flight byte tracking

### DIFF
--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -258,6 +258,7 @@ void JournalRecorder::open_object_set() {
   ldout(m_cct, 10) << "opening object set " << m_current_set << dendl;
 
   uint8_t splay_width = m_journal_metadata->get_splay_width();
+  bool overflowed = false;
 
   auto lockers{lock_object_recorders()};
   for (const auto& p : m_object_ptrs) {
@@ -267,8 +268,17 @@ void JournalRecorder::open_object_set() {
       ceph_assert(object_recorder->is_closed());
 
       // ready to close object and open object in active set
-      create_next_object_recorder(object_recorder);
+      if (create_next_object_recorder(object_recorder)) {
+        overflowed = true;
+      }
     }
+  }
+  lockers.clear();
+
+  if (overflowed) {
+    ldout(m_cct, 10) << "object set " << m_current_set << " now full" << dendl;
+    ldout(m_cct, 10) << "" << dendl;
+    close_and_advance_object_set(m_current_set);
   }
 }
 
@@ -288,6 +298,8 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
       // flush out all queued appends and hold future appends
       if (!object_recorder->close()) {
         ++m_in_flight_object_closes;
+        ldout(m_cct, 10) << "object " << object_recorder->get_oid() << " "
+                         << "close in-progress" << dendl;
       } else {
         ldout(m_cct, 10) << "object " << object_recorder->get_oid() << " closed"
                          << dendl;
@@ -310,7 +322,7 @@ ceph::ref_t<ObjectRecorder> JournalRecorder::create_object_recorder(
   return object_recorder;
 }
 
-void JournalRecorder::create_next_object_recorder(
+bool JournalRecorder::create_next_object_recorder(
     ceph::ref_t<ObjectRecorder> object_recorder) {
   ceph_assert(ceph_mutex_is_locked(m_lock));
 
@@ -336,8 +348,14 @@ void JournalRecorder::create_next_object_recorder(
       new_object_recorder->get_object_number());
   }
 
-  new_object_recorder->append(std::move(append_buffers));
+  bool object_full = new_object_recorder->append(std::move(append_buffers));
+  if (object_full) {
+    ldout(m_cct, 10) << "object " << new_object_recorder->get_oid() << " "
+                     << "now full" << dendl;
+  }
+
   m_object_ptrs[splay_offset] = std::move(new_object_recorder);
+  return object_full;
 }
 
 void JournalRecorder::handle_update() {

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -114,7 +114,7 @@ private:
 
   ceph::ref_t<ObjectRecorder> create_object_recorder(uint64_t object_number,
                                            ceph::mutex* lock);
-  void create_next_object_recorder(ceph::ref_t<ObjectRecorder> object_recorder);
+  bool create_next_object_recorder(ceph::ref_t<ObjectRecorder> object_recorder);
 
   void handle_update();
 

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -39,6 +39,7 @@ public:
 
 private:
   typedef std::map<uint8_t, ceph::ref_t<ObjectRecorder>> ObjectRecorderPtrs;
+  typedef std::vector<std::unique_lock<ceph::mutex>> Lockers;
 
   struct Listener : public JournalMetadataListener {
     JournalRecorder *journal_recorder;
@@ -120,17 +121,7 @@ private:
   void handle_closed(ObjectRecorder *object_recorder);
   void handle_overflow(ObjectRecorder *object_recorder);
 
-  void lock_object_recorders() {
-    for (auto& lock : m_object_locks) {
-      lock.lock();
-    }
-  }
-
-  void unlock_object_recorders() {
-    for (auto& lock : m_object_locks) {
-      lock.unlock();
-    }
-  }
+  Lockers lock_object_recorders();
 };
 
 } // namespace journal

--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -27,7 +27,7 @@ ObjectRecorder::ObjectRecorder(librados::IoCtx &ioctx, std::string_view oid,
     m_op_work_queue(work_queue), m_handler(handler),
     m_order(order), m_soft_max_size(1 << m_order),
     m_max_in_flight_appends(max_in_flight_appends),
-    m_lock(lock), m_last_flush_time(ceph_clock_now())
+    m_lock(lock)
 {
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext*>(m_ioctx.cct());
@@ -97,8 +97,8 @@ void ObjectRecorder::flush(Context *on_safe) {
     // if currently handling flush notifications, wait so that
     // we notify in the correct order (since lock is dropped on
     // callback)
-    if (m_in_flight_flushes) {
-      m_in_flight_flushes_cond.wait(locker);
+    while (m_in_flight_callbacks) {
+      m_in_flight_callbacks_cond.wait(locker);
     }
 
     // attach the flush to the most recent append
@@ -125,27 +125,21 @@ void ObjectRecorder::flush(Context *on_safe) {
 void ObjectRecorder::flush(const ceph::ref_t<FutureImpl>& future) {
   ldout(m_cct, 20) << "flushing " << *future << dendl;
 
-  m_lock->lock();
-  {
-    auto flush_handler = future->get_flush_handler();
-    auto my_handler = get_flush_handler();
-    if (flush_handler != my_handler) {
-      // if we don't own this future, re-issue the flush so that it hits the
-      // correct journal object owner
-      future->flush();
-      m_lock->unlock();
-      return;
-    } else if (future->is_flush_in_progress()) {
-      m_lock->unlock();
-      return;
-    }
+  std::unique_lock locker{*m_lock};
+  auto flush_handler = future->get_flush_handler();
+  auto my_handler = get_flush_handler();
+  if (flush_handler != my_handler) {
+    // if we don't own this future, re-issue the flush so that it hits the
+    // correct journal object owner
+    future->flush();
+    return;
+  } else if (future->is_flush_in_progress()) {
+    return;
   }
 
-  bool overflowed = send_appends(true, future);
-  if (overflowed) {
-    notify_handler_unlock();
-  } else {
-    m_lock->unlock();
+  if (!m_object_closed && !m_overflowed && send_appends(true, future)) {
+    m_in_flight_callbacks = true;
+    notify_handler_unlock(locker, true);
   }
 }
 
@@ -169,52 +163,63 @@ bool ObjectRecorder::close() {
   ceph_assert(ceph_mutex_is_locked(*m_lock));
 
   ldout(m_cct, 20) << dendl;
+
   send_appends(true, {});
 
   ceph_assert(!m_object_closed);
   m_object_closed = true;
-  return (m_in_flight_tids.empty() && !m_in_flight_flushes);
+
+  if (!m_in_flight_tids.empty() || m_in_flight_callbacks) {
+    m_object_closed_notify = true;
+    return false;
+  }
+
+  return true;
 }
 
 void ObjectRecorder::handle_append_flushed(uint64_t tid, int r) {
   ldout(m_cct, 20) << "tid=" << tid << ", r=" << r << dendl;
 
+  std::unique_lock locker{*m_lock};
+  m_in_flight_callbacks = true;
+
+  auto tid_iter = m_in_flight_tids.find(tid);
+  ceph_assert(tid_iter != m_in_flight_tids.end());
+  m_in_flight_tids.erase(tid_iter);
+
+  InFlightAppends::iterator iter = m_in_flight_appends.find(tid);
+  ceph_assert(iter != m_in_flight_appends.end());
+
+  bool notify_overflowed = false;
   AppendBuffers append_buffers;
-  {
-    m_lock->lock();
-    auto tid_iter = m_in_flight_tids.find(tid);
-    ceph_assert(tid_iter != m_in_flight_tids.end());
-    m_in_flight_tids.erase(tid_iter);
-
-    InFlightAppends::iterator iter = m_in_flight_appends.find(tid);
-    ceph_assert(iter != m_in_flight_appends.end());
-
-    if (r == -EOVERFLOW) {
-      ldout(m_cct, 10) << "append overflowed" << dendl;
-      m_overflowed = true;
-
-      // notify of overflow once all in-flight ops are complete
-      if (m_in_flight_tids.empty()) {
-        append_overflowed();
-        notify_handler_unlock();
-      } else {
-        m_lock->unlock();
-      }
-      return;
+  if (r == -EOVERFLOW) {
+    ldout(m_cct, 10) << "append overflowed: "
+                     << "idle=" << m_in_flight_tids.empty() << ", "
+                     << "previous_overflow=" << m_overflowed << dendl;
+    if (m_in_flight_tids.empty()) {
+      append_overflowed();
     }
 
+    if (!m_object_closed && !m_overflowed) {
+      notify_overflowed = true;
+    }
+    m_overflowed = true;
+  } else {
     append_buffers.swap(iter->second);
     ceph_assert(!append_buffers.empty());
 
     for (auto& append_buffer : append_buffers) {
-      m_object_bytes += append_buffer.second.length();
+      auto length = append_buffer.second.length();
+      m_object_bytes += length;
+
+      ceph_assert(m_in_flight_bytes >= length);
+      m_in_flight_bytes -= length;
     }
     ldout(m_cct, 20) << "object_bytes=" << m_object_bytes << dendl;
 
     m_in_flight_appends.erase(iter);
-    m_in_flight_flushes = true;
-    m_lock->unlock();
   }
+  locker.unlock();
 
   // Flag the associated futures as complete.
   for (auto& append_buffer : append_buffers) {
@@ -222,22 +227,16 @@ void ObjectRecorder::handle_append_flushed(uint64_t tid, int r) {
     append_buffer.first->safe(r);
   }
 
-  // wake up any flush requests that raced with a RADOS callback
-  m_lock->lock();
-  m_in_flight_flushes = false;
-  m_in_flight_flushes_cond.notify_all();
-
-  if (m_in_flight_appends.empty() && (m_object_closed || m_overflowed)) {
-    // all remaining unsent appends should be redirected to new object
-    notify_handler_unlock();
-  } else {
-    bool overflowed = send_appends(false, {});
-    if (overflowed) {
-      notify_handler_unlock();
-    } else {
-      m_lock->unlock();
-    }
+  // attempt to kick off more appends to the object
+  locker.lock();
+  if (!m_object_closed && !m_overflowed && send_appends(false, {})) {
+    notify_overflowed = true;
   }
+
+  ldout(m_cct, 20) << "pending tids=" << m_in_flight_tids << dendl;
+
+  // all remaining unsent appends should be redirected to new object
+  notify_handler_unlock(locker, notify_overflowed);
 }
 
 void ObjectRecorder::append_overflowed() {
@@ -280,10 +279,15 @@ bool ObjectRecorder::send_appends(bool force, ceph::ref_t<FutureImpl> flush_futu
   if (!force &&
       ((m_flush_interval > 0 && m_pending_buffers.size() >= m_flush_interval) ||
        (m_flush_bytes > 0 && m_pending_bytes >= m_flush_bytes) ||
-       (m_flush_age > 0 &&
-        m_last_flush_time + m_flush_age >= ceph_clock_now()))) {
+       (m_flush_age > 0 && !m_last_flush_time.is_zero() &&
+        m_last_flush_time + m_flush_age <= ceph_clock_now()))) {
     ldout(m_cct, 20) << "forcing batch flush" << dendl;
     force = true;
+  }
+
+  // start tracking flush time after the first append event
+  if (m_last_flush_time.is_zero()) {
+    m_last_flush_time = ceph_clock_now();
   }
 
   auto max_in_flight_appends = m_max_in_flight_appends;
@@ -315,10 +319,10 @@ bool ObjectRecorder::send_appends(bool force, ceph::ref_t<FutureImpl> flush_futu
     auto& bl = it->second;
     auto size = m_object_bytes + m_in_flight_bytes + append_bytes + bl.length();
     if (size == m_soft_max_size) {
-      ldout(m_cct, 10) << "object at capacity " << *future << dendl;
+      ldout(m_cct, 10) << "object at capacity (" << size << ") " << *future << dendl;
       m_overflowed = true;
     } else if (size > m_soft_max_size) {
-      ldout(m_cct, 10) << "object beyond capacity " << *future << dendl;
+      ldout(m_cct, 10) << "object beyond capacity (" << size << ") " << *future << dendl;
       m_overflowed = true;
       break;
     }
@@ -373,15 +377,43 @@ bool ObjectRecorder::send_appends(bool force, ceph::ref_t<FutureImpl> flush_futu
   return m_overflowed;
 }
 
-void ObjectRecorder::notify_handler_unlock() {
+void ObjectRecorder::wake_up_flushes() {
   ceph_assert(ceph_mutex_is_locked(*m_lock));
-  if (m_object_closed) {
-    m_lock->unlock();
-    m_handler->closed(this);
-  } else {
+  m_in_flight_callbacks = false;
+  m_in_flight_callbacks_cond.notify_all();
+}
+
+void ObjectRecorder::notify_handler_unlock(
+    std::unique_lock<ceph::mutex>& locker, bool notify_overflowed) {
+  ceph_assert(ceph_mutex_is_locked(*m_lock));
+  ceph_assert(m_in_flight_callbacks);
+
+  if (!m_object_closed && notify_overflowed) {
     // TODO need to delay completion until after aio_notify completes
-    m_lock->unlock();
+    ldout(m_cct, 10) << "overflow" << dendl;
+    ceph_assert(m_overflowed);
+
+    locker.unlock();
     m_handler->overflow(this);
+    locker.lock();
+  }
+
+  // wake up blocked flush requests
+  wake_up_flushes();
+
+  // An overflow notification might have blocked a close. A close
+  // notification could lead to the immediate destruction of this object
+  // so the object shouldn't be referenced anymore
+  bool object_closed_notify = false;
+  if (m_in_flight_tids.empty()) {
+    std::swap(object_closed_notify, m_object_closed_notify);
+  }
+  ceph_assert(m_object_closed || !object_closed_notify);
+  locker.unlock();
+
+  if (object_closed_notify) {
+    ldout(m_cct, 10) << "closed" << dendl;
+    m_handler->closed(this);
   }
 }
 

--- a/src/journal/ObjectRecorder.h
+++ b/src/journal/ObjectRecorder.h
@@ -135,20 +135,25 @@ private:
   InFlightTids m_in_flight_tids;
   InFlightAppends m_in_flight_appends;
   uint64_t m_object_bytes = 0;
+
   bool m_overflowed = false;
+
   bool m_object_closed = false;
+  bool m_object_closed_notify = false;
 
   bufferlist m_prefetch_bl;
 
-  bool m_in_flight_flushes = false;
-  ceph::condition_variable m_in_flight_flushes_cond;
+  bool m_in_flight_callbacks = false;
+  ceph::condition_variable m_in_flight_callbacks_cond;
   uint64_t m_in_flight_bytes = 0;
 
   bool send_appends(bool force, ceph::ref_t<FutureImpl> flush_sentinal);
   void handle_append_flushed(uint64_t tid, int r);
   void append_overflowed();
 
-  void notify_handler_unlock();
+  void wake_up_flushes();
+  void notify_handler_unlock(std::unique_lock<ceph::mutex>& locker,
+                             bool notify_overflowed);
 };
 
 } // namespace journal

--- a/src/test/journal/test_ObjectRecorder.cc
+++ b/src/test/journal/test_ObjectRecorder.cc
@@ -118,7 +118,8 @@ public:
     Handler m_handler;
   };
 
-  journal::AppendBuffer create_append_buffer(uint64_t tag_tid, uint64_t entry_tid,
+  journal::AppendBuffer create_append_buffer(uint64_t tag_tid,
+                                             uint64_t entry_tid,
                                              const std::string &payload) {
     auto future = ceph::make_ref<journal::FutureImpl>(tag_tid, entry_tid, 456);
     future->init(ceph::ref_t<journal::FutureImpl>());
@@ -237,7 +238,7 @@ TEST_F(TestObjectRecorder, AppendFlushByAge) {
   ASSERT_EQ(0, init_metadata(metadata));
 
   ceph::mutex lock = ceph::make_mutex("object_recorder_lock");
-  ObjectRecorderFlusher flusher(m_ioctx, m_work_queue, 0, 0, 0.1, -1);
+  ObjectRecorderFlusher flusher(m_ioctx, m_work_queue, 0, 0, 0.0005, -1);
   auto object = flusher.create_object(oid, 24, &lock);
 
   journal::AppendBuffer append_buffer1 = create_append_buffer(234, 123,
@@ -248,12 +249,20 @@ TEST_F(TestObjectRecorder, AppendFlushByAge) {
   ASSERT_FALSE(object->append(std::move(append_buffers)));
   lock.unlock();
 
-  journal::AppendBuffer append_buffer2 = create_append_buffer(234, 124,
-                                                              "payload");
-  append_buffers = {append_buffer2};
-  lock.lock();
-  ASSERT_FALSE(object->append(std::move(append_buffers)));
-  lock.unlock();
+  uint32_t offset  = 0;
+  journal::AppendBuffer append_buffer2;
+  while (!append_buffer1.first->is_flush_in_progress() &&
+         !append_buffer1.first->is_complete()) {
+    usleep(1000);
+
+    append_buffer2 = create_append_buffer(234, 124 + offset, "payload");
+    ++offset;
+    append_buffers = {append_buffer2};
+
+    lock.lock();
+    ASSERT_FALSE(object->append(std::move(append_buffers)));
+    lock.unlock();
+  }
 
   C_SaferCond cond;
   append_buffer2.first->wait(&cond);
@@ -269,7 +278,7 @@ TEST_F(TestObjectRecorder, AppendFilledObject) {
   ASSERT_EQ(0, init_metadata(metadata));
 
   ceph::mutex lock = ceph::make_mutex("object_recorder_lock");
-  ObjectRecorderFlusher flusher(m_ioctx, m_work_queue);
+  ObjectRecorderFlusher flusher(m_ioctx, m_work_queue, 0, 0, 0.0, -1);
   auto object = flusher.create_object(oid, 12, &lock);
 
   std::string payload(2048, '1');
@@ -439,8 +448,6 @@ TEST_F(TestObjectRecorder, Overflow) {
   append_buffer2.first->wait(&cond);
   ASSERT_EQ(0, cond.wait());
   ASSERT_EQ(0U, object1->get_pending_appends());
-
-  ASSERT_TRUE(flusher.wait_for_overflow());
 
   auto object2 = flusher.create_object(oid, 12, &lock2);
 


### PR DESCRIPTION
The flush by age was always causing an immediate flush due to a
backwards comparison. Additionally, the in-flight byte tracker was
never decremented which caused premature closure of the journal
object. Finally, there was a potential race condition between
closing the object and in-flight notification callbacks executing.

Fixes: https://tracker.ceph.com/issues/42598
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
