### PR TITLE
nautilus: rgw: Silence warning: control reaches end of non-void function

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3523,11 +3523,9 @@ RGWOp *RGWHandler_REST_Service_S3::op_post()
 RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
 {
   // Non-website mode
-  int list_type = 1;
-  s->info.args.get_int("list-type", &list_type, 1);
-
-   // Non-website mode    // Non-website mode
   if (get_data) {   
+    int list_type = 1;
+    s->info.args.get_int("list-type", &list_type, 1);
     switch (list_type) {
       case 1:
         return new RGWListBucket_ObjStore_S3;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3528,13 +3528,19 @@ RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
 
    // Non-website mode    // Non-website mode
   if (get_data) {   
-    if (list_type == 1) {
-       return new RGWListBucket_ObjStore_S3;     
-    } else if(list_type == 2) {
-      return new RGWListBucket_ObjStore_S3v2;
-    } } else {
-    return new RGWStatBucket_ObjStore_S3;    
-  }   }
+    switch (list_type) {
+      case 1:
+        return new RGWListBucket_ObjStore_S3;
+      case 2:
+        return new RGWListBucket_ObjStore_S3v2;
+      default:
+        ldpp_dout(s, 5) << __func__ << ": unsupported list-type " << list_type << dendl;
+        return new RGWListBucket_ObjStore_S3;
+    }
+  } else {
+    return new RGWStatBucket_ObjStore_S3;
+  }
+}
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_get()
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42836
possibly a backport of https://github.com/ceph/ceph/pull/28809
parent tracker: https://tracker.ceph.com/issues/40747

---

original PR body:

clean cherry-pick, no conflicts, no manual edits

---

updated using ceph-backport.sh version 15.0.0.6950
