### PR TITLE
qa/rgw: use 'testing' kms backend for other rgw subsuites

### DIFF
--- a/qa/suites/rgw/multifs/overrides.yaml
+++ b/qa/suites/rgw/multifs/overrides.yaml
@@ -4,6 +4,7 @@ overrides:
     conf:
       client:
         debug rgw: 20
+        rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false
   rgw:

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -8,5 +8,6 @@ overrides:
     conf:
       client:
         rgw lc debug interval: 10
+        rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false

--- a/qa/suites/rgw/website/overrides.yaml
+++ b/qa/suites/rgw/website/overrides.yaml
@@ -11,6 +11,7 @@ overrides:
         osd_max_pg_log_entries: 10
       client:
         debug rgw: 20
+        rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false
         rgw enable static website: True


### PR DESCRIPTION
resolves test failures under rgw/{multifs,thrash,website} similar to https://github.com/ceph/ceph/pull/30940