### PR TITLE
mgr/dashboard: do not show non-pool data in pool details

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
@@ -4,7 +4,7 @@
   <tab i18n-heading
        heading="Details">
     <cd-table-key-value [renderObjects]="true"
-                        [data]="selection.first()"
+                        [data]="filterNonPoolData(selection.first())"
                         [autoReload]="false">
     </cd-table-key-value>
   </tab>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
@@ -71,7 +71,7 @@ describe('PoolDetailsComponent', () => {
       expect(tabs[0].active).toBeTruthy();
     });
 
-    it('current active status of tabs should not change when selection is same with previour selection', () => {
+    it('current active status of tabs should not change when selection is the same as previous selection', () => {
       fixture.detectChanges();
       const tabs = poolDetailsComponent.tabsetChild.tabs;
       expect(tabs[0].active).toBeTruthy();
@@ -79,6 +79,24 @@ describe('PoolDetailsComponent', () => {
       tabs[1].active = true;
       fixture.detectChanges();
       expect(tabs[1].active).toBeTruthy();
+    });
+
+    it('returns pool details correctly', () => {
+      const pool = { prop1: 1, cdIsBinary: true, prop2: 2, cdExecuting: true, prop3: 3 };
+      const expectedPool = { prop1: 1, prop2: 2, prop3: 3 };
+
+      expect(poolDetailsComponent.filterNonPoolData(pool)).toEqual(expectedPool);
+    });
+
+    it('pool data filtering is called', () => {
+      const filterNonPoolDataSpy = spyOn(
+        poolDetailsComponent,
+        'filterNonPoolData'
+      ).and.callThrough();
+
+      fixture.detectChanges();
+
+      expect(filterNonPoolDataSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
+import * as _ from 'lodash';
 import { TabsetComponent } from 'ngx-bootstrap/tabs';
 
 import { PoolService } from '../../../shared/api/pool.service';
@@ -68,5 +69,9 @@ export class PoolDetailsComponent implements OnChanges {
         this.selectedPoolConfiguration = poolConf;
       });
     }
+  }
+
+  filterNonPoolData(pool: object): object {
+    return _.omit(pool, ['cdExecuting', 'cdIsBinary']);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -75,12 +75,6 @@ describe('PoolListComponent', () => {
     expect(component.columns.every((column) => Boolean(column.prop))).toBeTruthy();
   });
 
-  it('returns pool details correctly', () => {
-    const pool = { prop1: 1, cdIsBinary: true, prop2: 2, cdExecuting: true, prop3: 3 };
-    const expected = { prop1: 1, prop2: 2, prop3: 3 };
-    expect(component.getPoolDetails(pool)).toEqual(expected);
-  });
-
   describe('monAllowPoolDelete', () => {
     let configOptRead: boolean;
     let configurationService: ConfigurationService;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -278,10 +278,6 @@ export class PoolListComponent implements OnInit {
     return strings.join(', ');
   }
 
-  getPoolDetails(pool: object) {
-    return _.omit(pool, ['cdExecuting', 'cdIsBinary']);
-  }
-
   getSelectionTiers() {
     const cacheTierIds = this.selection.hasSingleSelection
       ? this.selection.first()['tiers'] || []


### PR DESCRIPTION
It fixes a regression introduced by https://github.com/ceph/ceph/pull/25602 :
'cdExecuting', 'cdIsBinary' are non-pool fields that are not being filtered anymore
and shown in pool details.

Now they are filtered.

Fixes: https://tracker.ceph.com/issues/42674
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
