### PR TITLE
mount.ceph: allow the source path to be omitted

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **mount.ceph** [*mon1_socket*\ ,\ *mon2_socket*\ ,...]:/[*subdir*] *dir* [
+| **mount.ceph** [*mon1_socket*\ ,\ *mon2_socket*\ ,...]:[*/subdir*] *dir* [
   -o *options* ]
 
 
@@ -43,7 +43,8 @@ the secret from it.
 
 A sub-directory of the file system can be mounted by specifying the (absolute)
 path to the sub-directory right after ":" after the socket in the device part
-of the mount command.
+of the mount command. If both the '/' and sub-directory are omitted, the '/'
+will be used in kernel space.
 
 Mount helper application conventions dictate that the first two options are
 device to be mounted and the mountpoint for that device. Options must be


### PR DESCRIPTION
In kernel space we allow the server path(here is the source path)
to be omitted, and then the full filesystem '/' as default.

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
