### PR TITLE
mds: inode number range delegation to clients

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1550,7 +1550,7 @@ void Client::dump_mds_requests(Formatter *f)
   }
 }
 
-int Client::verify_reply_trace(int r,
+int Client::verify_reply_trace(int r, MetaSession *session,
 			       MetaRequest *request, const MConstRef<MClientReply>& reply,
 			       InodeRef *ptarget, bool *pcreated,
 			       const UserPerm& perms)
@@ -1563,12 +1563,24 @@ int Client::verify_reply_trace(int r,
 
   extra_bl = reply->get_extra_bl();
   if (extra_bl.length() >= 8) {
-    // if the extra bufferlist has a buffer, we assume its the created inode
-    // and that this request to create succeeded in actually creating
-    // the inode (won the race with other create requests)
-    decode(created_ino, extra_bl);
-    got_created_ino = true;
+    if (session->mds_features.test(CEPHFS_FEATURE_OCTOPUS)) {
+     struct openc_response_t	ocres;
+
+     decode(ocres, extra_bl);
+     created_ino = ocres.created_ino;
+     /*
+      * The userland cephfs client doesn't have a way to do an async create
+      * (yet), so just discard delegated_inos for now. Eventually we should
+      * store them and use them in create calls, even if they are synchronous,
+      * if only for testing purposes.
+      */
+     ldout(cct, 10) << "delegated_inos: " << ocres.delegated_inos << dendl;
+    } else {
+     // u64 containing number of created ino
+     decode(created_ino, extra_bl);
+    }
     ldout(cct, 10) << "make_request created ino " << created_ino << dendl;
+    got_created_ino = true;
   }
 
   if (pcreated)
@@ -1676,6 +1688,7 @@ int Client::make_request(MetaRequest *request,
   if (use_mds >= 0)
     request->resend_mds = use_mds;
 
+  MetaSession *session = NULL;
   while (1) {
     if (request->aborted())
       break;
@@ -1710,7 +1723,6 @@ int Client::make_request(MetaRequest *request,
     }
 
     // open a session?
-    MetaSession *session = NULL;
     if (!have_open_session(mds)) {
       session = _get_or_open_mds_session(mds);
 
@@ -1775,7 +1787,7 @@ int Client::make_request(MetaRequest *request,
   request->dispatch_cond = 0;
   
   if (r >= 0 && ptarget)
-    r = verify_reply_trace(r, request, reply, ptarget, pcreated, perms);
+    r = verify_reply_trace(r, session, request, reply, ptarget, pcreated, perms);
 
   if (pdirbl)
     *pdirbl = reply->get_extra_bl();

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -802,7 +802,8 @@ protected:
   void put_request(MetaRequest *request);
   void unregister_request(MetaRequest *request);
 
-  int verify_reply_trace(int r, MetaRequest *request, const MConstRef<MClientReply>& reply,
+  int verify_reply_trace(int r, MetaSession *session, MetaRequest *request,
+			 const MConstRef<MClientReply>& reply,
 			 InodeRef *ptarget, bool *pcreated,
 			 const UserPerm& perms);
   void encode_cap_releases(MetaRequest *request, mds_rank_t mds);

--- a/src/doc/caching.txt
+++ b/src/doc/caching.txt
@@ -15,8 +15,8 @@ disambiguate multiple replicas of the same item (see below).
 
   map<int, int> replicas;  // maps replicating mds# to nonce
 
-The cached_by set _always_ includes all nodes that cache the
-partcuarly object, but may additionally include nodes that used to
+The cached_by set _always_ includes all nodes that cache a
+particular object, but may additionally include nodes that used to
 cache it but no longer do.  In those cases, an expire message should
 be in transit.  That is, we have two invariants:
 

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -255,11 +255,6 @@ bool MDRequestImpl::slave_rolling_back()
   return has_more() && more()->slave_rolling_back;
 }
 
-bool MDRequestImpl::did_ino_allocation() const
-{
-  return alloc_ino || used_prealloc_ino || prealloc_inos.size();
-}      
-
 bool MDRequestImpl::freeze_auth_pin(CInode *inode)
 {
   ceph_assert(!more()->rename_inode || more()->rename_inode == inode);

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -388,7 +388,6 @@ struct MDRequestImpl : public MutationImpl {
   bool has_witnesses();
   bool slave_did_prepare();
   bool slave_rolling_back();
-  bool did_ino_allocation() const;
   bool freeze_auth_pin(CInode *inode);
   void unfreeze_auth_pin(bool clear_inode=false);
   void set_remote_frozen_auth_pin(CInode *inode);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4366,7 +4366,14 @@ void Server::handle_client_openc(MDRequestRef& mdr)
 
   C_MDS_openc_finish *fin = new C_MDS_openc_finish(this, mdr, dn, in);
 
-  if (mdr->client_request->get_connection()->has_feature(CEPH_FEATURE_REPLY_CREATE_INODE)) {
+  if (mdr->session->info.has_feature(CEPHFS_FEATURE_OCTOPUS)) {
+    openc_response_t	ocresp;
+
+    dout(10) << "adding created_ino and delegated_inos" << dendl;
+    ocresp.created_ino = in->inode.ino;
+    ocresp.delegated_inos = mdr->session->info.delegated_inos;
+    encode(ocresp, mdr->reply_extra_bl);
+  } else if (mdr->client_request->get_connection()->has_feature(CEPH_FEATURE_REPLY_CREATE_INODE)) {
     dout(10) << "adding ino to reply to indicate inode was created" << dendl;
     // add the file created flag onto the reply if create_flags features is supported
     encode(in->inode.ino, mdr->reply_extra_bl);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -139,8 +139,9 @@ public:
   }
 
   void handle_client_session(const cref_t<MClientSession> &m);
-  void _session_logged(Session *session, uint64_t state_seq, 
-		       bool open, version_t pv, interval_set<inodeno_t>& inos,version_t piv);
+  void _session_logged(Session *session, uint64_t state_seq, bool open, version_t pv,
+		       interval_set<inodeno_t>& prealloc, interval_set<inodeno_t>& deleg,
+		       version_t piv);
   version_t prepare_force_open_sessions(map<client_t,entity_inst_t> &cm,
 					map<client_t,client_metadata_t>& cmm,
 					map<client_t,pair<Session*,uint64_t> >& smap);

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -79,6 +79,7 @@ void SessionMap::dump()
 	     << " state " << p->second->get_state_name()
 	     << " completed " << p->second->info.completed_requests
 	     << " prealloc_inos " << p->second->info.prealloc_inos
+	     << " delegated_inos " << p->second->info.delegated_inos
 	     << " used_inos " << p->second->info.used_inos
 	     << dendl;
 }
@@ -627,6 +628,7 @@ void SessionMap::wipe_ino_prealloc()
        p != session_map.end(); 
        ++p) {
     p->second->pending_prealloc_inos.clear();
+    p->second->info.delegated_inos.clear();
     p->second->info.prealloc_inos.clear();
     p->second->info.used_inos.clear();
   }

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -211,11 +211,6 @@ public:
     return session_cache_liveness.get();
   }
 
-  inodeno_t next_ino() const {
-    if (info.prealloc_inos.empty())
-      return 0;
-    return info.prealloc_inos.range_start();
-  }
   inodeno_t take_ino(inodeno_t ino = 0) {
     ceph_assert(!info.prealloc_inos.empty());
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -791,7 +791,7 @@ void EMetaBlob::encode(bufferlist& bl, uint64_t features) const
 }
 void EMetaBlob::decode(bufferlist::const_iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(7, 5, 5, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(8, 5, 5, bl);
   decode(lump_order, bl);
   decode(lump_map, bl);
   if (struct_v >= 4) {

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1496,11 +1496,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDSlaveUpdate *slaveup)
 	dout(20) << " (session prealloc " << session->info.prealloc_inos << ")" << dendl;
 	if (used_preallocated_ino) {
 	  if (!session->info.prealloc_inos.empty()) {
-	    inodeno_t next = session->next_ino();
 	    inodeno_t i = session->take_ino(used_preallocated_ino);
-	    if (next != i)
-	      mds->clog->warn() << " replayed op " << client_reqs << " used ino " << i
-			       << " but session next is " << next;
 	    ceph_assert(i == used_preallocated_ino);
 	    session->info.used_inos.clear();
 	  }

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -532,7 +532,7 @@ void session_info_t::dump(Formatter *f) const
   f->open_array_section("prealloc_inos");
   for (const auto& [start, len] : prealloc_inos) {
     f->open_object_section("ino_range");
-    f->dump_unsigned("start", start);
+    f->dump_stream("start") << start;
     f->dump_unsigned("length", len);
     f->close_section();
   }
@@ -541,7 +541,7 @@ void session_info_t::dump(Formatter *f) const
   f->open_array_section("used_inos");
   for (const auto& [start, len] : used_inos) {
     f->open_object_section("ino_range");
-    f->dump_unsigned("start", start);
+    f->dump_stream("start") << start;
     f->dump_unsigned("length", len);
     f->close_section();
   }

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1164,7 +1164,7 @@ struct client_metadata_t {
 WRITE_CLASS_ENCODER(client_metadata_t)
 
 /*
- * session_info_t
+ * session_info_t - durable part of a Session
  */
 struct session_info_t {
   entity_inst_t inst;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1170,6 +1170,7 @@ struct session_info_t {
   entity_inst_t inst;
   std::map<ceph_tid_t,inodeno_t> completed_requests;
   interval_set<inodeno_t> prealloc_inos;   // preallocated, ready to use.
+  interval_set<inodeno_t> delegated_inos;  // hand these out to client
   interval_set<inodeno_t> used_inos;       // journaling use
   client_metadata_t client_metadata;
   std::set<ceph_tid_t> completed_flushes;

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -262,6 +262,27 @@ struct InodeStat {
   // see CInode::encode_inodestat for encoder.
 };
 
+struct openc_response_t {
+  _inodeno_t			created_ino;
+  interval_set<inodeno_t>	delegated_inos;
+
+public:
+  void encode(ceph::buffer::list& bl) const {
+    using ceph::encode;
+    ENCODE_START(1, 1, bl);
+    encode(created_ino, bl);
+    encode(delegated_inos, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator &p) {
+    using ceph::decode;
+    DECODE_START(1, p);
+    decode(created_ino, p);
+    decode(delegated_inos, p);
+    DECODE_FINISH(p);
+  }
+} __attribute__ ((__may_alias__));
+WRITE_CLASS_ENCODER(openc_response_t)
 
 class MClientReply : public SafeMessage {
 public:


### PR DESCRIPTION
This is an initial set to have the MDS delegate ranges of the prealloc_inos set to the clients for use in async dirops. This is just a draft for now, and the kernel code does not exist yet.

The set starts with a few cleanup and bugfix patches that could probably be merged independently.

Old kernels will also barf when mounting an MDS with this set since they don't expect the extra field in an openc response. We'll also need to do something (possibly with feature bits) to work around that.

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
