### PR TITLE
nautilus: mgr/devicehealth: ensure we don't store empty objects

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -318,7 +318,8 @@ class Module(MgrModule):
         if raw_smart_data:
             for device, raw_data in raw_smart_data.items():
                 data = self.extract_smart_features(raw_data)
-                self.put_device_metrics(ioctx, device, data)
+                if device and data:
+                    self.put_device_metrics(ioctx, device, data)
         ioctx.close()
         return 0, "", ""
 
@@ -340,7 +341,8 @@ class Module(MgrModule):
                     continue
                 did_device[device] = 1
                 data = self.extract_smart_features(raw_data)
-                self.put_device_metrics(ioctx, device, data)
+                if device and data:
+                    self.put_device_metrics(ioctx, device, data)
         ioctx.close()
         return 0, "", ""
 
@@ -359,7 +361,8 @@ class Module(MgrModule):
         if raw_smart_data:
             for device, raw_data in raw_smart_data.items():
                 data = self.extract_smart_features(raw_data)
-                self.put_device_metrics(ioctx, device, data)
+                if device and data:
+                    self.put_device_metrics(ioctx, device, data)
         ioctx.close()
         return 0, "", ""
 
@@ -384,6 +387,7 @@ class Module(MgrModule):
                     daemon_type, daemon_id, outb))
 
     def put_device_metrics(self, ioctx, devid, data):
+        assert devid
         old_key = datetime.utcnow() - timedelta(
             seconds=int(self.retention_period))
         prune = old_key.strftime(TIME_FORMAT)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42739

---

backport of https://github.com/ceph/ceph/pull/31474
parent tracker: https://tracker.ceph.com/issues/41383

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh