### PR TITLE
mds: ignore the extra slash in the filepath

### DIFF
--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -161,6 +161,19 @@ public:
   int get_num_fwd() const { return head.num_fwd; }
   int get_retry_attempt() const { return head.num_retry; }
   int get_op() const { return head.op; }
+  bool is_snap_op() const
+  {
+    switch (get_op()) {
+    case CEPH_MDS_OP_LOOKUPSNAP:
+    case CEPH_MDS_OP_LSSNAP:
+    case CEPH_MDS_OP_MKSNAP:
+    case CEPH_MDS_OP_RMSNAP:
+    case CEPH_MDS_OP_RENAMESNAP:
+      return true;
+    }
+    return false;
+  }
+
   unsigned get_caller_uid() const { return head.caller_uid; }
   unsigned get_caller_gid() const { return head.caller_gid; }
   const vector<uint64_t>& get_caller_gid_list() const { return gid_list; }


### PR DESCRIPTION
For the path like: "mydir/mydir1//mydir2///", all the '' dir
name in // will be treated as ".snap". This will be buggy when
user just add some extra slashes by mistakes, and the kclient will
complain as BUG_ON and crash.


Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
