### PR TITLE
mgr/dashboard: disable pg_autoscale for new pools in e2e tests

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -58,6 +58,13 @@ if [ "$BASE_URL" == "" ]; then
     # Set SSL verify to False
     ./bin/ceph dashboard set-rgw-api-ssl-verify False
 
+    # Disable PG autoscaling for new pools. This is a temporary workaround.
+    # e2e tests for pools should be adapted to remove this workaround after
+    # these issues are resolved:
+    # - https://tracker.ceph.com/issues/38227
+    # - https://tracker.ceph.com/issues/42638
+    ./bin/ceph config set global osd_pool_default_pg_autoscale_mode off
+
     BASE_URL=$(./bin/ceph mgr services | jq -r .dashboard)
 fi
 


### PR DESCRIPTION
The pg_autoscaler might interfere the editing pool e2e test, disable the
global config to avoid this problem.

Fixes: https://tracker.ceph.com/issues/42608
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
