### PR TITLE
FIPS: audit and switch some memset & bzero users

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -285,6 +285,8 @@ public:
     // let's pad the data
     std::uint8_t pad_len = out_tmp.length() - in.length();
     ceph::bufferptr pad_buf{pad_len};
+    // FIPS zeroization audit 20191115: this memset is not intended to
+    // wipe out a secret after use.
     memset(pad_buf.c_str(), pad_len, pad_len);
 
     // form contiguous buffer for block cipher. The ctor copies shallowly.
@@ -360,6 +362,8 @@ public:
 
     std::array<unsigned char, AES_BLOCK_LEN> last_block;
     memcpy(last_block.data(), in.buf + in.length - tail_len, tail_len);
+    // FIPS zeroization audit 20191115: this memset is not intended to
+    // wipe out a secret after use.
     memset(last_block.data() + tail_len, pad_len, pad_len);
 
     // need a local copy because AES_cbc_encrypt takes `iv` as non-const.

--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -152,6 +152,7 @@ std::string OutputDataSocket::bind_and_listen(const std::string &sock_path, int 
 	<< "failed to create socket: " << cpp_strerror(err);
     return oss.str();
   }
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&address, 0, sizeof(struct sockaddr_un));
   address.sun_family = AF_UNIX;
   snprintf(address.sun_path, sizeof(address.sun_path),
@@ -198,6 +199,7 @@ void* OutputDataSocket::entry()
   ldout(m_cct, 5) << "entry start" << dendl;
   while (true) {
     struct pollfd fds[2];
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(fds, 0, sizeof(fds));
     fds[0].fd = m_sock_fd;
     fds[0].events = POLLIN | POLLRDBAND;

--- a/src/common/addr_parsing.c
+++ b/src/common/addr_parsing.c
@@ -99,6 +99,7 @@ char *resolve_addrs(const char *orig_str)
 
     //printf("name '%s' port '%s'\n", tok, port_str);
 
+    // FIPS zeroization audit 20191115: this memset is fine.
     memset(&hint, 0, sizeof(hint));
     hint.ai_family = AF_UNSPEC;
     hint.ai_socktype = SOCK_STREAM;

--- a/src/common/address_helper.cc
+++ b/src/common/address_helper.cc
@@ -22,6 +22,7 @@ int entity_addr_from_url(entity_addr_t *addr /* out */, const char *url)
 		string host(m[2].first, m[2].second);
 		string port(m[3].first, m[3].second);
 		addrinfo hints;
+		// FIPS zeroization audit 20191115: this memset is fine.
 		memset(&hints, 0, sizeof(hints));
 		hints.ai_family = PF_UNSPEC;
 		addrinfo *res;

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -176,6 +176,7 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
 	<< "failed to create socket: " << cpp_strerror(err);
     return oss.str();
   }
+  // FIPS zeroization audit 20191115: this memset is fine.
   memset(&address, 0, sizeof(struct sockaddr_un));
   address.sun_family = AF_UNIX;
   snprintf(address.sun_path, sizeof(address.sun_path),
@@ -228,6 +229,7 @@ void AdminSocket::entry() noexcept
   ldout(m_cct, 5) << "entry start" << dendl;
   while (true) {
     struct pollfd fds[2];
+    // FIPS zeroization audit 20191115: this memset is fine.
     memset(fds, 0, sizeof(fds));
     fds[0].fd = m_sock_fd;
     fds[0].events = POLLIN | POLLRDBAND;

--- a/src/common/admin_socket_client.cc
+++ b/src/common/admin_socket_client.cc
@@ -56,6 +56,7 @@ static std::string asok_connect(const std::string &path, int *fd)
   }
 
   struct sockaddr_un address;
+  // FIPS zeroization audit 20191115: this memset is fine.
   memset(&address, 0, sizeof(struct sockaddr_un));
   address.sun_family = AF_UNIX;
   snprintf(address.sun_path, sizeof(address.sun_path), "%s", path.c_str());

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -617,6 +617,7 @@ static ceph::spinlock debug_lock;
     ceph_assert(_raw);
     ceph_assert(l <= unused_tail_length());
     char* c = _raw->data + _off + _len;
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(c, 0, l);
     _len += l;
     return _len + _off;
@@ -637,6 +638,7 @@ static ceph::spinlock debug_lock;
   {
     if (crc_reset)
         _raw->invalidate_crc();
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(c_str(), 0, _len);
   }
 
@@ -645,6 +647,7 @@ static ceph::spinlock debug_lock;
     ceph_assert(o+l <= _len);
     if (crc_reset)
         _raw->invalidate_crc();
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(c_str()+o, 0, l);
   }
 
@@ -1758,6 +1761,7 @@ ssize_t buffer::list::pread_file(const char *fn, uint64_t off, uint64_t len, std
   }
 
   struct stat st;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&st, 0, sizeof(st));
   if (::fstat(fd, &st) < 0) {
     int err = errno;
@@ -1817,6 +1821,7 @@ int buffer::list::read_file(const char *fn, std::string *error)
   }
 
   struct stat st;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&st, 0, sizeof(st));
   if (::fstat(fd, &st) < 0) {
     int err = errno;

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -569,6 +569,7 @@ int CephContext::_do_command(
 	r = -EINVAL;
       } else {
 	char buf[4096];
+	// FIPS zeroization audit 20191115: this memset is not security related.
 	memset(buf, 0, sizeof(buf));
 	char *tmp = buf;
 	r = _conf.get_val(var.c_str(), &tmp, sizeof(buf));

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -162,6 +162,10 @@ static void shutdown() {
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 }
 
+void zeroize_for_security(void* const s, const size_t n) {
+  OPENSSL_cleanse(s, n);
+}
+
 } // namespace ceph::crypto::openssl
 
 
@@ -171,6 +175,10 @@ void ceph::crypto::init() {
 
 void ceph::crypto::shutdown([[maybe_unused]] const bool shared) {
   ceph::crypto::ssl::shutdown();
+}
+
+void ceph::crypto::zeroize_for_security(void* const s, const size_t n) {
+  ceph::crypto::ssl::zeroize_for_security(s, n);
 }
 
 ceph::crypto::ssl::OpenSSLDigest::OpenSSLDigest(const EVP_MD * _type)

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -33,6 +33,8 @@ namespace ceph {
     void assert_init();
     void init();
     void shutdown(bool shared=true);
+
+    void zeroize_for_security(void *s, size_t n);
   }
 }
 

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -98,7 +98,9 @@ namespace ceph::crypto::ssl {
   public:
     HMAC (const EVP_MD *type, const unsigned char *key, size_t length)
       : mpType(type) {
-      ::memset(&mContext, 0, sizeof(mContext));
+      // the strict FIPS zeroization doesn't seem to be necessary here.
+      // just in the case.
+      ::ceph::crypto::zeroize_for_security(&mContext, sizeof(mContext));
       const auto r = HMAC_Init_ex(&mContext, key, length, mpType, nullptr);
       if (r != 1) {
 	  throw DigestException("HMAC_Init_ex() failed");

--- a/src/common/code_environment.cc
+++ b/src/common/code_environment.cc
@@ -56,6 +56,7 @@ int get_process_name(char *buf, int len)
      * null-terminated. */
     return -ENAMETOOLONG;
   }
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(buf, 0, len);
   return prctl(PR_GET_NAME, buf);
 }

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -343,6 +343,7 @@ namespace cohort {
 	  if (csz) {
 	    p.csz = csz;
 	    p.cache = (T**) ::operator new(csz * sizeof(T*));
+	    // FIPS zeroization audit 20191115: this memset is not security related.
 	    memset(p.cache, 0, csz * sizeof(T*));
 	  }
 	  locks.push_back(&p.lock);

--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -48,6 +48,7 @@ int manual_fallocate(int fd, off_t offset, off_t len) {
     return errno;
   char data[1024*128];
   // TODO: compressing filesystems would require random data
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(data, 0x42, sizeof(data));
   for (off_t off = 0; off < len; off += sizeof(data)) {
     if (off + static_cast<off_t>(sizeof(data)) > len)

--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -249,6 +249,7 @@ int DNSResolver::resolve_ip_addr(CephContext *cct, res_state *res, const string&
   }
 
   char addr_buf[64];
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(addr_buf, 0, sizeof(addr_buf));
   inet_ntop(family, ns_rr_rdata(rr), addr_buf, sizeof(addr_buf));
   if (!addr->parse(addr_buf)) {
@@ -339,6 +340,7 @@ int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
     uint16_t priority = ns_get16(rdata); rdata += NS_INT16SZ;
     uint16_t weight = ns_get16(rdata); rdata += NS_INT16SZ;
     uint16_t port = ns_get16(rdata); rdata += NS_INT16SZ;
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(full_target, 0, sizeof(full_target));
     ns_name_uncompress(ns_msg_base(handle), ns_msg_end(handle),
                        rdata, full_target, sizeof(full_target));

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -65,6 +65,7 @@ void lockdep_register_ceph_context(CephContext *cct)
     lockdep_dout(1) << "lockdep start" << dendl;
     if (!free_ids_inited) {
       free_ids_inited = true;
+      // FIPS zeroization audit 20191115: this memset is not security related.
       memset((void*) &free_ids[0], 255, sizeof(free_ids));
     }
   }
@@ -90,6 +91,7 @@ void lockdep_unregister_ceph_context(CephContext *cct)
     held.clear();
     lock_names.clear();
     lock_ids.clear();
+    // FIPS zeroization audit 20191115: these memsets are not security related.
     memset((void*)&follows[0][0], 0, current_maxid * MAX_LOCKS/8);
     memset((void*)&follows_bt[0][0], 0, sizeof(BackTrace*) * current_maxid * MAX_LOCKS);
   }
@@ -213,6 +215,7 @@ void lockdep_unregister(int id)
   if (--refs == 0) {
     if (p != lock_names.end()) {
       // reset dependency ordering
+      // FIPS zeroization audit 20191115: this memset is not security related.
       memset((void*)&follows[id][0], 0, MAX_LOCKS/8);
       for (unsigned i=0; i<current_maxid; ++i) {
         delete follows_bt[id][i];

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -70,6 +70,7 @@ static std::string generate_object_name_fast(int objnum, int pid = 0)
 }
 
 static void sanitize_object_contents (bench_data *data, size_t length) {
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(data->object_contents, 'z', length);
 }
 

--- a/src/common/snap_types.h
+++ b/src/common/snap_types.h
@@ -14,9 +14,11 @@ struct SnapRealmInfo {
   std::vector<snapid_t> prior_parent_snaps;  // before parent_since
 
   SnapRealmInfo() {
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(&h, 0, sizeof(h));
   }
   SnapRealmInfo(inodeno_t ino_, snapid_t created_, snapid_t seq_, snapid_t current_parent_since_) {
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(&h, 0, sizeof(h));
     h.ino = ino_;
     h.created = created_;

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -615,8 +615,10 @@ extern "C" int _rados_pool_list(rados_t cluster, char *buf, size_t len)
   }
 
   char *b = buf;
-  if (b)
+  if (b) {
+    // FIPS zeroization audit 20191116: this memset is not security related.
     memset(b, 0, len);
+  }
   int needed = 0;
   std::list<std::pair<int64_t, std::string> >::const_iterator i = pools.begin();
   std::list<std::pair<int64_t, std::string> >::const_iterator p_end =
@@ -661,8 +663,10 @@ extern "C" int _rados_inconsistent_pg_list(rados_t cluster, int64_t pool_id,
   }
 
   char *b = buf;
-  if (b)
+  if (b) {
+    // FIPS zeroization audit 20191116: this memset is not security related.
     memset(b, 0, len);
+  }
   int needed = 0;
   for (const auto& s : pgs) {
     unsigned rl = s.length() + 1;
@@ -2002,6 +2006,7 @@ extern "C" int _rados_object_list(rados_ioctx_t io,
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
 
   // Zero out items so that they will be safe to free later
+  // FIPS zeroization audit 20191116: this memset is not security related.
   memset(result_items, 0, sizeof(rados_object_list_item) * result_item_count);
 
   std::list<librados::ListObjectImpl> result;

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -131,6 +131,7 @@ public:
     if (snap)
       snap_name = snap;
 
+    // FIPS zeroization audit 20191117: this memset is not security related.
     memset(&header, 0, sizeof(header));
 
     ThreadPool *thread_pool;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -148,6 +148,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     uint32_t hi = bid >> 32;
     uint32_t lo = bid & 0xFFFFFFFF;
     uint32_t extra = rand() % 0xFFFFFFFF;
+    // FIPS zeroization audit 20191117: this memset is not security related.
     memset(&ondisk, 0, sizeof(ondisk));
 
     memcpy(&ondisk.text, RBD_HEADER_TEXT, sizeof(RBD_HEADER_TEXT));

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -3546,6 +3546,7 @@ extern "C" int rbd_list2(rados_ioctx_t p, rbd_image_spec_t *images,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, list_enter, io_ctx.get_pool_name().c_str(),
              io_ctx.get_id());
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(images, 0, sizeof(*images) * *size);
   std::vector<librbd::image_spec_t> cpp_image_specs;
   int r = librbd::api::Image<>::list_images(io_ctx, &cpp_image_specs);
@@ -3734,6 +3735,7 @@ extern "C" int rbd_trash_list(rados_ioctx_t p, rbd_trash_image_info_t *entries,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, trash_list_enter,
              io_ctx.get_pool_name().c_str(), io_ctx.get_id());
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(entries, 0, sizeof(*entries) * *num_entries);
 
   vector<librbd::trash_image_info_t> cpp_entries;
@@ -4910,6 +4912,7 @@ extern "C" int rbd_get_parent(rbd_image_t image,
   int r = librbd::api::Image<>::get_parent(ictx, &cpp_parent_image,
                                            &cpp_parent_snap);
   if (r < 0) {
+    // FIPS zeroization audit 20191117: these memsets are not security related.
     memset(parent_image, 0, sizeof(rbd_linked_image_spec_t));
     memset(parent_snap, 0, sizeof(rbd_snap_spec_t));
   } else {
@@ -5011,6 +5014,7 @@ extern "C" int rbd_lock_get_owners(rbd_image_t image,
 {
   librbd::ImageCtx *ictx = reinterpret_cast<librbd::ImageCtx*>(image);
   tracepoint(librbd, lock_get_owners_enter, ictx);
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(lock_owners, 0, sizeof(*lock_owners) * *max_lock_owners);
   std::list<std::string> lock_owner_list;
   int r = librbd::lock_get_owners(ictx, lock_mode, &lock_owner_list);
@@ -5136,6 +5140,7 @@ extern "C" int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps,
     tracepoint(librbd, snap_list_exit, -EINVAL, 0);
     return -EINVAL;
   }
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(snaps, 0, sizeof(*snaps) * *max_snaps);
 
   int r = librbd::snap_list(ictx, cpp_snaps);
@@ -5328,6 +5333,7 @@ extern "C" int rbd_list_children2(rbd_image_t image,
   auto ictx = reinterpret_cast<librbd::ImageCtx*>(image);
   tracepoint(librbd, list_children_enter, ictx, ictx->name.c_str(),
              ictx->snap_name.c_str(), ictx->read_only);
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(children, 0, sizeof(*children) * *max_children);
 
   if (!max_children) {
@@ -5390,6 +5396,7 @@ extern "C" int rbd_list_children3(rbd_image_t image,
   auto ictx = reinterpret_cast<librbd::ImageCtx*>(image);
   tracepoint(librbd, list_children_enter, ictx, ictx->name.c_str(),
              ictx->snap_name.c_str(), ictx->read_only);
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(images, 0, sizeof(*images) * *max_images);
 
   std::vector<librbd::linked_image_spec_t> cpp_children;
@@ -5424,6 +5431,7 @@ extern "C" int rbd_list_descendants(rbd_image_t image,
                                     size_t *max_images)
 {
   auto ictx = reinterpret_cast<librbd::ImageCtx*>(image);
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(images, 0, sizeof(*images) * *max_images);
 
   std::vector<librbd::linked_image_spec_t> cpp_children;
@@ -6476,6 +6484,7 @@ extern "C" int rbd_group_image_list(rados_ioctx_t group_p,
   tracepoint(librbd, group_image_list_enter,
              group_ioctx.get_pool_name().c_str(),
 	     group_ioctx.get_id(), group_name);
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(images, 0, sizeof(*images) * *image_size);
 
   if (group_image_info_size != sizeof(rbd_group_image_info_t)) {
@@ -6607,6 +6616,7 @@ extern "C" int rbd_group_snap_list(rados_ioctx_t group_p,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
   tracepoint(librbd, group_snap_list_enter, group_ioctx.get_pool_name().c_str(),
 	     group_ioctx.get_id(), group_name);
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(snaps, 0, sizeof(*snaps) * *snaps_size);
 
   if (group_snap_info_size != sizeof(rbd_group_snap_info_t)) {
@@ -6776,6 +6786,7 @@ extern "C" int rbd_watchers_list(rbd_image_t image,
   librbd::ImageCtx *ictx = (librbd::ImageCtx*)image;
 
   tracepoint(librbd, list_watchers_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only);
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(watchers, 0, sizeof(*watchers) * *max_watchers);
   int r = librbd::list_watchers(ictx, watcher_list);
   if (r < 0) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -382,6 +382,7 @@ void MDCache::create_unlinked_system_inode(CInode *in, inodeno_t ino,
   in->inode.change_attr = 0;
   in->inode.export_pin = MDS_RANK_NONE;
 
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(&in->inode.dir_layout, 0, sizeof(in->inode.dir_layout));
   if (in->inode.is_dir()) {
     in->inode.dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3258,6 +3258,7 @@ CInode* Server::prepare_new_inode(MDRequestRef& mdr, CDir *dir, inodeno_t useino
 
   in->inode.mode = mode;
 
+  // FIPS zeroization audit 20191117: this memset is not security related.
   memset(&in->inode.dir_layout, 0, sizeof(in->inode.dir_layout));
   if (in->inode.is_dir()) {
     in->inode.dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -534,6 +534,7 @@ struct inode_t {
   inode_t()
   {
     clear_layout();
+    // FIPS zeroization audit 20191117: this memset is not security related.
     memset(&dir_layout, 0, sizeof(dir_layout));
   }
 
@@ -712,8 +713,10 @@ void inode_t<Allocator>::decode(bufferlist::const_iterator &p)
 
   if (struct_v >= 4)
     decode(dir_layout, p);
-  else
+  else {
+    // FIPS zeroization audit 20191117: this memset is not security related.
     memset(&dir_layout, 0, sizeof(dir_layout));
+  }
   decode(layout, p);
   decode(size, p);
   decode(truncate_seq, p);
@@ -1375,6 +1378,7 @@ struct cap_reconnect_t {
   bufferlist flockbl;
 
   cap_reconnect_t() {
+    // FIPS zeroization audit 20191117: this memset is not security related.
     memset(&capinfo, 0, sizeof(capinfo));
     snap_follows = 0;
   }
@@ -1404,6 +1408,7 @@ struct snaprealm_reconnect_t {
   mutable ceph_mds_snaprealm_reconnect realm;
 
   snaprealm_reconnect_t() {
+    // FIPS zeroization audit 20191117: this memset is not security related.
     memset(&realm, 0, sizeof(realm));
   }
   snaprealm_reconnect_t(inodeno_t ino, snapid_t seq, inodeno_t parent) {

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -95,6 +95,7 @@ class EventCenter {
   struct AssociatedCenters {
     EventCenter *centers[MAX_EVENTCENTER];
     AssociatedCenters() {
+      // FIPS zeroization audit 20191115: this memset is not security related.
       memset(centers, 0, MAX_EVENTCENTER * sizeof(EventCenter*));
     }
   };

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -119,6 +119,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
       struct iovec msgvec[IOV_MAX];
       uint64_t size = std::min<uint64_t>(left_pbrs, IOV_MAX);
       left_pbrs -= size;
+      // FIPS zeroization audit 20191115: this memset is not security related.
       memset(&msg, 0, sizeof(msg));
       msg.msg_iovlen = size;
       msg.msg_iov = msgvec;

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -90,6 +90,7 @@ void ProtocolV1::connect() {
 
   // reset connect state variables
   authorizer_buf.clear();
+  // FIPS zeroization audit 20191115: these memsets are not security related.
   memset(&connect_msg, 0, sizeof(connect_msg));
   memset(&connect_reply, 0, sizeof(connect_reply));
 
@@ -1539,6 +1540,7 @@ CtPtr ProtocolV1::handle_connect_message_write(int r) {
 CtPtr ProtocolV1::wait_connect_reply() {
   ldout(cct, 20) << __func__ << dendl;
 
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&connect_reply, 0, sizeof(connect_reply));
   return READ(sizeof(connect_reply), handle_connect_reply_1);
 }
@@ -1889,6 +1891,7 @@ CtPtr ProtocolV1::handle_client_banner(char *buffer, int r) {
 CtPtr ProtocolV1::wait_connect_message() {
   ldout(cct, 20) << __func__ << dendl;
 
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&connect_msg, 0, sizeof(connect_msg));
   return READ(sizeof(connect_msg), handle_connect_message_1);
 }
@@ -1953,6 +1956,7 @@ CtPtr ProtocolV1::handle_connect_message_2() {
   ceph_msg_connect_reply reply;
   bufferlist authorizer_reply;
 
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&reply, 0, sizeof(reply));
   reply.protocol_version =
       messenger->get_proto_version(connection->peer_type, false);
@@ -2556,6 +2560,7 @@ CtPtr ProtocolV1::server_ready() {
 		 << dendl;
 
   ldout(cct, 20) << __func__ << " accept done" << dendl;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&connect_msg, 0, sizeof(connect_msg));
 
   if (connection->delay_state) {

--- a/src/msg/async/crypto_onwire.cc
+++ b/src/msg/async/crypto_onwire.cc
@@ -7,6 +7,7 @@
 #include "crypto_onwire.h"
 
 #include "common/debug.h"
+#include "common/ceph_crypto.h"
 #include "include/types.h"
 
 #define dout_subsys ceph_subsys_ms
@@ -59,7 +60,7 @@ public:
   }
 
   ~AES128GCM_OnWireTxHandler() override {
-    memset(&nonce, 0, sizeof(nonce));
+    ::ceph::crypto::zeroize_for_security(&nonce, sizeof(nonce));
   }
 
   std::uint32_t calculate_segment_size(std::uint32_t size) override
@@ -169,7 +170,7 @@ public:
   }
 
   ~AES128GCM_OnWireRxHandler() override {
-    memset(&nonce, 0, sizeof(nonce));
+    ::ceph::crypto::zeroize_for_security(&nonce, sizeof(nonce));
   }
 
   std::uint32_t get_extra_size_at_final() override {

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -194,6 +194,7 @@ private:
     ceph_assert(std::size(segments) <= MAX_NUM_SEGMENTS);
 
     preamble_block_t main_preamble;
+    // FIPS zeroization audit 20191115: this memset is not security related.
     ::memset(&main_preamble, 0, sizeof(main_preamble));
 
     main_preamble.tag = static_cast<__u8>(T::tag);
@@ -262,6 +263,8 @@ public:
       // called auth tag) will be added by the cipher.
       {
         epilogue_secure_block_t epilogue;
+        // FIPS zeroization audit 20191115: this memset is not security
+        // related.
         ::memset(&epilogue, 0, sizeof(epilogue));
         ceph::bufferlist epilogue_bl;
         epilogue_bl.append(reinterpret_cast<const char*>(&epilogue),
@@ -272,6 +275,7 @@ public:
     } else {
       // plain mode
       epilogue_plain_block_t epilogue;
+      // FIPS zeroization audit 20191115: this memset is not security related.
       ::memset(&epilogue, 0, sizeof(epilogue));
 
       ceph::bufferlist::const_iterator hdriter(&segments.front(),

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -186,6 +186,7 @@ Infiniband::QueuePair::QueuePair(
 int Infiniband::QueuePair::modify_qp_to_error(void)
 {
     ibv_qp_attr qpa;
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(&qpa, 0, sizeof(qpa));
     qpa.qp_state = IBV_QPS_ERR;
     if (ibv_modify_qp(qp, &qpa, IBV_QP_STATE)) {
@@ -200,6 +201,7 @@ int Infiniband::QueuePair::modify_qp_to_rts(void)
 {
   // move from RTR state RTS
   ibv_qp_attr qpa;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&qpa, 0, sizeof(qpa));
   qpa.qp_state = IBV_QPS_RTS;
   /*
@@ -234,6 +236,7 @@ int Infiniband::QueuePair::modify_qp_to_rtr(void)
 {
   // move from INIT to RTR state
   ibv_qp_attr qpa;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&qpa, 0, sizeof(qpa));
   qpa.qp_state = IBV_QPS_RTR;
   qpa.path_mtu = IBV_MTU_1024;
@@ -270,6 +273,7 @@ int Infiniband::QueuePair::modify_qp_to_init(void)
 {
   // move from RESET to INIT state
   ibv_qp_attr qpa;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&qpa, 0, sizeof(qpa));
   qpa.qp_state   = IBV_QPS_INIT;
   qpa.pkey_index = 0;
@@ -306,6 +310,7 @@ int Infiniband::QueuePair::init()
 {
   ldout(cct, 20) << __func__ << " started." << dendl;
   ibv_qp_init_attr qpia;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&qpia, 0, sizeof(qpia));
   qpia.send_cq = txcq->get_cq();
   qpia.recv_cq = rxcq->get_cq();
@@ -478,6 +483,7 @@ int Infiniband::QueuePair::to_dead()
                  << " bound remote QueuePair, qp number: " << local_cm_meta.peer_qpn << dendl;
 
   struct ibv_send_wr *bad_wr = nullptr, beacon;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&beacon, 0, sizeof(beacon));
   beacon.wr_id = BEACON_WRID;
   beacon.opcode = IBV_WR_SEND;
@@ -769,6 +775,7 @@ int Infiniband::MemoryManager::Cluster::fill(uint32_t num)
   end = base + bytes;
   ceph_assert(base);
   chunk_base = static_cast<Chunk*>(::malloc(sizeof(Chunk) * num));
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(static_cast<void*>(chunk_base), 0, sizeof(Chunk) * num);
   free_chunks.reserve(num);
   ibv_mr* m = ibv_reg_mr(manager.pd->pd, base, bytes, IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE);
@@ -1128,6 +1135,7 @@ Infiniband::~Infiniband()
 ibv_srq* Infiniband::create_shared_receive_queue(uint32_t max_wr, uint32_t max_sge)
 {
   ibv_srq_init_attr sia;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&sia, 0, sizeof(sia));
   sia.srq_context = device->ctxt;
   sia.attr.max_wr = max_wr;

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -456,6 +456,7 @@ int RDMAConnectedSocketImpl::post_work_request(std::vector<Chunk*> &tx_buffers)
   ibv_send_wr* pre_wr = NULL;
   uint32_t num = 0; 
 
+  // FIPS zeroization audit 20191115: these memsets are not security related.
   memset(iswr, 0, sizeof(iswr));
   memset(isge, 0, sizeof(isge));
  
@@ -497,6 +498,7 @@ int RDMAConnectedSocketImpl::post_work_request(std::vector<Chunk*> &tx_buffers)
 
 void RDMAConnectedSocketImpl::fin() {
   ibv_send_wr wr;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&wr, 0, sizeof(wr));
 
   wr.wr_id = reinterpret_cast<uint64_t>(qp);

--- a/src/msg/async/rdma/RDMAIWARPConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAIWARPConnectedSocketImpl.cc
@@ -98,6 +98,7 @@ void RDMAIWARPConnectedSocketImpl::handle_cm_connection() {
         break;
       }
 
+      // FIPS zeroization audit 20191115: this memset is not security related.
       memset(&cm_params, 0, sizeof(cm_params));
       cm_params.retry_count = RETRY_COUNT;
       cm_params.qp_num = local_qpn;

--- a/src/msg/async/rdma/RDMAIWARPServerSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAIWARPServerSocketImpl.cc
@@ -90,6 +90,7 @@ int RDMAIWARPServerSocketImpl::accept(ConnectedSocket *sock, const SocketOptions
   RDMAIWARPConnectedSocketImpl* server =
     new RDMAIWARPConnectedSocketImpl(cct, ib, dispatcher, dynamic_cast<RDMAWorker*>(w), &info);
 
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(&local_conn_param, 0, sizeof(local_conn_param));
   local_conn_param.qp_num = server->get_local_qpn();
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1926,6 +1926,7 @@ struct object_stat_sum_t {
   }
 
   void clear() {
+    // FIPS zeroization audit 20191117: this memset is not security related.
     memset(this, 0, sizeof(*this));
   }
 
@@ -3935,10 +3936,12 @@ struct OSDOp {
   errorcode32_t rval = 0;
 
   OSDOp() {
+    // FIPS zeroization audit 20191115: this memset clean for security
     memset(&op, 0, sizeof(ceph_osd_op));
   }
 
   OSDOp(const int op_code) {
+    // FIPS zeroization audit 20191115: this memset clean for security
     memset(&op, 0, sizeof(ceph_osd_op));
     op.op = op_code;
   }

--- a/src/osdc/Striper.cc
+++ b/src/osdc/Striper.cc
@@ -475,6 +475,7 @@ void Striper::StripedReadResult::assemble_result(CephContext *cct, char *buffer,
     if (len < p->second.second) {
       if (len)
 	p->second.first.copy(0, len, buffer + curr);
+      // FIPS zeroization audit 20191117: this memset is not security related.
       memset(buffer + curr + len, 0, p->second.second - len);
     } else {
       p->second.first.copy(0, len, buffer + curr);

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -142,6 +142,7 @@ int RGWCivetWebFrontend::run()
   options.push_back(nullptr);
   /* Initialize the CivetWeb right now. */
   struct mg_callbacks cb;
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset((void *)&cb, 0, sizeof(cb));
   cb.begin_request = civetweb_callback;
   cb.log_message = rgw_civetweb_log_callback;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -502,24 +502,28 @@ static bool check_gmt_end(const char *s)
 
 static bool parse_rfc850(const char *s, struct tm *t)
 {
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(t, 0, sizeof(*t));
   return check_gmt_end(strptime(s, "%A, %d-%b-%y %H:%M:%S ", t));
 }
 
 static bool parse_asctime(const char *s, struct tm *t)
 {
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(t, 0, sizeof(*t));
   return check_str_end(strptime(s, "%a %b %d %H:%M:%S %Y", t));
 }
 
 static bool parse_rfc1123(const char *s, struct tm *t)
 {
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(t, 0, sizeof(*t));
   return check_gmt_end(strptime(s, "%a, %d %b %Y %H:%M:%S ", t));
 }
 
 static bool parse_rfc1123_alt(const char *s, struct tm *t)
 {
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(t, 0, sizeof(*t));
   return check_str_end(strptime(s, "%a, %d %b %Y %H:%M:%S %z", t));
 }
@@ -531,6 +535,7 @@ bool parse_rfc2616(const char *s, struct tm *t)
 
 bool parse_iso8601(const char *s, struct tm *t, uint32_t *pns, bool extended_format)
 {
+  // FIPS zeroization audit 20191115: this memset is not security related.
   memset(t, 0, sizeof(*t));
   const char *p;
 
@@ -1472,6 +1477,7 @@ class HexTable
 
 public:
   HexTable() {
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(table, -1, sizeof(table));
     int i;
     for (i = '0'; i<='9'; i++)

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -147,7 +147,7 @@ public:
   explicit AES_256_CBC(CephContext* cct): cct(cct) {
   }
   ~AES_256_CBC() {
-    memset(key, 0, AES_256_KEYSIZE);
+    ::ceph::crypto::zeroize_for_security(key, AES_256_KEYSIZE);
   }
   bool set_key(const uint8_t* _key, size_t key_size) {
     if (key_size != AES_256_KEYSIZE) {
@@ -865,7 +865,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
                               reinterpret_cast<const uint8_t*>(master_encryption_key.c_str()), AES_256_KEYSIZE,
                               reinterpret_cast<const uint8_t*>(key_selector.c_str()),
                               actual_key, AES_256_KEYSIZE) != true) {
-        memset(actual_key, 0, sizeof(actual_key));
+        ::ceph::crypto::zeroize_for_security(actual_key, sizeof(actual_key));
         return -EIO;
       }
       if (block_crypt) {
@@ -873,7 +873,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         aes->set_key(reinterpret_cast<const uint8_t*>(actual_key), AES_256_KEYSIZE);
         *block_crypt = std::move(aes);
       }
-      memset(actual_key, 0, sizeof(actual_key));
+      ::ceph::crypto::zeroize_for_security(actual_key, sizeof(actual_key));
       return 0;
     }
   }
@@ -1038,12 +1038,12 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
                             AES_256_KEYSIZE,
                             reinterpret_cast<const uint8_t*>(attr_key_selector.c_str()),
                             actual_key, AES_256_KEYSIZE) != true) {
-      memset(actual_key, 0, sizeof(actual_key));
+      ::ceph::crypto::zeroize_for_security(actual_key, sizeof(actual_key));
       return -EIO;
     }
     auto aes = std::unique_ptr<AES_256_CBC>(new AES_256_CBC(s->cct));
     aes->set_key(actual_key, AES_256_KEYSIZE);
-    memset(actual_key, 0, sizeof(actual_key));
+    ::ceph::crypto::zeroize_for_security(actual_key, sizeof(actual_key));
     if (block_crypt) *block_crypt = std::move(aes);
     return 0;
   }

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -438,6 +438,8 @@ namespace rgw {
 
     int stat(struct stat* st, uint32_t flags = FLAG_NONE) {
       /* partial Unix attrs */
+      /* FIPS zeroization audit 20191115: this memset is not security
+       * related. */
       memset(st, 0, sizeof(struct stat));
       st->st_dev = state.dev;
       st->st_ino = fh.fh_hk.object; // XXX

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -53,6 +53,7 @@ struct rgw_http_req_data : public RefCountedObject {
   std::unique_ptr<Completion> completion;
 
   rgw_http_req_data() : id(-1) {
+    // FIPS zeroization audit 20191115: this memset is not security related.
     memset(error_buf, 0, sizeof(error_buf));
   }
 

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -57,7 +57,7 @@ static int get_actual_key_from_conf(CephContext *cct,
     } else {
       res = -EIO;
     }
-    memset(_actual_key, 0, sizeof(_actual_key));
+    ::ceph::crypto::zeroize_for_security(_actual_key, sizeof(_actual_key));
   } else {
     ldout(cct, 20) << "Wrong size for key=" << key_id << dendl;
     res = -EIO;
@@ -169,7 +169,7 @@ static int request_key_from_vault_with_token(CephContext *cct,
     --res;
   }
   vault_token = std::string{buf, static_cast<size_t>(res)};
-  memset(buf, 0, sizeof(buf));
+  ::ceph::crypto::zeroize_for_security(buf, sizeof(buf));
 
   vault_addr = cct->_conf->rgw_crypt_vault_addr;
   if (vault_addr.empty()) {

--- a/src/rgw/rgw_ldap.cc
+++ b/src/rgw/rgw_ldap.cc
@@ -3,6 +3,7 @@
 
 #include "rgw_ldap.h"
 
+#include "common/ceph_crypto.h"
 #include "common/ceph_context.h"
 #include "common/common_init.h"
 #include "common/dout.h"
@@ -35,6 +36,7 @@ std::string parse_rgw_ldap_bindpw(CephContext* ctx)
         if (ldap_bindpw.back() == '\n')
           ldap_bindpw.pop_back();
       }
+      ::ceph::crypto::zeroize_for_security(bindpw, sizeof(bindpw));
   }
 
   return ldap_bindpw;

--- a/src/rgw/rgw_ldap.cc
+++ b/src/rgw/rgw_ldap.cc
@@ -27,12 +27,12 @@ std::string parse_rgw_ldap_bindpw(CephContext* ctx)
       memset(bindpw, 0, 1024);
       int pwlen = safe_read_file("" /* base */, ldap_secret.c_str(),
 				 bindpw, 1023);
-    if (pwlen > 0) {
-      ldap_bindpw = bindpw;
-      boost::algorithm::trim(ldap_bindpw);
-      if (ldap_bindpw.back() == '\n')
-	ldap_bindpw.pop_back();
-    }
+      if (pwlen > 0) {
+        ldap_bindpw = bindpw;
+        boost::algorithm::trim(ldap_bindpw);
+        if (ldap_bindpw.back() == '\n')
+          ldap_bindpw.pop_back();
+      }
   }
 
   return ldap_bindpw;

--- a/src/rgw/rgw_ldap.cc
+++ b/src/rgw/rgw_ldap.cc
@@ -23,6 +23,8 @@ std::string parse_rgw_ldap_bindpw(CephContext* ctx)
       << __func__ << " LDAP auth no rgw_ldap_secret file found in conf"
       << dendl;
     } else {
+      // FIPS zeroization audit 20191116: this memset is not intended to
+      // wipe out a secret after use.
       char bindpw[1024];
       memset(bindpw, 0, 1024);
       int pwlen = safe_read_file("" /* base */, ldap_secret.c_str(),

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -479,6 +479,8 @@ static int build_token(const string& swift_user,
   dout(20) << "build_token token=" << buf << dendl;
 
   char k[CEPH_CRYPTO_HMACSHA1_DIGESTSIZE];
+  // FIPS zeroization audit 20191116: this memset is not intended to
+  // wipe out a secret after use.
   memset(k, 0, sizeof(k));
   const char *s = key.c_str();
   for (int i = 0; i < (int)key.length(); i++, s++) {

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -487,6 +487,7 @@ static int build_token(const string& swift_user,
     k[i % CEPH_CRYPTO_HMACSHA1_DIGESTSIZE] |= *s;
   }
   calc_hmac_sha1(k, sizeof(k), bl.c_str(), bl.length(), p.c_str());
+  ::ceph::crypto::zeroize_for_security(k, sizeof(k));
 
   bl.append(p);
 

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -174,6 +174,7 @@ void seed::sha1(SHA1 *h, bufferlist &bl, off_t bl_len)
     h->Final((unsigned char *)sha);
     set_info_pieces(sha);
   }
+  ::ceph::crypto::zeroize_for_security(sha, sizeof(sha));
 }
 
 int seed::get_params()

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -155,6 +155,8 @@ void seed::sha1(SHA1 *h, bufferlist &bl, off_t bl_len)
   /* get sha1 */
   for (off_t i = 0; i < num; i++)
   {
+    // FIPS zeroization audit 20191116: this memset is not intended to
+    // wipe out a secret after use.
     memset(sha, 0x00, sizeof(sha));
     h->Update((unsigned char *)pstr, info.piece_length);
     h->Final((unsigned char *)sha);
@@ -165,6 +167,8 @@ void seed::sha1(SHA1 *h, bufferlist &bl, off_t bl_len)
   /* process remain */
   if (0 != remain)
   {
+    // FIPS zeroization audit 20191116: this memset is not intended to
+    // wipe out a secret after use.
     memset(sha, 0x00, sizeof(sha));
     h->Update((unsigned char *)pstr, remain);
     h->Final((unsigned char *)sha);


### PR DESCRIPTION
For the sake of compliance with FIPS memory where security material (like keys) was stored, should be cleaned when it isn't used anymore. This is intended to limit the impact of other security problems allowing to inspect memory.

In many cases such sanitization is performed with `memset` or `bzero` to zeroize the memory. However, C++ language, due to [the as-if rule](https://en.cppreference.com/w/cpp/language/as_if), provides less guarantees than necessary to ensure that a call to e.g. `memset` will be always translated into intended stores. This isn't something specific to it nor `bzero`. All a compiler needs to know to perform dead store elimination is the code itself (to exclude e.g. `volatile` fencing). Presumably it could assume how the things from standard library look internally – [like with an inlineable function](https://godbolt.org/z/XJnAnA).

The problem was already discussed in the GCC bug reports which finally have been marked as "invalid":
  * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=8537,
  * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71388.

Because of that we want to perform the security clean-ups with a dedicated procedure that takes responsibility of prohibiting compilers from optimizing it out. OpenSSL already provides such utility: `OPESNSSL_cleanse`. The first commit integrates it into Ceph's abstractions over crypto.
Its intended clients are some current users of `memset` and `bzero` found using the GCC's `deprecated` attribute. See: https://gist.github.com/rzarzynski/db9b4ca6b3d409d2ab8d38f4d6678063.

A subset of the detected users are audited and switched to `ceph::crypto::zeroize_for_security` by further commits.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
