### PR TITLE
mgr/dashboard: cheroot moved into a separate project 

### DIFF
--- a/src/pybind/mgr/dashboard/cherrypy_backports.py
+++ b/src/pybind/mgr/dashboard/cherrypy_backports.py
@@ -75,7 +75,7 @@ def patch_builtin_ssl_wrap(v, new_wrap):
     if v < StrictVersion("9.0.0"):
         from cherrypy.wsgiserver.ssl_builtin import BuiltinSSLAdapter as builtin_ssl
     else:
-        from cherrypy.cheroot.ssl.builtin import BuiltinSSLAdapter as builtin_ssl
+        from cheroot.ssl.builtin import BuiltinSSLAdapter as builtin_ssl
     builtin_ssl.wrap = new_wrap(builtin_ssl.wrap)
 
 


### PR DESCRIPTION
CherryPy > 9.0.0 moved the cheroot module into a separate project. See here https://github.com/cherrypy/cherrypy/pull/1548

Introduced in https://github.com/ceph/ceph/pull/31014

Signed-off-by: Joshua Schmid <jschmid@suse.de>


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
