### PR TITLE
mgr/ssh: add make check integration

### DIFF
--- a/src/pybind/mgr/ssh/__init__.py
+++ b/src/pybind/mgr/ssh/__init__.py
@@ -1,1 +1,6 @@
+import os
+
+if 'UNITTEST' in os.environ:
+    import tests
+
 from .module import SSHOrchestrator

--- a/src/pybind/mgr/ssh/tests/test_ssh.py
+++ b/src/pybind/mgr/ssh/tests/test_ssh.py
@@ -1,0 +1,15 @@
+from orchestrator import ServiceDescription
+from ..module import SSHOrchestrator
+from tests import mock
+
+
+@mock.patch("ssh.module.SSHOrchestrator.get_ceph_option", lambda _,key: __file__)
+def test_get_unique_name():
+    o = SSHOrchestrator('module_name', 0, 0)
+    existing = [
+        ServiceDescription(service_instance='mon.a')
+    ]
+    new_mon = o.get_unique_name(existing, 'mon')
+    assert new_mon.startswith('mon.')
+    assert new_mon != 'mon.a'
+

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -5,4 +5,4 @@ skipsdist = true
 [testenv]
 setenv = UNITTEST = true
 deps = -rrequirements.txt
-commands = pytest --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/}
+commands = pytest --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ ssh/}


### PR DESCRIPTION
Extracted from #30262

Might be able to drop the cmake integration, if we #30364 is in.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

**Depends on:**
- [x] #31561

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
