### PR TITLE
mds: Reorganize class members in ScatterLock header

### DIFF
--- a/src/mds/ScatterLock.h
+++ b/src/mds/ScatterLock.h
@@ -21,32 +21,6 @@
 #include "MDSContext.h"
 
 class ScatterLock : public SimpleLock {
-
-  struct more_bits_t {
-    xlist<ScatterLock*>::item item_updated;
-    utime_t update_stamp;
-
-    explicit more_bits_t(ScatterLock *lock) :
-      item_updated(lock)
-    {}
-  };
-
-  mutable std::unique_ptr<more_bits_t> _more;
-
-  more_bits_t *more() {
-    if (!_more)
-      _more.reset(new more_bits_t(this));
-    return _more.get();
-  }
-
-  enum {
-    SCATTER_WANTED   = 1 << 8,
-    UNSCATTER_WANTED = 1 << 9,
-    DIRTY            = 1 << 10,
-    FLUSHING         = 1 << 11,
-    FLUSHED          = 1 << 12,
-  };
-
 public:
   ScatterLock(MDSCacheObject *o, LockType *lt) :
     SimpleLock(o, lt) {}
@@ -231,6 +205,29 @@ public:
   }
 
 private:
+  struct more_bits_t {
+    xlist<ScatterLock*>::item item_updated;
+    utime_t update_stamp;
+
+    explicit more_bits_t(ScatterLock *lock) :
+      item_updated(lock)
+    {}
+  };
+
+  more_bits_t *more() {
+    if (!_more)
+      _more.reset(new more_bits_t(this));
+    return _more.get();
+  }
+
+  enum {
+    SCATTER_WANTED   = 1 << 8,
+    UNSCATTER_WANTED = 1 << 9,
+    DIRTY            = 1 << 10,
+    FLUSHING         = 1 << 11,
+    FLUSHED          = 1 << 12,
+  };
+
   void set_flushing() {
     state_flags |= FLUSHING;
   }
@@ -250,6 +247,8 @@ private:
       _more.reset();
     }
   }
+
+  mutable std::unique_ptr<more_bits_t> _more;
 };
 
 #endif


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42864
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
