### PR TITLE
mgr/dashboard: Unable to set boolean values to false when default is true

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -63,7 +63,7 @@ class ClusterConfiguration(RESTController):
 
         for section in avail_sections:
             for entry in value:
-                if not entry['value']:
+                if entry['value'] is None:
                     break
 
                 if entry['section'] == section:

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -98,16 +98,21 @@
           <ng-container *ngFor="let section of availSections">
             <div class="form-group row"
                  *ngIf="type === 'bool'">
-              <div class="offset-sm-3 col-sm-9">
-                <div class="custom-control custom-checkbox">
-                  <input type="checkbox"
-                         class="custom-control-input"
-                         [id]="section"
-                         [formControlName]="section">
-                  <label class="custom-control-label"
-                         [for]="section">{{ section }}
-                  </label>
-                </div>
+              <label class="col-form-label col-sm-3"
+                     [for]="section">{{ section }}
+              </label>
+              <div class="col-sm-9">
+                <select id="pool"
+                        name="pool"
+                        class="form-control custom-select"
+                        [formControlName]="section">
+                  <option [ngValue]="null"
+                          i18n>-- Default --</option>
+                  <option [ngValue]="true"
+                          i18n>true</option>
+                  <option [ngValue]="false"
+                          i18n>false</option>
+                </select>
               </div>
             </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -135,7 +135,7 @@ export class ConfigurationFormComponent implements OnInit {
 
     this.availSections.forEach((section) => {
       const sectionValue = this.configForm.getValue(section);
-      if (sectionValue) {
+      if (sectionValue !== null && sectionValue !== '') {
         values.push({ section: section, value: sectionValue });
       }
     });


### PR DESCRIPTION
With this PR user will be able to set boolean values to `false` when default is `true`.

Additionally, this PR introduces a "Clear" button that allows the user to revert the config to the default value:

Fixes: https://tracker.ceph.com/issues/41776

After
---

**Boolean Value:**
![Screenshot from 2019-11-19 13-13-03](https://user-images.githubusercontent.com/14297426/69150744-2bf2da80-0ad1-11ea-88e6-c8f3bf6b6932.png)

**Int Value:**
![Screenshot from 2019-11-19 13-25-47](https://user-images.githubusercontent.com/14297426/69150753-31502500-0ad1-11ea-8f70-d23218374bb0.png)

Before:
---
**Boolean Value:**
![Screenshot from 2019-11-19 13-27-49](https://user-images.githubusercontent.com/14297426/69150633-fd74ff80-0ad0-11ea-83b9-456b18a3c04b.png)

**Int Value:**
![Screenshot from 2019-11-19 13-22-11](https://user-images.githubusercontent.com/14297426/69150638-01a11d00-0ad1-11ea-8cc7-16eb551f1470.png)

