### PR TITLE
ceph-daemon: use `-e` instead of `--env`

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1225,7 +1225,7 @@ def command_shell():
         command = ['bash']
         podman_args += [
             '-it',
-            '--env', 'LANG=C',
+            '-e', 'LANG=C',
             '-e', "PS1=%s" % CUSTOM_PS1,
         ]
     c = CephContainer(
@@ -1247,7 +1247,7 @@ def command_enter():
         command = ['bash']
         podman_args += [
             '-it',
-            '--env', 'LANG=C',
+            '-e', 'LANG=C',
             '-e', "PS1=%s" % CUSTOM_PS1,
         ]
     c = get_container(args.fsid, daemon_type, daemon_id,


### PR DESCRIPTION
Older versions of podman don't allow intermixing `-e` and `--env`

```
# python3 ./ceph-daemon shell
Cannot use two forms of the same flag: e env
See 'podman run --help'.

# podman -v
podman version 1.0.1
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
