### PR TITLE
nautilus: pybind/mgr: Cancel output color control

### DIFF
--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -71,11 +71,11 @@ def format_units(n, width, colored, decimal):
         return formatted
 
 
-def format_dimless(n, width, colored=True):
+def format_dimless(n, width, colored=False):
     return format_units(n, width, colored, decimal=True)
 
 
-def format_bytes(n, width, colored=True):
+def format_bytes(n, width, colored=False):
     return format_units(n, width, colored, decimal=False)
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42850

---

backport of https://github.com/ceph/ceph/pull/31427
parent tracker: https://tracker.ceph.com/issues/42517

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh