### PR TITLE
doc: typo fix in doc/dev/dev_cluster_deployement.rst: s/hostanme/hostname/

### DIFF
--- a/doc/dev/dev_cluster_deployement.rst
+++ b/doc/dev/dev_cluster_deployement.rst
@@ -59,7 +59,7 @@ Options
 
 .. option:: -l, --localhost
 
-    Use localhost instead of hostanme.
+    Use localhost instead of hostname.
 
 .. option:: -m ip[:port]
 


### PR DESCRIPTION

Signed-off-by: Drunkard Zhang <gongfan193@gmail.com>

