### PR TITLE
ceph-daemon: -v|--verbose, not -d|--debug

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1558,7 +1558,7 @@ def _get_parser():
         default=UNIT_DIR,
         help='base directory for systemd units')
     parser.add_argument(
-        '--debug', '-d',
+        '--verbose', '-v',
         action='store_true',
         help='Show debug-level log messages')
     subparsers = parser.add_subparsers(help='sub-command')
@@ -1809,7 +1809,7 @@ if __name__ == "__main__":
     parser = _get_parser()
     args = parser.parse_args(av)
 
-    if args.debug:
+    if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
-v is more natural IMO

Signed-off-by: Sage Weil <sage@redhat.com>