### PR TITLE
mgr/dashboard: remove traceback/version assertions

### DIFF
--- a/qa/tasks/mgr/dashboard/test_perf_counters.py
+++ b/qa/tasks/mgr/dashboard/test_perf_counters.py
@@ -65,9 +65,7 @@ class PerfCountersControllerTest(DashboardTestCase):
         self.assertStatus(404)
         schema = JObj(sub_elems={
             'status': str,
-            'version': str,
             'detail': str,
-            'traceback': str,
-        })
+        }, allow_unknown=True)
         self.assertEqual(self._resp.json()['detail'], "'osd.{}' not found".format(unused_id))
         self.assertSchemaBody(schema)


### PR DESCRIPTION
Debug mode (https://github.com/ceph/ceph/pull/30522) by default hides
Cherrypy version and Python traceback on Error responses. Both can be
displayed optionally.

Some QA tests expect these two fields to be present in the error
responses and fail otherwise.

Fixes: https://tracker.ceph.com/issues/42708
Fixes: https://github.com/ceph/ceph/pull/30522
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
