### PR TITLE
mgr/ssh: annotate object representation

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -714,6 +714,10 @@ class ServiceDescription(object):
             return '%s.%s' % (self.service_type, self.service_instance)
         return self.service_type
 
+    def __repr__(self):
+        return "<ServiceDescription>({n_name}:{s_type})".format(n_name=self.nodename,
+                                                                  s_type=self.name())
+
     def to_json(self):
         out = {
             'nodename': self.nodename,
@@ -919,6 +923,9 @@ class InventoryNode(object):
     def from_nested_items(cls, hosts):
         devs = inventory.Devices.from_json
         return [cls(item[0], devs(item[1].data)) for item in hosts]
+
+    def __repr__(self):
+        return "<InventoryNode>({name})".format(name=self.name)
 
 
 class DeviceLightLoc(namedtuple('DeviceLightLoc', ['host', 'dev'])):


### PR DESCRIPTION
* InventoryNode

```
..mgr[ssh] wait: completions=[<TrivialReadCompletion>([<InventoryNode>(osd0), <InventoryNode>(zulu)])]
```

* ServiceDescription
```
..mgr[ssh] wait: completions=[<TrivialReadCompletion>([<ServiceDescription>(osd0:crash), <ServiceDescription>(osd0:mon), <ServiceDescription>(osd0:osd), <ServiceDescription>(osd0:mds), <ServiceDescription>(zulu:crash), <ServiceDescription>(zulu:mon)])]
```

This helps with identifying Completion objects.

Signed-off-by: Joshua Schmid <jschmid@suse.de>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
