### PR TITLE
test/bench_log: add usage function

### DIFF
--- a/src/test/bench_log.cc
+++ b/src/test/bench_log.cc
@@ -30,8 +30,19 @@ struct T : public Thread {
   }
 };
 
+void usage(const char *name) {
+  cout << name << " <threads> <lines>\n"
+       << "\t threads: the number of threads for this test.\n"
+       << "\t lines: the number of log entries per thread.\n";
+}
+
 int main(int argc, const char **argv)
 {
+  if (argc < 3) {
+    usage(argv[0]);
+    return EXIT_FAILURE;
+  }
+
   int threads = atoi(argv[1]);
   int num = atoi(argv[2]);
 


### PR DESCRIPTION
Currently, the bench_log does not have a usage function, so that when it is used, 
if no pararmeters are given, a segmentation error will occur. This causes confusion.
Now, we add the usage function and add (argc < 3) conditional judgment.

Signed-off-by: Xuqiang Chen <chenxuqiang3@hisilicon.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
