### PR TITLE
nautilus: common: fix typo in rgw_user_max_buckets option long description.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6681,7 +6681,7 @@ std::vector<Option> get_rgw_options() {
     .set_default(1000)
     .set_description("Max number of buckets per user")
     .set_long_description(
-        "A user can create this many buckets. Zero means unlimmited, negative number means "
+        "A user can create this many buckets. Zero means unlimited, negative number means "
         "user cannot create any buckets (although user will retain buckets already created."),
 
     Option("rgw_objexp_gc_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42795

---

backport of https://github.com/ceph/ceph/pull/31571
parent tracker: https://tracker.ceph.com/issues/42775

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh