### PR TITLE
luminous: rgw: parse_copy_location defers url-decode

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4367,6 +4367,7 @@ bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
   boost::string_view name_str;
   boost::string_view params_str;
 
+  // search for ? before url-decoding so we don't accidentally match %3F
   size_t pos = url_src.find('?');
   if (pos == string::npos) {
     name_str = url_src;
@@ -4380,14 +4381,11 @@ bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
     dec_src.remove_prefix(1);
 
   pos = dec_src.find('/');
-  if (pos ==string::npos)
+  if (pos == string::npos)
     return false;
 
-  boost::string_view bn_view{dec_src.substr(0, pos)};
-  bucket_name = std::string{bn_view.data(), bn_view.size()};
-
-  boost::string_view kn_view{dec_src.substr(pos + 1)};
-  key.name = std::string{kn_view.data(), kn_view.size()};
+  bucket_name = url_decode(dec_src.substr(0, pos));
+  key.name = url_decode(dec_src.substr(pos + 1));
 
   if (key.name.empty()) {
     return false;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3339,7 +3339,7 @@ int RGWHandler_REST_S3::init(RGWRados *store, struct req_state *s,
       (! s->info.env->get("HTTP_X_AMZ_COPY_SOURCE_RANGE")) &&
       (! s->info.args.exists("uploadId"))) {
 
-    ret = RGWCopyObj::parse_copy_location(url_decode(copy_source),
+    ret = RGWCopyObj::parse_copy_location(copy_source,
                                           s->init_state.src_bucket,
                                           s->src_object);
     if (!ret) {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2908,8 +2908,7 @@ int RGWHandler_REST_SWIFT::init(RGWRados* store, struct req_state* s,
 
   s->dialect = "swift";
 
-  std::string copy_source =
-    url_decode(s->info.env->get("HTTP_X_COPY_FROM", ""));
+  std::string copy_source = s->info.env->get("HTTP_X_COPY_FROM", "");
   if (! copy_source.empty()) {
     bool result = RGWCopyObj::parse_copy_location(copy_source, t->src_bucket,
 						  s->src_object);
@@ -2918,8 +2917,7 @@ int RGWHandler_REST_SWIFT::init(RGWRados* store, struct req_state* s,
   }
 
   if (s->op == OP_COPY) {
-    std::string req_dest =
-      url_decode(s->info.env->get("HTTP_DESTINATION", ""));
+    std::string req_dest = s->info.env->get("HTTP_DESTINATION", "");
     if (req_dest.empty())
       return -ERR_BAD_URL;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40127

---

backport of https://github.com/ceph/ceph/pull/25498
parent tracker: https://tracker.ceph.com/issues/27217

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh