### PR TITLE
osd:modify conf, timeout & suicide timeout, of workqueue at runtime to av…

### DIFF
--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -97,6 +97,12 @@ protected:
      * so at most one copy will execute simultaneously for a given thread pool.
      * It can be used for non-thread-safe finalization. */
     virtual void _void_process_finish(void *) = 0;
+    void set_timeout(time_t ti){
+      timeout_interval = ceph::make_timespan(ti);
+    }
+    void set_suicide_timeout(time_t sti){
+      suicide_interval = ceph::make_timespan(sti);
+    }
   };
 
   // track thread pool size changes

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -6092,6 +6092,8 @@ const char** FileStore::get_tracked_conf_keys() const
     "filestore_sloppy_crc",
     "filestore_sloppy_crc_block_size",
     "filestore_max_alloc_hint_size",
+    "filestore_op_thread_suicide_timeout",
+    "filestore_op_thread_timeout",
     NULL
   };
   return KEYS;
@@ -6159,6 +6161,12 @@ void FileStore::handle_conf_change(const ConfigProxy& conf,
     } else {
       dump_stop();
     }
+  }
+  if (changed.count("filestore_op_thread_timeout")){
+    op_wq.set_timeout(g_conf().get_val<int64_t>("filestore_op_thread_timeout"));
+  }
+  if (changed.count("filestore_op_thread_suicide_timeout")){
+    op_wq.set_suicide_timeout(g_conf().get_val<int64_t>("filestore_op_thread_suicide_timeout"));
   }
 }
 


### PR DESCRIPTION
…oid restarting osd

Signed-off-by: simon gao <simon29rock@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
