### PR TITLE
nautilus: core: Make dumping of reservation info congruent between scrub and recovery

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -45,4 +45,4 @@
   recovery locks held (in_progress) and waiting in priority queues.
 
 * New OSD daemon command dump_scrub_reservations which reveals the
-  scrub reservations that are active and pending.
+  scrub reservations that are held for local (primary) and remote (replica) PGs.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -43,3 +43,6 @@
 
 * New OSD daemon command dump_recovery_reservations which reveals the
   recovery locks held (in_progress) and waiting in priority queues.
+
+* New OSD daemon command dump_scrub_reservations which reveals the
+  scrub reservations that are active and pending.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -40,3 +40,6 @@
   value determined by the config options, for the average for any of the 3 intervals.
   New admin command ``ceph daemon osd.# dump_osd_network [threshold]`` will
   do the same but only including heartbeats initiated by the specified OSD.
+
+* New OSD daemon command dump_recovery_reservations which reveals the
+  recovery locks held (in_progress) and waiting in priority queues.

--- a/doc/dev/osd_internals/recovery_reservation.rst
+++ b/doc/dev/osd_internals/recovery_reservation.rst
@@ -48,6 +48,14 @@ necessary), the primary drops the local reservation and enters the
 Recovered state. Once all the PGs have reported they are clean, the
 primary enters the Clean state and marks itself active+clean.
 
+-----------------
+Dump Reservations
+-----------------
+
+An OSD daemon command dumps total local and remote reservations::
+
+  ceph daemon osd.<id> dump_recovery_reservations
+
 
 --------------
 Things to Note

--- a/doc/dev/osd_internals/scrub.rst
+++ b/doc/dev/osd_internals/scrub.rst
@@ -1,6 +1,9 @@
 
+Scrub internals and diagnostics
+===============================
+
 Scrubbing Behavior Table
-========================
+------------------------
 
 +-------------------------------------------------+----------+-----------+---------------+----------------------+
 |                                          Flags  | none     | noscrub   | nodeep_scrub  | noscrub/nodeep_scrub |
@@ -28,3 +31,11 @@ State variables
 - Initiated scrub state is  must_scrub && !must_deep_scrub && !time_for_deep
 - Initiated scrub after osd_deep_scrub_interval state is must scrub && !must_deep_scrub && time_for_deep
 - Initiated deep scrub state is  must_scrub && must_deep_scrub
+
+Scrub Reservations
+------------------
+
+An OSD daemon command dumps total local and remote reservations::
+
+  ceph daemon osd.<id> dump_scrub_reservations
+

