### PR TITLE
mgr/dashboard: RBD tests must use pools with power-of-two pg_n…

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -114,8 +114,8 @@ class RbdTest(DashboardTestCase):
     @classmethod
     def setUpClass(cls):
         super(RbdTest, cls).setUpClass()
-        cls.create_pool('rbd', 10, 'replicated')
-        cls.create_pool('rbd_iscsi', 10, 'replicated')
+        cls.create_pool('rbd', 2**3, 'replicated')
+        cls.create_pool('rbd_iscsi', 2**3, 'replicated')
 
         cls.create_image('rbd', 'img1', 2**30)
         cls.create_image('rbd', 'img2', 2*2**30)
@@ -325,7 +325,7 @@ class RbdTest(DashboardTestCase):
         if not self.bluestore_support:
             self.skipTest('requires bluestore cluster')
 
-        self.create_pool('data_pool', 12, 'erasure')
+        self.create_pool('data_pool', 2**4, 'erasure')
 
         rbd_name = 'test_rbd_in_data_pool'
         self.create_image('rbd', rbd_name, 10240, data_pool='data_pool')


### PR DESCRIPTION
Since https://github.com/ceph/ceph/pull/30525 cluster health will change to "**WARN**" if non-power-of-two pg_num pools are used.

`test_rbd.py` is creating pools with non-power-of-two pg_num which will result in a timeout while waiting for cluster to be in health "**OK**":

```
2019-11-05 17:12:49,329.329 INFO:__main__:======================================================================
2019-11-05 17:12:49,329.329 INFO:__main__:ERROR: test_list (tasks.mgr.dashboard.test_rbd.RbdTest)
2019-11-05 17:12:49,329.329 INFO:__main__:----------------------------------------------------------------------
2019-11-05 17:12:49,330.330 INFO:__main__:Traceback (most recent call last):
2019-11-05 17:12:49,330.330 INFO:__main__:  File "/ceph/qa/tasks/mgr/dashboard/helper.py", line 154, in setUp
2019-11-05 17:12:49,330.330 INFO:__main__:    self.wait_for_health_clear(20)
2019-11-05 17:12:49,330.330 INFO:__main__:  File "/ceph/qa/tasks/ceph_test_case.py", line 134, in wait_for_health_clear
2019-11-05 17:12:49,330.330 INFO:__main__:    self.wait_until_true(is_clear, timeout)
2019-11-05 17:12:49,331.331 INFO:__main__:  File "/ceph/qa/tasks/ceph_test_case.py", line 166, in wait_until_true
2019-11-05 17:12:49,331.331 INFO:__main__:    raise RuntimeError("Timed out after {0}s".format(elapsed))
2019-11-05 17:12:49,331.331 INFO:__main__:RuntimeError: Timed out after 20s
```

Fixes: https://tracker.ceph.com/issues/42709

Signed-off-by: Ricardo Marques <rimarques@suse.com>
