### PR TITLE
nautilus: common: fix typo in rgw_user_max_buckets option long description.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6655,7 +6655,7 @@ std::vector<Option> get_rgw_options() {
     .set_default(1000)
     .set_description("Max number of buckets per user")
     .set_long_description(
-        "A user can create this many buckets. Zero means unlimmited, negative number means "
+        "A user can create this many buckets. Zero means unlimited, negative number means "
         "user cannot create any buckets (although user will retain buckets already created."),
 
     Option("rgw_objexp_gc_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42795
possibly a backport of https://github.com/ceph/ceph/pull/31571
parent tracker: https://tracker.ceph.com/issues/42775

---

original PR body:

Fixes: https://tracker.ceph.com/issues/42775
 Signed-off-by: Alfonso Martínez <almartin@redhat.com>
 (cherry picked from commit c91c2cea65cb42c2b92b10543366e00079f7def8)


---

updated using ceph-backport.sh version 15.0.0.6950
