### PR TITLE
common/options: remove unused ms_msgr2_{sign,encrypt}_messages

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -975,16 +975,6 @@ std::vector<Option> get_global_options() {
     .set_default(100_M)
     .set_description("Limit messages that are read off the network but still being processed"),
 
-    Option("ms_msgr2_sign_messages", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
-    .set_description("Sign msgr2 frames' payload")
-    .add_see_also("ms_msgr2_encrypt_messages"),
-
-    Option("ms_msgr2_encrypt_messages", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
-    .set_description("Encrypt msgr2 frames' payload")
-    .add_see_also("ms_msgr2_sign_messages"),
-
     Option("ms_bind_ipv4", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("Bind servers to IPv4 address(es)")


### PR DESCRIPTION
These are unused since 1d29722f801c ("switch monc, daemons to use new
msgr2 auth frame exchange").  As they default to false, a confused user
might flip them to true and think that their client <-> OSD traffic is
encrypted.

The new set of options was added in c7ee66c3e54b
("auth,msg/async/ProtocolV2: negotiate connection modes").

Fixes: https://tracker.ceph.com/issues/42976
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>