### PR TITLE
mimic: osd/OSDMap.cc: don't output over/underfull messages to lderr

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4269,7 +4269,7 @@ int OSDMap::calc_pg_upmaps(
                      << dendl;
     }
     if (overfull.empty()) {
-      lderr(cct) << __func__ << " failed to build overfull" << dendl;
+      ldout(cct, 20) << __func__ << " failed to build overfull" << dendl;
       break;
     }
 
@@ -4293,7 +4293,7 @@ int OSDMap::calc_pg_upmaps(
                      << dendl;
     }
     if (underfull.empty()) {
-      lderr(cct) << __func__ << " failed to build underfull" << dendl;
+      ldout(cct, 20) << __func__ << " failed to build underfull" << dendl;
       break;
     }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42798

---

backport of https://github.com/ceph/ceph/pull/31542
parent tracker: https://tracker.ceph.com/issues/42756

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh