### PR TITLE
nautilus: mgr/ActivePyModules: behave if a module queries a devid that does not exist

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -2705,6 +2705,13 @@ function test_mgr_tell()
   ceph tell mgr osd status
 }
 
+function test_mgr_devices()
+{
+  ceph device ls
+  expect_false ceph device info doesnotexist
+  expect_false ceph device get-health-metrics doesnotexist
+}
+
 function test_per_pool_scrub_status()
 {
   ceph osd pool create noscrub_pool 12
@@ -2807,6 +2814,7 @@ MDS_TESTS+=" mon_mds_metadata"
 MDS_TESTS+=" mds_tell_help_command"
 
 MGR_TESTS+=" mgr_tell"
+MGR_TESTS+=" mgr_devices"
 
 TESTS+=$MON_TESTS
 TESTS+=$OSD_TESTS

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -314,10 +314,15 @@ PyObject *ActivePyModules::get_python(const std::string &what)
   } else if (what.size() > 7 &&
 	     what.substr(0, 7) == "device ") {
     string devid = what.substr(7);
-    daemon_state.with_device(devid, [&f, &tstate] (const DeviceState& dev) {
-        PyEval_RestoreThread(tstate);
-	f.dump_object("device", dev);
-      });
+    if (!daemon_state.with_device(
+	  devid,
+	  [&f, &tstate] (const DeviceState& dev) {
+	    PyEval_RestoreThread(tstate);
+	    f.dump_object("device", dev);
+	  })) {
+      // device not found
+      PyEval_RestoreThread(tstate);
+    }
     return f.get();
   } else if (what == "io_rate") {
     cluster_state.with_pgmap(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42648
possibly a backport of https://github.com/ceph/ceph/pull/31291
parent tracker: https://tracker.ceph.com/issues/42578

---

original PR body:

https://tracker.ceph.com/issues/42648

---

updated using ceph-backport.sh version 15.0.0.6814
