### PR TITLE
mgr/{dashboard,prometheus}: return FQDN instead of '0.0.0.0'

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -179,7 +179,7 @@ class CherryPyConfig(object):
 
         uri = "{0}://{1}:{2}{3}/".format(
             'https' if ssl else 'http',
-            socket.getfqdn() if server_addr == "::" else server_addr,
+            socket.getfqdn() if server_addr in ['::', '0.0.0.0'] else server_addr,
             server_port,
             self.url_prefix
         )

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1087,7 +1087,7 @@ class Module(MgrModule):
         # Publish the URI that others may use to access the service we're
         # about to start serving
         self.set_uri('http://{0}:{1}/'.format(
-            socket.getfqdn() if server_addr == '::' else server_addr,
+            socket.getfqdn() if server_addr in ['::', '0.0.0.0'] else server_addr,
             server_port
         ))
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/ceph/ceph/pull/28246.

The FQDN is returned if an IPv6 interface is available and no `server_addr` is set. '0.0.0.0' was returned if only IPv4 is available. This PR changes this behavior to also return the FQDN.

Fixes: https://tracker.ceph.com/issues/42664