--- a/qa/standalone/osd/osd-recovery-prio.sh
+++ b/qa/standalone/osd/osd-recovery-prio.sh
@@ -152,7 +152,7 @@ function TEST_recovery_priority() {
     # to be preempted.
     ceph osd pool set $pool3 size 2
     sleep 2
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations || return 1
 
     # 3. Item is in progress, adjust priority with no higher priority waiting
     for i in $(seq 1 $max_tries)
@@ -167,18 +167,18 @@ function TEST_recovery_priority() {
       sleep 2
     done
     flush_pg_stats || return 1
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations || return 1
 
     ceph osd out osd.$chk_osd1_2
     sleep 2
     flush_pg_stats || return 1
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations || return 1
     ceph pg dump pgs
 
     ceph osd pool set $pool2 size 2
     sleep 2
     flush_pg_stats || return 1
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/out || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/out || return 1
     cat $dir/out
     ceph pg dump pgs
 
@@ -217,7 +217,7 @@ function TEST_recovery_priority() {
       sleep 2
     done
     sleep 2
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/out || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/out || return 1
     cat $dir/out
     PRIO=$(cat $dir/out | jq "(.local_reservations.queues[].items[] | select(.item == \"${PG2}\")).prio")
     if [ "$PRIO" != "$FORCE_PRIO" ];
@@ -232,7 +232,7 @@ function TEST_recovery_priority() {
     ceph pg cancel-force-recovery $PG3 || return 1
     sleep 2
     #ceph osd set norecover
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/out || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/out || return 1
     cat $dir/out
     PRIO=$(cat $dir/out | jq "(.local_reservations.queues[].items[] | select(.item == \"${PG3}\")).prio")
     if [ "$PRIO" != "$NORMAL_PRIO" ];
@@ -257,14 +257,14 @@ function TEST_recovery_priority() {
 
     ceph pg cancel-force-recovery $PG2 || return 1
     sleep 5
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations || return 1
 
     # 2. Item is queued, re-queue and preempt because new priority higher than an in progress item
     flush_pg_stats || return 1
     ceph pg force-recovery $PG3 || return 1
     sleep 2
 
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/out || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/out || return 1
     cat $dir/out
     PRIO=$(cat $dir/out | jq "(.local_reservations.queues[].items[] | select(.item == \"${PG2}\")).prio")
     if [ "$PRIO" != "$NORMAL_PRIO" ];
@@ -290,7 +290,7 @@ function TEST_recovery_priority() {
     ceph osd unset noout
     ceph osd unset norecover
 
-    wait_for_clean "CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations" || return 1
+    wait_for_clean "CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations" || return 1
 
     ceph pg dump pgs
 
@@ -318,7 +318,7 @@ function TEST_recovery_priority() {
 # pool 2 with recovery_priority 2
 #
 # Start recovery by changing the pool sizes from 1 to 2
-# Use dump_reservations to verify priorities
+# Use dump_recovery_reservations to verify priorities
 function TEST_recovery_pool_priority() {
     local dir=$1
     local pools=3 # Don't assume the first 2 pools are exact what we want
@@ -426,10 +426,10 @@ function TEST_recovery_pool_priority() {
     ceph osd pool set $pool1 size 2
     ceph osd pool set $pool2 size 2
     sleep 10
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_reservations > $dir/dump.${chk_osd1_1}.out
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_1}) dump_recovery_reservations > $dir/dump.${chk_osd1_1}.out
     echo osd.${chk_osd1_1}
     cat $dir/dump.${chk_osd1_1}.out
-    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_2}) dump_reservations > $dir/dump.${chk_osd1_2}.out
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${chk_osd1_2}) dump_recovery_reservations > $dir/dump.${chk_osd1_2}.out
     echo osd.${chk_osd1_2}
     cat $dir/dump.${chk_osd1_2}.out
 

--- a/qa/standalone/scrub/osd-scrub-dump.sh
+++ b/qa/standalone/scrub/osd-scrub-dump.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 Red Hat <contact@redhat.com>
+#
+# Author: David Zafman <dzafman@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+MAX_SCRUBS=4
+SCRUB_SLEEP=2
+POOL_SIZE=3
+
+function run() {
+    local dir=$1
+    shift
+    local SLEEP=0
+    local CHUNK_MAX=5
+
+    export CEPH_MON="127.0.0.1:7184" # git grep '\<7184\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd_max_scrubs=$MAX_SCRUBS "
+    CEPH_ARGS+="--osd_scrub_sleep=$SLEEP "
+    CEPH_ARGS+="--osd_scrub_chunk_max=$CHUNK_MAX "
+    CEPH_ARGS+="--osd_scrub_sleep=$SCRUB_SLEEP "
+    CEPH_ARGS+="--osd_pool_default_size=$POOL_SIZE "
+
+    export -n CEPH_CLI_TEST_DUP_COMMAND
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_recover_unexpected() {
+    local dir=$1
+    shift
+    local OSDS=6
+    local PGS=16
+    local POOLS=3
+    local OBJS=1000
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    for o in $(seq 0 $(expr $OSDS - 1))
+    do
+        run_osd $dir $o
+    done
+
+    for i in $(seq 1 $POOLS)
+    do
+        create_pool test$i $PGS $PGS
+    done
+
+    wait_for_clean || return 1
+
+    dd if=/dev/urandom of=datafile bs=4k count=2
+    for i in $(seq 1 $POOLS)
+    do
+       for j in $(seq 1 $OBJS)
+       do
+	       rados -p test$i put obj$j datafile
+       done
+    done
+    rm datafile
+
+    ceph osd set noscrub
+    ceph osd set nodeep-scrub
+
+    for qpg in $(ceph pg dump pgs --format=json-pretty | jq '.pg_stats[].pgid')
+    do
+	primary=$(ceph pg dump pgs --format=json | jq ".pg_stats[] | select(.pgid == $qpg) | .acting_primary")
+	eval pg=$qpg   # strip quotes around qpg
+	CEPH_ARGS='' ceph daemon $(get_asok_path osd.$primary) trigger_scrub $pg
+    done
+
+    ceph pg dump pgs
+
+    max=$(CEPH_ARGS='' ceph daemon $(get_asok_path osd.0) dump_scrub_reservations | jq '.osd_max_scrubs')
+    if [ $max != $MAX_SCRUBS];
+    then
+	echo "ERROR: Incorrect osd_max_scrubs from dump_scrub_reservations"
+	return 1
+    fi
+
+    ceph osd unset noscrub
+
+    ok=false
+    for i in $(seq 0 300)
+    do
+	ceph pg dump pgs
+	if ceph pg dump pgs | grep scrubbing; then
+	    ok=true
+	    break
+	fi
+	sleep 1
+    done
+    if test $ok = "false"; then
+	echo "ERROR: Test set-up failed no scrubbing"
+	return 1
+    fi
+
+    local total=0
+    local zerocount=0
+    local maxzerocount=3
+    while(true)
+    do
+	pass=0
+	for o in $(seq 0 $(expr $OSDS - 1))
+	do
+		CEPH_ARGS='' ceph daemon $(get_asok_path osd.$o) dump_scrub_reservations
+		scrubs=$(CEPH_ARGS='' ceph daemon $(get_asok_path osd.$o) dump_scrub_reservations | jq '.scrubs_local + .scrubs_remote')
+		if [ $scrubs -gt $MAX_SCRUBS ]; then
+		    echo "ERROR: More than $MAX_SCRUBS currently reserved"
+		    return 1
+	        fi
+		pass=$(expr $pass + $scrubs)
+        done
+	if [ $pass = "0" ]; then
+	    zerocount=$(expr $zerocount + 1)
+	fi
+	if [ $zerocount -gt $maxzerocount ]; then
+	    break
+	fi
+	total=$(expr $total + $pass)
+	sleep $(expr $SCRUB_SLEEP \* 2)
+    done
+
+    # Check that there are no more scrubs
+    for i in $(seq 0 5)
+    do
+        if ceph pg dump pgs | grep scrubbing; then
+	    echo "ERROR: Extra scrubs after test completion...not expected"
+	    return 1
+        fi
+	sleep $SCRUB_SLEEP
+    done
+
+    echo $total total reservations seen
+
+    # Sort of arbitraty number based on PGS * POOLS * POOL_SIZE as the number of total scrub
+    # reservations that must occur.  However, the loop above might see the same reservation more
+    # than once.
+    actual_reservations=$(expr $PGS \* $POOLS \* $POOL_SIZE)
+    if [ $total -lt $actual_reservations ]; then
+	echo "ERROR: Unexpectedly low amount of scrub reservations seen during test"
+	return 1
+    fi
+
+    return 0
+}
+
+
+main osd-scrub-dump "$@"
+
+# Local Variables:
+# compile-command: "cd build ; make check && \
+#    ../qa/run-standalone.sh osd-scrub-dump.sh"
+# End:

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -229,8 +229,9 @@ OSDService::OSDService(OSD *osd) :
   pre_publish_lock{ceph::make_mutex("OSDService::pre_publish_lock")},
   max_oldest_map(0),
   peer_map_epoch_lock("OSDService::peer_map_epoch_lock"),
-  sched_scrub_lock("OSDService::sched_scrub_lock"), scrubs_pending(0),
-  scrubs_active(0),
+  sched_scrub_lock("OSDService::sched_scrub_lock"),
+  scrubs_local(0),
+  scrubs_remote(0),
   agent_lock("OSDService::agent_lock"),
   agent_valid_iterator(false),
   agent_ops(0),
@@ -1349,85 +1350,82 @@ void OSDService::share_map_peer(int peer, Connection *con, OSDMapRef map)
   }
 }
 
-bool OSDService::can_inc_scrubs_pending()
+bool OSDService::can_inc_scrubs()
 {
   bool can_inc = false;
   std::lock_guard l(sched_scrub_lock);
 
-  if (scrubs_pending + scrubs_active < cct->_conf->osd_max_scrubs) {
-    dout(20) << __func__ << " " << scrubs_pending << " -> " << (scrubs_pending+1)
-	     << " (max " << cct->_conf->osd_max_scrubs << ", active " << scrubs_active
-	     << ")" << dendl;
+  if (scrubs_local + scrubs_remote < cct->_conf->osd_max_scrubs) {
+    dout(20) << __func__ << " == true " << scrubs_local << " local + " << scrubs_remote
+	     << " remote < max " << cct->_conf->osd_max_scrubs << dendl;
     can_inc = true;
   } else {
-    dout(20) << __func__ << " " << scrubs_pending << " + " << scrubs_active
-	     << " active >= max " << cct->_conf->osd_max_scrubs << dendl;
+    dout(20) << __func__ << " == false " << scrubs_local << " local + " << scrubs_remote
+	     << " remote >= max " << cct->_conf->osd_max_scrubs << dendl;
   }
 
   return can_inc;
 }
 
-bool OSDService::inc_scrubs_pending()
+bool OSDService::inc_scrubs_local()
 {
   bool result = false;
 
   sched_scrub_lock.Lock();
-  if (scrubs_pending + scrubs_active < cct->_conf->osd_max_scrubs) {
-    dout(20) << "inc_scrubs_pending " << scrubs_pending << " -> " << (scrubs_pending+1)
-	     << " (max " << cct->_conf->osd_max_scrubs << ", active " << scrubs_active << ")" << dendl;
+  if (scrubs_local + scrubs_remote < cct->_conf->osd_max_scrubs) {
+    dout(20) << __func__ << " " << scrubs_local << " -> " << (scrubs_local+1)
+	     << " (max " << cct->_conf->osd_max_scrubs << ", remote " << scrubs_remote << ")" << dendl;
     result = true;
-    ++scrubs_pending;
+    ++scrubs_local;
   } else {
-    dout(20) << "inc_scrubs_pending " << scrubs_pending << " + " << scrubs_active << " active >= max " << cct->_conf->osd_max_scrubs << dendl;
+    dout(20) << __func__ << " " << scrubs_local << " local + " << scrubs_remote << " remote >= max " << cct->_conf->osd_max_scrubs << dendl;
   }
   sched_scrub_lock.Unlock();
 
   return result;
 }
 
-void OSDService::dec_scrubs_pending()
+void OSDService::dec_scrubs_local()
 {
   sched_scrub_lock.Lock();
-  dout(20) << "dec_scrubs_pending " << scrubs_pending << " -> " << (scrubs_pending-1)
-	   << " (max " << cct->_conf->osd_max_scrubs << ", active " << scrubs_active << ")" << dendl;
-  --scrubs_pending;
-  ceph_assert(scrubs_pending >= 0);
+  dout(20) << __func__ << " " << scrubs_local << " -> " << (scrubs_local-1)
+	   << " (max " << cct->_conf->osd_max_scrubs << ", remote " << scrubs_remote << ")" << dendl;
+  --scrubs_local;
+  ceph_assert(scrubs_local >= 0);
   sched_scrub_lock.Unlock();
 }
 
-void OSDService::inc_scrubs_active(bool reserved)
+bool OSDService::inc_scrubs_remote()
 {
+  bool result = false;
   sched_scrub_lock.Lock();
-  ++(scrubs_active);
-  if (reserved) {
-    --(scrubs_pending);
-    dout(20) << "inc_scrubs_active " << (scrubs_active-1) << " -> " << scrubs_active
-	     << " (max " << cct->_conf->osd_max_scrubs
-	     << ", pending " << (scrubs_pending+1) << " -> " << scrubs_pending << ")" << dendl;
-    ceph_assert(scrubs_pending >= 0);
+  if (scrubs_local + scrubs_remote < cct->_conf->osd_max_scrubs) {
+    dout(20) << __func__ << " " << scrubs_remote << " -> " << (scrubs_remote+1)
+	     << " (max " << cct->_conf->osd_max_scrubs << ", local " << scrubs_local << ")" << dendl;
+    result = true;
+    ++scrubs_remote;
   } else {
-    dout(20) << "inc_scrubs_active " << (scrubs_active-1) << " -> " << scrubs_active
-	     << " (max " << cct->_conf->osd_max_scrubs
-	     << ", pending " << scrubs_pending << ")" << dendl;
+    dout(20) << __func__ << " " << scrubs_local << " local + " << scrubs_remote << " remote >= max " << cct->_conf->osd_max_scrubs << dendl;
   }
   sched_scrub_lock.Unlock();
+  return result;
 }
 
-void OSDService::dec_scrubs_active()
+void OSDService::dec_scrubs_remote()
 {
   sched_scrub_lock.Lock();
-  dout(20) << "dec_scrubs_active " << scrubs_active << " -> " << (scrubs_active-1)
-	   << " (max " << cct->_conf->osd_max_scrubs << ", pending " << scrubs_pending << ")" << dendl;
-  --scrubs_active;
-  ceph_assert(scrubs_active >= 0);
+  dout(20) << __func__ << " " << scrubs_remote << " -> " << (scrubs_remote-1)
+	   << " (max " << cct->_conf->osd_max_scrubs << ", local " << scrubs_local << ")" << dendl;
+  --scrubs_remote;
+  ceph_assert(scrubs_remote >= 0);
   sched_scrub_lock.Unlock();
 }
 
 void OSDService::dump_scrub_reservations(Formatter *f)
 {
   std::lock_guard l{sched_scrub_lock};
-  f->dump_int("scrubs_active", scrubs_active);
-  f->dump_int("scrubs_pending", scrubs_pending);
+  f->dump_int("scrubs_local", scrubs_local);
+  f->dump_int("scrubs_remote", scrubs_remote);
   f->dump_int("osd_max_scrubs", cct->_conf->osd_max_scrubs);
 }
 
@@ -7917,7 +7915,7 @@ bool OSD::scrub_load_below_threshold()
 void OSD::sched_scrub()
 {
   // if not permitted, fail fast
-  if (!service.can_inc_scrubs_pending()) {
+  if (!service.can_inc_scrubs()) {
     return;
   }
   bool allow_requested_repair_only = false;
@@ -7974,7 +7972,7 @@ void OSD::sched_scrub()
         continue;
       }
       // If it is reserving, let it resolve before going to the next scrub job
-      if (pg->scrubber.reserved) {
+      if (pg->scrubber.local_reserved && !pg->scrubber.active) {
 	pg->unlock();
 	dout(30) << __func__ << ": reserve in progress pgid " << scrub.pgid << dendl;
 	break;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2623,7 +2623,7 @@ will start to track new ops received afterwards.";
     }
 
     f->close_section(); //watchers
-  } else if (admin_command == "dump_reservations") {
+  } else if (admin_command == "dump_recovery_reservations") {
     f->open_object_section("reservations");
     f->open_object_section("local_reservations");
     service.local_reserver.dump(f);
@@ -3457,7 +3457,7 @@ void OSD::final_init()
 				     "show clients which have active watches,"
 				     " and on which objects");
   ceph_assert(r == 0);
-  r = admin_socket->register_command("dump_reservations", "dump_reservations",
+  r = admin_socket->register_command("dump_recovery_reservations", "dump_recovery_reservations",
 				     asok_hook,
 				     "show recovery reservations");
   ceph_assert(r == 0);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1370,8 +1370,7 @@ bool OSDService::can_inc_scrubs()
 bool OSDService::inc_scrubs_local()
 {
   bool result = false;
-
-  sched_scrub_lock.Lock();
+  std::lock_guard l{sched_scrub_lock};
   if (scrubs_local + scrubs_remote < cct->_conf->osd_max_scrubs) {
     dout(20) << __func__ << " " << scrubs_local << " -> " << (scrubs_local+1)
 	     << " (max " << cct->_conf->osd_max_scrubs << ", remote " << scrubs_remote << ")" << dendl;
@@ -1380,25 +1379,22 @@ bool OSDService::inc_scrubs_local()
   } else {
     dout(20) << __func__ << " " << scrubs_local << " local + " << scrubs_remote << " remote >= max " << cct->_conf->osd_max_scrubs << dendl;
   }
-  sched_scrub_lock.Unlock();
-
   return result;
 }
 
 void OSDService::dec_scrubs_local()
 {
-  sched_scrub_lock.Lock();
+  std::lock_guard l{sched_scrub_lock};
   dout(20) << __func__ << " " << scrubs_local << " -> " << (scrubs_local-1)
 	   << " (max " << cct->_conf->osd_max_scrubs << ", remote " << scrubs_remote << ")" << dendl;
   --scrubs_local;
   ceph_assert(scrubs_local >= 0);
-  sched_scrub_lock.Unlock();
 }
 
 bool OSDService::inc_scrubs_remote()
 {
   bool result = false;
-  sched_scrub_lock.Lock();
+  std::lock_guard l{sched_scrub_lock};
   if (scrubs_local + scrubs_remote < cct->_conf->osd_max_scrubs) {
     dout(20) << __func__ << " " << scrubs_remote << " -> " << (scrubs_remote+1)
 	     << " (max " << cct->_conf->osd_max_scrubs << ", local " << scrubs_local << ")" << dendl;
@@ -1407,18 +1403,16 @@ bool OSDService::inc_scrubs_remote()
   } else {
     dout(20) << __func__ << " " << scrubs_local << " local + " << scrubs_remote << " remote >= max " << cct->_conf->osd_max_scrubs << dendl;
   }
-  sched_scrub_lock.Unlock();
   return result;
 }
 
 void OSDService::dec_scrubs_remote()
 {
-  sched_scrub_lock.Lock();
+  std::lock_guard l{sched_scrub_lock};
   dout(20) << __func__ << " " << scrubs_remote << " -> " << (scrubs_remote-1)
 	   << " (max " << cct->_conf->osd_max_scrubs << ", local " << scrubs_local << ")" << dendl;
   --scrubs_remote;
   ceph_assert(scrubs_remote >= 0);
-  sched_scrub_lock.Unlock();
 }
 
 void OSDService::dump_scrub_reservations(Formatter *f)

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -433,8 +433,8 @@ public:
 private:
   // -- scrub scheduling --
   Mutex sched_scrub_lock;
-  int scrubs_pending;
-  int scrubs_active;
+  int scrubs_local;
+  int scrubs_remote;
 
 public:
   struct ScrubJob {
@@ -509,11 +509,11 @@ public:
     f->close_section();
   }
 
-  bool can_inc_scrubs_pending();
-  bool inc_scrubs_pending();
-  void inc_scrubs_active(bool reserved);
-  void dec_scrubs_pending();
-  void dec_scrubs_active();
+  bool can_inc_scrubs();
+  bool inc_scrubs_local();
+  void dec_scrubs_local();
+  bool inc_scrubs_remote();
+  void dec_scrubs_remote();
   void dump_scrub_reservations(Formatter *f);
 
   void reply_op_error(OpRequestRef op, int err);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -514,6 +514,7 @@ public:
   void inc_scrubs_active(bool reserved);
   void dec_scrubs_pending();
   void dec_scrubs_active();
+  void dump_scrub_reservations(Formatter *f);
 
   void reply_op_error(OpRequestRef op, int err);
   void reply_op_error(OpRequestRef op, int err, eversion_t v, version_t uv);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1687,7 +1687,7 @@ public:
 
     // metadata
     set<pg_shard_t> reserved_peers;
-    bool reserved, reserve_failed;
+    bool local_reserved, remote_reserved, reserve_failed;
     epoch_t epoch_start;
 
     // common to both scrubs


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41785
possibly a backport of https://github.com/ceph/ceph/pull/30192
parent tracker: https://tracker.ceph.com/issues/41669

---

updated using ceph-backport.sh version 15.0.0.6869
