### PR TITLE
mgr/ssh: optionally specify names for mgr daemons

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -458,13 +458,14 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def update_mgrs(self, num, hosts):
+    def update_mgrs(self, num, hosts, names):
         # type: (int, List[str]) -> WriteCompletion
         """
         Update the number of cluster managers.
 
         :param num: requested number of managers.
         :param hosts: list of hosts (optional)
+        :param hosts: list of daemon names (optional)
         """
         raise NotImplementedError()
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -551,7 +551,17 @@ Usage:
             return HandleCommandResult(-errno.EINVAL,
                     stderr="Invalid number of mgrs: require {} > 0".format(num))
 
-        completion = self.update_mgrs(num, hosts)
+        names = None
+        if hosts:
+            names = []
+            newhosts = []
+            for i in hosts:
+                (h, n) = i.split('=', 1)
+                names.append(n)
+                newhosts.append(h)
+            hosts = newhosts
+
+        completion = self.update_mgrs(num, hosts, names)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -922,7 +922,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
         return self._create_daemon('mgr', name, host, keyring)
 
-    def update_mgrs(self, num, hosts):
+    def update_mgrs(self, num, hosts, names):
         """
         Adjust the number of cluster managers.
         """
@@ -978,11 +978,15 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                     "Error: {} hosts provided, expected {}".format(
                         len(hosts), num_new_mgrs))
 
+            for name in names:
+                if name and len([d for d in daemons if d.service_instance == name]):
+                    raise RuntimeError('name %s alrady exists', name)
+
             self.log.info("creating {} managers on hosts: '{}'".format(
                 num_new_mgrs, ",".join(hosts)))
 
             for i in range(num_new_mgrs):
-                name = self.get_unique_name(daemons)
+                name = names[i] or self.get_unique_name(daemons)
                 result = self._worker_pool.apply_async(self._create_mgr,
                                                        (hosts[i], name))
                 results.append(result)


### PR DESCRIPTION
Use '=' as a separator.

Signed-off-by: Sage Weil <sage@redhat.com>