### PR TITLE
nautilus: mgr/dashboard: Added breadcrumb tests to Object Gateway menu items

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.e2e-spec.ts
@@ -1,0 +1,19 @@
+import { Helper } from '../helper.po';
+import { BucketsPage } from './buckets.po';
+
+describe('RGW buckets page', () => {
+  let page: BucketsPage;
+
+  beforeAll(() => {
+    page = new BucketsPage();
+  });
+
+  afterEach(() => {
+    Helper.checkConsole();
+  });
+
+  it('should open and show breadcrumb', () => {
+    page.navigateTo();
+    expect(Helper.getBreadcrumbText()).toEqual('Buckets');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/buckets.po.ts
@@ -1,0 +1,7 @@
+import { browser } from 'protractor';
+
+export class BucketsPage {
+  navigateTo() {
+    return browser.get('/#/rgw/bucket');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.e2e-spec.ts
@@ -1,0 +1,19 @@
+import { Helper } from '../helper.po';
+import { DaemonsPage } from './daemons.po';
+
+describe('RGW daemons page', () => {
+  let page: DaemonsPage;
+
+  beforeAll(() => {
+    page = new DaemonsPage();
+  });
+
+  afterEach(() => {
+    Helper.checkConsole();
+  });
+
+  it('should open and show breadcrumb', () => {
+    page.navigateTo();
+    expect(Helper.getBreadcrumbText()).toEqual('Daemons');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/daemons.po.ts
@@ -1,0 +1,7 @@
+import { browser } from 'protractor';
+
+export class DaemonsPage {
+  navigateTo() {
+    return browser.get('/#/rgw/daemon');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.e2e-spec.ts
@@ -1,0 +1,19 @@
+import { Helper } from '../helper.po';
+import { UsersPage } from './users.po';
+
+describe('RGW users page', () => {
+  let page: UsersPage;
+
+  beforeAll(() => {
+    page = new UsersPage();
+  });
+
+  afterEach(() => {
+    Helper.checkConsole();
+  });
+
+  it('should open and show breadcrumb', () => {
+    page.navigateTo();
+    expect(Helper.getBreadcrumbText()).toEqual('Users');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/rgw/users.po.ts
@@ -1,0 +1,7 @@
+import { browser } from 'protractor';
+
+export class UsersPage {
+  navigateTo() {
+    return browser.get('/#/rgw/user');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/breadcrumbs/breadcrumbs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/breadcrumbs/breadcrumbs.component.html
@@ -1,7 +1,7 @@
 <ol *ngIf="crumbs.length"
     class="breadcrumb">
   <li *ngFor="let crumb of crumbs; let last = last"
-      [ngClass]="{ 'active': last }"
+      [ngClass]="{ 'active': last && finished }"
       class="breadcrumb-item">
     <a *ngIf="!last && crumb.path !== null"
        [routerLink]="crumb.path">{{ crumb.text }}</a>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/38987

---

backport of https://github.com/ceph/ceph/pull/25451
parent tracker: https://tracker.ceph.com/issues/37578

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh