### PR TITLE
mgr/dashboard: show "Rename" in header & button when renaming…

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h4 class="modal-title float-left"
-      i18n>{ editing, select, true {Rename} other {Create}} RBD Snapshot</h4>
+      i18n="form title|Example: Create rbdSnapshot@@formTitle">{{ action | titlecase }} {{ resource | upperFirst }}</h4>
   <button type="button"
           class="close float-right"
           aria-label="Close"
@@ -41,7 +41,7 @@
     <div class="button-group text-right">
       <cd-submit-button [form]="snapshotForm"
                         (submitAction)="submit()"
-                        i18n>{ editing, select, true {Rename} other {Create}} Snapshot</cd-submit-button>
+                        i18n="form action button|Example: Create rbdSnapshot@@formActionButton">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
       <cd-back-button [back]="modalRef.hide"
                       name="Close"
                       i18n-name>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
@@ -9,6 +9,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { ApiModule } from '../../../shared/api/api.module';
 import { ComponentsModule } from '../../../shared/components/components.module';
+import { PipesModule } from '../../../shared/pipes/pipes.module';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { RbdSnapshotFormComponent } from './rbd-snapshot-form.component';
 
@@ -20,6 +21,7 @@ describe('RbdSnapshotFormComponent', () => {
     imports: [
       ReactiveFormsModule,
       ComponentsModule,
+      PipesModule,
       HttpClientTestingModule,
       ApiModule,
       ToastrModule.forRoot(),
@@ -32,10 +34,31 @@ describe('RbdSnapshotFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdSnapshotFormComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show "Create" text', () => {
+    fixture.detectChanges();
+
+    const header = fixture.debugElement.nativeElement.querySelector('h4');
+    expect(header.textContent).toBe('Create RBD Snapshot');
+
+    const button = fixture.debugElement.nativeElement.querySelector('cd-submit-button');
+    expect(button.textContent).toBe('Create RBD Snapshot');
+  });
+
+  it('should show "Rename" text', () => {
+    component.setEditing();
+
+    fixture.detectChanges();
+
+    const header = fixture.debugElement.nativeElement.querySelector('h4');
+    expect(header.textContent).toBe('Rename RBD Snapshot');
+
+    const button = fixture.debugElement.nativeElement.querySelector('cd-submit-button');
+    expect(button.textContent).toBe('Rename RBD Snapshot');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 
+import { I18n } from '@ngx-translate/i18n-polyfill';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import { Subject } from 'rxjs';
 
 import { RbdService } from '../../../shared/api/rbd.service';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { FinishedTask } from '../../../shared/models/finished-task';
 import { NotificationService } from '../../../shared/services/notification.service';
@@ -24,6 +26,8 @@ export class RbdSnapshotFormComponent implements OnInit {
   snapshotForm: CdFormGroup;
 
   editing = false;
+  action: string;
+  resource: string;
 
   public onSubmit: Subject<string>;
 
@@ -31,8 +35,12 @@ export class RbdSnapshotFormComponent implements OnInit {
     public modalRef: BsModalRef,
     private rbdService: RbdService,
     private taskManagerService: TaskManagerService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private i18n: I18n,
+    private actionLabels: ActionLabelsI18n
   ) {
+    this.action = this.actionLabels.CREATE;
+    this.resource = this.i18n('RBD Snapshot');
     this.createForm();
   }
 
@@ -60,6 +68,7 @@ export class RbdSnapshotFormComponent implements OnInit {
    */
   setEditing(editing: boolean = true) {
     this.editing = editing;
+    this.action = this.editing ? this.actionLabels.RENAME : this.actionLabels.CREATE;
   }
 
   editAction() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -26,6 +26,7 @@ import { AuthStorageService } from '../../../shared/services/auth-storage.servic
 import { NotificationService } from '../../../shared/services/notification.service';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskListService } from '../../../shared/services/task-list.service';
+import { RbdSnapshotFormComponent } from '../rbd-snapshot-form/rbd-snapshot-form.component';
 import { RbdSnapshotListComponent } from './rbd-snapshot-list.component';
 import { RbdSnapshotModel } from './rbd-snapshot.model';
 
@@ -184,9 +185,16 @@ describe('RbdSnapshotListComponent', () => {
     beforeEach(() => {
       component.poolName = 'pool01';
       component.rbdName = 'image01';
-      spyOn(TestBed.get(BsModalService), 'show').and.callFake((content) => {
+      spyOn(TestBed.get(BsModalService), 'show').and.callFake(() => {
         const ref = new BsModalRef();
-        ref.content = new content();
+        ref.content = new RbdSnapshotFormComponent(
+          null,
+          null,
+          null,
+          null,
+          TestBed.get(I18n),
+          TestBed.get(ActionLabelsI18n)
+        );
         ref.content.onSubmit = new Subject();
         return ref;
       });


### PR DESCRIPTION
Show "Rename" in modal header & button when renaming RBD snapshot

Fixes: https://tracker.ceph.com/issues/42762
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
