### PR TITLE
mgr/dashboard: Manage PG autoscaling

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -67,8 +67,27 @@
         </div>
 
         <div *ngIf="form.getValue('poolType')">
-          <!-- Pg number -->
+          <!-- PG Autoscale Mode -->
           <div class="form-group row">
+            <label i18n
+                   class="col-form-label col-sm-3"
+                   for="pgAutoscaleMode">PG Autoscale</label>
+            <div class="col-sm-9">
+              <select class="form-control custom-select"
+                      id="pgAutoscaleMode"
+                      name="pgAutoscaleMode"
+                      formControlName="pgAutoscaleMode">
+                <option *ngFor="let mode of pgAutoscaleModes"
+                        [value]="mode">
+                  {{ mode }}
+                </option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Pg number -->
+          <div class="form-group row"
+               *ngIf="form.getValue('pgAutoscaleMode') !== 'on'">
             <label class="col-form-label col-sm-3"
                    for="pgNum">
               <ng-container i18n>Placement groups</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -18,6 +18,7 @@ import {
   i18nProviders
 } from '../../../../testing/unit-test-helper';
 import { NotFoundComponent } from '../../../core/not-found/not-found.component';
+import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { ErasureCodeProfileService } from '../../../shared/api/erasure-code-profile.service';
 import { PoolService } from '../../../shared/api/pool.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
@@ -39,6 +40,7 @@ describe('PoolFormComponent', () => {
   let component: PoolFormComponent;
   let fixture: ComponentFixture<PoolFormComponent>;
   let poolService: PoolService;
+  let configurationService: ConfigurationService;
   let form: CdFormGroup;
   let router: Router;
   let ecpService: ErasureCodeProfileService;
@@ -162,6 +164,10 @@ describe('PoolFormComponent', () => {
 
   beforeEach(() => {
     setUpPoolComponent();
+    configurationService = TestBed.get(ConfigurationService);
+    spyOn(configurationService, 'get').and.callFake(() => [
+      { default: 'off', enum_values: ['on', 'warn', 'off'], value: [] }
+    ]);
     poolService = TestBed.get(PoolService);
     spyOn(poolService, 'getInfo').and.callFake(() => [component.info]);
     ecpService = TestBed.get(ErasureCodeProfileService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
@@ -77,4 +77,23 @@ describe('ConfigurationService', () => {
     const reg = httpTesting.expectOne('api/cluster_conf/testOption?section=testSection');
     expect(reg.request.method).toBe('DELETE');
   });
+
+  it('should get value', () => {
+    const config = {
+      default: 'a',
+      value: [
+        { section: 'global', value: 'b' },
+        { section: 'mon', value: 'c' },
+        { section: 'mon.1', value: 'd' },
+        { section: 'mds', value: 'e' }
+      ]
+    };
+    expect(service.getValue(config, 'mon.1')).toBe('d');
+    expect(service.getValue(config, 'mon')).toBe('c');
+    expect(service.getValue(config, 'mds.1')).toBe('e');
+    expect(service.getValue(config, 'mds')).toBe('e');
+    expect(service.getValue(config, 'osd')).toBe('b');
+    config.value = [];
+    expect(service.getValue(config, 'osd')).toBe('a');
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.ts
@@ -10,6 +10,30 @@ import { ApiModule } from './api.module';
 export class ConfigurationService {
   constructor(private http: HttpClient) {}
 
+  private findValue(config, section: string) {
+    if (!config.value) {
+      return undefined;
+    }
+    return config.value.find((v) => v.section === section);
+  }
+
+  getValue(config, section: string) {
+    let val = this.findValue(config, section);
+    if (!val) {
+      const indexOfDot = section.indexOf('.');
+      if (indexOfDot !== -1) {
+        val = this.findValue(config, section.substring(0, indexOfDot));
+      }
+    }
+    if (!val) {
+      val = this.findValue(config, 'global');
+    }
+    if (val) {
+      return val.value;
+    }
+    return config.default;
+  }
+
   getConfigData() {
     return this.http.get('api/cluster_conf/');
   }


### PR DESCRIPTION
It's now possible to select the PG autoscale mode from the pool form.

By default, the value from config `osd_pool_default_pg_autoscale_mode` will be used.

![Screenshot from 2019-11-05 15-00-16](https://user-images.githubusercontent.com/14297426/68218947-11066d80-ffdd-11e9-82fe-fcd4f909e423.png)

Fixes: https://tracker.ceph.com/issues/38227

Signed-off-by: Ricardo Marques <rimarques@suse.com>
