### PR TITLE
common: Add pragmas to suppress a non-virtual-dtor warning.

### DIFF
--- a/src/common/error_code.h
+++ b/src/common/error_code.h
@@ -25,10 +25,15 @@ namespace ceph {
 
 // This is for error categories we define, so we can specify the
 // equivalent integral value at the point of definition.
+// Ignoring non-virtual-dtor warnings because the base dtor is
+// defined protected
+#pragma diagnostic push
+#pragma diagnostic ignored "-Wnon-virtual-dtor"
 class converting_category : public boost::system::error_category {
 public:
   virtual int from_code(int code) const noexcept = 0;
 };
+#pragma diagnostic pop
 
 const boost::system::error_category& ceph_category() noexcept;
 


### PR DESCRIPTION
Clang complains:

me/jenkins/workspace/ceph-master/src/common/error_code.h:28:7: warning: 'ceph::converting_category' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
class converting_category : public boost::system::error_category {
^
1 warning generated.

Fixes: https://tracker.ceph.com/issues/42909



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>