### PR TITLE
qa/suites/rados/mgr: whitelist evictions for mgr selftest

### DIFF
--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -18,6 +18,7 @@ tasks:
         - influxdb python module not found
         - \(MGR_ZABBIX_
         - foo bar
+        - evicting unresponsive clientx
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest


### PR DESCRIPTION
There is an mds client eviction warning in the cluster log as a side-effect of the mgr self-test.  I can't tell if this is supposed to happen or not.. but I think it started when we added the mgr shutdown...but I'm not quite sure!  @batrick any insight here?