### PR TITLE
ceph-volume: import mock.mock instead of unittest.mock (py2)

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest.mock import patch
+from mock.mock import patch
 from ceph_volume import process, exceptions
 from ceph_volume.api import lvm as api
 


### PR DESCRIPTION
Fixes: bb4de1a3fc238eaf9f717dc59c6bdf338ef6d657
Fixes: https://tracker.ceph.com/issues/42970

Signed-off-by: Jan Fajerski <jfajerski@suse.com>