### PR TITLE
ceph-daemon: add explicit pull at bootstrap start

### DIFF
--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -842,6 +842,9 @@ def command_bootstrap():
         if ret:
             raise RuntimeError('Failed to ping %s' % mon_ip)
 
+    logger.info('Pulling latest %s container...' % args.image)
+    call_throws([podman_path, 'pull', args.image])
+
     logger.info('Extracting ceph user uid/gid from container image...')
     (uid, gid) = extract_uid_gid()
 

--- a/src/ceph-daemon
+++ b/src/ceph-daemon
@@ -842,8 +842,9 @@ def command_bootstrap():
         if ret:
             raise RuntimeError('Failed to ping %s' % mon_ip)
 
-    logger.info('Pulling latest %s container...' % args.image)
-    call_throws([podman_path, 'pull', args.image])
+    if not args.skip_pull:
+        logger.info('Pulling latest %s container...' % args.image)
+        call_throws([podman_path, 'pull', args.image])
 
     logger.info('Extracting ceph user uid/gid from container image...')
     (uid, gid) = extract_uid_gid()
@@ -1719,6 +1720,10 @@ def _get_parser():
         '--skip-ping-check',
         action='store_true',
         help='do not verify that mon IP is pingable')
+    parser_bootstrap.add_argument(
+        '--skip-pull',
+        action='store_true',
+        help='do not pull the latest image before bootstrapping')
 
     parser_deploy = subparsers.add_parser(
     'deploy', help='deploy a daemon')


### PR DESCRIPTION
This is less confusing for users since the pull can be slow and the
uid/gid check is a weird thing to hang on for a long time.

Signed-off-by: Sage Weil <sage@redhat.com>