### PR TITLE
luminous: rgw: cls/user: cls_user_set_buckets_info overwrites creation_time

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -148,6 +148,8 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     } else if (op.add) {
       // bucket id may have changed (ie reshard)
       entry.bucket.bucket_id = update_entry.bucket.bucket_id;
+      // creation date may have changed (ie delete/recreate bucket)
+      entry.creation_time = update_entry.creation_time;
     }
 
     if (ret < 0) {

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1224,3 +1224,13 @@ def test_bucket_index_log_trim():
     # verify cold bucket has empty bilog
     cold_bilog = bilog_list(zone.zone, cold_bucket.name)
     assert(len(cold_bilog) == 0)
+
+def test_bucket_creation_time():
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+
+    zone_buckets = [zone.get_connection().get_all_buckets() for zone in zonegroup_conns.rw_zones]
+    for z1, z2 in combinations(zone_buckets, 2):
+        for a, b in zip(z1, z2):
+            eq(a.name, b.name)
+            eq(a.creation_date, b.creation_date)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/39733

---

backport of https://github.com/ceph/ceph/pull/28045
parent tracker: https://tracker.ceph.com/issues/39635

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh