### PR TITLE
rgw: beast frontend uses 512k mprotected coroutine stacks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "src/c-ares"]
 	path = src/c-ares
 	url = https://github.com/ceph/c-ares.git
+[submodule "src/spawn"]
+	path = src/spawn
+	url = https://github.com/ceph/spawn.git

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -235,6 +235,7 @@ macro(build_boost version)
         INTERFACE_LINK_LIBRARIES "${dependencies}")
       unset(dependencies)
     endif()
+    set(Boost_${c}_FOUND "TRUE")
   endforeach()
 
   # for header-only libraries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -703,6 +703,12 @@ if(WITH_RBD)
   add_subdirectory(rbd_replay)
 endif(WITH_RBD)
 
+if(WITH_BOOST_CONTEXT)
+  set(SPAWN_BUILD_TESTS OFF CACHE INTERNAL "disable building of spawn unit tests")
+  set(SPAWN_INSTALL OFF CACHE INTERNAL "disable installation of spawn headers")
+  add_subdirectory(spawn)
+endif()
+
 # RadosGW
 if(WITH_KVS)
   add_subdirectory(key_value_store)

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -22,31 +22,28 @@
 
 #ifndef HAVE_BOOST_CONTEXT
 
-// hide the dependencies on boost::context and boost::coroutines
-namespace boost::asio {
+// hide the dependency on boost::context
+namespace spawn {
 struct yield_context;
 }
 
 #else // HAVE_BOOST_CONTEXT
-#ifndef BOOST_COROUTINES_NO_DEPRECATION_WARNING
-#define BOOST_COROUTINES_NO_DEPRECATION_WARNING
-#endif
-#include <boost/asio/spawn.hpp>
+#include <spawn/spawn.hpp>
 
 #endif // HAVE_BOOST_CONTEXT
 
 
-/// optional-like wrapper for a boost::asio::yield_context and its associated
+/// optional-like wrapper for a spawn::yield_context and its associated
 /// boost::asio::io_context. operations that take an optional_yield argument
 /// will, when passed a non-empty yield context, suspend this coroutine instead
 /// of the blocking the thread of execution
 class optional_yield {
   boost::asio::io_context *c = nullptr;
-  boost::asio::yield_context *y = nullptr;
+  spawn::yield_context *y = nullptr;
  public:
   /// construct with a valid io and yield_context
   explicit optional_yield(boost::asio::io_context& c,
-                          boost::asio::yield_context& y) noexcept
+                          spawn::yield_context& y) noexcept
     : c(&c), y(&y) {}
 
   /// type tag to construct an empty object
@@ -60,7 +57,7 @@ class optional_yield {
   boost::asio::io_context& get_io_context() const noexcept { return *c; }
 
   /// return a reference to the yield_context. only valid if non-empty
-  boost::asio::yield_context& get_yield_context() const noexcept { return *y; }
+  spawn::yield_context& get_yield_context() const noexcept { return *y; }
 };
 
 // type tag object to construct an empty optional_yield

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -158,7 +158,8 @@ target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/su
 target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/fmt/include")
 
 if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_common PUBLIC spawn)
+  target_include_directories(rgw_common PRIVATE
+    $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
 endif()
 
 if(WITH_LTTNG)
@@ -420,6 +421,9 @@ if(WITH_RADOSGW_AMQP_ENDPOINT)
 endif()
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
   target_link_libraries(rgw_admin_user PRIVATE RDKafka::RDKafka)
+endif()
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(rgw_admin_user PRIVATE spawn)
 endif()
 
 if(WITH_TESTS)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -157,6 +157,10 @@ target_include_directories(rgw_common SYSTEM PUBLIC "services")
 target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src")
 target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/fmt/include")
 
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(rgw_common PUBLIC spawn)
+endif()
+
 if(WITH_LTTNG)
   # rgw/rgw_op.cc includes "tracing/rgw_op.h"
   # rgw/rgw_rados.cc includes "tracing/rgw_rados.h"
@@ -233,7 +237,7 @@ if(WITH_CURL_OPENSSL)
 endif()
 
 if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_a PRIVATE spawn)
+  target_link_libraries(rgw_a PUBLIC spawn)
 endif()
 
 set(rgw_libs rgw_a)
@@ -266,6 +270,10 @@ if(WITH_RADOSGW_BEAST_FRONTEND)
     rgw_dmclock_async_scheduler.cc)
 endif()
 
+add_library(rgw_schedulers STATIC ${rgw_schedulers_srcs})
+target_link_libraries(rgw_schedulers
+  PUBLIC dmclock::dmclock)
+
 add_library(radosgw SHARED ${radosgw_srcs} ${rgw_a_srcs} rgw_main.cc
   $<TARGET_OBJECTS:civetweb_common_objs>)
 
