### PR TITLE
nautilus: rgw: Silence warning: control reaches end of non-void function

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3523,11 +3523,9 @@ RGWOp *RGWHandler_REST_Service_S3::op_post()
 RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
 {
   // Non-website mode
-  int list_type = 1;
-  s->info.args.get_int("list-type", &list_type, 1);
-
-   // Non-website mode    // Non-website mode
-  if (get_data) {
+  if (get_data) {   
+    int list_type = 1;
+    s->info.args.get_int("list-type", &list_type, 1);
     switch (list_type) {
       case 1:
         return new RGWListBucket_ObjStore_S3;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2662,7 +2662,7 @@ void RGWGetLC_ObjStore_S3::execute()
 void RGWGetLC_ObjStore_S3::send_response()
 {
   if (op_ret) {
-    if (op_ret == -ENOENT) {	
+    if (op_ret == -ENOENT) {
       set_req_state_err(s, ERR_NO_SUCH_LC);
     } else {
       set_req_state_err(s, op_ret);
@@ -3527,14 +3527,20 @@ RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
   s->info.args.get_int("list-type", &list_type, 1);
 
    // Non-website mode    // Non-website mode
-  if (get_data) {   
-    if (list_type == 1) {
-       return new RGWListBucket_ObjStore_S3;     
-    } else if(list_type == 2) {
-      return new RGWListBucket_ObjStore_S3v2;
-    } } else {
-    return new RGWStatBucket_ObjStore_S3;    
-  }   }
+  if (get_data) {
+    switch (list_type) {
+      case 1:
+        return new RGWListBucket_ObjStore_S3;
+      case 2:
+        return new RGWListBucket_ObjStore_S3v2;
+      default:
+        ldpp_dout(s, 5) << __func__ << ": unsupported list-type " << list_type << dendl;
+        return new RGWListBucket_ObjStore_S3;
+    }
+  } else {
+    return new RGWStatBucket_ObjStore_S3;
+  }
+}
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_get()
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42836

---

backport of https://github.com/ceph/ceph/pull/28809
parent tracker: https://tracker.ceph.com/issues/40747

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh