### PR TITLE
mon/MonMap: encode (more) valid compat monmap when we have v2-only addrs

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -44,7 +44,16 @@ void mon_info_t::encode(ceph::buffer::list& bl, uint64_t features) const
   ENCODE_START(v, 1, bl);
   encode(name, bl);
   if (v < 3) {
-    encode(public_addrs.legacy_addr(), bl, features);
+    auto a = public_addrs.legacy_addr();
+    if (a != entity_addr_t()) {
+      encode(a, bl, features);
+    } else {
+      // note: we don't have a legacy addr here, so lie so that it looks
+      // like one, just so that old clients get a valid-looking map.
+      // they won't be able to talk to the v2 mons, but that's better
+      // than nothing.
+      encode(public_addrs.as_legacy_addr(), bl, features);
+    }
   } else {
     encode(public_addrs, bl, features);
   }


### PR DESCRIPTION
If we have 1 or more mons with v2-only addrs, pre-nautilus clients can't
talk to them.  If there are more than 1 such mons in the map, they also
fail when loading the map because they expect the addrs to be unique. In
such situations, lie by giving them v1 addrs that are actually v2 ip:port
(so not actually valid).  Hopefully there are enough other mons that do
 have v1 addrs that the clients can still connect.

Fixes: https://tracker.ceph.com/issues/42600