### PR TITLE
cls/rbd: sanitize the mirror image status peer address after reading from disk

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -4662,13 +4662,6 @@ int uuid_get(cls_method_context_t hctx, std::string *mirror_uuid) {
   return 0;
 }
 
-void sanitize_entity_inst(entity_inst_t* entity_inst) {
-  // make all addrs of type ANY because the type isn't what uniquely
-  // identifies them and clients and on-disk formats can be encoded
-  // with different backwards compatibility settings.
-  entity_inst->addr.set_type(entity_addr_t::TYPE_ANY);
-}
-
 int list_watchers(cls_method_context_t hctx,
                   std::set<entity_inst_t> *entities) {
   obj_list_watch_response_t watchers;
@@ -4681,7 +4674,7 @@ int list_watchers(cls_method_context_t hctx,
   entities->clear();
   for (auto &w : watchers.entries) {
     entity_inst_t entity_inst{w.name, w.addr};
-    sanitize_entity_inst(&entity_inst);
+    cls::rbd::sanitize_entity_inst(&entity_inst);
 
     entities->insert(entity_inst);
   }
@@ -5055,7 +5048,6 @@ int image_status_set(cls_method_context_t hctx, const string &global_image_id,
   ondisk_status.last_update = ceph_clock_now();
 
   int r = cls_get_request_origin(hctx, &ondisk_status.origin);
-  sanitize_entity_inst(&ondisk_status.origin);
   ceph_assert(r == 0);
 
   bufferlist bl;

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -287,7 +287,9 @@ std::ostream& operator<<(std::ostream& os,
 void MirrorImageSiteStatusOnDisk::encode_meta(bufferlist &bl,
                                               uint64_t features) const {
   ENCODE_START(1, 1, bl);
-  encode(origin, bl, features);
+  auto sanitized_origin = origin;
+  sanitize_entity_inst(&sanitized_origin);
+  encode(sanitized_origin, bl, features);
   ENCODE_FINISH(bl);
 }
 
@@ -300,6 +302,7 @@ void MirrorImageSiteStatusOnDisk::encode(bufferlist &bl,
 void MirrorImageSiteStatusOnDisk::decode_meta(bufferlist::const_iterator &it) {
   DECODE_START(1, it);
   decode(origin, it);
+  sanitize_entity_inst(&origin);
   DECODE_FINISH(it);
 }
 
@@ -1144,6 +1147,13 @@ std::ostream& operator<<(std::ostream& os, const AssertSnapcSeqState& state) {
     break;
   }
   return os;
+}
+
+void sanitize_entity_inst(entity_inst_t* entity_inst) {
+  // make all addrs of type ANY because the type isn't what uniquely
+  // identifies them and clients and on-disk formats can be encoded
+  // with different backwards compatibility settings.
+  entity_inst->addr.set_type(entity_addr_t::TYPE_ANY);
 }
 
 } // namespace rbd

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -869,6 +869,8 @@ inline void decode(AssertSnapcSeqState &state, bufferlist::const_iterator& it) {
 
 std::ostream& operator<<(std::ostream& os, const AssertSnapcSeqState& state);
 
+void sanitize_entity_inst(entity_inst_t* entity_inst);
+
 } // namespace rbd
 } // namespace cls
 


### PR DESCRIPTION
RADOS upgrade tests were failing when OSDs were partially upgraded since the
entity_addr_t::type overload wasn't being recovered when re-read. Now we will
always sanitize the on-disk entity address after reading it to avoid such
issues of on-disk encoding/decoding.

Fixes: https://tracker.ceph.com/issues/42891
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
