### PR TITLE
mimic: ceph-volume: mokeypatch calls to lvm related binaries

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -815,6 +815,7 @@ class TestSplitNameParser(object):
 class TestIsLV(object):
 
     def test_is_not_an_lv(self, monkeypatch):
+        monkeypatch.setattr(api.process, 'call', lambda x, **kw: ('', '', 0))
         monkeypatch.setattr(api, 'dmsetup_splitname', lambda x, **kw: {})
         assert api.is_lv('/dev/sda1', lvs=[]) is False
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -1,5 +1,6 @@
 import pytest
 from ceph_volume.devices.lvm.strategies import bluestore
+from ceph_volume.api import lvm
 
 
 class TestSingleType(object):
@@ -52,7 +53,7 @@ class TestSingleType(object):
 
 class TestMixedType(object):
 
-    def test_filter_all_data_devs(self, fakedevice, factory):
+    def test_filter_all_data_devs(self, fakedevice, factory, monkeypatch):
         # in this scenario the user passed a already used device to be used for
         # data and an unused device to be used as db device.
         db_dev = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=False, sys_api=dict(size=6073740000))
@@ -60,6 +61,7 @@ class TestMixedType(object):
         args = factory(filtered_devices=[data_dev], osds_per_device=1,
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
+        monkeypatch.setattr(lvm, 'VolumeGroup', lambda x, **kw: [])
         bluestore.MixedType(args, [], [db_dev], [])
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42534

---

backport of https://github.com/ceph/ceph/pull/31197
parent tracker: https://tracker.ceph.com/issues/42045

this backport was staged using ceph-backport.sh version 15.0.0.6814
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh