### PR TITLE
mon: remove the restriction of address type in init_with_hosts

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -503,7 +503,7 @@ int MonMap::init_with_hosts(const std::string& hostlist,
   vector<entity_addrvec_t> addrs;
   bool success = parse_ip_port_vec(
     hosts, addrs,
-    for_mkfs ? entity_addr_t::TYPE_MSGR2 : entity_addr_t::TYPE_ANY);
+    entity_addr_t::TYPE_ANY);
   free(hosts);
   if (!success)
     return -EINVAL;
@@ -516,8 +516,10 @@ int MonMap::init_with_hosts(const std::string& hostlist,
     string name = prefix;
     name += n;
     if (addrs[i].v.size() == 1) {
-      _add_ambiguous_addr(name, addrs[i].front(), 0, 0, false);
+      _add_ambiguous_addr(name, addrs[i].front(), 0, 0, for_mkfs);
     } else {
+      // they specified an addrvec, so let's assume they also specified
+      // the addr *type* and *port*.  (we could possibly improve this?)
       add(name, addrs[i], 0);
     }
   }


### PR DESCRIPTION
We have tried to build mon cluster from mon_host with FQDN ranther than IP. But we found every entity will have only a v2 address. 
This will cause some problems. We still hope that there is a way for us to generate address with both v1 and v2 ip.
Based on this, we found that init_with_hosts has different behaviors with init_with_ips in MonMap.cc. This modification should solve the problem.

Signed-off-by: Bear Xiong <xionghao18@qq.com>