### PR TITLE
luminous: doc/rgw: document CreateBucketConfiguration for s3 PUT Bucket api

### DIFF
--- a/doc/radosgw/placement.rst
+++ b/doc/radosgw/placement.rst
@@ -147,6 +147,8 @@ format must be edited manually:
   $ vi user.json
   $ radosgw-admin metadata put user:<user-id> < user.json
 
+.. _s3_bucket_placement:
+
 S3 Bucket Placement
 -------------------
 

--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -7,8 +7,6 @@ PUT Bucket
 Creates a new bucket. To create a bucket, you must have a user ID and a valid AWS Access Key ID to authenticate requests. You may not
 create buckets as an anonymous user.
 
-.. note:: We do not support request entities for ``PUT /{bucket}`` in this release.
-
 Constraints
 ~~~~~~~~~~~
 In general, bucket names should follow domain name constraints.
@@ -37,6 +35,16 @@ Parameters
 | ``x-amz-acl`` | Canned ACLs.         | ``private``, ``public-read``, ``public-read-write``, ``authenticated-read`` | No         |
 +---------------+----------------------+-----------------------------------------------------------------------------+------------+
 
+Request Entities
+~~~~~~~~~~~~~~~~
+
++-------------------------------+-----------+----------------------------------------------------------------+
+| Name                          | Type      | Description                                                    |
++===============================+===========+================================================================+
+| ``CreateBucketConfiguration`` | Container | A container for the bucket configuration.                      |
++-------------------------------+-----------+----------------------------------------------------------------+
+| ``LocationConstraint``        | String    | A zonegroup api name, with optional :ref:`s3_bucket_placement` |
++-------------------------------+-----------+----------------------------------------------------------------+
 
 
 HTTP Response


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/39603

---

backport of https://github.com/ceph/ceph/pull/27977
parent tracker: https://tracker.ceph.com/issues/39597

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh