### PR TITLE
os/bluestore: Revert rocksdb parallel compactions to 1

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4329,7 +4329,7 @@ std::vector<Option> get_global_options() {
     .set_description("max duration to force deferred submit"),
 
     Option("bluestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152,max_background_compactions=2")
+    .set_default("compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152,max_background_compactions=1")
     .set_description("Rocksdb options"),
 
     Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
Recently there have been several reports of rocksdb corruption that may (or may not) be related to several changes in the last couple of months:

https://github.com/ceph/ceph/pull/29026 // Update rokcsdb to v6.1.2
https://github.com/ceph/ceph/pull/29027 // Increase the number of parallel compactions to 2
https://github.com/ceph/ceph/pull/27317 // DeleteRange
https://github.com/ceph/ceph/pull/15183 // More DeleteRange

Out of an abundance of caution, this PR reverts the number of bluestore/rocksdb parallel compactions to 1.  This will have an impact on compaction throughput.  I'm marking this DNM for now so that @ifed01  can comment with some of the data from his investigation.

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
