### PR TITLE
mgr: Python cleanup and type check

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -236,9 +236,11 @@ class WriteCompletion(_Completion):
         """
         return not self.is_persistent
 
+
 def _hide_in_features(f):
     f._hide_in_features = True
     return f
+
 
 class Orchestrator(object):
     """
@@ -331,7 +333,6 @@ class Orchestrator(object):
                 ...     OrchestratorClientMixin().get_hosts()
                 ... except (OrchestratorError, NotImplementedError):
                 ...     ...
-
 
         :returns: Dict of API method names to ``{'available': True or False}``
         """
@@ -575,6 +576,7 @@ class Orchestrator(object):
         :return: List of strings
         """
         raise NotImplementedError()
+
 
 class UpgradeSpec(object):
     # Request to orchestrator to initiate an upgrade to a particular
@@ -1188,8 +1190,10 @@ class OutdatableDictMixin(object):
         self[key] = OutdatableData(self[key].data,
                                    datetime.datetime.fromtimestamp(0))
 
+
 class OutdatablePersistentDict(OutdatableDictMixin, PersistentStoreDict):
     pass
+
 
 class OutdatableDict(OutdatableDictMixin, dict):
     pass

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -41,6 +41,7 @@ def _cli_command(perm):
 _read_cli = _cli_command('r')
 _write_cli = _cli_command('rw')
 
+
 class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
     MODULE_OPTIONS = [
         {'name': 'orchestrator'}
@@ -89,7 +90,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
     def _get_device_locations(self, dev_id):
         # type: (str) -> List[orchestrator.DeviceLightLoc]
         locs = [d['location'] for d in self.get('devices')['devices'] if d['devid'] == dev_id]
-        return [orchestrator.DeviceLightLoc(**l) for l in  sum(locs, [])]
+        return [orchestrator.DeviceLightLoc(**l) for l in sum(locs, [])]
 
     @_read_cli(prefix='device ls-lights',
                desc='List currently active device indicator lights')


### PR DESCRIPTION
- Add/remove missing/obsolete empty lines
- Add type check doc
- Rename inner function args to make pylint happy

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
