### PR TITLE
mds: Reorganize class members in ScrubHeader header

### DIFF
--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -29,7 +29,7 @@ public:
   ScrubHeader(std::string_view tag_, bool is_tag_internal_, bool force_,
               bool recursive_, bool repair_, Formatter *f_)
     : tag(tag_), is_tag_internal(is_tag_internal_), force(force_),
-      recursive(recursive_), repair(repair_), formatter(f_), origin(nullptr)
+      recursive(recursive_), repair(repair_), formatter(f_)
   {
     ceph_assert(formatter != nullptr);
   }
@@ -56,7 +56,7 @@ protected:
   const bool recursive;
   const bool repair;
   Formatter * const formatter;
-  CInode *origin;
+  CInode *origin = nullptr;
 
   bool repaired = false;  // May be set during scrub if repairs happened
 };


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42865
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
