### PR TITLE
rbd-mirror: add namespace support to service daemon

### DIFF
--- a/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
@@ -50,8 +50,8 @@ struct Threads<librbd::MockTestImageCtx> {
 
 template<>
 struct ServiceDaemon<librbd::MockTestImageCtx> {
-  MOCK_METHOD3(add_or_update_attribute,
-               void(int64_t, const std::string&,
+  MOCK_METHOD4(add_or_update_namespace_attribute,
+               void(int64_t, const std::string&, const std::string&,
                     const service_daemon::AttributeValue&));
 };
 
@@ -299,7 +299,8 @@ TEST_F(TestMockInstanceReplayer, RemoveFinishedImage) {
   EXPECT_CALL(mock_image_replayer, is_blacklisted()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, is_finished()).WillOnce(Return(true));
   EXPECT_CALL(mock_image_replayer, destroy());
-  EXPECT_CALL(mock_service_daemon,add_or_update_attribute(_, _, _)).Times(3);
+  EXPECT_CALL(mock_service_daemon,
+              add_or_update_namespace_attribute(_, _, _, _)).Times(3);
 
   ASSERT_TRUE(start_image_replayers_ctx != nullptr);
   start_image_replayers_ctx->complete(0);

--- a/src/test/rbd_mirror/test_mock_NamespaceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_NamespaceReplayer.cc
@@ -221,8 +221,8 @@ std::map<int64_t, PoolWatcher<librbd::MockTestImageCtx> *> PoolWatcher<librbd::M
 
 template<>
 struct ServiceDaemon<librbd::MockTestImageCtx> {
-  MOCK_METHOD3(add_or_update_attribute,
-               void(int64_t, const std::string&,
+  MOCK_METHOD4(add_or_update_namespace_attribute,
+               void(int64_t, const std::string&, const std::string&,
                     const service_daemon::AttributeValue&));
   MOCK_METHOD2(remove_attribute,
                void(int64_t, const std::string&));
@@ -386,20 +386,6 @@ public:
       .WillOnce(CompleteContext(m_mock_threads->work_queue, 0));
   }
 
-  void expect_service_daemon_add_or_update_attribute(
-      MockServiceDaemon &mock_service_daemon, const std::string& key,
-      const service_daemon::AttributeValue& value) {
-    EXPECT_CALL(mock_service_daemon, add_or_update_attribute(_, key, value));
-  }
-
-  void expect_service_daemon_add_or_update_instance_id_attribute(
-      MockInstanceWatcher &mock_instance_watcher,
-      MockServiceDaemon &mock_service_daemon) {
-    expect_instance_watcher_get_instance_id(mock_instance_watcher, "1234");
-    expect_service_daemon_add_or_update_attribute(
-        mock_service_daemon, "instance_id", {std::string("1234")});
-  }
-
   MockThreads *m_mock_threads;
 };
 
@@ -515,9 +501,6 @@ TEST_F(TestMockNamespaceReplayer, Init) {
   expect_instance_watcher_init(*mock_instance_watcher, 0);
 
   MockServiceDaemon mock_service_daemon;
-  expect_service_daemon_add_or_update_instance_id_attribute(
-      *mock_instance_watcher, mock_service_daemon);
-
   MockNamespaceReplayer namespace_replayer(
       {}, m_local_io_ctx, m_remote_io_ctx, "local mirror uuid",
       "remote mirror uuid", "siteA", m_mock_threads, nullptr, nullptr,
@@ -558,9 +541,6 @@ TEST_F(TestMockNamespaceReplayer, AcuqireLeader) {
   expect_instance_watcher_init(*mock_instance_watcher, 0);
 
   MockServiceDaemon mock_service_daemon;
-  expect_service_daemon_add_or_update_instance_id_attribute(
-      *mock_instance_watcher, mock_service_daemon);
-
   MockNamespaceReplayer namespace_replayer(
       {}, m_local_io_ctx, m_remote_io_ctx, "local mirror uuid",
       "remote mirror uuid", "siteA", m_mock_threads, nullptr, nullptr,

--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -382,15 +382,15 @@ void InstanceReplayer<I>::start_image_replayers(int r) {
     start_image_replayer(current_it->second);
   }
 
-  // TODO: add namespace support to service daemon
-  if (m_local_io_ctx.get_namespace().empty()) {
-    m_service_daemon->add_or_update_attribute(
-      m_local_io_ctx.get_id(), SERVICE_DAEMON_ASSIGNED_COUNT_KEY, image_count);
-    m_service_daemon->add_or_update_attribute(
-      m_local_io_ctx.get_id(), SERVICE_DAEMON_WARNING_COUNT_KEY, warning_count);
-    m_service_daemon->add_or_update_attribute(
-      m_local_io_ctx.get_id(), SERVICE_DAEMON_ERROR_COUNT_KEY, error_count);
-  }
+  m_service_daemon->add_or_update_namespace_attribute(
+    m_local_io_ctx.get_id(), m_local_io_ctx.get_namespace(),
+    SERVICE_DAEMON_ASSIGNED_COUNT_KEY, image_count);
+  m_service_daemon->add_or_update_namespace_attribute(
+    m_local_io_ctx.get_id(), m_local_io_ctx.get_namespace(),
+    SERVICE_DAEMON_WARNING_COUNT_KEY, warning_count);
+  m_service_daemon->add_or_update_namespace_attribute(
+    m_local_io_ctx.get_id(), m_local_io_ctx.get_namespace(),
+    SERVICE_DAEMON_ERROR_COUNT_KEY, error_count);
 
   m_async_op_tracker.finish_op();
 }

--- a/src/tools/rbd_mirror/NamespaceReplayer.cc
+++ b/src/tools/rbd_mirror/NamespaceReplayer.cc
@@ -29,7 +29,6 @@ using ::operator<<;
 
 namespace {
 
-const std::string SERVICE_DAEMON_INSTANCE_ID_KEY("instance_id");
 const std::string SERVICE_DAEMON_LOCAL_COUNT_KEY("image_local_count");
 const std::string SERVICE_DAEMON_REMOTE_COUNT_KEY("image_remote_count");
 
@@ -183,16 +182,14 @@ void NamespaceReplayer<I>::handle_update(const std::string &mirror_uuid,
            << "added_count=" << added_image_ids.size() << ", "
            << "removed_count=" << removed_image_ids.size() << dendl;
 
-  // TODO: add namespace support to service daemon
-  if (m_local_io_ctx.get_namespace().empty()) {
-    m_service_daemon->add_or_update_attribute(
-        m_local_io_ctx.get_id(), SERVICE_DAEMON_LOCAL_COUNT_KEY,
-        m_local_pool_watcher->get_image_count());
-    if (m_remote_pool_watcher) {
-      m_service_daemon->add_or_update_attribute(
-          m_local_io_ctx.get_id(), SERVICE_DAEMON_REMOTE_COUNT_KEY,
-          m_remote_pool_watcher->get_image_count());
-    }
+  m_service_daemon->add_or_update_namespace_attribute(
+    m_local_io_ctx.get_id(), m_local_io_ctx.get_namespace(),
+    SERVICE_DAEMON_LOCAL_COUNT_KEY, m_local_pool_watcher->get_image_count());
+  if (m_remote_pool_watcher) {
+    m_service_daemon->add_or_update_namespace_attribute(
+      m_local_io_ctx.get_id(), m_local_io_ctx.get_namespace(),
+      SERVICE_DAEMON_REMOTE_COUNT_KEY,
+      m_remote_pool_watcher->get_image_count());
   }
 
   std::set<std::string> added_global_image_ids;
@@ -395,13 +392,6 @@ void NamespaceReplayer<I>::handle_init_instance_watcher(int r) {
     m_ret_val = r;
     shut_down_instance_replayer();
     return;
-  }
-
-  // TODO: add namespace support to service daemon
-  if (m_local_io_ctx.get_namespace().empty()) {
-    m_service_daemon->add_or_update_attribute(
-        m_local_io_ctx.get_id(), SERVICE_DAEMON_INSTANCE_ID_KEY,
-        m_instance_watcher->get_instance_id());
   }
 
   ceph_assert(m_on_finish != nullptr);

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -31,6 +31,7 @@ using ::operator<<;
 
 namespace {
 
+const std::string SERVICE_DAEMON_INSTANCE_ID_KEY("instance_id");
 const std::string SERVICE_DAEMON_LEADER_KEY("leader");
 
 const std::vector<std::string> UNIQUE_PEER_CONFIG_KEYS {
@@ -352,6 +353,10 @@ void PoolReplayer<I>::init(const std::string& site_name) {
     m_callout_id = service_daemon::CALLOUT_ID_NONE;
   }
 
+  m_service_daemon->add_or_update_attribute(
+    m_local_io_ctx.get_id(), SERVICE_DAEMON_INSTANCE_ID_KEY,
+    stringify(m_local_io_ctx.get_instance_id()));
+
   m_pool_replayer_thread.create("pool replayer");
 }
 
@@ -586,6 +591,7 @@ void PoolReplayer<I>::update_namespace_replayers() {
           delete namespace_replayer;
           ctx->complete(r);
         });
+      m_service_daemon->remove_namespace(m_local_pool_id, it->first);
       namespace_replayer->shut_down(on_shut_down);
       it = m_namespace_replayers.erase(it);
     } else {
@@ -611,6 +617,7 @@ void PoolReplayer<I>::update_namespace_replayers() {
           } else {
             std::lock_guard locker{m_lock};
             m_namespace_replayers[name] = namespace_replayer;
+            m_service_daemon->add_namespace(m_local_pool_id, name);
           }
           ctx->complete(r);
         });
@@ -716,6 +723,7 @@ void PoolReplayer<I>::namespace_replayer_acquire_leader(const std::string &name,
                 delete namespace_replayer;
                 on_finish->complete(r);
               });
+          m_service_daemon->remove_namespace(m_local_pool_id, name);
           namespace_replayer->shut_down(on_shut_down);
           return;
         }

--- a/src/tools/rbd_mirror/ServiceDaemon.h
+++ b/src/tools/rbd_mirror/ServiceDaemon.h
@@ -30,6 +30,9 @@ public:
   void add_pool(int64_t pool_id, const std::string& pool_name);
   void remove_pool(int64_t pool_id);
 
+  void add_namespace(int64_t pool_id, const std::string& namespace_name);
+  void remove_namespace(int64_t pool_id, const std::string& namespace_name);
+
   uint64_t add_or_update_callout(int64_t pool_id, uint64_t callout_id,
                                  service_daemon::CalloutLevel callout_level,
                                  const std::string& text);
@@ -37,6 +40,9 @@ public:
 
   void add_or_update_attribute(int64_t pool_id, const std::string& key,
                                const service_daemon::AttributeValue& value);
+  void add_or_update_namespace_attribute(
+      int64_t pool_id, const std::string& namespace_name,
+      const std::string& key, const service_daemon::AttributeValue& value);
   void remove_attribute(int64_t pool_id, const std::string& key);
 
 private:
@@ -52,11 +58,13 @@ private:
   };
   typedef std::map<uint64_t, Callout> Callouts;
   typedef std::map<std::string, service_daemon::AttributeValue> Attributes;
+  typedef std::map<std::string, Attributes> NamespaceAttributes;
 
   struct Pool {
     std::string name;
     Callouts callouts;
     Attributes attributes;
+    NamespaceAttributes ns_attributes;
 
     Pool(const std::string& name) : name(name) {
     }


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
