### PR TITLE
mimic: test/cls_rbd: removed mirror peer pool test cases

### DIFF
--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1680,8 +1680,8 @@ namespace librbd {
 
     int mirror_peer_add(librados::IoCtx *ioctx, const std::string &uuid,
                         const std::string &cluster_name,
-                        const std::string &client_name, int64_t pool_id) {
-      cls::rbd::MirrorPeer peer(uuid, cluster_name, client_name, pool_id);
+                        const std::string &client_name) {
+      cls::rbd::MirrorPeer peer(uuid, cluster_name, client_name, -1);
       bufferlist in_bl;
       encode(peer, in_bl);
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -349,8 +349,7 @@ namespace librbd {
                          std::vector<cls::rbd::MirrorPeer> *peers);
     int mirror_peer_add(librados::IoCtx *ioctx, const std::string &uuid,
                         const std::string &cluster_name,
-                        const std::string &client_name,
-                        int64_t pool_id = -1);
+                        const std::string &client_name);
     int mirror_peer_remove(librados::IoCtx *ioctx,
                            const std::string &uuid);
     int mirror_peer_set_client(librados::IoCtx *ioctx,

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1508,21 +1508,17 @@ TEST_F(TestClsRbd, mirror) {
   ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid2", "cluster2", "admin"));
   ASSERT_EQ(-ESTALE, mirror_peer_add(&ioctx, "uuid2", "cluster3", "foo"));
   ASSERT_EQ(-EEXIST, mirror_peer_add(&ioctx, "uuid3", "cluster1", "foo"));
-  ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid3", "cluster3", "admin", 123));
+  ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid3", "cluster3", "admin"));
   ASSERT_EQ(-EEXIST, mirror_peer_add(&ioctx, "uuid4", "cluster3", "admin"));
-  ASSERT_EQ(-EEXIST, mirror_peer_add(&ioctx, "uuid4", "cluster3", "admin", 123));
-  ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid4", "cluster3", "admin", 234));
 
   ASSERT_EQ(0, mirror_peer_list(&ioctx, &peers));
   std::vector<cls::rbd::MirrorPeer> expected_peers = {
     {"uuid1", "cluster1", "client", -1},
     {"uuid2", "cluster2", "admin", -1},
-    {"uuid3", "cluster3", "admin", 123},
-    {"uuid4", "cluster3", "admin", 234}};
+    {"uuid3", "cluster3", "admin", -1}};
   ASSERT_EQ(expected_peers, peers);
 
   ASSERT_EQ(0, mirror_peer_remove(&ioctx, "uuid5"));
-  ASSERT_EQ(0, mirror_peer_remove(&ioctx, "uuid4"));
   ASSERT_EQ(0, mirror_peer_remove(&ioctx, "uuid2"));
 
   ASSERT_EQ(-ENOENT, mirror_peer_set_client(&ioctx, "uuid4", "new client"));
@@ -1534,7 +1530,7 @@ TEST_F(TestClsRbd, mirror) {
   ASSERT_EQ(0, mirror_peer_list(&ioctx, &peers));
   expected_peers = {
     {"uuid1", "cluster1", "new client", -1},
-    {"uuid3", "new cluster", "admin", 123}};
+    {"uuid3", "new cluster", "admin", -1}};
   ASSERT_EQ(expected_peers, peers);
   ASSERT_EQ(-EBUSY, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_DISABLED));
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42702

---

backport of https://github.com/ceph/ceph/pull/30948
parent tracker: https://tracker.ceph.com/issues/42333

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh