### PR TITLE
nautilus: global: disable THP for Ceph daemons

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -830,6 +830,12 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_NO_MON_UPDATE)
     .set_description(""),
 
+    Option("thp", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_flag(Option::FLAG_STARTUP)
+    .set_description("enable transparent huge page (THP) support")
+    .set_long_description("Ceph is known to suffer from memory fragmentation due to THP use. This is indicated by RSS usage above configured memory targets. Enabling THP is currently discouraged until selective use of THP by Ceph is implemented."),
+
     Option("key", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description("Authentication key")

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -324,6 +324,11 @@ global_init(const std::map<std::string,std::string> *defaults,
   if (prctl(PR_SET_DUMPABLE, 1) == -1) {
     cerr << "warning: unable to set dumpable flag: " << cpp_strerror(errno) << std::endl;
   }
+#  if defined(PR_SET_THP_DISABLE)
+  if (!g_conf().get_val<bool>("thp") && prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0) == -1) {
+    cerr << "warning: unable to disable THP: " << cpp_strerror(errno) << std::endl;
+  }
+#  endif
 #endif
 
   // Expand metavariables. Invoke configuration observers. Open log file.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42818
possibly a backport of https://github.com/ceph/ceph/pull/31582
parent tracker: https://tracker.ceph.com/issues/42781

---

original PR body:

https://tracker.ceph.com/issues/42818

---

updated using ceph-backport.sh version 15.0.0.6950
