### PR TITLE
rgw/kafka: add ssl+sasl security to kafka

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -68,8 +68,10 @@ To update a topic, use the same command used for topic creation, with the topic 
    &push-endpoint=<endpoint>
    [&Attributes.entry.1.key=amqp-exchange&Attributes.entry.1.value=<exchange>]
    [&Attributes.entry.2.key=amqp-ack-level&Attributes.entry.2.value=none|broker]
-   [&Attributes.entry.3.key=verify-sll&Attributes.entry.3.value=true|false]
+   [&Attributes.entry.3.key=verify-ssl&Attributes.entry.3.value=true|false]
    [&Attributes.entry.4.key=kafka-ack-level&Attributes.entry.4.value=none|broker]
+   [&Attributes.entry.5.key=use-ssl&Attributes.entry.5.value=true|false]
+   [&Attributes.entry.6.key=ca-location&Attributes.entry.6.value=<file path>]
 
 Request parameters:
 
@@ -83,7 +85,8 @@ Request parameters:
 - AMQP0.9.1 endpoint
 
  - URI: ``amqp://[<user>:<password>@]<fqdn>[:<port>][/<vhost>]``
- - user/password defaults to : guest/guest
+ - user/password defaults to: guest/guest
+ - user/password may only be provided over HTTPS. Topic creation request will be rejected if not
  - port defaults to: 5672
  - vhost defaults to: "/"
  - amqp-exchange: the exchanges must exist and be able to route messages based on topics (mandatory parameter for AMQP0.9.1)
@@ -94,7 +97,11 @@ Request parameters:
 
 - Kafka endpoint 
 
- - URI: ``kafka://<fqdn>[:<port]``
+ - URI: ``kafka://[<user>:<password>@]<fqdn>[:<port]``
+ - if ``use-ssl`` is set to "true", secure connection will be used for connecting with the broker ("false" by default)
+ - if ``ca-location`` is provided, and secure connection is used, the specified CA will be used, instead of the default one, to authenticate the broker
+ - user/password may only be provided over HTTPS. Topic creation request will be rejected if not
+ - user/password may only be provided together with ``use-ssl``, connection to the broker would fail if not
  - port defaults to: 9092
  - kafka-ack-level: no end2end acking is required, as messages may persist in the broker before delivered into their final destination. Two ack methods exist:
 
@@ -161,6 +168,7 @@ Response will have the following format:
 - User: name of the user that created the topic
 - Name: name of the topic
 - EndPoinjtAddress: the push-endpoint URL
+- if endpoint URL contain user/password information, request must be made over HTTPS. Topic get request will be rejected if not 
 - EndPointArgs: the push-endpoint args
 - EndpointTopic: the topic name that should be sent to the endpoint (mat be different than the above topic name)
 - TopicArn: topic ARN
@@ -218,6 +226,8 @@ Response will have the following format:
             <RequestId></RequestId>
         </ResponseMetadata>
     </ListTopicsResponse>    
+
+- if endpoint URL contain user/password information, in any of the topic, request must be made over HTTPS. Topic list request will be rejected if not 
 
 Notifications
 ~~~~~~~~~~~~~

--- a/doc/radosgw/pubsub-module.rst
+++ b/doc/radosgw/pubsub-module.rst
@@ -150,7 +150,7 @@ To update a topic, use the same command used for topic creation, with the topic 
 
 ::
 
-   PUT /topics/<topic-name>[?push-endpoint=<endpoint>[&amqp-exchange=<exchange>][&amqp-ack-level=none|broker][&verify-ssl=true|false][&kafka-ack-level=none|broker]]
+   PUT /topics/<topic-name>[?push-endpoint=<endpoint>[&amqp-exchange=<exchange>][&amqp-ack-level=none|broker][&verify-ssl=true|false][&kafka-ack-level=none|broker][&use-ssl=true|false][&ca-location=<file path>]]
 
 Request parameters:
 
@@ -167,7 +167,8 @@ The endpoint URI may include parameters depending with the type of endpoint:
 - AMQP0.9.1 endpoint
 
  - URI: ``amqp://[<user>:<password>@]<fqdn>[:<port>][/<vhost>]``
- - user/password defaults to : guest/guest
+ - user/password defaults to: guest/guest
+ - user/password may only be provided over HTTPS. Topic creation request will be rejected if not
  - port defaults to: 5672
  - vhost defaults to: "/"
  - amqp-exchange: the exchanges must exist and be able to route messages based on topics (mandatory parameter for AMQP0.9.1)
@@ -178,7 +179,11 @@ The endpoint URI may include parameters depending with the type of endpoint:
 
 - Kafka endpoint 
 
- - URI: ``kafka://<fqdn>[:<port]``
+ - URI: ``kafka://[<user>:<password>@]<fqdn>[:<port]``
+ - if ``use-ssl`` is set to "true", secure connection will be used for connecting with the broker ("false" by default)
+ - if ``ca-location`` is provided, and secure connection is used, the specified CA will be used, instead of the default one, to authenticate the broker
+ - user/password may only be provided over HTTPS. Topic creation request will be rejected if not
+ - user/password may only be provided together with ``use-ssl``, connection to the broker would fail if not
  - port defaults to: 9092
  - kafka-ack-level: no end2end acking is required, as messages may persist in the broker before delivered into their final destination. Two ack methods exist:
 
@@ -212,7 +217,8 @@ Response will have the following format (JSON):
                "bucket_name":"",
                "oid_prefix":"",
                "push_endpoint":"",
-               "push_endpoint_args":""
+               "push_endpoint_args":"",
+               "push_endpoint_topic":""
            },
            "arn":""
        },
@@ -224,7 +230,9 @@ Response will have the following format (JSON):
 - dest.bucket_name: not used
 - dest.oid_prefix: not used
 - dest.push_endpoint: in case of S3-compliant notifications, this value will be used as the push-endpoint URL
+- if push-endpoint URL contain user/password information, request must be made over HTTPS. Topic get request will be rejected if not 
 - dest.push_endpoint_args: in case of S3-compliant notifications, this value will be used as the push-endpoint args
+- dest.push_endpoint_topic: in case of S3-compliant notifications, this value will hold the topic name as sent to the endpoint (may be different than the internal topic name)
 - topic.arn: topic ARN
 - subs: list of subscriptions associated with this topic
 
@@ -246,6 +254,8 @@ List all topics that user defined.
 
    GET /topics
  
+- if push-endpoint URL contain user/password information, in any of the topic, request must be made over HTTPS. Topic list request will be rejected if not 
+
 S3-Compliant Notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -316,7 +326,8 @@ Response will have the following format (JSON):
                "bucket_name":"",
                "oid_prefix":"",
                "push_endpoint":"",
-               "push_endpoint_args":""
+               "push_endpoint_args":"",
+               "push_endpoint_topic":""
             }
             "arn":""
          },
@@ -334,7 +345,7 @@ Creates a new subscription.
 
 ::
 
-   PUT /subscriptions/<sub-name>?topic=<topic-name>[?push-endpoint=<endpoint>[&amqp-exchange=<exchange>][&amqp-ack-level=none|broker][&verify-ssl=true|false][&kafka-ack-level=none|broker]]
+   PUT /subscriptions/<sub-name>?topic=<topic-name>[?push-endpoint=<endpoint>[&amqp-exchange=<exchange>][&amqp-ack-level=none|broker][&verify-ssl=true|false][&kafka-ack-level=none|broker][&ca-location=<file path>]]
 
 Request parameters:
 
@@ -363,7 +374,10 @@ The endpoint URI may include parameters depending with the type of endpoint:
 
 - Kafka endpoint 
 
- - URI: ``kafka://<fqdn>[:<port]``
+ - URI: ``kafka://[<user>:<password>@]<fqdn>[:<port]``
+ - if ``ca-location`` is provided, secure connection will be used for connection with the broker
+ - user/password may only be provided over HTTPS. Topic creation request will be rejected if not
+ - user/password may only be provided together with ``ca-location``. Topic creation request will be rejected if not
  - port defaults to: 9092
  - kafka-ack-level: no end2end acking is required, as messages may persist in the broker before delivered into their final destination. Two ack methods exist:
 
@@ -392,7 +406,8 @@ Response will have the following format (JSON):
            "bucket_name":"",
            "oid_prefix":"",
            "push_endpoint":"",
