### PR TITLE
common/options: decrease the default max_omap_entries_per_request

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3719,7 +3719,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_max_omap_entries_per_request", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(131072)
+    .set_default(1024)
     .set_description(""),
 
     Option("osd_max_omap_bytes_per_request", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
the default `131072` is too large to cut off the requests with
large `max_return` specified by clients.

In one of our clusters, we found many ops delay 10s+ to dequeue which bring slow requests.
```
2019-10-21 10:46:21.455413 7f1a4fbf3700 10 osd.0 102 dequeue_op 0x55d8a07789c0 prio 63 cost 22 latency 0.000122 osd_op(mds.0.152:75066382 1.6 1:707464f6:::10002bc44a1.00000000:head [omap-get-header,omap-get-vals,getxattr parent] snapc 0=[] ondisk+read+known_if_redirected+full_force e102) v9 pg pg[1.6( v 102'20527921 (102'20526400,102'20527921] local-lis/les=101/102 n=3949746 ec=26/26 lis/c 101/101 les/c/f 102/102/0 101/101/101) [0] r=0 lpr=101 crt=102'20527921 lcod 102'20527920 mlcod 102'20527920 active+clean]
2019-10-21 10:46:22.967828 7f1a4fbf3700 10 osd.0 102 dequeue_op 0x55d86b345860 prio 63 cost 22 latency 1.498414 osd_op(mds.0.152:75066388 1.6 1:630a4f6d:::1000488e52c.00000000:head [omap-get-header,omap-get-vals,getxattr parent] snapc 0=[] ondisk+read+known_if_redirected+full_force e102) v9 pg pg[1.6( v 102'20527921 (102'20526400,102'20527921] local-lis/les=101/102 n=3949746 ec=26/26 lis/c 101/101 les/c/f 102/102/0 101/101/101) [0] r=0 lpr=101 crt=102'20527921 lcod 102'20527920 mlcod 102'20527920 active+clean]
2019-10-21 10:46:22.969688 7f1a4fbf3700 10 osd.0 102 dequeue_op 0x55d8dfef8820 prio 63 cost 22 latency 1.493194 osd_op(mds.0.152:75066402 1.1 1:86b91080:::1000488e696.00000000:head [omap-get-header,omap-get-vals,getxattr parent] snapc 0=[] ondisk+read+known_if_redirected+full_force e102) v9 pg pg[1.1( v 102'10142693 (102'10141100,102'10142693] local-lis/les=101/102 n=1971877 ec=26/26 lis/c 101/101 les/c/f 102/102/0 101/101/101) [0] r=0 lpr=101 crt=102'10142693 lcod 102'10142692 mlcod 102'10142692 active+clean]
2019-10-21 10:46:26.523548 7f1a4fbf3700 10 osd.0 102 dequeue_op 0x55d8b6d861a0 prio 63 cost 22 latency 5.045803 osd_op(mds.0.152:75066406 1.6 1:7e3ad234:::1000488e584.00000000:head [omap-get-header,omap-get-vals,getxattr parent] snapc 0=[] ondisk+read+known_if_redirected+full_force e102) v9 pg pg[1.6( v 102'20527921 (102'20526400,102'20527921] local-lis/les=101/102 n=3949746 ec=26/26 lis/c 101/101 les/c/f 102/102/0 101/101/101) [0] r=0 lpr=101 crt=102'20527921 lcod 102'20527920 mlcod 102'20527920 active+clean]
2019-10-21 10:46:28.438593 7f1a4fbf3700 10 osd.0 102 dequeue_op 0x55d89311dba0 prio 63 cost 22 latency 6.959609 osd_op(mds.0.152:75066409 1.6 1:680ff053:::1000488e689.00000000:head [omap-get-header,omap-get-vals,getxattr parent] snapc 0=[] ondisk+read+known_if_redirected+full_force e102) v9 pg pg[1.6( v 102'20527921 (102'20526400,102'20527921] local-lis/les=101/102 n=3949746 ec=26/26 lis/c 101/101 les/c/f 102/102/0 101/101/101) [0] r=0 lpr=101 crt=102'20527921 lcod 102'20527920 mlcod 102'20527920 active+clean]
2019-10-21 10:46:29.874943 7f1a4fbf3700 10 osd.0 102 dequeue_op 0x55d8c3e91860 prio 63 cost 22 latency 8.387237 osd_op(mds.0.152:75066415 1.b 1:dcdee139:::1000488e70d.00000000:head [omap-get-header,omap-get-vals,getxattr parent] snapc 0=[] ondisk+read+known_if_redirected+full_force e102) v9 pg pg[1.b( v 102'10268273 (102'10266700,102'10268273] local-lis/les=101/102 n=1975249 ec=26/26 lis/c 101/101 les/c/f 102/102/0 101/101/101) [0] r=0 lpr=101 crt=102'10268273 lcod 102'10268272 mlcod 102'10268272 active+clean]
2019-10-21 10:46:31.527196 7f1a4fbf3700 10 osd.0 102 dequeue_op 0x55d8dfe7d860 prio 63 cost 22 latency 10.036463 osd_op(mds.0.152:75066421 1.1 1:893a268f:::1000488e6e2.00000000:head [omap-get-header,omap-get-vals,getxattr parent] snapc 0=[] ondisk+read+known_if_redirected+full_force e102) v9 pg pg[1.1( v 102'10142693 (102'10141100,102'10142693] local-lis/les=101/102 n=1971877 ec=26/26 lis/c 101/101 les/c/f 102/102/0 101/101/101) [0] r=0 lpr=101 crt=102'10142693 lcod 102'10142692 mlcod 102'10142692 active+clean]
```
dig into it and found the client try to get `9999` omap entries in one request, this op(request) consume about 2s (from `13:46:12.647668` to `13:46:14.629937`) to complete, which block the subsequent ops.

```
2019-10-22 13:46:12.647668 7ff7799ec700 20 osd.0 pg_epoch: 180 pg[1.6( v 180'22230791 (180'22229200,180'22230791] local-lis/les=175/176 n=3950040 ec=26/26 lis/c 175/175 les/c/f 176/176/0 175/175/175) [0] r=0 lpr=175 crt=180'22230790 lcod 180'22230790 mlcod 180'22230790 active+clean] Found key vdb_f0001.file_head
2019-10-22 13:46:12.647713 7ff7799ec700 20 osd.0 pg_epoch: 180 pg[1.6( v 180'22230791 (180'22229200,180'22230791] local-lis/les=175/176 n=3950040 ec=26/26 lis/c 175/175 les/c/f 176/176/0 175/175/175) [0] r=0 lpr=175 crt=180'22230790 lcod 180'22230790 mlcod 180'22230790 active+clean] Found key vdb_f0002.file_head
2019-10-22 13:46:12.647747 7ff7799ec700 20 osd.0 pg_epoch: 180 pg[1.6( v 180'22230791 (180'22229200,180'22230791] local-lis/les=175/176 n=3950040 ec=26/26 lis/c 175/175 les/c/f 176/176/0 175/175/175) [0] r=0 lpr=175 crt=180'22230790 lcod 180'22230790 mlcod 180'22230790 active+clean] Found key vdb_f0003.file_head
2019-10-22 13:46:12.647780 7ff7799ec700 20 osd.0 pg_epoch: 180 pg[1.6( v 180'22230791 (180'22229200,180'22230791] local-lis/les=175/176 n=3950040 ec=26/26 lis/c 175/175 les/c/f 176/176/0 175/175/175) [0] r=0 lpr=175 crt=180'22230790 lcod 180'22230790 mlcod 180'22230790 active+clean] Found key vdb_f0004.file_head
......
2019-10-22 13:46:14.629879 7ff7799ec700 20 osd.0 pg_epoch: 180 pg[1.6( v 180'22230791 (180'22229200,180'22230791] local-lis/les=175/176 n=3950040 ec=26/26 lis/c 175/175 les/c/f 176/176/0 175/175/175) [0] r=0 lpr=175 crt=180'22230790 lcod 180'22230790 mlcod 180'22230790 active+clean] Found key vdb_f9997.file_head
2019-10-22 13:46:14.629909 7ff7799ec700 20 osd.0 pg_epoch: 180 pg[1.6( v 180'22230791 (180'22229200,180'22230791] local-lis/les=175/176 n=3950040 ec=26/26 lis/c 175/175 les/c/f 176/176/0 175/175/175) [0] r=0 lpr=175 crt=180'22230790 lcod 180'22230790 mlcod 180'22230790 active+clean] Found key vdb_f9998.file_head
2019-10-22 13:46:14.629937 7ff7799ec700 20 osd.0 pg_epoch: 180 pg[1.6( v 180'22230791 (180'22229200,180'22230791] local-lis/les=175/176 n=3950040 ec=26/26 lis/c 175/175 les/c/f 176/176/0 175/175/175) [0] r=0 lpr=175 crt=180'22230790 lcod 180'22230790 mlcod 180'22230790 active+clean] Found key vdb_f9999.file_head
```

set `osd_max_omap_entries_per_request` to a smaller value to cut off the `large request` is a better choice. 

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
