### PR TITLE
backport-create-issue: resolve parent only if parent has backport issues

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -246,6 +246,8 @@ def maybe_resolve(issue, backports, dry_run):
     global delay_seconds
     global redmine
     global status2status_id
+    if not backports:
+        return None
     pending_backport_status_id = status2status_id["Pending Backport"]
     resolved_status_id = status2status_id["Resolved"]
     rejected_status_id = status2status_id["Rejected"]


### PR DESCRIPTION
This fixes an edge case. If a parent issue is in "Pending Backport" status
but without any backport issues, the script (when running with --resolve-parent)
was wrongly changing the status to "Resolved".
