### PR TITLE
install-deps.sh: Install python headers on openSUSE/SLE

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -414,6 +414,8 @@ else
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
         $SUDO $zypp_install systemd-rpm-macros
+        # python header files are needed to install inside the virtualenv (eg. xmlsec needs the header files)
+        $SUDO $zypp_install python-devel python3-devel
         munge_ceph_spec_in $with_seastar $for_make_check $DIR/ceph.spec
         $SUDO $zypp_install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         ;;


### PR DESCRIPTION
When installing python modules from source, the python headers are
needed when the module needs to compile code. This is eg. needed for
xmlsec. Without Python.h available, ./install-deps.sh fails with:

/tmp/pip-wheel-Kx6zVj/xmlsec/src/platform.h:16:10: \
    fatal error: Python.h: No such file or directory

Fixes: https://tracker.ceph.com/issues/42665

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>

