### PR TITLE
mgr/orchestrator_cli: Update doc link in README

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/README.md
+++ b/src/pybind/mgr/orchestrator_cli/README.md
@@ -1,6 +1,6 @@
 # Orchestrator CLI
 
-See also [../../../doc/mgr/orchestrator_cli.rst](../../../doc/mgr/orchestrator_cli.rst).
+See also [orchestrator cli doc](https://docs.ceph.com/docs/master/mgr/orchestrator_cli/).
 
 ## Running the Teuthology tests
 
@@ -11,6 +11,4 @@ framework and the `test_orchestrator` backend.
 
     $ pushd ../dashboard ; source ./run-backend-api-tests.sh ; popd
     $ run_teuthology_tests tasks.mgr.test_orchestrator_cli
-    $ cleanup_teuthology  
-
- 
+    $ cleanup_teuthology


### PR DESCRIPTION
Update the orchestrator cli doc link to fix page not found error. Also remove
some unnecessary blank lines.

Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
