### PR TITLE
install-deps.sh: install binutils 2.28 for xenial

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -144,6 +144,20 @@ function ensure_decent_cmake_on_ubuntu {
 	cmake
 }
 
+function ensure_decent_binutils_on_ubuntu {
+    local new=$1
+    local old=$(ld --version | head -n1 | grep -Po ' \K[0-9].*')
+    if dpkg --compare-versions $old ge $new; then
+        return
+    fi
+    install_pkg_on_ubuntu \
+	binutils \
+	7fa393306ed8b93019d225548474c0540b8928f7 \
+	xenial \
+	force \
+	binutils
+}
+
 function install_pkg_on_ubuntu {
     local project=$1
     shift
@@ -308,6 +322,7 @@ else
             *Xenial*)
                 ensure_decent_gcc_on_ubuntu 8 xenial
                 ensure_decent_cmake_on_ubuntu 3.10.1
+                ensure_decent_binutils_on_ubuntu 2.28
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu xenial
                 ;;
             *Bionic*)

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -125,10 +125,6 @@ ENDOFKEY
 }
 
 function ensure_decent_cmake_on_ubuntu {
-    # TODO: remove me after a while
-    # remove Kitware Apt Archive Automatic Signing Key
-    $SUDO apt-key del 40CD72DA
-    $SUDO rm -f /etc/apt/sources.list.d/kitware.list
     local new=$1
     if command -v cmake > /dev/null; then
         local old=$(cmake --version | grep -Po 'version \K[0-9].*')


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
