### PR TITLE
ceph-daemon: fix logrotate su line

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -693,7 +693,7 @@ def install_base_units(fsid):
     endscript
     missingok
     notifempty
-    su root ceph
+    su root root
 }
 """ % fsid)
 


### PR DESCRIPTION
The ceph group usually won't exist; rotate as root.root.

(If we leave this off, logrotate complains about directory ownership
and permissions and doesn't do anything.)

Signed-off-by: Sage Weil <sage@redhat.com>