### PR TITLE
os/bluestore: check bluefs allocations on log replay

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -912,6 +912,7 @@ OPTION(bluefs_buffered_io, OPT_BOOL)
 OPTION(bluefs_sync_write, OPT_BOOL)
 OPTION(bluefs_allocator, OPT_STR)     // stupid | bitmap
 OPTION(bluefs_preextend_wal_files, OPT_BOOL)  // this *requires* that rocksdb has recycling enabled
+OPTION(bluefs_log_replay_check_allocations, OPT_BOOL)
 
 OPTION(bluestore_bluefs, OPT_BOOL)
 OPTION(bluestore_bluefs_env_mirror, OPT_BOOL) // mirror to normal Env for debug

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3973,6 +3973,10 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description("Preextent rocksdb wal files on mkfs to avoid performance penalty"),
 
+    Option("bluefs_log_replay_check_allocations", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+      .set_default(true)
+      .set_description("Enables space allocations checking during log replay"),
+
     Option("bluestore_bluefs", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
     .set_flag(Option::FLAG_CREATE)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3975,7 +3975,7 @@ std::vector<Option> get_global_options() {
 
     Option("bluefs_log_replay_check_allocations", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
       .set_default(true)
-      .set_description("Enables space allocations checking during log replay"),
+      .set_description("Enables checks for allocations consistency during log replay"),
 
     Option("bluestore_bluefs", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -769,7 +769,6 @@ int BlueFS::_check_new_allocations(const bluefs_fnode_t& fnode,
     ceph_assert(id < dev_count);
     apply_for_bitset_range(e.offset, e.length, alloc_size[id], owned_blocks[id],
       [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-        ceph_assert(pos < bs.size());
         if (!bs.test(pos)) {
           fail = true;
         }
@@ -786,7 +785,6 @@ int BlueFS::_check_new_allocations(const bluefs_fnode_t& fnode,
 
     apply_for_bitset_range(e.offset, e.length, alloc_size[id], used_blocks[id],
       [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-        ceph_assert(pos < bs.size());
         if (bs.test(pos)) {
           fail = true;
         }
@@ -1030,7 +1028,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
               bool fail = false;
               apply_for_bitset_range(offset, length, alloc_size[id], owned_blocks[id],
                 [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-                  ceph_assert(pos < bs.size());
                   if (bs.test(pos)) {
                     fail = true;
                   } else {
@@ -1046,8 +1043,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
               }
               apply_for_bitset_range(offset, length, alloc_size[id], used_blocks[id],
                 [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-                  ceph_assert(pos < bs.size());
-                  
                   if (bs.test(pos)) {
                     fail = true;
                   }
@@ -1089,7 +1084,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
               bool fail = false;
               apply_for_bitset_range(offset, length, alloc_size[id], owned_blocks[id],
                 [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-                  ceph_assert(pos < bs.size());
                   if (!bs.test(pos)) {
                     fail = true;
                   } else {
@@ -1106,7 +1100,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 
               apply_for_bitset_range(offset, length, alloc_size[id], used_blocks[id],
                 [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-                  ceph_assert(pos < bs.size());
                   if (bs.test(pos)) {
                     fail = true;
                   }
@@ -1248,7 +1241,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                 auto id = e.bdev;
                 apply_for_bitset_range(e.offset, e.length, alloc_size[id], used_blocks[id],
                   [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-                    ceph_assert(pos < bs.size());
                     ceph_assert(bs.test(pos));
                     bs.reset(pos);
                   }
@@ -1292,7 +1284,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                 bool fail = false;
                 apply_for_bitset_range(e.offset, e.length, alloc_size[id], owned_blocks[id],
                   [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-                    ceph_assert(pos < bs.size());
                     if (!bs.test(pos)) {
                       fail = true;
                     }
@@ -1309,7 +1300,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 
                 apply_for_bitset_range(e.offset, e.length, alloc_size[id], used_blocks[id],
                   [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
-                    ceph_assert(pos < bs.size());
                     if (!bs.test(pos)) {
                       fail = true;
                     }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -767,7 +767,7 @@ int BlueFS::_check_new_allocations(const bluefs_fnode_t& fnode,
     auto id = e.bdev;
     bool fail = false;
     ceph_assert(id < dev_count);
-    apply(e.offset, e.length, alloc_size[id], owned_blocks[id],
+    apply_for_bitset_range(e.offset, e.length, alloc_size[id], owned_blocks[id],
       [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
         ceph_assert(pos < bs.size());
         if (!bs.test(pos)) {
@@ -784,7 +784,7 @@ int BlueFS::_check_new_allocations(const bluefs_fnode_t& fnode,
       return -EFAULT;
     }
 
-    apply(e.offset, e.length, alloc_size[id], used_blocks[id],
+    apply_for_bitset_range(e.offset, e.length, alloc_size[id], used_blocks[id],
       [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
         ceph_assert(pos < bs.size());
         if (bs.test(pos)) {
@@ -1028,7 +1028,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 
             if (cct->_conf->bluefs_log_replay_check_allocations) {
               bool fail = false;
-              apply(offset, length, alloc_size[id], owned_blocks[id],
+              apply_for_bitset_range(offset, length, alloc_size[id], owned_blocks[id],
                 [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
                   ceph_assert(pos < bs.size());
                   if (bs.test(pos)) {
@@ -1044,7 +1044,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                   << std::dec << ": already given" << dendl;
                 return -EFAULT;
               }
-              apply(offset, length, alloc_size[id], used_blocks[id],
+              apply_for_bitset_range(offset, length, alloc_size[id], used_blocks[id],
                 [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
                   ceph_assert(pos < bs.size());
                   
@@ -1087,7 +1087,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	    alloc[id]->init_rm_free(offset, length);
             if (cct->_conf->bluefs_log_replay_check_allocations) {
               bool fail = false;
-              apply(offset, length, alloc_size[id], owned_blocks[id],
+              apply_for_bitset_range(offset, length, alloc_size[id], owned_blocks[id],
                 [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
                   ceph_assert(pos < bs.size());
                   if (!bs.test(pos)) {
@@ -1104,7 +1104,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                 return -EFAULT;
               }
 
-              apply(offset, length, alloc_size[id], used_blocks[id],
+              apply_for_bitset_range(offset, length, alloc_size[id], used_blocks[id],
                 [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
                   ceph_assert(pos < bs.size());
                   if (bs.test(pos)) {
@@ -1246,7 +1246,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
               auto& fnode_extents = f->fnode.extents;
               for (auto e : fnode_extents) {
                 auto id = e.bdev;
-                apply(e.offset, e.length, alloc_size[id], used_blocks[id],
+                apply_for_bitset_range(e.offset, e.length, alloc_size[id], used_blocks[id],
                   [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
                     ceph_assert(pos < bs.size());
                     ceph_assert(bs.test(pos));
@@ -1290,7 +1290,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
               for (auto e : fnode_extents) {
                 auto id = e.bdev;
                 bool fail = false;
-                apply(e.offset, e.length, alloc_size[id], owned_blocks[id],
+                apply_for_bitset_range(e.offset, e.length, alloc_size[id], owned_blocks[id],
                   [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
                     ceph_assert(pos < bs.size());
                     if (!bs.test(pos)) {
@@ -1307,7 +1307,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                   return -EFAULT;
                 }
 
-                apply(e.offset, e.length, alloc_size[id], used_blocks[id],
+                apply_for_bitset_range(e.offset, e.length, alloc_size[id], used_blocks[id],
                   [&](uint64_t pos, boost::dynamic_bitset<uint64_t> &bs) {
                     ceph_assert(pos < bs.size());
                     if (!bs.test(pos)) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3401,7 +3401,6 @@ void BlueFS::debug_inject_duplicate_gift(unsigned id,
 {
   dout(0) << __func__ << dendl;
   if (id < alloc.size() && alloc[id]) {
-    //log_t.op_alloc_add(id, offset, len);
     alloc[id]->init_add_free(offset, len);
   }
 }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -544,6 +544,8 @@ public:
     return _truncate(h, offset);
   }
 
+  /// test purpose methods
+  void debug_inject_duplicate_gift(unsigned bdev, uint64_t offset, uint64_t len);
 };
 
 #endif

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -14,6 +14,7 @@
 #include "global/global_context.h"
 
 #include "boost/intrusive/list.hpp"
+#include "boost/dynamic_bitset.hpp"
 
 class PerfCounters;
 
@@ -384,6 +385,10 @@ private:
 
   int _open_super();
   int _write_super(int dev);
+  int _check_new_allocations(const bluefs_fnode_t& fnode,
+    size_t dev_count,
+    boost::dynamic_bitset<uint64_t>* owned_blocks,
+    boost::dynamic_bitset<uint64_t>* used_blocks);
   int _replay(bool noop, bool to_stdout = false); ///< replay journal
 
   FileWriter *_create_writer(FileRef f);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7026,7 +7026,6 @@ int BlueStore::_fsck_check_extents(
       apply_for_bitset_range(
         e.offset, e.length, granularity, used_blocks,
         [&](uint64_t pos, mempool_dynamic_bitset &bs) {
-	  ceph_assert(pos < bs.size());
 	  if (bs.test(pos)) {
 	    if (repairer) {
 	      repairer->note_misreference(
@@ -8086,7 +8085,6 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
   apply_for_bitset_range(
     0, std::max<uint64_t>(min_alloc_size, SUPER_RESERVED), fm->get_alloc_size(), used_blocks,
     [&](uint64_t pos, mempool_dynamic_bitset &bs) {
-	ceph_assert(pos < bs.size());
       bs.set(pos);
     }
   );
@@ -8127,7 +8125,6 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
       apply_for_bitset_range(
         e.get_start(), e.get_len(), fm->get_alloc_size(), used_blocks,
         [&](uint64_t pos, mempool_dynamic_bitset &bs) {
-	ceph_assert(pos < bs.size());
           bs.set(pos);
         }
 	);
@@ -8601,7 +8598,6 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
           apply_for_bitset_range(
             e.get_start(), e.get_len(), fm->get_alloc_size(), used_blocks,
             [&](uint64_t pos, mempool_dynamic_bitset &bs) {
-	  ceph_assert(pos < bs.size());
               bs.set(pos);
             }
           );
@@ -8617,7 +8613,6 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
         apply_for_bitset_range(
           e.get_start(), e.get_len(), fm->get_alloc_size(), used_blocks,
           [&](uint64_t pos, mempool_dynamic_bitset &bs) {
-	    ceph_assert(pos < bs.size());
 	    bs.reset(pos);
           }
         );
@@ -8629,7 +8624,6 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
         apply_for_bitset_range(
           offset, length, fm->get_alloc_size(), used_blocks,
           [&](uint64_t pos, mempool_dynamic_bitset &bs) {
-	    ceph_assert(pos < bs.size());
             if (bs.test(pos)) {
 	      if (offset == SUPER_RESERVED &&
 	          length == min_alloc_size - SUPER_RESERVED) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7023,7 +7023,7 @@ int BlueStore::_fsck_check_extents(
     }
     if (depth != FSCK_SHALLOW) {
       bool already = false;
-      apply(
+      apply_for_bitset_range(
         e.offset, e.length, granularity, used_blocks,
         [&](uint64_t pos, mempool_dynamic_bitset &bs) {
 	  ceph_assert(pos < bs.size());
@@ -8083,7 +8083,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 
   _fsck_collections(&errors);
   used_blocks.resize(fm->get_alloc_units());
-  apply(
+  apply_for_bitset_range(
     0, std::max<uint64_t>(min_alloc_size, SUPER_RESERVED), fm->get_alloc_size(), used_blocks,
     [&](uint64_t pos, mempool_dynamic_bitset &bs) {
 	ceph_assert(pos < bs.size());
@@ -8124,7 +8124,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     }
 
     for (auto e = bluefs_extents.begin(); e != bluefs_extents.end(); ++e) {
-      apply(
+      apply_for_bitset_range(
         e.get_start(), e.get_len(), fm->get_alloc_size(), used_blocks,
         [&](uint64_t pos, mempool_dynamic_bitset &bs) {
 	ceph_assert(pos < bs.size());
@@ -8598,7 +8598,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 	         << " ops " << wt.ops.size()
 	         << " released 0x" << std::hex << wt.released << std::dec << dendl;
         for (auto e = wt.released.begin(); e != wt.released.end(); ++e) {
-          apply(
+          apply_for_bitset_range(
             e.get_start(), e.get_len(), fm->get_alloc_size(), used_blocks,
             [&](uint64_t pos, mempool_dynamic_bitset &bs) {
 	  ceph_assert(pos < bs.size());
@@ -8614,7 +8614,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
       // remove bluefs_extents from used set since the freelist doesn't
       // know they are allocated.
       for (auto e = bluefs_extents.begin(); e != bluefs_extents.end(); ++e) {
-        apply(
+        apply_for_bitset_range(
           e.get_start(), e.get_len(), fm->get_alloc_size(), used_blocks,
           [&](uint64_t pos, mempool_dynamic_bitset &bs) {
 	    ceph_assert(pos < bs.size());
@@ -8626,7 +8626,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
       uint64_t offset, length;
       while (fm->enumerate_next(db, &offset, &length)) {
         bool intersects = false;
-        apply(
+        apply_for_bitset_range(
           offset, length, fm->get_alloc_size(), used_blocks,
           [&](uint64_t pos, mempool_dynamic_bitset &bs) {
 	    ceph_assert(pos < bs.size());

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -22,6 +22,7 @@
 
 #include "include/cpp-btree/btree_set.h"
 
+#include "bluestore_common.h"
 #include "BlueStore.h"
 #include "os/kv.h"
 #include "include/compat.h"
@@ -6982,20 +6983,6 @@ int BlueStore::cold_close()
   _close_fsid();
   _close_path();
   return 0;
-}
-
-static void apply(uint64_t off,
-                  uint64_t len,
-                  uint64_t granularity,
-                  BlueStore::mempool_dynamic_bitset &bitset,
-                  std::function<void(uint64_t,
-				     BlueStore::mempool_dynamic_bitset &)> f) {
-  auto end = round_up_to(off + len, granularity);
-  while (off < end) {
-    uint64_t pos = off / granularity;
-    f(pos, bitset);
-    off += granularity;
-  }
 }
 
 int _fsck_sum_extents(

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -18,7 +18,7 @@
 #include "include/intarith.h"
 
 template <class Bitset, class Func>
-void apply(uint64_t off,
+void apply_for_bitset_range(uint64_t off,
   uint64_t len,
   uint64_t granularity,
   Bitset &bitset,

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -24,12 +24,12 @@ void apply_for_bitset_range(uint64_t off,
   uint64_t granularity,
   Bitset &bitset,
   Func f) {
-  auto end = round_up_to(off + len, granularity);
-  while (off < end) {
-    uint64_t pos = off / granularity;
-    ceph_assert(pos < bitset.size());
+  auto end = round_up_to(off + len, granularity) / granularity;
+  ceph_assert(end <= bitset.size());
+  uint64_t pos = off / granularity;
+  while (pos < end) {
     f(pos, bitset);
-    off += granularity;
+    pos++;
   }
 }
 

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -1,0 +1,34 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_OSD_BLUESTORE_COMMON_H
+#define CEPH_OSD_BLUESTORE_COMMON_H
+
+#include "include/intarith.h"
+
+template <class Bitset, class Func>
+void apply(uint64_t off,
+  uint64_t len,
+  uint64_t granularity,
+  Bitset &bitset,
+  Func f) {
+  auto end = round_up_to(off + len, granularity);
+  while (off < end) {
+    uint64_t pos = off / granularity;
+    f(pos, bitset);
+    off += granularity;
+  }
+}
+
+#endif

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -16,6 +16,7 @@
 #define CEPH_OSD_BLUESTORE_COMMON_H
 
 #include "include/intarith.h"
+#include "include/ceph_assert.h"
 
 template <class Bitset, class Func>
 void apply_for_bitset_range(uint64_t off,
@@ -26,6 +27,7 @@ void apply_for_bitset_range(uint64_t off,
   auto end = round_up_to(off + len, granularity);
   while (off < end) {
     uint64_t pos = off / granularity;
+    ceph_assert(pos < bitset.size());
     f(pos, bitset);
     off += granularity;
   }


### PR DESCRIPTION
As bitmap allocator doesn't provide full consistency checking it might be useful for bluefs to do that on its own.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
