### PR TITLE
mgr/dashboard: fix e2e test failure for OSDs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.e2e-spec.ts
@@ -36,11 +36,6 @@ describe('OSDs page', () => {
       await expect(osds.getTableTotalCount()).toEqual(osds.getTableRows().count());
     });
 
-    it('should verify that selected footer increases when an entry is clicked', async () => {
-      await osds.getFirstCell().click();
-      await expect(osds.getTableSelectedCount()).toEqual(1);
-    });
-
     it('should verify that buttons exist', async () => {
       await expect(element(by.cssContainingText('button', 'Scrub')).isPresent()).toBe(true);
       await expect(
@@ -48,20 +43,29 @@ describe('OSDs page', () => {
       ).toBe(true);
     });
 
-    it('should show the correct text for the tab labels', async () => {
-      await osds.getFirstCell().click();
-      const tabHeadings = $$('#tabset-osd-details > div > tab').map((e) =>
-        e.getAttribute('heading')
-      );
-      await expect(tabHeadings).toEqual([
-        'Devices',
-        'Attributes (OSD map)',
-        'Metadata',
-        'Device health',
-        'Performance counter',
-        'Histogram',
-        'Performance Details'
-      ]);
+    describe('by selecting one row in OSDs List', () => {
+      beforeAll(async () => {
+        await osds.getFirstCell().click();
+      });
+
+      it('should verify that selected footer increases', async () => {
+        await expect(osds.getTableSelectedCount()).toEqual(1);
+      });
+
+      it('should show the correct text for the tab labels', async () => {
+        const tabHeadings = $$('#tabset-osd-details > div > tab').map((e) =>
+          e.getAttribute('heading')
+        );
+        await expect(tabHeadings).toEqual([
+          'Devices',
+          'Attributes (OSD map)',
+          'Metadata',
+          'Device health',
+          'Performance counter',
+          'Histogram',
+          'Performance Details'
+        ]);
+      });
     });
   });
 });


### PR DESCRIPTION
When clicking a selected row, the row becomes unselected and the detail
component is hidden. Rearrange related tests by selecting the row only
once.

Fixes: https://tracker.ceph.com/issues/42671
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
