### PR TITLE
luminous: rgw: TempURL should not allow PUTs with the X-Object-Manifest.

### DIFF
--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <array>
+#include <algorithm>
 
 #include <boost/utility/string_view.hpp>
 #include <boost/container/static_vector.hpp>
@@ -140,7 +141,20 @@ bool TempURLEngine::is_expired(const std::string& expires) const
   return false;
 }
 
-std::string extract_swift_subuser(const std::string& swift_user_name) {
+bool TempURLEngine::is_disallowed_header_present(const req_info& info) const
+{
+  static const auto headers = {
+    "HTTP_X_OBJECT_MANIFEST",
+  };
+
+  return std::any_of(std::begin(headers), std::end(headers),
+                     [&info](const char* header) {
+                       return info.env->exists(header);
+                     });
+}
+
+std::string extract_swift_subuser(const std::string& swift_user_name)
+{
   size_t pos = swift_user_name.find(':');
   if (std::string::npos == pos) {
     return swift_user_name;
@@ -282,6 +296,11 @@ TempURLEngine::authenticate(const req_state* const s) const
   if (is_expired(temp_url_expires)) {
     ldout(cct, 5) << "temp url link expired" << dendl;
     return result_t::reject(-EPERM);
+  }
+
+  if (is_disallowed_header_present(s->info)) {
+    ldout(cct, 5) << "temp url rejected due to disallowed header" << dendl;
+    return result_t::reject(-EINVAL);
   }
 
   /* We need to verify two paths because of compliance with Swift, Tempest

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -47,6 +47,7 @@ class TempURLEngine : public rgw::auth::Engine {
                       RGWUserInfo& owner_info) const;
   bool is_applicable(const req_state* s) const noexcept;
   bool is_expired(const std::string& expires) const;
+  bool is_disallowed_header_present(const req_info& info) const;
 
   class SignatureHelper;
   class PrefixableSignatureHelper;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40132

---

backport of https://github.com/ceph/ceph/pull/16659
parent tracker: https://tracker.ceph.com/issues/20797

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh