### PR TITLE
mgr/dashboard: Fix pool renaming functionality

### DIFF
--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -217,7 +217,7 @@ class PoolTest(DashboardTestCase):
     def test_pool_create_with_two_applications(self):
         self.__yield_pool(None, {
             'pool': 'dashboard_pool1',
-            'pg_num': '10',
+            'pg_num': '8',
             'pool_type': 'replicated',
             'application_metadata': ['rbd', 'sth'],
         })
@@ -228,7 +228,7 @@ class PoolTest(DashboardTestCase):
             ['osd', 'erasure-code-profile', 'set', 'ecprofile', 'crush-failure-domain=osd'])
         self.__yield_pool(None, {
             'pool': 'dashboard_pool2',
-            'pg_num': '10',
+            'pg_num': '8',
             'pool_type': 'erasure',
             'application_metadata': ['rbd'],
             'erasure_code_profile': 'ecprofile',
@@ -239,7 +239,7 @@ class PoolTest(DashboardTestCase):
     def test_pool_create_with_compression(self):
         pool = {
             'pool': 'dashboard_pool3',
-            'pg_num': '10',
+            'pg_num': '8',
             'pool_type': 'replicated',
             'compression_algorithm': 'zstd',
             'compression_mode': 'aggressive',
@@ -269,7 +269,7 @@ class PoolTest(DashboardTestCase):
             {
                 'pool_data': {
                     'pool': 'dashboard_pool_quota1',
-                    'pg_num': '10',
+                    'pg_num': '8',
                     'pool_type': 'replicated',
                 },
                 'pool_quotas_to_check': {
@@ -280,7 +280,7 @@ class PoolTest(DashboardTestCase):
             {
                 'pool_data': {
                     'pool': 'dashboard_pool_quota2',
-                    'pg_num': '10',
+                    'pg_num': '8',
                     'pool_type': 'replicated',
                     'quota_max_objects': 1024,
                     'quota_max_bytes': 1000,

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -298,6 +298,16 @@ class PoolTest(DashboardTestCase):
                 self._validate_pool_properties(pool['pool_quotas_to_check'],
                                                self._get_pool(pool_name))
 
+    def test_pool_update_name(self):
+        name = 'pool_update'
+        updated_name = 'pool_updated_name'
+        with self.__yield_pool(name, None, updated_name):
+            props = {'pool': updated_name}
+            self._task_put('/api/pool/{}'.format(name), props)
+            time.sleep(5)
+            self.assertStatus(200)
+            self._validate_pool_properties(props, self._get_pool(updated_name))
+
     def test_pool_update_metadata(self):
         pool_name = 'pool_update_metadata'
         with self.__yield_pool(pool_name):

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -44,8 +44,22 @@ class PoolTest(DashboardTestCase):
     }))
 
     @contextmanager
-    def __create_pool(self, name, data=None):
-        pool_data = data or {
+    def __yield_pool(self, name=None, data=None, deletion_name=None):
+        """
+        Use either just a name or whole description of a pool to create one.
+        This also validates the correct creation and deletion after the pool was used.
+
+        :param name: Name of the pool
+        :param data: Describes the pool in full length
+        :param deletion_name: Only needed if the pool was renamed
+        :return:
+        """
+        data = self._create_pool(name, data)
+        yield data
+        self._delete_pool(deletion_name or data['pool'])
+
+    def _create_pool(self, name, data):
+        data = data or {
             'pool': name,
             'pg_num': '4',
             'pool_type': 'replicated',
@@ -59,11 +73,12 @@ class PoolTest(DashboardTestCase):
                 'rbd_qos_iops_limit': 5000,
             }
         }
-        self._task_post('/api/pool/', pool_data)
+        self._task_post('/api/pool/', data)
         self.assertStatus(201)
-        time.sleep(5)
-        self._validate_pool_properties(pool_data, self._get_pool(name))
-        yield pool_data
+        self._validate_pool_properties(data, self._get_pool(data['pool']))
+        return data
+
+    def _delete_pool(self, name):
         self._task_delete('/api/pool/' + name)
         self.assertStatus(204)
 
@@ -125,13 +140,6 @@ class PoolTest(DashboardTestCase):
             pool = self._get_pool(pool['pool_name'])
         for p in ['pg_num', pgp_prop]:  # Should have the same values
             self.assertEqual(pool[p], int(value), '{}: {} != {}'.format(p, pool[p], value))
-
-    @classmethod
-    def tearDownClass(cls):
-        super(PoolTest, cls).tearDownClass()
-        for name in ['dashboard_pool1', 'dashboard_pool2', 'dashboard_pool3']:
-            cls._ceph_cmd(['osd', 'pool', 'delete', name, name, '--yes-i-really-really-mean-it'])
-        cls._ceph_cmd(['osd', 'erasure-code-profile', 'rm', 'ecprofile'])
 
     @DashboardTestCase.RunAs('test', 'test', [{'pool': ['create', 'update', 'delete']}])
     def test_read_access_permissions(self):
@@ -206,37 +214,29 @@ class PoolTest(DashboardTestCase):
         self.assertNotIn('flags_names', pool)
         self.assertSchema(pool['configuration'], self.pool_rbd_conf_schema)
 
-    def test_pool_create(self):
-        self._ceph_cmd(['osd', 'crush', 'rule', 'create-erasure', 'ecrule'])
-        self._ceph_cmd(
-            ['osd', 'erasure-code-profile', 'set', 'ecprofile', 'crush-failure-domain=osd'])
-
-        pool = {
+    def test_pool_create_with_two_applications(self):
+        self.__yield_pool(None, {
             'pool': 'dashboard_pool1',
             'pg_num': '10',
             'pool_type': 'replicated',
             'application_metadata': ['rbd', 'sth'],
-        }
-        self._task_post('/api/pool/', pool)
-        self.assertStatus(201)
-        self._validate_pool_properties(pool, self._get_pool(pool['pool']))
-        self._task_delete("/api/pool/" + pool['pool'])
-        self.assertStatus(204)
+        })
 
-        pool = {
+    def test_pool_create_with_ecp_and_rule(self):
+        self._ceph_cmd(['osd', 'crush', 'rule', 'create-erasure', 'ecrule'])
+        self._ceph_cmd(
+            ['osd', 'erasure-code-profile', 'set', 'ecprofile', 'crush-failure-domain=osd'])
+        self.__yield_pool(None, {
             'pool': 'dashboard_pool2',
             'pg_num': '10',
             'pool_type': 'erasure',
             'application_metadata': ['rbd'],
             'erasure_code_profile': 'ecprofile',
             'crush_rule': 'ecrule',
-        }
-        self._task_post('/api/pool/', pool)
-        self.assertStatus(201)
-        self._validate_pool_properties(pool, self._get_pool(pool['pool']))
-        self._task_delete("/api/pool/" + pool['pool'])
-        self.assertStatus(204)
+        })
+        self._ceph_cmd(['osd', 'erasure-code-profile', 'rm', 'ecprofile'])
 
+    def test_pool_create_with_compression(self):
         pool = {
             'pool': 'dashboard_pool3',
             'pg_num': '10',
@@ -250,24 +250,19 @@ class PoolTest(DashboardTestCase):
                 'rbd_qos_iops_limit': None,
             },
         }
-        expected_configuration = [{
-            'name': 'rbd_qos_bps_limit',
-            'source': 1,
-            'value': '2048',
-        }, {
-            'name': 'rbd_qos_iops_limit',
-            'source': 0,
-            'value': '0',
-        }]
-        self._task_post('/api/pool/', pool)
-        self.assertStatus(201)
-        new_pool = self._get_pool(pool['pool'])
-        self._validate_pool_properties(pool, new_pool)
-        for conf in expected_configuration:
-            self.assertIn(conf, new_pool['configuration'])
-
-        self._task_delete("/api/pool/" + pool['pool'])
-        self.assertStatus(204)
+        with self.__yield_pool(None, pool):
+            expected_configuration = [{
+                'name': 'rbd_qos_bps_limit',
+                'source': 1,
+                'value': '2048',
+            }, {
+                'name': 'rbd_qos_iops_limit',
+                'source': 0,
+                'value': '0',
+            }]
+            new_pool = self._get_pool(pool['pool'])
+            for conf in expected_configuration:
+                self.assertIn(conf, new_pool['configuration'])
 
     def test_pool_create_with_quotas(self):
         pools = [
@@ -299,13 +294,13 @@ class PoolTest(DashboardTestCase):
 
         for pool in pools:
             pool_name = pool['pool_data']['pool']
-            with self.__create_pool(pool_name, pool['pool_data']):
+            with self.__yield_pool(pool_name, pool['pool_data']):
                 self._validate_pool_properties(pool['pool_quotas_to_check'],
                                                self._get_pool(pool_name))
 
     def test_pool_update_metadata(self):
         pool_name = 'pool_update_metadata'
-        with self.__create_pool(pool_name):
+        with self.__yield_pool(pool_name):
             props = {'application_metadata': ['rbd', 'sth']}
             self._task_put('/api/pool/{}'.format(pool_name), props)
             time.sleep(5)
@@ -328,7 +323,7 @@ class PoolTest(DashboardTestCase):
 
     def test_pool_update_configuration(self):
         pool_name = 'pool_update_configuration'
-        with self.__create_pool(pool_name):
+        with self.__yield_pool(pool_name):
             configuration = {
                 'rbd_qos_bps_limit': 1024,
                 'rbd_qos_iops_limit': None,
@@ -350,7 +345,7 @@ class PoolTest(DashboardTestCase):
 
     def test_pool_update_compression(self):
         pool_name = 'pool_update_compression'
-        with self.__create_pool(pool_name):
+        with self.__yield_pool(pool_name):
             properties = {
                 'compression_algorithm': 'zstd',
                 'compression_mode': 'aggressive',
@@ -363,7 +358,7 @@ class PoolTest(DashboardTestCase):
 
     def test_pool_update_unset_compression(self):
         pool_name = 'pool_update_unset_compression'
-        with self.__create_pool(pool_name):
+        with self.__yield_pool(pool_name):
             self._task_put('/api/pool/' + pool_name, {'compression_mode': 'unset'})
             time.sleep(5)
             self._validate_pool_properties({
@@ -375,7 +370,7 @@ class PoolTest(DashboardTestCase):
 
     def test_pool_update_quotas(self):
         pool_name = 'pool_update_quotas'
-        with self.__create_pool(pool_name):
+        with self.__yield_pool(pool_name):
             properties = {
                 'quota_max_objects': 1024,
                 'quota_max_bytes': 1000,

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -83,6 +83,8 @@ class Pool(RESTController):
     @pool_task('edit', ['{pool_name}'])
     def set(self, pool_name, flags=None, application_metadata=None, configuration=None, **kwargs):
         self._set_pool_values(pool_name, application_metadata, flags, True, kwargs)
+        if kwargs.get('pool'):
+            pool_name = kwargs['pool']
         RbdConfiguration(pool_name).set_configuration(configuration)
         self._wait_for_pgs(pool_name)
 


### PR DESCRIPTION
The problem was that, if a pool was renamed the routine to update tried
to work on the old pool name and didn't used the info that the pool got
renamed, therefore an error occurred in the UI saying that the pool
could not be found.

Fixes: https://tracker.ceph.com/issues/42776
Signed-off-by: Stephan Müller <smueller@suse.com>

This PR also refactor the pool tests and changes the pg_num counts to a value that is a power of two in order to prevent health warnings.

![rename_of_pool](https://user-images.githubusercontent.com/16167865/68842981-9f5aad80-06c7-11ea-9dfc-7b87ad56a123.gif)

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
