### PR TITLE
ceph-daemon: add osd create test

### DIFF
--- a/test_ceph_daemon.sh
+++ b/test_ceph_daemon.sh
@@ -1,14 +1,29 @@
 #!/bin/bash -ex
 
+SCRIPT_NAME=$(basename ${BASH_SOURCE[0]})
+
 fsid='00000000-0000-0000-0000-0000deadbeef'
 image='ceph/daemon-base:latest-master-devel'
 [ -z "$ip" ] && ip=127.0.0.1
+
+OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"
+OSD_IMAGE_SIZE='6G'
+OSD_TO_CREATE=6
+OSD_VG_NAME=${SCRIPT_NAME%.*}
+OSD_LV_NAME=${SCRIPT_NAME%.*}
 
 CEPH_DAEMON=../src/ceph-daemon/ceph-daemon
 
 #A="-d"
 
+# clean up previous run(s)?
 $CEPH_DAEMON $A rm-cluster --fsid $fsid --force
+vgchange -an $OSD_VG_NAME || true
+loopdev=$(losetup -a | grep $(basename $OSD_IMAGE_NAME) | awk -F : '{print $1}')
+if ! [ "$loopdev" = "" ]; then
+    losetup -d $loopdev
+fi
+rm -f $OSD_IMAGE_NAME
 
 cat <<EOF > c
 [global]
@@ -64,6 +79,18 @@ for id in k j; do
 	--fsid $fsid \
 	--keyring k-mds.$id \
 	--config c
+done
+
+# add osd.{1,2,..}
+dd if=/dev/zero of=$OSD_IMAGE_NAME bs=1 count=0 seek=$OSD_IMAGE_SIZE
+loop_dev=$(losetup -f)
+losetup $loop_dev $OSD_IMAGE_NAME
+pvcreate $loop_dev && vgcreate $OSD_VG_NAME $loop_dev
+for id in `seq 0 $((--OSD_TO_CREATE))`; do
+    lvcreate -l $((100/$OSD_TO_CREATE))%VG -n $OSD_LV_NAME.$id $OSD_VG_NAME
+    $SUDO $CEPH_DAEMON shell --config c --keyring k -- \
+            ceph orchestrator osd create \
+                $(hostname):/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
 done
 
 bin/ceph -c c -k k -s


### PR DESCRIPTION
Create a sparse file and expose via LVM to test OSD creation in `ceph-daemon`.

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
