### PR TITLE
luminous: rgw: delete_obj_index() takes mtime for bilog

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9388,7 +9388,7 @@ int RGWRados::delete_system_obj(rgw_raw_obj& obj, RGWObjVersionTracker *objv_tra
   return 0;
 }
 
-int RGWRados::delete_obj_index(const rgw_obj& obj)
+int RGWRados::delete_obj_index(const rgw_obj& obj, ceph::real_time mtime)
 {
   std::string oid, key;
   get_obj_bucket_and_oid_loc(obj, oid, key);
@@ -9405,10 +9405,7 @@ int RGWRados::delete_obj_index(const rgw_obj& obj)
   RGWRados::Bucket bop(this, bucket_info);
   RGWRados::Bucket::UpdateIndex index_op(&bop, obj);
 
-  real_time removed_mtime;
-  int r = index_op.complete_del(-1 /* pool */, 0, removed_mtime, NULL);
-
-  return r;
+  return index_op.complete_del(-1 /* pool */, 0, mtime, NULL);
 }
 
 static void generate_fake_tag(RGWRados *store, map<string, bufferlist>& attrset, RGWObjManifest& manifest, bufferlist& manifest_bl, bufferlist& tag_bl)
@@ -13752,7 +13749,7 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
 
       if (loc.key.ns == RGW_OBJ_NS_MULTIPART) {
 	dout(10) << "check_disk_state(): removing manifest part from index: " << loc << dendl;
-	r = delete_obj_index(loc);
+	r = delete_obj_index(loc, astate->mtime);
 	if (r < 0) {
 	  dout(0) << "WARNING: delete_obj_index() returned r=" << r << dendl;
 	}
@@ -14619,7 +14616,7 @@ int RGWRados::delete_obj_aio(const rgw_obj& obj,
   handles.push_back(c);
 
   if (keep_index_consistent) {
-    ret = delete_obj_index(obj);
+    ret = delete_obj_index(obj, astate->mtime);
     if (ret < 0) {
       lderr(cct) << "ERROR: failed to delete obj index with ret=" << ret << dendl;
       return ret;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3274,7 +3274,7 @@ public:
   virtual int delete_system_obj(rgw_raw_obj& src_obj, RGWObjVersionTracker *objv_tracker = NULL);
 
   /** Remove an object from the bucket index */
-  int delete_obj_index(const rgw_obj& obj);
+  int delete_obj_index(const rgw_obj& obj, ceph::real_time mtime);
 
   /**
    * Get an attribute for a system object.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/39747

---

backport of https://github.com/ceph/ceph/pull/27980
parent tracker: https://tracker.ceph.com/issues/24991

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh