### PR TITLE
mon: enable msgr2 when legacy port is not 3300

### DIFF
--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -809,7 +809,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     for (auto& i : pending_map.mon_info) {
       if (i.second.public_addrs.v.size() == 1 &&
 	  i.second.public_addrs.front().is_legacy() &&
-	  i.second.public_addrs.front().get_port() == CEPH_MON_PORT_LEGACY) {
+	  i.second.public_addrs.front().get_port() != CEPH_MON_PORT_IANA) {
 	entity_addrvec_t av;
 	entity_addr_t a = i.second.public_addrs.front();
 	a.set_type(entity_addr_t::TYPE_MSGR2);


### PR DESCRIPTION
Signed-off-by: Chang Liu <liuchang0812@gmail.com>

Hi, @liewegas @tchaikov . Could we relax this port check ?  in some clusters, we are using different ports in MONs. currently `mon enable-msgr2` command enables msgr2 only when the legacy port is 6789. thanks!

```
[root@10 ~]# ceph mon dump
dumped monmap epoch 4
epoch 4
fsid 36cda771-938a-492b-8663-0b2566a48204
last_changed 2019-11-12 10:43:19.686519
created 2019-11-12 10:14:48.396827
min_mon_release 14 (nautilus)
0: [v2:10.104.150.218:3300/0,v1:10.104.150.218:6789/0] mon.10.104.150.218-CLUSTERMON_A
1: v1:10.104.153.16:6790/0 mon.10.104.153.16-CLUSTERMON_B
2: v1:10.104.61.119:6791/0 mon.10.104.61.119-CLUSTERMON_C
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
