### PR TITLE
ceph-daemon: append newline before public key string

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1171,8 +1171,19 @@ def command_bootstrap():
         logger.info('Adding key to root@localhost\'s authorized_keys...')
         if not os.path.exists('/root/.ssh'):
             os.mkdir('/root/.ssh', 0o700)
-        with open('/root/.ssh/authorized_keys', 'a') as f:
+        auth_keys_file = '/root/.ssh/authorized_keys'
+        add_newline = False
+        if os.path.exists(auth_keys_file):
+            with open(auth_keys_file, 'r') as f:
+                f.seek(0, 2)
+                if f.tell() > 0:
+                    f.seek(-1, 2)  # go to last character
+                    if f.read() != '\n':
+                        add_newline = True
+        with open(auth_keys_file, 'a') as f:
             os.fchmod(f.fileno(), 0o600)  # just in case we created it
+            if add_newline:
+                f.write('\n')
             f.write(ssh_pub.strip() + '\n')
 
         logger.info('Enabling ssh module...')


### PR DESCRIPTION
Sometimes, `authorized_keys` file does not end with a newline and
therefore the public key generated by ceph-daemon gets appended to
the same line of the previous key. Therefore we need to append a
newline before our key to guarantee that the above case does not
happen.

Signed-off-by: Ricardo Dias <rdias@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
