### PR TITLE
common: move gen_rand_alphanumeric() helpers into common

### DIFF
--- a/src/cls/otp/cls_otp_client.cc
+++ b/src/cls/otp/cls_otp_client.cc
@@ -22,7 +22,7 @@ using namespace librados;
 #include "cls/otp/cls_otp_ops.h"
 #include "cls/otp/cls_otp_client.h"
 
-#include "rgw/rgw_common.h" /* for gen_random_bytes() */
+#include "common/random_string.h" /* for gen_rand_alphanumeric */
 
 namespace rados {
   namespace cls {
@@ -61,9 +61,7 @@ namespace rados {
         op.id = id;
         op.val = val;
 #define TOKEN_LEN 16
-        char buf[TOKEN_LEN + 1];
-        gen_rand_alphanumeric(cct, buf, sizeof(buf));;
-        op.token = buf;
+        op.token = gen_rand_alphanumeric(cct, TOKEN_LEN);
         
         bufferlist in;
         bufferlist out;
@@ -74,7 +72,7 @@ namespace rados {
         }
 
         cls_otp_get_result_op op2;
-        op2.token = buf;
+        op2.token = op.token;
         bufferlist in2;
         bufferlist out2;
         encode(op2, in2);

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -84,6 +84,7 @@ set(common_srcs
   perf_histogram.cc
   pick_address.cc
   rabin.cc
+  random_string.cc
   reverse.c
   run_cmd.cc
   scrub_types.cc

--- a/src/common/random_string.cc
+++ b/src/common/random_string.cc
@@ -1,0 +1,127 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include <string_view>
+#include "auth/Crypto.h"
+#include "common/armor.h"
+#include "common/ceph_context.h"
+#include "common/dout.h"
+#include "random_string.h"
+
+int gen_rand_base64(CephContext *cct, char *dest, size_t size) /* size should be the required string size + 1 */
+{
+  char buf[size];
+  char tmp_dest[size + 4]; /* so that there's space for the extra '=' characters, and some */
+  int ret;
+
+  cct->random()->get_bytes(buf, sizeof(buf));
+
+  ret = ceph_armor(tmp_dest, &tmp_dest[sizeof(tmp_dest)],
+		   (const char *)buf, ((const char *)buf) + ((size - 1) * 3 + 4 - 1) / 4);
+  if (ret < 0) {
+    lderr(cct) << "ceph_armor failed" << dendl;
+    return ret;
+  }
+  tmp_dest[ret] = '\0';
+  memcpy(dest, tmp_dest, size);
+  dest[size-1] = '\0';
+
+  return 0;
+}
+
+// choose 'size' random characters from the given string table
+static void choose_from(CryptoRandom* random, std::string_view table,
+                        char *dest, size_t size)
+{
+  random->get_bytes(dest, size);
+
+  for (size_t i = 0; i < size; i++) {
+    auto pos = static_cast<unsigned>(dest[i]);
+    dest[i] = table[pos % table.size()];
+  }
+}
+
+
+void gen_rand_alphanumeric(CephContext *cct, char *dest, size_t size) /* size should be the required string size + 1 */
+{
+  // this is basically a modified base64 charset, url friendly
+  static constexpr char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  choose_from(cct->random(), table, dest, size-1);
+  dest[size-1] = 0;
+}
+
+std::string gen_rand_alphanumeric(CephContext *cct, size_t size)
+{
+  std::string str;
+  str.resize(size + 1);
+  gen_rand_alphanumeric(cct, str.data(), str.size());
+  str.pop_back(); // pop the extra \0
+  return str;
+}
+
+void gen_rand_alphanumeric_lower(CephContext *cct, char *dest, size_t size) /* size should be the required string size + 1 */
+{
+  static constexpr char table[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  choose_from(cct->random(), table, dest, size-1);
+  dest[size-1] = 0;
+}
+
+std::string gen_rand_alphanumeric_lower(CephContext *cct, size_t size)
+{
+  std::string str;
+  str.resize(size + 1);
+  gen_rand_alphanumeric_lower(cct, str.data(), str.size());
+  str.pop_back(); // pop the extra \0
+  return str;
+}
+
+
+void gen_rand_alphanumeric_upper(CephContext *cct, char *dest, size_t size) /* size should be the required string size + 1 */
+{
+  static constexpr char table[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  choose_from(cct->random(), table, dest, size-1);
+  dest[size-1] = 0;
+}
+
+std::string gen_rand_alphanumeric_upper(CephContext *cct, size_t size)
+{
+  std::string str;
+  str.resize(size + 1);
+  gen_rand_alphanumeric_upper(cct, str.data(), str.size());
+  str.pop_back(); // pop the extra \0
+  return str;
+}
+
+
+void gen_rand_alphanumeric_no_underscore(CephContext *cct, char *dest, size_t size) /* size should be the required string size + 1 */
+{
+  static constexpr char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-.";
+  choose_from(cct->random(), table, dest, size-1);
+  dest[size-1] = 0;
+}
+
+std::string gen_rand_alphanumeric_no_underscore(CephContext *cct, size_t size)
+{
+  std::string str;
+  str.resize(size + 1);
+  gen_rand_alphanumeric_no_underscore(cct, str.data(), str.size());
+  str.pop_back(); // pop the extra \0
+  return str;
+}
+
+
+void gen_rand_alphanumeric_plain(CephContext *cct, char *dest, size_t size) /* size should be the required string size + 1 */
+{
+  static constexpr char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  choose_from(cct->random(), table, dest, size-1);
+  dest[size-1] = 0;
+}
+
+std::string gen_rand_alphanumeric_plain(CephContext *cct, size_t size)
+{
+  std::string str;
+  str.resize(size + 1);
+  gen_rand_alphanumeric_plain(cct, str.data(), str.size());
+  str.pop_back(); // pop the extra \0
+  return str;
+}

--- a/src/common/random_string.h
+++ b/src/common/random_string.h
@@ -1,0 +1,36 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2009 Sage Weil <sage@newdream.net>
+ * Copyright (C) 2015 Yehuda Sadeh <yehuda@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <string>
+
+class CephContext;
+
+/* size should be the required string size + 1 */
+int gen_rand_base64(CephContext *cct, char *dest, size_t size);
+void gen_rand_alphanumeric(CephContext *cct, char *dest, size_t size);
+void gen_rand_alphanumeric_lower(CephContext *cct, char *dest, size_t size);
+void gen_rand_alphanumeric_upper(CephContext *cct, char *dest, size_t size);
+void gen_rand_alphanumeric_no_underscore(CephContext *cct, char *dest, size_t size);
+void gen_rand_alphanumeric_plain(CephContext *cct, char *dest, size_t size);
+
+// returns a std::string with 'size' random characters
+std::string gen_rand_alphanumeric(CephContext *cct, size_t size);
+std::string gen_rand_alphanumeric_lower(CephContext *cct, size_t size);
+std::string gen_rand_alphanumeric_upper(CephContext *cct, size_t size);
+std::string gen_rand_alphanumeric_no_underscore(CephContext *cct, size_t size);
+std::string gen_rand_alphanumeric_plain(CephContext *cct, size_t size);

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -26,7 +26,6 @@
 #include "common/convenience.h"
 #include "common/strtol.h"
 #include "include/str_list.h"
-#include "auth/Crypto.h"
 #include "rgw_crypt_sanitize.h"
 
 #include <sstream>
@@ -758,105 +757,6 @@ std::string calc_hash_sha256_restart_stream(SHA256 **phash)
   *phash = calc_hash_sha256_open_stream();
 
   return hash;
-}
-
-int gen_rand_base64(CephContext *cct, char *dest, int size) /* size should be the required string size + 1 */
-{
-  char buf[size];
-  char tmp_dest[size + 4]; /* so that there's space for the extra '=' characters, and some */
-  int ret;
-
-  cct->random()->get_bytes(buf, sizeof(buf));
-
-  ret = ceph_armor(tmp_dest, &tmp_dest[sizeof(tmp_dest)],
-		   (const char *)buf, ((const char *)buf) + ((size - 1) * 3 + 4 - 1) / 4);
-  if (ret < 0) {
-    lderr(cct) << "ceph_armor failed" << dendl;
-    return ret;
-  }
-  tmp_dest[ret] = '\0';
-  memcpy(dest, tmp_dest, size);
-  dest[size-1] = '\0';
-
-  return 0;
-}
-
-static const char alphanum_upper_table[]="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-void gen_rand_alphanumeric_upper(CephContext *cct, char *dest, int size) /* size should be the required string size + 1 */
-{
-  cct->random()->get_bytes(dest, size);
-
-  int i;
-  for (i=0; i<size - 1; i++) {
-    int pos = (unsigned)dest[i];
-    dest[i] = alphanum_upper_table[pos % (sizeof(alphanum_upper_table) - 1)];
-  }
-  dest[i] = '\0';
-}
-
-static const char alphanum_lower_table[]="0123456789abcdefghijklmnopqrstuvwxyz";
-
-void gen_rand_alphanumeric_lower(CephContext *cct, char *dest, int size) /* size should be the required string size + 1 */
-{
-  cct->random()->get_bytes(dest, size);
-
-  int i;
-  for (i=0; i<size - 1; i++) {
-    int pos = (unsigned)dest[i];
-    dest[i] = alphanum_lower_table[pos % (sizeof(alphanum_lower_table) - 1)];
-  }
-  dest[i] = '\0';
-}
-
-void gen_rand_alphanumeric_lower(CephContext *cct, string *str, int length)
-{
-  char buf[length + 1];
-  gen_rand_alphanumeric_lower(cct, buf, sizeof(buf));
-  *str = buf;
-}
-
-// this is basically a modified base64 charset, url friendly
-static const char alphanum_table[]="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-
-void gen_rand_alphanumeric(CephContext *cct, char *dest, int size) /* size should be the required string size + 1 */
-{
-  cct->random()->get_bytes(dest, size);
-
-  int i;
-  for (i=0; i<size - 1; i++) {
-    int pos = (unsigned)dest[i];
-    dest[i] = alphanum_table[pos & 63];
-  }
-  dest[i] = '\0';
-}
-
-static const char alphanum_no_underscore_table[]="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-.";
-
-void gen_rand_alphanumeric_no_underscore(CephContext *cct, char *dest, int size) /* size should be the required string size + 1 */
-{
-  cct->random()->get_bytes(dest, size);
-
-  int i;
-  for (i=0; i<size - 1; i++) {
-    int pos = (unsigned)dest[i];
-    dest[i] = alphanum_no_underscore_table[pos & 63];
-  }
-  dest[i] = '\0';
-}
-
-static const char alphanum_plain_table[]="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
-void gen_rand_alphanumeric_plain(CephContext *cct, char *dest, int size) /* size should be the required string size + 1 */
-{
-  cct->random()->get_bytes(dest, size);
-
-  int i;
-  for (i=0; i<size - 1; i++) {
-    int pos = (unsigned)dest[i];
-    dest[i] = alphanum_plain_table[pos % (sizeof(alphanum_plain_table) - 1)];
-  }
-  dest[i] = '\0';
 }
 
 int NameVal::parse()

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -22,6 +22,7 @@
 #include <boost/utility/string_view.hpp>
 
 #include "common/ceph_crypto.h"
+#include "common/random_string.h"
 #include "rgw_acl.h"
 #include "rgw_cors.h"
 #include "rgw_iam_policy.h"
@@ -257,15 +258,6 @@ using ceph::crypto::MD5;
 struct req_state;
 
 typedef void *RGWAccessHandle;
-
-/* size should be the required string size + 1 */
-int gen_rand_base64(CephContext *cct, char *dest, int size);
-void gen_rand_alphanumeric(CephContext *cct, char *dest, int size);
-void gen_rand_alphanumeric_lower(CephContext *cct, char *dest, int size);
-void gen_rand_alphanumeric_upper(CephContext *cct, char *dest, int size);
-void gen_rand_alphanumeric_no_underscore(CephContext *cct, char *dest, int size);
-void gen_rand_alphanumeric_plain(CephContext *cct, char *dest, int size);
-void gen_rand_alphanumeric_lower(CephContext *cct, string *str, int length);
 
 enum RGWIntentEvent {
   DEL_OBJ = 0,

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -91,12 +91,9 @@ void RGWLifecycleConfiguration_S3::decode_xml(XMLObj *obj)
 
   for (auto& rule : rules) {
     if (rule.get_id().empty()) {
-      string id;
-
       // S3 generates a 48 bit random ID, maybe we could generate shorter IDs
       static constexpr auto LC_ID_LENGTH = 48;
-
-      gen_rand_alphanumeric_lower(cct, &id, LC_ID_LENGTH);
+      string id = gen_rand_alphanumeric_lower(cct, LC_ID_LENGTH);
       rule.set_id(id);
     }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6277,8 +6277,7 @@ int RGWRados::olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWOb
 
   if (!has_tag) {
     /* obj tag */
-    string obj_tag;
-    gen_rand_alphanumeric_lower(cct, &obj_tag, 32);
+    string obj_tag = gen_rand_alphanumeric_lower(cct, 32);
 
     bufferlist bl;
     bl.append(obj_tag.c_str(), obj_tag.size());
@@ -6288,8 +6287,7 @@ int RGWRados::olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWOb
     state.obj_tag = bl;
 
     /* olh tag */
-    string olh_tag;
-    gen_rand_alphanumeric_lower(cct, &olh_tag, 32);
+    string olh_tag = gen_rand_alphanumeric_lower(cct, 32);
 
     bufferlist olh_bl;
     olh_bl.append(olh_tag.c_str(), olh_tag.size());
@@ -6315,8 +6313,7 @@ int RGWRados::olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWOb
   snprintf(buf, sizeof(buf), "%016llx", (unsigned long long)ut.sec());
   *op_tag = buf;
 
-  string s;
-  gen_rand_alphanumeric_lower(cct, &s, OLH_PENDING_TAG_LEN - op_tag->size());
+  string s = gen_rand_alphanumeric_lower(cct, OLH_PENDING_TAG_LEN - op_tag->size());
 
   op_tag->append(s);
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -889,6 +889,10 @@ add_executable(unittest_pageset test_pageset.cc)
 add_ceph_unittest(unittest_pageset)
 target_link_libraries(unittest_pageset global)
 
+add_executable(unittest_random_string test_random_string.cc $<TARGET_OBJECTS:unit-main>)
+add_ceph_unittest(unittest_random_string)
+target_link_libraries(unittest_random_string global ${rgw_libs})
+
 # unittest_any_
 add_executable(unittest_any test_any.cc)
 add_ceph_unittest(unittest_any)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -891,7 +891,7 @@ target_link_libraries(unittest_pageset global)
 
 add_executable(unittest_random_string test_random_string.cc $<TARGET_OBJECTS:unit-main>)
 add_ceph_unittest(unittest_random_string)
-target_link_libraries(unittest_random_string global ${rgw_libs})
+target_link_libraries(unittest_random_string global)
 
 # unittest_any_
 add_executable(unittest_any test_any.cc)

--- a/src/test/test_random_string.cc
+++ b/src/test/test_random_string.cc
@@ -1,0 +1,85 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "rgw/rgw_common.h"
+#include "common/ceph_context.h"
+#include "global/global_context.h"
+#include <gtest/gtest.h>
+
+inline bool is_alphanumeric_lower(char c) {
+  return std::islower(c) || std::isdigit(c);
+}
+inline bool is_alphanumeric_upper(char c) {
+  return std::isupper(c) || std::isdigit(c);
+}
+inline bool is_alphanumeric_plain(char c) {
+  return std::islower(c) || std::isupper(c) || std::isdigit(c);
+}
+inline bool is_alphanumeric_no_underscore(char c) {
+  return is_alphanumeric_plain(c) || c == '-' || c == '.';
+}
+inline bool is_alphanumeric(char c) {
+  return is_alphanumeric_plain(c) || c == '-' || c == '_';
+}
+inline bool is_base64(char c) {
+  return is_alphanumeric_plain(c) || c == '+' || c == '/';
+}
+
+TEST(RandomString, base64)
+{
+  char arr[65] = {};
+  ASSERT_EQ(0, gen_rand_base64(g_ceph_context, arr, sizeof(arr)));
+  EXPECT_EQ(0, arr[64]); // must be null terminated
+  EXPECT_TRUE(std::all_of(arr, arr + 64, is_base64));
+}
+
+TEST(RandomString, alphanumeric)
+{
+  char arr[65] = {};
+  gen_rand_alphanumeric(g_ceph_context, arr, sizeof(arr));
+  EXPECT_EQ(0, arr[64]);
+  EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric));
+}
+
+TEST(RandomString, alphanumeric_lower)
+{
+  char arr[65] = {};
+  gen_rand_alphanumeric_lower(g_ceph_context, arr, sizeof(arr));
+  EXPECT_EQ(0, arr[64]);
+  EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric_lower));
+}
+
+TEST(RandomString, alphanumeric_upper)
+{
+  char arr[65] = {};
+  gen_rand_alphanumeric_upper(g_ceph_context, arr, sizeof(arr));
+  EXPECT_EQ(0, arr[64]);
+  EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric_upper));
+}
+
+TEST(RandomString, alphanumeric_no_underscore)
+{
+  char arr[65] = {};
+  gen_rand_alphanumeric_no_underscore(g_ceph_context, arr, sizeof(arr));
+  EXPECT_EQ(0, arr[64]);
+  EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric_no_underscore));
+}
+
+TEST(RandomString, alphanumeric_plain)
+{
+  char arr[65] = {};
+  gen_rand_alphanumeric_plain(g_ceph_context, arr, sizeof(arr));
+  EXPECT_EQ(0, arr[64]);
+  EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric_plain));
+}