@@ -279,18 +287,16 @@ target_link_libraries(radosgw
   PRIVATE ${rgw_libs} rgw_schedulers
   PUBLIC dmclock::dmclock
 )
-if(WITH_RADOSGW_BEAST_FRONTEND AND WITH_RADOSGW_BEAST_OPENSSL)
-target_link_libraries(radosgw
-  # used by rgw_asio_frontend.cc
-  PRIVATE OpenSSL::SSL)
+if(WITH_RADOSGW_BEAST_FRONTEND)
+  target_link_libraries(rgw_schedulers PUBLIC spawn)
+  if(WITH_RADOSGW_BEAST_OPENSSL)
+    # used by rgw_asio_frontend.cc
+    target_link_libraries(radosgw PRIVATE OpenSSL::SSL)
+  endif()
 endif()
 set_target_properties(radosgw PROPERTIES OUTPUT_NAME radosgw VERSION 2.0.0
   SOVERSION 2)
 install(TARGETS radosgw DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-add_library(rgw_schedulers STATIC ${rgw_schedulers_srcs})
-target_link_libraries(rgw_schedulers
-  PUBLIC dmclock::dmclock)
 
 add_executable(radosgwd radosgw.cc)
 target_link_libraries(radosgwd radosgw librados
@@ -414,9 +420,6 @@ if(WITH_RADOSGW_AMQP_ENDPOINT)
 endif()
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
   target_link_libraries(rgw_admin_user PRIVATE RDKafka::RDKafka)
-endif()
-if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_admin_user PRIVATE Boost::coroutine Boost::context)
 endif()
 
 if(WITH_TESTS)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -233,7 +233,7 @@ if(WITH_CURL_OPENSSL)
 endif()
 
 if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_a PRIVATE Boost::coroutine Boost::context)
