### PR TITLE
rpm: revamp ceph-grafana-dashboards packaging for SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1161,6 +1161,7 @@ Summary:	The set of Grafana dashboards for monitoring purposes
 BuildArch:	noarch
 %if 0%{?suse_version}
 Group:		System/Filesystems
+Requires:	grafana > 6.3
 %endif
 %description grafana-dashboards
 This package provides a set of Grafana dashboards for monitoring of
@@ -2406,9 +2407,7 @@ exit 0
 
 %files grafana-dashboards
 %if 0%{?suse_version}
-%attr(0755,root,root) %dir %{_sysconfdir}/grafana
-%attr(0755,root,root) %dir %{_sysconfdir}/grafana/dashboards
-%attr(0755,root,root) %dir %{_sysconfdir}/grafana/dashboards/ceph-dashboard
+%attr(0750,root,grafana) %dir %{_sysconfdir}/grafana/dashboards/ceph-dashboard
 %else
 %attr(0755,root,root) %dir %{_sysconfdir}/grafana/dashboards/ceph-dashboard
 %endif

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1172,11 +1172,11 @@ integrated with the Ceph Manager Dashboard web UI.
 
 %if 0%{?suse_version}
 %package prometheus-alerts
-Summary:        Prometheus alerts for a Ceph deplyoment
+Summary:        Prometheus alerts for a Ceph deployment
 BuildArch:      noarch
 Group:          System/Monitoring
 %description prometheus-alerts
-This package provides Ceph’s default alerts for Prometheus.
+This package provides Ceph's default alerts for Prometheus.
 %endif
 
 #################################################################################


### PR DESCRIPTION
The only SUSE OSes Ceph Octopus will run on (other than Tumbleweed) will be
openSUSE Leap 15.2 and SLE-15-SP2. Both of these have grafana 6.3.5.

Signed-off-by: Nathan Cutler <ncutler@suse.com>