### PR TITLE
mgr/pg_autoscaler: default to pg_num[_min] = 16

### DIFF
--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -198,7 +198,7 @@ Ceph configuration file.
               value is the same as ``pg_num`` with ``mkpool``.
 
 :Type: 32-bit Integer
-:Default: ``8``
+:Default: ``16``
 
 
 ``osd pool default pgp num``

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2550,7 +2550,7 @@ std::vector<Option> get_global_options() {
     .add_service("mon"),
 
     Option("osd_pool_default_pg_num", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(8)
+    .set_default(16)
     .set_description("number of PGs for new pools")
     .set_flag(Option::FLAG_RUNTIME)
     .add_service("mon"),

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -24,7 +24,7 @@ Some terminology is made up for the purposes of this module:
 
 INTERVAL = 5
 
-PG_NUM_MIN = 4  # unless specified on a per-pool basis
+PG_NUM_MIN = 16  # unless specified on a per-pool basis
 
 def nearest_power_of_two(n):
     v = int(n)


### PR DESCRIPTION
4 or 8 PGs doesn't provide much parallelism at baseline.  Start with 16
and set the floor there; that's a more reasonable number of OSDs that
will be put to work on a single pool.

Note that there is no magic number here.  At some point someone has to
tell Ceph if an empty pool should get lots of PGs across lots of devices
to get the full throughput of the cluster.  But this will be a bit less
painful/surprising for users.

Fixes: https://tracker.ceph.com/issues/42509
Signed-off-by: Sage Weil <sage@redhat.com>