### PR TITLE
backport-create-issue: flush line before overprinting

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -294,6 +294,7 @@ def iterate_over_backports(r, issues, dry_run=False):
         if len(issue['backports']) == 0:
             logging.error(url(issue) + " the backport field is empty")
         update_relations(r, issue, dry_run)
+    print('                                     \r', end='', flush=True)
     logging.info("Processed {} issues".format(counter))
     return None
 


### PR DESCRIPTION
When iterating over "Pending Backport" issues, the script displays
a message for each issue, like so:

    Examining issue#53432 (345/543)

Since a newline is not printed, each subsequent message overwrites
the previous one. But the last one remained on the screen and was
being overwritten by a shorter log message, leaving behind an
unwanted artifact:

    INFO:root:Processed 334 issues)

Fixes: 8495d37695d43ea38e1b70851e4a6127ebb4fc76
Signed-off-by: Nathan Cutler <ncutler@suse.com>