### PR TITLE
ceph-daemon: fix 'version' field for legacy `ls`

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -1320,7 +1320,7 @@ def list_daemons():
                     if not host_version:
                         out, err, code = call(['ceph', '-v'])
                         if not code and out.startswith('ceph version '):
-                            host_version = out.split(' ')[3]
+                            host_version = out.split(' ')[2]
 
                     ls.append({
                         'style': 'legacy',


### PR DESCRIPTION
The `ls` command was reporting the git commit id instead of the ceph
version.

Signed-off-by: Michael Fritch <mfritch@suse.com>

Old behavior -
```
    {
        "style": "legacy",
        "name": "mgr.mon2",
        "fsid": "c5b2a335-ad78-4a10-a89b-84657184cfd6",
        "enabled": true,
        "state": "running",
        "version": "(994fd9e0ccc50c2f3a55a3b7a3d4e0ba74786d50)"
    },
```

New Behavior -
```
    {
        "style": "legacy",
        "name": "mgr.mon2",
        "fsid": "c5b2a335-ad78-4a10-a89b-84657184cfd6",
        "enabled": true,
        "state": "running",
        "version": "14.2.1"
    },
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
