### PR TITLE
nautilus: mgr/dashboard: Remove compression mode unset in pool from

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -100,9 +100,9 @@ class Pool(RESTController):
 
     def _set_pool_values(self, pool, application_metadata, flags, update_existing, kwargs):
         update_name = False
-        if update_existing:
-            current_pool = self._get(pool)
-            self._handle_update_compression_args(current_pool.get('options'), kwargs)
+        current_pool = self._get(pool)
+        if update_existing and kwargs.get('compression_mode') == 'unset':
+            self._prepare_compression_removal(current_pool.get('options'), kwargs)
         if flags and 'ec_overwrites' in flags:
             CephService.send_command('mon', 'osd pool set', pool=pool, var='allow_ec_overwrites',
                                      val='true')
@@ -135,8 +135,18 @@ class Pool(RESTController):
         if update_name:
             CephService.send_command('mon', 'osd pool rename', srcpool=pool, destpool=destpool)
 
-    def _handle_update_compression_args(self, options, kwargs):
-        if kwargs.get('compression_mode') == 'unset' and options is not None:
+    def _prepare_compression_removal(self, options, kwargs):
+        """
+        Presets payload with values to remove compression attributes in case they are not
+        needed anymore.
+
+        In case compression is not needed the dashboard will send 'compression_mode' with the
+        value 'unset'.
+
+        :param options: All set options for the current pool.
+        :param kwargs: Payload of the PUT / POST call
+        """
+        if options is not None:
             def reset_arg(arg, value):
                 if options.get(arg):
                     kwargs[arg] = value

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -168,7 +168,6 @@ export class PoolFormComponent implements OnInit {
 
   private initInfo(info: PoolFormInfo) {
     this.form.silentSet('algorithm', info.bluestore_compression_algorithm);
-    info.compression_modes.push('unset');
     this.info = info;
   }
 
@@ -580,7 +579,7 @@ export class PoolFormComponent implements OnInit {
             externalFieldName: 'compression_mode',
             formControlName: 'mode',
             editable: true,
-            replaceFn: () => 'unset'
+            replaceFn: () => 'unset' // Is used if no compression is set
           },
           {
             externalFieldName: 'srcpool',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42773

---

backport of https://github.com/ceph/ceph/pull/31376
parent tracker: https://tracker.ceph.com/issues/42624

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh