### PR TITLE
rbd/bench: outputs bytes/s format dynamically

### DIFF
--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -383,11 +383,15 @@ int do_bench(librbd::Image& image, io_type_t io_type,
       cur_off = 0;
 
       double time_sum = boost::accumulators::rolling_sum(time_acc);
-      printf("%5d  %8d  %8.2lf  %8.2lf\n",
-             (int)elapsed.count(),
-             (int)(ios - io_threads),
-             boost::accumulators::rolling_sum(ios_acc) / time_sum,
-             boost::accumulators::rolling_sum(off_acc) / time_sum);
+      std::cout.width(5);
+      std::cout << (int)elapsed.count();
+      std::cout.width(10);
+      std::cout << (int)(ios - io_threads);
+      std::cout.width(10);
+      std::cout << boost::accumulators::rolling_sum(ios_acc) / time_sum;
+      std::cout.width(10);
+      std::cout << byte_u_t(boost::accumulators::rolling_sum(off_acc) / time_sum) << "/s"
+                << std::endl;
       last = elapsed;
     }
   }
@@ -404,18 +408,23 @@ int do_bench(librbd::Image& image, io_type_t io_type,
   coarse_mono_time now = coarse_mono_clock::now();
   chrono::duration<double> elapsed = now - start;
 
-  printf("elapsed: %5d  ops: %8d  ops/sec: %8.2lf  bytes/sec: %8.2lf\n",
-         (int)elapsed.count(), ios, (double)ios / elapsed.count(),
-         (double)off / elapsed.count());
+  std::cout << "elapsed: " << (int)elapsed.count() << "   "
+            << "ops: " << ios << "   "
+            << "ops/sec: " << (double)ios / elapsed.count() << "   "
+            << "bytes/sec: " << byte_u_t((double)off / elapsed.count()) << "/s"
+            << std::endl;
 
   if (io_type == IO_TYPE_RW) {
-    printf("read_ops: %5d   read_ops/sec: %8.2lf   read_bytes/sec: %8.2lf\n",
-           read_ops, (double)read_ops / elapsed.count(),
-           (double)read_ops * io_size / elapsed.count());
+  std::cout << "read_ops: " << read_ops << "   "
+            << "read_ops/sec: " << (double)read_ops / elapsed.count() << "   "
+            << "read_bytes/sec: " << byte_u_t((double)read_ops * io_size / elapsed.count()) << "/s"
+            << std::endl;
 
-    printf("write_ops: %5d   write_ops/sec: %8.2lf   write_bytes/sec: %8.2lf\n",
-           write_ops, (double)write_ops / elapsed.count(),
-           (double)write_ops * io_size / elapsed.count());
+  std::cout << "write_ops: " << write_ops << "   "
+            << "write_ops/sec: " << (double)write_ops / elapsed.count() << "   "
+            << "write_bytes/sec: " << byte_u_t((double)write_ops * io_size / elapsed.count()) << "/s"
+            << std::endl;
+
   }
 
   return 0;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/40256
Signed-off-by: Zheng Yin <zhengyin@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
