### PR TITLE
mgr/dashboard: KeyError on dashboard reload

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/summary.py
+++ b/src/pybind/mgr/dashboard/controllers/summary.py
@@ -64,9 +64,9 @@ class Summary(BaseController):
         return result
 
     def _get_host(self):
-        mgr_map = mgr.get('mgr_map')
-        services = mgr_map['services']
-        return services['dashboard']
+        # type: () -> str
+        services = mgr.get('mgr_map')['services']
+        return services['dashboard'] if 'dashboard' in services else ''
 
     @Endpoint()
     def __call__(self):


### PR DESCRIPTION
When reloading the dashboard using `ceph mgr module disable/enable
dashbaord`, the error is thrown shortly after the dashboard module has
been reactivated, because `dashboard` is not yet available in
`services`. A second attempt works.

Fixes: https://tracker.ceph.com/issues/42684

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
