### PR TITLE
Revert "os/bluestore: add kv_drain_preceding_waiters indicate drain_preceding."

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1763,8 +1763,6 @@ public:
 
     std::atomic_int kv_submitted_waiters = {0};
 
-    std::atomic_int kv_drain_preceding_waiters = {0};
-
     std::atomic_bool zombie = {false};    ///< in zombie_osr set (collection going away)
 
     const uint32_t sequencer_id;


### PR DESCRIPTION
This reverts commit ff71ad472e94e14f392c618b6eb5e8608afec94f.

This change has two problems:

1- First, we want to be aggressive about deferred IO so that we don't have
to wait very long for things to flush.

2- Because we aren't aggressive, when the deferred io does finish, the kv
thread isn't woken back up, which means we hang.

More generally, I don't think we care about making aggressive mode avoid
wakeups, because it is exceedingly rare--it only happens when we are
splitting PGs.

Fixes: https://tracker.ceph.com/issues/42712
Signed-off-by: Sage Weil <sage@redhat.com>