### PR TITLE
nautilus: mgr/dashboard: Handle always-on Ceph Manager modules correctly

### DIFF
--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -42,6 +42,7 @@ class MgrModuleTest(MgrModuleTestCase):
                 JObj(sub_elems={
                     'name': JLeaf(str),
                     'enabled': JLeaf(bool),
+                    'always_on': JLeaf(bool),
                     'options': JObj(
                         {},
                         allow_unknown=True,
@@ -75,6 +76,7 @@ class MgrModuleTest(MgrModuleTestCase):
                 JObj(sub_elems={
                     'name': JLeaf(str),
                     'enabled': JLeaf(bool),
+                    'always_on': JLeaf(bool),
                     'options': JObj(
                         {},
                         allow_unknown=True,

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -562,7 +562,13 @@ ceph_get_version(BaseMgrModule *self, PyObject *args)
 }
 
 static PyObject *
-ceph_get_context(BaseMgrModule *self, PyObject *args)
+ceph_get_release_name(BaseMgrModule *self, PyObject *args)
+{
+  return PyString_FromString(ceph_release_to_str());
+}
+
+static PyObject *
+ceph_get_context(BaseMgrModule *self)
 {
   return self->py_modules->get_context();
 }
@@ -1056,8 +1062,11 @@ PyMethodDef BaseMgrModule_methods[] = {
   {"_ceph_cluster_log", (PyCFunction)ceph_cluster_log, METH_VARARGS,
    "Emit a cluster log message"},
 
-  {"_ceph_get_version", (PyCFunction)ceph_get_version, METH_VARARGS,
+  {"_ceph_get_version", (PyCFunction)ceph_get_version, METH_NOARGS,
    "Get the ceph version of this process"},
+
+  {"_ceph_get_release_name", (PyCFunction)ceph_get_release_name, METH_NOARGS,
+   "Get the ceph release name of this process"},
 
   {"_ceph_get_context", (PyCFunction)ceph_get_context, METH_NOARGS,
     "Get a CephContext* in a python capsule"},

--- a/src/pybind/mgr/dashboard/controllers/mgr_modules.py
+++ b/src/pybind/mgr/dashboard/controllers/mgr_modules.py
@@ -21,18 +21,19 @@ class MgrModules(RESTController):
         """
         result = []
         mgr_map = mgr.get('mgr_map')
+        always_on_modules = mgr_map['always_on_modules'][mgr.release_name]
         for module_config in mgr_map['available_modules']:
-            if module_config['name'] not in self.ignore_modules:
+            module_name = module_config['name']
+            if module_name not in self.ignore_modules:
+                always_on = module_name in always_on_modules
+                enabled = module_name in mgr_map['modules'] or always_on
                 result.append({
-                    'name': module_config['name'],
-                    'enabled': False,
+                    'name': module_name,
+                    'enabled': enabled,
+                    'always_on': always_on,
                     'options': self._convert_module_options(
                         module_config['module_options'])
                 })
-        for name in mgr_map['modules']:
-            if name not in self.ignore_modules:
-                obj = find_object_in_list('name', name, result)
-                obj['enabled'] = True
         return result
 
     def get(self, module_name):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
@@ -118,7 +118,8 @@ describe('MgrModuleListComponent', () => {
       spyOn(mgrModuleService, 'list').and.returnValues(observableThrowError('z'), observableOf([]));
       component.selection.selected.push({
         name: 'foo',
-        enabled: false
+        enabled: false,
+        always_on: false
       });
       component.selection.update();
       component.updateModuleState();
@@ -137,7 +138,8 @@ describe('MgrModuleListComponent', () => {
       spyOn(mgrModuleService, 'list').and.returnValue(observableOf([]));
       component.selection.selected.push({
         name: 'bar',
-        enabled: true
+        enabled: true,
+        always_on: false
       });
       component.selection.update();
       component.updateModuleState();
@@ -149,5 +151,26 @@ describe('MgrModuleListComponent', () => {
       expect(component.blockUI.stop).toHaveBeenCalled();
       expect(component.table.refreshBtn).toHaveBeenCalled();
     }));
+
+    it('should not disable module (1)', () => {
+      component.selection.selected = [
+        {
+          name: 'dashboard'
+        }
+      ];
+      component.selection.update();
+      expect(component.isTableActionDisabled('enabled')).toBeTruthy();
+    });
+
+    it('should not disable module (2)', () => {
+      component.selection.selected = [
+        {
+          name: 'bar',
+          always_on: true
+        }
+      ];
+      component.selection.update();
+      expect(component.isTableActionDisabled('enabled')).toBeTruthy();
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.ts
@@ -81,6 +81,7 @@ export class MgrModuleListComponent {
         permission: 'update',
         click: () => this.updateModuleState(),
         disable: () => this.isTableActionDisabled('disabled'),
+        disableDesc: () => this.getTableActionDisabledDesc(),
         icon: 'fa-stop'
       }
     ];
@@ -111,17 +112,31 @@ export class MgrModuleListComponent {
     if (!this.selection.hasSelection) {
       return true;
     }
+    const selected = this.selection.first();
     // Make sure the user can't modify the run state of the 'Dashboard' module.
     // This check is only done in the UI because the REST API should still be
     // able to do so.
-    if (this.selection.first().name === 'dashboard') {
+    if (selected.name === 'dashboard') {
+      return true;
+    }
+    // Always-on modules can't be disabled.
+    if (selected.always_on) {
       return true;
     }
     switch (state) {
       case 'enabled':
-        return this.selection.first().enabled;
+        return selected.enabled;
       case 'disabled':
-        return !this.selection.first().enabled;
+        return !selected.enabled;
+    }
+  }
+
+  getTableActionDisabledDesc(): string | undefined {
+    if (this.selection.hasSelection) {
+      const selected = this.selection.first();
+      if (selected.always_on) {
+        return this.i18n('This Manager module is always on.');
+      }
     }
   }
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -584,6 +584,15 @@ class MgrModule(ceph_module.BaseMgrModule):
     def version(self):
         return self._version
 
+    @property
+    def release_name(self):
+        """
+        Get the release name of the Ceph version, e.g. 'nautilus' or 'octopus'.
+        :return: Returns the release name of the Ceph version in lower case.
+        :rtype: str
+        """
+        return self._ceph_get_release_name()
+
     def get_context(self):
         """
         :return: a Python capsule containing a C++ CephContext pointer


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42809

---

backport of https://github.com/ceph/ceph/pull/30142
parent tracker: https://tracker.ceph.com/issues/41648

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh

Also cherry-picked (as they are to be merged together):

mgr/dashboard: test_mgr_module QA test has not been adapted to latest controller changes

 Fixes: https://tracker.ceph.com/issues/41993

Signed-off-by: Volker Theile <vtheile@suse.com>
cherry picked from commit 59a7bb209d0283493040665518082cc2fc80ee55)
