### PR TITLE
doc: add sudo in ceph status command

### DIFF
--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -254,7 +254,7 @@ The procedure is as follows:
 
 #. Verify that the monitor is running. ::
 
-	ceph -s
+	sudo ceph -s
 
    You should see output that the monitor you started is up and running, and
    you should see a health error indicating that placement groups are stuck


### PR DESCRIPTION
The keyring is created with sudo privilege, the current normal user won't have access to it

Signed-off-by: Jeffrey Chu <peihuachu1112@gmail.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
