### PR TITLE
qa/standalone/ceph-helpers.sh: destroy_osd: mark killed osd down

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -785,6 +785,7 @@ function destroy_osd() {
 
     ceph osd out osd.$id || return 1
     kill_daemons $dir TERM osd.$id || return 1
+    ceph osd down osd.$id || return 1
     ceph osd purge osd.$id --yes-i-really-mean-it || return 1
     teardown $dir/$id || return 1
     rm -fr $dir/$id

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -60,6 +60,7 @@ except ImportError:
 import uuid
 
 from distutils.spawn import find_executable
+from functools import wraps
 from glob import glob
 
 try:
@@ -225,6 +226,34 @@ def is_fsid(s):
     except ValueError:
         return False
     return True
+
+def infer_fsid(func):
+    """
+    If we only find a single fsid in /var/lib/ceph/*, use that
+    """
+    @wraps(func)
+    def _infer_fsid():
+        if args.fsid:
+            logger.debug('Using specified fsid: %s' % args.fsid)
+            return
+
+        fsid_list = []
+        for i in os.listdir(args.data_dir):
+            if is_fsid(i):
+                fsid_list.append(i)
+
+        logger.debug('Found fsids %s' % str(fsid_list))
+
+        if not fsid_list:
+            # TODO: raise?
+            return
+
+        if len(fsid_list) > 1:
+            raise RuntimeError('Cannot infer fsid, must specify --fsid')
+
+        logger.info('Inferring fsid %s' % fsid_list[0])
+        args.fsid = fsid_list[0]
+    return _infer_fsid
 
 def makedirs(dir, uid, gid, mode):
     # type: (str, int, int, int) -> None
@@ -1258,6 +1287,7 @@ def command_run():
 
 ##################################
 
+@infer_fsid
 def command_shell():
     # type: () -> int
     if args.fsid:
@@ -1296,6 +1326,7 @@ def command_shell():
 
 ##################################
 
+@infer_fsid
 def command_enter():
     # type: () -> int
     (daemon_type, daemon_id) = args.name.split('.', 1)
@@ -1315,6 +1346,7 @@ def command_enter():
 
 ##################################
 
+@infer_fsid
 def command_ceph_volume():
     # type: () -> None
     make_log_dir(args.fsid)
@@ -1357,6 +1389,7 @@ def command_ceph_volume():
 
 ##################################
 
+@infer_fsid
 def command_unit():
     # type: () -> None
     (daemon_type, daemon_id) = args.name.split('.', 1)
@@ -1368,6 +1401,7 @@ def command_unit():
 
 ##################################
 
+@infer_fsid
 def command_logs():
     # type: () -> None
     cmd = [container_path, 'logs']


### PR DESCRIPTION
With the osd fast shutdown, the OSD we're stopping might not be
marked down yet.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>