### PR TITLE
tools/blkin: Modified blkin to use TracepointProviders.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,8 +352,7 @@ endif()
 
 option(WITH_BLKIN "Use blkin to emit LTTng tracepoints for Zipkin" OFF)
 if(WITH_BLKIN)
-  find_package(LTTngUST REQUIRED)
-  set(BLKIN_LIBRARIES blkin ${LTTNGUST_LIBRARIES} lttng-ust-fork)
+  set(BLKIN_LIBRARIES blkin)
   include_directories(SYSTEM src/blkin/blkin-lib)
 endif(WITH_BLKIN)
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1267,6 +1267,11 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description("send ourselves a SIGTERM early during startup"),
 
+    Option("blkin_tracing", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("enables blkin tracing")
+    .set_long_description("Enables gathering of LTTNG traces compatible with zipkin tool"),
+
     // MON
     Option("mon_enable_op_tracker", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
@@ -3849,10 +3854,12 @@ std::vector<Option> get_global_options() {
 
     Option("osd_blkin_trace_all", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
+    .add_see_also("blkin_tracing")
     .set_description(""),
 
     Option("osdc_blkin_trace_all", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
+    .add_see_also("blkin_tracing")
     .set_description(""),
 
     Option("osd_discard_disconnected_ops", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -7350,6 +7357,7 @@ static std::vector<Option> get_rbd_options() {
 
     Option("rbd_blkin_trace_all", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
+    .add_see_also("blkin_tracing")
     .set_description("create a blkin trace for all RBD requests"),
 
     Option("rbd_validate_pool", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -215,7 +215,7 @@
 #include "messages/MOSDPGUpdateLogMissingReply.h"
 
 #ifdef WITH_BLKIN
-#include "Messenger.h"
+#include "msg/Messenger.h"
 #endif
 
 #define DEBUGLVL  10    // debug level of output

--- a/src/tracing/CMakeLists.txt
+++ b/src/tracing/CMakeLists.txt
@@ -48,6 +48,7 @@ add_tracing_library(os_tp objectstore.tp 1.0.0)
 add_tracing_library(bluestore_tp bluestore.tp 1.0.0)
 add_tracing_library(rgw_op_tp rgw_op.tp 1.0.0)
 add_tracing_library(rgw_rados_tp rgw_rados.tp 1.0.0)
+add_tracing_library(zipkin_tp zipkin.tp 1.0.0)
 
 install(TARGETS rados_tp osd_tp os_tp rgw_rados_tp rgw_op_tp DESTINATION ${CMAKE_INSTALL_LIBDIR})
 if(WITH_RBD)

--- a/src/tracing/zipkin.c
+++ b/src/tracing/zipkin.c
@@ -1,0 +1,6 @@
+#define TRACEPOINT_CREATE_PROBES
+/*
+ * The header containing our TRACEPOINT_EVENTs.
+ */
+#include "tracing/zipkin.h"
+

--- a/src/tracing/zipkin.tp
+++ b/src/tracing/zipkin.tp
@@ -1,0 +1,115 @@
+/*
+ * Zipkin lttng-ust tracepoint provider.
+ */
+
+TRACEPOINT_EVENT(
+	zipkin,
+	keyval_string,
+	TP_ARGS(const char *, trace_name, const char *, service,
+		int, port, const char *, ip, long, trace,
+		long, span, long, parent_span,
+		const char *, key, const char *, val ),
+
+	TP_FIELDS(
+		/*
+		 * Each span has a name mentioned on it in the UI
+		 * This is the trace name
+		 */
+		ctf_string(trace_name, trace_name)
+		/*
+		 * Each trace takes place in a specific machine-endpoint
+		 * This is identified by a name, a port number and an ip
+		 */
+		ctf_string(service_name, service)
+		ctf_integer(int, port_no, port)
+		ctf_string(ip, ip)
+		/*
+		 * According to the tracing semantics each trace should have
+		 * a trace id, a span id and a parent span id
+		 */
+		ctf_integer(long, trace_id, trace)
+		ctf_integer(long, span_id, span)
+		ctf_integer(long, parent_span_id, parent_span)
+		/*
+		 * The following is the real annotated information
+		 */
+		ctf_string(key, key)
+		ctf_string(val, val)
+		)
+	)
+TRACEPOINT_LOGLEVEL(
+	zipkin,
+	keyval_string,
+	TRACE_WARNING)
+
+/*
+ * This tracepoint allows for integers to come out keyval
+ */
+
+TRACEPOINT_EVENT(
+	zipkin,
+	keyval_integer,
+	TP_ARGS(const char *, trace_name, const char *, service,
+		int, port, const char *, ip, long, trace,
+		long, span, long, parent_span,
+		const char *, key, int64_t, val ),
+
+	TP_FIELDS(
+		/*
+		 * Each span has a name mentioned on it in the UI
+		 * This is the trace name
+		 */
+		ctf_string(trace_name, trace_name)
+		/*
+		 * Each trace takes place in a specific machine-endpoint
+		 * This is identified by a name, a port number and an ip
+		 */
+		ctf_string(service_name, service)
+		ctf_integer(int, port_no, port)
+		ctf_string(ip, ip)
+		/*
+		 * According to the tracing semantics each trace should have
+		 * a trace id, a span id and a parent span id
+		 */
+		ctf_integer(long, trace_id, trace)
+		ctf_integer(long, span_id, span)
+		ctf_integer(long, parent_span_id, parent_span)
+		/*
+		 * The following is the real annotated information
+		 */
+		ctf_string(key, key)
+		ctf_integer(int64_t, val, val)
+		)
+	)
+TRACEPOINT_LOGLEVEL(
+	zipkin,
+	keyval_integer,
+	TRACE_WARNING)
+/*
+ * In this event we follow the same semantics but we trace timestamp
+ * annotations
+ */
+
+TRACEPOINT_EVENT(
+	zipkin,
+	timestamp,
+	TP_ARGS(const char *, trace_name, const char *, service,
+		int, port, const char *, ip, long, trace,
+		long, span, long, parent_span,
+		const char *, event),
+
+	TP_FIELDS(
+		ctf_string(trace_name, trace_name)
+		ctf_string(service_name, service)
+		ctf_integer(int, port_no, port)
+		ctf_string(ip, ip)
+		ctf_integer(long, trace_id, trace)
+		ctf_integer(long, span_id, span)
+		ctf_integer(long, parent_span_id, parent_span)
+		ctf_string(event, event)
+		)
+	)
+TRACEPOINT_LOGLEVEL(
+	zipkin,
+	timestamp,
+	TRACE_WARNING)


### PR DESCRIPTION
This modification unifies blkin lttng tracepoints with rest of ceph.
Now blkin traces no longer need lib-ust-fork to work properly.
This is ultimately temporary, as blkin is going to be phased out.
It requires https://github.com/ceph/blkin/pull/12 .

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>