### PR TITLE
mimic: pybind/mgr: Cancel output color control

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -91,10 +91,10 @@ class Module(MgrModule):
         else:
             return formatted
 
-    def format_dimless(self, n, width, colored=True):
+    def format_dimless(self, n, width, colored=False):
         return self.format_units(n, width, colored, decimal=True)
     
-    def format_bytes(self, n, width, colored=True):
+    def format_bytes(self, n, width, colored=False):
         return self.format_units(n, width, colored, decimal=False)
         
     def get_latest(self, daemon_type, daemon_name, stat):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42851

---

backport of https://github.com/ceph/ceph/pull/31427
parent tracker: https://tracker.ceph.com/issues/42517

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh