### PR TITLE
mgr/test_orchestrator: Add dummy data

### DIFF
--- a/src/pybind/mgr/test_orchestrator/README.md
+++ b/src/pybind/mgr/test_orchestrator/README.md
@@ -1,0 +1,16 @@
+# Activate module
+You can activate the Ceph Manager module by running:
+```
+$ ceph mgr module enable test_orchestrator
+$ ceph orchestrator set backend test_orchestrator
+```
+
+# Check status
+```
+ceph orchestrator status
+```
+
+# Import dummy data
+```
+$ ceph test_orchestrator load_data -i ./dummy_data.json
+```

--- a/src/pybind/mgr/test_orchestrator/dummy_data.json
+++ b/src/pybind/mgr/test_orchestrator/dummy_data.json
@@ -1,0 +1,155 @@
+{
+  "inventory": [
+    {
+      "name": "host0",
+      "devices": [
+        {
+          "available": false,
+          "rejected_reasons": ["locked"],
+          "sys_api": {
+            "scheduler_mode": "",
+            "rotational": "0",
+            "vendor": "",
+            "human_readable_size": "50.00 GB",
+            "sectors": 0,
+            "sas_device_handle": "",
+            "partitions": {},
+            "rev": "",
+            "sas_address": "",
+            "locked": 1,
+            "sectorsize": "512",
+            "removable": "0",
+            "path": "/dev/dm-0",
+            "support_discard": "",
+            "model": "",
+            "ro": "0",
+            "nr_requests": "128",
+            "size": 53687091200
+          },
+          "lvs": [],
+          "path": "/dev/dm-0"
+        },
+        {
+          "available": false,
+          "rejected_reasons": ["locked"],
+          "sys_api": {
+            "scheduler_mode": "",
+            "rotational": "0",
+            "vendor": "",
+            "human_readable_size": "31.47 GB",
+            "sectors": 0,
+            "sas_device_handle": "",
+            "partitions": {},
+            "rev": "",
+            "sas_address": "",
+            "locked": 1,
+            "sectorsize": "512",
+            "removable": "0",
+            "path": "/dev/dm-1",
+            "support_discard": "",
+            "model": "",
+            "ro": "0",
+            "nr_requests": "128",
+            "size": 33789313024
+          },
+          "lvs": [],
+          "path": "/dev/dm-1"
+        },
+        {
+          "available": false,
+          "rejected_reasons": ["locked"],
+          "sys_api": {
+            "scheduler_mode": "",
+            "rotational": "0",
+            "vendor": "",
+            "human_readable_size": "394.27 GB",
+            "sectors": 0,
+            "sas_device_handle": "",
+            "partitions": {},
+            "rev": "",
+            "sas_address": "",
+            "locked": 1,
+            "sectorsize": "512",
+            "removable": "0",
+            "path": "/dev/dm-2",
+            "support_discard": "",
+            "model": "",
+            "ro": "0",
+            "nr_requests": "128",
+            "size": 423347879936
+          },
+          "lvs": [],
+          "path": "/dev/dm-2"
+        },
+        {
+          "available": false,
+          "rejected_reasons": ["locked"],
+          "sys_api": {
+            "scheduler_mode": "cfq",
+            "rotational": "0",
+            "vendor": "ATA",
+            "human_readable_size": "476.94 GB",
+            "sectors": 0,
+            "sas_device_handle": "",
+            "partitions": {
+              "sda2": {
+                "start": "411648",
+                "holders": [],
+                "sectorsize": 512,
+                "sectors": "2097152",
+                "size": "1024.00 MB"
+              },
+              "sda3": {
+                "start": "2508800",
+                "holders": ["dm-1", "dm-2", "dm-0"],
+                "sectorsize": 512,
+                "sectors": "997705728",
+                "size": "475.74 GB"
+              },
+              "sda1": {
+                "start": "2048",
+                "holders": [],
+                "sectorsize": 512,
+                "sectors": "409600",
+                "size": "200.00 MB"
+              }
+            },
+            "rev": "0000",
+            "sas_address": "",
+            "locked": 1,
+            "sectorsize": "512",
+            "removable": "0",
+            "path": "/dev/sda",
+            "support_discard": "",
+            "model": "SanDisk SD8SN8U5",
+            "ro": "0",
+            "nr_requests": "128",
+            "size": 512110190592
+          },
+          "lvs": [
+            {
+              "comment": "not used by ceph",
+              "name": "swap"
+            },
+            {
+              "comment": "not used by ceph",
+              "name": "home"
+            },
+            {
+              "comment": "not used by ceph",
+              "name": "root"
+            }
+          ],
+          "path": "/dev/sda"
+        }
+      ]
+    }
+  ],
+  "services": [
+    {
+      "nodename": "host0",
+      "service_type": "osd",
+      "service_instance": "1"
+    }
+  ]
+}


### PR DESCRIPTION
Add a JSON file containing dummy data for testing the orchestrator.

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
