### PR TITLE
mgr/ssh: allow passing LV to 'orchestrator osd create'

### DIFF
--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -725,7 +725,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 if osd['tags']['ceph.cluster_fsid'] != fsid:
                     self.log.debug('mismatched fsid, skipping %s' % osd)
                     continue
-                if len(list(set(devices) & set(osd['devices']))) == 0:
+                if len(list(set(devices) & set(osd['devices']))) == 0 and osd.get('lv_path') not in devices:
                     self.log.debug('mismatched devices, skipping %s' % osd)
                     continue
 


### PR DESCRIPTION
In this case,

 ceph orchestrator osd create smithi009:/dev/vg_nvme/lv_1

produced

    "0": [
        {
            "devices": [
                "/dev/nvme0n1"
            ],
            "lv_name": "lv_1",
            "lv_path": "/dev/vg_nvme/lv_1",
            "lv_size": "89.40g",
            "lv_tags": "ceph.block_device=/dev/vg_nvme/lv_1,ceph.block_uuid=a1vfDi-0jor-VEPK-DZVd-K90y-cqG1-QoXr9l,ceph.cephx_lockbox_secret=,ceph.cluster_fsid=5d6d2c1c-0362-11ea-825a-001a4aab830c,ceph.cluster_name=ceph,ceph.crush_device_class=None,ceph.encrypted=0,ceph.osd_fsid=04175a6e-55e7-4244-b683-79da76f723af,ceph.osd_id=0,ceph.type=block,ceph.vdo=0",
            "lv_uuid": "a1vfDi-0jor-VEPK-DZVd-K90y-cqG1-QoXr9l",
            "name": "lv_1",
            "path": "/dev/vg_nvme/lv_1",
            "tags": {
                "ceph.block_device": "/dev/vg_nvme/lv_1",
                "ceph.block_uuid": "a1vfDi-0jor-VEPK-DZVd-K90y-cqG1-QoXr9l",
                "ceph.cephx_lockbox_secret": "",
                "ceph.cluster_fsid": "5d6d2c1c-0362-11ea-825a-001a4aab830c",
                "ceph.cluster_name": "ceph",
                "ceph.crush_device_class": "None",
                "ceph.encrypted": "0",
                "ceph.osd_fsid": "04175a6e-55e7-4244-b683-79da76f723af",
                "ceph.osd_id": "0",
                "ceph.type": "block",
                "ceph.vdo": "0"
            },
            "type": "block",
            "vg_name": "vg_nvme"
        }
    ],

Signed-off-by: Sage Weil <sage@redhat.com>