### PR TITLE
nautilus: ceph-volume: use fsync for dd command

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -66,6 +66,7 @@ def zap_data(path):
         'of={path}'.format(path=path),
         'bs=1M',
         'count=10',
+        'conv=fsync'
     ])
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42741

---

backport of https://github.com/ceph/ceph/pull/31479
parent tracker: https://tracker.ceph.com/issues/39156

this backport was staged using ceph-backport.sh version 15.0.0.6814
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh