### PR TITLE
ceph-volume: assume msgrV1 for all branches containing mimic

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/functional/tests/conftest.py
@@ -19,7 +19,7 @@ def node(host, request):
     ceph_dev_branch = os.environ.get("CEPH_DEV_BRANCH", "master")
     group_names = ansible_vars["group_names"]
     num_osd_ports = 4
-    if ceph_dev_branch in ['luminous', 'mimic']:
+    if 'mimic' in ceph_dev_branch or 'luminous' in ceph_dev_branch:
         num_osd_ports = 2
 
     # capture the initial/default state


### PR DESCRIPTION
With nautilus and newer OSDs listen on v1 ports and v2 ports. Assume
that if mimic (or luminous) occur in the branch name, the OSDs are
running msgrv1 only.

Fixes: https://tracker.ceph.com/issues/42791

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
