### PR TITLE
mon: optionally bind to public_addrv (instead of public_addr or public_network)

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -343,7 +343,7 @@ class ClusterConfigurationTest(DashboardTestCase):
         self.assertIn('services', data)
         self.assertIn('type', data)
         self.assertIn('desc', data)
-        self.assertIn(data['type'], ['str', 'bool', 'float', 'int', 'size', 'uint', 'addr', 'uuid',
+        self.assertIn(data['type'], ['str', 'bool', 'float', 'int', 'size', 'uint', 'addr', 'addrvec', 'uuid',
                                      'secs'])
 
         if 'value' in data:

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1158,6 +1158,9 @@ def command_deploy():
     if daemon_type == 'mon':
         if args.mon_ip:
             config += '[mon.%s]\n\tpublic_addr = %s\n' % (daemon_id, args.mon_ip)
+        elif args.mon_addrv:
+            config += '[mon.%s]\n\tpublic_addrv = %s\n' % (daemon_id,
+                                                           args.mon_addrv)
         elif args.mon_network:
             config += '[mon.%s]\n\tpublic_network = %s\n' % (daemon_id,
                                                              args.mon_network)
@@ -1747,6 +1750,9 @@ def _get_parser():
     parser_deploy.add_argument(
         '--mon-ip',
         help='mon IP')
+    parser_deploy.add_argument(
+        '--mon-addrv',
+        help='mon IPs (e.g., [v2:localipaddr:3300,v1:localipaddr:6789])')
     parser_deploy.add_argument(
         '--mon-network',
         help='mon network (CIDR)')

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -15,6 +15,7 @@
 /* note: no header guard */
 OPTION(host, OPT_STR) // "" means that ceph will use short hostname
 OPTION(public_addr, OPT_ADDR)
+OPTION(public_addrv, OPT_ADDRVEC)
 OPTION(public_bind_addr, OPT_ADDR)
 OPTION(cluster_addr, OPT_ADDR)
 OPTION(public_network, OPT_STR)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -366,6 +366,11 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_STARTUP)
     .add_service({"mon", "mds", "osd", "mgr"}),
 
+    Option("public_addrv", Option::TYPE_ADDRVEC, Option::LEVEL_BASIC)
+    .set_description("public-facing address to bind to")
+    .set_flag(Option::FLAG_STARTUP)
+    .add_service({"mon", "mds", "osd", "mgr"}),
+
     Option("public_bind_addr", Option::TYPE_ADDR, Option::LEVEL_ADVANCED)
     .set_default(entity_addr_t())
     .set_flag(Option::FLAG_STARTUP)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -176,7 +176,7 @@ int Option::parse_value(
       return -EINVAL;
     }
     *out = addr;
-  } else if (type == Option::TYPE_ADDR) {
+  } else if (type == Option::TYPE_ADDRVEC) {
     entity_addrvec_t addr;
     if (!addr.parse(val.c_str())){
       return -EINVAL;

--- a/test_ceph_daemon.sh
+++ b/test_ceph_daemon.sh
@@ -33,7 +33,7 @@ if [ -n "$ip2" ]; then
     --image $image \
     deploy --name mon.b \
     --fsid $fsid \
-    --mon-ip $ip2 \
+    --mon-addrv "[v2:$ip2:3300,v1:$ip2:6789]" \
     --keyring /var/lib/ceph/$fsid/mon.a/keyring \
     --config c
 fi


### PR DESCRIPTION
The teuthology task is particular about assigning ports to mons because it often puts multiple mons on the same host.  Add the ability for ceph-mon to bind to a specific addrvec, and for ceph-daemon to pass that through when deploying an additional mon.  (It was already possible to specify a full addrvec on the first monitor.)