### PR TITLE
ceph-daemon: add additional debug logging

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1231,7 +1231,9 @@ def command_run():
     # type: () -> int
     (daemon_type, daemon_id) = args.name.split('.', 1)
     c = get_container(args.fsid, daemon_type, daemon_id)
-    return subprocess.call(c.run_cmd())
+    command = c.run_cmd()
+    logger.debug("Running command: %s" % ' '.join(command))
+    return subprocess.call(command)
 
 ##################################
 
@@ -1270,7 +1272,9 @@ def command_shell():
         args=[],
         container_args=container_args,
         volume_mounts=mounts)
-    return subprocess.call(c.shell_cmd(command))
+    command = c.shell_cmd(command)
+    logger.debug("Running command: %s" % ' '.join(command))
+    return subprocess.call(command)
 
 ##################################
 
@@ -1292,7 +1296,9 @@ def command_enter():
         ]
     c = get_container(args.fsid, daemon_type, daemon_id,
                       container_args=container_args)
-    return subprocess.call(c.exec_cmd(command))
+    command = c.exec_cmd(command)
+    logger.debug("Running command: %s" % ' '.join(command))
+    return subprocess.call(command)
 
 ##################################
 
@@ -1359,7 +1365,7 @@ def command_logs():
     # type: () -> None
     if not args.fsid:
         raise RuntimeError('must pass --fsid to specify cluster')
-    cmd = [container_path, 'logs']
+    cmd = [str(container_path), 'logs'] # type: List[str]
     if args.follow:
         cmd.append('-f')
     if args.tail:
@@ -1368,6 +1374,7 @@ def command_logs():
 
     # call this directly, without our wrapper, so that we get an unmolested
     # stdout with logger prefixing.
+    logger.debug("Running command: %s" % ' '.join(cmd))
     subprocess.call(cmd) # type: ignore
 
 ##################################


### PR DESCRIPTION
Adds additional detail before invoking subprocess for the
`run`, `shell`, `enter`, and `logs` commands

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
