### PR TITLE
ceph-daemon: several fsid inference fixes

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1330,6 +1330,8 @@ def command_shell():
 @infer_fsid
 def command_enter():
     # type: () -> int
+    if not args.fsid:
+        raise RuntimeError('must pass --fsid to specify cluster')
     (daemon_type, daemon_id) = args.name.split('.', 1)
     container_args = [] # type: List[str]
     if args.command:
@@ -1393,6 +1395,8 @@ def command_ceph_volume():
 @infer_fsid
 def command_unit():
     # type: () -> None
+    if not args.fsid:
+        raise RuntimeError('must pass --fsid to specify cluster')
     (daemon_type, daemon_id) = args.name.split('.', 1)
     unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
     call_throws([
@@ -1405,6 +1409,8 @@ def command_unit():
 @infer_fsid
 def command_logs():
     # type: () -> None
+    if not args.fsid:
+        raise RuntimeError('must pass --fsid to specify cluster')
     cmd = [container_path, 'logs']
     if args.follow:
         cmd.append('-f')

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1352,7 +1352,8 @@ def command_enter():
 @infer_fsid
 def command_ceph_volume():
     # type: () -> None
-    make_log_dir(args.fsid)
+    if args.fsid:
+        make_log_dir(args.fsid)
 
     mounts = get_container_mounts(args.fsid, 'osd', None)
 

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -235,7 +235,7 @@ def infer_fsid(func):
     def _infer_fsid():
         if args.fsid:
             logger.debug('Using specified fsid: %s' % args.fsid)
-            return
+            return func()
 
         fsid_list = []
         for i in os.listdir(args.data_dir):
@@ -246,7 +246,7 @@ def infer_fsid(func):
 
         if not fsid_list:
             # TODO: raise?
-            return
+            return func()
 
         if len(fsid_list) > 1:
             raise RuntimeError('Cannot infer fsid, must specify --fsid')


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>