### PR TITLE
mon/HealthMonitor: add a health_warn 

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -606,6 +606,22 @@ bool HealthMonitor::check_member_health()
       d.detail.push_back(ds.str());
     }
   }
+  // MON_OSD_REPORT_TIMEOUT_TOO_SMALL
+  {
+    // mon_osd_report_timeout <= osd_beacon_report_interval will result in mon mark
+    // the osd down wrongly. Sometimes we change one and may ingnore the other one. 
+    // It is a error configuration but not easy be found by ceph beginner, so we should
+    // report a HEALTH_WARN in this case.As osd_beacon_report_interval can be configued
+    // separately by osd, we cannot get the realtime osd config here, the warnging is 
+    // incomplete.
+    if (g_conf()->mon_osd_report_timeout <= g_conf()->osd_beacon_report_interval) {
+      ostringstream ss, ds;
+      ss << "mon%plurals% %names% %hasorhave% mon_osd_report_timeout is less than or equal to osd_beacon_report_interval";
+      auto& d = next.add("MON_OSD_REPORT_TIMEOUT_TOO_SMALL", HEALTH_WARN, ss.str(), 1);
+      ds << "mon." << mon->name << " mon_osd_report_timeout is less than or equal to osd_beacon_report_interval";
+      d.detail.push_back(ds.str());
+    }
+  }
 
   auto p = quorum_checks.find(mon->rank);
   if (p == quorum_checks.end()) {


### PR DESCRIPTION
mon/HealthMonitor: add a health_warn when mon_osd_report_timeout <= osd_beacon_report_interval

when mon_osd_report_timeout <= osd_beacon_report_interval, mon maynot receive
osd'beacon before mon_osd_report_timeout, so mon will mark the osd down. Sometimes
we change one and may ingnore the other one. It is an error configuration but not
easy to be found by ceph beginner, so we should report a HEALTH_WARN in this case.
As osd_beacon_report_interval can be configued separately by osd, we cannot get
the realtime osd config here, the warnging is incomplete.

Fixes: https://tracker.ceph.com/issues/42659
Signed-off-by: luo rixin <luorixin@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
