### PR TITLE
♪ I've got the world on a string, sittin' on a rainbow ♪

### DIFF
--- a/src/cls/otp/cls_otp_client.cc
+++ b/src/cls/otp/cls_otp_client.cc
@@ -16,7 +16,7 @@
 #include "msg/msg_types.h"
 #include "include/rados/librados.hpp"
 #include "include/utime.h"
- 
+
 using namespace librados;
 
 #include "cls/otp/cls_otp_ops.h"

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -878,7 +878,8 @@ struct rgw_usage_log_entry {
     DECODE_FINISH(bl);
   }
 
-  void aggregate(const rgw_usage_log_entry& e, map<string, bool> *categories = NULL) {
+  void aggregate(const rgw_usage_log_entry& e,
+		 std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>> *categories = nullptr) {
     if (owner.empty()) {
       owner = e.owner;
       bucket = e.bucket;
@@ -894,7 +895,8 @@ struct rgw_usage_log_entry {
     }
   }
 
-  void sum(rgw_usage_data& usage, map<string, bool>& categories) const {
+  void sum(rgw_usage_data& usage,
+	   std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>>& categories) const {
     usage = rgw_usage_data();
     for (map<string, rgw_usage_data>::const_iterator iter = usage_map.begin(); iter != usage_map.end(); ++iter) {
       if (!categories.size() || categories.count(iter->first)) {

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1591,6 +1591,10 @@ static ceph::spinlock debug_lock;
     return s;
   }
 
+  std::string_view buffer::list::to_string_view() {
+    return { c_str(), length() };
+  }
+
   void buffer::list::substr_of(const list& other, unsigned off, unsigned len)
   {
     if (off + len > other.length())

--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -475,6 +475,11 @@ void decode_json_obj(utime_t& val, JSONObj *obj)
   }
 }
 
+void encode_json(const char *name, std::string_view val, Formatter *f)
+{
+  f->dump_string(name, val);
+}
+
 void encode_json(const char *name, const string& val, Formatter *f)
 {
   f->dump_string(name, val);

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -376,6 +376,7 @@ static void encode_json(const char *name, const T& val, ceph::Formatter *f)
 
 class utime_t;
 
+void encode_json(const char *name, std::string_view val, ceph::Formatter *f);
 void encode_json(const char *name, const std::string& val, ceph::Formatter *f);
 void encode_json(const char *name, const char *val, ceph::Formatter *f);
 void encode_json(const char *name, bool val, ceph::Formatter *f);

--- a/src/common/iso_8601.cc
+++ b/src/common/iso_8601.cc
@@ -17,14 +17,14 @@ using std::stringstream;
 using std::string;
 using std::uint16_t;
 
-using boost::none;
-using boost::optional;
-using boost::string_ref;
+using std::nullopt;
+using std::optional;
+using std::string_view;
 
 using ceph::real_clock;
 using ceph::real_time;
 
-using sriter = string_ref::const_iterator;
+using sriter = string_view::const_iterator;
 
 namespace {
 // This assumes a contiguous block of numbers in the correct order.
@@ -39,15 +39,15 @@ optional<real_time> calculate(const tm& t, uint32_t n = 0) {
   ceph_assert(n < 1000000000);
   time_t tt = internal_timegm(&t);
   if (tt == static_cast<time_t>(-1)) {
-    return none;
+    return nullopt;
   }
 
-  return boost::make_optional<real_time>(real_clock::from_time_t(tt)
-                                         + nanoseconds(n));
+  return std::make_optional<real_time>(real_clock::from_time_t(tt)
+				       + nanoseconds(n));
 }
 }
 
-optional<real_time> from_iso_8601(const string_ref s,
+optional<real_time> from_iso_8601(const string_view s,
 				  const bool ws_terminates) noexcept {
   auto end = s.cend();
   auto read_digit = [end](sriter& c) mutable {
@@ -98,7 +98,7 @@ optional<real_time> from_iso_8601(const string_ref s,
     {
       auto y = read_digits(c, 4);
       if (y < 1970) {
-	return none;
+	return nullopt;
       }
       t.tm_year = y - 1900;
     }
@@ -146,7 +146,7 @@ optional<real_time> from_iso_8601(const string_ref s,
   } catch (std::invalid_argument& e) {
     // fallthrough
   }
-  return none;
+  return nullopt;
 }
 
 string to_iso_8601(const real_time t,

--- a/src/common/iso_8601.h
+++ b/src/common/iso_8601.h
@@ -4,8 +4,9 @@
 #ifndef CEPH_COMMON_ISO_8601_H
 #define CEPH_COMMON_ISO_8601_H
 
-#include <boost/optional.hpp>
-#include <boost/utility/string_ref.hpp>
+#include <optional>
+#include <string>
+#include <string_view>
 
 #include "common/ceph_time.h"
 
@@ -27,10 +28,10 @@ namespace ceph {
 //     *    If there is no day, it is assumed to be the first.
 //     *    If there is no month, it is assumed to be January.
 //
-// If a date is invalid, boost::none is returned.
+// If a date is invalid, std::nullopt is returned.
 
-boost::optional<ceph::real_time> from_iso_8601(
-  boost::string_ref s, const bool ws_terminates = true) noexcept;
+std::optional<ceph::real_time> from_iso_8601(
+  std::string_view s, const bool ws_terminates = true) noexcept;
 
 enum class iso_8601_format {
   Y, YM, YMD, YMDh, YMDhm, YMDhms, YMDhmsn

--- a/src/common/sstring.hh
+++ b/src/common/sstring.hh
@@ -27,6 +27,7 @@
 #define SSTRING_HH_
 
 #include <type_traits>
+#include <string_view>
 #include <boost/utility/string_view.hpp>
 
 #include "include/buffer.h"
@@ -529,6 +530,9 @@ public:
     }
     operator boost::basic_string_view<char_type, traits_type>() const {
 		return boost::basic_string_view<char_type, traits_type>(str(), size());
+    }
+    operator std::basic_string_view<char_type, traits_type>() const {
+		return std::basic_string_view<char_type, traits_type>(str(), size());
     }
     template <typename string_type, typename T>
     friend inline string_type to_sstring(T value);

--- a/src/common/str_util.h
+++ b/src/common/str_util.h
@@ -166,7 +166,8 @@ Iterator substr_insert(std::string_view s,
 // Returns the found number on success. Returns an empty optional on
 // failure OR on trailing characters.
 template<typename T>
-std::optional<T> parse(std::string_view s, int base = 10)
+auto parse(std::string_view s, int base = 10)
+  -> std::enable_if_t<std::is_integral_v<T>, std::optional<T>>
 {
   T t;
   auto r = std::from_chars(s.data(), s.data() + s.size(), t, base);
@@ -180,7 +181,8 @@ std::optional<T> parse(std::string_view s, int base = 10)
 // string_view to remove the parsed number. Set the supplied
 // string_view to empty if it ends with the number.
 template<typename T>
-std::optional<T> consume(std::string_view& s, int base = 10)
+auto consume(std::string_view& s, int base = 10)
+  -> std::enable_if_t<std::is_integral_v<T>, std::optional<T>>
 {
   T t;
   auto r = std::from_chars(s.data(), s.data() + s.size(), t, base);

--- a/src/common/str_util.h
+++ b/src/common/str_util.h
@@ -21,6 +21,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 namespace ceph {
 // Because *somebody* built an entire operating system on the idea of
@@ -83,6 +84,74 @@ nul_terminated_copy(std::string_view source)
   if (!b)
     dest.reset();
   return dest;
+}
+
+// Control Flow results, to control breaking substr_do (and possibly
+// other things down the road.)
+enum class cf {
+  go, // Continue execution
+  stop // Stop here
+};
+
+// Default delimiters for substr_do and associates.
+inline constexpr std::string_view default_delims = ";,= \t";
+
+/// Split a string using the given delimiters, passing each piece as a
+/// (non-null-terminated) std::string_view to the callback.
+template<typename F>
+void substr_do(
+  std::string_view s, F&& f,
+  std::enable_if_t<!std::is_same_v<std::invoke_result_t<F, std::string_view>,
+                                   cf>, std::string_view> d = default_delims)
+{
+  auto pos = s.find_first_not_of(d);
+  while (pos != s.npos) {
+    s.remove_prefix(pos);
+    auto end = s.find_first_of(d);
+    f(s.substr(0, end));
+    pos = s.find_first_not_of(d, end);
+  }
+}
+
+// As above, but let the function specify whether to continue after
+// every call. f, must return a member of cf at every
+// execution. cf::stop will, unsurprisingly, stop.
+template<typename F>
+void substr_do(
+  std::string_view s, F&& f,
+  std::enable_if_t<std::is_same_v<std::invoke_result_t<F, std::string_view>,
+                                  cf>, std::string_view> d = default_delims)
+{
+  auto pos = s.find_first_not_of(d);
+  while (pos != s.npos) {
+    s.remove_prefix(pos);
+    auto end = s.find_first_of(d);
+    cf b = f(s.substr(0, end));
+    if (b == cf::stop)
+      break;
+    pos = s.find_first_not_of(d, end);
+  }
+}
+
+// Insert each delimited substring into a container, specified by the
+// output iterator. Will insert a std::string_view if possible, and a
+// std::string otherwise.
+template<typename Iterator>
+Iterator substr_insert(std::string_view s,
+		       Iterator i,
+		       std::string_view d = default_delims)
+{
+  substr_do(s,
+	    [&](auto&& s) {
+	      if constexpr (std::is_assignable_v<decltype(*i),
+			                         std::string_view>) {
+	        *i = s;
+	      } else {
+	        *i = std::string(s);
+	      }
+	      ++i;
+	    }, d);
+  return i;
 }
 }
 #endif // CEPH_COMMON_STR_UTIL_H

--- a/src/common/str_util.h
+++ b/src/common/str_util.h
@@ -1,0 +1,88 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat <contact@redhat.com>
+ * Author: Adam C. Emerson <aemerson@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_COMMON_STR_UTIL_H
+#define CEPH_COMMON_STR_UTIL_H
+
+#include <array>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace ceph {
+// Because *somebody* built an entire operating system on the idea of
+// NUL-terminated strings, and you don't want to have to allocate
+// memory just to pass a filename to open(2).
+//
+// If the total length of source is less than N, copies the contents
+// of source to dest, appending a NUL and returning true.
+//
+// Otherwise, returns false.
+template<std::size_t N>
+bool nul_terminated_copy(std::string_view source,
+			 char* dest)
+{
+  if (source.size() < N) {
+    auto i = std::copy(std::cbegin(source), std::cend(source),
+		       dest);
+    *i = '\0';
+    return true;
+  } else {
+    return false;
+  }
+}
+
+
+// Same thing with a C-style array
+template<std::size_t N>
+bool nul_terminated_copy(std::string_view source,
+			 char (&dest)[N])
+{
+  if constexpr (N == 0) {
+    return true;
+  }
+  return nul_terminated_copy<N>(source, &dest[0]);
+}
+
+// Same thing with a standard array
+template<std::size_t N>
+bool nul_terminated_copy(std::string_view source,
+			 std::array<char, N>& dest)
+{
+  if constexpr (N == 0) {
+    return true;
+  }
+  return nul_terminated_copy<N>(source, dest.data());
+}
+
+// Same as above, except with RVO instead of caller-provided-storage.
+//
+// If the total length of source is less than N, returns an optional
+// array containing a NUL-terminated copy.
+//
+// Otherwise, returns an empty optional.
+template<std::size_t N>
+std::optional<std::array<char, N>>
+nul_terminated_copy(std::string_view source)
+{
+  std::optional<std::array<char, N>> dest(std::in_place);
+  auto b = nul_terminated_copy<N>(source, dest->data());
+  if (!b)
+    dest.reset();
+  return dest;
+}
+}
+#endif // CEPH_COMMON_STR_UTIL_H

--- a/src/common/str_util.h
+++ b/src/common/str_util.h
@@ -34,7 +34,7 @@ namespace ceph {
 //
 // Otherwise, returns false.
 template<std::size_t N>
-bool nul_terminated_copy(std::string_view source,
+inline bool nul_terminated_copy(std::string_view source,
 			 char* dest)
 {
   if (source.size() < N) {
@@ -270,6 +270,18 @@ inline std::string_view trim(std::string_view src,
   src.remove_suffix(src.size() - ++n);
 
   return src;
+}
+
+// Because we don't get std::basic_string_view::starts_with and
+// std::basic_string_view::ends_with until C++ 20
+constexpr inline bool starts_with(std::string_view s, std::string_view sub) {
+  return (s.size() >= sub.size() &&
+	  s.compare(0, sub.size(), sub) == 0);
+}
+
+constexpr inline bool ends_with(std::string_view s, std::string_view sub) {
+  return (s.size() >= sub.size() &&
+	  s.compare(s.size() - sub.size(), std::string_view::npos, sub) == 0);
 }
 }
 #endif // CEPH_COMMON_STR_UTIL_H

--- a/src/common/str_util.h
+++ b/src/common/str_util.h
@@ -252,5 +252,24 @@ auto transform(std::string_view source, F&& f)
   }
   return dest;
 }
+
+// Trim some kinds of characters off a string_view, most notably
+// whitespace.
+inline std::string_view trim(std::string_view src,
+			     std::string_view exclude = space)
+{
+  if (src.empty())
+    return {};
+
+  auto n = src.find_first_not_of(exclude);
+  if (n == std::string_view::npos)
+    return {};
+  src.remove_prefix(n);
+
+  n = src.find_last_not_of(exclude);
+  src.remove_suffix(src.size() - ++n);
+
+  return src;
+}
 }
 #endif // CEPH_COMMON_STR_UTIL_H

--- a/src/erasure-code/ErasureCodePlugin.h
+++ b/src/erasure-code/ErasureCodePlugin.h
@@ -47,7 +47,7 @@ namespace ceph {
     ceph::mutex lock = ceph::make_mutex("ErasureCodePluginRegistry::lock");
     bool loading = false;
     bool disable_dlclose = false;
-    std::map<std::string,ErasureCodePlugin*> plugins;
+    std::map<std::string,ErasureCodePlugin*, std::less<>> plugins;
 
     static ErasureCodePluginRegistry singleton;
 
@@ -66,9 +66,9 @@ namespace ceph {
 
     int add(const std::string &name, ErasureCodePlugin *plugin);
     int remove(const std::string &name);
-    ErasureCodePlugin *get(const std::string &name);
+    ErasureCodePlugin *get(std::string_view name);
 
-    int load(const std::string &plugin_name,
+    int load(std::string_view plugin_name,
 	     const std::string &directory,
 	     ErasureCodePlugin **plugin,
 	     std::ostream *ss);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1235,6 +1235,7 @@ inline namespace v14_2_0 {
     const char& operator[](unsigned n) const;
     char *c_str();
     std::string to_str() const;
+    std::string_view to_string_view();
 
     void substr_of(const list& other, unsigned off, unsigned len);
 

--- a/src/include/ipaddr.h
+++ b/src/include/ipaddr.h
@@ -1,5 +1,10 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_IPADDR_H
 #define CEPH_IPADDR_H
+
+#include <string_view>
 
 class entity_addr_t;
 
@@ -25,10 +30,10 @@ const struct ifaddrs *find_ip_in_subnet(const struct ifaddrs *addrs,
  *
  * if the network string is invalid, return false.
  */
-bool parse_network(const char *s,
+bool parse_network(std::string_view s,
 		   struct sockaddr_storage *network,
 		   unsigned int *prefix_len);
-bool parse_network(const char *s,
+bool parse_network(std::string_view s,
 		   entity_addr_t *network,
 		   unsigned int *prefix_len);
 

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -16,6 +16,8 @@
 #define CEPH_MSG_TYPES_H
 
 #include <sstream>
+#include <string>
+#include <string_view>
 
 #include <netinet/in.h>
 
@@ -441,6 +443,7 @@ struct entity_addr_t {
   }
 
   bool parse(const char *s, const char **end = 0, int type=0);
+  bool parse(std::string_view& s, int type = 0);
 
   void decode_legacy_addr_after_marker(ceph::buffer::list::const_iterator& bl)
   {

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -23,7 +23,6 @@
 #include "rgw/rgw_acl_s3.h"
 #include "rgw_acl.h"
 
-#include "include/str_list.h"
 #include "include/stringify.h"
 #include "global/global_init.h"
 #include "global/signal_handler.h"

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -256,7 +256,7 @@ namespace rgw {
     }
 
     /* now expected by rgw_log_op() */
-    rgw_env.set("REQUEST_METHOD", s->info.method);
+    rgw_env.set("REQUEST_METHOD", string(s->info.method.value_or("")));
     rgw_env.set("REQUEST_URI", s->info.request_uri);
     rgw_env.set("QUERY_STRING", "");
 

--- a/src/rgw/librgw_admin_user.cc
+++ b/src/rgw/librgw_admin_user.cc
@@ -24,7 +24,6 @@
 
 #include "include/types.h"
 #include "include/rgw/librgw_admin_user.h"
-#include "include/str_list.h"
 #include "include/stringify.h"
 #include "global/global_init.h"
 #include "global/signal_handler.h"

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -309,7 +309,7 @@ public:
                     uint32_t perm_mask);
   uint32_t get_group_perm(ACLGroupTypeEnum group, uint32_t perm_mask);
   uint32_t get_referer_perm(uint32_t current_perm,
-                            std::string http_referer,
+                            std::string_view http_referer,
                             uint32_t perm_mask);
   void encode(bufferlist& bl) const {
     ENCODE_START(4, 3, bl);
@@ -419,13 +419,13 @@ public:
   uint32_t get_perm(const DoutPrefixProvider* dpp,
                     const rgw::auth::Identity& auth_identity,
                     uint32_t perm_mask,
-                    const char * http_referer);
+		    std::optional<std::string_view> http_referer);
   uint32_t get_group_perm(ACLGroupTypeEnum group, uint32_t perm_mask);
   bool verify_permission(const DoutPrefixProvider* dpp,
                          const rgw::auth::Identity& auth_identity,
                          uint32_t user_perm_mask,
                          uint32_t perm,
-                         const char * http_referer = nullptr);
+                         std::optional<std::string_view> http_referer = std::nullopt);
 
   void encode(bufferlist& bl) const {
     ENCODE_START(2, 2, bl);

--- a/src/rgw/rgw_acl_s3.h
+++ b/src/rgw/rgw_acl_s3.h
@@ -9,7 +9,6 @@
 #include <iosfwd>
 #include <include/types.h>
 
-#include "include/str_list.h"
 #include "rgw_xml.h"
 #include "rgw_acl.h"
 

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -75,7 +75,7 @@ static boost::optional<ACLGrant> referrer_to_grant(std::string url_spec,
 {
   /* This function takes url_spec as non-ref std::string because of the trim
    * operation that is essential to preserve compliance with Swift. It can't
-   * be easily accomplished with boost::string_ref. */
+   * be easily accomplished with std::string_view. */
   try {
     bool is_negative;
     ACLGrant grant;

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -30,8 +30,8 @@ public:
   int create(RGWUserCtl *user_ctl,
              const rgw_user& id,
              const std::string& name,
-             const char* read_list,
-             const char* write_list,
+	     std::optional<std::string_view> read_list,
+	     std::optional<std::string_view> write_list,
              uint32_t& rw_mask);
   void filter_merge(uint32_t mask, RGWAccessControlPolicy_SWIFT *policy);
   void to_str(std::string& read, std::string& write);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1723,7 +1723,7 @@ static int send_to_url(const string& url, const string& access,
   key.key = secret;
 
   param_vec_t params;
-  RGWRESTSimpleRequest req(g_ceph_context, info.method, url, NULL, &params);
+  RGWRESTSimpleRequest req(g_ceph_context, string(*info.method), url, NULL, &params);
 
   bufferlist response;
   int ret = req.forward_request(key, info, MAX_REST_RESPONSE, &in_data, &response);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4960,14 +4960,7 @@ int main(int argc, const char **argv)
   }
 
   if (!op_mask_str.empty()) {
-    uint32_t op_mask;
-    int ret = rgw_parse_op_type_list(op_mask_str, &op_mask);
-    if (ret < 0) {
-      cerr << "failed to parse op_mask: " << cpp_strerror(-ret) << std::endl;
-      return -ret;
-    }
-
-    user_op.set_op_mask(op_mask);
+    user_op.set_op_mask(rgw_parse_op_type_list(op_mask_str));
   }
 
   if (key_type != KEY_TYPE_UNDEFINED)

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1,7 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
-#include <errno.h>
+#include <cerrno>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -22,6 +22,7 @@ extern "C" {
 #include "common/Formatter.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
+#include "common/str_util.h"
 
 #include "include/util.h"
 
@@ -2736,12 +2737,12 @@ int main(int argc, const char **argv)
   std::string role_name, path, assume_role_doc, policy_name, perm_policy_doc, path_prefix;
   std::string redirect_zone;
   bool redirect_zone_set = false;
-  list<string> endpoints;
+  std::vector<string> endpoints;
   int tmp_int;
   int sync_from_all_specified = false;
   bool sync_from_all = false;
-  list<string> sync_from;
-  list<string> sync_from_rm;
+  std::vector<string> sync_from;
+  std::vector<string> sync_from_rm;
   int is_master_int;
   int set_default = 0;
   bool is_master = false;
@@ -2805,9 +2806,9 @@ int main(int argc, const char **argv)
   string object_version;
   string placement_id;
   string storage_class;
-  list<string> tags;
-  list<string> tags_add;
-  list<string> tags_rm;
+  std::vector<string> tags;
+  std::vector<string> tags_add;
+  std::vector<string> tags_rm;
 
   int64_t max_objects = -1;
   int64_t max_size = -1;
@@ -3131,11 +3132,11 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--storage-class", (char*)NULL)) {
       storage_class = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--tags", (char*)NULL)) {
-      get_str_list(val, tags);
+      ceph::substr_insert(val, std::back_inserter(tags));
     } else if (ceph_argparse_witharg(args, i, &val, "--tags-add", (char*)NULL)) {
-      get_str_list(val, tags_add);
+      ceph::substr_insert(val, std::back_inserter(tags_add));
     } else if (ceph_argparse_witharg(args, i, &val, "--tags-rm", (char*)NULL)) {
-      get_str_list(val, tags_rm);
+      ceph::substr_insert(val, std::back_inserter(tags_rm));
     } else if (ceph_argparse_witharg(args, i, &val, "--api-name", (char*)NULL)) {
       api_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--zone-id", (char*)NULL)) {
@@ -3143,11 +3144,11 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--zone-new-name", (char*)NULL)) {
       zone_new_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--endpoints", (char*)NULL)) {
-      get_str_list(val, endpoints);
+      ceph::substr_insert(val, std::back_inserter(endpoints));
     } else if (ceph_argparse_witharg(args, i, &val, "--sync-from", (char*)NULL)) {
-      get_str_list(val, sync_from);
+      ceph::substr_insert(val, std::back_inserter(sync_from));
     } else if (ceph_argparse_witharg(args, i, &val, "--sync-from-rm", (char*)NULL)) {
-      get_str_list(val, sync_from_rm);
+      ceph::substr_insert(val, std::back_inserter(sync_from_rm));
     } else if (ceph_argparse_binary_flag(args, i, &tmp_int, NULL, "--sync-from-all", (char*)NULL)) {
       sync_from_all = (bool)tmp_int;
       sync_from_all_specified = true;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -31,7 +31,7 @@ extern "C" {
 #include "global/global_init.h"
 
 #include "include/utime.h"
-#include "include/str_list.h"
+#include "common/str_util.h"
 
 #include "rgw_user.h"
 #include "rgw_bucket.h"
@@ -2778,7 +2778,8 @@ int main(int argc, const char **argv)
   int check_head_obj_locator = false;
   int max_buckets = -1;
   bool max_buckets_specified = false;
-  map<string, bool> categories;
+  std::string cat_str;
+  std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>> categories;
   string caps;
   int check_objects = false;
   RGWUserAdminOpState user_op;
@@ -3035,13 +3036,12 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char*)NULL)) {
       format = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--categories", (char*)NULL)) {
-      string cat_str = val;
-      list<string> cat_list;
-      list<string>::iterator iter;
-      get_str_list(cat_str, cat_list);
-      for (iter = cat_list.begin(); iter != cat_list.end(); ++iter) {
-	categories[*iter] = true;
-      }
+      cat_str = val;
+      ceph::substr_do(
+	cat_str,
+	[&](std::string_view s) {
+	  categories.insert(s);
+	});
     } else if (ceph_argparse_binary_flag(args, i, &delete_child_objects, NULL, "--purge-objects", (char*)NULL)) {
       // do nothing
     } else if (ceph_argparse_binary_flag(args, i, &pretty_format, NULL, "--pretty-format", (char*)NULL)) {

--- a/src/rgw/rgw_arn.h
+++ b/src/rgw/rgw_arn.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <boost/optional.hpp>
 
-class rgw_obj;
-class rgw_bucket;
+struct rgw_obj;
+struct rgw_bucket;
 
 namespace rgw {
 

--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -47,7 +47,7 @@ int ClientIO::init_env(CephContext *cct)
       continue;
     }
 
-    static const boost::string_ref HTTP_{"HTTP_"};
+    static const std::string_view HTTP_{"HTTP_"};
 
     char buf[name.size() + HTTP_.size() + 1];
     auto dest = std::copy(std::begin(HTTP_), std::end(HTTP_), buf);
@@ -160,8 +160,8 @@ size_t ClientIO::complete_header()
   return sent;
 }
 
-size_t ClientIO::send_header(const boost::string_ref& name,
-                             const boost::string_ref& value)
+size_t ClientIO::send_header(std::string_view name,
+                             std::string_view value)
 {
   static constexpr char HEADER_SEP[] = ": ";
   static constexpr char HEADER_END[] = "\r\n";

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -42,8 +42,8 @@ class ClientIO : public io::RestfulClient,
   void flush() override;
   size_t send_status(int status, const char *status_name) override;
   size_t send_100_continue() override;
-  size_t send_header(const boost::string_ref& name,
-                     const boost::string_ref& value) override;
+  size_t send_header(std::string_view name,
+                     std::string_view value) override;
   size_t send_content_length(uint64_t len) override;
   size_t complete_header() override;
 

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -10,8 +10,6 @@
 #include "rgw_http_client.h"
 #include "rgw_keystone.h"
 
-#include "include/str_list.h"
-
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -12,7 +12,6 @@
 #include "common/errno.h"
 #include "common/ceph_json.h"
 #include "include/types.h"
-#include "include/str_list.h"
 
 #include "rgw_common.h"
 #include "rgw_keystone.h"

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -266,9 +266,9 @@ TokenEngine::authenticate(const DoutPrefixProvider* dpp,
  * Try to validate S3 auth against keystone s3token interface
  */
 std::pair<boost::optional<rgw::keystone::TokenEnvelope>, int>
-EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const boost::string_view& access_key_id,
+EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, std::string_view access_key_id,
                              const std::string& string_to_sign,
-                             const boost::string_view& signature) const
+                             std::string_view signature) const
 {
   /* prepare keystone url */
   std::string keystone_url = config.get_endpoint_url();
@@ -354,7 +354,7 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const boost::string_
 
 std::pair<boost::optional<std::string>, int> EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
                                                                                  const std::string& user_id,
-                                                                                 const boost::string_view& access_key_id) const
+                                                                                 std::string_view access_key_id) const
 {
   /*  Fetch from /users/{USER_ID}/credentials/OS-EC2/{ACCESS_KEY_ID} */
   /* Should return json with response key "credential" which contains entry "secret"*/
@@ -374,7 +374,7 @@ std::pair<boost::optional<std::string>, int> EC2Engine::get_secret_from_keystone
   keystone_url.append("users/");
   keystone_url.append(user_id);
   keystone_url.append("/credentials/OS-EC2/");
-  keystone_url.append(access_key_id.to_string());
+  keystone_url.append(access_key_id);
 
   /* get authentication token for Keystone. */
   std::string admin_token;
@@ -444,9 +444,9 @@ std::pair<boost::optional<std::string>, int> EC2Engine::get_secret_from_keystone
  */
 std::pair<boost::optional<rgw::keystone::TokenEnvelope>, int>
 EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
-			    const boost::string_view& access_key_id,
+			    std::string_view access_key_id,
                             const std::string& string_to_sign,
-                            const boost::string_view& signature,
+                            std::string_view signature,
 			    const signature_factory_t& signature_factory) const
 {
   using server_signature_t = VersionAbstractor::server_signature_t;
@@ -455,7 +455,7 @@ EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 
   /* Get a token from the cache if one has already been stored */
   boost::optional<boost::tuple<rgw::keystone::TokenEnvelope, std::string>>
-    t = secret_cache.find(access_key_id.to_string());
+    t = secret_cache.find(access_key_id);
 
   /* Check that credentials can correctly be used to sign data */
   if (t) {
@@ -480,7 +480,7 @@ EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
 
     if (secret) {
       /* Add token, secret pair to cache, and set timeout */
-      secret_cache.add(access_key_id.to_string(), *token, *secret);
+      secret_cache.add(std::string(access_key_id), *token, *secret);
     }
   }
 
@@ -527,9 +527,9 @@ EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
 
 rgw::auth::Engine::result_t EC2Engine::authenticate(
   const DoutPrefixProvider* dpp,
-  const boost::string_view& access_key_id,
-  const boost::string_view& signature,
-  const boost::string_view& session_token,
+  std::string_view access_key_id,
+  std::string_view signature,
+  std::string_view session_token,
   const string_to_sign_t& string_to_sign,
   const signature_factory_t& signature_factory,
   const completer_factory_t& completer_factory,
@@ -593,13 +593,13 @@ rgw::auth::Engine::result_t EC2Engine::authenticate(
   }
 }
 
-bool SecretCache::find(const std::string& token_id,
+bool SecretCache::find(std::string_view token_id,
                        SecretCache::token_envelope_t& token,
 		       std::string &secret)
 {
   std::lock_guard<std::mutex> l(lock);
 
-  map<std::string, secret_entry>::iterator iter = secrets.find(token_id);
+  auto iter = secrets.find(token_id);
   if (iter == secrets.end()) {
     return false;
   }
@@ -615,7 +615,7 @@ bool SecretCache::find(const std::string& token_id,
   token = entry.token;
   secret = entry.secret;
 
-  secrets_lru.push_front(token_id);
+  secrets_lru.push_front(std::string(token_id));
   entry.lru_iter = secrets_lru.begin();
 
   return true;

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -83,7 +83,7 @@ class SecretCache {
 
   const boost::intrusive_ptr<CephContext> cct;
 
-  std::map<std::string, secret_entry> secrets;
+  std::map<std::string, secret_entry, std::less<>> secrets;
   std::list<std::string> secrets_lru;
 
   std::mutex lock;
@@ -111,8 +111,8 @@ public:
     return instance;
   }
 
-  bool find(const std::string& token_id, token_envelope_t& token, std::string& secret);
-  boost::optional<boost::tuple<token_envelope_t, std::string>> find(const std::string& token_id) {
+  bool find(std::string_view token_id, token_envelope_t& token, std::string& secret);
+  boost::optional<boost::tuple<token_envelope_t, std::string>> find(std::string_view token_id) {
     token_envelope_t token_envlp;
     std::string secret;
     if (find(token_id, token_envlp, secret)) {
@@ -141,26 +141,26 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
                             ) const noexcept;
   std::pair<boost::optional<token_envelope_t>, int>
   get_from_keystone(const DoutPrefixProvider* dpp,
-                    const boost::string_view& access_key_id,
+                    std::string_view access_key_id,
                     const std::string& string_to_sign,
-                    const boost::string_view& signature) const;
+                    std::string_view signature) const;
   std::pair<boost::optional<token_envelope_t>, int>
   get_access_token(const DoutPrefixProvider* dpp,
-                   const boost::string_view& access_key_id,
+                   std::string_view access_key_id,
                    const std::string& string_to_sign,
-                   const boost::string_view& signature,
+                   std::string_view signature,
 		   const signature_factory_t& signature_factory) const;
   result_t authenticate(const DoutPrefixProvider* dpp,
-                        const boost::string_view& access_key_id,
-                        const boost::string_view& signature,
-                        const boost::string_view& session_token,
+                        std::string_view access_key_id,
+                        std::string_view signature,
+                        std::string_view session_token,
                         const string_to_sign_t& string_to_sign,
                         const signature_factory_t& signature_factory,
                         const completer_factory_t& completer_factory,
                         const req_state* s) const override;
   std::pair<boost::optional<std::string>, int> get_secret_from_keystone(const DoutPrefixProvider* dpp,
                                                                         const std::string& user_id,
-                                                                        const boost::string_view& access_key_id) const;
+                                                                        std::string_view access_key_id) const;
 public:
   EC2Engine(CephContext* const cct,
             const rgw::auth::s3::AWSEngine::VersionAbstractor* const ver_abstractor,

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -831,10 +831,10 @@ AWSv4ComplMulti::ChunkMeta::create_next(CephContext* const cct,
                                         const char* const metabuf,
                                         const size_t metabuf_len)
 {
-  boost::string_ref metastr(metabuf, metabuf_len);
+  std::string_view metastr(metabuf, metabuf_len);
 
   const size_t semicolon_pos = metastr.find(";");
-  if (semicolon_pos == boost::string_ref::npos) {
+  if (semicolon_pos == std::string_view::npos) {
     ldout(cct, 20) << "AWSv4ComplMulti cannot find the ';' separator"
                    << dendl;
     throw rgw::io::Exception(EINVAL, std::system_category());
@@ -852,7 +852,7 @@ AWSv4ComplMulti::ChunkMeta::create_next(CephContext* const cct,
   /* Parse the chunk_signature=... part. */
   const auto signature_part = metastr.substr(semicolon_pos + 1);
   const size_t eq_sign_pos = signature_part.find("=");
-  if (eq_sign_pos == boost::string_ref::npos) {
+  if (eq_sign_pos == std::string_view::npos) {
     ldout(cct, 20) << "AWSv4ComplMulti: cannot find the '=' separator"
                    << dendl;
     throw rgw::io::Exception(EINVAL, std::system_category());
@@ -860,7 +860,7 @@ AWSv4ComplMulti::ChunkMeta::create_next(CephContext* const cct,
 
   /* OK, we have at least the beginning of a signature. */
   const size_t data_sep_pos = signature_part.find("\r\n");
-  if (data_sep_pos == boost::string_ref::npos) {
+  if (data_sep_pos == std::string_view::npos) {
     ldout(cct, 20) << "AWSv4ComplMulti: no new line at signature end"
                    << dendl;
     throw rgw::io::Exception(EINVAL, std::system_category());

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -270,8 +270,8 @@ class AWSv4ComplMulti : public rgw::auth::Completer,
 
   CephContext* const cct;
 
-  const boost::string_view date;
-  const boost::string_view credential_scope;
+  const std::string_view date;
+  const std::string_view credential_scope;
   const signing_key_t signing_key;
 
   class ChunkMeta {
@@ -287,8 +287,8 @@ class AWSv4ComplMulti : public rgw::auth::Completer,
         signature(signature.to_string()) {
     }
 
-    explicit ChunkMeta(const boost::string_view& signature)
-      : signature(signature.to_string()) {
+    explicit ChunkMeta(std::string_view signature)
+      : signature(signature) {
     }
 
   public:
@@ -314,7 +314,7 @@ class AWSv4ComplMulti : public rgw::auth::Completer,
 
     /* Factory: create an object representing metadata of first, initial chunk
      * in a stream. */
-    static ChunkMeta create_first(const boost::string_view& seed_signature) {
+    static ChunkMeta create_first(std::string_view seed_signature) {
       return ChunkMeta(seed_signature);
     }
 
@@ -339,9 +339,9 @@ public:
   /* We need the constructor to be public because of the std::make_shared that
    * is employed by the create() method. */
   AWSv4ComplMulti(const req_state* const s,
-                  boost::string_view date,
-                  boost::string_view credential_scope,
-                  boost::string_view seed_signature,
+                  std::string_view date,
+                  std::string_view credential_scope,
+                  std::string_view seed_signature,
                   const signing_key_t& signing_key)
     : io_base_t(nullptr),
       cct(s->cct),
@@ -371,9 +371,9 @@ public:
 
   /* Factories. */
   static cmplptr_t create(const req_state* s,
-                          boost::string_view date,
-                          boost::string_view credential_scope,
-                          boost::string_view seed_signature,
+                          std::string_view date,
+                          std::string_view credential_scope,
+                          std::string_view seed_signature,
                           const boost::optional<std::string>& secret_key);
 
 };
@@ -455,12 +455,12 @@ static constexpr char AWS4_STREAMING_PAYLOAD_HASH[] = \
   "STREAMING-AWS4-HMAC-SHA256-PAYLOAD";
 
 int parse_v4_credentials(const req_info& info,                     /* in */
-			 boost::string_view& access_key_id,        /* out */
-			 boost::string_view& credential_scope,     /* out */
-			 boost::string_view& signedheaders,        /* out */
-			 boost::string_view& signature,            /* out */
-			 boost::string_view& date,                 /* out */
-			 boost::string_view& session_token,        /* out */
+			 std::string_view& access_key_id,        /* out */
+			 std::string_view& credential_scope,     /* out */
+			 std::string_view& signedheaders,        /* out */
+			 std::string_view& signature,            /* out */
+			 std::string_view& date,                 /* out */
+			 std::string_view& session_token,        /* out */
 			 const bool using_qs);                     /* in */
 
 static inline bool char_needs_aws4_escaping(const char c, bool encode_slash)
@@ -500,7 +500,7 @@ static inline std::string aws4_uri_encode(const std::string& src, bool encode_sl
   return result;
 }
 
-static inline std::string aws4_uri_recode(const boost::string_view& src, bool encode_slash)
+static inline std::string aws4_uri_recode(std::string_view src, bool encode_slash)
 {
   std::string decoded = url_decode(src);
   return aws4_uri_encode(decoded, encode_slash);
@@ -580,30 +580,30 @@ std::string get_v4_canonical_qs(const req_info& info, bool using_qs);
 
 boost::optional<std::string>
 get_v4_canonical_headers(const req_info& info,
-                         const boost::string_view& signedheaders,
+                         std::string_view signedheaders,
                          bool using_qs,
                          bool force_boto2_compat);
 
 extern sha256_digest_t
 get_v4_canon_req_hash(CephContext* cct,
-                      const boost::string_view& http_verb,
+                      std::string_view http_verb,
                       const std::string& canonical_uri,
                       const std::string& canonical_qs,
                       const std::string& canonical_hdrs,
-                      const boost::string_view& signed_hdrs,
-                      const boost::string_view& request_payload_hash);
+                      std::string_view signed_hdrs,
+                      std::string_view request_payload_hash);
 
 AWSEngine::VersionAbstractor::string_to_sign_t
 get_v4_string_to_sign(CephContext* cct,
-                      const boost::string_view& algorithm,
-                      const boost::string_view& request_date,
-                      const boost::string_view& credential_scope,
+                      std::string_view algorithm,
+                      std::string_view request_date,
+                      std::string_view credential_scope,
                       const sha256_digest_t& canonreq_hash);
 
 extern AWSEngine::VersionAbstractor::server_signature_t
-get_v4_signature(const boost::string_view& credential_scope,
+get_v4_signature(std::string_view credential_scope,
                  CephContext* const cct,
-                 const boost::string_view& secret_key,
+                 std::string_view secret_key,
                  const AWSEngine::VersionAbstractor::string_to_sign_t& string_to_sign);
 
 extern AWSEngine::VersionAbstractor::server_signature_t

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -11,7 +11,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/container/static_vector.hpp>
-#include <boost/utility/string_ref.hpp>
 #include <boost/utility/string_view.hpp>
 
 #include "common/sstring.hh"
@@ -281,10 +280,10 @@ class AWSv4ComplMulti : public rgw::auth::Completer,
 
     ChunkMeta(const size_t data_starts_in_stream,
               const size_t data_length,
-              const boost::string_ref signature)
+              const std::string_view signature)
       : data_offset_in_stream(data_starts_in_stream),
         data_length(data_length),
-        signature(signature.to_string()) {
+        signature(signature) {
     }
 
     explicit ChunkMeta(std::string_view signature)

--- a/src/rgw/rgw_b64.h
+++ b/src/rgw/rgw_b64.h
@@ -19,14 +19,14 @@ namespace rgw {
    * A header-only Base64 encoder built on boost::archive.  The
    * formula is based on a class poposed for inclusion in boost in
    * 2011 by Denis Shevchenko (abandoned), updated slightly
-   * (e.g., uses boost::string_view).
+   * (e.g., uses std::string_view).
    *
    * Also, wrap_width added as template argument, based on
    * feedback from Marcus.
    */
 
   template<int wrap_width = std::numeric_limits<int>::max()>
-  inline std::string to_base64(boost::string_view sview)
+  inline std::string to_base64(std::string_view sview)
   {
     using namespace boost::archive::iterators;
 
@@ -43,7 +43,7 @@ namespace rgw {
       insert_linebreaks<
         base64_from_binary<
           transform_width<
-	    boost::string_view::const_iterator
+	    std::string_view::const_iterator
             ,6,8>
           >
           ,wrap_width
@@ -59,7 +59,7 @@ namespace rgw {
     return outstr;
   }
 
-  inline std::string from_base64(boost::string_view sview)
+  inline std::string from_base64(std::string_view sview)
   {
     using namespace boost::archive::iterators;
     if (sview.empty())
@@ -70,7 +70,7 @@ namespace rgw {
       transform_width<
       binary_from_base64<
 	remove_whitespace<
-	  boost::string_view::const_iterator>>
+	  std::string_view::const_iterator>>
       ,8,6
       > b64_iter;
 

--- a/src/rgw/rgw_b64.h
+++ b/src/rgw/rgw_b64.h
@@ -4,7 +4,6 @@
 #ifndef RGW_B64_H
 #define RGW_B64_H
 
-#include <boost/utility/string_ref.hpp>
 #include <boost/utility/string_view.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/binary_from_base64.hpp>

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -7,7 +7,6 @@
 #include <map>
 #include <sstream>
 
-#include <boost/utility/string_ref.hpp>
 #include <boost/format.hpp>
 
 #include "common/errno.h"
@@ -193,8 +192,8 @@ int rgw_bucket_parse_bucket_instance(const string& bucket_instance, string *buck
 int rgw_bucket_parse_bucket_key(CephContext *cct, const string& key,
                                 rgw_bucket *bucket, int *shard_id)
 {
-  boost::string_ref name{key};
-  boost::string_ref instance;
+  std::string_view name{key};
+  std::string_view instance;
 
   // split tenant/name
   auto pos = name.find('/');

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -4,7 +4,6 @@
 #include <string.h>
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/utility/string_ref.hpp>
 
 #include "civetweb/civetweb.h"
 #include "rgw_civetweb.h"
@@ -100,7 +99,7 @@ int RGWCivetWeb::init_env(CephContext *cct)
       return -EINVAL;
     }
 
-    const boost::string_ref name(header->name);
+    const std::string_view name(header->name);
     const auto& value = header->value;
 
     if (boost::algorithm::iequals(name, "content-length")) {
@@ -116,7 +115,7 @@ int RGWCivetWeb::init_env(CephContext *cct)
       explicit_conn_close = boost::algorithm::iequals(value, "close");
     }
 
-    static const boost::string_ref HTTP_{"HTTP_"};
+    static const std::string_view HTTP_{"HTTP_"};
 
     char buf[name.size() + HTTP_.size() + 1];
     auto dest = std::copy(std::begin(HTTP_), std::end(HTTP_), buf);
@@ -180,8 +179,8 @@ size_t RGWCivetWeb::send_100_continue()
   return sent;
 }
 
-size_t RGWCivetWeb::send_header(const boost::string_ref& name,
-                                const boost::string_ref& value)
+size_t RGWCivetWeb::send_header(std::string_view name,
+                                std::string_view value)
 {
   static constexpr char HEADER_SEP[] = ": ";
   static constexpr char HEADER_END[] = "\r\n";

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -32,8 +32,8 @@ public:
 
   size_t send_status(int status, const char *status_name) override;
   size_t send_100_continue() override;
-  size_t send_header(const boost::string_ref& name,
-                     const boost::string_ref& value) override;
+  size_t send_header(std::string_view name,
+                     std::string_view value) override;
   size_t send_content_length(uint64_t len) override;
   size_t complete_header() override;
 

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -4,8 +4,6 @@
 #include <set>
 #include <string>
 
-#include <boost/utility/string_ref.hpp>
-
 #include "rgw_frontend.h"
 #include "rgw_client_io_filters.h"
 #include "rgw_dmclock_sync_scheduler.h"
@@ -122,7 +120,7 @@ int RGWCivetWebFrontend::run()
   }
 
   /* Prepare options for CivetWeb. */
-  const std::set<boost::string_ref> rgw_opts = { "port", "prefix" };
+  const std::set<std::string_view> rgw_opts = { "port", "prefix" };
 
   std::vector<const char*> options;
 

--- a/src/rgw/rgw_client_io.h
+++ b/src/rgw/rgw_client_io.h
@@ -11,8 +11,6 @@
 #include <stdlib.h>
 #include <system_error>
 
-#include <boost/utility/string_ref.hpp>
-
 #include "include/types.h"
 #include "rgw_common.h"
 
@@ -103,9 +101,9 @@ public:
   /* Generate header. On success returns number of bytes generated for a direct
    * client of RadosGW. On failure throws rgw::io::Exception containing errno.
    *
-   * boost::string_ref is being used because of length it internally carries. */
-  virtual size_t send_header(const boost::string_ref& name,
-                             const boost::string_ref& value) = 0;
+   * std::string_view is being used because of length it internally carries. */
+  virtual size_t send_header(std::string_view name,
+                             std::string_view value) = 0;
 
   /* Inform a client about a content length. Takes number of bytes as @len.
    * On success returns number of bytes generated for a direct client of RadosGW.
@@ -215,8 +213,8 @@ public:
     return get_decoratee().send_100_continue();
   }
 
-  size_t send_header(const boost::string_ref& name,
-                     const boost::string_ref& value) override {
+  size_t send_header(std::string_view name,
+                     std::string_view value) override {
     return get_decoratee().send_header(name, value);
   }
 

--- a/src/rgw/rgw_client_io_filters.h
+++ b/src/rgw/rgw_client_io_filters.h
@@ -55,8 +55,8 @@ public:
     return sent;
   }
 
-  size_t send_header(const boost::string_ref& name,
-                     const boost::string_ref& value) override {
+  size_t send_header(std::string_view name,
+                     std::string_view value) override {
     const auto sent = DecoratedRestfulClient<T>::send_header(name, value);
     lsubdout(cct, rgw, 30) << "AccountingFilter::send_header: e="
         << (enabled ? "1" : "0") << ", sent=" << sent << ", total="
@@ -386,8 +386,8 @@ protected:
 
   std::vector<std::pair<std::string, std::string>> headers;
 
-  size_t send_header(const boost::string_ref& name,
-                     const boost::string_ref& value) override {
+  size_t send_header(std::string_view name,
+                     std::string_view value) override {
     switch (phase) {
     case ReorderState::RGW_EARLY_HEADERS:
     case ReorderState::RGW_STATUS_SEEN:

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -559,10 +559,9 @@ bool parse_iso8601(const char *s, struct tm *t, uint32_t *pns, bool extended_for
       str[len - 1] != 'Z')
     return false;
 
-  uint32_t ms;
   boost::string_view nsstr = str.substr(1,  len - 2);
-  int r = stringtoul(nsstr.to_string(), &ms);
-  if (r < 0)
+  auto ms = ceph::parse<uint32_t>({ nsstr.data(), nsstr.size() });
+  if (!ms)
     return false;
 
   if (!pns) {
@@ -585,7 +584,7 @@ bool parse_iso8601(const char *s, struct tm *t, uint32_t *pns, bool extended_for
     1 };
 
 
-  *pns = ms * mul_table[nsstr.size()];
+  *pns = *ms * mul_table[nsstr.size()];
 
   return true;
 }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -549,7 +549,7 @@ bool parse_iso8601(const char *s, struct tm *t, uint32_t *pns, bool extended_for
     dout(0) << "parse_iso8601 failed" << dendl;
     return false;
   }
-  const boost::string_view str = rgw_trim_whitespace(boost::string_view(p));
+  const std::string_view str = rgw_trim_whitespace(p);
   int len = str.size();
 
   if (len == 0 || (len == 1 && str[0] == 'Z'))
@@ -559,7 +559,7 @@ bool parse_iso8601(const char *s, struct tm *t, uint32_t *pns, bool extended_for
       str[len - 1] != 'Z')
     return false;
 
-  boost::string_view nsstr = str.substr(1,  len - 2);
+  std::string_view nsstr = str.substr(1,  len - 2);
   auto ms = ceph::parse<uint32_t>({ nsstr.data(), nsstr.size() });
   if (!ms)
     return false;
@@ -609,12 +609,12 @@ int parse_key_value(string& in_str, string& key, string& val)
   return parse_key_value(in_str, "=", key,val);
 }
 
-boost::optional<std::pair<boost::string_view, boost::string_view>>
-parse_key_value(const boost::string_view& in_str,
-                const boost::string_view& delim)
+boost::optional<std::pair<std::string_view, std::string_view>>
+parse_key_value(std::string_view in_str,
+                std::string_view delim)
 {
   const size_t pos = in_str.find(delim);
-  if (pos == boost::string_view::npos) {
+  if (pos == std::string_view::npos) {
     return boost::none;
   }
 
@@ -624,8 +624,8 @@ parse_key_value(const boost::string_view& in_str,
   return std::make_pair(key, val);
 }
 
-boost::optional<std::pair<boost::string_view, boost::string_view>>
-parse_key_value(const boost::string_view& in_str)
+boost::optional<std::pair<std::string_view, std::string_view>>
+parse_key_value(std::string_view in_str)
 {
   return parse_key_value(in_str, "=");
 }
@@ -711,7 +711,7 @@ using ceph::crypto::SHA256;
 /*
  * calculate the sha256 hash value of a given msg
  */
-sha256_digest_t calc_hash_sha256(const boost::string_view& msg)
+sha256_digest_t calc_hash_sha256(std::string_view msg)
 {
   sha256_digest_t hash;
 
@@ -1492,7 +1492,7 @@ static char hex_to_num(char c)
   return hex_table.to_num(c);
 }
 
-std::string url_decode(const boost::string_view& src_str, bool in_query)
+std::string url_decode(std::string_view src_str, bool in_query)
 {
   std::string dest_str;
   dest_str.reserve(src_str.length() + 1);
@@ -1611,9 +1611,9 @@ string rgw_trim_whitespace(const string& src)
   return src.substr(start, end - start + 1);
 }
 
-boost::string_view rgw_trim_whitespace(const boost::string_view& src)
+std::string_view rgw_trim_whitespace(std::string_view src)
 {
-  boost::string_view res = src;
+  std::string_view res = src;
 
   while (res.size() > 0 && std::isspace(res.front())) {
     res.remove_prefix(1);
@@ -1940,7 +1940,7 @@ uint32_t rgw_parse_op_type_list(std::string_view str)
   return parse_list_of_flags(op_type_mapping, str);
 }
 
-bool match_policy(boost::string_view pattern, boost::string_view input,
+bool match_policy(std::string_view pattern, std::string_view input,
                   uint32_t flag)
 {
   const uint32_t flag2 = flag & (MATCH_POLICY_ACTION|MATCH_POLICY_ARN) ?
@@ -1948,8 +1948,8 @@ bool match_policy(boost::string_view pattern, boost::string_view input,
   const bool colonblocks = !(flag & (MATCH_POLICY_RESOURCE |
 				     MATCH_POLICY_STRING));
 
-  const auto npos = boost::string_view::npos;
-  boost::string_view::size_type last_pos_input = 0, last_pos_pattern = 0;
+  const auto npos = std::string_view::npos;
+  std::string_view::size_type last_pos_input = 0, last_pos_pattern = 0;
   while (true) {
     auto cur_pos_input = colonblocks ? input.find(":", last_pos_input) : npos;
     auto cur_pos_pattern =

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2650,8 +2650,8 @@ static constexpr uint32_t MATCH_POLICY_STRING = 0x08;
 extern bool match_policy(boost::string_view pattern, boost::string_view input,
                          uint32_t flag);
 
-extern string camelcase_dash_http_attr(const string& orig);
-extern string lowercase_dash_http_attr(const string& orig);
+std::string camelcase_dash_http_attr(std::string_view orig);
+std::string lowercase_dash_http_attr(std::string_view orig);
 
 void rgw_setup_saved_curl_handles();
 void rgw_release_all_curl_handles();

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -608,7 +608,7 @@ class RGWUserCaps
   int add_cap(const string& cap);
   int remove_cap(const string& cap);
 public:
-  static int parse_cap_perm(const string& str, uint32_t *perm);
+  static uint32_t parse_cap_perm(std::string_view str);
   int add_from_string(const string& str);
   int remove_from_string(const string& str);
 
@@ -2640,7 +2640,7 @@ extern void calc_hash_sha256_update_stream(ceph::crypto::SHA256* hash,
 extern std::string calc_hash_sha256_close_stream(ceph::crypto::SHA256** phash);
 extern std::string calc_hash_sha256_restart_stream(ceph::crypto::SHA256** phash);
 
-extern int rgw_parse_op_type_list(const string& str, uint32_t *perm);
+uint32_t rgw_parse_op_type_list(std::string_view str);
 
 static constexpr uint32_t MATCH_POLICY_ACTION = 0x01;
 static constexpr uint32_t MATCH_POLICY_RESOURCE = 0x02;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -322,7 +322,7 @@ class RGWHTTPArgs {
   }
 
   /** Set the arguments; as received */
-  void set(const std::string& s) {
+  void set(std::string_view s) {
     has_resp_modifier = false;
     val_map.clear();
     sub_resources.clear();
@@ -2473,19 +2473,18 @@ extern void parse_csv_string(const string& ival, vector<string>& ovals);
 extern int parse_key_value(string& in_str, string& key, string& val);
 extern int parse_key_value(string& in_str, const char *delim, string& key, string& val);
 
-extern boost::optional<std::pair<boost::string_view, boost::string_view>>
-parse_key_value(const boost::string_view& in_str,
-                const boost::string_view& delim);
-extern boost::optional<std::pair<boost::string_view, boost::string_view>>
-parse_key_value(const boost::string_view& in_str);
+extern boost::optional<std::pair<std::string_view, std::string_view>>
+parse_key_value(std::string_view in_str,
+                std::string_view delim);
+extern boost::optional<std::pair<std::string_view, std::string_view>>
+parse_key_value(std::string_view in_str);
 
 
 /** time parsing */
 extern int parse_time(const char *time_str, real_time *time);
 extern bool parse_rfc2616(const char *s, struct tm *t);
 extern bool parse_iso8601(const char *s, struct tm *t, uint32_t *pns = NULL, bool extended_format = true);
-extern string rgw_trim_whitespace(const string& src);
-extern boost::string_view rgw_trim_whitespace(const boost::string_view& src);
+std::string_view rgw_trim_whitespace(std::string_view src);
 extern string rgw_trim_quotes(const string& val);
 
 extern void rgw_to_iso8601(const real_time& t, char *dest, int buf_size);
@@ -2560,7 +2559,7 @@ extern bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp, st
 /** Convert an input URL into a sane object name
  * by converting %-escaped strings into characters, etc*/
 extern void rgw_uri_escape_char(char c, string& dst);
-extern std::string url_decode(const boost::string_view& src_str,
+extern std::string url_decode(std::string_view src_str,
                               bool in_query = false);
 extern void url_encode(const std::string& src, string& dst,
                        bool encode_slash = true);
@@ -2570,7 +2569,7 @@ extern void calc_hmac_sha1(const char *key, int key_len,
                           const char *msg, int msg_len, char *dest);
 
 static inline sha1_digest_t
-calc_hmac_sha1(const boost::string_view& key, const boost::string_view& msg) {
+calc_hmac_sha1(std::string_view key, std::string_view msg) {
   sha1_digest_t dest;
   calc_hmac_sha1(key.data(), key.size(), msg.data(), msg.size(),
                  reinterpret_cast<char*>(dest.v));
@@ -2592,7 +2591,7 @@ calc_hmac_sha256(const char *key, const int key_len,
 }
 
 static inline sha256_digest_t
-calc_hmac_sha256(const boost::string_view& key, const boost::string_view& msg) {
+calc_hmac_sha256(std::string_view key, std::string_view msg) {
   sha256_digest_t dest;
   calc_hmac_sha256(key.data(), key.size(),
                    msg.data(), msg.size(),
@@ -2602,7 +2601,7 @@ calc_hmac_sha256(const boost::string_view& key, const boost::string_view& msg) {
 
 static inline sha256_digest_t
 calc_hmac_sha256(const sha256_digest_t &key,
-                 const boost::string_view& msg) {
+                 std::string_view msg) {
   sha256_digest_t dest;
   calc_hmac_sha256(reinterpret_cast<const char*>(key.v), sha256_digest_t::SIZE,
                    msg.data(), msg.size(),
@@ -2612,7 +2611,7 @@ calc_hmac_sha256(const sha256_digest_t &key,
 
 static inline sha256_digest_t
 calc_hmac_sha256(const std::vector<unsigned char>& key,
-                 const boost::string_view& msg) {
+                 std::string_view msg) {
   sha256_digest_t dest;
   calc_hmac_sha256(reinterpret_cast<const char*>(key.data()), key.size(),
                    msg.data(), msg.size(),
@@ -2623,7 +2622,7 @@ calc_hmac_sha256(const std::vector<unsigned char>& key,
 template<size_t KeyLenN>
 static inline sha256_digest_t
 calc_hmac_sha256(const std::array<unsigned char, KeyLenN>& key,
-                 const boost::string_view& msg) {
+                 std::string_view msg) {
   sha256_digest_t dest;
   calc_hmac_sha256(reinterpret_cast<const char*>(key.data()), key.size(),
                    msg.data(), msg.size(),
@@ -2631,7 +2630,7 @@ calc_hmac_sha256(const std::array<unsigned char, KeyLenN>& key,
   return dest;
 }
 
-extern sha256_digest_t calc_hash_sha256(const boost::string_view& msg);
+extern sha256_digest_t calc_hash_sha256(std::string_view msg);
 
 extern ceph::crypto::SHA256* calc_hash_sha256_open_stream();
 extern void calc_hash_sha256_update_stream(ceph::crypto::SHA256* hash,
@@ -2647,7 +2646,7 @@ static constexpr uint32_t MATCH_POLICY_RESOURCE = 0x02;
 static constexpr uint32_t MATCH_POLICY_ARN = 0x04;
 static constexpr uint32_t MATCH_POLICY_STRING = 0x08;
 
-extern bool match_policy(boost::string_view pattern, boost::string_view input,
+extern bool match_policy(std::string_view pattern, std::string_view input,
                          uint32_t flag);
 
 std::string camelcase_dash_http_attr(std::string_view orig);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1686,9 +1686,12 @@ struct rgw_obj_key {
 
   rgw_obj_key() {}
   // cppcheck-suppress noExplicitConstructor
-  rgw_obj_key(const string& n) : name(n) {}
-  rgw_obj_key(const string& n, const string& i) : name(n), instance(i) {}
-  rgw_obj_key(const string& n, const string& i, const string& _ns) : name(n), instance(i), ns(_ns) {}
+  rgw_obj_key(string n) : name(std::move(n)) {}
+  rgw_obj_key(string n, string i) : name(std::move(n)),
+				    instance(std::move(i)) {}
+  rgw_obj_key(string n, string i, string _ns) : name(std::move(n)),
+						instance(std::move(i)),
+						ns(std::move(_ns)) {}
 
   rgw_obj_key(const rgw_obj_index_key& k) {
     parse_index_key(k.name, &name, &ns);

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -22,7 +22,7 @@
 
 #include "include/types.h"
 #include "common/debug.h"
-#include "include/str_list.h"
+#include "common/str_util.h"
 #include "common/Formatter.h"
 #include "common/str_util.h"
 
@@ -85,10 +85,10 @@ static bool is_string_in_set(const set<string, std::less<>>& s,
   for(auto it = s.begin(); it != s.end(); ++it) {
     size_t off;
     if ((off = (*it).find("*"))!=string::npos) {
-      list<string> ssplit;
+      std::deque<string> ssplit;
       unsigned flen = 0;
 
-      get_str_list((*it), "* \t", ssplit);
+      ceph::substr_insert((*it), std::back_inserter(ssplit), "* \t");
       if (off != 0) {
         string sl = ssplit.front();
         flen = sl.length();
@@ -99,7 +99,7 @@ static bool is_string_in_set(const set<string, std::less<>>& s,
       }
       if (off != ((*it).length() - 1)) {
         string sl = ssplit.front();
-        dout(10) << "Finding " << sl << ", in " << h 
+        dout(10) << "Finding " << sl << ", in " << h
           << ", at offset not less than " << flen << dendl;
         if (h.size() < sl.size() ||
 	    h.compare((h.size() - sl.size()), sl.size(), sl) != 0)
@@ -137,7 +137,7 @@ bool RGWCORSRule::is_header_allowed(std::string_view h) {
 
 void RGWCORSRule::format_exp_headers(string& s) {
   s = "";
-  for(list<string>::iterator it = exposable_hdrs.begin();
+  for(auto it = exposable_hdrs.begin();
       it != exposable_hdrs.end(); ++it) {
       if (s.length() > 0)
         s.append(",");

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -40,17 +40,17 @@ class RGWCORSRule
 protected:
   uint32_t       max_age;
   uint8_t        allowed_methods;
-  std::string         id;
+  std::string    id;
   std::set<string, std::less<>> allowed_hdrs; /* If you change this, you need to discard lowercase_allowed_hdrs */
   std::set<string, std::less<>> lowercase_allowed_hdrs; /* Not built until needed in RGWCORSRule::is_header_allowed */
   std::set<string, std::less<>> allowed_origins;
-  std::list<string> exposable_hdrs;
+  std::vector<string> exposable_hdrs;
 
 public:
   RGWCORSRule() : max_age(CORS_MAX_AGE_INVALID),allowed_methods(0) {}
   RGWCORSRule(const std::set<string, std::less<>>& o,
 	      const std::set<string, std::less<>>& h,
-              const std::list<string>& e, uint8_t f, uint32_t a)
+              const std::vector<string>& e, uint8_t f, uint32_t a)
       :max_age(a),
        allowed_methods(f),
        allowed_hdrs(h),

--- a/src/rgw/rgw_cors_s3.cc
+++ b/src/rgw/rgw_cors_s3.cc
@@ -65,8 +65,7 @@ void RGWCORSRule_S3::to_xml(XMLFormatter& f) {
     f.dump_unsigned("MaxAgeSeconds", max_age);
   }
   /*ExposeHeader*/
-  for(list<string>::iterator it = exposable_hdrs.begin(); 
-      it != exposable_hdrs.end(); ++it) {
+  for(auto it = exposable_hdrs.begin(); it != exposable_hdrs.end(); ++it) {
     f.dump_string("ExposeHeader", *it);
   }
   f.close_section();

--- a/src/rgw/rgw_cors_swift.h
+++ b/src/rgw/rgw_cors_swift.h
@@ -35,7 +35,8 @@ class RGWCORSConfiguration_SWIFT : public RGWCORSConfiguration
 		    std::optional<std::string_view> expose_headers,
 		    std::optional<std::string_view> max_age) {
       std::set<string, std::less<>> o, h, oc;
-      std::list<string> e;
+      std::vector<std::string> e;
+
       unsigned long a = CORS_MAX_AGE_INVALID;
       uint8_t flags = RGW_CORS_ALL;
 

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -588,7 +588,8 @@ int RGWAsyncFetchRemoteObj::_send_request()
   rgw_obj dest_obj(bucket_info.bucket, dest_key.value_or(key));
 
   std::optional<uint64_t> bytes_transferred;
-  int r = store->getRados()->fetch_remote_obj(obj_ctx,
+  int r = store->getRados()->fetch_remote_obj(
+                       obj_ctx,
                        rgw_user(user_id),
                        NULL, /* req_info */
                        source_zone,
@@ -602,8 +603,8 @@ int RGWAsyncFetchRemoteObj::_send_request()
                        NULL, /* const real_time* mod_ptr, */
                        NULL, /* const real_time* unmod_ptr, */
                        false, /* high precision time */
-                       NULL, /* const char *if_match, */
-                       NULL, /* const char *if_nomatch, */
+		       std::nullopt, /* optional<string_view> if_match, */
+		       std::nullopt, /* optional<string_view> if_nomatch, */
                        RGWRados::ATTRSMOD_NONE,
                        copy_if_newer,
                        attrs,

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1,22 +1,29 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
 /**
  * Crypto filters for Put/Post/Get operations.
  */
 
-#include <rgw/rgw_op.h>
-#include <rgw/rgw_crypt.h>
-#include <auth/Crypto.h>
-#include <rgw/rgw_b64.h>
-#include <rgw/rgw_rest_s3.h>
-#include "include/ceph_assert.h"
 #include <boost/utility/string_view.hpp>
-#include "crypto/crypto_accel.h"
-#include "crypto/crypto_plugin.h"
-#include "rgw/rgw_kms.h"
+
+#include <fmt/format.h>
 
 #include <openssl/evp.h>
+
+#include "include/ceph_assert.h"
+
+#include "auth/Crypto.h"
+
+#include "crypto/crypto_accel.h"
+#include "crypto/crypto_plugin.h"
+
+#include "rgw/rgw_op.h"
+#include "rgw/rgw_crypt.h"
+#include "rgw/rgw_b64.h"
+#include "rgw/rgw_rest_s3.h"
+#include "rgw/rgw_kms.h"
+
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -579,7 +586,7 @@ std::string create_random_key_selector(CephContext * const cct) {
 
 static inline void set_attr(map<string, bufferlist>& attrs,
                             const char* key,
-                            boost::string_view value)
+                            std::string_view value)
 {
   bufferlist bl;
   bl.append(value.data(), value.size());
@@ -618,7 +625,7 @@ static const crypt_option_names crypt_options[] = {
     {"HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID",      "x-amz-server-side-encryption-aws-kms-key-id"},
 };
 
-static boost::string_view get_crypt_attribute(
+static std::string_view get_crypt_attribute(
     const RGWEnv* env,
     std::map<std::string,
              RGWPostObj_ObjStore::post_form_part,
@@ -632,16 +639,16 @@ static boost::string_view get_crypt_attribute(
     auto iter
       = parts->find(crypt_options[option].post_part_name);
     if (iter == parts->end())
-      return boost::string_view();
+      return std::string_view();
     bufferlist& data = iter->second.data;
-    boost::string_view str = boost::string_view(data.c_str(), data.length());
+    std::string_view str = std::string_view(data.c_str(), data.length());
     return rgw_trim_whitespace(str);
   } else {
     const char* hdr = env->get(crypt_options[option].http_header_name, nullptr);
     if (hdr != nullptr) {
-      return boost::string_view(hdr);
+      return std::string_view(hdr);
     } else {
-      return boost::string_view();
+      return std::string_view();
     }
   }
 }
@@ -658,7 +665,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
   int res = 0;
   crypt_http_responses.clear();
   {
-    boost::string_view req_sse_ca =
+    std::string_view req_sse_ca =
         get_crypt_attribute(s->info.env, parts, X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
     if (! req_sse_ca.empty()) {
       if (req_sse_ca != "AES256") {
@@ -694,7 +701,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         return -EINVAL;
       }
 
-      boost::string_view keymd5 =
+      std::string_view keymd5 =
           get_crypt_attribute(s->info.env, parts, X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
 
       std::string keymd5_bin;
@@ -737,10 +744,10 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
       }
 
       crypt_http_responses["x-amz-server-side-encryption-customer-algorithm"] = "AES256";
-      crypt_http_responses["x-amz-server-side-encryption-customer-key-MD5"] = keymd5.to_string();
+      crypt_http_responses["x-amz-server-side-encryption-customer-key-MD5"] = std::string(keymd5);
       return 0;
     } else {
-      boost::string_view customer_key =
+      std::string_view customer_key =
           get_crypt_attribute(s->info.env, parts, X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY);
       if (!customer_key.empty()) {
         ldout(s->cct, 5) << "ERROR: SSE-C encryption request is missing the header "
@@ -751,7 +758,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         return -EINVAL;
       }
 
-      boost::string_view customer_key_md5 =
+      std::string_view customer_key_md5 =
           get_crypt_attribute(s->info.env, parts, X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
       if (!customer_key_md5.empty()) {
         ldout(s->cct, 5) << "ERROR: SSE-C encryption request is missing the header "
@@ -764,7 +771,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
     }
 
     /* AMAZON server side encryption with KMS (key management service) */
-    boost::string_view req_sse =
+    std::string_view req_sse =
         get_crypt_attribute(s->info.env, parts, X_AMZ_SERVER_SIDE_ENCRYPTION);
     if (! req_sse.empty()) {
 
@@ -775,7 +782,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
       }
 
       if (req_sse == "aws:kms") {
-	boost::string_view key_id =
+	std::string_view key_id =
           get_crypt_attribute(s->info.env, parts, X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID);
 	if (key_id.empty()) {
 	  ldout(s->cct, 5) << "ERROR: not provide a valid key id" << dendl;
@@ -789,7 +796,9 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
 	res = get_actual_key_from_kms(s->cct, key_id, key_selector, actual_key);
 	if (res != 0) {
 	  ldout(s->cct, 5) << "ERROR: failed to retrieve actual key from key_id: " << key_id << dendl;
-	  s->err.message = "Failed to retrieve the actual key, kms-keyid: " + key_id.to_string();
+	  s->err.message =
+	    fmt::format("Failed to retrieve the actual key, kms-keyid: {}",
+			key_id);
 	  return res;
 	}
 	if (actual_key.size() != AES_256_KEYSIZE) {
@@ -810,7 +819,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
 	actual_key.replace(0, actual_key.length(), actual_key.length(), '\000');
 
 	crypt_http_responses["x-amz-server-side-encryption"] = "aws:kms";
-	crypt_http_responses["x-amz-server-side-encryption-aws-kms-key-id"] = key_id.to_string();
+	crypt_http_responses["x-amz-server-side-encryption-aws-kms-key-id"] =std::string(key_id);
 	return 0;
       } else if (req_sse == "AES256") {
 	/* if a default encryption key was provided, we will use it for SSE-S3 */
@@ -823,7 +832,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
       }
     } else {
       /* x-amz-server-side-encryption not present or empty */
-      boost::string_view key_id =
+      std::string_view key_id =
 	get_crypt_attribute(s->info.env, parts,
 			    X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID);
       if (!key_id.empty()) {

--- a/src/rgw/rgw_crypt_sanitize.cc
+++ b/src/rgw/rgw_crypt_sanitize.cc
@@ -65,7 +65,7 @@ std::ostream& operator<<(std::ostream& out, const s3_policy& x) {
 
 std::ostream& operator<<(std::ostream& out, const auth& x) {
   if (g_ceph_context->_conf->rgw_crypt_suppress_logs &&
-      x.s->info.env->get(HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY, nullptr) != nullptr)
+      x.s->info.env->exists(HTTP_X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
   {
     out << suppression_message;
     return out;

--- a/src/rgw/rgw_crypt_sanitize.h
+++ b/src/rgw/rgw_crypt_sanitize.h
@@ -15,10 +15,10 @@ namespace crypt_sanitize {
  * Temporary container for suppressing printing if variable contains secret key.
  */
 struct env {
-  boost::string_ref name;
-  boost::string_ref value;
+  std::string_view name;
+  std::string_view value;
 
-  env(boost::string_ref name, boost::string_ref value)
+  env(std::string_view name, std::string_view value)
   : name(name), value(value) {}
 };
 
@@ -26,9 +26,9 @@ struct env {
  * Temporary container for suppressing printing if aws meta attributes contains secret key.
  */
 struct x_meta_map {
-  boost::string_ref name;
-  boost::string_ref value;
-  x_meta_map(boost::string_ref name, boost::string_ref value)
+  std::string_view name;
+  std::string_view value;
+  x_meta_map(std::string_view name, std::string_view value)
   : name(name), value(value) {}
 };
 
@@ -36,9 +36,9 @@ struct x_meta_map {
  * Temporary container for suppressing printing if s3_policy calculation variable contains secret key.
  */
 struct s3_policy {
-  boost::string_ref name;
-  boost::string_ref value;
-  s3_policy(boost::string_ref name, boost::string_ref value)
+  std::string_view name;
+  std::string_view value;
+  s3_policy(std::string_view name, std::string_view value)
   : name(name), value(value) {}
 };
 
@@ -47,8 +47,8 @@ struct s3_policy {
  */
 struct auth {
   const req_state* const s;
-  boost::string_ref value;
-  auth(const req_state* const s, boost::string_ref value)
+  std::string_view value;
+  auth(const req_state* const s, std::string_view value)
   : s(s), value(value) {}
 };
 

--- a/src/rgw/rgw_crypt_sanitize.h
+++ b/src/rgw/rgw_crypt_sanitize.h
@@ -56,8 +56,8 @@ struct auth {
  * Temporary container for suppressing printing if log made from civetweb may contain secret key.
  */
 struct log_content {
-  const boost::string_view buf;
-  explicit log_content(const boost::string_view buf)
+  const std::string_view buf;
+  explicit log_content(const std::string_view buf)
   : buf(buf) {}
 };
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1,8 +1,6 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
-#include <boost/utility/string_ref.hpp>
-
 #include "common/ceph_json.h"
 #include "common/RWLock.h"
 #include "common/RefCountedObj.h"

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -54,8 +54,8 @@ size_t RGWFCGX::send_100_continue()
   return sent;
 }
 
-size_t RGWFCGX::send_header(const boost::string_ref& name,
-                            const boost::string_ref& value)
+size_t RGWFCGX::send_header(std::string_view name,
+                            std::string_view value)
 {
   static constexpr char HEADER_SEP[] = ": ";
   static constexpr char HEADER_END[] = "\r\n";

--- a/src/rgw/rgw_fcgi.h
+++ b/src/rgw/rgw_fcgi.h
@@ -30,8 +30,8 @@ public:
   int init_env(CephContext* cct) override;
   size_t send_status(int status, const char* status_name) override;
   size_t send_100_continue() override;
-  size_t send_header(const boost::string_ref& name,
-                     const boost::string_ref& value) override;
+  size_t send_header(std::string_view name,
+                     std::string_view value) override;
   size_t send_content_length(uint64_t len) override;
   size_t complete_header() override;
 

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -7,9 +7,13 @@
 #include "common/Formatter.h"
 
 #include <list>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <ostream>
+
+#include "common/Formatter.h"
+
+#include "cls/rgw/cls_rgw_types.h"
 
 struct plain_stack_entry {
   int size;
@@ -20,7 +24,7 @@ struct plain_stack_entry {
  * FIXME: This was a hack to send certain swift messages.
  * There is a much better way to do this.
  */
-class RGWFormatter_Plain : public Formatter {
+class RGWFormatter_Plain : public ceph::Formatter {
   void reset_buf();
 public:
   explicit RGWFormatter_Plain(bool use_kv = false);
@@ -30,7 +34,7 @@ public:
   void output_header() override {};
   void output_footer() override {};
   void enable_line_break() override {};
-  void flush(ostream& os) override;
+  void flush(std::ostream& os) override;
   void reset() override;
 
   void open_array_section(const char *name) override;

--- a/src/rgw/rgw_frontend.cc
+++ b/src/rgw/rgw_frontend.cc
@@ -4,7 +4,6 @@
 #include <signal.h>
 
 #include "rgw_frontend.h"
-#include "include/str_list.h"
 
 #include "include/ceph_assert.h"
 

--- a/src/rgw/rgw_frontend.cc
+++ b/src/rgw/rgw_frontend.cc
@@ -32,11 +32,12 @@ int RGWFrontendConfig::parse_config(const string& config,
       continue;
     }
 
-    int ret = parse_key_value(entry, key, val);
-    if (ret < 0) {
+    auto kv = parse_key_value(entry);
+    if (!kv) {
       cerr << "ERROR: can't parse " << entry << std::endl;
-      return ret;
+      return -EINVAL;
     }
+    std::tie(key, val) = std::move(*kv);
 
     dout(0) << "framework conf key: " << key << ", val: " << val << dendl;
     config_map.emplace(std::move(key), std::move(val));

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -4,8 +4,6 @@
 #include "include/compat.h"
 #include "common/errno.h"
 
-#include <boost/utility/string_ref.hpp>
-
 #include <curl/curl.h>
 #include <curl/easy.h>
 #include <curl/multi.h>
@@ -587,12 +585,12 @@ RGWHTTPClient::~RGWHTTPClient()
 
 int RGWHTTPHeadersCollector::receive_header(void * const ptr, const size_t len)
 {
-  const boost::string_ref header_line(static_cast<const char *>(ptr), len);
+  const std::string_view header_line(static_cast<const char *>(ptr), len);
 
   /* We're tokening the line that way due to backward compatibility. */
   const size_t sep_loc = header_line.find_first_of(" \t:");
 
-  if (boost::string_ref::npos == sep_loc) {
+  if (std::string_view::npos == sep_loc) {
     /* Wrongly formatted header? Just skip it. */
     return 0;
   }
@@ -609,8 +607,8 @@ int RGWHTTPHeadersCollector::receive_header(void * const ptr, const size_t len)
   const size_t val_loc_s = value_part.find_first_not_of(' ');
   const size_t val_loc_e = value_part.find_first_of("\r\n");
 
-  if (boost::string_ref::npos == val_loc_s ||
-      boost::string_ref::npos == val_loc_e) {
+  if (std::string_view::npos == val_loc_s ||
+      std::string_view::npos == val_loc_e) {
     /* Empty value case. */
     found_headers.emplace(name, header_value_t());
   } else {

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -371,7 +371,7 @@ bool ParseState::key(const char* s, size_t l) {
   bool ifexists = false;
   if (w->id == TokenID::Condition && w->kind == TokenKind::statement) {
     static constexpr char IfExists[] = "IfExists";
-    if (boost::algorithm::ends_with(boost::string_view{s, l}, IfExists)) {
+    if (boost::algorithm::ends_with(std::string_view{s, l}, IfExists)) {
       ifexists = true;
       token_len -= sizeof(IfExists)-1;
     }

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -15,7 +15,6 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/optional.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/utility/string_ref.hpp>
 #include <boost/variant.hpp>
 
 #include "common/ceph_time.h"
@@ -285,7 +284,11 @@ struct Condition {
 				  * 1000000000)));
       }
 
-      return from_iso_8601(boost::string_ref(s), false);
+      auto i = from_iso_8601(s, false);
+      if (!i)
+	return boost::none;
+      else
+	return *i;
     } catch (const std::logic_error& e) {
       return boost::none;
     }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1519,24 +1519,15 @@ void rgw_bucket_shard_sync_info::dump(Formatter *f) const
   encode_json("inc_marker", inc_marker, f);
 }
 
-/* This utility function shouldn't conflict with the overload of std::to_string
- * provided by string_ref since Boost 1.54 as it's defined outside of the std
- * namespace. I hope we'll remove it soon - just after merging the Matt's PR
- * for bundled Boost. It would allow us to forget that CentOS 7 has Boost 1.53. */
-static inline std::string to_string(const boost::string_ref& s)
-{
-  return std::string(s.data(), s.length());
-}
-
 void rgw::keystone::AdminTokenRequestVer2::dump(Formatter* const f) const
 {
   f->open_object_section("token_request");
     f->open_object_section("auth");
       f->open_object_section("passwordCredentials");
-        encode_json("username", ::to_string(conf.get_admin_user()), f);
-        encode_json("password", ::to_string(conf.get_admin_password()), f);
+        encode_json("username", conf.get_admin_user(), f);
+        encode_json("password", conf.get_admin_password(), f);
       f->close_section();
-      encode_json("tenantName", ::to_string(conf.get_admin_tenant()), f);
+      encode_json("tenantName", conf.get_admin_tenant(), f);
     f->close_section();
   f->close_section();
 }
@@ -1552,22 +1543,22 @@ void rgw::keystone::AdminTokenRequestVer3::dump(Formatter* const f) const
         f->open_object_section("password");
           f->open_object_section("user");
             f->open_object_section("domain");
-              encode_json("name", ::to_string(conf.get_admin_domain()), f);
+              encode_json("name", conf.get_admin_domain(), f);
             f->close_section();
-            encode_json("name", ::to_string(conf.get_admin_user()), f);
-            encode_json("password", ::to_string(conf.get_admin_password()), f);
+            encode_json("name", conf.get_admin_user(), f);
+            encode_json("password", conf.get_admin_password(), f);
           f->close_section();
         f->close_section();
       f->close_section();
       f->open_object_section("scope");
         f->open_object_section("project");
           if (! conf.get_admin_project().empty()) {
-            encode_json("name", ::to_string(conf.get_admin_project()), f);
+            encode_json("name", conf.get_admin_project(), f);
           } else {
-            encode_json("name", ::to_string(conf.get_admin_tenant()), f);
+            encode_json("name", conf.get_admin_tenant(), f);
           }
           f->open_object_section("domain");
-            encode_json("name", ::to_string(conf.get_admin_domain()), f);
+            encode_json("name", conf.get_admin_domain(), f);
           f->close_section();
         f->close_section();
       f->close_section();

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -560,7 +560,7 @@ void RGWUserInfo::decode_json(JSONObj *obj)
 
   string mask_str;
   JSONDecoder::decode_json("op_mask", mask_str, obj);
-  rgw_parse_op_type_list(mask_str, &op_mask);
+  op_mask = rgw_parse_op_type_list(mask_str);
 
   bool sys = false;
   JSONDecoder::decode_json("system", sys, obj);

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -11,7 +11,6 @@
 #include "common/errno.h"
 #include "common/ceph_json.h"
 #include "include/types.h"
-#include "include/str_list.h"
 
 #include "rgw_common.h"
 #include "rgw_keystone.h"

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -7,7 +7,6 @@
 #include <type_traits>
 
 #include <boost/optional.hpp>
-#include <boost/utility/string_ref.hpp>
 
 #include "rgw_common.h"
 #include "rgw_http_client.h"
@@ -45,11 +44,11 @@ public:
   virtual ApiVersion get_api_version() const noexcept = 0;
 
   virtual std::string get_admin_token() const noexcept = 0;
-  virtual boost::string_ref get_admin_user() const noexcept = 0;
+  virtual std::string_view get_admin_user() const noexcept = 0;
   virtual std::string get_admin_password() const noexcept = 0;
-  virtual boost::string_ref get_admin_tenant() const noexcept = 0;
-  virtual boost::string_ref get_admin_project() const noexcept = 0;
-  virtual boost::string_ref get_admin_domain() const noexcept = 0;
+  virtual std::string_view get_admin_tenant() const noexcept = 0;
+  virtual std::string_view get_admin_project() const noexcept = 0;
+  virtual std::string_view get_admin_domain() const noexcept = 0;
 };
 
 class CephCtxConfig : public Config {
@@ -70,21 +69,21 @@ public:
 
   std::string get_admin_token() const noexcept override;
 
-  boost::string_ref get_admin_user() const noexcept override {
+  std::string_view get_admin_user() const noexcept override {
     return g_ceph_context->_conf->rgw_keystone_admin_user;
   }
 
   std::string get_admin_password() const noexcept override;
 
-  boost::string_ref get_admin_tenant() const noexcept override {
+  std::string_view get_admin_tenant() const noexcept override {
     return g_ceph_context->_conf->rgw_keystone_admin_tenant;
   }
 
-  boost::string_ref get_admin_project() const noexcept override {
+  std::string_view get_admin_project() const noexcept override {
     return g_ceph_context->_conf->rgw_keystone_admin_project;
   }
 
-  boost::string_ref get_admin_domain() const noexcept override {
+  std::string_view get_admin_domain() const noexcept override {
     return g_ceph_context->_conf->rgw_keystone_admin_domain;
   }
 };

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -41,8 +41,8 @@ static void concat_url(std::string &url, std::string path) {
 }
 
 static int get_actual_key_from_conf(CephContext *cct,
-                                    boost::string_view key_id,
-                                    boost::string_view key_selector,
+                                    std::string_view key_id,
+                                    std::string_view key_selector,
                                     std::string& actual_key)
 {
   int res = 0;
@@ -84,7 +84,7 @@ static int get_actual_key_from_conf(CephContext *cct,
 }
 
 static int request_key_from_barbican(CephContext *cct,
-                                     boost::string_view key_id,
+                                     std::string_view key_id,
                                      const std::string& barbican_token,
                                      std::string& actual_key) {
   int res;
@@ -123,7 +123,7 @@ static int request_key_from_barbican(CephContext *cct,
 }
 
 static int get_actual_key_from_barbican(CephContext *cct,
-                                        boost::string_view key_id,
+                                        std::string_view key_id,
                                         std::string& actual_key)
 {
   int res = 0;
@@ -142,7 +142,7 @@ static int get_actual_key_from_barbican(CephContext *cct,
 }
 
 static int request_key_from_vault_with_token(CephContext *cct,
-                                             boost::string_view key_id,
+                                             std::string_view key_id,
                                              bufferlist *secret_bl)
 {
   std::string token_file, secret_url, vault_token;
@@ -213,7 +213,7 @@ static int request_key_from_vault_with_token(CephContext *cct,
 }
 
 static int get_actual_key_from_vault(CephContext *cct,
-                                     boost::string_view key_id,
+                                     std::string_view key_id,
                                      std::string& actual_key)
 {
   int res = 0;
@@ -267,8 +267,8 @@ static int get_actual_key_from_vault(CephContext *cct,
 }
 
 int get_actual_key_from_kms(CephContext *cct,
-                            boost::string_view key_id,
-                            boost::string_view key_selector,
+                            std::string_view key_id,
+                            std::string_view key_selector,
                             std::string& actual_key)
 {
   std::string kms_backend;

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -26,8 +26,8 @@ static const std::string RGW_SSE_KMS_VAULT_AUTH_AGENT = "agent";
  * \return
  */
 int get_actual_key_from_kms(CephContext *cct,
-                            boost::string_view key_id,
-                            boost::string_view key_selector,
+                            std::string_view key_id,
+                            std::string_view key_selector,
                             std::string& actual_key);
 
 #endif

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -366,7 +366,7 @@ WRITE_CLASS_ENCODER(LCRule)
 struct transition_action
 {
   int days;
-  boost::optional<ceph::real_time> date;
+  std::optional<ceph::real_time> date;
   string storage_class;
   transition_action() : days(0) {}
 };
@@ -380,7 +380,7 @@ struct lc_op
   int expiration{0};
   int noncur_expiration{0};
   int mp_expiration{0};
-  boost::optional<ceph::real_time> expiration_date;
+  std::optional<ceph::real_time> expiration_date;
   boost::optional<RGWObjTags> obj_tags;
   map<string, transition_action> transitions;
   map<string, transition_action> noncur_transitions;

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -16,8 +16,8 @@
 
 static bool check_date(const string& _date)
 {
-  boost::optional<ceph::real_time> date = ceph::from_iso_8601(_date);
-  if (boost::none == date) {
+  auto date = ceph::from_iso_8601(_date);
+  if (!date) {
     return false;
   }
   struct timespec time = ceph::real_clock::to_timespec(*date);

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -9,7 +9,6 @@
 #include <iostream>
 #include <include/types.h>
 
-#include "include/str_list.h"
 #include "rgw_lc.h"
 #include "rgw_xml.h"
 #include "rgw_tag_s3.h"

--- a/src/rgw/rgw_loadgen.cc
+++ b/src/rgw/rgw_loadgen.cc
@@ -111,8 +111,8 @@ size_t RGWLoadGenIO::send_100_continue()
   return 0;
 }
 
-size_t RGWLoadGenIO::send_header(const boost::string_ref& name,
-                                 const boost::string_ref& value)
+size_t RGWLoadGenIO::send_header(std::string_view name,
+                                 std::string_view value)
 {
   return 0;
 }

--- a/src/rgw/rgw_loadgen.h
+++ b/src/rgw/rgw_loadgen.h
@@ -50,8 +50,8 @@ public:
 
   size_t send_status(int status, const char *status_name) override;
   size_t send_100_continue() override;
-  size_t send_header(const boost::string_ref& name,
-                     const boost::string_ref& value) override;
+  size_t send_header(std::string_view name,
+                     std::string_view value) override;
   size_t complete_header() override;
   size_t send_content_length(uint64_t len) override;
 

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -21,9 +21,9 @@
 
 static void set_param_str(struct req_state *s, const char *name, string& str)
 {
-  const char *p = s->info.env->get(name);
+  auto p = s->info.env->get(name);
   if (p)
-    str = p;
+    str = *p;
 }
 
 string render_log_object_name(const string& format,
@@ -367,27 +367,26 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
     set_param_str(s, "HTTP_REFERER", entry.referrer);
 
   std::string uri;
-  if (s->info.env->exists("REQUEST_METHOD")) {
-    uri.append(s->info.env->get("REQUEST_METHOD"));
+  if (auto rm = s->info.env->get("REQUEST_METHOD")) {
+    uri.append(*rm);
     uri.append(" ");
   }
 
-  if (s->info.env->exists("REQUEST_URI")) {
-    uri.append(s->info.env->get("REQUEST_URI"));
+  if (auto x = s->info.env->get("REQUEST_URI")) {
+    uri.append(*x);
   }
 
-  if (s->info.env->exists("QUERY_STRING")) {
-    const char* qs = s->info.env->get("QUERY_STRING");
-    if(qs && (*qs != '\0')) {
+  if (auto qs = s->info.env->get("QUERY_STRING")) {
+    if (!qs->empty()) {
       uri.append("?");
-      uri.append(qs);
+      uri.append(*qs);
     }
   }
 
-  if (s->info.env->exists("HTTP_VERSION")) {
+  if (auto hv = s->info.env->get("HTTP_VERSION")) {
     uri.append(" ");
     uri.append("HTTP/");
-    uri.append(s->info.env->get("HTTP_VERSION"));
+    uri.append(*hv);
   }
 
   entry.uri = std::move(uri);

--- a/src/rgw/rgw_notify_event_type.cc
+++ b/src/rgw/rgw_notify_event_type.cc
@@ -1,8 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
 // vim: ts=8 sw=2 smarttab
 
+#include "common/str_util.h"
 #include "rgw_notify_event_type.h"
-#include "include/str_list.h"
 
 namespace rgw::notify {
 
@@ -75,8 +75,11 @@ bool operator==(EventType lhs, EventType rhs) {
 
 void from_string_list(const std::string& string_list, EventTypeList& event_list) {
   event_list.clear();
-  ceph::for_each_substr(string_list, ",", [&event_list] (auto token) {
-    event_list.push_back(rgw::notify::from_string(std::string(token.begin(), token.end())));
-  });
+  ceph::substr_do(
+    string_list,
+    [&event_list](std::string_view token) {
+      event_list.push_back(rgw::notify::from_string(std::string(token.begin(),
+								token.end())));
+    }, ",");
 }
 }

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -19,7 +19,6 @@
 #include "global/global_init.h"
 
 #include "include/utime.h"
-#include "include/str_list.h"
 
 #include "rgw_user.h"
 #include "rgw_bucket.h"

--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -19,7 +19,6 @@
 #include "global/global_init.h"
 
 #include "include/utime.h"
-#include "include/str_list.h"
 
 #include "rgw_user.h"
 #include "rgw_bucket.h"

--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -26,7 +26,6 @@
 #include "global/global_init.h"
 
 #include "include/utime.h"
-#include "include/str_list.h"
 
 #include "rgw_sal.h"
 

--- a/src/rgw/rgw_object_lock.cc
+++ b/src/rgw/rgw_object_lock.cc
@@ -70,8 +70,8 @@ void RGWObjectRetention::decode_xml(XMLObj *obj) {
   }
   string date_str;
   RGWXMLDecoder::decode_xml("RetainUntilDate", date_str, obj, true);
-  boost::optional<ceph::real_time> date = ceph::from_iso_8601(date_str);
-  if (boost::none == date) {
+  auto date = ceph::from_iso_8601(date_str);
+  if (!date) {
     throw RGWXMLDecoder::err("invalid RetainUntilDate value");
   }
   retain_until_date = *date;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1756,7 +1756,7 @@ static int get_obj_user_manifest_iterate_cb(rgw_bucket& bucket,
 
 int RGWGetObj::handle_user_manifest(const char *prefix)
 {
-  const boost::string_view prefix_view(prefix);
+  const std::string_view prefix_view(prefix);
   ldpp_dout(this, 2) << "RGWGetObj::handle_user_manifest() prefix="
                    << prefix_view << dendl;
 
@@ -4579,7 +4579,7 @@ int RGWDeleteObj::handle_slo_manifest(bufferlist& bl)
     const string& path_str = iter.path;
 
     const size_t sep_pos = path_str.find('/', 1 /* skip first slash */);
-    if (boost::string_view::npos == sep_pos) {
+    if (std::string_view::npos == sep_pos) {
       return -EINVAL;
     }
 
@@ -4821,12 +4821,12 @@ void RGWDeleteObj::execute()
   }
 }
 
-bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
+bool RGWCopyObj::parse_copy_location(std::string_view url_src,
 				     string& bucket_name,
 				     rgw_obj_key& key)
 {
-  boost::string_view name_str;
-  boost::string_view params_str;
+  std::string_view name_str;
+  std::string_view params_str;
 
   // search for ? before url-decoding so we don't accidentally match %3F
   size_t pos = url_src.find('?');
@@ -4837,7 +4837,7 @@ bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
     params_str = url_src.substr(pos + 1);
   }
 
-  boost::string_view dec_src{name_str};
+  std::string_view dec_src{name_str};
   if (dec_src[0] == '/')
     dec_src.remove_prefix(1);
 
@@ -4854,7 +4854,7 @@ bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
 
   if (! params_str.empty()) {
     RGWHTTPArgs args;
-    args.set(params_str.to_string());
+    args.set(params_str);
     args.parse();
 
     key.instance = args.get("versionId", NULL);
@@ -5405,7 +5405,7 @@ void RGWPutLC::execute()
 
   std::string content_md5_bin;
   try {
-    content_md5_bin = rgw::from_base64(boost::string_view(content_md5));
+    content_md5_bin = rgw::from_base64(std::string_view(content_md5));
   } catch (...) {
     s->err.message = "Request header Content-MD5 contains character "
                      "that is not base64 encoded.";

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -740,7 +740,7 @@ protected:
   string end_date;
   int show_log_entries;
   int show_log_sum;
-  map<string, bool> categories;
+  std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>> categories;
   map<rgw_user_bucket, rgw_usage_log_entry> usage;
   map<string, rgw_usage_log_entry> summary_map;
   map<string, cls_user_bucket_entry> buckets_usage;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -576,7 +576,7 @@ protected:
   virtual void send_response() override = 0;
 
   boost::optional<std::pair<std::string, rgw_obj_key>>
-  parse_path(const boost::string_ref& path);
+  parse_path(std::string_view path);
   
   std::pair<std::string, std::string>
   handle_upload_path(struct req_state *s);
@@ -585,12 +585,12 @@ protected:
 				     const rgw_obj& obj,
 				     std::map<std::string, ceph::bufferlist>& battrs,
                                      ACLOwner& bucket_owner /* out */);
-  int handle_file(boost::string_ref path,
+  int handle_file(std::string_view path,
                   size_t size,
                   AlignedStreamGetter& body);
 
   int handle_dir_verify_permission();
-  int handle_dir(boost::string_ref path);
+  int handle_dir(std::string_view path);
 
 public:
   RGWBulkUploadOp()

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1433,7 +1433,7 @@ public:
     copy_if_newer = false;
   }
 
-  static bool parse_copy_location(const boost::string_view& src,
+  static bool parse_copy_location(std::string_view src,
                                   string& bucket_name,
                                   rgw_obj_key& object);
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -256,11 +256,11 @@ public:
 class RGWGetObj : public RGWOp {
 protected:
   seed torrent; // get torrent
-  const char *range_str;
-  const char *if_mod;
-  const char *if_unmod;
-  const char *if_match;
-  const char *if_nomatch;
+  std::optional<std::string_view> range_str;
+  std::optional<std::string_view> if_mod;
+  std::optional<std::string_view> if_unmod;
+  std::optional<std::string_view> if_match;
+  std::optional<std::string_view> if_nomatch;
   uint32_t mod_zone_id;
   uint64_t mod_pg_ver;
   off_t ofs;
@@ -301,11 +301,6 @@ protected:
   int init_common();
 public:
   RGWGetObj() {
-    range_str = NULL;
-    if_mod = NULL;
-    if_unmod = NULL;
-    if_match = NULL;
-    if_nomatch = NULL;
     mod_zone_id = 0;
     mod_pg_ver = 0;
     start = 0;
@@ -971,7 +966,7 @@ protected:
   bool relaxed_region_enforcement;
   bool obj_lock_enabled;
   RGWCORSConfiguration cors_config;
-  boost::optional<std::string> swift_ver_location;
+  std::optional<std::string> swift_ver_location;
   map<string, buffer::list> attrs;
   set<string> rmattr_names;
 
@@ -1076,12 +1071,12 @@ class RGWPutObj : public RGWOp {
 protected:
   seed torrent;
   off_t ofs;
-  const char *supplied_md5_b64;
-  const char *supplied_etag;
-  const char *if_match;
-  const char *if_nomatch;
+  std::optional<std::string_view> supplied_md5_b64;
+  std::optional<std::string_view> supplied_etag;
+  std::optional<std::string_view> if_match;
+  std::optional<std::string_view> if_nomatch;
   std::string copy_source;
-  const char *copy_source_range;
+  std::optional<std::string_view> copy_source_range;
   RGWBucketInfo copy_source_bucket_info;
   string copy_source_tenant_name;
   string copy_source_bucket_name;
@@ -1093,7 +1088,7 @@ protected:
   bool chunked_upload;
   RGWAccessControlPolicy policy;
   std::unique_ptr <RGWObjTags> obj_tags;
-  const char *dlo_manifest;
+  std::optional<std::string_view> dlo_manifest;
   RGWSLOInfo *slo_info;
   map<string, bufferlist> attrs;
   ceph::real_time mtime;
@@ -1119,15 +1114,9 @@ protected:
 
 public:
   RGWPutObj() : ofs(0),
-                supplied_md5_b64(NULL),
-                supplied_etag(NULL),
-                if_match(NULL),
-                if_nomatch(NULL),
-                copy_source_range(NULL),
                 copy_source_range_fst(0),
                 copy_source_range_lst(0),
                 chunked_upload(0),
-                dlo_manifest(NULL),
                 slo_info(NULL),
                 olh_epoch(0),
                 append(false),
@@ -1186,8 +1175,8 @@ protected:
   off_t max_len;
   int len;
   off_t ofs;
-  const char *supplied_md5_b64;
-  const char *supplied_etag;
+  std::optional<std::string_view> supplied_md5_b64;
+  std::optional<std::string_view> supplied_etag;
   string etag;
   RGWAccessControlPolicy policy;
   map<string, bufferlist> attrs;
@@ -1203,10 +1192,7 @@ public:
   RGWPostObj() : min_len(0),
                  max_len(LLONG_MAX),
                  len(0),
-                 ofs(0),
-                 supplied_md5_b64(nullptr),
-                 supplied_etag(nullptr) {
-  }
+                 ofs(0) {}
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
     attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
@@ -1281,7 +1267,7 @@ protected:
   RGWAccessControlPolicy policy;
   RGWCORSConfiguration cors_config;
   rgw_placement_rule placement_rule;
-  boost::optional<std::string> swift_ver_location;
+  std::optional<std::string> swift_ver_location;
 
 public:
   RGWPutMetadataBucket()
@@ -1312,12 +1298,10 @@ class RGWPutMetadataObject : public RGWOp {
 protected:
   RGWAccessControlPolicy policy;
   boost::optional<ceph::real_time> delete_at;
-  const char *dlo_manifest;
+  std::optional<std::string_view> dlo_manifest;
 
 public:
-  RGWPutMetadataObject()
-    : dlo_manifest(NULL)
-  {}
+  RGWPutMetadataObject() {}
 
   void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
@@ -1373,10 +1357,10 @@ public:
 class RGWCopyObj : public RGWOp {
 protected:
   RGWAccessControlPolicy dest_policy;
-  const char *if_mod;
-  const char *if_unmod;
-  const char *if_match;
-  const char *if_nomatch;
+  std::optional<std::string_view> if_mod;
+  std::optional<std::string_view> if_unmod;
+  std::optional<std::string_view> if_match;
+  std::optional<std::string_view> if_nomatch;
   // Required or it is not a copy operation
   std::string_view copy_source;
   // Not actually required
@@ -1418,10 +1402,6 @@ protected:
 
 public:
   RGWCopyObj() {
-    if_mod = NULL;
-    if_unmod = NULL;
-    if_match = NULL;
-    if_nomatch = NULL;
     ofs = 0;
     len = 0;
     end = -1;
@@ -1522,13 +1502,11 @@ public:
 class RGWPutLC : public RGWOp {
 protected:
   bufferlist data;
-  const char *content_md5;
+  std::optional<std::string_view> content_md5;
   string cookie;
 
 public:
-  RGWPutLC() {
-    content_md5 = nullptr;
-  }
+  RGWPutLC() = default;
   ~RGWPutLC() override {}
 
   void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *dialect_handler) override {
@@ -1627,13 +1605,10 @@ public:
 
 class RGWOptionsCORS : public RGWOp {
 protected:
-  RGWCORSRule *rule;
-  const char *origin, *req_hdrs, *req_meth;
-
+  RGWCORSRule *rule = nullptr;
+  std::optional<std::string_view> origin, req_hdrs, req_meth;
 public:
-  RGWOptionsCORS() : rule(NULL), origin(NULL),
-                     req_hdrs(NULL), req_meth(NULL) {
-  }
+  RGWOptionsCORS() = default;
 
   int verify_permission() override {return 0;}
   int validate_cors_request(RGWCORSConfiguration *cc);
@@ -1932,9 +1907,9 @@ extern vector<rgw::IAM::Policy> get_iam_user_policy_from_attr(CephContext* cct,
                         map<string, bufferlist>& attrs,
                         const string& tenant);
 
-static inline int get_system_versioning_params(req_state *s,
-					      uint64_t *olh_epoch,
-					      string *version_id)
+inline int get_system_versioning_params(req_state *s,
+					uint64_t *olh_epoch,
+					string *version_id)
 {
   if (!s->system_request) {
     return 0;
@@ -1990,10 +1965,10 @@ static inline void format_xattr(std::string &xattr)
  * On failure returns a negative error code.
  *
  */
-static inline int rgw_get_request_metadata(CephContext* const cct,
-                                           struct req_info& info,
-                                           std::map<std::string, ceph::bufferlist>& attrs,
-                                           const bool allow_empty_attrs = true)
+inline int rgw_get_request_metadata(CephContext* const cct,
+				    struct req_info& info,
+				    std::map<std::string, ceph::bufferlist>& attrs,
+				    const bool allow_empty_attrs = true)
 {
   static const std::set<std::string> blacklisted_headers = {
       "x-amz-server-side-encryption-customer-algorithm",
@@ -2053,8 +2028,8 @@ static inline int rgw_get_request_metadata(CephContext* const cct,
   return 0;
 } /* rgw_get_request_metadata */
 
-static inline void encode_delete_at_attr(boost::optional<ceph::real_time> delete_at,
-					map<string, bufferlist>& attrs)
+inline void encode_delete_at_attr(boost::optional<ceph::real_time> delete_at,
+				  map<string, bufferlist>& attrs)
 {
   if (delete_at == boost::none) {
     return;
@@ -2065,7 +2040,7 @@ static inline void encode_delete_at_attr(boost::optional<ceph::real_time> delete
   attrs[RGW_ATTR_DELETE_AT] = delatbl;
 } /* encode_delete_at_attr */
 
-static inline void encode_obj_tags_attr(RGWObjTags* obj_tags, map<string, bufferlist>& attrs)
+inline void encode_obj_tags_attr(RGWObjTags* obj_tags, map<string, bufferlist>& attrs)
 {
   if (obj_tags == nullptr){
     // we assume the user submitted a tag format which we couldn't parse since
@@ -2079,23 +2054,21 @@ static inline void encode_obj_tags_attr(RGWObjTags* obj_tags, map<string, buffer
   attrs[RGW_ATTR_TAGS] = tagsbl;
 }
 
-static inline int encode_dlo_manifest_attr(const char * const dlo_manifest,
-					  map<string, bufferlist>& attrs)
+inline int encode_dlo_manifest_attr(std::string_view dlo_manifest,
+				    map<string, bufferlist>& attrs)
 {
-  string dm = dlo_manifest;
-
-  if (dm.find('/') == string::npos) {
+  if (dlo_manifest.find('/') == string::npos) {
     return -EINVAL;
   }
 
   bufferlist manifest_bl;
-  manifest_bl.append(dlo_manifest, strlen(dlo_manifest) + 1);
+  manifest_bl.append(dlo_manifest);
   attrs[RGW_ATTR_USER_MANIFEST] = manifest_bl;
 
   return 0;
 } /* encode_dlo_manifest_attr */
 
-static inline void complete_etag(MD5& hash, string *etag)
+inline void complete_etag(MD5& hash, string *etag)
 {
   char etag_buf[CEPH_CRYPTO_MD5_DIGESTSIZE];
   char etag_buf_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
@@ -2215,7 +2188,7 @@ public:
   int verify_permission() override;
   void pre_exec() override;
   void execute() override;
-  virtual void send_response() = 0;
+  void send_response() override = 0;
   virtual int get_params() = 0;
   const char* name() const override { return "put_bucket_object_lock"; }
   RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_OBJ_LOCK; }
@@ -2227,7 +2200,7 @@ public:
   int verify_permission() override;
   void pre_exec() override;
   void execute() override;
-  virtual void send_response() = 0;
+  void send_response() override = 0;
   const char* name() const override {return "get_bucket_object_lock"; }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_OBJ_LOCK; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
@@ -2258,7 +2231,7 @@ public:
   int verify_permission() override;
   void pre_exec() override;
   void execute() override;
-  virtual void send_response() = 0;
+  void send_response() override = 0;
   const char* name() const override {return "get_obj_retention"; }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_RETENTION; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
@@ -2286,7 +2259,7 @@ public:
   int verify_permission() override;
   void pre_exec() override;
   void execute() override;
-  virtual void send_response() = 0;
+  void send_response() override = 0;
   const char* name() const override {return "get_obj_legal_hold"; }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_LEGAL_HOLD; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
@@ -2352,7 +2325,7 @@ public:
   dmc::client_id dmclock_client() override { return dmc::client_id::admin; }
 };
 
-static inline int parse_value_and_bound(
+inline int parse_value_and_bound(
     const string &input,
     int &output,
     const long lower_bound,

--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -39,7 +39,7 @@ int rgw_opa_authorize(RGWOp *& op,
   JSONFormatter jf;
   jf.open_object_section("");
   jf.open_object_section("input");
-  jf.dump_string("method", s->info.env->get("REQUEST_METHOD"));
+  jf.dump_string("method", s->info.env->get("REQUEST_METHOD").value_or(""));
   jf.dump_string("relative_uri", s->relative_uri.c_str());
   jf.dump_string("decoded_uri", s->decoded_uri.c_str());
   jf.dump_string("params", s->info.request_params.c_str());

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -277,8 +277,8 @@ int AtomicObjectProcessor::complete(size_t accounted_size,
                                     ceph::real_time set_mtime,
                                     std::map<std::string, bufferlist>& attrs,
                                     ceph::real_time delete_at,
-                                    const char *if_match,
-                                    const char *if_nomatch,
+                                    std::optional<std::string_view> if_match,
+                                    std::optional<std::string_view> if_nomatch,
                                     const std::string *user_data,
                                     rgw_zone_set *zones_trace,
                                     bool *pcanceled, optional_yield y)
@@ -415,8 +415,8 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
                                        ceph::real_time set_mtime,
                                        std::map<std::string, bufferlist>& attrs,
                                        ceph::real_time delete_at,
-                                       const char *if_match,
-                                       const char *if_nomatch,
+				       std::optional<std::string_view> if_match,
+				       std::optional<std::string_view> if_nomatch,
                                        const std::string *user_data,
                                        rgw_zone_set *zones_trace,
                                        bool *pcanceled, optional_yield y)
@@ -557,7 +557,7 @@ int AppendObjectProcessor::prepare(optional_yield y)
     //get the current obj etag
     iter = astate->attrset.find(RGW_ATTR_ETAG);
     if (iter != astate->attrset.end()) {
-      string s = rgw_string_unquote(iter->second.c_str());
+      auto s = rgw_string_unquote(iter->second.to_string_view());
       size_t pos = s.find("-");
       cur_etag = s.substr(0, pos);
     }
@@ -594,10 +594,15 @@ int AppendObjectProcessor::prepare(optional_yield y)
   return 0;
 }
 
-int AppendObjectProcessor::complete(size_t accounted_size, const string &etag, ceph::real_time *mtime,
-                                    ceph::real_time set_mtime, map <string, bufferlist> &attrs,
-                                    ceph::real_time delete_at, const char *if_match, const char *if_nomatch,
-                                    const string *user_data, rgw_zone_set *zones_trace, bool *pcanceled,
+int AppendObjectProcessor::complete(size_t accounted_size, const string &etag,
+				    ceph::real_time *mtime,
+				    ceph::real_time set_mtime,
+				    map <string, bufferlist> &attrs,
+                                    ceph::real_time delete_at,
+				    std::optional<std::string_view> if_match,
+				    std::optional<std::string_view> if_nomatch,
+				    const string *user_data,
+				    rgw_zone_set *zones_trace, bool *pcanceled,
                                     optional_yield y)
 {
   int r = writer.drain();

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -39,7 +39,8 @@ class ObjectProcessor : public DataProcessor {
                        ceph::real_time *mtime, ceph::real_time set_mtime,
                        std::map<std::string, bufferlist>& attrs,
                        ceph::real_time delete_at,
-                       const char *if_match, const char *if_nomatch,
+                       std::optional<std::string_view> if_match,
+		       std::optional<std::string_view> if_nomatch,
                        const std::string *user_data,
                        rgw_zone_set *zones_trace, bool *canceled,
                        optional_yield y) = 0;
@@ -190,7 +191,8 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
                ceph::real_time *mtime, ceph::real_time set_mtime,
                std::map<std::string, bufferlist>& attrs,
                ceph::real_time delete_at,
-               const char *if_match, const char *if_nomatch,
+               std::optional<std::string_view> if_match,
+	       std::optional<std::string_view> if_nomatch,
                const std::string *user_data,
                rgw_zone_set *zones_trace, bool *canceled,
                optional_yield y) override;
@@ -237,7 +239,8 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
                ceph::real_time *mtime, ceph::real_time set_mtime,
                std::map<std::string, bufferlist>& attrs,
                ceph::real_time delete_at,
-               const char *if_match, const char *if_nomatch,
+               std::optional<std::string_view> if_match,
+	       std::optional<std::string_view> if_nomatch,
                const std::string *user_data,
                rgw_zone_set *zones_trace, bool *canceled,
                optional_yield y) override;
@@ -272,11 +275,12 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
     int complete(size_t accounted_size, const string& etag,
                  ceph::real_time *mtime, ceph::real_time set_mtime,
                  map<string, bufferlist>& attrs, ceph::real_time delete_at,
-                 const char *if_match, const char *if_nomatch, const string *user_data,
+                 std::optional<std::string_view> if_match,
+		 std::optional<std::string_view> if_nomatch,
+		 const string *user_data,
                  rgw_zone_set *zones_trace, bool *canceled,
                  optional_yield y) override;
   };
 
 } // namespace putobj
 } // namespace rgw
-

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -324,8 +324,8 @@ void dump_errno(struct req_state *s, int http_ret)
 }
 
 void dump_header(struct req_state* const s,
-                 const boost::string_ref& name,
-                 const boost::string_ref& val)
+                 std::string_view name,
+                 std::string_view val)
 {
   try {
     RESTFUL_IO(s)->send_header(name, val);
@@ -336,24 +336,24 @@ void dump_header(struct req_state* const s,
 }
 
 void dump_header(struct req_state* const s,
-                 const boost::string_ref& name,
+                 std::string_view name,
                  ceph::buffer::list& bl)
 {
   return dump_header(s, name, rgw_sanitized_hdrval(bl));
 }
 
 void dump_header(struct req_state* const s,
-                 const boost::string_ref& name,
+                 std::string_view name,
                  const long long val)
 {
   char buf[32];
   const auto len = snprintf(buf, sizeof(buf), "%lld", val);
 
-  return dump_header(s, name, boost::string_ref(buf, len));
+  return dump_header(s, name, std::string_view(buf, len));
 }
 
 void dump_header(struct req_state* const s,
-                 const boost::string_ref& name,
+                 std::string_view name,
                  const utime_t& ut)
 {
   char buf[32];
@@ -361,7 +361,7 @@ void dump_header(struct req_state* const s,
 	                    static_cast<long long>(ut.sec()),
                             static_cast<int>(ut.usec() / 10));
 
-  return dump_header(s, name, boost::string_ref(buf, len));
+  return dump_header(s, name, std::string_view(buf, len));
 }
 
 void dump_content_length(struct req_state* const s, const uint64_t len)
@@ -386,7 +386,7 @@ static void dump_chunked_encoding(struct req_state* const s)
 }
 
 void dump_etag(struct req_state* const s,
-               const boost::string_ref& etag,
+               std::string_view etag,
                const bool quoted)
 {
   if (etag.empty()) {
@@ -442,7 +442,7 @@ void dump_time_header(struct req_state *s, const char *name, real_time t)
     return;
   }
 
-  return dump_header(s, name, boost::string_ref(timestr, len));
+  return dump_header(s, name, std::string_view(timestr, len));
 }
 
 std::string dump_time_to_str(const real_time& t)
@@ -467,7 +467,7 @@ void dump_epoch_header(struct req_state *s, const char *name, real_time t)
                             (long long)ut.sec(),
                             (long long)ut.nsec());
 
-  return dump_header(s, name, boost::string_ref(buf, len));
+  return dump_header(s, name, std::string_view(buf, len));
 }
 
 void dump_time(struct req_state *s, const char *name, real_time *t)
@@ -742,7 +742,7 @@ void dump_range(struct req_state* const s,
                    static_cast<long long>(total));
   }
 
-  return dump_header(s, "Content-Range", boost::string_ref(range_buf, len));
+  return dump_header(s, "Content-Range", std::string_view(range_buf, len));
 }
 
 

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -830,10 +830,11 @@ int RESTArgs::get_uint64(struct req_state *s, const string& name,
     return 0;
   }
 
-  int r = stringtoull(sval, val);
-  if (r < 0)
-    return r;
+  auto r = ceph::parse<uint64_t>(sval);
+  if (!r)
+    return -EINVAL;
 
+  *val = *r;
   return 0;
 }
 
@@ -851,10 +852,11 @@ int RESTArgs::get_int64(struct req_state *s, const string& name,
     return 0;
   }
 
-  int r = stringtoll(sval, val);
-  if (r < 0)
-    return r;
+  auto r = ceph::parse<int64_t>(sval);
+  if (!r)
+    return -EINVAL;
 
+  *val = *r;
   return 0;
 }
 
@@ -872,10 +874,11 @@ int RESTArgs::get_uint32(struct req_state *s, const string& name,
     return 0;
   }
 
-  int r = stringtoul(sval, val);
-  if (r < 0)
-    return r;
+  auto r = ceph::parse<uint32_t>(sval);
+  if (!r)
+    return -EINVAL;
 
+  *val = *r;
   return 0;
 }
 
@@ -893,10 +896,11 @@ int RESTArgs::get_int32(struct req_state *s, const string& name,
     return 0;
   }
 
-  int r = stringtol(sval, val);
-  if (r < 0)
-    return r;
+  auto r = ceph::parse<int32_t>(sval);
+  if (!r)
+    return -EINVAL;
 
+  *val = *r;
   return 0;
 }
 

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1091,11 +1091,11 @@ void RGWPostObj_ObjStore::parse_boundary_params(const std::string& params_str,
     size_t eqpos = param.find('=');
 
     if (std::string::npos != eqpos) {
-      std::string param_name = rgw_trim_whitespace(param.substr(0, eqpos));
+      std::string param_name(rgw_trim_whitespace(param.substr(0, eqpos)));
       std::string val = rgw_trim_quotes(param.substr(eqpos + 1));
       params[std::move(param_name)] = std::move(val);
     } else {
-      params[rgw_trim_whitespace(param)] = "";
+      params[std::string(rgw_trim_whitespace(param))] = "";
     }
 
     pos = end + 1;
@@ -1294,7 +1294,7 @@ int RGWPostObj_ObjStore::read_form_part_header(struct post_form_part* const part
   /*
    * iterate through fields
    */
-    std::string line = rgw_trim_whitespace(string(bl.c_str(), bl.length()));
+    std::string line(rgw_trim_whitespace(string(bl.c_str(), bl.length())));
 
     if (line.empty()) {
       break;
@@ -1351,7 +1351,7 @@ std::string RGWPostObj_ObjStore::get_part_str(parts_collection_t& parts,
   if (part_str(parts, name, &val)) {
     return val;
   } else {
-    return rgw_trim_whitespace(def_val);
+    return std::string(rgw_trim_whitespace(def_val));
   }
 }
 

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -28,7 +28,7 @@ std::tuple<int, bufferlist > rgw_rest_read_all_input(struct req_state *s,
                                         const uint64_t max_len,
                                         const bool allow_chunked=true);
 
-static inline boost::string_ref rgw_sanitized_hdrval(ceph::buffer::list& raw)
+inline boost::string_ref rgw_sanitized_hdrval(ceph::buffer::list& raw)
 {
   /* std::string and thus boost::string_ref ARE OBLIGED to carry multiple
    * 0x00 and count them to the length of a string. We need to take that

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -709,9 +709,9 @@ extern void dump_start(struct req_state *s);
 extern void list_all_buckets_start(struct req_state *s);
 extern void dump_owner(struct req_state *s, const rgw_user& id, string& name,
 		       const char *section = NULL);
-extern void dump_header(struct req_state* s,
-                        std::string_view name,
-                        std::string_view val);
+void dump_header(struct req_state* s,
+		 std::string_view name,
+		 std::string_view val);
 extern void dump_header(struct req_state* s,
                         std::string_view name,
                         ceph::buffer::list& bl);
@@ -782,9 +782,9 @@ static inline std::string compute_domain_uri(const struct req_state *s) {
     std::string uri =
     env.get("SERVER_PORT_SECURE") ? "https://" : "http://";
     if (env.exists("SERVER_NAME")) {
-      uri.append(env.get("SERVER_NAME", "<SERVER_NAME>"));
+      uri.append(env.get("SERVER_NAME").value_or("<SERVER_NAME>"));
     } else {
-      uri.append(env.get("HTTP_HOST", "<HTTP_HOST>"));
+      uri.append(env.get("HTTP_HOST").value_or("<HTTP_HOST>"));
     }
     return uri;
   }();
@@ -792,7 +792,7 @@ static inline std::string compute_domain_uri(const struct req_state *s) {
 }
 
 extern void dump_content_length(struct req_state *s, uint64_t len);
-extern int64_t parse_content_length(const char *content_length);
+int64_t parse_content_length(std::string_view);
 extern void dump_etag(struct req_state *s,
                       std::string_view etag,
                       bool quoted = false);
@@ -810,11 +810,13 @@ extern std::string dump_time_to_str(const real_time& t);
 extern void dump_bucket_from_state(struct req_state *s);
 extern void dump_redirect(struct req_state *s, const string& redirect);
 extern bool is_valid_url(const char *url);
-extern void dump_access_control(struct req_state *s, const char *origin,
-				const char *meth,
-				const char *hdr, const char *exp_hdr,
-				uint32_t max_age);
-extern void dump_access_control(req_state *s, RGWOp *op);
+void dump_access_control(struct req_state *s,
+			 std::optional<std::string_view> origin,
+			 std::optional<std::string_view> meth,
+			 std::optional<std::string_view> hdr,
+			 std::optional<std::string_view> exp_hdr,
+			 uint32_t max_age);
+void dump_access_control(req_state *s, RGWOp *op);
 
 extern int dump_body(struct req_state* s, const char* buf, size_t len);
 extern int dump_body(struct req_state* s, /* const */ ceph::buffer::list& bl);

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -5,7 +5,6 @@
 
 #define TIME_BUF_SIZE 128
 
-#include <boost/utility/string_ref.hpp>
 #include <boost/container/flat_set.hpp>
 #include "common/sstring.hh"
 #include "common/ceph_json.h"
@@ -28,9 +27,9 @@ std::tuple<int, bufferlist > rgw_rest_read_all_input(struct req_state *s,
                                         const uint64_t max_len,
                                         const bool allow_chunked=true);
 
-inline boost::string_ref rgw_sanitized_hdrval(ceph::buffer::list& raw)
+inline std::string_view rgw_sanitized_hdrval(ceph::buffer::list& raw)
 {
-  /* std::string and thus boost::string_ref ARE OBLIGED to carry multiple
+  /* std::string and thus std::string_view ARE OBLIGED to carry multiple
    * 0x00 and count them to the length of a string. We need to take that
    * into consideration and sanitize the size of a ceph::buffer::list used
    * to store metadata values (x-amz-meta-*, X-Container-Meta-*, etags).
@@ -41,11 +40,11 @@ inline boost::string_ref rgw_sanitized_hdrval(ceph::buffer::list& raw)
   if (len && data[len - 1] == '\0') {
     /* That's the case - the null byte has been included at the last position
      * of the bufferlist. We need to restore the proper string length we'll
-     * pass to string_ref. */
+     * pass to string_view. */
     len--;
   }
 
-  return boost::string_ref(data, len);
+  return std::string_view(data, len);
 }
 
 template <class T>
@@ -711,22 +710,22 @@ extern void list_all_buckets_start(struct req_state *s);
 extern void dump_owner(struct req_state *s, const rgw_user& id, string& name,
 		       const char *section = NULL);
 extern void dump_header(struct req_state* s,
-                        const boost::string_ref& name,
-                        const boost::string_ref& val);
+                        std::string_view name,
+                        std::string_view val);
 extern void dump_header(struct req_state* s,
-                        const boost::string_ref& name,
+                        std::string_view name,
                         ceph::buffer::list& bl);
 extern void dump_header(struct req_state* s,
-                        const boost::string_ref& name,
+                        std::string_view name,
                         long long val);
 extern void dump_header(struct req_state* s,
-                        const boost::string_ref& name,
+                        std::string_view name,
                         const utime_t& val);
 
 template <class... Args>
 static inline void dump_header_prefixed(struct req_state* s,
-                                        const boost::string_ref& name_prefix,
-                                        const boost::string_ref& name,
+                                        std::string_view name_prefix,
+                                        std::string_view name,
                                         Args&&... args) {
   char full_name_buf[name_prefix.size() + name.size() + 1];
   const auto len = snprintf(full_name_buf, sizeof(full_name_buf), "%.*s%.*s",
@@ -734,15 +733,15 @@ static inline void dump_header_prefixed(struct req_state* s,
                             name_prefix.data(),
                             static_cast<int>(name.length()),
                             name.data());
-  boost::string_ref full_name(full_name_buf, len);
+  std::string_view full_name(full_name_buf, len);
   return dump_header(s, std::move(full_name), std::forward<Args>(args)...);
 }
 
 template <class... Args>
 static inline void dump_header_infixed(struct req_state* s,
-                                       const boost::string_ref& prefix,
-                                       const boost::string_ref& infix,
-                                       const boost::string_ref& sufix,
+                                       std::string_view prefix,
+                                       std::string_view infix,
+                                       std::string_view sufix,
                                        Args&&... args) {
   char full_name_buf[prefix.size() + infix.size() + sufix.size() + 1];
   const auto len = snprintf(full_name_buf, sizeof(full_name_buf), "%.*s%.*s%.*s",
@@ -752,24 +751,24 @@ static inline void dump_header_infixed(struct req_state* s,
                             infix.data(),
                             static_cast<int>(sufix.length()),
                             sufix.data());
-  boost::string_ref full_name(full_name_buf, len);
+  std::string_view full_name(full_name_buf, len);
   return dump_header(s, std::move(full_name), std::forward<Args>(args)...);
 }
 
 template <class... Args>
 static inline void dump_header_quoted(struct req_state* s,
-                                      const boost::string_ref& name,
-                                      const boost::string_ref& val) {
+                                      std::string_view name,
+                                      std::string_view val) {
   /* We need two extra bytes for quotes. */
   char qvalbuf[val.size() + 2 + 1];
   const auto len = snprintf(qvalbuf, sizeof(qvalbuf), "\"%.*s\"",
                             static_cast<int>(val.length()), val.data());
-  return dump_header(s, name, boost::string_ref(qvalbuf, len));
+  return dump_header(s, name, std::string_view(qvalbuf, len));
 }
 
 template <class ValueT>
 static inline void dump_header_if_nonempty(struct req_state* s,
-                                           const boost::string_ref& name,
+                                           std::string_view name,
                                            const ValueT& value) {
   if (name.length() > 0 && value.length() > 0) {
     return dump_header(s, name, value);
@@ -795,7 +794,7 @@ static inline std::string compute_domain_uri(const struct req_state *s) {
 extern void dump_content_length(struct req_state *s, uint64_t len);
 extern int64_t parse_content_length(const char *content_length);
 extern void dump_etag(struct req_state *s,
-                      const boost::string_ref& etag,
+                      std::string_view etag,
                       bool quoted = false);
 extern void dump_epoch_header(struct req_state *s, const char *name, real_time t);
 extern void dump_time_header(struct req_state *s, const char *name, real_time t);

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -5,8 +5,6 @@
 #include "rgw_bucket.h"
 #include "rgw_rest_bucket.h"
 
-#include "include/str_list.h"
-
 #include "services/svc_sys_obj.h"
 #include "services/svc_zone.h"
 

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -276,8 +276,8 @@ void RGWOp_Set_Bucket_Quota::execute()
   if (s->content_length > 0) {
     use_http_params = false;
   } else {
-    const char *encoding = s->info.env->get("HTTP_TRANSFER_ENCODING");
-    use_http_params = (!encoding || strcmp(encoding, "chunked") != 0);
+    auto encoding = s->info.env->get("HTTP_TRANSFER_ENCODING");
+    use_http_params = (!encoding || *encoding == "chunked");
   }
   RGWQuotaInfo quota;
   if (!use_http_params) {

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -9,7 +9,6 @@
 
 #include "common/armor.h"
 #include "common/strtol.h"
-#include "include/str_list.h"
 #include "rgw_crypt_sanitize.h"
 
 #define dout_context g_ceph_context

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -140,7 +140,7 @@ int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *_method, const 
   map<string, string> meta_map;
   map<string, string> sub_resources;
 
-  rgw_create_s3_canonical_header(method.c_str(), NULL, NULL, date_str.c_str(),
+  rgw_create_s3_canonical_header(method, std::nullopt, std::nullopt, date_str.c_str(),
 				 meta_map, meta_map, url.c_str(), sub_resources,
 				 canonical_header);
 
@@ -320,7 +320,7 @@ int RGWRESTSimpleRequest::forward_request(RGWAccessKey& key, req_info& info, siz
     set_send_length(inbl->length());
   }
 
-  method = new_info.method;
+  method = new_info.method.value_or("");
   url = new_url;
 
   int r = process(null_yield);
@@ -764,7 +764,7 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
   }
   
 
-  method = new_info.method;
+  method = new_info.method.value_or("");
   url = headers_gen.get_url();
 
   return 0;

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -106,7 +106,7 @@ int RGWRESTConn::forward(const rgw_user& uid, req_info& info, obj_version *objv,
     snprintf(buf, sizeof(buf), "%lld", (long long)objv->ver);
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "ver", buf));
   }
-  RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params);
+  RGWRESTSimpleRequest req(cct, std::string(info.method.value_or("")), url, NULL, &params);
   return req.forward_request(key, info, max_response, inbl, outbl);
 }
 

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -11,7 +11,7 @@
 
 RGWRESTConn::RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc,
                          const string& _remote_id,
-                         const list<string>& remote_endpoints,
+                         const vector<string>& remote_endpoints,
                          HostStyle _host_style)
   : cct(_cct),
     endpoints(remote_endpoints.begin(), remote_endpoints.end()),
@@ -25,7 +25,7 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc,
 
 RGWRESTConn::RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc,
                          const string& _remote_id,
-                         const list<string>& remote_endpoints,
+                         const vector<string>& remote_endpoints,
                          RGWAccessKey _cred,
                          HostStyle _host_style)
   : cct(_cct),

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -77,8 +77,8 @@ class RGWRESTConn
 
 public:
 
-  RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc, const string& _remote_id, const list<string>& endpoints, HostStyle _host_style = PathStyle);
-  RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred, HostStyle _host_style = PathStyle);
+  RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc, const string& _remote_id, const vector<string>& endpoints, HostStyle _host_style = PathStyle);
+  RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc, const string& _remote_id, const vector<string>& endpoints, RGWAccessKey _cred, HostStyle _host_style = PathStyle);
 
   // custom move needed for atomic
   RGWRESTConn(RGWRESTConn&& other);
@@ -191,10 +191,11 @@ class S3RESTConn : public RGWRESTConn {
 
 public:
 
-  S3RESTConn(CephContext *_cct, RGWSI_Zone *svc_zone, const string& _remote_id, const list<string>& endpoints, HostStyle _host_style = PathStyle) :
+  S3RESTConn(CephContext *_cct, RGWSI_Zone *svc_zone, const string& _remote_id,
+	     const vector<string>& endpoints, HostStyle _host_style = PathStyle) :
     RGWRESTConn(_cct, svc_zone, _remote_id, endpoints, _host_style) {}
 
-  S3RESTConn(CephContext *_cct, RGWSI_Zone *svc_zone, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred, HostStyle _host_style = PathStyle):
+  S3RESTConn(CephContext *_cct, RGWSI_Zone *svc_zone, const string& _remote_id, const vector<string>& endpoints, RGWAccessKey _cred, HostStyle _host_style = PathStyle):
     RGWRESTConn(_cct, svc_zone, _remote_id, endpoints, _cred, _host_style) {}
   ~S3RESTConn() override = default;
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1814,8 +1814,8 @@ int RGWPutObj_ObjStore_S3::get_params()
   auto obj_lock_date_str = s->info.env->get("HTTP_X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE");
   auto obj_legal_hold_str = s->info.env->get("HTTP_X_AMZ_OBJECT_LOCK_LEGAL_HOLD");
   if (obj_lock_mode_str && obj_lock_date_str) {
-    boost::optional<ceph::real_time> date = ceph::from_iso_8601(obj_lock_date_str);
-    if (boost::none == date || ceph::real_clock::to_time_t(*date) <= ceph_clock_now()) {
+    auto date = ceph::from_iso_8601(obj_lock_date_str);
+    if (!date || ceph::real_clock::to_time_t(*date) <= ceph_clock_now()) {
         ret = -EINVAL;
         ldpp_dout(this,0) << "invalid x-amz-object-lock-retain-until-date value" << dendl;
         return ret;
@@ -4929,7 +4929,7 @@ rgw::auth::s3::LDAPEngine::authenticate(
   const completer_factory_t& completer_factory,
   const req_state* const s) const
 {
-  /* boost filters and/or string_ref may throw on invalid input */
+  /* boost filters may throw on invalid input */
   rgw::RGWToken base64_token;
   try {
     base64_token = rgw::from_base64(access_key_id);
@@ -5115,7 +5115,7 @@ rgw::auth::s3::STSEngine::authenticate(
   if (! token.expiration.empty()) {
     std::string expiration = token.expiration;
     if (! expiration.empty()) {
-      boost::optional<real_clock::time_point> exp = ceph::from_iso_8601(expiration, false);
+      auto exp = ceph::from_iso_8601(expiration, false);
       if (exp) {
         real_clock::time_point now = real_clock::now();
         if (now >= *exp) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -650,7 +650,9 @@ int RGWGetUsage_ObjStore_S3::get_params()
   return 0;
 }
 
-static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log_entry& entry, map<string, bool> *categories)
+static void dump_usage_categories_info(
+  Formatter *formatter, const rgw_usage_log_entry& entry,
+  std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>>* categories)
 {
   formatter->open_array_section("categories");
   map<string, rgw_usage_data>::const_iterator uiter;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -843,9 +843,9 @@ public:
   public:
     virtual ~VersionAbstractor() {};
 
-    using access_key_id_t = boost::string_view;
-    using client_signature_t = boost::string_view;
-    using session_token_t = boost::string_view;
+    using access_key_id_t = std::string_view;
+    using client_signature_t = std::string_view;
+    using session_token_t = std::string_view;
     using server_signature_t = basic_sstring<char, uint16_t, SIGNATURE_MAX_SIZE>;
     using string_to_sign_t = std::string;
 
@@ -894,9 +894,9 @@ protected:
    * the signature get_auth_data() of VersionAbstractor is too complicated.
    * Replace these thing with a simple, dedicated structure. */
   virtual result_t authenticate(const DoutPrefixProvider* dpp,
-                                const boost::string_view& access_key_id,
-                                const boost::string_view& signature,
-                                const boost::string_view& session_token,
+                                std::string_view access_key_id,
+                                std::string_view signature,
+                                std::string_view session_token,
                                 const string_to_sign_t& string_to_sign,
                                 const signature_factory_t& signature_factory,
                                 const completer_factory_t& completer_factory,
@@ -912,7 +912,7 @@ class AWSGeneralAbstractor : public AWSEngine::VersionAbstractor {
 
   virtual boost::optional<std::string>
   get_v4_canonical_headers(const req_info& info,
-                           const boost::string_view& signedheaders,
+                           std::string_view signedheaders,
                            const bool using_qs) const;
 
   auth_data_t get_auth_data_v2(const req_state* s) const;
@@ -929,7 +929,7 @@ public:
 class AWSGeneralBoto2Abstractor : public AWSGeneralAbstractor {
   boost::optional<std::string>
   get_v4_canonical_headers(const req_info& info,
-                           const boost::string_view& signedheaders,
+                           std::string_view signedheaders,
                            const bool using_qs) const override;
 
 public:
@@ -971,9 +971,9 @@ protected:
   auth_info_t get_creds_info(const rgw::RGWToken& token) const noexcept;
 
   result_t authenticate(const DoutPrefixProvider* dpp,
-                        const boost::string_view& access_key_id,
-                        const boost::string_view& signature,
-                        const boost::string_view& session_token,
+                        std::string_view access_key_id,
+                        std::string_view signature,
+                        std::string_view session_token,
                         const string_to_sign_t& string_to_sign,
                         const signature_factory_t&,
                         const completer_factory_t& completer_factory,
@@ -1004,9 +1004,9 @@ class LocalEngine : public AWSEngine {
   const rgw::auth::LocalApplier::Factory* const apl_factory;
 
   result_t authenticate(const DoutPrefixProvider* dpp,
-                        const boost::string_view& access_key_id,
-                        const boost::string_view& signature,
-                        const boost::string_view& session_token,
+                        std::string_view access_key_id,
+                        std::string_view signature,
+                        std::string_view session_token,
                         const string_to_sign_t& string_to_sign,
                         const signature_factory_t& signature_factory,
                         const completer_factory_t& completer_factory,
@@ -1040,13 +1040,13 @@ class STSEngine : public AWSEngine {
   acl_strategy_t get_acl_strategy() const { return nullptr; };
   auth_info_t get_creds_info(const STS::SessionToken& token) const noexcept;
 
-  int get_session_token(const DoutPrefixProvider* dpp, const boost::string_view& session_token,
+  int get_session_token(const DoutPrefixProvider* dpp, std::string_view session_token,
                         STS::SessionToken& token) const;
 
   result_t authenticate(const DoutPrefixProvider* dpp, 
-                        const boost::string_view& access_key_id,
-                        const boost::string_view& signature,
-                        const boost::string_view& session_token,
+                        std::string_view access_key_id,
+                        std::string_view signature,
+                        std::string_view session_token,
                         const string_to_sign_t& string_to_sign,
                         const signature_factory_t& signature_factory,
                         const completer_factory_t& completer_factory,

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -87,11 +87,11 @@ public:
   // conditional params for error pages.
   int get_params() override {
       if (is_errordoc_request) {
-        range_str = NULL;
-        if_mod = NULL;
-        if_unmod = NULL;
-        if_match = NULL;
-        if_nomatch = NULL;
+        range_str = std::nullopt;
+        if_mod = std::nullopt;
+        if_unmod = std::nullopt;
+        if_match = std::nullopt;
+        if_nomatch = std::nullopt;
         return 0;
       } else {
         return RGWGetObj_ObjStore_S3::get_params();

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -32,8 +32,6 @@
 #include <sstream>
 #include <memory>
 
-#include <boost/utility/string_ref.hpp>
-
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -34,8 +34,6 @@
 #include <sstream>
 #include <memory>
 
-#include <boost/utility/string_ref.hpp>
-
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
@@ -2395,14 +2393,14 @@ int RGWSwiftWebsiteHandler::error_handler(const int err_no,
 
 bool RGWSwiftWebsiteHandler::is_web_mode() const
 {
-  const boost::string_ref webmode = s->info.env->get("HTTP_X_WEB_MODE", "");
+  const std::string_view webmode = s->info.env->get("HTTP_X_WEB_MODE", "");
   return boost::algorithm::iequals(webmode, "true");
 }
 
 bool RGWSwiftWebsiteHandler::can_be_website_req() const
 {
   /* Static website works only with the GET or HEAD method. Nothing more. */
-  static const std::set<boost::string_ref> ws_methods = { "GET", "HEAD" };
+  static const std::set<std::string_view> ws_methods = { "GET", "HEAD" };
   if (ws_methods.count(s->info.method) == 0) {
     return false;
   }

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -12,8 +12,6 @@
 #include "rgw_swift_auth.h"
 #include "rgw_http_errors.h"
 
-#include <boost/utility/string_ref.hpp>
-
 class RGWGetObj_ObjStore_SWIFT : public RGWGetObj_ObjStore {
   int custom_http_ret = 0;
 public:
@@ -296,11 +294,11 @@ public:
   SignatureHelper() = default;
 
   const char* calc(const std::string& key,
-                   const boost::string_ref& path_info,
-                   const boost::string_ref& redirect,
-                   const boost::string_ref& max_file_size,
-                   const boost::string_ref& max_file_count,
-                   const boost::string_ref& expires) {
+                   std::string_view path_info,
+                   std::string_view redirect,
+                   std::string_view max_file_size,
+                   std::string_view max_file_count,
+                   std::string_view expires) {
     using ceph::crypto::HMACSHA1;
     using UCHARPTR = const unsigned char*;
 

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -7,7 +7,6 @@
 #include "rgw_user.h"
 #include "rgw_rest_user.h"
 
-#include "include/str_list.h"
 #include "include/ceph_assert.h"
 
 #include "services/svc_zone.h"

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -162,14 +162,7 @@ void RGWOp_User_Create::execute()
   op_state.set_secret_key(secret_key);
 
   if (!op_mask_str.empty()) {
-    uint32_t op_mask;
-    int ret = rgw_parse_op_type_list(op_mask_str, &op_mask);
-    if (ret < 0) {
-      ldout(s->cct, 0) << "failed to parse op_mask: " << ret << dendl;
-      http_ret = -EINVAL;
-      return;
-    }
-    op_state.set_op_mask(op_mask);
+    op_state.set_op_mask(rgw_parse_op_type_list(op_mask_str));
   }
 
   if (!key_type_str.empty()) {
@@ -291,12 +284,7 @@ void RGWOp_User_Modify::execute()
   }
 
   if (!op_mask_str.empty()) {
-    uint32_t op_mask;
-    if (rgw_parse_op_type_list(op_mask_str, &op_mask) < 0) {
-        ldout(s->cct, 0) << "failed to parse op_mask" << dendl;
-        http_ret = -EINVAL;
-        return;
-    }   
+    auto op_mask = rgw_parse_op_type_list(op_mask_str);
     op_state.set_op_mask(op_mask);
   }
 
@@ -307,14 +295,7 @@ void RGWOp_User_Modify::execute()
     op_state.set_system(system);
 
   if (!op_mask_str.empty()) {
-    uint32_t op_mask;
-    int ret = rgw_parse_op_type_list(op_mask_str, &op_mask);
-    if (ret < 0) {
-      ldout(s->cct, 0) << "failed to parse op_mask: " << ret << dendl;
-      http_ret = -EINVAL;
-      return;
-    }
-    op_state.set_op_mask(op_mask);
+    op_state.set_op_mask(rgw_parse_op_type_list(op_mask_str));
   }
   
   if (!store->svc()->zone->is_meta_master()) {

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -912,8 +912,8 @@ void RGWOp_Quota_Set::execute()
   if (s->content_length > 0) {
     use_http_params = false;
   } else {
-    const char *encoding = s->info.env->get("HTTP_TRANSFER_ENCODING");
-    use_http_params = (!encoding || strcmp(encoding, "chunked") != 0);
+    auto encoding = s->info.env->get("HTTP_TRANSFER_ENCODING");
+    use_http_params = (!encoding || *encoding == "chunked");
   }
 
   if (use_http_params && set_all) {

--- a/src/rgw/rgw_string.cc
+++ b/src/rgw/rgw_string.cc
@@ -13,7 +13,7 @@ static bool ci_char_eq(char c1, char c2)
   return tolower(c1) == tolower(c2);
 }
 
-bool match_wildcards(boost::string_view pattern, boost::string_view input,
+bool match_wildcards(std::string_view pattern, std::string_view input,
                      uint32_t flags)
 {
   const auto eq = (flags & MATCH_CASE_INSENSITIVE) ? &ci_char_eq : &char_eq;

--- a/src/rgw/rgw_string.h
+++ b/src/rgw/rgw_string.h
@@ -87,7 +87,7 @@ template <std::size_t N>
 struct string_traits<char[N]> : string_traits<const char[N]> {};
 
 // helpers for string_cat_reserve()
-static inline void append_to(std::string& s) {}
+inline void append_to(std::string& s) {}
 template <typename... Args>
 void append_to(std::string& s, std::string_view v, Args... args)
 {

--- a/src/rgw/rgw_string.h
+++ b/src/rgw/rgw_string.h
@@ -30,12 +30,12 @@ inline int stringcasecmp(std::string_view s1, std::string_view s2)
   return strncasecmp(s1.data(), s2.data(), std::min(s1.size(), s2.size()));
 }
 
-/* A converter between boost::string_view and null-terminated C-strings.
+/* A converter between std::string_view and null-terminated C-strings.
  * It copies memory while trying to utilize the local memory instead of
  * issuing dynamic allocations. */
 template<std::size_t N = 128>
 inline boost::container::small_vector<char, N>
-sview2cstr(const boost::string_view& sv)
+sview2cstr(std::string_view sv)
 {
   boost::container::small_vector<char, N> cstr;
   cstr.reserve(sv.size() + sizeof('\0'));
@@ -89,27 +89,27 @@ struct string_traits<char[N]> : string_traits<const char[N]> {};
 // helpers for string_cat_reserve()
 static inline void append_to(std::string& s) {}
 template <typename... Args>
-void append_to(std::string& s, const boost::string_view& v, const Args&... args)
+void append_to(std::string& s, std::string_view v, Args... args)
 {
   s.append(v.begin(), v.end());
   append_to(s, args...);
 }
 
 // helpers for string_join_reserve()
-static inline void join_next(std::string& s, const boost::string_view& d) {}
+inline void join_next(std::string& s, std::string_view d) {}
 template <typename... Args>
-void join_next(std::string& s, const boost::string_view& d,
-               const boost::string_view& v, const Args&... args)
+void join_next(std::string& s, std::string_view d,
+               std::string_view v, const Args&... args)
 {
   s.append(d.begin(), d.end());
   s.append(v.begin(), v.end());
   join_next(s, d, args...);
 }
 
-static inline void join(std::string& s, const boost::string_view& d) {}
+inline void join(std::string& s, std::string_view d) {}
 template <typename... Args>
-void join(std::string& s, const boost::string_view& d,
-          const boost::string_view& v, const Args&... args)
+void join(std::string& s, std::string_view d,
+          std::string_view v, const Args&... args)
 {
   s.append(v.begin(), v.end());
   join_next(s, d, args...);
@@ -139,7 +139,7 @@ std::string string_cat_reserve(const Args&... args)
 /// joins the given string arguments with a delimiter, returning as a
 /// std::string that gets preallocated with reserve()
 template <typename... Args>
-std::string string_join_reserve(const boost::string_view& delim,
+std::string string_join_reserve(std::string_view delim,
                                 const Args&... args)
 {
   size_t delim_size = delim.size() * std::max<ssize_t>(0, sizeof...(args) - 1);
@@ -152,7 +152,7 @@ std::string string_join_reserve(const boost::string_view& delim,
 template <typename... Args>
 std::string string_join_reserve(char delim, const Args&... args)
 {
-  return string_join_reserve(boost::string_view{&delim, 1}, args...);
+  return string_join_reserve(std::string_view{&delim, 1}, args...);
 }
 
 
@@ -161,8 +161,8 @@ inline constexpr uint32_t MATCH_CASE_INSENSITIVE = 0x01;
 
 /// attempt to match the given input string with the pattern, which may contain
 /// the wildcard characters * and ?
-bool match_wildcards(boost::string_view pattern,
-		     boost::string_view input,
+bool match_wildcards(std::string_view pattern,
+		     std::string_view input,
 		     uint32_t flags = 0);
 
 #endif

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -193,8 +193,8 @@ public:
   SignatureHelper() = default;
 
   const char* calc(const std::string& key,
-                   const boost::string_view& method,
-                   const boost::string_view& path,
+                   std::string_view method,
+                   std::string_view path,
                    const std::string& expires) {
 
     using ceph::crypto::HMACSHA1;
@@ -227,9 +227,9 @@ class TempURLEngine::PrefixableSignatureHelper
     : private TempURLEngine::SignatureHelper {
   using base_t = SignatureHelper;
 
-  const boost::string_view decoded_uri;
-  const boost::string_view object_name;
-  boost::string_view no_obj_uri;
+  const std::string_view decoded_uri;
+  const std::string_view object_name;
+  std::string_view no_obj_uri;
 
   const boost::optional<const std::string&> prefix;
 
@@ -242,7 +242,7 @@ public:
       prefix(prefix) {
     /* Transform: v1/acct/cont/obj - > v1/acct/cont/
      *
-     * NOTE(rzarzynski): we really want to substr() on boost::string_view,
+     * NOTE(rzarzynski): we really want to substr() on std::string_view,
      * not std::string. Otherwise we would end with no_obj_uri referencing
      * a temporary. */
     no_obj_uri = \
@@ -250,8 +250,8 @@ public:
   }
 
   const char* calc(const std::string& key,
-                   const boost::string_view& method,
-                   const boost::string_view& path,
+                   std::string_view method,
+                   std::string_view path,
                    const std::string& expires) {
     if (!prefix) {
       return base_t::calc(key, method, path, expires);
@@ -327,14 +327,14 @@ TempURLEngine::authenticate(const DoutPrefixProvider* dpp, const req_state* cons
 
   /* XXX can we search this ONCE? */
   const size_t pos = g_conf()->rgw_swift_url_prefix.find_last_not_of('/') + 1;
-  const boost::string_view ref_uri = s->decoded_uri;
-  const std::array<boost::string_view, 2> allowed_paths = {
+  const std::string_view ref_uri = s->decoded_uri;
+  const std::array<std::string_view, 2> allowed_paths = {
     ref_uri,
     ref_uri.substr(pos + 1)
   };
 
   /* Account owner calculates the signature also against a HTTP method. */
-  boost::container::static_vector<boost::string_view, 3> allowed_methods;
+  boost::container::static_vector<std::string_view, 3> allowed_methods;
   if (strcmp("HEAD", s->info.method) == 0) {
     /* HEAD requests are specially handled. */
     /* TODO: after getting a newer boost (with static_vector supporting

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -19,7 +19,6 @@
 
 #include "rgw_client_io.h"
 #include "rgw_http_client.h"
-#include "include/str_list.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -188,7 +188,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
   std::string get_token(const req_state* const s) const override {
     /* Returning a reference here would end in GCC complaining about a reference
      * to temporary. */
-    return s->info.env->get("HTTP_X_AUTH_TOKEN", "");
+    return std::string(s->info.env->get("HTTP_X_AUTH_TOKEN").value_or(""));
   }
 
   aplptr_t create_apl_remote(CephContext* const cct,

--- a/src/rgw/rgw_tag.h
+++ b/src/rgw/rgw_tag.h
@@ -41,7 +41,7 @@ protected:
   bool emplace_tag(std::string&& key, std::string&& val);
   int check_and_add_tag(const std::string& key, const std::string& val="");
   size_t count() const {return tag_map.size();}
-  int set_from_string(const std::string& input);
+  int set_from_string(std::string_view input);
   void clear() { tag_map.clear(); }
   bool empty() const noexcept { return tag_map.empty(); }
   const tag_map_t& get_tags() const {return tag_map;}

--- a/src/rgw/rgw_tar.h
+++ b/src/rgw/rgw_tar.h
@@ -12,7 +12,6 @@
 
 #include <boost/optional.hpp>
 #include <boost/range/adaptor/reversed.hpp>
-#include <boost/utility/string_ref.hpp>
 
 namespace rgw {
 namespace tar {
@@ -107,22 +106,22 @@ public:
     }
   }
 
-  boost::string_ref get_filename() const {
-    return boost::string_ref(header->filename,
+  std::string_view get_filename() const {
+    return std::string_view(header->filename,
                              std::min(sizeof(header->filename),
                                       strlen(header->filename)));
   }
 
   size_t get_filesize() const {
-    /* The string_ref is pretty suitable here because tar encodes its
+    /* The string_view is pretty suitable here because tar encodes its
      * metadata in ASCII. */
-    const boost::string_ref raw(header->filesize, sizeof(header->filesize));
+    const std::string_view raw(header->filesize, sizeof(header->filesize));
 
     /* We need to find where the padding ends. */
     const auto pad_ends_at = std::min(raw.find_last_not_of('\0'),
                                       raw.find_last_not_of(' '));
     const auto trimmed = raw.substr(0,
-      pad_ends_at == boost::string_ref::npos ? boost::string_ref::npos
+      pad_ends_at == std::string_view::npos ? std::string_view::npos
                                              : pos2len(pad_ends_at));
 
     size_t sum = 0, mul = 1;

--- a/src/rgw/rgw_token.cc
+++ b/src/rgw/rgw_token.cc
@@ -23,7 +23,6 @@
 #include "common/debug.h"
 #include "global/global_init.h"
 #include "include/ceph_assert.h"
-#include "include/str_list.h"
 
 #include "rgw_token.h"
 #include "rgw_b64.h"

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -75,13 +75,13 @@ public:
   }
 
   //key len
-  void bencode_key(const std::string& key, bufferlist& bl) 
+  void bencode_key(std::string_view key, bufferlist& bl) 
   {
     int len = key.length();
-    char info[100] = { 0 }; 
+    char info[100] = { 0 };
     sprintf(info, "%d:", len);
     bl.append(info, strlen(info));
-    bl.append(key.c_str(), len); 
+    bl.append(key.data(), len);
   }
 };
 

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -347,7 +347,7 @@ struct BucketTrimObserver {
   virtual ~BucketTrimObserver() = default;
 
   virtual void on_bucket_trimmed(std::string&& bucket_instance) = 0;
-  virtual bool trimmed_recently(const boost::string_view& bucket_instance) = 0;
+  virtual bool trimmed_recently(std::string_view bucket_instance) = 0;
 };
 
 /// populate the status with the minimum stable marker of each shard
@@ -1055,7 +1055,7 @@ class BucketTrimManager::Impl : public TrimCounters::Server,
     trimmed.insert(std::move(bucket_instance), clock_type::now());
   }
 
-  bool trimmed_recently(const boost::string_view& bucket_instance) override {
+  bool trimmed_recently(std::string_view bucket_instance) override {
     std::lock_guard<std::mutex> lock(mutex);
     return trimmed.lookup(bucket_instance);
   }
@@ -1073,14 +1073,14 @@ int BucketTrimManager::init()
   return impl->watcher.start();
 }
 
-void BucketTrimManager::on_bucket_changed(const boost::string_view& bucket)
+void BucketTrimManager::on_bucket_changed(std::string_view bucket)
 {
   std::lock_guard<std::mutex> lock(impl->mutex);
   // filter recently trimmed bucket instances out of bucket change counter
   if (impl->trimmed.lookup(bucket)) {
     return;
   }
-  impl->counter.insert(bucket.to_string());
+  impl->counter.insert(std::string(bucket));
 }
 
 RGWCoroutine* BucketTrimManager::create_bucket_trim_cr(RGWHTTPManager *http)

--- a/src/rgw/rgw_trim_bilog.h
+++ b/src/rgw/rgw_trim_bilog.h
@@ -36,7 +36,7 @@ namespace sal {
 struct BucketChangeObserver {
   virtual ~BucketChangeObserver() = default;
 
-  virtual void on_bucket_changed(const boost::string_view& bucket_instance) = 0;
+  virtual void on_bucket_changed(std::string_view bucket_instance) = 0;
 };
 
 /// Configuration for BucketTrimManager
@@ -78,7 +78,7 @@ class BucketTrimManager : public BucketChangeObserver {
   int init();
 
   /// increment a counter for the given bucket instance
-  void on_bucket_changed(const boost::string_view& bucket_instance) override;
+  void on_bucket_changed(std::string_view bucket_instance) override;
 
   /// create a coroutine to run the bucket trim process every trim interval
   RGWCoroutine* create_bucket_trim_cr(RGWHTTPManager *http);

--- a/src/rgw/rgw_trim_datalog.h
+++ b/src/rgw/rgw_trim_datalog.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 class RGWCoroutine;
 class RGWRados;
 class RGWHTTPManager;

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -10,7 +10,8 @@
 
 
 
-static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log_entry& entry, map<string, bool> *categories)
+static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log_entry& entry,
+				       std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>> *categories)
 {
   formatter->open_array_section("categories");
   map<string, rgw_usage_data>::const_iterator uiter;
@@ -30,7 +31,8 @@ static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log
 }
 
 int RGWUsage::show(RGWRados *store, const rgw_user& uid, const string& bucket_name, uint64_t start_epoch,
-		   uint64_t end_epoch, bool show_log_entries, bool show_log_sum, map<string, bool> *categories,
+		   uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
+		   std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>> *categories,
 		   RGWFormatterFlusher& flusher)
 {
   uint32_t max_entries = 1000;

--- a/src/rgw/rgw_usage.h
+++ b/src/rgw/rgw_usage.h
@@ -9,6 +9,8 @@
 #include <unordered_set>
 
 #include "common/Formatter.h"
+
+#include "rgw_basic_types.h"
 #include "rgw_formats.h"
 
 class RGWRados;
@@ -17,8 +19,9 @@ class RGWRados;
 class RGWUsage
 {
 public:
-  static int show(RGWRados *store, const rgw_user& uid, const string& bucket_name, uint64_t start_epoch,
-	          uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
+  static int show(RGWRados *store, const rgw_user& uid,
+		  const std::string& bucket_name, uint64_t start_epoch,
+		  uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
 		  std::unordered_set<std::string_view,
 		                     std::hash<std::string_view>,
 		                     std::equal_to<>> *categories,

--- a/src/rgw/rgw_usage.h
+++ b/src/rgw/rgw_usage.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <map>
+#include <unordered_set>
 
 #include "common/Formatter.h"
 #include "rgw_formats.h"
@@ -18,7 +19,10 @@ class RGWUsage
 public:
   static int show(RGWRados *store, const rgw_user& uid, const string& bucket_name, uint64_t start_epoch,
 	          uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
-		  std::map<std::string, bool> *categories, RGWFormatterFlusher& flusher);
+		  std::unordered_set<std::string_view,
+		                     std::hash<std::string_view>,
+		                     std::equal_to<>> *categories,
+		  RGWFormatterFlusher& flusher);
 
   static int trim(RGWRados *store, const rgw_user& uid, const string& bucket_name, uint64_t start_epoch,
 	          uint64_t end_epoch);

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1,8 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
-#include <errno.h>
-
+#include <cerrno>
 #include <string>
 #include <map>
 #include <boost/algorithm/string.hpp>
@@ -2583,7 +2582,7 @@ public:
              RGWMDLogSyncType type) override;
 
   int do_remove(RGWSI_MetaBackend_Handler::Op *op, string& entry, RGWObjVersionTracker& objv_tracker,
-                optional_yield y) {
+                optional_yield y) override {
     RGWUserInfo info;
 
     rgw_user user = RGWSI_User::user_from_meta_key(entry);

--- a/src/rgw/rgw_web_idp.h
+++ b/src/rgw/rgw_web_idp.h
@@ -4,6 +4,8 @@
 #ifndef CEPH_RGW_WEB_IDP_H
 #define CEPH_RGW_WEB_IDP_H
 
+#include <string>
+
 namespace rgw {
 namespace web_idp {
 
@@ -16,7 +18,7 @@ struct WebTokenClaims {
   //Issuer of this token
   std::string iss;
   //Human-readable id for the resource owner
-  string user_name;
+  std::string user_name;
 };
 
 }; /* namespace web_idp */

--- a/src/rgw/rgw_website.cc
+++ b/src/rgw/rgw_website.cc
@@ -14,14 +14,17 @@
  * 
  */
 
+#include "acconfig.h"
+
+#include <cerrno>
+#include <string>
+#include <list>
+
+#include <fmt/format.h>
+
 #include "common/debug.h"
 #include "common/ceph_json.h"
 
-#include "acconfig.h"
-
-#include <errno.h>
-#include <string>
-#include <list>
 #include "include/types.h"
 #include "rgw_website.h"
 
@@ -33,15 +36,17 @@ bool RGWBWRoutingRuleCondition::check_key_condition(const string& key) {
 }
 
 
-void RGWBWRoutingRule::apply_rule(const string& default_protocol, const string& default_hostname,
-                                           const string& key, string *new_url, int *redirect_code)
+void RGWBWRoutingRule::apply_rule(std::string_view default_protocol,
+				  std::string_view default_hostname,
+				  std::string_view key, string *new_url,
+				  int *redirect_code)
 {
   RGWRedirectInfo& redirect = redirect_info.redirect;
 
-  string protocol = (!redirect.protocol.empty() ? redirect.protocol : default_protocol);
-  string hostname = (!redirect.hostname.empty() ? redirect.hostname : default_hostname);
+  auto protocol = (!redirect.protocol.empty() ? redirect.protocol : default_protocol);
+  auto hostname = (!redirect.hostname.empty() ? redirect.hostname : default_hostname);
 
-  *new_url = protocol + "://" + hostname + "/";
+  *new_url = fmt::format("{}://{}/", protocol, hostname);
 
   if (!redirect_info.replace_key_prefix_with.empty()) {
     *new_url += redirect_info.replace_key_prefix_with;
@@ -52,8 +57,8 @@ void RGWBWRoutingRule::apply_rule(const string& default_protocol, const string& 
     *new_url += key;
   }
 
-  if(redirect.http_redirect_code > 0) 
-	  *redirect_code = redirect.http_redirect_code;
+  if (redirect.http_redirect_code > 0)
+    *redirect_code = redirect.http_redirect_code;
 }
 
 bool RGWBWRoutingRules::check_key_and_error_code_condition(const string &key, int error_code, RGWBWRoutingRule **rule)
@@ -118,7 +123,7 @@ bool RGWBucketWebsiteConf::get_effective_key(const string& key, string *effectiv
   } else if (key[key.size() - 1] == '/') {
     *effective_key = key + index_doc_suffix;
   } else if (! is_file) {
-    *effective_key = key + "/" + index_doc_suffix; 
+    *effective_key = key + "/" + index_doc_suffix;
   } else {
     *effective_key = key;
   }

--- a/src/rgw/rgw_website.h
+++ b/src/rgw/rgw_website.h
@@ -139,9 +139,9 @@ struct RGWBWRoutingRule
     return condition.check_error_code_condition(error_code);
   }
 
-  void apply_rule(const std::string& default_protocol,
-                  const std::string& default_hostname,
-                  const std::string& key,
+  void apply_rule(std::string_view default_protocol,
+                  std::string_view default_hostname,
+                  std::string_view key,
                   std::string *redirect,
                   int *redirect_code);
 };

--- a/src/rgw/rgw_worker.h
+++ b/src/rgw/rgw_worker.h
@@ -1,5 +1,3 @@
-
-
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
@@ -23,8 +21,9 @@
 #include "common/Thread.h"
 #include "common/ceph_mutex.h"
 
+#include "rgw/rgw_rados.h"
+
 class CephContext;
-class RGWRados;
 
 class RGWRadosThread {
   class Worker : public Thread {
@@ -60,12 +59,12 @@ protected:
 
   std::atomic<bool> down_flag = { false };
 
-  string thread_name;
+  std::string thread_name;
 
   virtual uint64_t interval_msec() = 0;
   virtual void stop_process() {}
 public:
-  RGWRadosThread(RGWRados *_store, const string& thread_name = "radosgw")
+  RGWRadosThread(RGWRados *_store, const std::string& thread_name = "radosgw")
     : worker(NULL), cct(_store->ctx()), store(_store), thread_name(thread_name) {}
   virtual ~RGWRadosThread() {
     stop();

--- a/src/rgw/rgw_xml.h
+++ b/src/rgw/rgw_xml.h
@@ -165,7 +165,7 @@ namespace RGWXMLDecoder {
   void decode_xml(const char *name, T& val, T& default_val, XMLObj* obj);
 }
 
-static inline ostream& operator<<(ostream &out, RGWXMLDecoder::err& err)
+inline ostream& operator<<(ostream &out, RGWXMLDecoder::err& err)
 {
   return out << err.what();
 }
@@ -176,7 +176,7 @@ void decode_xml_obj(T& val, XMLObj *obj)
   val.decode_xml(obj);
 }
 
-static inline void decode_xml_obj(string& val, XMLObj *obj)
+inline void decode_xml_obj(string& val, XMLObj *obj)
 {
   val = obj->get_data();
 }

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -177,8 +177,9 @@ int RGWZoneGroup::equals(const string& other_zonegroup) const
 }
 
 int RGWZoneGroup::add_zone(const RGWZoneParams& zone_params, bool *is_master, bool *read_only,
-                           const list<string>& endpoints, const string *ptier_type,
-                           bool *psync_from_all, list<string>& sync_from, list<string>& sync_from_rm,
+                           const vector<string>& endpoints, const string *ptier_type,
+                           bool *psync_from_all, vector<string>& sync_from,
+			   vector<string>& sync_from_rm,
                            string *predirect_zone, RGWSyncModulesManager *sync_mgr)
 {
   auto& zone_id = zone_params.get_id();

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -540,7 +540,7 @@ WRITE_CLASS_ENCODER(RGWZoneParams)
 struct RGWZone {
   std::string id;
   std::string name;
-  list<std::string> endpoints;
+  std::vector<std::string> endpoints;
   bool log_meta;
   bool log_data;
   bool read_only;
@@ -685,7 +685,7 @@ WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTarget)
 
 struct RGWZoneGroup : public RGWSystemMetaObj {
   std::string api_name;
-  list<std::string> endpoints;
+  std::vector<std::string> endpoints;
   bool is_master = false;
 
   std::string master_zone;
@@ -719,7 +719,7 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
   RGWZoneGroup(const std::string &id, const std::string &name):RGWSystemMetaObj(id, name) {}
   explicit RGWZoneGroup(const std::string &_name):RGWSystemMetaObj(_name) {}
   RGWZoneGroup(const std::string &_name, bool _is_master, CephContext *cct, RGWSI_SysObj* sysobj_svc,
-	       const std::string& _realm_id, const list<std::string>& _endpoints)
+	       const std::string& _realm_id, const vector<std::string>& _endpoints)
     : RGWSystemMetaObj(_name, cct , sysobj_svc), endpoints(_endpoints), is_master(_is_master),
       realm_id(_realm_id) {}
 
@@ -777,8 +777,9 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
   int create_default(bool old_format = false);
   int equals(const std::string& other_zonegroup) const;
   int add_zone(const RGWZoneParams& zone_params, bool *is_master, bool *read_only,
-               const list<std::string>& endpoints, const std::string *ptier_type,
-               bool *psync_from_all, list<std::string>& sync_from, list<std::string>& sync_from_rm,
+               const vector<std::string>& endpoints, const std::string *ptier_type,
+               bool *psync_from_all, vector<std::string>& sync_from,
+	       vector<std::string>& sync_from_rm,
                std::string *predirect_zone, RGWSyncModulesManager *sync_mgr);
   int remove_zone(const std::string& zone_id);
   int rename_zone(const RGWZoneParams& zone_params);

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -187,7 +187,7 @@ int RGWSI_Zone::do_start()
       continue;
     }
     ldout(cct, 20) << "generating connection object for zone " << z.name << " id " << z.id << dendl;
-    RGWRESTConn *conn = new RGWRESTConn(cct, this, z.id, z.endpoints);
+    auto conn = new RGWRESTConn(cct, this, z.id, z.endpoints);
     zone_conn_map[id] = conn;
     if (zone_syncs_from(*zone_public_config, z) ||
         zone_syncs_from(z, *zone_public_config)) {

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -318,4 +318,6 @@ add_executable(unittest_rabin_chunk test_rabin_chunk.cc
 target_link_libraries(unittest_rabin_chunk global ceph-common)
 add_ceph_unittest(unittest_rabin_chunk)
 
-
+add_executable(unittest_str_util test_str_util.cc)
+target_link_libraries(unittest_str_util GTest::GTest)
+add_ceph_unittest(unittest_str_util)

--- a/src/test/common/test_str_util.cc
+++ b/src/test/common/test_str_util.cc
@@ -15,7 +15,9 @@
 
 #include <array>
 #include <cerrno>
+#include <cstdint>
 #include <string_view>
+#include <type_traits>
 
 #include <gtest/gtest.h>
 
@@ -24,7 +26,9 @@
 using namespace std::literals;
 
 using ceph::cf;
+using ceph::consume;
 using ceph::nul_terminated_copy;
+using ceph::parse;
 using ceph::substr_do;
 using ceph::substr_insert;
 
@@ -134,4 +138,240 @@ TEST(Insert, String) {
   std::vector<std::string> d;
   substr_insert(testlist, std::back_inserter(d));
   EXPECT_EQ(d, std::vector({"a"s, "b"s, "c"s, "d"s}));
+}
+
+template<typename T>
+inline void test_parse() {
+  auto r = parse<T>("23"sv);
+  ASSERT_TRUE(r);
+  EXPECT_EQ(*r, 23);
+
+  r = parse<T>("    23"sv);
+  EXPECT_FALSE(r);
+
+  r = parse<T>("-5"sv);
+  if constexpr (std::is_signed_v<T>) {
+    ASSERT_TRUE(r);
+    EXPECT_EQ(*r, -5);
+  } else {
+    EXPECT_FALSE(r);
+  }
+
+  r = parse<T>("meow"sv);
+  EXPECT_FALSE(r);
+
+  r = parse<T>("9yards"sv);
+  EXPECT_FALSE(r);
+}
+
+TEST(Parse, Char) {
+  test_parse<char>();
+}
+
+TEST(Parse, UChar) {
+  test_parse<unsigned char>();
+}
+
+TEST(Parse, SChar) {
+  test_parse<signed char>();
+}
+
+TEST(Parse, UInt8) {
+  test_parse<std::uint8_t>();
+}
+
+TEST(Parse, Int8) {
+  test_parse<std::int8_t>();
+}
+
+TEST(Parse, UInt16) {
+  test_parse<std::uint16_t>();
+}
+
+TEST(Parse, Int16) {
+  test_parse<std::int16_t>();
+}
+
+TEST(Parse, UInt32) {
+  test_parse<std::uint32_t>();
+}
+
+TEST(Parse, Int32) {
+  test_parse<std::int32_t>();
+}
+
+TEST(Parse, UInt64) {
+  test_parse<std::uint64_t>();
+}
+
+TEST(Parse, Int64) {
+  test_parse<std::int64_t>();
+}
+
+TEST(Parse, UIntMax) {
+  test_parse<std::uintmax_t>();
+}
+
+TEST(Parse, IntMax) {
+  test_parse<std::intmax_t>();
+}
+
+TEST(Parse, UIntPtr) {
+  test_parse<std::uintptr_t>();
+}
+
+TEST(Parse, IntPtr) {
+  test_parse<std::intptr_t>();
+}
+
+TEST(Parse, UShort) {
+  test_parse<unsigned short>();
+}
+
+TEST(Parse, Short) {
+  test_parse<short>();
+}
+
+TEST(Parse, ULong) {
+  test_parse<unsigned long>();
+}
+
+TEST(Parse, Long) {
+  test_parse<long>();
+}
+
+TEST(Parse, ULongLong) {
+  test_parse<unsigned long long>();
+}
+
+TEST(Parse, LongLong) {
+  test_parse<long long>();
+}
+
+template<typename T>
+inline void test_consume() {
+  auto pos = "23"sv;
+  auto spacepos = "    23"sv;
+  auto neg = "-5"sv;
+  auto meow = "meow"sv;
+  auto trail = "9yards"sv;
+
+  auto v = pos;
+  auto r = consume<T>(v);
+  ASSERT_TRUE(r);
+  EXPECT_EQ(*r, 23);
+  EXPECT_TRUE(v.empty());
+
+  v = spacepos;
+  r = consume<T>(v);
+  EXPECT_FALSE(r);
+  EXPECT_EQ(v, spacepos);
+
+  v = neg;
+  r = consume<T>(v);
+  if constexpr (std::is_signed_v<T>) {
+    ASSERT_TRUE(r);
+    EXPECT_EQ(*r, -5);
+    EXPECT_TRUE(v.empty());
+  } else {
+    EXPECT_FALSE(r);
+    EXPECT_EQ(v, neg);
+  }
+
+  v = meow;
+  r = consume<T>(v);
+  EXPECT_FALSE(r);
+  EXPECT_EQ(v, meow);
+
+  v = trail;
+  r = consume<T>(v);
+  ASSERT_TRUE(r);
+  EXPECT_EQ(*r, 9);
+  auto w = trail;
+  w.remove_prefix(1);
+  EXPECT_EQ(v, w);
+}
+
+TEST(Consume, Char) {
+  test_consume<char>();
+}
+
+TEST(Consume, UChar) {
+  test_consume<unsigned char>();
+}
+
+TEST(Consume, SChar) {
+  test_consume<signed char>();
+}
+
+TEST(Consume, UInt8) {
+  test_consume<std::uint8_t>();
+}
+
+TEST(Consume, Int8) {
+  test_consume<std::int8_t>();
+}
+
+TEST(Consume, UInt16) {
+  test_consume<std::uint16_t>();
+}
+
+TEST(Consume, Int16) {
+  test_consume<std::int16_t>();
+}
+
+TEST(Consume, UInt32) {
+  test_consume<std::uint32_t>();
+}
+
+TEST(Consume, Int32) {
+  test_consume<std::int32_t>();
+}
+
+TEST(Consume, UInt64) {
+  test_consume<std::uint64_t>();
+}
+
+TEST(Consume, Int64) {
+  test_consume<std::int64_t>();
+}
+
+TEST(Consume, UIntMax) {
+  test_consume<std::uintmax_t>();
+}
+
+TEST(Consume, IntMax) {
+  test_consume<std::intmax_t>();
+}
+
+TEST(Consume, UIntPtr) {
+  test_consume<std::uintptr_t>();
+}
+
+TEST(Consume, IntPtr) {
+  test_consume<std::intptr_t>();
+}
+
+TEST(Consume, UShort) {
+  test_consume<unsigned short>();
+}
+
+TEST(Consume, Short) {
+  test_consume<short>();
+}
+
+TEST(Consume, ULong) {
+  test_consume<unsigned long>();
+}
+
+TEST(Consume, Long) {
+  test_consume<long>();
+}
+
+TEST(Consume, ULongLong) {
+  test_consume<unsigned long long>();
+}
+
+TEST(Consume, LongLong) {
+  test_consume<long long>();
 }

--- a/src/test/common/test_str_util.cc
+++ b/src/test/common/test_str_util.cc
@@ -33,6 +33,7 @@ using ceph::parse;
 using ceph::substr_do;
 using ceph::substr_insert;
 using ceph::transform;
+using ceph::trim;
 
 static constexpr auto foo = "foo"sv;
 static constexpr auto fred = "fred"sv;
@@ -413,4 +414,26 @@ TEST(Transform, MultiV) {
 		  return "''"sv;
 		return "f"sv;
 	      }), "''ffff''"s);
+}
+
+TEST(Trim, Space) {
+  EXPECT_EQ(trim("foo"sv), "foo"sv);
+  EXPECT_EQ(trim("    foo"sv), "foo"sv);
+  EXPECT_EQ(trim("    foo    "sv), "foo"sv);
+  EXPECT_EQ(trim("foo    "sv), "foo"sv);
+  EXPECT_EQ(trim("foo "sv), "foo"sv);
+  EXPECT_EQ(trim(" foo"sv), "foo"sv);
+  EXPECT_EQ(trim("    "sv), ""sv);
+  EXPECT_EQ(trim(""sv), ""sv);
+}
+
+TEST(Trim, Mix) {
+  EXPECT_EQ(trim("foo"sv, ".,"sv), "foo"sv);
+  EXPECT_EQ(trim(".,.,foo"sv, ",."sv), "foo"sv);
+  EXPECT_EQ(trim(".,.,foo.,.,"sv, ".,"sv), "foo"sv);
+  EXPECT_EQ(trim("foo.,.,"sv, ".,"sv), "foo"sv);
+  EXPECT_EQ(trim("foo."sv, ".,"sv), "foo"sv);
+  EXPECT_EQ(trim(",foo"sv, ".,"sv), "foo"sv);
+  EXPECT_EQ(trim(".,.,"sv, ".,"sv), ""sv);
+  EXPECT_EQ(trim(""sv, ".,"sv), ""sv);
 }

--- a/src/test/rgw/test_rgw_crypto.cc
+++ b/src/test/rgw/test_rgw_crypto.cc
@@ -35,7 +35,7 @@ public:
 
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override
   {
-    sink << boost::string_ref(bl.c_str()+bl_ofs, bl_len);
+    sink << std::string_view(bl.c_str()+bl_ofs, bl_len);
     return 0;
   }
   std::string get_sink()
@@ -50,7 +50,7 @@ class ut_put_sink: public rgw::putobj::DataProcessor
 public:
   int process(bufferlist&& bl, uint64_t ofs) override
   {
-    sink << boost::string_ref(bl.c_str(),bl.length());
+    sink << std::string_view(bl.c_str(),bl.length());
     return 0;
   }
   std::string get_sink()
@@ -138,8 +138,8 @@ TEST(TestRGWCrypto, verify_AES_256_CBC_identity)
       ASSERT_TRUE(aes->decrypt(encrypted, 0, end - begin, decrypted, offset));
 
       ASSERT_EQ(decrypted.length(), end - begin);
-      ASSERT_EQ(boost::string_ref(input.c_str() + begin, end - begin),
-                boost::string_ref(decrypted.c_str(), end - begin) );
+      ASSERT_EQ(std::string_view(input.c_str() + begin, end - begin),
+                std::string_view(decrypted.c_str(), end - begin) );
     }
   }
 }
@@ -186,8 +186,8 @@ TEST(TestRGWCrypto, verify_AES_256_CBC_identity_2)
       ASSERT_TRUE(aes->decrypt(encrypted, 0, end, decrypted, offset));
 
       ASSERT_EQ(decrypted.length(), end);
-      ASSERT_EQ(boost::string_ref(input.c_str(), end),
-                boost::string_ref(decrypted.c_str(), end) );
+      ASSERT_EQ(std::string_view(input.c_str(), end),
+                std::string_view(decrypted.c_str(), end) );
     }
   }
 }
@@ -263,8 +263,8 @@ TEST(TestRGWCrypto, verify_AES_256_CBC_identity_3)
       }
       ASSERT_EQ(encrypted1.length(), end);
       ASSERT_EQ(encrypted2.length(), end);
-      ASSERT_EQ(boost::string_ref(encrypted1.c_str(), end),
-                boost::string_ref(encrypted2.c_str(), end) );
+      ASSERT_EQ(std::string_view(encrypted1.c_str(), end),
+                std::string_view(encrypted2.c_str(), end) );
     }
   }
 }
@@ -312,8 +312,8 @@ TEST(TestRGWCrypto, verify_AES_256_CBC_size_0_15)
       ASSERT_TRUE(aes->encrypt(encrypted, 0, end, decrypted, offset));
       ASSERT_EQ(encrypted.length(), end);
       ASSERT_EQ(decrypted.length(), end);
-      ASSERT_EQ(boost::string_ref(input.c_str(), end),
-                boost::string_ref(decrypted.c_str(), end) );
+      ASSERT_EQ(std::string_view(input.c_str(), end),
+                std::string_view(decrypted.c_str(), end) );
     }
   }
 }
@@ -388,8 +388,8 @@ TEST(TestRGWCrypto, verify_AES_256_CBC_identity_last_block)
       }
       ASSERT_EQ(encrypted1.length(), end);
       ASSERT_EQ(encrypted2.length(), end);
-      ASSERT_EQ(boost::string_ref(encrypted1.c_str(), end),
-                boost::string_ref(encrypted2.c_str(), end) );
+      ASSERT_EQ(std::string_view(encrypted1.c_str(), end),
+                std::string_view(encrypted2.c_str(), end) );
     }
   }
 }
@@ -436,7 +436,7 @@ TEST(TestRGWCrypto, verify_RGWGetObj_BlockDecrypt_ranges)
     const std::string& decrypted = get_sink.get_sink();
     size_t expected_len = end - begin + 1;
     ASSERT_EQ(decrypted.length(), expected_len);
-    ASSERT_EQ(decrypted, boost::string_ref(input.c_str()+begin, expected_len));
+    ASSERT_EQ(decrypted, std::string_view(input.c_str()+begin, expected_len));
   }
 }
 
@@ -492,7 +492,7 @@ TEST(TestRGWCrypto, verify_RGWGetObj_BlockDecrypt_chunks)
     const std::string& decrypted = get_sink.get_sink();
     size_t expected_len = end - begin + 1;
     ASSERT_EQ(decrypted.length(), expected_len);
-    ASSERT_EQ(decrypted, boost::string_ref(input.c_str()+begin, expected_len));
+    ASSERT_EQ(decrypted, std::string_view(input.c_str()+begin, expected_len));
   }
 }
 
@@ -740,8 +740,8 @@ TEST(TestRGWCrypto, verify_RGWPutObj_BlockEncrypt_chunks)
     ASSERT_TRUE(cbc->decrypt(encrypted, 0, test_size, decrypted, 0));
 
     ASSERT_EQ(decrypted.length(), test_size);
-    ASSERT_EQ(boost::string_ref(decrypted.c_str(), test_size),
-              boost::string_ref(input.c_str(), test_size));
+    ASSERT_EQ(std::string_view(decrypted.c_str(), test_size),
+              std::string_view(input.c_str(), test_size));
   }
 }
 
@@ -790,7 +790,7 @@ TEST(TestRGWCrypto, verify_Encrypt_Decrypt)
     decrypt.handle_data(bl, 0, bl.length());
     decrypt.flush();
     ASSERT_EQ(get_sink.get_sink().length(), test_size);
-    ASSERT_EQ(get_sink.get_sink(), boost::string_ref((char*)test_in,test_size));
+    ASSERT_EQ(get_sink.get_sink(), std::string_view((char*)test_in,test_size));
   }
   while (test_size < 20000);
 }
@@ -808,4 +808,3 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/src/test/rgw/test_rgw_string.cc
+++ b/src/test/rgw/test_rgw_string.cc
@@ -19,7 +19,7 @@ const std::string abc{"abc"};
 const char *def{"def"}; // const char*
 char ghi_arr[] = {'g', 'h', 'i', '\0'};
 char *ghi{ghi_arr}; // char*
-constexpr boost::string_view jkl{"jkl", 3};
+constexpr std::string_view jkl{"jkl", 3};
 #define mno "mno" // string literal (char[4])
 char pqr[] = {'p', 'q', 'r', '\0'};
 

--- a/src/test/test_cors.cc
+++ b/src/test/test_cors.cc
@@ -335,7 +335,7 @@ size_t cors_read_xml(void *ptr, size_t s, size_t n, void *ud){
 
 void send_cors(set<string, std::less<>> o,
                set<string, std::less<>> h,
-               list<string> e, uint8_t flags,
+               std::vector<string> e, uint8_t flags,
                unsigned max_age){
   if(g_test->get_key_type() == KEY_TYPE_S3){
     RGWCORSRule rule(o, h, e, flags, max_age);
@@ -367,7 +367,7 @@ void send_cors(set<string, std::less<>> o,
     }
     if(!e.empty()){
       string e_h;
-      for(list<string>::iterator lit = e.begin(); lit != e.end(); ++lit){
+      for(auto lit = e.begin(); lit != e.end(); ++lit){
         if(e_h.length() > 0)e_h.append(" ");
         e_h.append(*lit);
       }
@@ -397,7 +397,7 @@ TEST(TestCORS, getcors_firsttime){
 TEST(TestCORS, putcors_firsttime){
   ASSERT_EQ(0, create_bucket());
   set<string, less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "example.com");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT;
@@ -423,7 +423,7 @@ TEST(TestCORS, putcors_firsttime){
 TEST(TestCORS, putcors_invalid_hostname){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "*.example.*");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT;
@@ -443,7 +443,7 @@ TEST(TestCORS, putcors_invalid_hostname){
 TEST(TestCORS, putcors_invalid_headers){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "www.example.com");
   h.insert(h.end(), "*-Header-*");
@@ -465,7 +465,7 @@ TEST(TestCORS, putcors_invalid_headers){
 TEST(TestCORS, optionscors_test_options_1){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "*.example.com");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT;
@@ -497,7 +497,7 @@ TEST(TestCORS, optionscors_test_options_1){
 TEST(TestCORS, optionscors_test_options_2){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "*.example.com");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT | RGW_CORS_DELETE | RGW_CORS_HEAD;
@@ -532,7 +532,7 @@ TEST(TestCORS, optionscors_test_options_2){
 TEST(TestCORS, optionscors_test_options_3){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "*");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT | RGW_CORS_DELETE | RGW_CORS_HEAD;
@@ -598,7 +598,7 @@ TEST(TestCORS, optionscors_test_options_3){
 TEST(TestCORS, optionscors_test_options_4){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "example.com");
   h.insert(h.end(), "Header1");
@@ -692,7 +692,7 @@ TEST(TestCORS, optionscors_test_options_4){
 TEST(TestCORS, optionscors_test_options_5){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "example.com");
   e.insert(e.end(), "Expose1");
@@ -720,7 +720,7 @@ TEST(TestCORS, optionscors_test_options_5){
 TEST(TestCORS, optionscors_test_options_6){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
   unsigned err = (g_test->get_key_type() == KEY_TYPE_SWIFT)?401U:403U;
 
   origins.insert(origins.end(), "http://www.example.com");
@@ -743,7 +743,7 @@ TEST(TestCORS, optionscors_test_options_6){
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
   EXPECT_EQ(err, g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: http://www.example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
@@ -810,7 +810,7 @@ TEST(TestCORS, optionscors_test_options_6){
 TEST(TestCORS, optionscors_test_options_7){
   ASSERT_EQ(0, create_bucket());
   set<string, std::less<>> origins, h;
-  list<string> e;
+  vector<string> e;
 
   origins.insert(origins.end(), "example.com");
   h.insert(h.end(), "Header*");
@@ -850,7 +850,7 @@ TEST(TestCORS, deletecors_firsttime){
 
 TEST(TestCORS, deletecors_test){
   set<string, less<>> origins, h;
-  list<string> e;
+  vector<string> e;
   if(g_test->get_key_type() == KEY_TYPE_SWIFT)return;
   ASSERT_EQ(0, create_bucket());
   origins.insert(origins.end(), "example.com");

--- a/src/test/test_cors.cc
+++ b/src/test/test_cors.cc
@@ -333,8 +333,9 @@ size_t cors_read_xml(void *ptr, size_t s, size_t n, void *ud){
   return len;
 }
 
-void send_cors(set<string> o, set<string> h,
-               list<string> e, uint8_t flags, 
+void send_cors(set<string, std::less<>> o,
+               set<string, std::less<>> h,
+               list<string> e, uint8_t flags,
                unsigned max_age){
   if(g_test->get_key_type() == KEY_TYPE_S3){
     RGWCORSRule rule(o, h, e, flags, max_age);
@@ -347,8 +348,8 @@ void send_cors(set<string> o, set<string> h,
 
     g_test->send_request(string("PUT"), string("/" S3_BUCKET_NAME "?cors"), cors_read_xml, 
                          (void *)&ss, ss.str().length());
-  }else if(g_test->get_key_type() == KEY_TYPE_SWIFT){
-    set<string>::iterator it;
+  } else if (g_test->get_key_type() == KEY_TYPE_SWIFT) {
+    set<string, less<>>::iterator it;
     string a_o;
     for(it = o.begin(); it != o.end(); ++it){
       if(a_o.length() > 0)a_o.append(" ");
@@ -395,7 +396,7 @@ TEST(TestCORS, getcors_firsttime){
 
 TEST(TestCORS, putcors_firsttime){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "example.com");
@@ -421,7 +422,7 @@ TEST(TestCORS, putcors_firsttime){
 
 TEST(TestCORS, putcors_invalid_hostname){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "*.example.*");
@@ -441,7 +442,7 @@ TEST(TestCORS, putcors_invalid_hostname){
 
 TEST(TestCORS, putcors_invalid_headers){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "www.example.com");
@@ -463,7 +464,7 @@ TEST(TestCORS, putcors_invalid_headers){
 
 TEST(TestCORS, optionscors_test_options_1){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "*.example.com");
@@ -495,7 +496,7 @@ TEST(TestCORS, optionscors_test_options_1){
 
 TEST(TestCORS, optionscors_test_options_2){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "*.example.com");
@@ -530,12 +531,12 @@ TEST(TestCORS, optionscors_test_options_2){
 
 TEST(TestCORS, optionscors_test_options_3){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "*");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT | RGW_CORS_DELETE | RGW_CORS_HEAD;
-  
+
   send_cors(origins, h, e, flags, CORS_MAX_AGE_INVALID);
   EXPECT_EQ(((g_test->get_key_type() == KEY_TYPE_SWIFT)?202U:200U), g_test->get_resp_code());
 
@@ -596,7 +597,7 @@ TEST(TestCORS, optionscors_test_options_3){
 
 TEST(TestCORS, optionscors_test_options_4){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "example.com");
@@ -604,10 +605,10 @@ TEST(TestCORS, optionscors_test_options_4){
   h.insert(h.end(), "Header2");
   h.insert(h.end(), "*");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT;
-  
+
   send_cors(origins, h, e, flags, CORS_MAX_AGE_INVALID);
   EXPECT_EQ(((g_test->get_key_type() == KEY_TYPE_SWIFT)?202U:200U), g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
@@ -690,17 +691,17 @@ TEST(TestCORS, optionscors_test_options_4){
 
 TEST(TestCORS, optionscors_test_options_5){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "example.com");
   e.insert(e.end(), "Expose1");
   e.insert(e.end(), "Expose2");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT;
-  
+
   send_cors(origins, h, e, flags, CORS_MAX_AGE_INVALID);
   EXPECT_EQ(((g_test->get_key_type() == KEY_TYPE_SWIFT)?202U:200U), g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
@@ -718,26 +719,26 @@ TEST(TestCORS, optionscors_test_options_5){
 
 TEST(TestCORS, optionscors_test_options_6){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
   unsigned err = (g_test->get_key_type() == KEY_TYPE_SWIFT)?401U:403U;
 
   origins.insert(origins.end(), "http://www.example.com");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT;
-  
+
   send_cors(origins, h, e, flags, CORS_MAX_AGE_INVALID);
   EXPECT_EQ(((g_test->get_key_type() == KEY_TYPE_SWIFT)?202U:200U), g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
   EXPECT_EQ(err, g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: http://example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
   EXPECT_EQ(err, g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: www.example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
@@ -787,12 +788,12 @@ TEST(TestCORS, optionscors_test_options_6){
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
   EXPECT_EQ(200U, g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: http://example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
   EXPECT_EQ(err, g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: www.example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->send_request(string("OPTIONS"), BUCKET_URL);
@@ -808,7 +809,7 @@ TEST(TestCORS, optionscors_test_options_6){
 
 TEST(TestCORS, optionscors_test_options_7){
   ASSERT_EQ(0, create_bucket());
-  set<string> origins, h;
+  set<string, std::less<>> origins, h;
   list<string> e;
 
   origins.insert(origins.end(), "example.com");
@@ -817,10 +818,10 @@ TEST(TestCORS, optionscors_test_options_7){
   h.insert(h.end(), "*-Length");
   h.insert(h.end(), "foo*foo");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT;
-  
+
   send_cors(origins, h, e, flags, CORS_MAX_AGE_INVALID);
   EXPECT_EQ(((g_test->get_key_type() == KEY_TYPE_SWIFT)?202U:200U), g_test->get_resp_code());
-  
+
   g_test->set_extra_header(string("Origin: example.com"));
   g_test->set_extra_header(string("Access-Control-Request-Method: GET"));
   g_test->set_extra_header(string("Access-Control-Allow-Headers: Header1, Header2, Header3, "
@@ -848,13 +849,13 @@ TEST(TestCORS, deletecors_firsttime){
 }
 
 TEST(TestCORS, deletecors_test){
-  set<string> origins, h;
+  set<string, less<>> origins, h;
   list<string> e;
   if(g_test->get_key_type() == KEY_TYPE_SWIFT)return;
   ASSERT_EQ(0, create_bucket());
   origins.insert(origins.end(), "example.com");
   uint8_t flags = RGW_CORS_GET | RGW_CORS_PUT;
-  
+
   send_cors(origins, h, e, flags, CORS_MAX_AGE_INVALID);
   EXPECT_EQ(((g_test->get_key_type() == KEY_TYPE_SWIFT)?202U:200U), g_test->get_resp_code());
 

--- a/src/test/test_rgw_admin_log.cc
+++ b/src/test/test_rgw_admin_log.cc
@@ -26,7 +26,7 @@ extern "C"{
 #include <curl/curl.h>
 }
 #include "common/ceph_crypto.h"
-#include "include/str_list.h"
+#include "common/str_util.h"
 #include "common/ceph_json.h"
 #include "common/code_environment.h"
 #include "common/ceph_argparse.h"
@@ -306,15 +306,13 @@ int run_rgw_admin(string& cmd, string& resp) {
   pid = fork();
   if (pid == 0) {
     /* child */
-    list<string> l;
-    get_str_list(cmd, " \t", l);
+    std::vector<string> l;
+    ceph::substr_insert(cmd, std::back_inserter(l), " \t");
     char *argv[l.size()];
     unsigned loop = 1;
-
     argv[0] = (char *)"radosgw-admin";
-    for (list<string>::iterator it = l.begin(); 
-         it != l.end(); ++it) {
-      argv[loop++] = (char *)(*it).c_str();
+    for (auto& arg : l) {
+      argv[loop++] = arg.data();
     }
     argv[loop] = NULL;
     if (!freopen(RGW_ADMIN_RESP_PATH, "w+", stdout)) {


### PR DESCRIPTION
Improve string handling:

* Do not allocate an object on the heap, traverse it, and throw it away when traversing substrings will do.
* Prefer `string_view` to `const char*` since they don't have to be zero terminated.
* Rewrite/provide alternatives to accept `string_view` and not depend on zero termination.

Not strictly string related but:

* Replace map<T, bool> that only has things inserted in it and tested for membership with a set. Preferably an unordered set.