--- a/src/test/test_random_string.cc
+++ b/src/test/test_random_string.cc
@@ -12,7 +12,7 @@
  *
  */
 
-#include "rgw/rgw_common.h"
+#include "common/random_string.h"
 #include "common/ceph_context.h"
 #include "global/global_context.h"
 #include <gtest/gtest.h>
@@ -52,12 +52,26 @@ TEST(RandomString, alphanumeric)
   EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric));
 }
 
+TEST(RandomString, alphanumeric_string)
+{
+  std::string str = gen_rand_alphanumeric(g_ceph_context, 64);
+  EXPECT_EQ(64, str.size());
+  EXPECT_TRUE(std::all_of(str.begin(), str.end(), is_alphanumeric));
+}
+
 TEST(RandomString, alphanumeric_lower)
 {
   char arr[65] = {};
   gen_rand_alphanumeric_lower(g_ceph_context, arr, sizeof(arr));
   EXPECT_EQ(0, arr[64]);
   EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric_lower));
+}
+
+TEST(RandomString, alphanumeric_lower_string)
+{
+  std::string str = gen_rand_alphanumeric_lower(g_ceph_context, 64);
+  EXPECT_EQ(64, str.size());
+  EXPECT_TRUE(std::all_of(str.begin(), str.end(), is_alphanumeric_lower));
 }
 
 TEST(RandomString, alphanumeric_upper)
