### PR TITLE
mds: allow stray dir fragmentation

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -1152,8 +1152,7 @@ void MDBalancer::maybe_fragment(CDir *dir, bool hot)
   // split/merge
   if (bal_fragment_dirs && bal_fragment_interval > 0 &&
       dir->is_auth() &&
-      !dir->inode->is_base() &&  // not root/mdsdir (for now at least)
-      !dir->inode->is_stray()) { // not straydir
+      !dir->inode->is_base()) {
 
     // split
     if (g_conf()->mds_bal_split_size > 0 && (dir->should_split() || hot)) {
@@ -1167,12 +1166,12 @@ void MDBalancer::maybe_fragment(CDir *dir, bool hot)
                    << *dir << dendl;
         }
       }
-    }
-
-    // merge?
-    if (dir->get_frag() != frag_t() && dir->should_merge() &&
-	merge_pending.count(dir->dirfrag()) == 0) {
-      queue_merge(dir);
+    } else {
+      // merge?
+      if (dir->get_frag() != frag_t() && dir->should_merge() &&
+          merge_pending.count(dir->dirfrag()) == 0) {
+        queue_merge(dir);
+      }
     }
   }
 }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3084,7 +3084,8 @@ bool Server::check_access(MDRequestRef& mdr, CInode *in, unsigned mask)
 bool Server::check_fragment_space(MDRequestRef &mdr, CDir *in)
 {
   const auto size = in->get_frag_size();
-  if (size >= g_conf()->mds_bal_fragment_size_max) {
+  if (size >= g_conf()->mds_bal_fragment_size_max &&
+      !g_conf().get_val<bool>("mds_bal_fragment_dirs")) {
     dout(10) << "fragment " << *in << " size exceeds " << g_conf()->mds_bal_fragment_size_max << " (ENOSPC)" << dendl;
     respond_to_request(mdr, -ENOSPC);
     return false;


### PR DESCRIPTION
* allow stray dir fragmentation for better/dynamic dir management

Stray dir fragmentation helps to avoid **no space left on device** errors during mass unlink operations.

Fixes: https://tracker.ceph.com/issues/41782
Signed-off-by: Milind Changire <mchangir@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>