### PR TITLE
cephfs-shell: Fix rmdir -p issues and add tests for rmdir

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -178,64 +178,57 @@ class TestMkdir(TestCephFSShell):
 class TestRmdir(TestCephFSShell):
     dir_name = "test_dir"
 
-    def dir_deleted(self, msg, opt=" "):
-        self.run_cephfs_shell_cmd("rmdir"+ opt + self.dir_name)
-        self.assertFalse(path.exists(path.join(self.mount_a.mountpoint,
-                                               self.dir_name)), msg)
-
-    def dir_not_deleted(self, msg, opt=" "):
-        rmdir_output = self.get_cephfs_shell_cmd_error("rmdir" + opt + self.dir_name)
-        log.info("cephfs-shell rmdir output:\n{}".format(rmdir_output))
-        self.assertTrue(path.exists(path.join(self.mount_a.mountpoint,
-                                              self.dir_name)), msg)
+    def dir_does_not_exists(self):
+        """
+        Tests that directory does not exists
+        """
+        try:
+            self.mount_a.stat(self.dir_name)
+        except CommandFailedError as e:
+            if  e.exitstatus == 2:
+                return 0
+            raise
 
     def test_rmdir(self):
         """
         Test that rmdir deletes directory
         """
         self.run_cephfs_shell_cmd("mkdir " + self.dir_name)
-        self.dir_deleted("test_dir is not deleted")
+        self.run_cephfs_shell_cmd("rmdir "+ self.dir_name)
+        self.dir_does_not_exists()
 
     def test_rmdir_non_existing_dir(self):
         """
-        Test that rmdir outputs error for non existing directory
+        Test that rmdir does not delete a non existing directory
         """
         rmdir_output = self.get_cephfs_shell_cmd_error("rmdir test_dir")
-        log.info("cephfs-shell rmdir output:\n{}".format(rmdir_output))
-        self.assertTrue(rmdir_output, "Something went wrong!! non existing dir deleted")
+        log.info("rmdir error output:\n{}".format(rmdir_output))
+        self.dir_does_not_exists()
 
-    def test_rmdir_non_empty_dir(self):
+    def test_rmdir_dir_with_file(self):
         """
-        Test that rmdir outputs error for non empty directory
+        Test that rmdir does not delete directory containing file
         """
         self.run_cephfs_shell_cmd("mkdir " + self.dir_name)
         self.run_cephfs_shell_cmd("put - test_dir/dumpfile", stdin="Valid File")
-        self.dir_not_deleted("non-empty test_dir is deleted")
+        self.run_cephfs_shell_cmd("rmdir" + self.dir_name)
+        self.mount_a.stat(self.dir_name)
 
     def test_rmdir_existing_file(self):
         """
-        Test that rmdir outputs error on file
+        Test that rmdir does not delete a file
         """
         self.run_cephfs_shell_cmd("put - dumpfile", stdin="Valid File")
-        try:
-            self.run_cephfs_shell_cmd("rmdir dumpfile")
-        except Exception as e:
-            o = self.get_cephfs_shell_cmd_output("ls")
-            log.info("cephfs-shell output:\n{}".format(o))
-            log.info("cephfs-shell output Exception:\n{}".format(e))
-            """
-            self.assertTrue(path.exists(path.join(self.mount_a.mountpoint,
-                            "dumpfile")),
-                            "Something went wrong!! rmdir deleted a file")
-            """
+        self.run_cephfs_shell_cmd("rmdir dumpfile")
+        self.mount_a.stat("dumpfile")
 
     def test_rmdir_p(self):
         """
         Test that rmdir -p deletes all empty directories in the root directory passed
         """
         self.run_cephfs_shell_cmd("mkdir -p test_dir/t1/t2/t3")
-        self.dir_deleted("test_dir containing empty directories is not deleted",
-                         " -p ")
+        self.run_cephfs_shell_cmd("rmdir -p "+ self.dir_name)
+        self.dir_does_not_exists()
 
     def test_rmdir_p_valid_path(self):
         """
@@ -243,24 +236,24 @@ class TestRmdir(TestCephFSShell):
         """
         self.run_cephfs_shell_cmd("mkdir -p test_dir/t1/t2/t3")
         self.run_cephfs_shell_cmd("rmdir -p test_dir/t1/t2/t3")
-        self.assertFalse(path.exists(path.join(self.mount_a.mountpoint, self.dir_name)),
-                         "test_dir/t1/t2/t3 is not deleted")
+        self.dir_does_not_exists()
 
     def test_rmdir_p_non_existing_dir(self):
         """
-        Test that rmdir -p does not delete invalid directory
+        Test that rmdir -p does not delete an invalid directory
         """
         rmdir_output = self.get_cephfs_shell_cmd_error("rmdir -p test_dir")
