### PR TITLE
mgr/dashboard: install teuthology using pip

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -30,7 +30,7 @@ Alternative usage:
 
 """
 
-from StringIO import StringIO
+from six import StringIO
 from collections import defaultdict
 import getpass
 import signal

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -56,49 +56,13 @@ setup_teuthology() {
     TEMP_DIR=`mktemp -d`
     cd $TEMP_DIR
 
-    cat <<EOF > t_reqs.txt
-apache-libcloud==2.2.1
-asn1crypto==0.22.0
-backports.ssl-match-hostname==3.5.0.1
-bcrypt==3.1.4
-certifi==2018.1.18
-cffi==1.10.0
-chardet==3.0.4
-configobj==5.0.6
-cryptography==2.1.4
-enum34==1.1.6
-gevent==1.2.2
-greenlet==0.4.13
-idna==2.5
-ipaddress==1.0.18
-Jinja2==2.9.6
-manhole==1.5.0
-MarkupSafe==1.0
-netaddr==0.7.19
-packaging==16.8
-paramiko==2.4.0
-pexpect==4.4.0
-psutil==5.4.3
-ptyprocess==0.5.2
-pyasn1==0.2.3
-pycparser==2.17
-PyNaCl==1.2.1
-pyparsing==2.2.0
-python-dateutil==2.6.1
-PyYAML==3.12
-requests==2.18.4
-six==1.10.0
-urllib3==1.22
-EOF
-
     virtualenv --python=${TEUTHOLOGY_PYTHON_BIN:-/usr/bin/python} venv
     source venv/bin/activate
     pip install 'setuptools >= 12'
-    pip install -r t_reqs.txt
+    pip install git+https://github.com/ceph/teuthology#egg=teuthology[test]
     pushd $CURR_DIR
     pip install -r requirements.txt -c constraints.txt
     popd
-    git clone --depth 1 https://github.com/ceph/teuthology.git
 
     deactivate
 }
@@ -161,7 +125,7 @@ run_teuthology_tests() {
         export PYBIND=$LOCAL_BUILD_DIR/src/pybind
         pybind_dir=$PYBIND
     fi
-    export PYTHONPATH=$TEMP_DIR/teuthology:$source_dir/qa:$LOCAL_BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$pybind_dir:$python_common_dir:${COVERAGE_PATH}
+    export PYTHONPATH=$source_dir/qa:$LOCAL_BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$pybind_dir:$python_common_dir:${COVERAGE_PATH}
     export RGW=${RGW:-1}
 
     export COVERAGE_ENABLED=true


### PR DESCRIPTION
python3.7 does not support gevent 1.2.2

see https://github.com/gevent/gevent/issues/1297#issuecomment-432474054

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
