### PR TITLE
ceph-volume: util: look for executable in $PATH

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_system.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_system.py
@@ -205,8 +205,9 @@ class TestWhich(object):
         assert system.which('exedir') == 'exedir'
 
     def test_executable_exists_as_file(self, monkeypatch):
-        monkeypatch.setattr(system.os.path, 'isfile', lambda x: True)
-        monkeypatch.setattr(system.os.path, 'exists', lambda x: True)
+        monkeypatch.setattr(system.os, 'getenv', lambda x, y: '')
+        monkeypatch.setattr(system.os.path, 'isfile', lambda x: x != 'ceph')
+        monkeypatch.setattr(system.os.path, 'exists', lambda x: x != 'ceph')
         assert system.which('ceph') == '/usr/local/bin/ceph'
 
     def test_warnings_when_executable_isnt_matched(self, monkeypatch, capsys):
@@ -214,9 +215,7 @@ class TestWhich(object):
         monkeypatch.setattr(system.os.path, 'exists', lambda x: False)
         system.which('exedir')
         cap = capsys.readouterr()
-        assert 'Absolute path not found for executable: exedir' in cap.err
-        assert 'Ensure $PATH environment variable contains common executable locations' in cap.err
-
+        assert 'Executable exedir not in PATH' in cap.err
 
 @pytest.fixture
 def stub_which(monkeypatch):

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -33,7 +33,21 @@ def generate_uuid():
 
 def which(executable):
     """find the location of an executable"""
-    locations = (
+    def _get_path(executable, locations):
+        for location in locations:
+            executable_path = os.path.join(location, executable)
+            if os.path.exists(executable_path) and os.path.isfile(executable_path):
+                return executable_path
+        return None
+
+    path = os.getenv('PATH', '')
+    path_locations = path.split(':')
+    exec_in_path = _get_path(executable, path_locations)
+    if exec_in_path:
+        return exec_in_path
+    mlogger.warning('Executable {} not in PATH: {}'.format(executable, path))
+
+    static_locations = (
         '/usr/local/bin',
         '/bin',
         '/usr/bin',
@@ -41,13 +55,10 @@ def which(executable):
         '/usr/sbin',
         '/sbin',
     )
-
-    for location in locations:
-        executable_path = os.path.join(location, executable)
-        if os.path.exists(executable_path) and os.path.isfile(executable_path):
-            return executable_path
-    mlogger.warning('Absolute path not found for executable: %s', executable)
-    mlogger.warning('Ensure $PATH environment variable contains common executable locations')
+    exec_in_static_locations = _get_path(executable, static_locations)
+    if exec_in_static_locations:
+        mlogger.warning('Found executable under {}, please ensure $PATH is set correctly!'.format(exec_in_static_locations))
+        return exec_in_static_locations
     # fallback to just returning the argument as-is, to prevent a hard fail,
     # and hoping that the system might have the executable somewhere custom
     return executable


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/36728

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
