### PR TITLE
ceph-daemon: Remove data dir during adopt

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -1401,12 +1401,14 @@ def command_adopt():
 
         # data
         logger.info('Moving data...')
-        data_dir_src = ('/var/lib/ceph/%s/%s-%s/*' %
+        data_dir_src = ('/var/lib/ceph/%s/%s-%s' %
                         (daemon_type, args.cluster, daemon_id))
         data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id)
-        for data_file in glob(data_dir_src):
+        for data_file in glob(os.path.join(data_dir_src, '*')):
             logger.debug('Move \'%s\' -> \'%s\'' % (data_file, data_dir_dst))
             shutil.move(data_file, data_dir_dst)
+        logger.debug('Remove dir \'%s\'' % (data_dir_src))
+        os.rmdir(data_dir_src)
 
         # config
         config_src = '/etc/ceph/%s.conf' % (args.cluster)


### PR DESCRIPTION
ceph-daemon is leaving behind an empty dir after successfully adopting a legacy service.

```
# python3 ./ceph-daemon -d adopt --name mds.mon1 --style legacy
<snip>

# ll /var/lib/ceph/c5b2a335-ad78-4a10-a89b-84657184cfd6/mds.mon1/
total 12
-rwx------ 1 root root 716 Nov  6 15:47 cmd
-rw-r--r-- 1 root root 852 Nov  6 15:47 config
-rw------- 1 ceph ceph 263 Nov  4 21:00 keyring
# ll /var/lib/ceph/mds/ceph-mon1/
total 0
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
