### PR TITLE
cephfs-shell: print helpful message when conf file is not found

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -71,9 +71,22 @@ def setup_cephfs(config_file):
     """
     Mounting a cephfs
     """
+    from cephfs import ObjectNotFound
+    from cephfs import Error
+
     global cephfs
-    cephfs = libcephfs.LibCephFS(conffile=config_file)
-    cephfs.mount()
+    try:
+        cephfs = libcephfs.LibCephFS(conffile=config_file)
+        cephfs.mount()
+    except ObjectNotFound as e:
+        print('couldn\'t find ceph configuration not found')
+        sys.exit(1)
+    except Error as e:
+        print(e)
+        sys.exit(1)
+    else:
+        del ObjectNotFound
+        del Error
 
 
 def mode_notation(mode):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42508



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>