### PR TITLE
script/run_tox.sh: do not use python2 if we have python3

### DIFF
--- a/src/script/run_tox.sh
+++ b/src/script/run_tox.sh
@@ -120,7 +120,17 @@ function main() {
             echo "$PWD already exists, but it's not a virtualenv. test_name empty?"
             exit 1
         fi
-        $source_dir/src/tools/setup-virtualenv.sh ${venv_path}
+        # try to use the prefered python for creating the virtual env for
+        # bootstrapping tox.
+        case $tox_envs in
+            py3*)
+                virtualenv_python=python3;;
+            py2*)
+                virtualenv_python=python2;;
+            *)
+                virtualenv_python=python3;;
+        esac
+        $source_dir/src/tools/setup-virtualenv.sh --python=${virtualenv_python} ${venv_path}
     fi
     source ${venv_path}/bin/activate
     pip install tox


### PR DESCRIPTION
always use python3 for bootstrapping tox environment unless the tox-env
contains "py2"

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
