### PR TITLE
doc/install/manual-deployment: Change owner to ceph for the keyring file

### DIFF
--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -174,6 +174,10 @@ The procedure is as follows:
 	sudo ceph-authtool /tmp/ceph.mon.keyring --import-keyring /etc/ceph/ceph.client.admin.keyring
 	sudo ceph-authtool /tmp/ceph.mon.keyring --import-keyring /var/lib/ceph/bootstrap-osd/ceph.keyring
 
+#. Change the owner for ``ceph.mon.keyring``. ::
+
+	sudo chown ceph:ceph /tmp/ceph.mon.keyring
+
 #. Generate a monitor map using the hostname(s), host IP address(es) and the FSID.
    Save it as ``/tmp/monmap``::
 


### PR DESCRIPTION
The keyring will be 600 by default with the owner of the current user who issues the command, which will make command "sudo -u ceph ceph-mon --mkfs" fail since the user "ceph" don't have access to the keyring file.

Because of that, the mon data directory won't have the keyring file copied and when "sudo systemctl start ceph-mon" it will show error "unable to read magic from mon data"

Signed-off-by: Jeffrey Chu <peihuachu1112@gmail.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
