### PR TITLE
mds: Reorganize struct members in Mutation header

### DIFF
--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -40,40 +40,14 @@ struct sr_t;
 struct MDLockCache;
 
 struct MutationImpl : public TrackedOp {
-  metareqid_t reqid;
-  __u32 attempt = 0;      // which attempt for this request
-  LogSegment *ls = nullptr;  // the log segment i'm committing to
-
-private:
-  utime_t mds_stamp; ///< mds-local timestamp (real time)
-  utime_t op_stamp;  ///< op timestamp (client provided)
-
 public:
-  // flag mutation as slave
-  mds_rank_t slave_to_mds = MDS_RANK_NONE;  // this is a slave request if >= 0.
-
   // -- my pins and auth_pins --
   struct ObjectState {
     bool pinned = false;
     bool auth_pinned = false;
     mds_rank_t remote_auth_pinned = MDS_RANK_NONE;
   };
-  ceph::unordered_map<MDSCacheObject*, ObjectState> object_states;
-  int num_pins = 0;
-  int num_auth_pins = 0;
-  int num_remote_auth_pins = 0;
 
-  const ObjectState* find_object_state(MDSCacheObject *obj) const {
-    auto it = object_states.find(obj);
-    return it != object_states.end() ? &it->second : nullptr;
-  }
-
-  bool is_any_remote_auth_pin() const { return num_remote_auth_pins > 0; }
-
-  // cache pins (so things don't expire)
-  CInode* stickydiri = nullptr;
-
-  
   // held locks
   struct LockOp {
     enum {
@@ -83,11 +57,10 @@ public:
       REMOTE_WRLOCK	= 8,
       STATE_PIN		= 16, // no RW after locked, just pin lock state
     };
-    SimpleLock* lock;
-    mutable unsigned flags;
-    mutable mds_rank_t wrlock_target;
+
     LockOp(SimpleLock *l, unsigned f=0, mds_rank_t t=MDS_RANK_NONE) :
       lock(l), flags(f), wrlock_target(t) {}
+
     bool is_rdlock() const { return !!(flags & RDLOCK); }
     bool is_xlock() const { return !!(flags & XLOCK); }
     bool is_wrlock() const { return !!(flags & WRLOCK); }
@@ -101,9 +74,17 @@ public:
     bool operator<(const LockOp& r) const {
       return lock < r.lock;
     }
+
+    SimpleLock* lock;
+    mutable unsigned flags;
+    mutable mds_rank_t wrlock_target;
   };
 
   struct LockOpVec : public vector<LockOp> {
+    LockOpVec() {
+      reserve(32);
+    }
+
     void add_rdlock(SimpleLock *lock) {
       emplace_back(lock, LockOp::RDLOCK);
     }
@@ -128,17 +109,31 @@ public:
       emplace_back(lock, LockOp::WRLOCK | LockOp::STATE_PIN);
     }
     void sort_and_merge();
-
-    LockOpVec() {
-      reserve(32);
-    }
   };
+
   using lock_set = set<LockOp>;
   using lock_iterator = lock_set::iterator;
-  lock_set locks;  // full ordering
 
-  MDLockCache* lock_cache = nullptr;
-  bool lock_cache_disabled = false;
+  // keep our default values synced with MDRequestParam's
+  MutationImpl() : TrackedOp(nullptr, utime_t()) {}
+  MutationImpl(OpTracker *tracker, utime_t initiated,
+	       const metareqid_t &ri, __u32 att=0, mds_rank_t slave_to=MDS_RANK_NONE)
+    : TrackedOp(tracker, initiated),
+      reqid(ri), attempt(att),
+      slave_to_mds(slave_to) {}
+  ~MutationImpl() override {
+    ceph_assert(!locking);
+    ceph_assert(!lock_cache);
+    ceph_assert(num_pins == 0);
+    ceph_assert(num_auth_pins == 0);
+  }
+
+  const ObjectState* find_object_state(MDSCacheObject *obj) const {
+    auto it = object_states.find(obj);
+    return it != object_states.end() ? &it->second : nullptr;
+  }
+
+  bool is_any_remote_auth_pin() const { return num_remote_auth_pins > 0; }
 
   void disable_lock_cache() {
     lock_cache_disabled = true;
@@ -161,48 +156,6 @@ public:
   }
   bool is_last_locked(SimpleLock *lock) const {
     return lock == last_locked;
-  }
-
-  SimpleLock *last_locked = nullptr;
-  // lock we are currently trying to acquire.  if we give up for some reason,
-  // be sure to eval() this.
-  SimpleLock *locking = nullptr;
-  mds_rank_t locking_target_mds = -1;
-
-  // if this flag is set, do not attempt to acquire further locks.
-  //  (useful for wrlock, which may be a moving auth target)
-  enum {
-    SNAP_LOCKED		= 1,
-    SNAP2_LOCKED	= 2,
-    PATH_LOCKED		= 4,
-    ALL_LOCKED		= 8,
-  };
-  int locking_state = 0;
-
-  bool committing = false;
-  bool aborted = false;
-  bool killed = false;
-
-  // for applying projected inode changes
-  list<CInode*> projected_inodes;
-  std::vector<CDir*> projected_fnodes;
-  list<ScatterLock*> updated_locks;
-
-  list<CInode*> dirty_cow_inodes;
-  list<pair<CDentry*,version_t> > dirty_cow_dentries;
-
-  // keep our default values synced with MDRequestParam's
-  MutationImpl() : TrackedOp(nullptr, utime_t()) {}
-  MutationImpl(OpTracker *tracker, utime_t initiated,
-	       const metareqid_t &ri, __u32 att=0, mds_rank_t slave_to=MDS_RANK_NONE)
-    : TrackedOp(tracker, initiated),
-      reqid(ri), attempt(att),
-      slave_to_mds(slave_to) { }
-  ~MutationImpl() override {
-    ceph_assert(!locking);
-    ceph_assert(!lock_cache);
-    ceph_assert(num_pins == 0);
-    ceph_assert(num_auth_pins == 0);
   }
 
   bool is_master() const { return slave_to_mds == MDS_RANK_NONE; }