+  target_link_libraries(rgw_a PRIVATE spawn)
 endif()
 
 set(rgw_libs rgw_a)

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -80,12 +80,12 @@ struct Handler {
 
 template <typename Op>
 Aio::OpFunc aio_abstract(Op&& op, boost::asio::io_context& context,
-                         boost::asio::yield_context yield) {
+                         spawn::yield_context yield) {
   return [op = std::move(op), &context, yield] (Aio* aio, AioResult& r) mutable {
       // arrange for the completion Handler to run on the yield_context's strand
       // executor so it can safely call back into Aio without locking
       using namespace boost::asio;
-      async_completion<yield_context, void()> init(yield);
+      async_completion<spawn::yield_context, void()> init(yield);
       auto ex = get_associated_executor(init.completion_handler);
 
       auto& ref = r.obj.get_ref();

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -83,7 +83,7 @@ class BlockingAioThrottle final : public Aio, private Throttle {
 // functions must be called within the coroutine strand
 class YieldingAioThrottle final : public Aio, private Throttle {
   boost::asio::io_context& context;
-  boost::asio::yield_context yield;
+  spawn::yield_context yield;
   struct Handler;
 
   // completion callback associated with the waiter
@@ -97,7 +97,7 @@ class YieldingAioThrottle final : public Aio, private Throttle {
 
  public:
   YieldingAioThrottle(uint64_t window, boost::asio::io_context& context,
-                      boost::asio::yield_context yield)
+                      spawn::yield_context yield)
     : Throttle(window), context(context), yield(yield)
   {}
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -302,6 +302,10 @@ target_link_libraries(ceph_test_librgw_file_nfsns
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(ceph_test_librgw_file_nfsns spawn)
+endif()
+
 
 # ceph_test_librgw_file_aw (nfs write transaction [atomic write] tests)
 add_executable(ceph_test_librgw_file_aw
@@ -326,6 +330,9 @@ target_link_libraries(ceph_test_librgw_file_marker
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(ceph_test_librgw_file_marker spawn)
+endif()
 
 # ceph_test_rgw_token
 add_executable(ceph_test_rgw_token

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -133,6 +133,9 @@ add_executable(ceph_test_rados_api_tier_pp
   $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(ceph_test_rados_api_tier_pp
   librados global ${UNITTEST_LIBS} Boost::system radostest-cxx)
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(ceph_test_rados_api_tier_pp spawn)
+endif()
 
 add_executable(ceph_test_rados_api_snapshots
   snapshots.cc)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -40,9 +40,9 @@ add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)
 add_ceph_unittest(unittest_rgw_reshard_wait)
 target_link_libraries(unittest_rgw_reshard_wait ${rgw_libs})
 
-set(test_rgw_a_src
-  test_rgw_common.cc)
+set(test_rgw_a_src test_rgw_common.cc)
 add_library(test_rgw_a STATIC ${test_rgw_a_src})
+target_link_libraries(test_rgw_a ${rgw_libs})
 
 # ceph_test_rgw_manifest
 set(test_rgw_manifest_srcs test_rgw_manifest.cc)
@@ -50,7 +50,6 @@ add_executable(ceph_test_rgw_manifest
   ${test_rgw_manifest_srcs}
   )
 target_link_libraries(ceph_test_rgw_manifest
-  ${rgw_libs}
   test_rgw_a
   cls_rgw_client
   cls_lock_client
@@ -73,7 +72,6 @@ add_executable(ceph_test_rgw_obj
   ${test_rgw_obj_srcs}
   )
 target_link_libraries(ceph_test_rgw_obj
-  ${rgw_libs}
   test_rgw_a
   cls_rgw_client
   cls_lock_client

--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -13,6 +13,7 @@
  */
 
 #include "rgw/rgw_reshard.h"
+#include <spawn/spawn.hpp>
 
 #include <gtest/gtest.h>
 
@@ -64,7 +65,7 @@ TEST(ReshardWait, wait_yield)
   RGWReshardWait waiter(wait_duration);
 
   boost::asio::io_context context;
-  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+  spawn::spawn(context, [&] (spawn::yield_context yield) {
       EXPECT_EQ(0, waiter.wait(optional_yield{context, yield}));
     });
 
@@ -89,8 +90,8 @@ TEST(ReshardWait, stop_yield)
   RGWReshardWait short_waiter(short_duration);
 
   boost::asio::io_context context;
-  boost::asio::spawn(context,
-    [&] (boost::asio::yield_context yield) {
+  spawn::spawn(context,
+    [&] (spawn::yield_context yield) {
       EXPECT_EQ(-ECANCELED, long_waiter.wait(optional_yield{context, yield}));
     });
 
@@ -133,13 +134,13 @@ TEST(ReshardWait, stop_multiple)
   // spawn 4 coroutines
   boost::asio::io_context context;
   {
-    auto async_waiter = [&] (boost::asio::yield_context yield) {
+    auto async_waiter = [&] (spawn::yield_context yield) {
         EXPECT_EQ(-ECANCELED, long_waiter.wait(optional_yield{context, yield}));
       };
-    boost::asio::spawn(context, async_waiter);
-    boost::asio::spawn(context, async_waiter);
-    boost::asio::spawn(context, async_waiter);
-    boost::asio::spawn(context, async_waiter);
+    spawn::spawn(context, async_waiter);
+    spawn::spawn(context, async_waiter);
+    spawn::spawn(context, async_waiter);
+    spawn::spawn(context, async_waiter);
   }
 
   const auto start = Clock::now();

--- a/src/test/rgw/test_rgw_throttle.cc
+++ b/src/test/rgw/test_rgw_throttle.cc
@@ -19,7 +19,7 @@
 #include "include/scope_guard.h"
 
 #ifdef HAVE_BOOST_CONTEXT
-#include <boost/asio/spawn.hpp>
+#include <spawn/spawn.hpp>
 #endif
 #include <gtest/gtest.h>
 
@@ -38,6 +38,7 @@ struct RadosEnv : public ::testing::Environment {
     ASSERT_EQ(0, r);
   }
   void TearDown() override {
+    rados->shutdown();
     rados.reset();
   }
 };
@@ -171,8 +172,8 @@ TEST_F(Aio_Throttle, YieldCostOverWindow)
   auto obj = make_obj(__PRETTY_FUNCTION__);
 
   boost::asio::io_context context;
-  boost::asio::spawn(context,
-    [&] (boost::asio::yield_context yield) {
+  spawn::spawn(context,
+    [&] (spawn::yield_context yield) {
       YieldingAioThrottle throttle(4, context, yield);
       scoped_completion op;
       auto c = throttle.get(obj, wait_on(op), 8, 0);
@@ -193,8 +194,8 @@ TEST_F(Aio_Throttle, YieldingThrottleOverMax)
   uint64_t outstanding = 0;
 
   boost::asio::io_context context;
-  boost::asio::spawn(context,
-    [&] (boost::asio::yield_context yield) {
+  spawn::spawn(context,
+    [&] (spawn::yield_context yield) {
       YieldingAioThrottle throttle(window, context, yield);
       for (uint64_t i = 0; i < total; i++) {
         using namespace std::chrono_literals;


### PR DESCRIPTION
adds a submodule for https://github.com/cbodley/spawn, a header-only fork of boost::asio::spawn(). the beast frontend uses this to customize the coroutine stack allocator in order to use mmap/mprotect to detect overflows. the default stack size is raised from 128K to 512K

~depends on commits from https://github.com/ceph/ceph/pull/31567 so that cls_otp doesn't also need to link against spawn and boost::context~

TODO:
- [x] fork https://github.com/cbodley/spawn under the ceph organization
- [x] fix spawn's use of find_package(Boost) that relies on having a boost/version.hpp