### PR TITLE
mgr/ssh: remove superfluous parameters

### DIFF
--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -249,9 +249,9 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     def handle_command(self, inbuf, command):
         if command["prefix"] == "ssh set-ssh-config":
-            return self._set_ssh_config(inbuf, command)
+            return self._set_ssh_config(inbuf)
         elif command["prefix"] == "ssh clear-ssh-config":
-            return self._clear_ssh_config(inbuf, command)
+            return self._clear_ssh_config()
         else:
             raise NotImplementedError(command["prefix"])
 
@@ -299,7 +299,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
                 ", ".join(map(lambda h: "'{}'".format(h),
                     unregistered_hosts))))
 
-    def _set_ssh_config(self, inbuf, command):
+    def _set_ssh_config(self, inbuf):
         """
         Set an ssh_config file provided from stdin
 
@@ -311,7 +311,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         self.set_store("ssh_config", inbuf)
         return 0, "", ""
 
-    def _clear_ssh_config(self, inbuf, command):
+    def _clear_ssh_config(self):
         """
         Clear the ssh_config file provided from stdin
         """


### PR DESCRIPTION
in _set_ssh_config and _clear_ssh_config

Signed-off-by: Joshua Schmid <jschmid@suse.de>


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
