### PR TITLE
nautilus: rgw: use explicit to_string() overload for boost::string_ref

### DIFF
--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1532,10 +1532,10 @@ void rgw::keystone::AdminTokenRequestVer2::dump(Formatter* const f) const
   f->open_object_section("token_request");
     f->open_object_section("auth");
       f->open_object_section("passwordCredentials");
-        encode_json("username", to_string(conf.get_admin_user()), f);
+        encode_json("username", ::to_string(conf.get_admin_user()), f);
         encode_json("password", conf.get_admin_password(), f);
       f->close_section();
-      encode_json("tenantName", to_string(conf.get_admin_tenant()), f);
+      encode_json("tenantName", ::to_string(conf.get_admin_tenant()), f);
     f->close_section();
   f->close_section();
 }
@@ -1551,9 +1551,9 @@ void rgw::keystone::AdminTokenRequestVer3::dump(Formatter* const f) const
         f->open_object_section("password");
           f->open_object_section("user");
             f->open_object_section("domain");
-              encode_json("name", to_string(conf.get_admin_domain()), f);
+              encode_json("name", ::to_string(conf.get_admin_domain()), f);
             f->close_section();
-            encode_json("name", to_string(conf.get_admin_user()), f);
+            encode_json("name", ::to_string(conf.get_admin_user()), f);
             encode_json("password", conf.get_admin_password(), f);
           f->close_section();
         f->close_section();
@@ -1561,12 +1561,12 @@ void rgw::keystone::AdminTokenRequestVer3::dump(Formatter* const f) const
       f->open_object_section("scope");
         f->open_object_section("project");
           if (! conf.get_admin_project().empty()) {
-            encode_json("name", to_string(conf.get_admin_project()), f);
+            encode_json("name", ::to_string(conf.get_admin_project()), f);
           } else {
-            encode_json("name", to_string(conf.get_admin_tenant()), f);
+            encode_json("name", ::to_string(conf.get_admin_tenant()), f);
           }
           f->open_object_section("domain");
-            encode_json("name", to_string(conf.get_admin_domain()), f);
+            encode_json("name", ::to_string(conf.get_admin_domain()), f);
           f->close_section();
         f->close_section();
       f->close_section();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42838
possibly a backport of https://github.com/ceph/ceph/pull/28013
parent tracker: https://tracker.ceph.com/issues/39611

---

original PR body:

On current nautilus I'm now running into another build failure on my IBM Z Ubuntu 19.04 system, which had already shown up earlier on mainline as described under http://tracker.ceph.com/issues/39611.
 Im not sure why I havent seen this before, maybe it came in with another backport.
 In any case, the fix is straightforward by backporting commit 04c326795d2afe63c679f2542565763fee6acc09.


---

updated using ceph-backport.sh version 15.0.0.6950
