### PR TITLE
mgr/volumes: improve volume deletion process

### DIFF
--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -1074,6 +1074,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
     def remove_mds(self, name):
         daemons = self._get_services('mds')
         results = []
+        self.log.debug("Attempting to remove volume: {}".format(name))
         for d in daemons:
             if d.service_instance == name or d.service_instance.startswith(name + '.'):
                 results.append(self._worker_pool.apply_async(

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -257,13 +257,7 @@ class VolumeClient(object):
                    'data': data_pool}
         return self.mgr.mon_command(command)
 
-    def remove_filesystem(self, fs_name, confirm):
-        if confirm != "--yes-i-really-mean-it":
-            return -errno.EPERM, "", "WARNING: this will *PERMANENTLY DESTROY* all data " \
-                "stored in the filesystem '{0}'. If you are *ABSOLUTELY CERTAIN* " \
-                "that is what you want, re-issue the command followed by " \
-                "--yes-i-really-mean-it.".format(fs_name)
-
+    def remove_filesystem(self, fs_name):
         command = {'prefix': 'fs fail', 'fs_name': fs_name}
         r, outb, outs = self.mgr.mon_command(command)
         if r != 0:
@@ -319,6 +313,12 @@ class VolumeClient(object):
         if self.stopping.isSet():
             return -errno.ESHUTDOWN, "", "shutdown in progress"
 
+        if confirm != "--yes-i-really-mean-it":
+            return -errno.EPERM, "", "WARNING: this will *PERMANENTLY DESTROY* all data " \
+                "stored in the filesystem '{0}'. If you are *ABSOLUTELY CERTAIN* " \
+                "that is what you want, re-issue the command followed by " \
+                "--yes-i-really-mean-it.".format(volname)
+
         self.purge_queue.cancel_purge_job(volname)
         self.connection_pool.del_fs_handle(volname, wait=True)
         # Tear down MDS daemons
@@ -337,7 +337,7 @@ class VolumeClient(object):
         # In case orchestrator didn't tear down MDS daemons cleanly, or
         # there was no orchestrator, we force the daemons down.
         if self.volume_exists(volname):
-            r, outb, outs = self.remove_filesystem(volname, confirm)
+            r, outb, outs = self.remove_filesystem(volname)
             if r != 0:
                 return r, outb, outs
         else:


### PR DESCRIPTION
Instead of checking if the --yes-i-really-mean-it
flag was set _after_ removing the MDS daemon, we
need to check if before starting any removal operation.

Signed-off-by: Joshua Schmid <jschmid@suse.de>