### PR TITLE
nautilus: mgr: daemon state for mds not available

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -3,6 +3,8 @@
 
 * Nautilus-based librbd clients can now open images on Jewel clusters.
 
+* The format of MDSs in `ceph fs dump` has changed.
+
 * The RGW "num_rados_handles" has been removed.
   If you were using a value of "num_rados_handles" greater than 1
   multiply your current "objecter_inflight_ops" and

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -258,7 +258,7 @@ bool Beacon::is_laggy()
   return false;
 }
 
-void Beacon::set_want_state(const MDSMap &mdsmap, MDSMap::DaemonState const newstate)
+void Beacon::set_want_state(const MDSMap &mdsmap, MDSMap::DaemonState newstate)
 {
   std::unique_lock lock(mutex);
 

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -66,7 +66,7 @@ public:
   void handle_mds_beacon(const MMDSBeacon::const_ref &m);
   void send();
 
-  void set_want_state(const MDSMap &mdsmap, MDSMap::DaemonState const newstate);
+  void set_want_state(const MDSMap &mdsmap, MDSMap::DaemonState newstate);
   MDSMap::DaemonState get_want_state() const;
 
   /**

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -111,9 +111,8 @@ void FSMap::print(ostream& out) const
     out << "Standby daemons:" << std::endl << " " << std::endl;
   }
 
-  for (const auto &p : standby_daemons) {
-    p.second.print_summary(out);
-    out << std::endl;
+  for (const auto& p : standby_daemons) {
+    out << p.second << std::endl;
   }
 }
 

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -52,10 +52,10 @@ void FSMap::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("standbys");
-  for (const auto &i : standby_daemons) {
+  for (const auto& [gid, info] : standby_daemons) {
     f->open_object_section("info");
-    i.second.dump(f);
-    f->dump_int("epoch", standby_epochs.at(i.first));
+    info.dump(f);
+    f->dump_int("epoch", standby_epochs.at(gid));
     f->close_section();
   }
   f->close_section();

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -513,9 +513,6 @@ int MDSDaemon::init()
     return -ETIMEDOUT;
   }
 
-  mgrc.init();
-  messenger->add_dispatcher_head(&mgrc);
-
   mds_lock.Lock();
   if (beacon.get_want_state() == CEPH_MDS_STATE_DNE) {
     dout(4) << __func__ << ": terminated already, dropping out" << dendl;
@@ -524,7 +521,6 @@ int MDSDaemon::init()
   }
 
   monc->sub_want("mdsmap", 0, 0);
-  monc->sub_want("mgrmap", 0, 0);
   monc->renew_subs();
 
   mds_lock.Unlock();
@@ -926,6 +922,14 @@ void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
     respawn();
   }
 
+  if (old_state == DS::STATE_NULL && new_state != DS::STATE_NULL) {
+    /* The MDS has been added to the FSMap, now we can init the MgrClient */
+    mgrc.init();
+    messenger->add_dispatcher_tail(&mgrc);
+    monc->sub_want("mgrmap", 0, 0);
+    monc->renew_subs(); /* MgrMap receipt drives connection to ceph-mgr */
+  }
+
   // mark down any failed peers
   for (const auto& [gid, info] : oldmap->get_mds_info()) {
     if (mdsmap->get_mds_info().count(gid) == 0) {
@@ -1035,7 +1039,8 @@ void MDSDaemon::suicide()
   }
   beacon.shutdown();
 
-  mgrc.shutdown();
+  if (mgrc.is_initialized())
+    mgrc.shutdown();
 
   if (mds_rank) {
     mds_rank->shutdown();

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -882,8 +882,6 @@ void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
 
   dout(1) << "Updating MDS map to version " << epoch << " from " << m->get_source() << dendl;
 
-  entity_addrvec_t addrs;
-
   // keep old map, for a moment
   std::unique_ptr<MDSMap> oldmap;
   oldmap.swap(mdsmap);
@@ -891,13 +889,8 @@ void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
   // decode and process
   mdsmap.reset(new MDSMap);
   mdsmap->decode(m->get_encoded());
-  const MDSMap::DaemonState new_state = mdsmap->get_state_gid(mds_gid_t(monc->get_global_id()));
-  const int incarnation = mdsmap->get_inc_gid(mds_gid_t(monc->get_global_id()));
 
   monc->sub_got("mdsmap", mdsmap->get_epoch());
-
-  // Calculate my effective rank (either my owned rank or the rank I'm following if STATE_STANDBY_REPLAY
-  mds_rank_t whoami = mdsmap->get_rank_gid(mds_gid_t(monc->get_global_id()));
 
   // verify compatset
   CompatSet mdsmap_compat(MDSMap::get_compat_set_all());
@@ -908,56 +901,80 @@ void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
 	    << " not writeable with daemon features " << mdsmap_compat
 	    << ", killing myself" << dendl;
     suicide();
-    goto out;
+    return;
+  }
+
+  // Calculate my effective rank (either my owned rank or the rank I'm following if STATE_STANDBY_REPLAY
+  const auto addrs = messenger->get_myaddrs();
+  const auto myid = monc->get_global_id();
+  const auto mygid = mds_gid_t(myid);
+  const auto whoami = mdsmap->get_rank_gid(mygid);
+  const auto old_state = oldmap->get_state_gid(mygid);
+  const auto new_state = mdsmap->get_state_gid(mygid);
+  const auto incarnation = mdsmap->get_inc_gid(mygid);
+  dout(10) << "my gid is " << myid << dendl;
+  dout(10) << "map says I am mds." << whoami << "." << incarnation
+	   << " state " << ceph_mds_state_name(new_state) << dendl;
+  dout(10) << "msgr says I am " << addrs << dendl;
+
+  // If we're removed from the MDSMap, stop all processing.
+  using DS = MDSMap::DaemonState;
+  if (old_state != DS::STATE_NULL && new_state == DS::STATE_NULL) {
+    const auto& oldinfo = oldmap->get_info_gid(mygid);
+    const auto existing = mdsmap->find_mds_gid_by_name(name);
+    if (g_conf()->mds_enforce_unique_name && existing != MDS_GID_NONE) {
+      const auto& info = mdsmap->get_info_gid(existing);
+      dout(1) << "Map replaced me " << oldinfo
+              << " with another MDS of the same name: " << info
+              << "; quitting!" << dendl;
+
+      /* Monitors should never go backwards! */
+      ceph_assert(info.global_id > myid);
+
+      // Call suicide() rather than respawn() because if someone else has
+      // taken our ID, we don't want to keep restarting and fighting them for
+      // the ID.
+      suicide();
+      return;
+    }
+
+    dout(1) << "Map removed me " << oldinfo
+            << " from cluster due to lost contact; respawning" << dendl;
+    respawn();
   }
 
   // mark down any failed peers
-  for (const auto &p : oldmap->get_mds_info()) {
-    if (mdsmap->get_mds_info().count(p.first) == 0) {
-      dout(10) << " peer mds gid " << p.first << " removed from map" << dendl;
-      messenger->mark_down_addrs(p.second.addrs);
+  for (const auto& [gid, info] : oldmap->get_mds_info()) {
+    if (mdsmap->get_mds_info().count(gid) == 0) {
+      dout(10) << " peer mds gid " << gid << " removed from map" << dendl;
+      messenger->mark_down_addrs(info.addrs);
     }
   }
 
-  // see who i am
-  dout(10) << "my gid is " << monc->get_global_id() << dendl;
-  dout(10) << "map says I am mds." << whoami << "." << incarnation
-	   << " state " << ceph_mds_state_name(new_state) << dendl;
-
-  addrs = messenger->get_myaddrs();
-  dout(10) << "msgr says i am " << addrs << dendl;
-
   if (whoami == MDS_RANK_NONE) {
-    if (mds_rank != NULL) {
-      const auto myid = monc->get_global_id();
-      // We have entered a rank-holding state, we shouldn't be back
-      // here!
-      if (g_conf()->mds_enforce_unique_name) {
-        if (mds_gid_t existing = mdsmap->find_mds_gid_by_name(name)) {
-          const MDSMap::mds_info_t& i = mdsmap->get_info_gid(existing);
-          if (i.global_id > myid) {
-            dout(1) << "Map replaced me with another mds." << whoami
-                    << " with gid (" << i.global_id << ") larger than myself ("
-                    << myid << "); quitting!" << dendl;
-            // Call suicide() rather than respawn() because if someone else
-            // has taken our ID, we don't want to keep restarting and
-            // fighting them for the ID.
-            suicide();
-            return;
-          }
-        }
-      }
-
-      dout(1) << "Map removed me (mds." << whoami << " gid:"
-              << myid << ") from cluster due to lost contact; respawning" << dendl;
-      respawn();
-    }
-    // MDSRank not active: process the map here to see if we have
-    // been assigned a rank.
+    // We do not hold a rank:
     dout(10) <<  __func__ << ": handling map in rankless mode" << dendl;
-    _handle_mds_map(*mdsmap);
-  } else {
 
+    if (new_state == DS::STATE_STANDBY) {
+      /* Note: STATE_BOOT is never an actual state in the FSMap. The Monitors
+       * generally mark a new MDS as STANDBY (although it's possible to
+       * immediately be assigned a rank).
+       */
+      if (old_state == DS::STATE_NULL) {
+        dout(1) << "Monitors have assigned me to become a standby." << dendl;
+        beacon.set_want_state(*mdsmap, new_state);
+      } else if (old_state == DS::STATE_STANDBY) {
+        dout(5) << "I am still standby" << dendl;
+      }
+    } else if (new_state == DS::STATE_NULL) {
+      /* We are not in the MDSMap yet! Keep waiting: */
+      ceph_assert(beacon.get_want_state() == DS::STATE_BOOT);
+      dout(10) << "not in map yet" << dendl;
+    } else {
+      /* We moved to standby somehow from another state */
+      ceph_abort("invalid transition to standby");
+    }
+  } else {
     // Did we already hold a different rank?  MDSMonitor shouldn't try
     // to change that out from under me!
     if (mds_rank && whoami != mds_rank->get_nodeid()) {
@@ -983,34 +1000,7 @@ void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
     mds_rank->handle_mds_map(m, *oldmap);
   }
 
-out:
   beacon.notify_mdsmap(*mdsmap);
-}
-
-void MDSDaemon::_handle_mds_map(const MDSMap &mdsmap)
-{
-  MDSMap::DaemonState new_state = mdsmap.get_state_gid(mds_gid_t(monc->get_global_id()));
-
-  // Normal rankless case, we're marked as standby
-  if (new_state == MDSMap::STATE_STANDBY) {
-    beacon.set_want_state(mdsmap, new_state);
-    dout(1) << "Map has assigned me to become a standby" << dendl;
-
-    return;
-  }
-
-  // Case where we thought we were standby, but MDSMap disagrees
-  if (beacon.get_want_state() == MDSMap::STATE_STANDBY) {
-    dout(10) << "dropped out of mdsmap, try to re-add myself" << dendl;
-    new_state = MDSMap::STATE_BOOT;
-    beacon.set_want_state(mdsmap, new_state);
-    return;
-  }
-
-  // Case where we have sent a boot beacon that isn't reflected yet
-  if (beacon.get_want_state() == MDSMap::STATE_BOOT) {
-    dout(10) << "not in map yet" << dendl;
-  }
 }
 
 void MDSDaemon::handle_signal(int signum)

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -921,25 +921,8 @@ void MDSDaemon::handle_mds_map(const MMDSMap::const_ref &m)
   using DS = MDSMap::DaemonState;
   if (old_state != DS::STATE_NULL && new_state == DS::STATE_NULL) {
     const auto& oldinfo = oldmap->get_info_gid(mygid);
-    const auto existing = mdsmap->find_mds_gid_by_name(name);
-    if (g_conf()->mds_enforce_unique_name && existing != MDS_GID_NONE) {
-      const auto& info = mdsmap->get_info_gid(existing);
-      dout(1) << "Map replaced me " << oldinfo
-              << " with another MDS of the same name: " << info
-              << "; quitting!" << dendl;
-
-      /* Monitors should never go backwards! */
-      ceph_assert(info.global_id > myid);
-
-      // Call suicide() rather than respawn() because if someone else has
-      // taken our ID, we don't want to keep restarting and fighting them for
-      // the ID.
-      suicide();
-      return;
-    }
-
     dout(1) << "Map removed me " << oldinfo
-            << " from cluster due to lost contact; respawning" << dendl;
+            << " from cluster; respawning! See cluster/monitor logs for details." << dendl;
     respawn();
   }
 

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -159,7 +159,6 @@ protected:
       bool *need_reply);
   void handle_command(const MCommand::const_ref &m);
   void handle_mds_map(const MMDSMap::const_ref &m);
-  void _handle_mds_map(const MDSMap &oldmap);
 
 private:
   struct MDSCommand {

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -165,16 +165,16 @@ void MDSMap::dump(Formatter *f) const
     f->dump_int("mds", *p);
   f->close_section();
   f->open_object_section("info");
-  for (map<mds_gid_t,mds_info_t>::const_iterator p = mds_info.begin(); p != mds_info.end(); ++p) {
+  for (const auto& [gid, info] : mds_info) {
     char s[25]; // 'gid_' + len(str(ULLONG_MAX)) + '\0'
-    sprintf(s, "gid_%llu", (long long unsigned)p->first);
+    sprintf(s, "gid_%llu", (long long unsigned)gid);
     f->open_object_section(s);
-    p->second.dump(f);
+    info.dump(f);
     f->close_section();
   }
   f->close_section();
   f->open_array_section("data_pools");
-  for (const auto p: data_pools)
+  for (const auto& p: data_pools)
     f->dump_int("pool", p);
   f->close_section();
   f->dump_int("metadata_pool", metadata_pool);
@@ -354,19 +354,19 @@ void MDSMap::get_health(list<pair<health_status_t,string> >& summary,
 	if (!is_up(i))
 	  continue;
 	mds_gid_t gid = up.find(i)->second;
-	map<mds_gid_t,mds_info_t>::const_iterator info = mds_info.find(gid);
+	const auto& info = mds_info.at(gid);
 	stringstream ss;
 	if (is_resolve(i))
-	  ss << "mds." << info->second.name << " at " << info->second.addrs
+	  ss << "mds." << info.name << " at " << info.addrs
 	     << " rank " << i << " is resolving";
 	if (is_replay(i))
-	  ss << "mds." << info->second.name << " at " << info->second.addrs
+	  ss << "mds." << info.name << " at " << info.addrs
 	     << " rank " << i << " is replaying journal";
 	if (is_rejoin(i))
-	  ss << "mds." << info->second.name << " at " << info->second.addrs
+	  ss << "mds." << info.name << " at " << info.addrs
 	     << " rank " << i << " is rejoining";
 	if (is_reconnect(i))
-	  ss << "mds." << info->second.name << " at " << info->second.addrs
+	  ss << "mds." << info.name << " at " << info.addrs
 	     << " rank " << i << " is reconnecting to clients";
 	if (ss.str().length())
 	  detail->push_back(make_pair(HEALTH_WARN, ss.str()));
@@ -387,20 +387,14 @@ void MDSMap::get_health(list<pair<health_status_t,string> >& summary,
     summary.push_back(make_pair(HEALTH_WARN, ss.str()));
   }
 
-  map<mds_gid_t, mds_info_t>::const_iterator m_end = mds_info.end();
   set<string> laggy;
   for (const auto &u : up) {
-    map<mds_gid_t, mds_info_t>::const_iterator m = mds_info.find(u.second);
-    if (m == m_end) {
-      std::cerr << "Up rank " << u.first << " GID " << u.second << " not found!" << std::endl;
-    }
-    ceph_assert(m != m_end);
-    const mds_info_t &mds_info(m->second);
-    if (mds_info.laggy()) {
-      laggy.insert(mds_info.name);
+    const auto& info = mds_info.at(u.second);
+    if (info.laggy()) {
+      laggy.insert(info.name);
       if (detail) {
 	std::ostringstream oss;
-	oss << "mds." << mds_info.name << " at " << mds_info.addrs
+	oss << "mds." << info.name << " at " << info.addrs
 	    << " is laggy/unresponsive";
 	detail->push_back(make_pair(HEALTH_WARN, oss.str()));
       }
@@ -450,10 +444,10 @@ void MDSMap::get_health_checks(health_check_map_t *checks) const
       if (!is_up(i))
 	continue;
       mds_gid_t gid = up.find(i)->second;
-      map<mds_gid_t,mds_info_t>::const_iterator info = mds_info.find(gid);
+      const auto& info = mds_info.at(gid);
       stringstream ss;
-      ss << "fs " << fs_name << " mds." << info->second.name << " at "
-	 << info->second.addrs << " rank " << i;
+      ss << "fs " << fs_name << " mds." << info.name << " at "
+	 << info.addrs << " rank " << i;
       if (is_resolve(i))
 	ss << " is resolving";
       if (is_replay(i))

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -92,24 +92,21 @@ void MDSMap::mds_info_t::dump(Formatter *f) const
   f->dump_unsigned("flags", flags);
 }
 
-void MDSMap::mds_info_t::print_summary(ostream &out) const
+void MDSMap::mds_info_t::dump(std::ostream& o) const
 {
-  out << global_id << ":\t"
-      << addrs
-      << " '" << name << "'"
-      << " mds." << rank
-      << "." << inc
-      << " " << ceph_mds_state_name(state)
-      << " seq " << state_seq;
+  o << "[mds." << name << "{" <<  rank << ":" << global_id << "}"
+       << " state " << ceph_mds_state_name(state)
+       << " seq " << state_seq;
   if (laggy()) {
-    out << " laggy since " << laggy_since;
+    o << " laggy since " << laggy_since;
   }
   if (!export_targets.empty()) {
-    out << " export_targets=" << export_targets;
+    o << " export targets " << export_targets;
   }
   if (is_frozen()) {
-    out << " frozen";
+    o << " frozen";
   }
+  o << " addr " << addrs << "]";
 }
 
 void MDSMap::mds_info_t::generate_test_instances(list<mds_info_t*>& ls)
@@ -239,13 +236,9 @@ void MDSMap::print(ostream& out) const
   }
 
   for (const auto &p : foo) {
-    const mds_info_t& info = mds_info.at(p.second);
-    info.print_summary(out);
-    out << "\n";
+    out << mds_info.at(p.second) << "\n";
   }
 }
-
-
 
 void MDSMap::print_summary(Formatter *f, ostream *out) const
 {

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -320,8 +320,8 @@ public:
     return get_enabled() && (is_data_pool(poolid) || metadata_pool == poolid);
   }
 
-  const std::map<mds_gid_t,mds_info_t>& get_mds_info() const { return mds_info; }
-  const mds_info_t& get_mds_info_gid(mds_gid_t gid) const {
+  const auto& get_mds_info() const { return mds_info; }
+  const auto& get_mds_info_gid(mds_gid_t gid) const {
     return mds_info.at(gid);
   }
   const mds_info_t& get_mds_info(mds_rank_t m) const {
@@ -329,11 +329,9 @@ public:
     return mds_info.at(up.at(m));
   }
   mds_gid_t find_mds_gid_by_name(std::string_view s) const {
-    for (std::map<mds_gid_t,mds_info_t>::const_iterator p = mds_info.begin();
-	 p != mds_info.end();
-	 ++p) {
-      if (p->second.name == s) {
-	return p->first;
+    for (const auto& [gid, info] : mds_info) {
+      if (info.name == s) {
+	return gid;
       }
     }
     return MDS_GID_NONE;
@@ -510,29 +508,29 @@ public:
   bool is_dne_gid(mds_gid_t gid) const     { return mds_info.count(gid) == 0; }
 
   /**
-   * Get MDS rank state if the rank is up, else STATE_NULL
+   * Get MDS daemon status by GID
    */
-  DaemonState get_state(mds_rank_t m) const {
-    std::map<mds_rank_t, mds_gid_t>::const_iterator u = up.find(m);
-    if (u == up.end())
+  auto get_state_gid(mds_gid_t gid) const {
+    auto it = mds_info.find(gid);
+    if (it == mds_info.end())
       return STATE_NULL;
-    return get_state_gid(u->second);
+    return it->second.state;
   }
 
   /**
-   * Get MDS daemon status by GID
+   * Get MDS rank state if the rank is up, else STATE_NULL
    */
-  DaemonState get_state_gid(mds_gid_t gid) const {
-    std::map<mds_gid_t,mds_info_t>::const_iterator i = mds_info.find(gid);
-    if (i == mds_info.end())
+  auto get_state(mds_rank_t m) const {
+    auto it = up.find(m);
+    if (it == up.end())
       return STATE_NULL;
-    return i->second.state;
+    return get_state_gid(it->second);
   }
 
-  const mds_info_t& get_info(const mds_rank_t m) const {
+  const auto& get_info(mds_rank_t m) const {
     return mds_info.at(up.at(m));
   }
-  const mds_info_t& get_info_gid(const mds_gid_t gid) const {
+  const auto& get_info_gid(mds_gid_t gid) const {
     return mds_info.at(gid);
   }
 

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -138,7 +138,7 @@ public:
     }
     void decode(bufferlist::const_iterator& p);
     void dump(Formatter *f) const;
-    void print_summary(ostream &out) const;
+    void dump(std::ostream&) const;
 
     // The long form name for use in cluster log messages`
     std::string human_name() const;
@@ -678,6 +678,11 @@ WRITE_CLASS_ENCODER_FEATURES(MDSMap)
 inline ostream& operator<<(ostream &out, const MDSMap &m) {
   m.print_summary(NULL, &out);
   return out;
+}
+
+inline std::ostream& operator<<(std::ostream& o, const MDSMap::mds_info_t& info) {
+  info.dump(o);
+  return o;
 }
 
 #endif

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -44,6 +44,7 @@ void MgrClient::init()
   ceph_assert(msgr != nullptr);
 
   timer.init();
+  initialized = true;
 }
 
 void MgrClient::shutdown()

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -149,10 +149,14 @@ public:
     std::map<std::string,std::string>&& status);
   void update_daemon_health(std::vector<DaemonHealthMetric>&& metrics);
 
+  bool is_initialized() const { return initialized; }
+
 private:
   void _send_stats();
   void _send_pgstats();
   void _send_report();
+
+  bool initialized = false;
 };
 
 #endif


### PR DESCRIPTION
This backport does not include e765f2d533440cfc4189f36fcaba24617a302e84 because the service registration is not backported (it's part of `fs top` for Octopus).

Fixes: https://tracker.ceph.com/issues/42713