### PR TITLE
mgr/dashboard: Use new ImageSpec class

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/block/images.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/images.e2e-spec.ts
@@ -37,8 +37,8 @@ describe('Images page', () => {
 
   describe('create, edit & delete image test', () => {
     const poolName = 'e2e_images_pool';
-    const imageName = 'e2e_images_image';
-    const newImageName = 'e2e_images_image_new';
+    const imageName = 'e2e_images#image';
+    const newImageName = 'e2e_images#image_new';
 
     beforeAll(async () => {
       await pools.navigateTo('create'); // Need pool for image testing
@@ -70,9 +70,9 @@ describe('Images page', () => {
   });
 
   describe('move to trash, restore and purge image tests', () => {
-    const poolName = 'trashpool';
-    const imageName = 'trashimage';
-    const newImageName = 'newtrashimage';
+    const poolName = 'trash_pool';
+    const imageName = 'trash#image';
+    const newImageName = 'newtrash#image';
 
     beforeAll(async () => {
       await pools.navigateTo('create'); // Need pool for image testing

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/images.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/images.po.ts
@@ -35,9 +35,9 @@ export class ImagesPageHelper extends PageHelper {
   async editImage(name, pool, newName, newSize) {
     const base_url = '/#/block/rbd/edit/';
     const editURL = base_url
-      .concat(pool)
+      .concat(encodeURIComponent(pool))
       .concat('%2F')
-      .concat(name);
+      .concat(encodeURIComponent(name));
     await browser.get(editURL);
 
     await element(by.id('name')).click(); // click name box and send new name

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
@@ -2,7 +2,7 @@ import { PoolPageHelper } from './pools.po';
 
 describe('Pools page', () => {
   let pools: PoolPageHelper;
-  const poolName = 'pool_e2e_pool_test';
+  const poolName = 'pool_e2e_pool/test';
 
   beforeAll(async () => {
     pools = new PoolPageHelper();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -14,6 +14,7 @@ import { delay } from 'rxjs/operators';
 import { ActivatedRouteStub } from '../../../../testing/activated-route-stub';
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { RbdService } from '../../../shared/api/rbd.service';
+import { ImageSpec } from '../../../shared/models/image-spec';
 import { SharedModule } from '../../../shared/shared.module';
 import { RbdConfigurationFormComponent } from '../rbd-configuration-form/rbd-configuration-form.component';
 import { RbdFormMode } from './rbd-form-mode.enum';
@@ -181,20 +182,20 @@ describe('RbdFormComponent', () => {
     it('with namespace', () => {
       activatedRoute.setParams({ image_spec: 'foo%2Fbar%2Fbaz' });
 
-      expect(rbdService.get).toHaveBeenCalledWith('foo', 'bar', 'baz');
+      expect(rbdService.get).toHaveBeenCalledWith(new ImageSpec('foo', 'bar', 'baz'));
     });
 
     it('without snapName', () => {
       activatedRoute.setParams({ image_spec: 'foo%2Fbar', snap: undefined });
 
-      expect(rbdService.get).toHaveBeenCalledWith('foo', null, 'bar');
+      expect(rbdService.get).toHaveBeenCalledWith(new ImageSpec('foo', null, 'bar'));
       expect(component.snapName).toBeUndefined();
     });
 
     it('with snapName', () => {
       activatedRoute.setParams({ image_spec: 'foo%2Fbar', snap: 'baz%2Fbaz' });
 
-      expect(rbdService.get).toHaveBeenCalledWith('foo', null, 'bar');
+      expect(rbdService.get).toHaveBeenCalledWith(new ImageSpec('foo', null, 'bar'));
       expect(component.snapName).toBe('baz/baz');
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
@@ -9,6 +9,7 @@ import { RbdService } from '../../../shared/api/rbd.service';
 import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { FinishedTask } from '../../../shared/models/finished-task';
+import { ImageSpec } from '../../../shared/models/image-spec';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { TaskManagerService } from '../../../shared/services/task-manager.service';
 
@@ -73,14 +74,15 @@ export class RbdSnapshotFormComponent implements OnInit {
 
   editAction() {
     const snapshotName = this.snapshotForm.getValue('snapshotName');
+    const imageSpec = new ImageSpec(this.poolName, this.namespace, this.imageName);
     const finishedTask = new FinishedTask();
     finishedTask.name = 'rbd/snap/edit';
     finishedTask.metadata = {
-      image_spec: this.rbdService.getImageSpec(this.poolName, this.namespace, this.imageName),
+      image_spec: imageSpec.toString(),
       snapshot_name: snapshotName
     };
     this.rbdService
-      .renameSnapshot(this.poolName, this.namespace, this.imageName, this.snapName, snapshotName)
+      .renameSnapshot(imageSpec, this.snapName, snapshotName)
       .toPromise()
       .then(() => {
         this.taskManagerService.subscribe(
@@ -100,14 +102,15 @@ export class RbdSnapshotFormComponent implements OnInit {
 
   createAction() {
     const snapshotName = this.snapshotForm.getValue('snapshotName');
+    const imageSpec = new ImageSpec(this.poolName, this.namespace, this.imageName);
     const finishedTask = new FinishedTask();
     finishedTask.name = 'rbd/snap/create';
     finishedTask.metadata = {
-      image_spec: this.rbdService.getImageSpec(this.poolName, this.namespace, this.imageName),
+      image_spec: imageSpec.toString(),
       snapshot_name: snapshotName
     };
     this.rbdService
-      .createSnapshot(this.poolName, this.namespace, this.imageName, snapshotName)
+      .createSnapshot(imageSpec, snapshotName)
       .toPromise()
       .then(() => {
         this.taskManagerService.subscribe(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.ts
@@ -17,6 +17,7 @@ import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { ExecutingTask } from '../../../shared/models/executing-task';
 import { FinishedTask } from '../../../shared/models/finished-task';
+import { ImageSpec } from '../../../shared/models/image-spec';
 import { Permission } from '../../../shared/models/permissions';
 import { CdDatePipe } from '../../../shared/pipes/cd-date.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
@@ -115,10 +116,8 @@ export class RbdTrashListComponent implements OnInit {
     ];
 
     const itemFilter = (entry, task) => {
-      return (
-        this.rbdService.getImageSpec(entry.pool_name, entry.namespace, entry.id) ===
-        task.metadata['image_id_spec']
-      );
+      const imageSpec = new ImageSpec(entry.pool_name, entry.namespace, entry.id);
+      return imageSpec.toString() === task.metadata['image_id_spec'];
     };
 
     const taskFilter = (task) => {
@@ -191,7 +190,7 @@ export class RbdTrashListComponent implements OnInit {
     const namespace = this.selection.first().namespace;
     const imageId = this.selection.first().id;
     const expiresAt = this.selection.first().deferment_end_time;
-    const imageIdSpec = this.rbdService.getImageSpec(poolName, namespace, imageId);
+    const imageIdSpec = new ImageSpec(poolName, namespace, imageId);
 
     this.modalRef = this.modalService.show(CriticalConfirmationModalComponent, {
       initialState: {
@@ -202,9 +201,9 @@ export class RbdTrashListComponent implements OnInit {
         submitActionObservable: () =>
           this.taskWrapper.wrapTaskAroundCall({
             task: new FinishedTask('rbd/trash/remove', {
-              image_id_spec: imageIdSpec
+              image_id_spec: imageIdSpec.toString()
             }),
-            call: this.rbdService.removeTrash(poolName, namespace, imageId, true)
+            call: this.rbdService.removeTrash(imageIdSpec, true)
           })
       }
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.html
@@ -9,7 +9,7 @@
           [formGroup]="moveForm"
           novalidate>
       <div class="modal-body">
-        <p i18n>To move <kbd>{{ imageSpec }}</kbd> to trash,
+        <p i18n>To move <kbd>{{ imageSpecStr }}</kbd> to trash,
           click <kbd>Move Image</kbd>. Optionally, you can pick an expiration date.</p>
 
         <div class="form-group">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.spec.ts
@@ -39,6 +39,8 @@ describe('RbdTrashMoveModalComponent', () => {
     component.metaType = 'RBD';
     component.poolName = 'foo';
     component.imageName = 'bar';
+
+    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -47,7 +49,6 @@ describe('RbdTrashMoveModalComponent', () => {
   });
 
   it('should finish running ngOnInit', () => {
-    fixture.detectChanges();
     expect(component.pattern).toEqual('foo/bar');
   });
 
@@ -88,7 +89,6 @@ describe('RbdTrashMoveModalComponent', () => {
       const oldDate = moment()
         .add(24, 'hour')
         .toISOString();
-      fixture.detectChanges();
       component.moveForm.patchValue({ expiresAt: oldDate });
 
       component.moveImage();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.ts
@@ -9,6 +9,7 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { ExecutingTask } from '../../../shared/models/executing-task';
 import { FinishedTask } from '../../../shared/models/finished-task';
+import { ImageSpec } from '../../../shared/models/image-spec';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 
 @Component({
@@ -21,7 +22,8 @@ export class RbdTrashMoveModalComponent implements OnInit {
   poolName: string;
   namespace: string;
   imageName: string;
-  imageSpec: string;
+  imageSpec: ImageSpec;
+  imageSpecStr: string;
   executingTasks: ExecutingTask[];
 
   moveForm: CdFormGroup;
@@ -60,7 +62,8 @@ export class RbdTrashMoveModalComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.imageSpec = this.rbdService.getImageSpec(this.poolName, this.namespace, this.imageName);
+    this.imageSpec = new ImageSpec(this.poolName, this.namespace, this.imageName);
+    this.imageSpecStr = this.imageSpec.toString();
     this.pattern = `${this.poolName}/${this.imageName}`;
   }
 
@@ -79,9 +82,9 @@ export class RbdTrashMoveModalComponent implements OnInit {
     this.taskWrapper
       .wrapTaskAroundCall({
         task: new FinishedTask('rbd/trash/move', {
-          image_spec: this.imageSpec
+          image_spec: this.imageSpecStr
         }),
-        call: this.rbdService.moveTrash(this.poolName, this.namespace, this.imageName, delay)
+        call: this.rbdService.moveTrash(this.imageSpec, delay)
       })
       .subscribe(undefined, undefined, () => {
         this.modalRef.hide();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.ts
@@ -7,6 +7,7 @@ import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { ExecutingTask } from '../../../shared/models/executing-task';
 import { FinishedTask } from '../../../shared/models/finished-task';
+import { ImageSpec } from '../../../shared/models/image-spec';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 
 @Component({
@@ -33,7 +34,7 @@ export class RbdTrashRestoreModalComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.imageSpec = this.rbdService.getImageSpec(this.poolName, this.namespace, this.imageName);
+    this.imageSpec = new ImageSpec(this.poolName, this.namespace, this.imageName).toString();
     this.restoreForm = this.fb.group({
       name: this.imageName
     });
@@ -41,14 +42,15 @@ export class RbdTrashRestoreModalComponent implements OnInit {
 
   restore() {
     const name = this.restoreForm.getValue('name');
+    const imageSpec = new ImageSpec(this.poolName, this.namespace, this.imageId);
 
     this.taskWrapper
       .wrapTaskAroundCall({
         task: new FinishedTask('rbd/trash/restore', {
-          image_id_spec: this.rbdService.getImageSpec(this.poolName, this.namespace, this.imageId),
+          image_id_spec: imageSpec.toString(),
           new_image_name: name
         }),
-        call: this.rbdService.restoreTrash(this.poolName, this.namespace, this.imageId, name)
+        call: this.rbdService.restoreTrash(imageSpec, name)
       })
       .subscribe(
         undefined,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 
 import { configureTestBed, i18nProviders } from '../../../testing/unit-test-helper';
+import { ImageSpec } from '../models/image-spec';
 import { RbdConfigurationService } from '../services/rbd-configuration.service';
 import { RbdService } from './rbd.service';
 
@@ -35,20 +36,20 @@ describe('RbdService', () => {
   });
 
   it('should call delete', () => {
-    service.delete('poolName', null, 'rbdName').subscribe();
+    service.delete(new ImageSpec('poolName', null, 'rbdName')).subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName');
     expect(req.request.method).toBe('DELETE');
   });
 
   it('should call update', () => {
-    service.update('poolName', null, 'rbdName', 'foo').subscribe();
+    service.update(new ImageSpec('poolName', null, 'rbdName'), 'foo').subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName');
     expect(req.request.body).toEqual('foo');
     expect(req.request.method).toBe('PUT');
   });
 
   it('should call get', () => {
-    service.get('poolName', null, 'rbdName').subscribe();
+    service.get(new ImageSpec('poolName', null, 'rbdName')).subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName');
     expect(req.request.method).toBe('GET');
   });
@@ -60,14 +61,14 @@ describe('RbdService', () => {
   });
 
   it('should call copy', () => {
-    service.copy('poolName', null, 'rbdName', 'foo').subscribe();
+    service.copy(new ImageSpec('poolName', null, 'rbdName'), 'foo').subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName/copy');
     expect(req.request.body).toEqual('foo');
     expect(req.request.method).toBe('POST');
   });
 
   it('should call flatten', () => {
-    service.flatten('poolName', null, 'rbdName').subscribe();
+    service.flatten(new ImageSpec('poolName', null, 'rbdName')).subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName/flatten');
     expect(req.request.body).toEqual(null);
     expect(req.request.method).toBe('POST');
@@ -80,7 +81,7 @@ describe('RbdService', () => {
   });
 
   it('should call createSnapshot', () => {
-    service.createSnapshot('poolName', null, 'rbdName', 'snapshotName').subscribe();
+    service.createSnapshot(new ImageSpec('poolName', null, 'rbdName'), 'snapshotName').subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName/snap');
     expect(req.request.body).toEqual({
       snapshot_name: 'snapshotName'
@@ -89,7 +90,9 @@ describe('RbdService', () => {
   });
 
   it('should call renameSnapshot', () => {
-    service.renameSnapshot('poolName', null, 'rbdName', 'snapshotName', 'foo').subscribe();
+    service
+      .renameSnapshot(new ImageSpec('poolName', null, 'rbdName'), 'snapshotName', 'foo')
+      .subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName/snap/snapshotName');
     expect(req.request.body).toEqual({
       new_snap_name: 'foo'
@@ -98,7 +101,9 @@ describe('RbdService', () => {
   });
 
   it('should call protectSnapshot', () => {
-    service.protectSnapshot('poolName', null, 'rbdName', 'snapshotName', true).subscribe();
+    service
+      .protectSnapshot(new ImageSpec('poolName', null, 'rbdName'), 'snapshotName', true)
+      .subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName/snap/snapshotName');
     expect(req.request.body).toEqual({
       is_protected: true
@@ -107,7 +112,9 @@ describe('RbdService', () => {
   });
 
   it('should call rollbackSnapshot', () => {
-    service.rollbackSnapshot('poolName', null, 'rbdName', 'snapshotName').subscribe();
+    service
+      .rollbackSnapshot(new ImageSpec('poolName', null, 'rbdName'), 'snapshotName')
+      .subscribe();
     const req = httpTesting.expectOne(
       'api/block/image/poolName%2FrbdName/snap/snapshotName/rollback'
     );
@@ -116,20 +123,22 @@ describe('RbdService', () => {
   });
 
   it('should call cloneSnapshot', () => {
-    service.cloneSnapshot('poolName', null, 'rbdName', 'snapshotName', null).subscribe();
+    service
+      .cloneSnapshot(new ImageSpec('poolName', null, 'rbdName'), 'snapshotName', null)
+      .subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName/snap/snapshotName/clone');
     expect(req.request.body).toEqual(null);
     expect(req.request.method).toBe('POST');
   });
 
   it('should call deleteSnapshot', () => {
-    service.deleteSnapshot('poolName', null, 'rbdName', 'snapshotName').subscribe();
+    service.deleteSnapshot(new ImageSpec('poolName', null, 'rbdName'), 'snapshotName').subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName/snap/snapshotName');
     expect(req.request.method).toBe('DELETE');
   });
 
   it('should call moveTrash', () => {
-    service.moveTrash('poolName', null, 'rbdName', 1).subscribe();
+    service.moveTrash(new ImageSpec('poolName', null, 'rbdName'), 1).subscribe();
     const req = httpTesting.expectOne('api/block/image/poolName%2FrbdName/move_trash');
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({ delay: 1 });
@@ -137,27 +146,27 @@ describe('RbdService', () => {
 
   describe('should compose image spec', () => {
     it('with namespace', () => {
-      expect(service.getImageSpec('mypool', 'myns', 'myimage')).toBe('mypool/myns/myimage');
+      expect(new ImageSpec('mypool', 'myns', 'myimage').toString()).toBe('mypool/myns/myimage');
     });
 
     it('without namespace', () => {
-      expect(service.getImageSpec('mypool', null, 'myimage')).toBe('mypool/myimage');
+      expect(new ImageSpec('mypool', null, 'myimage').toString()).toBe('mypool/myimage');
     });
   });
 
   describe('should parse image spec', () => {
     it('with namespace', () => {
-      const [poolName, namespace, rbdName] = service.parseImageSpec('mypool/myns/myimage');
-      expect(poolName).toBe('mypool');
-      expect(namespace).toBe('myns');
-      expect(rbdName).toBe('myimage');
+      const imageSpec = ImageSpec.fromString('mypool/myns/myimage');
+      expect(imageSpec.poolName).toBe('mypool');
+      expect(imageSpec.namespace).toBe('myns');
+      expect(imageSpec.imageName).toBe('myimage');
     });
 
     it('without namespace', () => {
-      const [poolName, namespace, rbdName] = service.parseImageSpec('mypool/myimage');
-      expect(poolName).toBe('mypool');
-      expect(namespace).toBeNull();
-      expect(rbdName).toBe('myimage');
+      const imageSpec = ImageSpec.fromString('mypool/myimage');
+      expect(imageSpec.poolName).toBe('mypool');
+      expect(imageSpec.namespace).toBeNull();
+      expect(imageSpec.imageName).toBe('myimage');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/image-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/image-spec.ts
@@ -1,0 +1,25 @@
+export class ImageSpec {
+  static fromString(imageSpec: string) {
+    const imageSpecSplited = imageSpec.split('/');
+
+    const poolName = imageSpecSplited[0];
+    const namespace = imageSpecSplited.length >= 3 ? imageSpecSplited[1] : null;
+    const imageName = imageSpecSplited.length >= 3 ? imageSpecSplited[2] : imageSpecSplited[1];
+
+    return new this(poolName, namespace, imageName);
+  }
+
+  constructor(public poolName: string, public namespace: string, public imageName: string) {}
+
+  private getNameSpace() {
+    return this.namespace ? `${this.namespace}/` : '';
+  }
+
+  toString() {
+    return `${this.poolName}/${this.getNameSpace()}${this.imageName}`;
+  }
+
+  toStringEncoded() {
+    return encodeURIComponent(`${this.poolName}/${this.getNameSpace()}${this.imageName}`);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
 
-import { RbdService } from '../api/rbd.service';
 import { Components } from '../enum/components.enum';
 import { FinishedTask } from '../models/finished-task';
+import { ImageSpec } from '../models/image-spec';
 import { Task } from '../models/task';
 
 export class TaskMessageOperation {
@@ -58,7 +58,7 @@ class TaskMessage {
   providedIn: 'root'
 })
 export class TaskMessageService {
-  constructor(private i18n: I18n, private rbdService: RbdService) {}
+  constructor(private i18n: I18n) {}
 
   defaultMessage = this.newTaskMessage(
     new TaskMessageOperation(this.i18n('Executing'), this.i18n('execute'), this.i18n('Executed')),
@@ -103,31 +103,31 @@ export class TaskMessageService {
         id: `${metadata.image_spec}`
       }),
     create: (metadata) => {
-      const id = this.rbdService.getImageSpec(
+      const id = new ImageSpec(
         metadata.pool_name,
         metadata.namespace,
         metadata.image_name
-      );
+      ).toString();
       return this.i18n(`RBD '{{id}}'`, {
         id: id
       });
     },
     child: (metadata) => {
-      const id = this.rbdService.getImageSpec(
+      const id = new ImageSpec(
         metadata.child_pool_name,
         metadata.child_namespace,
         metadata.child_image_name
-      );
+      ).toString();
       return this.i18n(`RBD '{{id}}'`, {
         id: id
       });
     },
     destination: (metadata) => {
-      const id = this.rbdService.getImageSpec(
+      const id = new ImageSpec(
         metadata.dest_pool_name,
         metadata.dest_namespace,
         metadata.dest_image_name
-      );
+      ).toString();
       return this.i18n(`RBD '{{id}}'`, {
         id: id
       });


### PR DESCRIPTION
This class should be used when dealing with RBD image specs.
It allows the creation of an ImageSpec given the names of the pool, image and
namespace. Alternatively you can also create one with an already existing
image spec string.

With it you keep the access to each individual component and can also convert it
to a well formated string.

Fixes: https://tracker.ceph.com/issues/42787

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