-           "push_endpoint_args":""
+           "push_endpoint_args":"",
+           "push_endpoint_topic":""
        }
        "s3_id":""
    }             
@@ -400,6 +415,13 @@ Response will have the following format (JSON):
 - user: name of the user that created the subscription
 - name: name of the subscription
 - topic: name of the topic the subscription is associated with
+- dest.bucket_name: name of the bucket storing the events
+- dest.oid_prefix: oid prefix for the events stored in the bucket
+- dest.push_endpoint: in case of S3-compliant notifications, this value will be used as the push-endpoint URL
+- if push-endpoint URL contain user/password information, request must be made over HTTPS. Topic get request will be rejected if not 
+- dest.push_endpoint_args: in case of S3-compliant notifications, this value will be used as the push-endpoint args
+- dest.push_endpoint_topic: in case of S3-compliant notifications, this value will hold the topic name as sent to the endpoint (may be different than the internal topic name)
+- s3_id: in case of S3-compliant notifications, this will hold the notification name that created the subscription
 
 Delete Subscription
 ```````````````````

--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -3,40 +3,52 @@
 set -e
 
 rgw_frontend=${RGW_FRONTEND:-"beast"}
-script_root=`dirname $0`
-script_root=`(cd $script_root;pwd)`
+script_root=$(dirname "$0")
+script_root=$(cd "$script_root" && pwd)
 [ -z "$BUILD_DIR" ] && BUILD_DIR=build
 if [ -e CMakeCache.txt ]; then
     script_root=$PWD
-elif [ -e $script_root/../${BUILD_DIR}/CMakeCache.txt ]; then
-    cd $script_root/../${BUILD_DIR}
+elif [ -e "$script_root"/../${BUILD_DIR}/CMakeCache.txt ]; then
+    cd "$script_root"/../${BUILD_DIR}
     script_root=$PWD
 fi
-ceph_bin=$script_root/bin
-vstart_path=`dirname $0`
+#ceph_bin=$script_root/bin
+vstart_path=$(dirname "$0")
 
-[ "$#" -lt 2 ] && echo "usage: $0 <name> <port> [params...]" && exit 1
+[ "$#" -lt 3 ] && echo "usage: $0 <name> <port> <ssl-port> [params...]" && exit 1
 
 name=$1
 port=$2
+ssl_port=$3
+cert_param=""
+port_param="port=$port"
 
-if [ ! -z "$RGW_FRONTEND_THREADS" ]; then
+if [ "$ssl_port" -gt 0 ]; then
+    cert_param="ssl_certificate=./cert.pem"
+    if [ "$rgw_frontend" = "civetweb" ]; then
+        port_param="port=${port} port=${ssl_port}s"
+    else
+        port_param="port=${port} ssl_port=${ssl_port}"
+    fi
+fi
+
+if [ -n "$RGW_FRONTEND_THREADS" ]; then
     set_frontend_threads="num_threads=$RGW_FRONTEND_THREADS"
 fi
 
-shift 2
+shift 3
 
 run_root=$script_root/run/$name
 pidfile=$run_root/out/radosgw.${port}.pid
 asokfile=$run_root/out/radosgw.${port}.asok
 logfile=$run_root/out/radosgw.${port}.log
 
-$vstart_path/mstop.sh $name radosgw $port
+"$vstart_path"/mstop.sh "$name" radosgw "$port"
 
-$vstart_path/mrun $name ceph -c $run_root/ceph.conf \
-	-k $run_root/keyring auth get-or-create client.rgw.$port mon \
-	'allow rw' osd 'allow rwx' mgr 'allow rw' >> $run_root/keyring
+"$vstart_path"/mrun "$name" ceph -c "$run_root"/ceph.conf \
+	-k "$run_root"/keyring auth get-or-create client.rgw."$port" mon \
+	'allow rw' osd 'allow rwx' mgr 'allow rw' >> "$run_root"/keyring
 
-$vstart_path/mrun $name radosgw --rgw-frontends="$rgw_frontend port=$port $set_frontend_threads" \
-	-n client.rgw.$port --pid-file=$pidfile \
-	--admin-socket=$asokfile "$@" --log-file=$logfile
+"$vstart_path"/mrun "$name" radosgw --rgw-frontends="$rgw_frontend $port_param $set_frontend_threads $cert_param" \
+	-n client.rgw."$port" --pid-file="$pidfile" \
+	--admin-socket="$asokfile" "$@" --log-file="$logfile"

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -142,7 +142,8 @@ set(librgw_common_srcs
   rgw_perf_counters.cc
   rgw_rest_iam.cc
   rgw_object_lock.cc
-  rgw_kms.cc)
+  rgw_kms.cc
+  rgw_url.cc)
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)

--- a/src/rgw/rgw_kafka.h
+++ b/src/rgw/rgw_kafka.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <functional>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/optional.hpp>
 
 class CephContext;
 
@@ -30,7 +31,7 @@ bool init(CephContext* cct);
 void shutdown();
 
 // connect to a kafka endpoint
-connection_ptr_t connect(const std::string& url);
+connection_ptr_t connect(const std::string& url, bool use_ssl, bool verify_ssl, boost::optional<const std::string&> ca_location);
 
 // publish a message over a connection that was already created
 int publish(connection_ptr_t& conn,
@@ -72,6 +73,9 @@ size_t get_max_queue();
 
 // disconnect from a kafka broker
 bool disconnect(connection_ptr_t& conn);
+
+// display connection as string
+std::string to_string(const connection_ptr_t& conn);
 
 }
 

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -341,19 +341,21 @@ struct rgw_pubsub_sub_dest {
   std::string push_endpoint;
   std::string push_endpoint_args;
   std::string arn_topic;
+  bool stored_secret = false;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     encode(bucket_name, bl);
     encode(oid_prefix, bl);
     encode(push_endpoint, bl);
     encode(push_endpoint_args, bl);
     encode(arn_topic, bl);
+    encode(stored_secret, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(3, bl);
+    DECODE_START(4, bl);
     decode(bucket_name, bl);
     decode(oid_prefix, bl);
     decode(push_endpoint, bl);
@@ -362,6 +364,9 @@ struct rgw_pubsub_sub_dest {
     }
     if (struct_v >= 3) {
         decode(arn_topic, bl);
+    }
+    if (struct_v >= 4) {
+        decode(stored_secret, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -19,6 +19,7 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
+
 // command (AWS compliant): 
 // POST
 // Action=CreateTopic&Name=<topic-name>[&push-endpoint=<endpoint>[&<arg1>=<value1>]]
@@ -27,21 +28,25 @@ public:
   int get_params() override {
     topic_name = s->info.args.get("Name");
     if (topic_name.empty()) {
-        ldout(s->cct, 1) << "CreateTopic Action 'Name' argument is missing" << dendl;
-        return -EINVAL;
+      ldout(s->cct, 1) << "CreateTopic Action 'Name' argument is missing" << dendl;
+      return -EINVAL;
     }
 
     dest.push_endpoint = s->info.args.get("push-endpoint");
+
+    if (!validate_and_update_endpoint_secret(dest, s->cct, *(s->info.env))) {
+      return -EINVAL;
+    }
     for (const auto param : s->info.args.get_params()) {
-        if (param.first == "Action" || param.first == "Name" || param.first == "PayloadHash") {
-            continue;
-        }
-        dest.push_endpoint_args.append(param.first+"="+param.second+"&");
+      if (param.first == "Action" || param.first == "Name" || param.first == "PayloadHash") {
+        continue;
+      }
+      dest.push_endpoint_args.append(param.first+"="+param.second+"&");
     }
 
     if (!dest.push_endpoint_args.empty()) {
-        // remove last separator
-        dest.push_endpoint_args.pop_back();
+      // remove last separator
+      dest.push_endpoint_args.pop_back();
     }
     
     // dest object only stores endpoint info
@@ -160,8 +165,8 @@ public:
     const auto topic_arn = rgw::ARN::parse((s->info.args.get("TopicArn")));
 
     if (!topic_arn || topic_arn->resource.empty()) {
-        ldout(s->cct, 1) << "DeleteTopic Action 'TopicArn' argument is missing or invalid" << dendl;
-        return -EINVAL;
+      ldout(s->cct, 1) << "DeleteTopic Action 'TopicArn' argument is missing or invalid" << dendl;
+      return -EINVAL;
     }
 
     topic_name = topic_arn->resource;
@@ -199,21 +204,21 @@ namespace {
 // ctor and set are done according to the "type" argument
 // if type is not "key" or "value" its a no-op
 class Attribute {
-    std::string key;
-    std::string value;
+  std::string key;
+  std::string value;
 public:
-    Attribute(const std::string& type, const std::string& key_or_value) {
-        set(type, key_or_value);
+  Attribute(const std::string& type, const std::string& key_or_value) {
+    set(type, key_or_value);
+  }
+  void set(const std::string& type, const std::string& key_or_value) {
+    if (type == "key") {
+      key = key_or_value;
+    } else if (type == "value") {
+      value = key_or_value;
     }
-    void set(const std::string& type, const std::string& key_or_value) {
-        if (type == "key") {
-            key = key_or_value;
-        } else if (type == "value") {
-            value = key_or_value;
-        }
-    }
-    const std::string& get_key() const { return key; }
-    const std::string& get_value() const { return value; }
+  }
+  const std::string& get_key() const { return key; }
+  const std::string& get_value() const { return value; }
 };
 
 using AttributeMap = std::map<unsigned, Attribute>;
@@ -431,11 +436,11 @@ void RGWPSCreateNotif_ObjStore_S3::execute() {
   if (store->getRados()->get_sync_module()) {
     const auto psmodule = dynamic_cast<RGWPSSyncModuleInstance*>(store->getRados()->get_sync_module().get());
     if (psmodule) {
-        const auto& conf = psmodule->get_effective_conf();
-        data_bucket_prefix = conf["data_bucket_prefix"];
-        data_oid_prefix = conf["data_oid_prefix"];
-        // TODO: allow "push-only" on PS zone as well
-        push_only = false;
+      const auto& conf = psmodule->get_effective_conf();
+      data_bucket_prefix = conf["data_bucket_prefix"];
+      data_oid_prefix = conf["data_oid_prefix"];
+      // TODO: allow "push-only" on PS zone as well
+      push_only = false;
     }
   }
 

--- a/src/rgw/rgw_rest_pubsub_common.h
+++ b/src/rgw/rgw_rest_pubsub_common.h
@@ -6,6 +6,11 @@
 #include "rgw_op.h"
 #include "rgw_pubsub.h"
 
+// make sure that endpoint is a valid URL
+// make sure that if user/password are passed inside URL, it is over secure connection
+// update rgw_pubsub_sub_dest to indicate that a password is stored in the URL
+bool validate_and_update_endpoint_secret(rgw_pubsub_sub_dest& dest, CephContext *cct, const RGWEnv& env);
+
 // create a topic
 class RGWPSCreateTopicOp : public RGWDefaultResponseOp {
 protected:

--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -26,6 +26,10 @@ public:
     topic_name = s->object.name;
 
     dest.push_endpoint = s->info.args.get("push-endpoint");
+    
+    if (!validate_and_update_endpoint_secret(dest, s->cct, *(s->info.env))) {
+      return -EINVAL;
+    }
     dest.push_endpoint_args = s->info.args.get_str();
     // dest object only stores endpoint info
     // bucket to store events/records will be set only when subscription is created
@@ -169,9 +173,12 @@ public:
     const auto& conf = psmodule->get_effective_conf();
 
     dest.push_endpoint = s->info.args.get("push-endpoint");
+    if (!validate_and_update_endpoint_secret(dest, s->cct, *(s->info.env))) {
+      return -EINVAL;
+    }
+    dest.push_endpoint_args = s->info.args.get_str();
     dest.bucket_name = string(conf["data_bucket_prefix"]) + s->owner.get_id().to_str() + "-" + topic_name;
     dest.oid_prefix = string(conf["data_oid_prefix"]) + sub_name + "/";
-    dest.push_endpoint_args = s->info.args.get_str();
     dest.arn_topic = topic_name;
 
     return 0;

--- a/src/rgw/rgw_url.cc
+++ b/src/rgw/rgw_url.cc
@@ -1,0 +1,48 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <string>
+#include <regex>
+
+namespace rgw {
+
+namespace {
+  const auto USER_GROUP_IDX = 3;
+  const auto PASSWORD_GROUP_IDX = 4;
+  const auto HOST_GROUP_IDX = 5;
+
+  const std::string schema_re = "([[:alpha:]]+:\\/\\/)";
+  const std::string user_pass_re = "(([^:\\s]+):([^@\\s]+)@)?";
+  const std::string host_port_re = "([[:alnum:].:-]+)";
+}
+
+bool parse_url_authority(const std::string& url, std::string& host, std::string& user, std::string& password) {
+  const std::string re = schema_re + user_pass_re + host_port_re;
+  const std::regex url_regex(re, std::regex::icase);
+  std::smatch url_match_result;
+
+  if (std::regex_match(url, url_match_result, url_regex)) {
+    host = url_match_result[HOST_GROUP_IDX];
+    user = url_match_result[USER_GROUP_IDX];  
+    password = url_match_result[PASSWORD_GROUP_IDX];
+	return true; 
+  }
+
+  return false;
+}
+
+bool parse_url_userinfo(const std::string& url, std::string& user, std::string& password) {
+  const std::string re = schema_re + user_pass_re + host_port_re;
+  const std::regex url_regex(re);
+  std::smatch url_match_result;
+
+  if (std::regex_match(url, url_match_result, url_regex)) {
+    user = url_match_result[USER_GROUP_IDX];  
+    password = url_match_result[PASSWORD_GROUP_IDX];
+	return true; 
+  }
+
+  return false;
+}
+}
+

--- a/src/rgw/rgw_url.h
+++ b/src/rgw/rgw_url.h
@@ -1,0 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <string>
+namespace rgw {
+// parse a URL of the form: http|https|amqp|amqps|kafka://[user:password@]<host>[:port]
+bool parse_url_authority(const std::string& url, std::string& host, std::string& user, std::string& password);
+bool parse_url_userinfo(const std::string& url, std::string& user, std::string& password);
+}
+

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -187,6 +187,12 @@ add_ceph_unittest(unittest_rgw_kms)
 
 target_link_libraries(unittest_rgw_kms ${rgw_libs})
 
+# unittest_rgw_url
+add_executable(unittest_rgw_url test_rgw_url.cc)
+add_ceph_unittest(unittest_rgw_url)
+
+target_link_libraries(unittest_rgw_url ${rgw_libs})
+
 add_executable(ceph_test_rgw_gc_log test_rgw_gc_log.cc $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(ceph_test_rgw_gc_log ${rgw_libs} radostest-cxx)
 install(TARGETS ceph_test_rgw_gc_log DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/rgw/rgw_multi/conn.py
+++ b/src/test/rgw/rgw_multi/conn.py
@@ -14,3 +14,17 @@ def get_gateway_connection(gateway, credentials):
                 calling_format = boto.s3.connection.OrdinaryCallingFormat())
     return gateway.connection
 
+def get_gateway_secure_connection(gateway, credentials):
+    """ secure connect to the given gateway """
+    if gateway.ssl_port == 0:
+        return None
+    if gateway.secure_connection is None:
+        gateway.secure_connection = boto.connect_s3(
+            aws_access_key_id = credentials.access_key,
+            aws_secret_access_key = credentials.secret,
+            host = gateway.host,
+            port = gateway.ssl_port,
+            is_secure = True,
+            validate_certs=False,
+            calling_format = boto.s3.connection.OrdinaryCallingFormat())
+    return gateway.secure_connection

--- a/src/test/rgw/rgw_multi/multisite.py
+++ b/src/test/rgw/rgw_multi/multisite.py
@@ -3,7 +3,7 @@ from six import StringIO
 
 import json
 
-from .conn import get_gateway_connection
+from .conn import get_gateway_connection, get_gateway_secure_connection
 
 class Cluster:
     """ interface to run commands against a distinct ceph cluster """
@@ -18,13 +18,14 @@ class Gateway:
     """ interface to control a single radosgw instance """
     __metaclass__ = ABCMeta
 
-    def __init__(self, host = None, port = None, cluster = None, zone = None, proto = 'http', connection = None):
+    def __init__(self, host = None, port = None, cluster = None, zone = None, ssl_port = 0):
         self.host = host
         self.port = port
         self.cluster = cluster
         self.zone = zone
-        self.proto = proto
-        self.connection = connection
+        self.connection = None
+        self.secure_connection = None
+        self.ssl_port = ssl_port
 
     @abstractmethod
     def start(self, args = []):
@@ -37,7 +38,7 @@ class Gateway:
         pass
 
     def endpoint(self):
-        return '%s://%s:%d' % (self.proto, self.host, self.port)
+        return 'http://%s:%d' % (self.host, self.port)
 
 class SystemObject:
     """ interface for system objects, represented in json format and
@@ -181,6 +182,7 @@ class ZoneConn(object):
 
         if self.zone.gateways is not None:
             self.conn = get_gateway_connection(self.zone.gateways[0], self.credentials)
+            self.secure_conn = get_gateway_secure_connection(self.zone.gateways[0], self.credentials)
 
     def get_connection(self):
         return self.conn

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -66,18 +66,6 @@ log = logging.getLogger('rgw_multi.tests')
 num_buckets = 0
 run_prefix=''.join(random.choice(string.ascii_lowercase) for _ in range(6))
 
-def get_gateway_connection(gateway, credentials):
-    """ connect to the given gateway """
-    if gateway.connection is None:
-        gateway.connection = boto.connect_s3(
-                aws_access_key_id = credentials.access_key,
-                aws_secret_access_key = credentials.secret,
-                host = gateway.host,
-                port = gateway.port,
-                is_secure = False,
-                calling_format = boto.s3.connection.OrdinaryCallingFormat())
-    return gateway.connection
-
 def get_zone_connection(zone, credentials):
     """ connect to the zone's first gateway """
     if isinstance(credentials, list):

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -97,7 +97,7 @@ class Gateway(multisite.Gateway):
         # e.g. RGW_FRONTEND=civetweb
         # to run test under valgrind memcheck, set RGW_VALGRIND to 'yes'
         # e.g. RGW_VALGRIND=yes
-        cmd = [mstart_path + 'mrgw.sh', self.cluster.cluster_id, str(self.port)]
+        cmd = [mstart_path + 'mrgw.sh', self.cluster.cluster_id, str(self.port), str(self.ssl_port)]
         if self.id:
             cmd += ['-i', self.id]
         cmd += ['--debug-rgw=20', '--debug-ms=1']
@@ -183,6 +183,7 @@ def init(parse_args):
                                          'checkpoint_retries': 60,
                                          'checkpoint_delay': 5,
                                          'reconfigure_delay': 5,
+                                         'use_ssl': 'false',
                                          })
     try:
         path = os.environ['RGW_MULTI_TEST_CONF']
@@ -213,6 +214,7 @@ def init(parse_args):
     parser.add_argument('--checkpoint-delay', type=int, default=cfg.getint(section, 'checkpoint_delay'))
     parser.add_argument('--reconfigure-delay', type=int, default=cfg.getint(section, 'reconfigure_delay'))
     parser.add_argument('--num-ps-zones', type=int, default=cfg.getint(section, 'num_ps_zones'))
+    parser.add_argument('--use-ssl', type=bool, default=cfg.getboolean(section, 'use_ssl'))
 
 
     es_cfg = []
@@ -269,9 +271,29 @@ def init(parse_args):
     num_az_zones = cfg.getint(section, 'num_az_zones')
 
     num_ps_zones = args.num_ps_zones if num_ps_zones_from_conf == 0 else num_ps_zones_from_conf 
-    print('num_ps_zones = ' + str(num_ps_zones))
 
     num_zones = args.num_zones + num_es_zones + num_cloud_zones + num_ps_zones + num_az_zones
+
+    use_ssl = cfg.getboolean(section, 'use_ssl')
+
+    if use_ssl and bootstrap:
+        cmd = ['openssl', 'req', 
+                '-x509', 
+                '-newkey', 'rsa:4096', 
+                '-sha256', 
+                '-nodes', 
+                '-keyout', 'key.pem', 
+                '-out', 'cert.pem', 
+                '-subj', '/CN=localhost', 
+                '-days', '3650']
+        bash(cmd)
+        # append key to cert
+        fkey = open('./key.pem', 'r')
+        if fkey.mode == 'r':
+            fcert = open('./cert.pem', 'a')
+            fcert.write(fkey.read())
+            fcert.close()
+        fkey.close()
 
     for zg in range(0, args.num_zonegroups):
         zonegroup = multisite.ZoneGroup(zonegroup_name(zg), period)
@@ -362,11 +384,13 @@ def init(parse_args):
             if bootstrap:
                 period.update(zone, commit=True)
 
+            ssl_port_offset = 1000
             # start the gateways
             for g in range(0, args.gateways_per_zone):
                 port = gateway_port(zg, g + z * args.gateways_per_zone)
                 client_id = gateway_name(zg, z, g)
-                gateway = Gateway(client_id, 'localhost', port, cluster, zone)
+                gateway = Gateway(client_id, 'localhost', port, cluster, zone, 
+                        ssl_port = port+ssl_port_offset if use_ssl else 0)
                 if bootstrap:
                     gateway.start()
                 zone.gateways.append(gateway)

--- a/src/test/rgw/test_rgw_url.cc
+++ b/src/test/rgw/test_rgw_url.cc
@@ -1,0 +1,90 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "rgw/rgw_url.h"
+#include <string>
+#include <gtest/gtest.h>
+
+using namespace rgw;
+
+TEST(TestURL, SimpleAuthority)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "http://example.com";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
+    ASSERT_TRUE(user.empty());
+    ASSERT_TRUE(password.empty());
+    EXPECT_STREQ(host.c_str(), "example.com"); 
+}
+
+TEST(TestURL, IPAuthority)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "http://1.2.3.4";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
+    ASSERT_TRUE(user.empty());
+    ASSERT_TRUE(password.empty());
+    EXPECT_STREQ(host.c_str(), "1.2.3.4"); 
+}
+
+TEST(TestURL, IPv6Authority)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "http://FE80:CD00:0000:0CDE:1257:0000:211E:729C";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
+    ASSERT_TRUE(user.empty());
+    ASSERT_TRUE(password.empty());
+    EXPECT_STREQ(host.c_str(), "FE80:CD00:0000:0CDE:1257:0000:211E:729C"); 
+}
+
+TEST(TestURL, AuthorityWithUserinfo)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "http://user:password@example.com";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
+    EXPECT_STREQ(host.c_str(), "example.com"); 
+    EXPECT_STREQ(user.c_str(), "user"); 
+    EXPECT_STREQ(password.c_str(), "password"); 
+}
+
+TEST(TestURL, AuthorityWithPort)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "http://user:password@example.com:1234";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
+    EXPECT_STREQ(host.c_str(), "example.com:1234"); 
+    EXPECT_STREQ(user.c_str(), "user"); 
+    EXPECT_STREQ(password.c_str(), "password"); 
+}
+
+TEST(TestURL, DifferentSchema)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "kafka://example.com";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
+    ASSERT_TRUE(user.empty());
+    ASSERT_TRUE(password.empty());
+    EXPECT_STREQ(host.c_str(), "example.com"); 
+}
+
+TEST(TestURL, InvalidHost)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "http://exa_mple.com";
+    ASSERT_FALSE(parse_url_authority(url, host, user, password));
+}
+


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

- [x] add `use-ssl` flag to indicate secure kafka connection
- [x] make `ca-location` optional in case of secure kafka connection
- [x] secure test setup for kafka

This allows configuring secure communication between RGW and the kafka broker.
Currently 3 options are possible:
- no security, endpoint configuration is similar to the base PR
- SSL: secure channel with server authentication. To enable that the CA certificate of the server should be located on the RGW host, and configured as a parameter. For example: 
``kafka://localhost:9093?use-ssl=true``
- SSL+SASL: secure channel with server authentication. while client is authenticated with plaintext SASL (user+password) over the secure channel. For example: 
``kafka://alice:alice-secret@localhost:9094?use-ssl=true``

In both secure cases, the CA location could be set explicitly using the "ca-location" parameter.
E.g. ``ca-location=/etc/kafka/ca.crt``

This PR also prevent from sending user/password not over secure connection, both when setting an endpoint, and when fetching endpoint data (for kafka, amqp etc.)
Therefore, for tests to work, the multi-site cluster should be created with the ``use_ssl`` set to "true. This adds an HTTPS frontend to each RGW, allowing for topics to be created with endpoints that include user/password.

For more details on how to test and validate the change (including broker side configuration) see the comment in: https://github.com/ceph/ceph/blob/b1ad774c7f43e750b23f23c1fdf04a8493d02a07/src/test/rgw/rgw_multi/tests_ps.py#L417