### PR TITLE
rgw: correct some error log about reshard in cls_rgw.cc.

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3845,7 +3845,7 @@ static int rgw_guard_bucket_resharding(cls_method_context_t hctx, bufferlist *in
   try {
     decode(op, in_iter);
   } catch (buffer::error& err) {
-    CLS_LOG(1, "ERROR: cls_rgw_clear_bucket_resharding: failed to decode entry\n");
+    CLS_LOG(1, "ERROR: %s(): failed to decode entry\n", __func__);
     return -EINVAL;
   }
 
@@ -3872,7 +3872,7 @@ static int rgw_get_bucket_resharding(cls_method_context_t hctx,
   try {
     decode(op, in_iter);
   } catch (buffer::error& err) {
-    CLS_LOG(1, "ERROR: cls_rgw_clear_bucket_resharding: failed to decode entry\n");
+    CLS_LOG(1, "ERROR: %s(): failed to decode entry\n", __func__);
     return -EINVAL;
   }
 


### PR DESCRIPTION
The error logs don't correspond to the function name.
Signed-off-by: zhangshaowen <zhangshaowen@cmss.chinamobile.com>

