### PR TITLE
ceph-daemon: make ps1 a raw string

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -8,7 +8,7 @@ UNIT_DIR='/etc/systemd/system'
 LOG_DIR_MODE=0o770
 DATA_DIR_MODE=0o700
 PODMAN_PREFERENCE = ['podman', 'docker']  # prefer podman to docker
-CUSTOM_PS1='[ceph: \u@\h \W]\\$ '
+CUSTOM_PS1=r'[ceph: \u@\h \W]\\$ '
 
 """
 You can invoke ceph-daemon in two ways:


### PR DESCRIPTION
python3 interprets '\u' as a unicode escape

```
# python3 ./ceph-daemon shell 
  File "../src/ceph-daemon/ceph-daemon", line 11
    CUSTOM_PS1='[ceph: \u@\h \W]\\$ '
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
