### PR TITLE
rgw: fix rgw crash when token is not base64 encode

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5046,7 +5046,13 @@ int
 rgw::auth::s3::STSEngine::get_session_token(const DoutPrefixProvider* dpp, const boost::string_view& session_token,
                                             STS::SessionToken& token) const
 {
-  string decodedSessionToken = rgw::from_base64(session_token);
+  string decodedSessionToken;
+  try {
+    decodedSessionToken = rgw::from_base64(session_token);
+  } catch (...) {
+    ldpp_dout(dpp, 0) << "ERROR: Invalid session token, not base64 encoded." << dendl;
+    return -EINVAL;
+  }
 
   auto* cryptohandler = cct->get_crypto_handler(CEPH_CRYPTO_AES);
   if (! cryptohandler) {


### PR DESCRIPTION
Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>
when we use sts auth by set rgw_s3_auth_use_sts = true
```
< GET / HTTP/1.1
< Host: 127.0.0.1:7480
< Accept-Encoding: gzip, deflate
< Accept: */*
< User-Agent: python-requests/2.6.0 CPython/2.7.5 Linux/3.10.0-327.el7.x86_64
< Connection: keep-alive
< X-Amz-Security-Token: Butel-CDN
< date: Sat, 23 Nov 2019 11:55:17 GMT
< Authorization: AWS yly:nyW3LipUHqg+5sfStSkzvdz4i6k=
```

when the user set any string not base64 encode, like Butel-CDN, the rgw will crash , 
