### PR TITLE
rgw: fix a bug that bucket instance obj can't be removed after resharding completed

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -375,7 +375,7 @@ int RGWBucketReshard::cancel()
 class BucketInfoReshardUpdate
 {
   rgw::sal::RGWRadosStore *store;
-  RGWBucketInfo bucket_info;
+  RGWBucketInfo& bucket_info;
   std::map<string, bufferlist> bucket_attrs;
 
   bool in_progress{false};


### PR DESCRIPTION
BucketInfoReshardUpdate will update the objv_tracker when setting resharding status. But the outside bucket_info's objv_tracker is not updated and remove_bucket_instance_info will fail.

Fixes: https://tracker.ceph.com/issues/42691

Signed-off-by: zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


