### PR TITLE
qa/standalone/test_ceph_daemon: Fix ceph daemon standalone test

### DIFF
--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -11,6 +11,12 @@ if [ -z "$CEPH_DAEMON" ]; then
     which ceph-daemon && CEPH_DAEMON=$(which ceph-daemon)
 fi
 
+# at this point, we need $CEPH_DAEMON set
+if [ -z "$CEPH_DAEMON" ]; then
+    echo "ceph-daemon not found.Please set \$CEPH_DAEMON"
+    exit 1
+fi
+
 # respawn ourselves with a shebang
 PYTHONS="python3 python2"  # which pythons we test
 if [ -z "$PYTHON_KLUDGE" ]; then

--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -6,6 +6,7 @@ IMAGE='ceph/daemon-base:latest-master-devel'
 [ -z "$SUDO" ] && SUDO=sudo
 
 if [ -z "$CEPH_DAEMON" ]; then
+    [ -x src/ceph-daemon ] && CEPH_DAEMON=src/ceph-daemon
     [ -x ../src/ceph-daemon ] && CEPH_DAEMON=../src/ceph-daemon
     [ -x ./ceph-daemon ] && CEPH_DAEMON=.ceph-daemon
     which ceph-daemon && CEPH_DAEMON=$(which ceph-daemon)


### PR DESCRIPTION
Fix multiple problems with qa/standalone/test_ceph_daemon.sh :

- fix hang when no CEPH_DAEMON is set/found
- allow running the script from root/ dir
- allow using custom images