### PR TITLE
mgr/dashboard: Update dev documentation URL

### DIFF
--- a/src/pybind/mgr/dashboard/README.rst
+++ b/src/pybind/mgr/dashboard/README.rst
@@ -13,8 +13,9 @@ Enabling and Starting the Dashboard
 
 If you want to start the dashboard from within a development environment, you
 need to have built Ceph (see the toplevel ``README.md`` file and the `developer
-documentation <http://docs.ceph.com/docs/master/dev/>`_ for details on how to
-accomplish this.
+documentation
+<https://docs.ceph.com/docs/master/dev/developer_guide/#building-from-source>`_
+for details on how to accomplish this.
 
 Finally, you need to build the dashboard frontend code. See the file
 ``HACKING.rst`` in this directory for instructions on setting up the necessary
@@ -25,7 +26,7 @@ will configure and enable the dashboard automatically. The URL and login
 credentials are displayed when the script finishes.
 
 Please see the `Ceph Dashboard documentation
-<http://docs.ceph.com/docs/master/mgr/dashboard/>`_ for details on how to enable
+<https://docs.ceph.com/docs/master/mgr/dashboard/>`_ for details on how to enable
 and configure the dashboard manually and how to configure other settings, e.g.
 access to the Ceph object gateway.
 


### PR DESCRIPTION
Update the developer documentation URL because the old one is only returning "403 Forbidden".

Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
