### PR TITLE
pybind/mgr/CMakeLists: exclude tox.ini, requirements.txt from install

### DIFF
--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -18,4 +18,6 @@ install(DIRECTORY
   REGEX "CMakeLists.txt" EXCLUDE
   REGEX "\\.gitignore" EXCLUDE
   REGEX "hello/.*" EXCLUDE
-  REGEX "osd_perf_query/.*" EXCLUDE)
+  REGEX "osd_perf_query/.*" EXCLUDE
+  REGEX "tox.ini" EXCLUDE
+  REGEX "requirements.txt" EXCLUDE)


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>