### PR TITLE
ceph-daemon: infer fsid for some commands

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -60,6 +60,7 @@ except ImportError:
 import uuid
 
 from distutils.spawn import find_executable
+from functools import wraps
 from glob import glob
 
 try:
@@ -225,6 +226,35 @@ def is_fsid(s):
     except ValueError:
         return False
     return True
+
+def infer_fsid(func):
+    """
+    If we only find a single fsid in /var/lib/ceph/*, use that
+    """
+    @wraps(func)
+    def _infer_fsid():
+        if args.fsid:
+            logger.debug('Using specified fsid: %s' % args.fsid)
+            return
+
+        fsid_list = []
+        for i in os.listdir(args.data_dir):
+            if is_fsid(i):
+                fsid_list.append(i)
+
+        logger.debug('Found fsids %s' % str(fsid_list))
+
+        if not fsid_list:
+            # TODO: raise?
+            return
+
+        if len(fsid_list) > 1:
+            raise RuntimeError('Cannot infer fsid, must specify --fsid')
+
+        logger.info('Inferring fsid %s' % fsid_list[0])
+        args.fsid = fsid_list[0]
+        return func()
+    return _infer_fsid
 
 def makedirs(dir, uid, gid, mode):
     # type: (str, int, int, int) -> None
@@ -1258,6 +1288,7 @@ def command_run():
 
 ##################################
 
+@infer_fsid
 def command_shell():
     # type: () -> int
     if args.fsid:
@@ -1296,6 +1327,7 @@ def command_shell():
 
 ##################################
 
+@infer_fsid
 def command_enter():
     # type: () -> int
     (daemon_type, daemon_id) = args.name.split('.', 1)
@@ -1315,6 +1347,7 @@ def command_enter():
 
 ##################################
 
+@infer_fsid
 def command_ceph_volume():
     # type: () -> None
     make_log_dir(args.fsid)
@@ -1357,6 +1390,7 @@ def command_ceph_volume():
 
 ##################################
 
+@infer_fsid
 def command_unit():
     # type: () -> None
     (daemon_type, daemon_id) = args.name.split('.', 1)
@@ -1368,6 +1402,7 @@ def command_unit():
 
 ##################################
 
+@infer_fsid
 def command_logs():
     # type: () -> None
     cmd = [container_path, 'logs']
@@ -1751,7 +1786,6 @@ def _get_parser():
     parser_enter.set_defaults(func=command_enter)
     parser_enter.add_argument(
         '--fsid',
-        required=True,
         help='cluster FSID')
     parser_enter.add_argument(
         '--name', '-n',
@@ -1766,7 +1800,6 @@ def _get_parser():
     parser_ceph_volume.set_defaults(func=command_ceph_volume)
     parser_ceph_volume.add_argument(
         '--fsid',
-        required=True,
         help='cluster FSID')
     parser_ceph_volume.add_argument(
         '--config-and-keyring',
@@ -1783,7 +1816,6 @@ def _get_parser():
         help='systemd command (start, stop, restart, enable, disable, ...)')
     parser_unit.add_argument(
         '--fsid',
-        required=True,
         help='cluster FSID')
     parser_unit.add_argument(
         '--name', '-n',
@@ -1795,7 +1827,6 @@ def _get_parser():
     parser_logs.set_defaults(func=command_logs)
     parser_logs.add_argument(
         '--fsid',
-        required=True,
         help='cluster FSID')
     parser_logs.add_argument(
         '--name', '-n',


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>