### PR TITLE
osd: release backoffs during merge

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8440,6 +8440,11 @@ bool OSD::advance_pg(
 	  pg->write_if_dirty(rctx);
 	  dispatch_context(rctx, pg, pg->get_osdmap(), &handle);
 	  pg->ch->flush();
+	  // release backoffs explicitly, since the on_shutdown path
+	  // aggressively tears down backoff state.
+	  if (pg->is_primary()) {
+	    pg->release_pg_backoffs();
+	  }
 	  pg->on_shutdown();
 	  OSDShard *sdata = pg->osd_shard;
 	  {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1085,11 +1085,13 @@ protected:
     hobject_t end = info.pgid.pgid.get_hobj_end(pool.info.get_pg_num());
     add_backoff(s, begin, end);
   }
+public:
   void release_pg_backoffs() {
     hobject_t begin = info.pgid.pgid.get_hobj_start();
     hobject_t end = info.pgid.pgid.get_hobj_end(pool.info.get_pg_num());
     release_backoffs(begin, end);
   }
+protected:
 
   // -- scrub --
 public:


### PR DESCRIPTION
When we merge PGs, ensure that backoffs release messages are sent to
the client before the victim PG is destroyed.  This is /almost/ handled
by on_shutdown(), except that the shutdown code is aggressive about
tearing down backoff state in order to manage the PGRef lifecycle
carefully--and because in the shutdown (or normal PG/pool deletion) case
it doesn't matter what (if anything) we tell the client.

Fix this by simply queuing the backoff release prior to shutting down the
merge source PG.

An alternative appraoch would be to rejigger the PGRef release timing, but
that code is very fragile and this is a more targetted fix for this issue.
We might consider a more careful look in the future... or not!

Signed-off-by: Sage Weil <sage@redhat.com>