### PR TITLE
ceph-daemon: Fix handling for symlinks on python2

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -280,10 +280,31 @@ def make_log_dir(fsid, uid=None, gid=None):
     makedirs(log_dir, uid, gid, LOG_DIR_MODE)
     return log_dir
 
-def move_file(src, dst):
+def copy_file(src, dst, uid=None, gid=None):
+    # type: (str, str, int, int) -> str
+    """
+    Copy a file from src to dst
+    """
+    if not uid or not gid:
+        (uid, gid) = extract_uid_gid()
+
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+
+    logger.debug('Copy \'%s\' -> \'%s\'' % (src, dst))
+    shutil.copyfile(src, dst)
+    os.chown(dst, uid, gid)
+
+    return dst
+
+def move_file(src, dst, uid=None, gid=None):
+    # type: (str, str, int, int) -> str
     """
     Move a file from src to dst
     """
+    if not uid or not gid:
+        (uid, gid) = extract_uid_gid()
+
     if os.path.isdir(dst):
         dst = os.path.join(dst, os.path.basename(src))
 
@@ -296,6 +317,7 @@ def move_file(src, dst):
     else:
         logger.debug('Move \'%s\' -> \'%s\'' % (src, dst))
         shutil.move(src, dst)
+    os.chown(dst, uid, gid)
 
     return dst
 
@@ -1516,7 +1538,7 @@ def command_adopt():
         data_dir_src = os.path.abspath(args.legacy_dir + data_dir_src)
         data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id)
         for data_file in iglob(os.path.join(data_dir_src, '*')):
-            move_file(data_file, data_dir_dst)
+            move_file(data_file, data_dir_dst, uid=uid, gid=gid)
         logger.debug('Remove dir \'%s\'' % (data_dir_src))
         if os.path.ismount(data_dir_src):
             call_throws(['umount', data_dir_src])
@@ -1526,8 +1548,7 @@ def command_adopt():
         config_src = '/etc/ceph/%s.conf' % (args.cluster)
         config_src = os.path.abspath(args.legacy_dir + config_src)
         config_dst = os.path.join(data_dir_dst, 'config')
-        logger.debug('Copy \'%s\' -> \'%s\'' % (config_src, config_dst))
-        shutil.copy(config_src, config_dst)
+        copy_file(config_src, config_dst, uid=uid, gid=gid)
 
         # logs
         logger.info('Moving logs...')
@@ -1536,7 +1557,7 @@ def command_adopt():
         log_dir_src = os.path.abspath(args.legacy_dir + log_dir_src)
         log_dir_dst = make_log_dir(fsid, uid=uid, gid=gid)
         for log_file in iglob(log_dir_src):
-            move_file(log_file, log_dir_dst)
+            move_file(log_file, log_dir_dst, uid=uid, gid=gid)
 
         logger.info('Creating new units...')
         c = get_container(fsid, daemon_type, daemon_id)

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -280,6 +280,25 @@ def make_log_dir(fsid, uid=None, gid=None):
     makedirs(log_dir, uid, gid, LOG_DIR_MODE)
     return log_dir
 
+def move_file(src, dst):
+    """
+    Move a file from src to dst
+    """
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+
+    if os.path.islink(src):
+        # shutil.move() in python2 does not handle symlinks correctly
+        src_rl = os.readlink(src)
+        logger.debug('symlink \'%s\' -> \'%s\'' % (dst, src_rl))
+        os.symlink(src_rl, dst)
+        os.unlink(src)
+    else:
+        logger.debug('Move \'%s\' -> \'%s\'' % (src, dst))
+        shutil.move(src, dst)
+
+    return dst
+
 def find_program(filename):
     # type: (str) -> str
     name = find_executable(filename)
@@ -1497,8 +1516,7 @@ def command_adopt():
         data_dir_src = os.path.abspath(args.legacy_dir + data_dir_src)
         data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id)
         for data_file in glob(os.path.join(data_dir_src, '*')):
-            logger.debug('Move \'%s\' -> \'%s\'' % (data_file, data_dir_dst))
-            shutil.move(data_file, data_dir_dst)
+            move_file(data_file, data_dir_dst)
         logger.debug('Remove dir \'%s\'' % (data_dir_src))
         if os.path.ismount(data_dir_src):
             call_throws(['umount', data_dir_src])
@@ -1518,8 +1536,7 @@ def command_adopt():
         log_dir_src = os.path.abspath(args.legacy_dir + log_dir_src)
         log_dir_dst = make_log_dir(fsid, uid=uid, gid=gid)
         for log_file in glob(log_dir_src):
-            logger.debug('Move \'%s\' -> \'%s\'' % (log_file, log_dir_dst))
-            shutil.move(log_file, log_dir_dst)
+            move_file(log_file, log_dir_dst)
 
         logger.info('Creating new units...')
         c = get_container(fsid, daemon_type, daemon_id)

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -61,7 +61,7 @@ import uuid
 
 from distutils.spawn import find_executable
 from functools import wraps
-from glob import glob
+from glob import iglob
 
 
 container_path = None
@@ -1515,7 +1515,7 @@ def command_adopt():
                         (daemon_type, args.cluster, daemon_id))
         data_dir_src = os.path.abspath(args.legacy_dir + data_dir_src)
         data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id)
-        for data_file in glob(os.path.join(data_dir_src, '*')):
+        for data_file in iglob(os.path.join(data_dir_src, '*')):
             move_file(data_file, data_dir_dst)
         logger.debug('Remove dir \'%s\'' % (data_dir_src))
         if os.path.ismount(data_dir_src):
@@ -1535,7 +1535,7 @@ def command_adopt():
                         (args.cluster, daemon_type, daemon_id))
         log_dir_src = os.path.abspath(args.legacy_dir + log_dir_src)
         log_dir_dst = make_log_dir(fsid, uid=uid, gid=gid)
-        for log_file in glob(log_dir_src):
+        for log_file in iglob(log_dir_src):
             move_file(log_file, log_dir_dst)
 
         logger.info('Creating new units...')


### PR DESCRIPTION
`shutil.move` correctly handles symlinks under python3, but fails when run with python2.

Signed-off-by: Michael Fritch mfritch@suse.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
