### PR TITLE
mds: fix revoking caps after after stale->resume circle

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5169,7 +5169,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
 		<< " mds." << mds << " seq " << m->get_seq()
 		<< " caps now " << ccap_string(new_caps)
 		<< " was " << ccap_string(cap->issued)
-		<< (was_stale ? "" : " (stale)") << dendl;
+		<< (was_stale ? " (stale)" : "") << dendl;
 
   if (was_stale)
       cap->issued = cap->implemented = CEPH_CAP_PIN;

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2022,6 +2022,24 @@ int Locker::issue_caps(CInode *in, Capability *only_cap)
 	mds->queue_waiter_front(new C_Locker_RevokeStaleCap(this, in, it->first));
 	continue;
       }
+
+      if (!cap->is_valid() && (pending & ~CEPH_CAP_PIN)) {
+	// After stale->resume circle, client thinks it only has CEPH_CAP_PIN.
+	// mds needs to re-issue caps, then do revocation.
+	long seq = cap->issue(pending, true);
+
+	dout(7) << "   sending MClientCaps to client." << it->first
+		<< " seq " << seq << " re-issue " << ccap_string(pending) << dendl;
+
+	auto m = make_message<MClientCaps>(CEPH_CAP_OP_GRANT, in->ino(),
+					   in->find_snaprealm()->inode->ino(),
+					   cap->get_cap_id(), cap->get_last_seq(),
+					   pending, wanted, 0, cap->get_mseq(),
+					   mds->get_osd_epoch_barrier());
+	in->encode_cap_message(m, cap);
+
+	mds->send_message_client_counted(m, cap->get_session());
+      }
     }
 
     // notify clients about deleted inode, to make sure they release caps ASAP.
@@ -2060,10 +2078,8 @@ int Locker::issue_caps(CInode *in, Capability *only_cap)
 
       auto m = make_message<MClientCaps>(op, in->ino(),
 					 in->find_snaprealm()->inode->ino(),
-					 cap->get_cap_id(),
-					 cap->get_last_seq(),
-					 after, wanted, 0,
-					 cap->get_mseq(),
+					 cap->get_cap_id(), cap->get_last_seq(),
+					 after, wanted, 0, cap->get_mseq(),
 					 mds->get_osd_epoch_barrier());
       in->encode_cap_message(m, cap);
 


### PR DESCRIPTION
After session stale->resume circle, client thinks its caps get lost. But
MDS may keep some client caps untouched. To revoke untouched caps, MDS
needs to re-issue them to client, then do revocation. If MDS skips the
're-issue' step, client will not response to the cap revoke.

Fixes: https://tracker.ceph.com/issues/42826

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
