### PR TITLE
nautilus: Revert "rocksdb: enable rocksdb_rmrange=true by default"

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3980,7 +3980,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("rocksdb_enable_rmrange", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description("Refer to github.com/facebook/rocksdb/wiki/DeleteRange-Implementation"),
 
     Option("rocksdb_max_items_rmrange", Option::TYPE_UINT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
This reverts commit 29bafe57503066c962cc692a66178b083fd43343.

We have observed drastically poor performance when rocksdb_rmrange is
used for every key deletion.

This change is specific to nautilus, since we are experimenting with rocksdb_rmrange
along with https://github.com/ceph/ceph/pull/31442 in master.

Signed-off-by: Neha Ojha <nojha@redhat.com>