### PR TITLE
src/msg/async/net_handler.cc: Fix compilation

### DIFF
--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -122,9 +122,9 @@ void NetHandler::set_priority(int sd, int prio, int domain)
   if (prio < 0) {
     return;
   }
+  int r = -1;
 #ifdef IPTOS_CLASS_CS6
   int iptos = IPTOS_CLASS_CS6;
-  int r = -1;
   switch (domain) {
   case AF_INET:
     r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, &iptos, sizeof(iptos));


### PR DESCRIPTION
On a Cray system I'm working on, it seems that `SO_PRIORITY` is defined, but `IPTOS_CLASS_CS6` is not. Without this patch, compilation fails at line 150:

```
r = ::setsockopt(sd, SOL_SOCKET, SO_PRIORITY, &prio, sizeof(prio));
```

beacuse the variable `r` is not defined (originally it is defined inside the `#ifdef IPTOS_CLASS_CS6` block).


Fixes: https://tracker.ceph.com/issues/42821

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
