### PR TITLE
nautilus: mgr/dashboard/test_mgr_module: sync w/ telemetry

### DIFF
--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -115,7 +115,6 @@ class MgrModuleTelemetryTest(MgrModuleTestCase):
                     'description': str,
                     'enabled': bool,
                     'interval': int,
-                    'last_opt_revision': int,
                     'leaderboard': bool,
                     'organization': str,
                     'proxy': str,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42811

---

backport of https://github.com/ceph/ceph/pull/29461
parent tracker: https://tracker.ceph.com/issues/41055

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh