### PR TITLE
RGW: url-encode the kms keyid in reqeusts to barbican

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1613,6 +1613,14 @@ std::string url_encode(const std::string& src, bool encode_slash)
   return dst;
 }
 
+std::string url_encode(const boost::string_view src, bool encode_slash)
+{
+  std::string dst;
+  url_encode(src.to_string(), dst, encode_slash);
+
+  return dst;
+}
+
 std::string url_remove_prefix(const std::string& url)
 {
   std::string dst = url;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2263,6 +2263,7 @@ extern std::string url_decode(const std::string_view& src_str,
 extern void url_encode(const std::string& src, string& dst,
                        bool encode_slash = true);
 extern std::string url_encode(const std::string& src, bool encode_slash = true);
+extern std::string url_encode(const boost::string_view src, bool encode_slash = true);
 extern std::string url_remove_prefix(const std::string& url); // Removes hhtp, https and www from url
 /* destination should be CEPH_CRYPTO_HMACSHA1_DIGESTSIZE bytes long */
 extern void calc_hmac_sha1(const char *key, int key_len,

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include "include/str_map.h"
 #include "common/safe_io.h"
+#include "rgw/rgw_common.h"
 #include "rgw/rgw_crypt.h"
 #include "rgw/rgw_keystone.h"
 #include "rgw/rgw_b64.h"
@@ -313,7 +314,7 @@ static int request_key_from_barbican(CephContext *cct,
     return -EINVAL;
   }
   concat_url(secret_url, "/v1/secrets/");
-  concat_url(secret_url, std::string(key_id));
+  concat_url(secret_url, url_encode(key_id));
 
   bufferlist secret_bl;
   RGWHTTPTransceiver secret_req(cct, "GET", secret_url, &secret_bl);


### PR DESCRIPTION
Barbican operates via a REST api and we pass it the keyid as a part of
the URL. As such we need to make sure the keyid is URL encoded in case
the keyid ever uses a character not supported HTTP protocol.

This patch encodes the keyid sent to barbican by using the url_encode
method from rgw_common. A new `url_encode` signiture with a sting_view
source has been added to help keep the code simple.

Fixes: https://tracker.ceph.com/issues/39488
Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
