### PR TITLE
mds: properly evaluate unstable locks when evicting client

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2143,6 +2143,7 @@ bool Locker::revoke_stale_caps(Session *session)
   // invalidate all caps
   session->inc_cap_gen();
 
+  bool ret = true;
   std::vector<CInode*> to_eval;
 
   for (auto p = session->caps.begin(); !p.end(); ) {
@@ -2159,8 +2160,10 @@ bool Locker::revoke_stale_caps(Session *session)
     if (!revoking)
       continue;
 
-    if (revoking & CEPH_CAP_ANY_WR)
-      return false;
+    if (revoking & CEPH_CAP_ANY_WR) {
+      ret = false;
+      break;
+    }
 
     int issued = cap->issued();
     CInode *in = cap->get_inode();
@@ -2195,7 +2198,7 @@ bool Locker::revoke_stale_caps(Session *session)
       request_inode_file_caps(in);
   }
 
-  return true;
+  return ret;
 }
 
 void Locker::resume_stale_caps(Session *session)


### PR DESCRIPTION
make sure we call Locker::eval_gather() for inodes in 'to_eval' list.

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>
Fixes: https://tracker.ceph.com/issues/42759


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
