### PR TITLE
mgr/crash: behave when posted crash has no backtrace

### DIFF
--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -181,7 +181,8 @@ class Module(MgrModule):
             metadata = self.validate_crash_metadata(inbuf)
         except Exception as e:
             return errno.EINVAL, '', 'malformed crash metadata: %s' % e
-        metadata['stack_sig'] = self.calc_sig(
+        if 'backtrace' in metadata:
+            metadata['stack_sig'] = self.calc_sig(
                 metadata.get('backtrace'), metadata.get('assert_msg'))
         crashid = metadata['crash_id']
 


### PR DESCRIPTION
This is the case when the qa/tasks/mgr/test_crash.py test runs, and could
happen in the real world too, perhaps, if someone fed us wonky input.

Signed-off-by: Sage Weil <sage@redhat.com>