### PR TITLE
rgw:cleanup:remove un-used class member in RGWDeleteLC

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1553,19 +1553,8 @@ public:
 };
 
 class RGWDeleteLC : public RGWOp {
-protected:
-  size_t len;
-  char *data;
-
 public:
-  RGWDeleteLC() {
-    len = 0;
-    data = NULL;
-  }
-  ~RGWDeleteLC() override {
-    free(data);
-  }
-
+  RGWDeleteLC() = default;
   int verify_permission() override;
   void pre_exec() override;
   void execute() override;


### PR DESCRIPTION
Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


