### PR TITLE
nautilus: mgr/dashboard: fix restored RBD image naming issue

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.ts
@@ -133,7 +133,7 @@ export class RbdService {
     });
   }
 
-  restoreTrash(poolName, imageId, newImageName) {
+  restoreTrash(poolName, imageId, @cdEncodeNot newImageName) {
     return this.http.post(
       `api/block/image/trash/${poolName}/${imageId}/restore`,
       { new_image_name: newImageName },


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42948

---

backport of https://github.com/ceph/ceph/pull/31590
parent tracker: https://tracker.ceph.com/issues/42785

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh