### PR TITLE
qa/suites/rados/singleton-nomsgr/all/balancer: whitelist PG_AVAILABILITY

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
@@ -4,6 +4,8 @@ tasks:
 - install:
 - ceph:
     fs: xfs
+    log-whitelist:
+      - \(PG_AVAILABILITY\)
 - cram:
     clients:
       client.0:


### PR DESCRIPTION
Balancer triggers peering, which may make PGs briefly go inactive.