### PR TITLE
ceph-mon: keep v1 address type when explicitly set

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -194,8 +194,10 @@ entity_addrvec_t make_mon_addrs(entity_addr_t a)
   } else if (a.get_port() == CEPH_MON_PORT_LEGACY) {
     a.set_type(entity_addr_t::TYPE_LEGACY);
     addrs.v.push_back(a);
-  } else {
+  } else if (a.get_type() == entity_addr_t::TYPE_ANY) {
     a.set_type(entity_addr_t::TYPE_MSGR2);
+    addrs.v.push_back(a);
+  } else {
     addrs.v.push_back(a);
   }
   return addrs;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42906

Signed-off-by: Ricardo Dias <rdias@suse.com>


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
