### PR TITLE
mgr/ssh: implement mon add, mgr add 

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -142,7 +142,6 @@ class _Completion(G):
         # type: () -> bool
         raise NotImplementedError()
 
-
 def raise_if_exception(c):
     # type: (_Completion) -> None
     """
@@ -213,7 +212,6 @@ class TrivialReadCompletion(ReadCompletion):
     @property
     def is_complete(self):
         return True
-
 
 class WriteCompletion(_Completion):
     """
@@ -505,6 +503,24 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def add_mgrs(self, hosts):
+        # type: (List[Tuple[str,str]]) -> WriteCompletion
+        """
+        Add mgrs to cluster.
+
+        :param hosts: list of hosts
+        """
+        raise NotImplementedError()
+
+    def remove_mgrs(self, hosts):
+        # type: (List[Tuple[str,str]]) -> WriteCompletion
+        """
+        Removes mgrs from the cluster.
+
+        :param hosts: list of hosts
+        """
+        raise NotImplementedError()
+
     def update_mons(self, num, hosts):
         # type: (int, List[Tuple[str,str]]) -> WriteCompletion
         """
@@ -512,6 +528,24 @@ class Orchestrator(object):
 
         :param num: requested number of monitors.
         :param hosts: list of hosts + network + name (optional)
+        """
+        raise NotImplementedError()
+
+    def add_mon(self, hosts):
+        # type: (List[Tuple[str,str]]) -> WriteCompletion
+        """
+        Add monitor to cluster.
+
+        :param hosts: list of hosts + network (required)
+        """
+        raise NotImplementedError()
+
+    def remove_mon(self, hosts):
+        # type: (List[Tuple[str,str]]) -> WriteCompletion
+        """
+        Remove monitor from cluster.
+
+        :param hosts: list of hosts
         """
         raise NotImplementedError()
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -567,6 +567,45 @@ Usage:
         orchestrator.raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
+    @_write_cli('orchestrator mgr add',
+                "name=hosts,type=CephString,n=N,req=true",
+                'add manager instances to hosts')
+    def _add_mgrs(self, hosts=[]):
+        if not hosts:
+            return HandleCommandResult(-errno.EINVAL,
+                    stderr="Need to provide hosts")
+
+        completion = self.add_mgrs(hosts)
+        self._orchestrator_wait([completion])
+        orchestrator.raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_write_cli('orchestrator mgr rm',
+                "name=hosts,type=CephString,n=N,req=true",
+                'remove manager instances from hosts')
+    def _remove_mgrs(self, hosts=[]):
+        if not hosts:
+            return HandleCommandResult(-errno.EINVAL,
+                    stderr="Need to provide hosts")
+
+        completion = self.remove_mgrs(hosts)
+        self._orchestrator_wait([completion])
+        orchestrator.raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_write_cli('orchestrator mon rm',
+                "name=hosts,type=CephString,n=N,req=true",
+                'remove monitor instances from hosts')
+    def _remove_mons(self, hosts=[]):
+        if not hosts:
+            return HandleCommandResult(-errno.EINVAL,
+                    stderr="Need to provide hosts")
+
+        completion = self.remove_mon(hosts)
+        self._orchestrator_wait([completion])
+        orchestrator.raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
     @_write_cli('orchestrator mon update',
                 "name=num,type=CephInt,req=true "
                 "name=hosts,type=CephString,n=N,req=false",
@@ -586,6 +625,25 @@ Usage:
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)
 
         completion = self.update_mons(num, hosts)
+        self._orchestrator_wait([completion])
+        orchestrator.raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_write_cli('orchestrator mon add',
+                "name=hosts,type=CephString,n=N,req=true",
+                'Add a monitor instance to host')
+    def _add_mon(self, hosts=[]):
+        if not hosts:
+            return HandleCommandResult(-errno.EINVAL,
+                    stderr="Need to provide hosts")
+
+        try:
+            hosts = list(map(orchestrator.split_host_with_network, hosts))
+        except Exception as e:
+            msg = "Failed to parse host list: '{}': {}".format(hosts, e)
+            return HandleCommandResult(-errno.EINVAL, stderr=msg)
+
+        completion = self.add_mon(hosts)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())


### PR DESCRIPTION
If you currently want to increase the number of instances of a
mgr or mon you have to use:

`ceph orchestartor {mon, mgr} update $current_num+1 $host:$network_conf`

This is fine for rook, but not so userfriendly for the SSH-Orchestrator.

Adding an more imperative way of adding and removing mons/mgrs.

`ceph orchestrator {mon, mgr} {add, rm} $host:$optional_network_conf`

Signed-off-by: Joshua Schmid <jschmid@suse.de>
