### PR TITLE
mgr/orchestrator: do not try to iterate through None

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -667,10 +667,13 @@ class PlacementSpec(object):
     """
     For APIs that need to specify a node subset
     """
-    def __init__(self, label=None, nodes=[]):
+    def __init__(self, label=None, nodes=None):
         self.label = label
+        if nodes:
+            self.nodes = [parse_host_specs(x, require_network=False) for x in nodes]
+        else:
+            self.nodes = []
 
-        self.nodes = [parse_host_specs(x, require_network=False) for x in nodes]
 
 def handle_type_error(method):
     @wraps(method)


### PR DESCRIPTION
`PlacementSpec` instances could be constructed with `nodes=None`, see
`OrchestratorCli._mds_add()` in orchestrator_cli/module.py, so we need
to handle the case of `None`.

also, it's dangerous to pass a list as the default parameter to a
method in python, as the value of reference point to that list will
be stored. and multiple calls of that method will share the same
instance of list. which is not expected under most circumstances.

in this change, list comprehension is unsed instead of more functional
`list(map(...))`, because, the behavior of `map()` in python3 is quite
different from that in python2. in python3, `map()` returns an iterator.
and `list()` actually materializes the iterator by walking through it,
and `list()` changes the iterator by advancing it. so, to improve the
readability and to reduce the menta load of developers, list
comprehension is better in most cases.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
