### PR TITLE
[WIP] mgr/dashboard: 'Last Change' Column Heading

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -146,7 +146,7 @@ export class PoolListComponent implements OnInit {
       },
       {
         prop: 'last_change',
-        name: this.i18n('Last Change'),
+        name: this.i18n('Latest Edit'),
         flexGrow: 1,
         cellClass: 'text-right'
       },


### PR DESCRIPTION
From about 1460-1900 px the Last Change column pushes the up/down arrow to a third row of text while all other column headers only take up two rows. Changing the text of that column header could make it look nicer in that size range without detracting anything else.

Fixes: https://tracker.ceph.com/issues/42914

Signed-off-by: Adam King <adking@redhat.com>