@@ -68,6 +82,13 @@ TEST(RandomString, alphanumeric_upper)
   EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric_upper));
 }
 
+TEST(RandomString, alphanumeric_upper_string)
+{
+  std::string str = gen_rand_alphanumeric_upper(g_ceph_context, 64);
+  EXPECT_EQ(64, str.size());
+  EXPECT_TRUE(std::all_of(str.begin(), str.end(), is_alphanumeric_upper));
+}
+
 TEST(RandomString, alphanumeric_no_underscore)
 {
   char arr[65] = {};
@@ -76,10 +97,24 @@ TEST(RandomString, alphanumeric_no_underscore)
   EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric_no_underscore));
 }
 
+TEST(RandomString, alphanumeric_no_underscore_string)
+{
+  std::string str = gen_rand_alphanumeric_no_underscore(g_ceph_context, 64);
+  EXPECT_EQ(64, str.size());
+  EXPECT_TRUE(std::all_of(str.begin(), str.end(), is_alphanumeric_no_underscore));
+}
+
 TEST(RandomString, alphanumeric_plain)
 {
   char arr[65] = {};
   gen_rand_alphanumeric_plain(g_ceph_context, arr, sizeof(arr));
   EXPECT_EQ(0, arr[64]);
   EXPECT_TRUE(std::all_of(arr, arr + 64, is_alphanumeric_plain));
+}
+
+TEST(RandomString, alphanumeric_plain_string)
+{
+  std::string str = gen_rand_alphanumeric_plain(g_ceph_context, 64);
+  EXPECT_EQ(64, str.size());
+  EXPECT_TRUE(std::all_of(str.begin(), str.end(), is_alphanumeric_plain));
 }


### PR DESCRIPTION
and adds overloads that return std::string directly

the motivation is to remove cls_otp's dependency on rgw_common.h