### PR TITLE
mgr/ssh: set up dummy known_hosts file

### DIFF
--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -33,7 +33,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SSH_CONFIG = ('Host *\n'
                       'User root\n'
-                      'StrictHostKeyChecking no\n')
+                      'StrictHostKeyChecking no\n'
+                      'UserKnownHostsFile /dev/null\n')
 
 # high-level TODO:
 #  - bring over some of the protections from ceph-deploy that guard against


### PR DESCRIPTION
Currently the mgr daemon is spitting out messages in stderr about failing to add hosts to known_hsots because the ceph user doesn't have a ~/.ssh/known_hosts.  Since we have StrictHostKeyChecking off anyway, use a dummy file here.