### PR TITLE
luminous: tests: qa/tasks/ceph.py: pass cluster_name to get_mons

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -383,14 +383,14 @@ def cephfs_setup(ctx, config):
     yield
 
 
-def get_mons(roles, ips):
+def get_mons(roles, ips, cluster_name):
     """
     Get monitors and their associated addresses
     """
     mons = {}
     ports = {}
     mon_id = 0
-    is_mon = teuthology.is_type('mon')
+    is_mon = teuthology.is_type('mon', cluster_name)
     for idx, roles in enumerate(roles):
         for role in roles:
             if not is_mon(role):
@@ -590,7 +590,7 @@ def cluster(ctx, config):
     roles = [role_list for (remote, role_list) in remotes_and_roles]
     ips = [host for (host, port) in
            (remote.ssh.get_transport().getpeername() for (remote, role_list) in remotes_and_roles)]
-    mons = get_mons(roles, ips)
+    mons = get_mons(roles, ips, cluster_name)
     conf = skeleton_config(
         ctx, roles=roles, ips=ips, mons=mons, cluster=cluster_name,
     )

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -443,8 +443,7 @@ def skeleton_config(ctx, roles, ips, mons, cluster='ceph'):
     return conf
 
 def create_simple_monmap(ctx, remote, conf, mons,
-                         path=None,
-                         mon_bind_addrvec=False):
+                         path=None):
     """
     Writes a simple monmap based on current ceph.conf into path, or
     <testdir>/monmap by default.
@@ -469,12 +468,9 @@ def create_simple_monmap(ctx, remote, conf, mons,
         '--create',
         '--clobber',
     ]
-    for (name, addr) in addresses:
-        n = name[4:]
-        if mon_bind_addrvec:
-            args.extend(('--addv', n, addr))
-        else:
-            args.extend(('--add', n, addr))
+    for (role, addr) in addresses:
+        _, _, n = teuthology.split_role(role)
+        args.extend(('--add', n, addr))
     if not path:
         path = '{tdir}/monmap'.format(tdir=testdir)
     args.extend([

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -610,6 +610,7 @@ def cluster(ctx, config):
         ctx.ceph = {}
     ctx.ceph[cluster_name] = argparse.Namespace()
     ctx.ceph[cluster_name].conf = conf
+    ctx.ceph[cluster_name].mons = mons
 
     default_keyring = '/etc/ceph/{cluster}.keyring'.format(cluster=cluster_name)
     keyring_path = config.get('keyring_path', default_keyring)

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -2505,7 +2505,7 @@ class CephManager:
         """
         Extract all the monitor status information from the cluster
         """
-        addr = self.ctx.ceph[self.cluster].conf['mon.%s' % mon]['mon addr']
+        addr = self.ctx.ceph[self.cluster].mons['mon.%s' % mon]
         out = self.raw_cluster_cmd('-m', addr, 'mon_status')
         return json.loads(out)
 

--- a/qa/tasks/mon_seesaw.py
+++ b/qa/tasks/mon_seesaw.py
@@ -23,7 +23,7 @@ def _get_next_port(ctx, ip, cluster):
     # assuming we have only one cluster here.
     used = []
     for name in teuthology.get_mon_names(ctx, cluster):
-        addr = ctx.ceph[cluster].conf[name]['mon addr']
+        addr = ctx.ceph[cluster].mons[name]
         mon_ip, mon_port = addr.split(':')
         if mon_ip != ip:
             continue


### PR DESCRIPTION
NOTE: fix for bad backport #30842

backport tracker: https://tracker.ceph.com/issues/42663

---

backport of https://github.com/ceph/ceph/pull/31424 (NOTE: mimic-only fix)
parent tracker: https://tracker.ceph.com/issues/42658

this backport was staged using ceph-backport.sh version 15.0.0.6869
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh