### PR TITLE
ceph-daemon: add `--legacy-dir` arg to `ls` command

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1322,28 +1322,34 @@ def command_logs():
 ##################################
 
 def command_ls():
-    ls = list_daemons(detail=not args.no_detail)
+    ls = list_daemons(detail=not args.no_detail,
+                      legacy_dir=args.legacy_dir)
     print(json.dumps(ls, indent=4))
 
-def list_daemons(detail=True):
+def list_daemons(detail=True, legacy_dir=None):
     host_version = None
     ls = []
 
+    data_dir = args.data_dir
+    if legacy_dir is not None:
+        data_dir = os.path.abspath(legacy_dir + data_dir)
+
     # /var/lib/ceph
-    if os.path.exists(args.data_dir):
-        for i in os.listdir(args.data_dir):
+    if os.path.exists(data_dir):
+        for i in os.listdir(data_dir):
             if i in ['mon', 'osd', 'mds', 'mgr']:
                 daemon_type = i
-                for j in os.listdir(os.path.join(args.data_dir, i)):
+                for j in os.listdir(os.path.join(data_dir, i)):
                     if '-' not in j:
                         continue
                     (cluster, daemon_id) = j.split('-', 1)
-                    fsid = get_legacy_daemon_fsid(cluster, daemon_type,
-                                                  daemon_id) or 'unknown'
+                    fsid = get_legacy_daemon_fsid(
+                            cluster, daemon_type, daemon_id,
+                            legacy_dir=legacy_dir)
                     i = {
                         'style': 'legacy',
                         'name': '%s.%s' % (daemon_type, daemon_id),
-                        'fsid': fsid,
+                        'fsid': fsid if fsid is not None else 'unknown',
                     }
                     if detail:
                         (i['enabled'], i['state']) = check_unit(
@@ -1359,7 +1365,7 @@ def list_daemons(detail=True):
                     ls.append(i)
             elif is_fsid(i):
                 fsid = i
-                for j in os.listdir(os.path.join(args.data_dir, i)):
+                for j in os.listdir(os.path.join(data_dir, i)):
                     if j == 'crash':
                         name = 'crash'
                         unit_name = 'ceph-%s-crash.service' % fsid
@@ -1583,11 +1589,15 @@ def _get_parser():
 
     parser_ls = subparsers.add_parser(
         'ls', help='list daemon instances on this host')
+    parser_ls.set_defaults(func=command_ls)
     parser_ls.add_argument(
         '--no-detail',
         action='store_true',
         help='Do not include daemon status')
-    parser_ls.set_defaults(func=command_ls)
+    parser_ls.add_argument(
+        '--legacy-dir',
+        default='/',
+        help='base directory for legacy daemon data')
 
     parser_adopt = subparsers.add_parser(
         'adopt', help='adopt daemon deployed with a different tool')


### PR DESCRIPTION
Extend the `ls` command to work against a relative (legacy) base path.

```
# ls -lah ./foobar/var/lib/ceph/
total 0
drwxr-x--- 1 167 167  0 Jun 13 04:50 bootstrap-mds
drwxr-x--- 1 167 167  0 Jun 13 04:50 bootstrap-mgr
drwxr-x--- 1 167 167 24 Nov 10 15:18 bootstrap-osd
drwxr-x--- 1 167 167  0 Jun 13 04:50 bootstrap-rbd
drwxr-x--- 1 167 167  0 Jun 13 04:50 bootstrap-rbd-mirror
drwxr-x--- 1 167 167  0 Jun 13 04:50 bootstrap-rgw
drwxr-x--- 1 167 167 12 Nov 10 15:09 crash
drwxr-x--- 1 167 167 20 Nov 10 15:28 mds
drwxr-x--- 1 167 167 20 Nov 10 15:16 mgr
drwxr-x--- 1 167 167 20 Nov 10 15:16 mon
drwxr-x--- 1 167 167 72 Nov 10 15:25 osd
drwxr-x--- 1 167 167 22 Nov 10 15:16 tmp
```

```
# python3 ./ceph-daemon  ls --legacy-dir ./foobar/  
[
    {
        "style": "legacy",
        "name": "osd.3",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    },
    {
        "style": "legacy",
        "name": "osd.2",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    },
    {
        "style": "legacy",
        "name": "osd.5",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    },
    {
        "style": "legacy",
        "name": "osd.0",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    },
    {
        "style": "legacy",
        "name": "osd.1",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    },
    {
        "style": "legacy",
        "name": "osd.4",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    },
    {
        "style": "legacy",
        "name": "mgr.admin",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    },
    {
        "style": "legacy",
        "name": "mds.admin",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    },
    {
        "style": "legacy",
        "name": "mon.admin",
        "fsid": "00000000-0000-0000-0000-ffffdeadbeef",
        "enabled": false,
        "state": "stopped",
        "host_version": null
    }
]

```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
