### PR TITLE
test/librbd: fix mock warnings in TestMockIoImageRequest

### DIFF
--- a/src/test/librbd/io/test_mock_ImageRequestWQ.cc
+++ b/src/test/librbd/io/test_mock_ImageRequestWQ.cc
@@ -255,6 +255,16 @@ struct TestMockIoImageRequestWQ : public TestMockFixture {
   void expect_start_op(MockImageDispatchSpec &mock_image_request) {
     EXPECT_CALL(mock_image_request, start_op()).Times(1);
   }
+
+  void expect_get_image_extents(MockImageDispatchSpec &mock_image_request,
+                                const Extents &extents) {
+    EXPECT_CALL(mock_image_request, get_image_extents())
+      .WillOnce(Return(extents));
+  }
+
+  void expect_get_tid(MockImageDispatchSpec &mock_image_request, uint64_t tid) {
+    EXPECT_CALL(mock_image_request, get_tid()).WillOnce(Return(tid));
+  }
 };
 
 TEST_F(TestMockIoImageRequestWQ, AcquireLockError) {
@@ -270,6 +280,8 @@ TEST_F(TestMockIoImageRequestWQ, AcquireLockError) {
   auto mock_queued_image_request = new MockImageDispatchSpec();
   expect_was_throttled(*mock_queued_image_request, false);
   expect_set_throttled(*mock_queued_image_request);
+  expect_get_image_extents(*mock_queued_image_request, {});
+  expect_get_tid(*mock_queued_image_request, 0);
 
   InSequence seq;
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);
@@ -317,6 +329,8 @@ TEST_F(TestMockIoImageRequestWQ, AcquireLockBlacklisted) {
   auto mock_queued_image_request = new MockImageDispatchSpec();
   expect_was_throttled(*mock_queued_image_request, false);
   expect_set_throttled(*mock_queued_image_request);
+  expect_get_image_extents(*mock_queued_image_request, {});
+  expect_get_tid(*mock_queued_image_request, 0);
 
   InSequence seq;
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);
@@ -357,6 +371,8 @@ TEST_F(TestMockIoImageRequestWQ, RefreshError) {
   auto mock_queued_image_request = new MockImageDispatchSpec();
   expect_was_throttled(*mock_queued_image_request, false);
   expect_set_throttled(*mock_queued_image_request);
+  expect_get_image_extents(*mock_queued_image_request, {});
+  expect_get_tid(*mock_queued_image_request, 0);
 
   InSequence seq;
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);


### PR DESCRIPTION
(introduced in 081d28ae)

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
