### PR TITLE
systemd: Wait 5 seconds before attempting a restart of an OSD

### DIFF
--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -27,6 +27,7 @@ TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+RestartSec=10
 
 [Install]
 WantedBy=ceph-osd.target


### PR DESCRIPTION
In commit 92f8ec the RestartSec parameter was removed which now
causes systemd to restart a failed OSD immediately.

After a reboot, while the network is still coming online, this can
cause problems.

Although network-online.target should guarantee us that the network
is online it doesn't guarantee that DNS resolving works.

If mon_host points to a DNS entry it could be that this cannot be
resolved yet and thus fails to start the OSDs on boot.

Fixes: https://tracker.ceph.com/issues/42761

Signed-off-by: Wido den Hollander <wido@42on.com>