-        log.info("cephfs-shell rmdir output:\n{}".format(rmdir_output))
-        self.assertTrue(rmdir_output, "Something went wrong!! non existing dir deleted")
+        log.info("rmdir error output:\n{}".format(rmdir_output))
+        self.dir_does_not_exists()
 
-    def test_rmdir_p_non_empty_dir(self):
+    def test_rmdir_p_dir_with_file(self):
         """
-        Test that rmdir -p outputs error for non empty directory
+        Test that rmdir -p does not delete the directory containing a file
         """
         self.run_cephfs_shell_cmd("mkdir " + self.dir_name)
         self.run_cephfs_shell_cmd("put - test_dir/dumpfile", stdin="Valid File")
-        self.dir_not_deleted("non-empty test_dir is deleted with -p", " -p ")
+        self.run_cephfs_shell_cmd("rmdir -p " + self.dir_name)
+        self.mount_a.stat(self.dir_name)
 
 class TestGetAndPut(TestCephFSShell):
     # the 'put' command gets tested as well with the 'get' comamnd

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -189,6 +189,14 @@ class TestRmdir(TestCephFSShell):
                          "Something went wrong!! test_dir is not deleted")
 
 
+    def test_rmdir_non_existing_dir(self):
+        """
+        Test that rmdir outputs error for non existing directory
+        """
+        rmdir_output = self.get_cephfs_shell_cmd_error("rmdir test_dir")
+        log.info("cephfs-shell rmdir output:\n{}".format(rmdir_output))
+        self.assertTrue(rmdir_output, "Something went wrong!! non existing dir deleted")
+
 class TestGetAndPut(TestCephFSShell):
     # the 'put' command gets tested as well with the 'get' comamnd
     def test_put_and_get_without_target_directory(self):

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -215,6 +215,15 @@ class TestRmdir(TestCephFSShell):
         self.assertFalse(path.exists(path.join(self.mount_a.mountpoint, self.dir_name)),
                         "Something went wrong!! test_dir is not deleted")
 
+    def test_rmdir_p_valid_path(self):
+        """
+        Test that rmdir -p deletes all empty directories in the path passed
+        """
+        self.run_cephfs_shell_cmd("mkdir -p test_dir/t1/t2/t3")
+        self.run_cephfs_shell_cmd("rmdir -p test_dir/t1/t2/t3")
+        self.assertFalse(path.exists(path.join(self.mount_a.mountpoint, self.dir_name)),
+                         "Something went wrong!! test_dir/t1/t2/t3 is not deleted")
+
 
 class TestGetAndPut(TestCephFSShell):
     # the 'put' command gets tested as well with the 'get' comamnd

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -175,6 +175,20 @@ class TestMkdir(TestCephFSShell):
         o = self.mount_a.stat('d5/d6/d7')
         log.info("mount_a output:\n{}".format(o))
 
+class TestRmdir(TestCephFSShell):
+    dir_name = "test_dir"
+
+    def test_rmdir(self):
+        """
+        Test that rmdir deletes directory
+        """
+        self.run_cephfs_shell_cmd("mkdir " + self.dir_name)
+        self.run_cephfs_shell_cmd("rmdir " + self.dir_name)
+
+        self.assertFalse(path.exists(self.dir_name),
+                         "Something went wrong!! test_dir is not deleted")
+
+
 class TestGetAndPut(TestCephFSShell):
     # the 'put' command gets tested as well with the 'get' comamnd
     def test_put_and_get_without_target_directory(self):

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -232,6 +232,16 @@ class TestRmdir(TestCephFSShell):
         log.info("cephfs-shell rmdir output:\n{}".format(rmdir_output))
         self.assertTrue(rmdir_output, "Something went wrong!! non existing dir deleted")
 
+    def test_rmdir_p_non_empty_dir(self):
+        """
+        Test that rmdir -p outputs error for non empty directory
+        """
+        self.run_cephfs_shell_cmd("mkdir " + self.dir_name)
+        self.run_cephfs_shell_cmd("put - test_dir/dumpfile", stdin="Valid File")
+        self.run_cephfs_shell_cmd("rmdir -p " + self.dir_name)
+        self.assertTrue(path.exists(path.join(self.mount_a.mountpoint, self.dir_name)),
+                        "Something went wrong!! test_dir is deleted")
+
 class TestGetAndPut(TestCephFSShell):
     # the 'put' command gets tested as well with the 'get' comamnd
     def test_put_and_get_without_target_directory(self):

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -197,6 +197,16 @@ class TestRmdir(TestCephFSShell):
         log.info("cephfs-shell rmdir output:\n{}".format(rmdir_output))
         self.assertTrue(rmdir_output, "Something went wrong!! non existing dir deleted")
 
