### PR TITLE
osd/OSDMap: Show health warning if a pool is configured with size 1

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -38,6 +38,17 @@
 
     ceph config set global mon_warn_on_pool_pg_num_not_power_of_two false
 
+* Ceph will issue a health warning if a RADOS pool's ``size`` is set to 1
+  or in other words the pool is configured with no redundancy. This can
+  be fixed by setting the pool size to the minimum recommended value
+  with::
+
+    ceph osd pool set <pool-name> size <num-replicas>
+
+  The warning can be silenced with::
+
+    ceph config set global mon_warn_on_pool_no_redundancy false
+
 
 >=15.0.0
 --------

--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -420,6 +420,14 @@ by setting it in the ``[mon]`` section of the configuration file.
 :Default: ``0``
 
 
+``mon warn on pool no redundancy``
+
+:Description: Issue a ``HEALTH_WARN`` in cluster log if any pool is
+              configured with no replicas.
+:Type: Boolean
+:Default: ``True``
+
+
 ``mon cache target full warn ratio``
 
 :Description: Position between pool's ``cache_target_full`` and

--- a/qa/standalone/mon/health-mute.sh
+++ b/qa/standalone/mon/health-mute.sh
@@ -37,6 +37,21 @@ function TEST_mute() {
 
     ceph -s
     ceph health | grep HEALTH_OK || return 1
+    # test warning on setting pool size=1
+    ceph osd pool set foo size 1
+    ceph -s
+    ceph health | grep HEALTH_WARN || return 1
+    ceph health detail | grep POOL_NO_REDUNDANCY || return 1
+    ceph health mute POOL_NO_REDUNDANCY
+    ceph -s
+    ceph health | grep HEALTH_OK | grep POOL_NO_REDUNDANCY || return 1
+    ceph health unmute POOL_NO_REDUNDANCY
+    ceph -s
+    ceph health | grep HEALTH_WARN || return 1
+    # restore pool size to default
+    ceph osd pool set foo size 3
+    ceph -s
+    ceph health | grep HEALTH_OK || return 1
     ceph osd set noup
     ceph -s
     ceph health detail | grep OSDMAP_FLAGS || return 1

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -29,6 +29,7 @@
 	mon warn on osd down out interval zero = false
 	mon warn on too few osds = false
 	mon_warn_on_pool_pg_num_not_power_of_two = false
+        mon_warn_on_pool_no_redundancy = false
 
         osd pool default erasure code profile = "plugin=jerasure technique=reed_sol_van k=2 m=1 ruleset-failure-domain=osd crush-failure-domain=osd"
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1712,6 +1712,13 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description("issue POOL_PG_NUM_NOT_POWER_OF_TWO warning if pool has a non-power-of-two pg_num value"),
 
+    Option("mon_warn_on_pool_no_redundancy", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .add_service("mon")
+    .set_description("Issue a health warning if any pool is configured with no replicas")
+    .add_see_also("osd_pool_default_size")
+    .add_see_also("osd_pool_default_min_size"),
+
     Option("mon_warn_on_misplaced", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .add_service("mgr")

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5915,6 +5915,27 @@ void OSDMap::check_health(CephContext *cct,
       d.detail.swap(detail);
     }
   }
+
+  // POOL_NO_REDUNDANCY
+  if (cct->_conf.get_val<bool>("mon_warn_on_pool_no_redundancy"))
+  {
+    list<string> detail;
+    for (auto it : get_pools()) {
+      if (it.second.get_size() == 1) {
+        ostringstream ss;
+        ss << "pool '" << get_pool_name(it.first)
+           << "' has no replicas configured";
+        detail.push_back(ss.str());
+      }
+    }
+    if (!detail.empty()) {
+      ostringstream ss;
+      ss << detail.size() << " pool(s) have no replicas configured";
+      auto& d = checks->add("POOL_NO_REDUNDANCY", HEALTH_WARN,
+        ss.str(), detail.size());
+      d.detail.swap(detail);
+    }
+  }
 }
 
 int OSDMap::parse_osd_id_list(const vector<string>& ls, set<int> *out,


### PR DESCRIPTION
Introduce a config option called 'mon_warn_on_pool_no_redundancy'
that is used to show a health warning if any pool in the ceph cluster is
configured with a size of 1. The user can mute the warning using 'ceph
health mute POOL_NO_REDUNDANCY'.

Add standalone test to verify warning on setting pool size=1.

Fixes: https://tracker.ceph.com/issues/41666
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
