### PR TITLE
mgr/ssh,ceph-daemon: improve service ls

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1492,22 +1492,26 @@ def list_daemons(detail=True, legacy_dir=None):
                         # get container id
                         (i['enabled'], i['state']) = check_unit(unit_name)
                         container_id = None
+                        image_name = None
+                        image_id = None
                         version = None
                         out, err, code = call(
                             [
                                 container_path, 'inspect',
-                                '--format', '{{.Id}}',
+                                '--format', '{{.Id}},{{.Config.Image}},{{.Image}}',
                                 'ceph-%s-%s' % (fsid, j)
                             ],
                             verbose_on_failure=False)
                         if not code:
-                            container_id = out.strip()[0:12]
+                            (container_id, image_name, image_id) = out.strip().split(',')
                             out, err, code = call(
                                 [container_path, 'exec', container_id,
                                  'ceph', '-v'])
                             if not code and out.startswith('ceph version '):
                                 version = out.split(' ')[2]
                         i['container_id'] = container_id
+                        i['container_image_name'] = image_name
+                        i['container_image'] = image_id
                         i['version'] = version
                     ls.append(i)
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -439,7 +439,7 @@ std::vector<Option> get_global_options() {
     Option("container_image", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("container image (used by ssh orchestrator)")
     .set_flag(Option::FLAG_STARTUP)
-    .set_default("ceph/daemon-base"),
+    .set_default("ceph/daemon-base:latest-master-devel"),
 
     // lockdep
     Option("lockdep", Option::TYPE_BOOL, Option::LEVEL_DEV)

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -758,6 +758,12 @@ class ServiceDescription(object):
         return "<ServiceDescription>({n_name}:{s_type})".format(n_name=self.nodename,
                                                                   s_type=self.name())
 
+    def entity_name(self):
+        if self.service_type in ['osd','mon','mgr','mds']:
+            return self.name()
+        else:
+            return 'client.' + self.name()
+
     def to_json(self):
         out = {
             'nodename': self.nodename,

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -696,15 +696,21 @@ class ServiceDescription(object):
     has decided the service should run.
     """
 
-    def __init__(self, nodename=None, container_id=None, service=None, service_instance=None,
+    def __init__(self, nodename=None,
+                 container_id=None, container_image=None,
+                 container_image_name=None,
+                 service=None, service_instance=None,
                  service_type=None, version=None, rados_config_location=None,
                  service_url=None, status=None, status_desc=None):
         # Node is at the same granularity as InventoryNode
         self.nodename = nodename
 
         # Not everyone runs in containers, but enough people do to
-        # justify having this field here.
-        self.container_id = container_id
+        # justify having the container_id (runtime id) and container_image
+        # (image name)
+        self.container_id = container_id                  # runtime id
+        self.container_image = container_image            # image hash
+        self.container_image_name = container_image_name  # image friendly name
 
         # Some services can be deployed in groups. For example, mds's can
         # have an active and standby daemons, and nfs-ganesha can run daemons

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -269,8 +269,8 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             return HandleCommandResult(stdout=json.dumps(data))
         else:
             table = PrettyTable(
-                ['NAME', 'HOST', 'CONTAINER', 'VERSION', 'STATUS',
-                 'DESCRIPTION'],
+                ['NAME', 'HOST', 'STATUS',
+                 'VERSION', 'IMAGE NAME', 'IMAGE ID', 'CONTAINER ID'],
                 border=False)
             table.align = 'l'
             table.left_padding_width = 0
@@ -286,10 +286,11 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
                 table.add_row((
                     s.name(),
                     ukn(s.nodename),
-                    ukn(s.container_id),
-                    ukn(s.version),
                     status,
-                    ukn(s.status_desc)))
+                    ukn(s.version),
+                    ukn(s.container_image_name),
+                    ukn(s.container_image)[0:12],
+                    ukn(s.container_id)[0:12]))
 
             return HandleCommandResult(stdout=table.get_string())
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -47,8 +47,37 @@ _write_cli = _cli_command('rw')
 
 class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
     MODULE_OPTIONS = [
-        {'name': 'orchestrator'}
+        {
+            'name': 'orchestrator',
+            'default': None,
+            'desc': 'Orchestrator backend',
+            'enum_allowed': ['ssh', 'rook', 'ansible', 'deepsea'],
+            'runtime': True,
+        },
     ]
+    NATIVE_OPTIONS = []
+
+    def __init__(self, *args, **kwargs):
+        super(OrchestratorCli, self).__init__(*args, **kwargs)
+
+        # ensure config options members are initialized; see config_notify()
+        self.config_notify()
+
+    def config_notify(self):
+        """
+        This method is called whenever one of our config options is changed.
+        """
+        for opt in self.MODULE_OPTIONS:
+            setattr(self,
+                    opt['name'],
+                    self.get_module_option(opt['name']) or opt['default'])
+            self.log.debug(' mgr option %s = %s',
+                           opt['name'], getattr(self, opt['name']))
+        for opt in self.NATIVE_OPTIONS:
+            setattr(self,
+                    opt,
+                    self.get_ceph_option(opt))
+            self.log.debug(' native option %s = %s', opt, getattr(self, opt))
 
     def __init__(self, *args, **kwargs):
         super(OrchestratorCli, self).__init__(*args, **kwargs)
@@ -165,7 +194,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             return self.light_off(light_type, devid, force)
 
     def _select_orchestrator(self):
-        return self.get_module_option("orchestrator")
+        return self.orchestrator
 
     @_write_cli('orchestrator host add',
                 "name=host,type=CephString,req=true",
@@ -609,6 +638,7 @@ Usage:
 
         if module_name is None or module_name == "":
             self.set_module_option("orchestrator", None)
+            self.orchestrator = None
             return HandleCommandResult()
 
         for module in mgr_map['available_modules']:
@@ -636,6 +666,7 @@ Usage:
                                            stderr="'{0}' is not an orchestrator module".format(module_name))
 
             self.set_module_option("orchestrator", module_name)
+            self.orchestrator = module_name
 
             return HandleCommandResult()
 
@@ -644,7 +675,7 @@ Usage:
     @_read_cli('orchestrator status',
                desc='Report configured backend and its status')
     def _status(self):
-        o = self._select_orchestrator()
+        o = self.orchestrator
         if o is None:
             raise orchestrator.NoOrchestrator()
 
@@ -659,9 +690,9 @@ Usage:
                                        ))
 
     def self_test(self):
-        old_orch = self._select_orchestrator()
+        old_orch = self.orchestrator
         self._set_backend('')
-        assert self._select_orchestrator() is None
+        assert self.orchestrator is None
         self._set_backend(old_orch)
 
         e = self.remote('selftest', 'remote_from_orchestrator_cli_self_test', "ZeroDivisionError")

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -541,8 +541,10 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 if service_name and not sd.service_instance.startswith(service_name + '.'):
                     continue
                 sd.nodename = host
-                sd.container_id = d['container_id']
-                sd.version = d['version']
+                sd.container_id = d.get('container_id')
+                sd.container_image_name = d.get('container_image_name')
+                sd.container_image = d.get('container_image')
+                sd.version = d.get('version')
                 sd.status_desc = d['state']
                 sd.status = {
                     'running': 1,


### PR DESCRIPTION
```
NAME           HOST STATUS  VERSION   IMAGE NAME                                     IMAGE ID     CONTAINER ID 
crash.gnit     gnit running <unknown> docker.io/ceph/daemon-base:latest-master-devel 2e79ac96690f a4b0abe4f618 
mds.foo.tcwncg gnit running <unknown> docker.io/ceph/daemon-base:latest-master-devel 2e79ac96690f 2b7e0a53d474 
```
(The VERSION column is broken because podman exec seems broken on fedora 31.)