### PR TITLE
luminous: mgr/prometheus: assign a value to osd_dev_node when obj_store is not filestore or bluestore

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -521,6 +521,8 @@ class Module(MgrModule):
                 osd_wal_dev_node = osd_metadata.get('bluefs_wal_dev_node', '')
             # collect bluestore db backend
                 osd_db_dev_node = osd_metadata.get('bluefs_db_dev_node', '')
+            else:
+                osd_dev_node = "unknown"
             if osd_dev_node and osd_dev_node == "unknown":
                 osd_dev_node = None
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -508,6 +508,7 @@ class Module(MgrModule):
                     'osd.{}'.format(id_),
                 ))
 
+            osd_dev_node = None
             if obj_store == "filestore":
             # collect filestore backend device
                 osd_dev_node = osd_metadata.get('backend_filestore_dev_node', None)
@@ -521,8 +522,6 @@ class Module(MgrModule):
                 osd_wal_dev_node = osd_metadata.get('bluefs_wal_dev_node', '')
             # collect bluestore db backend
                 osd_db_dev_node = osd_metadata.get('bluefs_db_dev_node', '')
-            else:
-                osd_dev_node = "unknown"
             if osd_dev_node and osd_dev_node == "unknown":
                 osd_dev_node = None
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42784

---

backport of https://github.com/ceph/ceph/pull/30534
parent tracker: https://tracker.ceph.com/issues/42017

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh