### PR TITLE
build: add static analysis targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -647,3 +647,6 @@ add_tags(ctags
   EXCLUDE_OPTS ${CTAG_EXCLUDES}
   EXCLUDES "*.js" "*.css")
 add_custom_target(tags DEPENDS ctags)
+
+find_package(CppCheck)
+find_package(IWYU)

--- a/cmake/modules/FindCppCheck.cmake
+++ b/cmake/modules/FindCppCheck.cmake
@@ -1,0 +1,30 @@
+unset(CPPCHECK_BIN CACHE)
+find_program(CPPCHECK_BIN cppcheck)
+
+if(CPPCHECK_BIN)
+  find_file(PROJECT_FILE compile_commands.json PATH .)
+  if(NOT PROJECT_FILE)
+    message(STATUS "Found cppcheck, but no \"compile_commands.json\" file. To enable cppcheck, set CMAKE_EXPORT_COMPILE_COMMANDS to \"ON\" and build again.")
+    return()
+  endif()
+
+  include(ProcessorCount)
+  ProcessorCount(N)
+   
+  execute_process(COMMAND cppcheck --version OUTPUT_VARIABLE CPPCHECK_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+  separate_arguments(CPPCHECK_VERSION)
+  list(GET CPPCHECK_VERSION 1 VERSION_NUMBER)
+  if(VERSION_NUMBER VERSION_GREATER_EQUAL 1.88)
+    set(CPP_STD_VERSION "c++17")
+  else()
+    set(CPP_STD_VERSION "c++14")
+  endif()
+
+  add_custom_target(cppcheck
+    COMMAND ${CPPCHECK_BIN} --verbose -j${N} --std=${CPP_STD_VERSION} --inline-suppr --project=${PROJECT_FILE} 2> cppcheck.txt | grep done
+    )
+
+  message(STATUS "Found cppcheck. To perform static analysis using cppcheck, use: \"make cppcheck\". Results will be stored in \"cppcheck.txt\".")
+else()
+  message(STATUS "Could not find cppcheck. To perform static analysis using cppcheck install the tool (e.g. \"yum install cppcheck\").")
+endif()

--- a/cmake/modules/FindIWYU.cmake
+++ b/cmake/modules/FindIWYU.cmake
@@ -1,0 +1,27 @@
+unset(IWYU_BIN CACHE)
+find_program(IWYU_BIN iwyu_tool.py)
+
+if(IWYU_BIN)
+  find_file(PROJECT_FILE compile_commands.json PATH .)
+  if(NOT PROJECT_FILE)
+    message(STATUS "Found IWYU, but no \"compile_commands.json\" file. To enable IWYU, set CMAKE_EXPORT_COMPILE_COMMANDS to \"ON\" and build again.")
+    return()
+  endif()
+
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(STATUS "Found IWYU, but clang++ is not used used. To enable IWYU, set CMAKE_C_COMPILER to \"clang\" and CMAKE_CXX_COMPILER to \"clang++\" and build again.")
+    return()
+  endif()
+
+  include(ProcessorCount)
+  ProcessorCount(N)
+   
+  add_custom_target(iwyu
+    COMMAND echo "IWYU is analyzing includes - this may take a while..."
+    COMMAND ${IWYU_BIN} -j${N} -p . > iwyu.txt
+    )
+
+  message(STATUS "Found IWYU. To perform header analysis using IWYU, use: \"make iwyu\". Results will be stored in \"iwyu.txt\".")
+else()
+  message(STATUS "Could not find IWYU. To perform header analysis using IWYU install the tool (e.g. \"yum install iwyu\").")
+endif()


### PR DESCRIPTION
adding static analysis targets:
- [x] cppcheck: http://cppcheck.sourceforge.net/. ``make cppcheck`` should generate ``cppcheck.txt`` with the error found by the tool
- [x] iwyu: https://include-what-you-use.org/. ``make iwyu`` should generate `iwyu.txt`` file with the modification suggestion
- [x] verify that iwyu run with clang and not gcc

> Notes:
> 1. In all cases the analysis is based on ``compile_commands.json``, and therefore requires ``CMAKE_EXPORT_COMPILE_COMMANDS`` to be set.
> 2. tools are not automatically installed, and require manual installations. cmake will be prniting a message in such a case
> 3. scan-build target will be added in a separate PR
