### PR TITLE
nautilus: mgr/dashboard: do not show non-pool data in pool details

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
@@ -4,7 +4,7 @@
   <tab i18n-heading
        heading="Details">
     <cd-table-key-value [renderObjects]="true"
-                        [data]="selection.first()"
+                        [data]="filterNonPoolData(selection.first())"
                         [autoReload]="false">
     </cd-table-key-value>
   </tab>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
@@ -71,7 +71,7 @@ describe('PoolDetailsComponent', () => {
       expect(tabs[0].active).toBeTruthy();
     });
 
-    it('current active status of tabs should not change when selection is same with previour selection', () => {
+    it('current active status of tabs should not change when selection is the same as previous selection', () => {
       fixture.detectChanges();
       const tabs = poolDetailsComponent.tabsetChild.tabs;
       expect(tabs[0].active).toBeTruthy();
@@ -79,6 +79,24 @@ describe('PoolDetailsComponent', () => {
       tabs[1].active = true;
       fixture.detectChanges();
       expect(tabs[1].active).toBeTruthy();
+    });
+
+    it('returns pool details correctly', () => {
+      const pool = { prop1: 1, cdIsBinary: true, prop2: 2, cdExecuting: true, prop3: 3 };
+      const expectedPool = { prop1: 1, prop2: 2, prop3: 3 };
+
+      expect(poolDetailsComponent.filterNonPoolData(pool)).toEqual(expectedPool);
+    });
+
+    it('pool data filtering is called', () => {
+      const filterNonPoolDataSpy = spyOn(
+        poolDetailsComponent,
+        'filterNonPoolData'
+      ).and.callThrough();
+
+      fixture.detectChanges();
+
+      expect(filterNonPoolDataSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
+import * as _ from 'lodash';
 import { TabsetComponent } from 'ngx-bootstrap/tabs';
 
 import { PoolService } from '../../../shared/api/pool.service';
@@ -68,5 +69,9 @@ export class PoolDetailsComponent implements OnChanges {
         this.selectedPoolConfiguration = poolConf;
       });
     }
+  }
+
+  filterNonPoolData(pool: object): object {
+    return _.omit(pool, ['cdExecuting', 'cdIsBinary']);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -74,12 +74,6 @@ describe('PoolListComponent', () => {
     expect(component.columns.every((column) => Boolean(column.prop))).toBeTruthy();
   });
 
-  it('returns pool details correctly', () => {
-    const pool = { prop1: 1, cdIsBinary: true, prop2: 2, cdExecuting: true, prop3: 3 };
-    const expected = { prop1: 1, prop2: 2, prop3: 3 };
-    expect(component.getPoolDetails(pool)).toEqual(expected);
-  });
-
   describe('monAllowPoolDelete', () => {
     let configurationService: ConfigurationService;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -272,10 +272,6 @@ export class PoolListComponent implements OnInit {
     return strings.join(', ');
   }
 
-  getPoolDetails(pool: object) {
-    return _.omit(pool, ['cdExecuting', 'cdIsBinary']);
-  }
-
   getSelectionTiers() {
     const cacheTierIds = this.selection.hasSingleSelection ? this.selection.first()['tiers'] : [];
     this.selectionCacheTiers = this.pools.filter((pool) => cacheTierIds.includes(pool.pool));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42694
possibly a backport of https://github.com/ceph/ceph/pull/31456
parent tracker: https://tracker.ceph.com/issues/42674

---

original PR body:

Fixes: https://tracker.ceph.com/issues/42694
 Signed-off-by: Alfonso Martínez <almartin@redhat.com>
 (cherry picked from commit 9db76caf8bb9307a573f9acbb83cadbc5cee63ae)


---

updated using ceph-backport.sh version 15.0.0.6950
