### PR TITLE
nautilus: ceph-volume: assume msgrV1 for all branches containing mimic

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/functional/tests/conftest.py
@@ -19,7 +19,7 @@ def node(host, request):
     ceph_dev_branch = os.environ.get("CEPH_DEV_BRANCH", "master")
     group_names = ansible_vars["group_names"]
     num_osd_ports = 4
-    if ceph_dev_branch in ['luminous', 'mimic']:
+    if 'mimic' in ceph_dev_branch or 'luminous' in ceph_dev_branch:
         num_osd_ports = 2
 
     # capture the initial/default state


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42800

---

backport of https://github.com/ceph/ceph/pull/31592
parent tracker: https://tracker.ceph.com/issues/42791

this backport was staged using ceph-backport.sh version 15.0.0.6814
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh