### PR TITLE
Fix rgw storage classes doc

### DIFF
--- a/doc/radosgw/placement.rst
+++ b/doc/radosgw/placement.rst
@@ -147,6 +147,12 @@ Then provide the zone placement info for that storage class:
         --data-pool default.rgw.cold.data \
         --compression lz4
 
+Finally, restart the Ceph Object Gateway:
+
+::
+
+  # systemctl restart ceph-radosgw@rgw.`hostname -s`
+
 Customizing Placement
 =====================
 


### PR DESCRIPTION
Fix rgw storage classes doc

To apply the new storage class it is mandatory to restart the rgw, we should mention it.

Signed-off-by: Or Friedmann <ofriedma@redhat.com>