### PR TITLE
nautilus: qa/tasks/ceph.conf.template: increase mon tell retries

### DIFF
--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -37,6 +37,9 @@
 	mon cluster log file level = debug
 	debug asserts on shutdown = true
 
+	# we see this fail in qa on *nautilus*; bump up retries
+	mon_client_directed_command_retry = 4
+
 [osd]
         osd journal size = 100
 


### PR DESCRIPTION
With lots of ms failure injection we see these failing in QA.  Bump this
up as a kludge for nautilus *only*; the master tell implementation no
longer sucks.

Fixes: https://tracker.ceph.com/issues/42783
Signed-off-by: Sage Weil <sage@redhat.com>