### PR TITLE
doc/rados: add "mon warn osd usage percent" warning

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -357,6 +357,17 @@ by setting it in the ``[mon]`` section of the configuration file.
 :Default: ``True``
 
 
+``mon warn osd usage percent``
+
+:Description: Issue a ``HEALTH_WARN`` if usage percent between OSDs exceeds
+              specified value. Useful in situitions when OSD's aren't evenly
+	      used, which can cause overpopulation and crashing of some OSD's
+	      while the cluster seems to have space available overall.
+
+:Type: Float
+:Default: .40
+
+
 ``mon warn on crush straw calc version zero``
 
 :Description: Issue a ``HEALTH_WARN`` in cluster log if the CRUSH's


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/18986

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
