### PR TITLE
mgr/pg_autoscaler: only generate target_* health warnings if targets set

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -491,7 +491,7 @@ class PgAutoscaler(MgrModule):
         too_much_target_ratio = []
         for root_id, total in iteritems(total_ratio):
             total_target = total_target_ratio[root_id]
-            if total > 1.0:
+            if total_target > 0 and total > 1.0:
                 too_much_target_ratio.append(
                     'Pools %s overcommit available storage by %.03fx due to '
                     'target_size_ratio %.03f on pools %s' % (
@@ -519,7 +519,7 @@ class PgAutoscaler(MgrModule):
         too_much_target_bytes = []
         for root_id, total in iteritems(total_bytes):
             total_target = total_target_bytes[root_id]
-            if total > root_map[root_id].capacity:
+            if total_target > 0 and total > root_map[root_id].capacity:
                 too_much_target_bytes.append(
                     'Pools %s overcommit available storage by %.03fx due to '
                     'target_size_bytes %s on pools %s' % (


### PR DESCRIPTION
We may get into a situation where the pool stats appear to exceed the
cluster capacity.  If that happens, don't generate confusing health
messages about the target_{ratio,bytes} pool settings when they aren't
actually set at all.

Fixes: https://tracker.ceph.com/issues/42301
Signed-off-by: Sage Weil <sage@redhat.com>