@@ -263,78 +216,71 @@ public:
 
   virtual void dump(Formatter *f) const {}
   void _dump_op_descriptor_unlocked(ostream& stream) const override;
+
+  metareqid_t reqid;
+  __u32 attempt = 0;      // which attempt for this request
+  LogSegment *ls = nullptr;  // the log segment i'm committing to
+
+  // flag mutation as slave
+  mds_rank_t slave_to_mds = MDS_RANK_NONE;  // this is a slave request if >= 0.
+
+  ceph::unordered_map<MDSCacheObject*, ObjectState> object_states;
+  int num_pins = 0;
+  int num_auth_pins = 0;
+  int num_remote_auth_pins = 0;
+  // cache pins (so things don't expire)
+  CInode* stickydiri = nullptr;
+
+  lock_set locks;  // full ordering
+  MDLockCache* lock_cache = nullptr;
+  bool lock_cache_disabled = false;
+  SimpleLock *last_locked = nullptr;
+  // Lock we are currently trying to acquire. If we give up for some reason,
+  // be sure to eval() this.
+  SimpleLock *locking = nullptr;
+  mds_rank_t locking_target_mds = -1;
+
+  // if this flag is set, do not attempt to acquire further locks.
+  //  (useful for wrlock, which may be a moving auth target)
+  enum {
+    SNAP_LOCKED		= 1,
+    SNAP2_LOCKED	= 2,
+    PATH_LOCKED		= 4,
+    ALL_LOCKED		= 8,
+  };
+  int locking_state = 0;
+
+  bool committing = false;
+  bool aborted = false;
+  bool killed = false;
+
+  // for applying projected inode changes
+  list<CInode*> projected_inodes;
+  std::vector<CDir*> projected_fnodes;
+  list<ScatterLock*> updated_locks;
+
+  list<CInode*> dirty_cow_inodes;
+  list<pair<CDentry*,version_t> > dirty_cow_dentries;
+
+private:
+  utime_t mds_stamp; ///< mds-local timestamp (real time)
+  utime_t op_stamp;  ///< op timestamp (client provided)
 };