+    def test_rmdir_existing_file(self):
+        """
+        Test that rmdir outputs error on file
+        """
+        self.run_cephfs_shell_cmd("put - dumpfile", stdin="Valid File")
+        self.run_cephfs_shell_cmd("rmdir dumpfile")
+        self.assertTrue(path.exists(path.join(self.mount_a.mountpoint, "dumpfile")),
+                        "Something went wrong!! rmdir deleted a file")
+
+
 class TestGetAndPut(TestCephFSShell):
     # the 'put' command gets tested as well with the 'get' comamnd
     def test_put_and_get_without_target_directory(self):

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -206,6 +206,15 @@ class TestRmdir(TestCephFSShell):
         self.assertTrue(path.exists(path.join(self.mount_a.mountpoint, "dumpfile")),
                         "Something went wrong!! rmdir deleted a file")
 
+    def test_rmdir_p(self):
+        """
+        Test that rmdir -p deletes all empty directories in the root directory passed
+        """
+        self.run_cephfs_shell_cmd("mkdir -p test_dir/t1/t2/t3")
+        self.run_cephfs_shell_cmd("rmdir -p " + self.dir_name)
+        self.assertFalse(path.exists(path.join(self.mount_a.mountpoint, self.dir_name)),
+                        "Something went wrong!! test_dir is not deleted")
+
 
 class TestGetAndPut(TestCephFSShell):
     # the 'put' command gets tested as well with the 'get' comamnd

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -197,6 +197,16 @@ class TestRmdir(TestCephFSShell):
         log.info("cephfs-shell rmdir output:\n{}".format(rmdir_output))
         self.assertTrue(rmdir_output, "Something went wrong!! non existing dir deleted")
 
+    def test_rmdir_non_empty_dir(self):
+        """
+        Test that rmdir outputs error for non empty directory
+        """
+        self.run_cephfs_shell_cmd("mkdir " + self.dir_name)
+        self.run_cephfs_shell_cmd("put - test_dir/dumpfile", stdin="Valid File")
+        self.run_cephfs_shell_cmd("rmdir " + self.dir_name)
+        self.assertTrue(path.exists(path.join(self.mount_a.mountpoint, self.dir_name)),
+                        "Something went wrong!! non-empty test_dir is not deleted")
+
     def test_rmdir_existing_file(self):
         """
         Test that rmdir outputs error on file

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -224,6 +224,13 @@ class TestRmdir(TestCephFSShell):
         self.assertFalse(path.exists(path.join(self.mount_a.mountpoint, self.dir_name)),
                          "Something went wrong!! test_dir/t1/t2/t3 is not deleted")
 
+    def test_rmdir_p_non_existing_dir(self):
+        """
+        Test that rmdir -p does not delete invalid directory
+        """
+        rmdir_output = self.get_cephfs_shell_cmd_error("rmdir -p test_dir")
+        log.info("cephfs-shell rmdir output:\n{}".format(rmdir_output))
+        self.assertTrue(rmdir_output, "Something went wrong!! non existing dir deleted")
 
 class TestGetAndPut(TestCephFSShell):
     # the 'put' command gets tested as well with the 'get' comamnd

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -876,16 +876,21 @@ class CephFSShell(Cmd):
                 continue
             else:
                 is_pattern = False
-            path = os.path.normpath(os.path.join(cephfs.getcwd(), path))
+
             if args.parent:
-                files = reversed(sorted(set(dirwalk(path))))
+                path = os.path.join(cephfs.getcwd(), path.rsplit(b'/')[0])
+                files = list(sorted(set(dirwalk(path)), reverse=True))
+                if not files:
+                    path = b'.'
                 for filepath in files:
-                    filepath = os.path.normpath(filepath)
-                    if filepath[1:] != path:
-                        try:
-                            cephfs.rmdir(filepath)
-                        except libcephfs.Error:
-                            cephfs.unlink(filepath)
+                    try:
+                        cephfs.rmdir(os.path.normpath(filepath))
+                    except libcephfs.Error as e:
+                        perror(e)
+                        path = b'.'
+                        break
+            else:
+                path = os.path.normpath(os.path.join(cephfs.getcwd(), path))
             if not is_pattern and path != os.path.normpath(b''):
                 try:
                     cephfs.rmdir(path)


### PR DESCRIPTION
This patch series fixes following issues:
- Deletion of non-empty directories
- Deletion of only last child directory when root directories are also passed

Also adds tests for rmdir.

Fixes: https://tracker.ceph.com/issues/40861
Fixes: https://tracker.ceph.com/issues/40863
Signed-off-by: Varsha Rao <varao@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
