### PR TITLE
mgr/dashboard: CephFS quota management

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -414,7 +414,7 @@ class CephFS(RESTController):
         return cfs.get_quotas(path)
 
     @RESTController.Resource('POST')
-    def set_quotas(self, fs_id, path, max_bytes, max_files):
+    def set_quotas(self, fs_id, path, max_bytes=None, max_files=None):
         """
         Set the quotas of the specified path.
         :param fs_id: The filesystem identifier.

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.html
@@ -18,10 +18,20 @@
       <div class="card-body">
         <legend i18n>Quotas</legend>
         <cd-table [data]="settings"
-                  [columns]="settingsColumns"
+                  [columns]="quota.columns"
                   [limit]="0"
                   [footer]="false"
+                  selectionType="single"
+                  (updateSelection)="quota.updateSelection($event)"
+                  [onlyActionHeader]="true"
+                  identifier="quotaKey"
+                  [forceIdentifier]="true"
                   [toolHeader]="false">
+          <cd-table-actions class="only-table-actions"
+                            [permission]="permission"
+                            [selection]="quota.selection"
+                            [tableActions]="quota.tableActions">
+          </cd-table-actions>
         </cd-table>
 
         <legend i18n>Snapshots</legend>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Validators } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
@@ -15,11 +16,18 @@ import {
   PermissionHelper
 } from '../../../../testing/unit-test-helper';
 import { CephfsService } from '../../../shared/api/cephfs.service';
+import { ConfirmationModalComponent } from '../../../shared/components/confirmation-modal/confirmation-modal.component';
+import { FormModalComponent } from '../../../shared/components/form-modal/form-modal.component';
+import { NotificationType } from '../../../shared/enum/notification-type.enum';
+import { CdValidators } from '../../../shared/forms/cd-validators';
+import { CdTableAction } from '../../../shared/models/cd-table-action';
+import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import {
   CephfsDir,
   CephfsQuotas,
   CephfsSnapshot
 } from '../../../shared/models/cephfs-directory-models';
+import { NotificationService } from '../../../shared/services/notification.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { CephfsDirectoriesComponent } from './cephfs-directories.component';
 
@@ -28,6 +36,12 @@ describe('CephfsDirectoriesComponent', () => {
   let fixture: ComponentFixture<CephfsDirectoriesComponent>;
   let cephfsService: CephfsService;
   let lsDirSpy;
+  let modalShowSpy;
+  let notificationShowSpy;
+  let minValidator;
+  let maxValidator;
+  let minBinaryValidator;
+  let maxBinaryValidator;
   let originalDate;
   let modal;
 
@@ -44,6 +58,7 @@ describe('CephfsDirectoriesComponent', () => {
     parent: Tree;
     createdSnaps: CephfsSnapshot[] | any[];
     deletedSnaps: CephfsSnapshot[] | any[];
+    updatedQuotas: { [path: string]: CephfsQuotas };
   };
 
   // Object contains mock functions
@@ -62,9 +77,9 @@ describe('CephfsDirectoriesComponent', () => {
       }
       return snapshots;
     },
-    dir: (path: string, name: string, modifier: number): CephfsDir => {
-      const dirPath = `${path === '/' ? '' : path}/${name}`;
-      let snapshots = mockLib.snapshots(path, modifier);
+    dir: (parentPath: string, name: string, modifier: number): CephfsDir => {
+      const dirPath = `${parentPath === '/' ? '' : parentPath}/${name}`;
+      let snapshots = mockLib.snapshots(parentPath, modifier);
       const extraSnapshots = mockData.createdSnaps.filter((s) => s.path === dirPath);
       if (extraSnapshots.length > 0) {
         snapshots = snapshots.concat(extraSnapshots);
@@ -78,8 +93,11 @@ describe('CephfsDirectoriesComponent', () => {
       return {
         name,
         path: dirPath,
-        parent: path,
-        quotas: mockLib.quotas(1024 * modifier, 10 * modifier),
+        parent: parentPath,
+        quotas: Object.assign(
+          mockLib.quotas(1024 * modifier, 10 * modifier),
+          mockData.updatedQuotas[dirPath] || {}
+        ),
         snapshots: snapshots
       };
     },
@@ -120,6 +138,10 @@ describe('CephfsDirectoriesComponent', () => {
         created: new Date().toString()
       });
       return of(name);
+    },
+    updateQuota: (_id, path, updated: CephfsQuotas) => {
+      mockData.updatedQuotas[path] = Object.assign(mockData.updatedQuotas[path] || {}, updated);
+      return of('Response');
     },
     modalShow: (comp, init) => {
       modal = modalServiceShow(comp, init);
@@ -175,6 +197,43 @@ describe('CephfsDirectoriesComponent', () => {
       component.snapshot.selection.selected = snapshots;
       component.deleteSnapshotModal();
       modal.component.callSubmitAction();
+    },
+    updateQuotaThroughModal: (attribute: string, value: number) => {
+      component.quota.selection.selected = component.settings.filter(
+        (q) => q.quotaKey === attribute
+      );
+      component.updateQuotaModal();
+      modal.component.onSubmitForm({ [attribute]: value });
+    },
+    unsetQuotaThroughModal: (attribute: string) => {
+      component.quota.selection.selected = component.settings.filter(
+        (q) => q.quotaKey === attribute
+      );
+      component.unsetQuotaModal();
+      modal.component.onSubmit();
+    },
+    setFourQuotaDirs: (quotas: number[][]) => {
+      expect(quotas.length).toBe(4); // Make sure this function is used correctly
+      let path = '';
+      quotas.forEach((quota, index) => {
+        index += 1;
+        mockLib.mkDir(path, index.toString(), quota[0], quota[1]);
+        path += '/' + index;
+      });
+      mockData.parent = {
+        value: '3',
+        id: '/1/2/3',
+        parent: {
+          value: '2',
+          id: '/1/2',
+          parent: {
+            value: '1',
+            id: '/1',
+            parent: { value: '/', id: '/' }
+          }
+        }
+      } as Tree;
+      mockLib.selectNode('/1/2/3/4');
     }
   };
 
@@ -186,16 +245,94 @@ describe('CephfsDirectoriesComponent', () => {
     requestedPaths: (expected: string[]) => expect(get.requestedPaths()).toEqual(expected),
     snapshotsByName: (snaps: string[]) =>
       expect(component.selectedDir.snapshots.map((s) => s.name)).toEqual(snaps),
-    quotaSettings: (
-      fileValue: number | string,
-      fileOrigin: string,
-      sizeValue: string,
-      sizeOrigin: string
-    ) =>
-      expect(component.settings).toEqual([
-        { name: 'Max files', value: fileValue, origin: fileOrigin },
-        { name: 'Max size', value: sizeValue, origin: sizeOrigin }
-      ])
+    dirQuotas: (bytes: number, files: number) => {
+      expect(component.selectedDir.quotas).toEqual({ max_bytes: bytes, max_files: files });
+    },
+    noQuota: (key: 'bytes' | 'files') => {
+      assert.quotaRow(key, '', 0, '');
+    },
+    quotaIsNotInherited: (key: 'bytes' | 'files', shownValue, nextMaximum) => {
+      const dir = component.selectedDir;
+      const path = dir.path;
+      assert.quotaRow(key, shownValue, nextMaximum, path);
+    },
+    quotaIsInherited: (key: 'bytes' | 'files', shownValue, path) => {
+      const isBytes = key === 'bytes';
+      const nextMaximum = get.nodeIds()[path].quotas[isBytes ? 'max_bytes' : 'max_files'];
+      assert.quotaRow(key, shownValue, nextMaximum, path);
+    },
+    quotaRow: (
+      key: 'bytes' | 'files',
+      shownValue: number | string,
+      nextTreeMaximum: number,
+      originPath: string
+    ) => {
+      const isBytes = key === 'bytes';
+      expect(component.settings[isBytes ? 1 : 0]).toEqual({
+        row: {
+          name: `Max ${isBytes ? 'size' : key}`,
+          value: shownValue,
+          originPath
+        },
+        quotaKey: `max_${key}`,
+        dirValue: expect.any(Number),
+        nextTreeMaximum: {
+          value: nextTreeMaximum,
+          path: expect.any(String)
+        }
+      });
+    },
+    quotaUnsetModalTexts: (titleText, message, notificationMsg) => {
+      expect(modalShowSpy).toHaveBeenCalledWith(ConfirmationModalComponent, {
+        initialState: expect.objectContaining({
+          titleText,
+          description: message,
+          buttonText: 'Unset'
+        })
+      });
+      expect(notificationShowSpy).toHaveBeenCalledWith(NotificationType.success, notificationMsg);
+    },
+    quotaUpdateModalTexts: (titleText, message, notificationMsg) => {
+      expect(modalShowSpy).toHaveBeenCalledWith(FormModalComponent, {
+        initialState: expect.objectContaining({
+          titleText,
+          message,
+          submitButtonText: 'Save'
+        })
+      });
+      expect(notificationShowSpy).toHaveBeenCalledWith(NotificationType.success, notificationMsg);
+    },
+    quotaUpdateModalField: (
+      type: string,
+      label: string,
+      key: string,
+      value: number,
+      max: number,
+      errors?: { [key: string]: string }
+    ) => {
+      expect(modalShowSpy).toHaveBeenCalledWith(FormModalComponent, {
+        initialState: expect.objectContaining({
+          fields: [
+            {
+              type,
+              label,
+              errors,
+              name: key,
+              value,
+              validators: expect.anything(),
+              required: true
+            }
+          ]
+        })
+      });
+      if (type === 'binary') {
+        expect(minBinaryValidator).toHaveBeenCalledWith(0);
+        expect(maxBinaryValidator).toHaveBeenCalledWith(max);
+      } else {
+        expect(minValidator).toHaveBeenCalledWith(0);
+        expect(maxValidator).toHaveBeenCalledWith(max);
+      }
+    }
   };
 
   configureTestBed({
@@ -217,7 +354,8 @@ describe('CephfsDirectoriesComponent', () => {
       nodes: undefined,
       parent: undefined,
       createdSnaps: [],
-      deletedSnaps: []
+      deletedSnaps: [],
+      updatedQuotas: {}
     };
     originalDate = Date;
     spyOn(global, 'Date').and.callFake(mockLib.date);
@@ -226,8 +364,10 @@ describe('CephfsDirectoriesComponent', () => {
     lsDirSpy = spyOn(cephfsService, 'lsDir').and.callFake(mockLib.lsDir);
     spyOn(cephfsService, 'mkSnapshot').and.callFake(mockLib.mkSnapshot);
     spyOn(cephfsService, 'rmSnapshot').and.callFake(mockLib.rmSnapshot);
+    spyOn(cephfsService, 'updateQuota').and.callFake(mockLib.updateQuota);
 
-    spyOn(TestBed.get(BsModalService), 'show').and.callFake(mockLib.modalShow);
+    modalShowSpy = spyOn(TestBed.get(BsModalService), 'show').and.callFake(mockLib.modalShow);
+    notificationShowSpy = spyOn(TestBed.get(NotificationService), 'show').and.stub();
 
     fixture = TestBed.createComponent(CephfsDirectoriesComponent);
     component = fixture.componentInstance;
@@ -292,6 +432,50 @@ describe('CephfsDirectoriesComponent', () => {
         '/a/a/b'
       ]);
     });
+
+    describe('test quota update mock', () => {
+      const PATH = '/a';
+      const ID = 2;
+
+      const updateQuota = (quotas: CephfsQuotas) => mockLib.updateQuota(ID, PATH, quotas);
+
+      const expectMockUpdate = (max_bytes?: number, max_files?: number) =>
+        expect(mockData.updatedQuotas[PATH]).toEqual({
+          max_bytes,
+          max_files
+        });
+
+      const expectLsUpdate = (max_bytes?: number, max_files?: number) => {
+        let dir: CephfsDir;
+        mockLib.lsDir(ID, '/').subscribe((dirs) => (dir = dirs.find((d) => d.path === PATH)));
+        expect(dir.quotas).toEqual({
+          max_bytes,
+          max_files
+        });
+      };
+
+      it('tests to set quotas', () => {
+        expectLsUpdate(1024, 10);
+
+        updateQuota({ max_bytes: 512 });
+        expectMockUpdate(512);
+        expectLsUpdate(512, 10);
+
+        updateQuota({ max_files: 100 });
+        expectMockUpdate(512, 100);
+        expectLsUpdate(512, 100);
+      });
+
+      it('tests to unset quotas', () => {
+        updateQuota({ max_files: 0 });
+        expectMockUpdate(undefined, 0);
+        expectLsUpdate(1024, 0);
+
+        updateQuota({ max_bytes: 0 });
+        expectMockUpdate(0, 0);
+        expectLsUpdate(0, 0);
+      });
+    });
   });
 
   it('calls lsDir only if an id exits', () => {
@@ -353,7 +537,8 @@ describe('CephfsDirectoriesComponent', () => {
       mockLib.selectNode('/a');
       const dir = get.dirs().find((d) => d.path === '/a');
       expect(component.selectedDir).toEqual(dir);
-      assert.quotaSettings(10, '/a', '1 KiB', '/a');
+      assert.quotaIsNotInherited('files', 10, 0);
+      assert.quotaIsNotInherited('bytes', '1 KiB', 0);
     });
 
     it('should extend the list by subdirectories when expanding and omit already called path', () => {
@@ -401,47 +586,32 @@ describe('CephfsDirectoriesComponent', () => {
     });
 
     describe('used quotas', () => {
-      const setUpDirs = (quotas: number[][]) => {
-        let path = '';
-        quotas.forEach((quota, index) => {
-          index += 1;
-          mockLib.mkDir(path, index.toString(), quota[0], quota[1]);
-          path += '/' + index;
-        });
-        mockData.parent = {
-          value: '3',
-          id: '/1/2/3',
-          parent: {
-            value: '2',
-            id: '/1/2',
-            parent: {
-              value: '1',
-              id: '/1',
-              parent: { value: '/', id: '/' }
-            }
-          }
-        } as Tree;
-        mockLib.selectNode('/1/2/3/4');
-      };
-
       it('should use no quota if none is set', () => {
-        setUpDirs([[0, 0], [0, 0], [0, 0], [0, 0]]);
-        assert.quotaSettings('', '', '', '');
+        mockLib.setFourQuotaDirs([[0, 0], [0, 0], [0, 0], [0, 0]]);
+        assert.noQuota('files');
+        assert.noQuota('bytes');
+        assert.dirQuotas(0, 0);
       });
 
       it('should use quota from upper parents', () => {
-        setUpDirs([[100, 0], [0, 8], [0, 0], [0, 0]]);
-        assert.quotaSettings(100, '/1', '8 KiB', '/1/2');
+        mockLib.setFourQuotaDirs([[100, 0], [0, 8], [0, 0], [0, 0]]);
+        assert.quotaIsInherited('files', 100, '/1');
+        assert.quotaIsInherited('bytes', '8 KiB', '/1/2');
+        assert.dirQuotas(0, 0);
       });
 
       it('should use quota from the parent with the lowest value (deep inheritance)', () => {
-        setUpDirs([[200, 1], [100, 4], [400, 3], [300, 2]]);
-        assert.quotaSettings(100, '/1/2', '1 KiB', '/1');
+        mockLib.setFourQuotaDirs([[200, 1], [100, 4], [400, 3], [300, 2]]);
+        assert.quotaIsInherited('files', 100, '/1/2');
+        assert.quotaIsInherited('bytes', '1 KiB', '/1');
+        assert.dirQuotas(2048, 300);
       });
 
       it('should use current value', () => {
-        setUpDirs([[200, 2], [300, 4], [400, 3], [100, 1]]);
-        assert.quotaSettings(100, '/1/2/3/4', '1 KiB', '/1/2/3/4');
+        mockLib.setFourQuotaDirs([[200, 2], [300, 4], [400, 3], [100, 1]]);
+        assert.quotaIsNotInherited('files', 100, 200);
+        assert.quotaIsNotInherited('bytes', '1 KiB', 2048);
+        assert.dirQuotas(1024, 100);
       });
     });
   });
@@ -468,11 +638,6 @@ describe('CephfsDirectoriesComponent', () => {
       mockLib.createSnapshotThroughModal('deleteAll');
       mockLib.deleteSnapshotsThroughModal(component.selectedDir.snapshots);
       assert.snapshotsByName([]);
-    });
-
-    afterEach(() => {
-      // Makes sure the directory is updated correctly
-      expect(component.selectedDir).toEqual(get.nodeIds()[component.selectedDir.path]);
     });
   });
 
@@ -515,6 +680,241 @@ describe('CephfsDirectoriesComponent', () => {
         actions: [],
         primary: { multiple: '', executing: '', single: '', no: '' }
       }
+    });
+  });
+
+  describe('quotas', () => {
+    beforeEach(() => {
+      // Spies
+      minValidator = spyOn(Validators, 'min').and.callThrough();
+      maxValidator = spyOn(Validators, 'max').and.callThrough();
+      minBinaryValidator = spyOn(CdValidators, 'binaryMin').and.callThrough();
+      maxBinaryValidator = spyOn(CdValidators, 'binaryMax').and.callThrough();
+      // Select /a/c/b
+      mockLib.changeId(1);
+      mockLib.selectNode('/a');
+      mockLib.selectNode('/a/c');
+      mockLib.selectNode('/a/c/b');
+      // Quotas after selection
+      assert.quotaIsInherited('files', 10, '/a');
+      assert.quotaIsInherited('bytes', '1 KiB', '/a');
+      assert.dirQuotas(2048, 20);
+    });
+
+    describe('update modal', () => {
+      describe('max_files', () => {
+        beforeEach(() => {
+          mockLib.updateQuotaThroughModal('max_files', 5);
+        });
+
+        it('should update max_files correctly', () => {
+          expect(cephfsService.updateQuota).toHaveBeenCalledWith(1, '/a/c/b', { max_files: 5 });
+          assert.quotaIsNotInherited('files', 5, 10);
+        });
+
+        it('uses the correct form field', () => {
+          assert.quotaUpdateModalField('number', 'Max files', 'max_files', 20, 10, {
+            min: 'Value has to be at least 0 or more',
+            max: 'Value has to be at most 10 or less'
+          });
+        });
+
+        it('shows the right texts', () => {
+          assert.quotaUpdateModalTexts(
+            "Update CephFS files quota for '/a/c/b'",
+            "The inherited files quota 10 from '/a' is the maximum value to be used.",
+            "Updated CephFS files quota for '/a/c/b'"
+          );
+        });
+      });
+
+      describe('max_bytes', () => {
+        beforeEach(() => {
+          mockLib.updateQuotaThroughModal('max_bytes', 512);
+        });
+
+        it('should update max_files correctly', () => {
+          expect(cephfsService.updateQuota).toHaveBeenCalledWith(1, '/a/c/b', { max_bytes: 512 });
+          assert.quotaIsNotInherited('bytes', '512 B', 1024);
+        });
+
+        it('uses the correct form field', () => {
+          mockLib.updateQuotaThroughModal('max_bytes', 512);
+          assert.quotaUpdateModalField('binary', 'Max size', 'max_bytes', 2048, 1024);
+        });
+
+        it('shows the right texts', () => {
+          assert.quotaUpdateModalTexts(
+            "Update CephFS size quota for '/a/c/b'",
+            "The inherited size quota 1 KiB from '/a' is the maximum value to be used.",
+            "Updated CephFS size quota for '/a/c/b'"
+          );
+        });
+      });
+
+      describe('action behaviour', () => {
+        it('opens with next maximum as maximum if directory holds the current maximum', () => {
+          mockLib.updateQuotaThroughModal('max_bytes', 512);
+          mockLib.updateQuotaThroughModal('max_bytes', 888);
+          assert.quotaUpdateModalField('binary', 'Max size', 'max_bytes', 512, 1024);
+        });
+
+        it("uses 'Set' action instead of 'Update' if the quota is not set (0)", () => {
+          mockLib.updateQuotaThroughModal('max_bytes', 0);
+          mockLib.updateQuotaThroughModal('max_bytes', 200);
+          assert.quotaUpdateModalTexts(
+            "Set CephFS size quota for '/a/c/b'",
+            "The inherited size quota 1 KiB from '/a' is the maximum value to be used.",
+            "Set CephFS size quota for '/a/c/b'"
+          );
+        });
+      });
+    });
+
+    describe('unset modal', () => {
+      describe('max_files', () => {
+        beforeEach(() => {
+          mockLib.updateQuotaThroughModal('max_files', 5); // Sets usable quota
+          mockLib.unsetQuotaThroughModal('max_files');
+        });
+
+        it('should unset max_files correctly', () => {
+          expect(cephfsService.updateQuota).toHaveBeenCalledWith(1, '/a/c/b', { max_files: 0 });
+          assert.dirQuotas(2048, 0);
+        });
+
+        it('shows the right texts', () => {
+          assert.quotaUnsetModalTexts(
+            "Unset CephFS files quota for '/a/c/b'",
+            "Unset files quota 5 from '/a/c/b' in order to inherit files quota 10 from '/a'.",
+            "Unset CephFS files quota for '/a/c/b'"
+          );
+        });
+      });
+
+      describe('max_bytes', () => {
+        beforeEach(() => {
+          mockLib.updateQuotaThroughModal('max_bytes', 512); // Sets usable quota
+          mockLib.unsetQuotaThroughModal('max_bytes');
+        });
+
+        it('should unset max_files correctly', () => {
+          expect(cephfsService.updateQuota).toHaveBeenCalledWith(1, '/a/c/b', { max_bytes: 0 });
+          assert.dirQuotas(0, 20);
+        });
+
+        it('shows the right texts', () => {
+          assert.quotaUnsetModalTexts(
+            "Unset CephFS size quota for '/a/c/b'",
+            "Unset size quota 512 B from '/a/c/b' in order to inherit size quota 1 KiB from '/a'.",
+            "Unset CephFS size quota for '/a/c/b'"
+          );
+        });
+      });
+
+      describe('action behaviour', () => {
+        it('uses different Text if no quota is inherited', () => {
+          mockLib.selectNode('/a');
+          mockLib.unsetQuotaThroughModal('max_bytes');
+          assert.quotaUnsetModalTexts(
+            "Unset CephFS size quota for '/a'",
+            "Unset size quota 1 KiB from '/a' in order to have no quota on the directory.",
+            "Unset CephFS size quota for '/a'"
+          );
+        });
+
+        it('uses different Text if quota is already inherited', () => {
+          mockLib.unsetQuotaThroughModal('max_bytes');
+          assert.quotaUnsetModalTexts(
+            "Unset CephFS size quota for '/a/c/b'",
+            "Unset size quota 2 KiB from '/a/c/b' which isn't used because of the inheritance " +
+              "of size quota 1 KiB from '/a'.",
+            "Unset CephFS size quota for '/a/c/b'"
+          );
+        });
+      });
+    });
+  });
+
+  describe('table actions', () => {
+    let actions: CdTableAction[];
+
+    const empty = (): CdTableSelection => {
+      const selection = new CdTableSelection();
+      return selection;
+    };
+
+    const select = (value: number): CdTableSelection => {
+      const selection = new CdTableSelection();
+      selection.selected = [{ dirValue: value }];
+      return selection;
+    };
+
+    beforeEach(() => {
+      actions = component.quota.tableActions;
+    });
+
+    it("shows 'Set' for empty and not set quotas", () => {
+      const isSetVisible = actions[0].visible;
+      expect(isSetVisible(empty())).toBe(true);
+      expect(isSetVisible(select(0))).toBe(true);
+      expect(isSetVisible(select(1))).toBe(false);
+    });
+
+    it("shows 'Update' for set quotas only", () => {
+      const isUpdateVisible = actions[1].visible;
+      expect(isUpdateVisible(empty())).toBeFalsy();
+      expect(isUpdateVisible(select(0))).toBe(false);
+      expect(isUpdateVisible(select(1))).toBe(true);
+    });
+
+    it("only enables 'Unset' for set quotas only", () => {
+      const isUnsetDisabled = actions[2].disable;
+      expect(isUnsetDisabled(empty())).toBe(true);
+      expect(isUnsetDisabled(select(0))).toBe(true);
+      expect(isUnsetDisabled(select(1))).toBe(false);
+    });
+
+    it('should test all quota table actions permission combinations', () => {
+      const permissionHelper: PermissionHelper = new PermissionHelper(component.permission);
+      const tableActions = permissionHelper.setPermissionsAndGetActions(
+        component.quota.tableActions
+      );
+
+      expect(tableActions).toEqual({
+        'create,update,delete': {
+          actions: ['Set', 'Update', 'Unset'],
+          primary: { multiple: 'Set', executing: 'Set', single: 'Set', no: 'Set' }
+        },
+        'create,update': {
+          actions: ['Set', 'Update', 'Unset'],
+          primary: { multiple: 'Set', executing: 'Set', single: 'Set', no: 'Set' }
+        },
+        'create,delete': {
+          actions: [],
+          primary: { multiple: '', executing: '', single: '', no: '' }
+        },
+        create: {
+          actions: [],
+          primary: { multiple: '', executing: '', single: '', no: '' }
+        },
+        'update,delete': {
+          actions: ['Set', 'Update', 'Unset'],
+          primary: { multiple: 'Set', executing: 'Set', single: 'Set', no: 'Set' }
+        },
+        update: {
+          actions: ['Set', 'Update', 'Unset'],
+          primary: { multiple: 'Set', executing: 'Set', single: 'Set', no: 'Set' }
+        },
+        delete: {
+          actions: [],
+          primary: { multiple: '', executing: '', single: '', no: '' }
+        },
+        'no-permissions': {
+          actions: [],
+          primary: { multiple: '', executing: '', single: '', no: '' }
+        }
+      });
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -78,4 +78,21 @@ describe('CephfsService', () => {
     const req = httpTesting.expectOne('api/cephfs/1/rm_snapshot?path=%252Fsome%252Fpath&name=snap');
     expect(req.request.method).toBe('POST');
   });
+
+  it('should call updateQuota', () => {
+    service.updateQuota(1, '/some/path', { max_bytes: 1024 }).subscribe();
+    let req = httpTesting.expectOne('api/cephfs/1/set_quotas?path=%252Fsome%252Fpath');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ max_bytes: 1024 });
+
+    service.updateQuota(1, '/some/path', { max_files: 10 }).subscribe();
+    req = httpTesting.expectOne('api/cephfs/1/set_quotas?path=%252Fsome%252Fpath');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ max_files: 10 });
+
+    service.updateQuota(1, '/some/path', { max_bytes: 1024, max_files: 10 }).subscribe();
+    req = httpTesting.expectOne('api/cephfs/1/set_quotas?path=%252Fsome%252Fpath');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ max_bytes: 1024, max_files: 10 });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -5,7 +5,7 @@ import * as _ from 'lodash';
 import { Observable } from 'rxjs';
 
 import { cdEncode } from '../decorators/cd-encode';
-import { CephfsDir } from '../models/cephfs-directory-models';
+import { CephfsDir, CephfsQuotas } from '../models/cephfs-directory-models';
 import { ApiModule } from './api.module';
 
 @cdEncode
@@ -55,13 +55,22 @@ export class CephfsService {
     if (!_.isUndefined(name)) {
       params = params.append('name', name);
     }
-    return this.http.post(`${this.baseURL}/${id}/mk_snapshot`, null, { params: params });
+    return this.http.post(`${this.baseURL}/${id}/mk_snapshot`, null, { params });
   }
 
   rmSnapshot(id, path, name) {
     let params = new HttpParams();
     params = params.append('path', path);
     params = params.append('name', name);
-    return this.http.post(`${this.baseURL}/${id}/rm_snapshot`, null, { params: params });
+    return this.http.post(`${this.baseURL}/${id}/rm_snapshot`, null, { params });
+  }
+
+  updateQuota(id, path, quotas: CephfsQuotas) {
+    let params = new HttpParams();
+    params = params.append('path', path);
+    return this.http.post(`${this.baseURL}/${id}/set_quotas`, quotas, {
+      observe: 'response',
+      params
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
@@ -7,6 +7,9 @@
           novalidate>
       <div class="modal-body">
         <ng-container *ngTemplateOutlet="bodyTpl; context: bodyContext"></ng-container>
+        <p *ngIf="description">
+          {{description}}
+        </p>
       </div>
       <div class="modal-footer">
         <div class="button-group text-right">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.spec.ts
@@ -25,7 +25,7 @@ export class MockModule {}
 @Component({
   template: `
     <ng-template #fillTpl>
-      The description of the confirmation modal is mandatory.
+      Template based description.
     </ng-template>
   `
 })
@@ -45,6 +45,7 @@ class MockComponent {
           titleText: 'Title is a must have',
           buttonText: 'Action label',
           bodyTpl: this.fillTpl,
+          description: 'String based description.',
           onSubmit: () => {
             this.returnValue = 'The submit action has to hide manually.';
             this.modalRef.hide();
@@ -155,7 +156,8 @@ describe('ConfirmationModalComponent', () => {
     it('has no description defined', () => {
       expectError(
         {
-          bodyTpl: undefined
+          bodyTpl: undefined,
+          description: undefined
         },
         'No description defined'
       );
@@ -197,7 +199,7 @@ describe('ConfirmationModalComponent', () => {
 
     it('should show the description', () => {
       expect(fh.getText('.modal-body')).toBe(
-        'The description of the confirmation modal is mandatory.'
+        'Template based description.  String based description.'
       );
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.ts
@@ -11,10 +11,13 @@ import { Subscription } from 'rxjs';
 })
 export class ConfirmationModalComponent implements OnInit, OnDestroy {
   // Needed
-  bodyTpl: TemplateRef<any>;
   buttonText: string;
   titleText: string;
   onSubmit: Function;
+
+  // One of them is needed
+  bodyTpl?: TemplateRef<any>;
+  description?: TemplateRef<any>;
 
   // Optional
   bodyData?: object;
@@ -45,7 +48,7 @@ export class ConfirmationModalComponent implements OnInit, OnDestroy {
       throw new Error('No action name defined');
     } else if (!this.titleText) {
       throw new Error('No title defined');
-    } else if (!this.bodyTpl) {
+    } else if (!this.bodyTpl && !this.description) {
       throw new Error('No description defined');
     }
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
@@ -5,54 +5,49 @@
   </ng-container>
   <ng-container class="modal-content">
     <form [formGroup]="formGroup"
+          #formDir="ngForm"
           novalidate>
       <div class="modal-body">
         <p *ngIf="message">{{ message }}</p>
         <ng-container *ngFor="let field of fields">
-          <div class="form-group row">
-            <ng-container [ngSwitch]="field.type">
-              <ng-template [ngSwitchCase]="'inputText'">
-                <label *ngIf="field.label"
-                       class="col-form-label col-sm-3"
-                       [for]="field.name">
-                  {{ field.label }}
-                </label>
-                <div [ngClass]="{'col-sm-9': field.label, 'col-sm-12': !field.label}">
-                  <input type="text"
-                         class="form-control"
-                         [id]="field.name"
-                         [name]="field.name"
-                         [formControlName]="field.name">
-                  <span *ngIf="formGroup.hasError('required', field.name)"
-                        class="invalid-feedback"
-                        i18n>This field is required.</span>
-                </div>
-              </ng-template>
-              <ng-template [ngSwitchCase]="'select'">
-                <label *ngIf="field.label"
-                       class="col-form-label col-sm-3"
-                       [for]="field.name">
-                  {{ field.label }}
-                </label>
-                <div [ngClass]="{'col-sm-9': field.label, 'col-sm-12': !field.label}">
-                  <select class="form-control custom-select"
-                          [id]="field.name"
-                          [formControlName]="field.name">
-                    <option *ngIf="field.placeholder"
-                            [ngValue]="null">
-                      {{ field.placeholder }}
-                    </option>
-                    <option *ngFor="let option of field.options"
-                            [value]="option.value">
-                      {{ option.text }}
-                    </option>
-                  </select>
-                  <span *ngIf="formGroup.hasError('required', field.name)"
-                        class="invalid-feedback"
-                        i18n>This field is required.</span>
-                </div>
-              </ng-template>
-            </ng-container>
+          <div class="form-group row cd-{{field.name}}-form-group">
+            <label *ngIf="field.label"
+                   class="col-form-label col-sm-3"
+                   [for]="field.name">
+              {{ field.label }}
+            </label>
+            <div [ngClass]="{'col-sm-9': field.label, 'col-sm-12': !field.label}">
+              <input *ngIf="['text', 'number'].includes(field.type)"
+                     [type]="field.type"
+                     class="form-control"
+                     [id]="field.name"
+                     [name]="field.name"
+                     [formControlName]="field.name">
+              <input *ngIf="field.type === 'binary'"
+                     type="text"
+                     class="form-control"
+                     [id]="field.name"
+                     [name]="field.name"
+                     [formControlName]="field.name"
+                     cdDimlessBinary>
+              <select *ngIf="field.name === 'select'"
+                      class="form-control custom-select"
+                      [id]="field.name"
+                      [formControlName]="field.name">
+                <option *ngIf="field.placeholder"
+                        [ngValue]="null">
+                  {{ field.placeholder }}
+                </option>
+                <option *ngFor="let option of field.options"
+                        [value]="option.value">
+                  {{ option.text }}
+                </option>
+              </select>
+              <span *ngIf="formGroup.showError(field.name,formDir)"
+                    class="invalid-feedback">
+                {{ getError(field) }}
+              </span>
+            </div>
           </div>
         </ng-container>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
@@ -8,8 +8,10 @@ import { BsModalRef, ModalModule } from 'ngx-bootstrap/modal';
 import {
   configureTestBed,
   FixtureHelper,
+  FormHelper,
   i18nProviders
 } from '../../../../testing/unit-test-helper';
+import { CdValidators } from '../../forms/cd-validators';
 import { SharedModule } from '../../shared.module';
 import { FormModalComponent } from './form-modal.component';
 
@@ -17,6 +19,7 @@ describe('InputModalComponent', () => {
   let component: FormModalComponent;
   let fixture: ComponentFixture<FormModalComponent>;
   let fh: FixtureHelper;
+  let formHelper: FormHelper;
   let submitted;
 
   const initialState = {
@@ -24,15 +27,24 @@ describe('InputModalComponent', () => {
     message: 'Some description',
     fields: [
       {
-        type: 'inputText',
+        type: 'text',
         name: 'requiredField',
         value: 'some-value',
         required: true
       },
       {
-        type: 'inputText',
+        type: 'number',
         name: 'optionalField',
-        label: 'Optional'
+        label: 'Optional',
+        errors: { min: 'Value has to be above zero!' },
+        validators: [Validators.min(0), Validators.max(10)]
+      },
+      {
+        type: 'binary',
+        name: 'dimlessBinary',
+        label: 'Size',
+        value: 2048,
+        validators: [CdValidators.binaryMin(1024), CdValidators.binaryMax(3072)]
       }
     ],
     submitButtonText: 'Submit button name',
@@ -56,6 +68,7 @@ describe('InputModalComponent', () => {
     Object.assign(component, initialState);
     fixture.detectChanges();
     fh = new FixtureHelper(fixture);
+    formHelper = new FormHelper(component.formGroup);
   });
 
   it('should create', () => {
@@ -86,6 +99,61 @@ describe('InputModalComponent', () => {
   it('gives back all form values on submit', () => {
     component.onSubmitForm(component.formGroup.value);
     expect(submitted).toEqual({
+      dimlessBinary: 2048,
+      requiredField: 'some-value',
+      optionalField: null
+    });
+  });
+
+  it('tests required field validation', () => {
+    formHelper.expectErrorChange('requiredField', '', 'required');
+  });
+
+  it('tests required field message', () => {
+    formHelper.setValue('requiredField', '', true);
+    fh.expectTextToBe('.cd-requiredField-form-group .invalid-feedback', 'This field is required.');
+  });
+
+  it('tests custom validator on number field', () => {
+    formHelper.expectErrorChange('optionalField', -1, 'min');
+    formHelper.expectErrorChange('optionalField', 11, 'max');
+  });
+
+  it('tests custom validator error message', () => {
+    formHelper.setValue('optionalField', -1, true);
+    fh.expectTextToBe(
+      '.cd-optionalField-form-group .invalid-feedback',
+      'Value has to be above zero!'
+    );
+  });
+
+  it('tests default error message', () => {
+    formHelper.setValue('optionalField', 11, true);
+    fh.expectTextToBe('.cd-optionalField-form-group .invalid-feedback', 'An error occurred.');
+  });
+
+  it('tests binary error messages', () => {
+    formHelper.setValue('dimlessBinary', '4 K', true);
+    fh.expectTextToBe(
+      '.cd-dimlessBinary-form-group .invalid-feedback',
+      'Size has to be at most 3 KiB or less'
+    );
+    formHelper.setValue('dimlessBinary', '0.5 K', true);
+    fh.expectTextToBe(
+      '.cd-dimlessBinary-form-group .invalid-feedback',
+      'Size has to be at least 1 KiB or more'
+    );
+  });
+
+  it('shows result of dimlessBinary pipe', () => {
+    fh.expectFormFieldToBe('#dimlessBinary', '2 KiB');
+  });
+
+  it('changes dimlessBinary value and the result will still be a number', () => {
+    formHelper.setValue('dimlessBinary', '3 K', true);
+    component.onSubmitForm(component.formGroup.value);
+    expect(submitted).toEqual({
+      dimlessBinary: 3072,
       requiredField: 'some-value',
       optionalField: null
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.ts
@@ -1,24 +1,15 @@
 import { Component, OnInit } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormControl, ValidatorFn, Validators } from '@angular/forms';
 
+import { I18n } from '@ngx-translate/i18n-polyfill';
 import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { DimlessBinaryPipe } from 'app/shared/pipes/dimless-binary.pipe';
 import { CdFormBuilder } from '../../forms/cd-form-builder';
-
-interface CdFormFieldConfig {
-  type: 'inputText' | 'select';
-  name: string;
-  label?: string;
-  value?: any;
-  required?: boolean;
-  // --- select ---
-  placeholder?: string;
-  options?: Array<{
-    text: string;
-    value: any;
-  }>;
-}
+import { CdFormGroup } from '../../forms/cd-form-group';
+import { CdFormModalFieldConfig } from '../../models/cd-form-modal-field-config';
+import { FormatterService } from '../../services/formatter.service';
 
 @Component({
   selector: 'cd-form-modal',
@@ -29,32 +20,90 @@ export class FormModalComponent implements OnInit {
   // Input
   titleText: string;
   message: string;
-  fields: CdFormFieldConfig[];
+  fields: CdFormModalFieldConfig[];
   submitButtonText: string;
   onSubmit: Function;
 
   // Internal
-  formGroup: FormGroup;
+  formGroup: CdFormGroup;
 
-  constructor(public bsModalRef: BsModalRef, private formBuilder: CdFormBuilder) {}
-
-  createForm() {
-    const controlsConfig = {};
-    this.fields.forEach((field) => {
-      const validators = [];
-      if (_.isBoolean(field.required) && field.required) {
-        validators.push(Validators.required);
-      }
-      controlsConfig[field.name] = new FormControl(_.defaultTo(field.value, null), { validators });
-    });
-    this.formGroup = this.formBuilder.group(controlsConfig);
-  }
+  constructor(
+    public bsModalRef: BsModalRef,
+    private formBuilder: CdFormBuilder,
+    private formatter: FormatterService,
+    private dimlessBinaryPipe: DimlessBinaryPipe,
+    private i18n: I18n
+  ) {}
 
   ngOnInit() {
     this.createForm();
   }
 
+  createForm() {
+    const controlsConfig = {};
+    this.fields.forEach((field) => {
+      controlsConfig[field.name] = this.createFormControl(field);
+    });
+    this.formGroup = this.formBuilder.group(controlsConfig);
+  }
+
+  private createFormControl(field: CdFormModalFieldConfig): FormControl {
+    let validators: ValidatorFn[] = [];
+    if (_.isBoolean(field.required) && field.required) {
+      validators.push(Validators.required);
+    }
+    if (field.validators) {
+      validators = validators.concat(field.validators);
+    }
+    return new FormControl(
+      _.defaultTo(
+        field.type === 'binary' ? this.dimlessBinaryPipe.transform(field.value) : field.value,
+        null
+      ),
+      { validators }
+    );
+  }
+
+  getError(field: CdFormModalFieldConfig): string {
+    const formErrors = this.formGroup.get(field.name).errors;
+    const errors = Object.keys(formErrors).map((key) => {
+      return this.getErrorMessage(key, formErrors[key], field.errors);
+    });
+    return errors.join('<br>');
+  }
+
+  private getErrorMessage(
+    error: string,
+    errorContext: any,
+    fieldErrors: { [error: string]: string }
+  ): string {
+    if (fieldErrors) {
+      const customError = fieldErrors[error];
+      if (customError) {
+        return customError;
+      }
+    }
+    if (['binaryMin', 'binaryMax'].includes(error)) {
+      // binaryMin and binaryMax return a function that take I18n to
+      // provide a translated error message.
+      return errorContext(this.i18n);
+    }
+    if (error === 'required') {
+      return this.i18n('This field is required.');
+    }
+    return this.i18n('An error occurred.');
+  }
+
   onSubmitForm(values) {
+    const binaries = this.fields
+      .filter((field) => field.type === 'binary')
+      .map((field) => field.name);
+    binaries.forEach((key) => {
+      const value = values[key];
+      if (value) {
+        values[key] = this.formatter.toBytes(value);
+      }
+    });
     this.bsModalRef.hide();
     if (_.isFunction(this.onSubmit)) {
       this.onSubmit(values);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -82,11 +82,13 @@ export class ActionLabelsI18n {
   REMOVE: string;
   EDIT: string;
   CANCEL: string;
+  CHANGE: string;
   COPY: string;
   CLONE: string;
   DEEP_SCRUB: string;
   DESTROY: string;
   EVICT: string;
+  EXPIRE: string;
   FLATTEN: string;
   MARK_DOWN: string;
   MARK_IN: string;
@@ -94,17 +96,18 @@ export class ActionLabelsI18n {
   MARK_OUT: string;
   PROTECT: string;
   PURGE: string;
+  RECREATE: string;
   RENAME: string;
   RESTORE: string;
   REWEIGHT: string;
   ROLLBACK: string;
   SCRUB: string;
+  SET: string;
   SHOW: string;
   TRASH: string;
   UNPROTECT: string;
-  RECREATE: string;
-  EXPIRE: string;
-  CHANGE: string;
+  UNSET: string;
+  UPDATE: string;
 
   constructor(private i18n: I18n) {
     /* Create a new item */
@@ -115,12 +118,15 @@ export class ActionLabelsI18n {
 
     /* Add an existing item to a container */
     this.ADD = this.i18n('Add');
+    this.SET = this.i18n('Set');
 
     /* Remove an item from a container WITHOUT deleting it */
     this.REMOVE = this.i18n('Remove');
+    this.UNSET = this.i18n('Unset');
 
     /* Make changes to an existing item */
     this.EDIT = this.i18n('Edit');
+    this.UPDATE = this.i18n('Update');
     this.CANCEL = this.i18n('Cancel');
 
     /* Non-standard actions */

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -3,6 +3,12 @@
                 i18n>Failed to load data.</cd-alert-panel>
 
 <div class="dataTables_wrapper">
+  <div *ngIf="onlyActionHeader"
+       class="dataTables_header clearfix">
+    <div class="cd-datatable-actions">
+      <ng-content select=".only-table-actions"></ng-content>
+    </div>
+  </div>
   <div class="dataTables_header clearfix"
        *ngIf="toolHeader">
     <!-- actions -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -68,6 +68,9 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   // Method used for setting column widths.
   @Input()
   columnMode? = 'flex';
+  // Display only actions in header (make sure to disable toolHeader) and use ".only-table-actions"
+  @Input()
+  onlyActionHeader? = false;
   // Display the tool header, including reload button, pagination and search fields?
   @Input()
   toolHeader? = true;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.spec.ts
@@ -526,4 +526,33 @@ describe('CdValidators', () => {
       expect(validatorFn(form.get('z'))).toEqual({ required: true });
     });
   });
+
+  describe('dimmlessBinary validators', () => {
+    const i18nMock = (a: string, b: { value: string }) => a.replace('{{value}}', b.value);
+
+    beforeEach(() => {
+      form = new CdFormGroup({
+        x: new FormControl('2 KiB', [CdValidators.binaryMin(1024), CdValidators.binaryMax(3072)])
+      });
+      formHelper = new FormHelper(form);
+    });
+
+    it('should not raise exception an exception for valid change', () => {
+      formHelper.expectValidChange('x', '2.5 KiB');
+    });
+
+    it('should not raise minimum error', () => {
+      formHelper.expectErrorChange('x', '0.5 KiB', 'binaryMin');
+      expect(form.get('x').getError('binaryMin')(i18nMock)).toBe(
+        'Size has to be at least 1 KiB or more'
+      );
+    });
+
+    it('should not raise maximum error', () => {
+      formHelper.expectErrorChange('x', '4 KiB', 'binaryMax');
+      expect(form.get('x').getError('binaryMax')(i18nMock)).toBe(
+        'Size has to be at most 3 KiB or less'
+      );
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -6,9 +6,13 @@ import {
   Validators
 } from '@angular/forms';
 
+import { I18n } from '@ngx-translate/i18n-polyfill';
 import * as _ from 'lodash';
 import { Observable, of as observableOf, timer as observableTimer } from 'rxjs';
 import { map, switchMapTo, take } from 'rxjs/operators';
+
+import { DimlessBinaryPipe } from '../pipes/dimless-binary.pipe';
+import { FormatterService } from '../services/formatter.service';
 
 export function isEmptyInputValue(value: any): boolean {
   return value == null || value.length === 0;
@@ -319,6 +323,46 @@ export class CdValidators {
         return null;
       }
       return { invalidUuid: 'This is not a valid UUID' };
+    };
+  }
+
+  /**
+   * A simple minimum validator vor cd-binary inputs.
+   *
+   * To use the validation message pass I18n into the function as it cannot
+   * be called in a static one.
+   */
+  static binaryMin(bytes: number): ValidatorFn {
+    return (control: AbstractControl): { [key: string]: (i18n: I18n) => string } | null => {
+      const formatterService = new FormatterService();
+      const currentBytes = new FormatterService().toBytes(control.value);
+      if (bytes <= currentBytes) {
+        return null;
+      }
+      const value = new DimlessBinaryPipe(formatterService).transform(bytes);
+      return {
+        binaryMin: (i18n: I18n) => i18n(`Size has to be at least {{value}} or more`, { value })
+      };
+    };
+  }
+
+  /**
+   * A simple maximum validator vor cd-binary inputs.
+   *
+   * To use the validation message pass I18n into the function as it cannot
+   * be called in a static one.
+   */
+  static binaryMax(bytes: number): ValidatorFn {
+    return (control: AbstractControl): { [key: string]: (i18n: I18n) => string } | null => {
+      const formatterService = new FormatterService();
+      const currentBytes = formatterService.toBytes(control.value);
+      if (bytes >= currentBytes) {
+        return null;
+      }
+      const value = new DimlessBinaryPipe(formatterService).transform(bytes);
+      return {
+        binaryMax: (i18n: I18n) => i18n(`Size has to be at most {{value}} or less`, { value })
+      };
     };
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-form-modal-field-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-form-modal-field-config.ts
@@ -1,0 +1,19 @@
+import { ValidatorFn } from '@angular/forms';
+
+export class CdFormModalFieldConfig {
+  name: string;
+  // 'binary' will use cdDimlessBinary directive on input element
+  // 'select' will use select element
+  type: 'number' | 'text' | 'binary' | 'select';
+  label?: string;
+  required?: boolean;
+  value?: any;
+  errors?: { [errorName: string]: string };
+  validators: ValidatorFn[];
+  // only for type select
+  placeholder?: string;
+  options?: Array<{
+    text: string;
+    value: any;
+  }>;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs-directory-models.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cephfs-directory-models.ts
@@ -7,8 +7,8 @@ export class CephfsSnapshot {
 }
 
 export class CephfsQuotas {
-  max_bytes: number;
-  max_files: number;
+  max_bytes?: number;
+  max_files?: number;
 }
 
 export class CephfsDir {

--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -45,7 +45,7 @@
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
     "prefer-const": true,
-    "quotemark": [true, "single"],
+    "quotemark": [true, "single", "avoid-escape"],
     "radix": true,
     "semicolon": [true, "always"],
     "triple-equals": [true, "allow-null-check"],

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -224,7 +224,9 @@ class CephFS(object):
         :param max_files: The file limit.
         :type max_files: int | None
         """
-        self.cfs.setxattr(path, 'ceph.quota.max_bytes',
-                          str(max_bytes if max_bytes else 0).encode(), 0)
-        self.cfs.setxattr(path, 'ceph.quota.max_files',
-                          str(max_files if max_files else 0).encode(), 0)
+        if max_bytes is not None:
+            self.cfs.setxattr(path, 'ceph.quota.max_bytes',
+                              str(max_bytes).encode(), 0)
+        if max_files is not None:
+            self.cfs.setxattr(path, 'ceph.quota.max_files',
+                              str(max_files).encode(), 0)


### PR DESCRIPTION
Now both CephFS quotas can be changed with a validation against the next
tree maximum in the file tree, that prevents setting the quotas in a way
that would not be usable.

Fixes: https://tracker.ceph.com/issues/38287
Signed-off-by: Stephan Müller <smueller@suse.com>

Here is how it looks like:

![quota-management](https://user-images.githubusercontent.com/16167865/69431159-770e2700-0d37-11ea-8e36-3dff5fef1a8b.gif)


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
