### PR TITLE
luminous: qa: cfuse_workunit_kernel_untar_build fails on Ubuntu 18.04

### DIFF
--- a/qa/cephfs/begin.yaml
+++ b/qa/cephfs/begin.yaml
@@ -2,4 +2,8 @@ tasks:
   - install:
       extra_packages:
         - python3-cephfs
+      # For kernel_untar_build workunit
+      extra_system_packages:
+        deb: ['bison', 'flex', 'libelf-dev', 'libssl-dev']
+        rpm: ['bison', 'flex', 'elfutils-libelf-devel', 'openssl-devel']
   - ceph:

--- a/qa/suites/kcephfs/cephfs/begin.yaml
+++ b/qa/suites/kcephfs/cephfs/begin.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin.yaml

--- a/qa/suites/kcephfs/cephfs/inline/no.yaml
+++ b/qa/suites/kcephfs/cephfs/inline/no.yaml
@@ -1,3 +1,0 @@
-tasks:
-- install:
-- ceph:

--- a/qa/suites/kcephfs/cephfs/inline/yes.yaml
+++ b/qa/suites/kcephfs/cephfs/inline/yes.yaml
@@ -1,6 +1,4 @@
 tasks:
-- install:
-- ceph:
 - exec:
     client.0:
       - sudo ceph mds set inline_data true --yes-i-really-mean-it

--- a/qa/suites/kcephfs/mixed-clients/begin.yaml
+++ b/qa/suites/kcephfs/mixed-clients/begin.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin.yaml

--- a/qa/suites/kcephfs/mixed-clients/tasks/kernel_cfuse_workunits_dbench_iozone.yaml
+++ b/qa/suites/kcephfs/mixed-clients/tasks/kernel_cfuse_workunits_dbench_iozone.yaml
@@ -1,6 +1,4 @@
 tasks:
-- install:
-- ceph:
 - parallel:
    - user-workload
    - kclient-workload

--- a/qa/suites/kcephfs/mixed-clients/tasks/kernel_cfuse_workunits_untarbuild_blogbench.yaml
+++ b/qa/suites/kcephfs/mixed-clients/tasks/kernel_cfuse_workunits_untarbuild_blogbench.yaml
@@ -1,6 +1,4 @@
 tasks:
-- install:
-- ceph:
 - parallel:
    - user-workload
    - kclient-workload

--- a/qa/suites/kcephfs/recovery/begin.yaml
+++ b/qa/suites/kcephfs/recovery/begin.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin.yaml

--- a/qa/suites/kcephfs/recovery/mounts/kmounts.yaml
+++ b/qa/suites/kcephfs/recovery/mounts/kmounts.yaml
@@ -1,4 +1,2 @@
 tasks:
-- install:
-- ceph:
 - kclient:

--- a/qa/suites/kcephfs/thrash/begin.yaml
+++ b/qa/suites/kcephfs/thrash/begin.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin.yaml

--- a/qa/suites/kcephfs/thrash/thrashers/default.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/default.yaml
@@ -1,7 +1,7 @@
-tasks:
-- install:
-- ceph:
+overrides:
+  ceph:
     log-whitelist:
-    - but it is still running
-    - objects unfound and apparently lost
+      - but it is still running
+      - objects unfound and apparently lost
+tasks:
 - thrashosds:

--- a/qa/suites/kcephfs/thrash/thrashers/mds.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/mds.yaml
@@ -1,9 +1,7 @@
-tasks:
-- install:
-- ceph:
-- mds_thrash:
-
 overrides:
   ceph:
     log-whitelist:
       - not responding, replacing
+
+tasks:
+- mds_thrash:

--- a/qa/suites/kcephfs/thrash/thrashers/mon.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/mon.yaml
@@ -2,9 +2,8 @@ overrides:
   ceph:
     log-whitelist:
     - \(MON_DOWN\)
+
 tasks:
-- install:
-- ceph:
 - mon_thrash:
     revive_delay: 20
     thrash_delay: 1

--- a/qa/workunits/kernel_untar_build.sh
+++ b/qa/workunits/kernel_untar_build.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-wget -q http://download.ceph.com/qa/linux-4.0.5.tar.xz
+wget -O linux.tar.gz http://download.ceph.com/qa/linux-4.17.tar.gz
 
 mkdir t
 cd t
-tar Jxvf ../linux*.xz
+tar xzf ../linux.tar.gz
 cd linux*
 make defconfig
 make -j`grep -c processor /proc/cpuinfo`


### PR DESCRIPTION
https://tracker.ceph.com/issues/42672

Cherry-picked from the mimic backport.