### PR TITLE
ceph-daemon: set container_image during bootstrap

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -831,6 +831,7 @@ def command_bootstrap():
         cp.add_section('global')
     cp.set('global', 'fsid', fsid);
     cp.set('global', 'mon host', addr_arg)
+    cp.set('global', 'container_image', args.image)
     cpf = StringIO()
     cp.write(cpf)
     config = cpf.getvalue()


### PR DESCRIPTION
Set the new cluster's container_image to match the image we bootstrapped
with.

Signed-off-by: Sage Weil <sage@redhat.com>