### PR TITLE
os/bluestore: drop (semi-broken) 'nvme' automatic class

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -311,3 +311,10 @@
   its orignal behaviour of indicating an output file. This reverts it to a more
   consisten behaviour when compared to other tools. Specifying obect size is now
   accomplished by using an upper case O ``-O``.
+
+* In certain rare cases, OSDs would self-classify themselves as type
+  'nvme' instead of 'hdd' or 'ssh'.  This appears to be limited to
+  cases where BlueStore was deployed with older versions of ceph-disk,
+  or manually without ceph-volume and LVM.  Going forward, the OSD
+  will limit itself to only 'hdd' and 'ssd' (or whatever device class the user
+  manually specifies).

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -55,7 +55,6 @@ public:
   int partition(char* partition, size_t max) const;
   // from a device (e.g., "sdb")
   bool support_discard() const;
-  bool is_nvme() const;
   bool is_rotational() const;
   int get_numa_node(int *node) const;
   int dev(char *dev, size_t max) const;

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -326,9 +326,6 @@ int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm)
     blkdev.serial(buffer, sizeof(buffer));
     (*pm)[prefix + "serial"] = buffer;
 
-    if (blkdev.is_nvme())
-      (*pm)[prefix + "type"] = "nvme";
-
     // numa
     int node;
     r = blkdev.get_numa_node(&node);

--- a/src/os/bluestore/PMEMDevice.cc
+++ b/src/os/bluestore/PMEMDevice.cc
@@ -157,8 +157,6 @@ int PMEMDevice::collect_metadata(const string& prefix, map<string,string> *pm) c
     blkdev.serial(buffer, sizeof(buffer));
     (*pm)[prefix + "serial"] = buffer;
 
-    if (blkdev.is_nvme())
-      (*pm)[prefix + "type"] = "nvme";
   } else {
     (*pm)[prefix + "access_mode"] = "file";
     (*pm)[prefix + "path"] = path;

--- a/src/test/common/test_blkdev.cc
+++ b/src/test/common/test_blkdev.cc
@@ -78,14 +78,6 @@ TEST_F(BlockDevTest, discard)
   EXPECT_TRUE(sdb.support_discard());
 }
 
-TEST_F(BlockDevTest, is_nvme)
-{
-  // It would be nice to have a positive NVME test too, but I don't have any
-  // examples for the canned data.
-  EXPECT_FALSE(sda.is_nvme());
-  EXPECT_FALSE(sdb.is_nvme());
-}
-
 TEST_F(BlockDevTest, is_rotational)
 {
   EXPECT_FALSE(sda.is_rotational());

--- a/src/test/test_get_blkdev_props.cc
+++ b/src/test/test_get_blkdev_props.cc
@@ -43,8 +43,6 @@ int main(int argc, char **argv)
 
 	discard_support = blkdev.support_discard();
 
-	nvme = blkdev.is_nvme();
-
 	rotational = blkdev.is_rotational();
 
 	if ((ret = blkdev.dev(dev, BUFSIZE)) < 0) {
@@ -81,7 +79,6 @@ int main(int argc, char **argv)
 	fprintf(stdout, "Size:\t\t%" PRId64 "\n", size);
 	fprintf(stdout, "Discard:\t%s\n",
 		discard_support ? "supported" : "not supported");
-	fprintf(stdout, "NVME:\t\t%s\n", nvme ? "yes" : "no");
 	fprintf(stdout, "Rotational:\t%s\n", rotational ? "yes" : "no");
 	fprintf(stdout, "Dev:\t\t%s\n", dev);
 	fprintf(stdout, "Whole disk:\t%s\n", wholedisk);


### PR DESCRIPTION
The SSD vs nvme distinction is weak to useless, and there are
HDDs with nvme interfaces coming in the future.

AFAICS this only works when bluestore is running on the raw nvme
block device--it doesn't work through LVM, which means it isn't
used on most clusters.





<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>