### PR TITLE
mgr: _exit(0) from signal handler even if we are standby

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -222,9 +222,7 @@ std::map<std::string, std::string> Mgr::load_store()
 void Mgr::handle_signal(int signum)
 {
   ceph_assert(signum == SIGINT || signum == SIGTERM);
-  derr << "*** Got signal " << sig_str(signum) << " ***" << dendl;
   shutdown();
-  _exit(0);  // exit with 0 result code, as if we had done an orderly shutdown
 }
 
 // A reference for use by the signal handler
@@ -232,9 +230,11 @@ static Mgr *signal_mgr = nullptr;
 
 static void handle_mgr_signal(int signum)
 {
+  derr << " *** Got signal " << sig_str(signum) << " ***" << dendl;
   if (signal_mgr) {
     signal_mgr->handle_signal(signum);
   }
+  _exit(0);  // exit with 0 result code, as if we had done an orderly shutdown
 }
 
 void Mgr::init()


### PR DESCRIPTION
In 3d360b97ed7dead8e9a5f602cfaf61ab7b41e531 a signal handler was added to
shut down modules and associated clients cleanly, but the standby case
was left ignoring the signal completely.

Fixes: https://tracker.ceph.com/issues/42744
Signed-off-by: Sage Weil <sage@redhat.com>