### PR TITLE
mgr/volumes: improve mgr/ssh support for mds deployment via 'fs volume create'

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -670,7 +670,7 @@ class PlacementSpec(object):
     def __init__(self, label=None, nodes=[]):
         self.label = label
 
-        self.nodes = [parse_host_specs(x, require_network=False) for x in nodes]
+        self.nodes = [parse_host_specs(x, require_network=False) for x in nodes if x]
 
 def handle_type_error(method):
     @wraps(method)

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -1036,7 +1036,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
     def add_mds(self, spec):
         if not spec.placement.nodes or len(spec.placement.nodes) < spec.count:
-            raise RuntimeError("must specify at least %d hosts" % spec.count)
+            raise RuntimeError("Must specify at least %d hosts when using the SSH-Orchestrator." % spec.count)
         daemons = self._get_services('mds')
         results = []
         num_added = 0

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -1036,7 +1036,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
     def add_mds(self, spec):
         if not spec.placement.nodes or len(spec.placement.nodes) < spec.count:
-            raise RuntimeError("Must specify at least %d hosts when using the SSH-Orchestrator." % spec.count)
+            raise orchestrator.OrchestratorValidationError("Must specify at least %d hosts when using the SSH-Orchestrator." % spec.count)
         daemons = self._get_services('mds')
         results = []
         num_added = 0

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -281,7 +281,7 @@ class VolumeClient(object):
             orchestrator.raise_if_exception(completion)
         except (ImportError, orchestrator.OrchestratorError):
             return 0, "", "Volume created successfully (no MDS daemons created)"
-        except RuntimeError as e:
+        except orchestrator.OrchestratorValidationError as e:
             return 0, "", "{} (Volume created successfully)".format(str(e))
         except Exception as e:
             # Don't let detailed orchestrator exceptions (python backtraces)
@@ -292,7 +292,7 @@ class VolumeClient(object):
 
     ### volume operations -- create, rm, ls
 
-    def create_volume(self, volname, host):
+    def create_volume(self, volname, mds_host):
         """
         create volume  (pool, filesystem and mds)
         """
@@ -313,7 +313,7 @@ class VolumeClient(object):
             log.error("Filesystem creation error: {0} {1} {2}".format(r, outb, outs))
             return r, outb, outs
         # create mds
-        return self.create_mds(volname, host)
+        return self.create_mds(volname, mds_host)
 
     def delete_volume(self, volname, confirm):
         """

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -15,7 +15,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs volume create '
-                   'name=name,type=CephString ',
+                   'name=name,type=CephString,req=true '
+                   'name=host,type=CephString,req=false ',
             'desc': "Create a CephFS volume",
             'perm': 'rw'
         },
@@ -203,8 +204,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_fs_volume_create(self, inbuf, cmd):
         # TODO: validate name against any rules for pool/fs names
         # (...are there any?)
-        vol_id = cmd['name']
-        return self.vc.create_volume(vol_id)
+        vol_id = cmd.get('name')
+        host = cmd.get('host', '')
+        return self.vc.create_volume(vol_id, host)
 
     def _cmd_fs_volume_rm(self, inbuf, cmd):
         vol_name = cmd['vol_name']


### PR DESCRIPTION
The mds vstart deployment is currently broken for the ssh-orchestrator.

vstart first spawns an MDS daemon and then tries to create a fs

`ceph fs volume create a`

This calls in the mgr/orch backend to also create a MDS daemon. This will work for rook at it doesn't need an explicit host. The ssh-orch however does need it.

So I added parameter for `host` (optional)

old:
ceph fs volume create <fs_name>

new:
ceph fs volume create <fs_name> (hostname)

This will allow the ssh-orchestrator to deploy
a MDS daemon on the provided host.
If this is not specified and the ssh-backend is used
it will result in an RuntimeError. The volumes will
still be created though. 

(still reports a failure but doesn't break vstart)


edit: 

volume removal seems to be broken as it doesn't remove the daemon correctly. I'll follow up on this in another PR. (see https://github.com/ceph/ceph/pull/31762)


Signed-off-by: Joshua Schmid <jschmid@suse.de>
