### PR TITLE
kv/RocksDBStore: Add minimum key limit before invoking DeleteRange.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3597,6 +3597,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("rocksdb_delete_range_threshold", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1024)
+    .set_description("The number of keys required to invoke DeleteRange when deleting muliple keys."),
+
     Option("rocksdb_bloom_bits_per_key", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(20)
     .set_description("Number of bits per key to use for RocksDB's bloom filters.")

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -120,6 +120,7 @@ public:
   /// compact the underlying rocksdb store
   bool compact_on_mount;
   bool disableWAL;
+  const uint64_t delete_range_threshold;
   void compact() override;
 
   void compact_async() override {
@@ -157,7 +158,8 @@ public:
     compact_queue_stop(false),
     compact_thread(this),
     compact_on_mount(false),
-    disableWAL(false)
+    disableWAL(false),
+    delete_range_threshold(cct->_conf.get_val<uint64_t>("rocksdb_delete_range_threshold"))
   {}
 
   ~RocksDBStore() override;


### PR DESCRIPTION
This is a spiritual resurrection of #27317 after the changes were reverted in #15183.  It turns out that DeleteRange is still incredibly problematic.  Multiple range tombstones will very quickly fragment RocksDB's memtables leading to exceptionally bad RocksDB performance and ultimately extremely slow and resource intensive OSDs.  This PR works the same way as #27317 by creating a threshold where N (1024 by default) keys must be deleted at once before DeleteRange is invoked.

An easy to reproduce test that showcases this behavior is to create 10000 RGW buckets, then immediately delete them.  Optionally a subsequent workload can be immediately invoked to showcase that performance continues to suffer in general until a memtable flush is invoked.

```
hsbench -b 10000 -d -1 -m ixi -n 1 -t 128 -z 4K -s <secret> -a <access> -u http://127.0.0.1:7480
```

Creating 10000 buckets is relatively fast in both cases...

| | master | wip-kv-deleterange-keys |
| -- | -- | -- |
| Duration (seconds) | 3.04 | 3.09 |
| Buckets/Second | 3290.77 | 3239 |
| Avg Latency (ms) | 38.53 | 39.2 |
| 99% Latency (ms) | 65.84 | 60.94 |
| Max Latency (ms) | 127.14 | 104.96 |

...However deleting 10000 buckets is roughly **67 times slower** when DeleteRange is used... (Note: this is across multiple DeleteRange calls rather than a single call based on bucket deletion works)

| | master | wip-kv-deleterange-keys |
-- | -- | --
Duration (seconds) | **675.39** | 9.42
Buckets/Second | **14.81** | 1061.83
Avg Latency (ms) | **8600.9** | 120.12
99% Latency (ms) | **33540.28** | 150.14
Max Latency (ms) | **50655** | 171.89

...Worse, after many RangeTombstones are placed in the memtable subsequent operations are also slow until the memtable is flushed.  Creating 10000 new buckets in master is now **144 times slower**...


| | master | wip-kv-deleterange-keys |
-- | -- | --
Duration (seconds) | **444.97** | 3.1
Buckets/Second | **22.47** | 3228.76
Avg Latency (ms) | **5672.44** | 39.45
99% Latency (ms) | **11055.03** | 67.43
Max Latency (ms) | **13682.59** | 87.4

...And even worse, the OSD will consume massive amounts of CPU when this is happening.  Deleting 10000 buckets used ~10 cores for 675 seconds on master and ~2-3 cores for 9 seconds with this PR applied.  The reason for this is that DeleteRange induced fragmentation in the memtables causes a huge amount of iterator overhead as can be seen by a wallclock profile of the TP_OSD_TP threads:

```
+ 41.72% rocksdb::DBImpl::NewInternalIterator
  + 41.72% rocksdb::MemTable::NewRangeTombstoneIterator
    + 41.72% std::make_shared<rocksdb::FragmentedRangeTombstoneList, std::unique_ptr<rocksdb::InternalIteratorBase<rocksdb::Slice>, std::default_delete<rocksdb::InternalIteratorBase<rocksdb::Slice> > >, rocksdb::InternalKeyComparator const&>
```

This PR fixes the current issue by essentially never or rarely invoking DeleteRange.  If we start using it more often again in the future (say by regularly deleting >1024 keys at once) we will also need to flush the memtables after concurrent DeleteRange calls to avoid fragmentation.

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