-
-inline ostream& operator<<(ostream &out, const MutationImpl &mut)
-{
-  mut.print(out);
-  return out;
-}
-
-typedef boost::intrusive_ptr<MutationImpl> MutationRef;
-
-
 
 /**
  * MDRequestImpl: state we track for requests we are currently processing.
  * mostly information about locks held, so that we can drop them all
- * the request is finished or forwarded.  see request_*().
+ * the request is finished or forwarded. see request_*().
  */
 struct MDRequestImpl : public MutationImpl {
-  Session *session;
-  elist<MDRequestImpl*>::item item_session_request;  // if not on list, op is aborted.
-
-  // -- i am a client (master) request
-  cref_t<MClientRequest> client_request; // client request (if any)
-
-  // tree and depth info of path1 and path2
-  inodeno_t dir_root[2] = {0, 0};
-  int dir_depth[2] = {-1, -1};
-  file_layout_t dir_layout;
-
-  // store up to two sets of dn vectors, inode pointers, for request path1 and path2.
-  vector<CDentry*> dn[2];
-  CInode *in[2];
-  CDentry *straydn;
-  snapid_t snapid;
-
-  CInode *tracei;
-  CDentry *tracedn;
-
-  inodeno_t alloc_ino, used_prealloc_ino;  
-  interval_set<inodeno_t> prealloc_inos;
-
-  int snap_caps = 0;
-  int getattr_caps = 0;		///< caps requested by getattr
-  bool no_early_reply = false;
-  bool did_early_reply = false;
-  bool o_trunc = false;		///< request is an O_TRUNC mutation
-  bool has_completed = false;	///< request has already completed
-
-  bufferlist reply_extra_bl;
-
-  // inos we did a embedded cap release on, and may need to eval if we haven't since reissued
-  map<vinodeno_t, ceph_seq_t> cap_releases;  
-
-  // -- i am a slave request
-  cref_t<MMDSSlaveRequest> slave_request; // slave request (if one is pending; implies slave == true)
-
-  // -- i am an internal op
-  int internal_op;
-  Context *internal_op_finish;
-  void *internal_op_private;
-
-  // indicates how may retries of request have been made
-  int retry;
-
-  bool is_batch_head = false;
-
-  // indicator for vxattr osdmap update
-  bool waited_for_osdmap;
+  // TrackedOp stuff
+  typedef boost::intrusive_ptr<MDRequestImpl> Ref;
 
   // break rarely-used fields into a separately allocated structure 
   // to save memory for most ops
   struct More {
+    More() {}
+
     int slave_error = 0;
     set<mds_rank_t> slaves;           // mds nodes that have slave requests to me (implies client_request)
     set<mds_rank_t> waiting_on_slave; // peers i'm waiting for slavereq replies from. 
@@ -384,23 +330,12 @@ struct MDRequestImpl : public MutationImpl {
     // for internal ops doing lookup
     filepath filepath1;
     filepath filepath2;
-
-    More() {}
-  } *_more;
-
+  } *_more = nullptr;
 
   // ---------------------------------------------------
   struct Params {
-    metareqid_t reqid;
-    __u32 attempt;
-    cref_t<MClientRequest> client_req;
-    cref_t<Message> triggering_slave_req;
-    mds_rank_t slave_to;
-    utime_t initiated;
-    utime_t throttled, all_read, dispatched;
-    int internal_op;
     // keep these default values synced to MutationImpl's
-    Params() : attempt(0), slave_to(MDS_RANK_NONE), internal_op(-1) {}
+    Params() {}
     const utime_t& get_recv_stamp() const {
       return initiated;
     }
@@ -413,19 +348,20 @@ struct MDRequestImpl : public MutationImpl {
     const utime_t& get_dispatch_stamp() const {
       return dispatched;
     }
+    metareqid_t reqid;
+    __u32 attempt = 0;
+    cref_t<MClientRequest> client_req;
+    cref_t<Message> triggering_slave_req;
+    mds_rank_t slave_to = MDS_RANK_NONE;
+    utime_t initiated;
+    utime_t throttled, all_read, dispatched;
+    int internal_op = -1;
   };
   MDRequestImpl(const Params* params, OpTracker *tracker) :
     MutationImpl(tracker, params->initiated,
 		 params->reqid, params->attempt, params->slave_to),
-    session(NULL), item_session_request(this),
-    client_request(params->client_req), straydn(NULL), snapid(CEPH_NOSNAP),
-    tracei(NULL), tracedn(NULL), alloc_ino(0), used_prealloc_ino(0),
-    internal_op(params->internal_op), internal_op_finish(NULL),
-    internal_op_private(NULL),
-    retry(0),
-    waited_for_osdmap(false), _more(NULL) {
-    in[0] = in[1] = NULL;
-  }
+    item_session_request(this), client_request(params->client_req),
+    internal_op(params->internal_op) {}
   ~MDRequestImpl() override;
   
   More* more();
@@ -455,8 +391,56 @@ struct MDRequestImpl : public MutationImpl {
   cref_t<MClientRequest> release_client_request();
   void reset_slave_request(const cref_t<MMDSSlaveRequest>& req=nullptr);
 
-  // TrackedOp stuff
-  typedef boost::intrusive_ptr<MDRequestImpl> Ref;
+  Session *session = nullptr;
+  elist<MDRequestImpl*>::item item_session_request;  // if not on list, op is aborted.
+
+  // -- i am a client (master) request
+  cref_t<MClientRequest> client_request; // client request (if any)
+
+  // tree and depth info of path1 and path2
+  inodeno_t dir_root[2] = {0, 0};
+  int dir_depth[2] = {-1, -1};
+  file_layout_t dir_layout;
+  // store up to two sets of dn vectors, inode pointers, for request path1 and path2.
+  vector<CDentry*> dn[2];
+  CInode *in[2] = {};
+  CDentry *straydn = nullptr;
+  snapid_t snapid = CEPH_NOSNAP;
+
+  CInode *tracei = nullptr;
+  CDentry *tracedn = nullptr;
+
+  inodeno_t alloc_ino = 0, used_prealloc_ino = 0;
+  interval_set<inodeno_t> prealloc_inos;
+
+  int snap_caps = 0;
+  int getattr_caps = 0;		///< caps requested by getattr
+  bool no_early_reply = false;
+  bool did_early_reply = false;
+  bool o_trunc = false;		///< request is an O_TRUNC mutation
+  bool has_completed = false;	///< request has already completed
+
+  bufferlist reply_extra_bl;
+
+  // inos we did a embedded cap release on, and may need to eval if we haven't since reissued
+  map<vinodeno_t, ceph_seq_t> cap_releases;
+
+  // -- i am a slave request
+  cref_t<MMDSSlaveRequest> slave_request; // slave request (if one is pending; implies slave == true)
+
+  // -- i am an internal op
+  int internal_op;
+  Context *internal_op_finish = nullptr;
+  void *internal_op_private = nullptr;
+
+  // indicates how may retries of request have been made
+  int retry = 0;
+
+  bool is_batch_head = false;
+
+  // indicator for vxattr osdmap update
+  bool waited_for_osdmap = false;
+
   std::vector<Ref> batch_reqs;
 protected:
   void _dump(Formatter *f) const override;
@@ -465,20 +449,10 @@ private:
   mutable ceph::spinlock msg_lock;
 };
 
-typedef boost::intrusive_ptr<MDRequestImpl> MDRequestRef;
-
-
 struct MDSlaveUpdate {
-  int origop;
-  bufferlist rollback;
-  elist<MDSlaveUpdate*>::item item;
-  Context *waiter;
-  set<CInode*> olddirs;
-  set<CInode*> unlinked;
   MDSlaveUpdate(int oo, bufferlist &rbl, elist<MDSlaveUpdate*> &list) :
     origop(oo),
-    item(this),
-    waiter(0) {
+    item(this) {
     rollback.claim(rbl);
     list.push_back(&item);
   }
@@ -487,6 +461,12 @@ struct MDSlaveUpdate {
     if (waiter)
       waiter->complete(0);
   }
+  int origop;
+  bufferlist rollback;
+  elist<MDSlaveUpdate*>::item item;
+  Context *waiter = nullptr;
+  set<CInode*> olddirs;
+  set<CInode*> unlinked;
 };
 
 struct MDLockCacheItem {
@@ -495,27 +475,12 @@ struct MDLockCacheItem {
 };
 
 struct MDLockCache : public MutationImpl {
-  CInode *diri;
-  Capability *client_cap;
-  int opcode;
-  file_layout_t dir_layout;
-
-  elist<MDLockCache*>::item item_cap_lock_cache;
-
   using LockItem = MDLockCacheItem;
-  // link myself to locked locks
-  std::unique_ptr<LockItem[]> items_lock;
 
   struct DirItem {
     MDLockCache *parent = nullptr;
     elist<DirItem*>::item item_dir;
   };
-  // link myself to auth-pinned dirfrags
-  std::unique_ptr<DirItem[]> items_dir;
-  std::vector<CDir*> auth_pinned_dirfrags;
-
-  int ref = 1;
-  bool invalidating = false;
 
   MDLockCache(Capability *cap, int op) :
     MutationImpl(), diri(cap->get_inode()), client_cap(cap), opcode(op) {
@@ -533,6 +498,31 @@ struct MDLockCache : public MutationImpl {
   void attach_locks();
   void attach_dirfrags(std::vector<CDir*>&& dfv);
   void detach_all();
+
+  CInode *diri;
+  Capability *client_cap;
+  int opcode;
+  file_layout_t dir_layout;
+
+  elist<MDLockCache*>::item item_cap_lock_cache;
+
+  // link myself to locked locks
+  std::unique_ptr<LockItem[]> items_lock;
+
+  // link myself to auth-pinned dirfrags
+  std::unique_ptr<DirItem[]> items_dir;
+  std::vector<CDir*> auth_pinned_dirfrags;
+
+  int ref = 1;
+  bool invalidating = false;
 };
 
+typedef boost::intrusive_ptr<MutationImpl> MutationRef;
+typedef boost::intrusive_ptr<MDRequestImpl> MDRequestRef;
+
+inline ostream& operator<<(ostream &out, const MutationImpl &mut)
+{
+  mut.print(out);
+  return out;
+}
 #endif


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42690
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
