### PR TITLE
luminous: doc: fixed --read-only argument value in multisite doc

### DIFF
--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -569,7 +569,7 @@ disaster recovery.
    ::
 
        # radosgw-admin zone modify --rgw-zone={zone-name} --master --default \
-                                   --read-only=False
+                                   --read-only=false
 
 2. Update the period to make the changes take effect.
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40496

---

backport of https://github.com/ceph/ceph/pull/28655
parent tracker: https://tracker.ceph.com/issues/40458

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh