### PR TITLE
qa: update s3-test download code for s3-test tasks

### DIFF
--- a/qa/machine_types/vps.yaml
+++ b/qa/machine_types/vps.yaml
@@ -7,6 +7,7 @@ overrides:
         mon lease: 15
         mon lease ack timeout: 25
   s3tests:
+    force-branch: ceph-master
     idle_timeout: 1200
   ceph-fuse:
     client.0:

--- a/qa/rgw_pool_type/ec-profile.yaml
+++ b/qa/rgw_pool_type/ec-profile.yaml
@@ -7,4 +7,5 @@ overrides:
       m: 1
       crush-failure-domain: osd
   s3tests:
+    force-branch: ceph-master
     slow_backend: true

--- a/qa/rgw_pool_type/ec.yaml
+++ b/qa/rgw_pool_type/ec.yaml
@@ -2,4 +2,5 @@ overrides:
   rgw:
     ec-data-pool: true
   s3tests:
+    force-branch: ceph-master
     slow_backend: true

--- a/qa/suites/smoke/basic/tasks/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rgw_ec_s3tests.yaml
@@ -9,6 +9,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      force-branch: ceph-master
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/smoke/basic/tasks/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rgw_s3tests.yaml
@@ -5,6 +5,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      force-branch: ceph-master
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/teuthology/rgw/tasks/s3tests-civetweb.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-civetweb.yaml
@@ -11,7 +11,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: master
+      force-branch: ceph-master
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
@@ -11,7 +11,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: master
+      force-branch: ceph-master
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
@@ -12,7 +12,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: master
+      force-branch: ceph-master
 overrides:
   ceph:
     fs: xfs

--- a/qa/tasks/s3readwrite.py
+++ b/qa/tasks/s3readwrite.py
@@ -18,29 +18,32 @@ from teuthology.orchestra.connection import split_user
 
 log = logging.getLogger(__name__)
 
-
 @contextlib.contextmanager
 def download(ctx, config):
     """
     Download the s3 tests from the git builder.
     Remove downloaded s3 file upon exit.
-    
+
     The context passed in should be identical to the context
     passed in to the main task.
     """
     assert isinstance(config, dict)
     log.info('Downloading s3-tests...')
     testdir = teuthology.get_testdir(ctx)
-    for (client, cconf) in config.items():
-        branch = cconf.get('force-branch', None)
-        if not branch:
-            branch = cconf.get('branch', 'master')
-        sha1 = cconf.get('sha1')
+    for (client, client_config) in config.items():
+        s3tests_branch = client_config.get('force-branch', None)
+        if not s3tests_branch:
+            raise ValueError(
+                "Could not determine what branch to use for s3-tests. Please add 'force-branch: {s3-tests branch name}' to the .yaml config for this s3readwrite task.")
+
+        log.info("Using branch '%s' for s3tests", s3tests_branch)
+        sha1 = client_config.get('sha1')
+        git_remote = client_config.get('git_remote', teuth_config.ceph_git_base_url)
         ctx.cluster.only(client).run(
             args=[
                 'git', 'clone',
-                '-b', branch,
-                teuth_config.ceph_git_base_url + 's3-tests.git',
+                '-b', s3tests_branch,
+                git_remote + 's3-tests.git',
                 '{tdir}/s3-tests'.format(tdir=testdir),
                 ],
             )

--- a/qa/tasks/s3roundtrip.py
+++ b/qa/tasks/s3roundtrip.py
@@ -18,35 +18,48 @@ from teuthology.orchestra.connection import split_user
 
 log = logging.getLogger(__name__)
 
-
 @contextlib.contextmanager
 def download(ctx, config):
     """
     Download the s3 tests from the git builder.
     Remove downloaded s3 file upon exit.
-    
+
     The context passed in should be identical to the context
     passed in to the main task.
     """
     assert isinstance(config, dict)
     log.info('Downloading s3-tests...')
     testdir = teuthology.get_testdir(ctx)
-    for (client, cconf) in config.items():
-        branch = cconf.get('force-branch', None)
-        if not branch:
-            branch = cconf.get('branch', 'master')
+    for (client, client_config) in config.items():
+        s3tests_branch = client_config.get('force-branch', None)
+        if not s3tests_branch:
+            raise ValueError(
+                "Could not determine what branch to use for s3-tests. Please add 'force-branch: {s3-tests branch name}' to the .yaml config for this s3roundtrip task.")
+
+        log.info("Using branch '%s' for s3tests", s3tests_branch)
+        sha1 = client_config.get('sha1')
+        git_remote = client_config.get('git_remote', teuth_config.ceph_git_base_url)
         ctx.cluster.only(client).run(
             args=[
                 'git', 'clone',
-                '-b', branch,
-                teuth_config.ceph_git_base_url + 's3-tests.git',
+                '-b', s3tests_branch,
+                git_remote + 's3-tests.git',
                 '{tdir}/s3-tests'.format(tdir=testdir),
                 ],
             )
+        if sha1 is not None:
+            ctx.cluster.only(client).run(
+                args=[
+                    'cd', '{tdir}/s3-tests'.format(tdir=testdir),
+                    run.Raw('&&'),
+                    'git', 'reset', '--hard', sha1,
+                    ],
+                )
     try:
         yield
     finally:
         log.info('Removing s3-tests...')
+        testdir = teuthology.get_testdir(ctx)
         for client in config:
             ctx.cluster.only(client).run(
                 args=[
@@ -55,6 +68,7 @@ def download(ctx, config):
                     '{tdir}/s3-tests'.format(tdir=testdir),
                     ],
                 )
+
 
 def _config_user(s3tests_conf, section, user):
     """

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -31,27 +31,19 @@ def download(ctx, config):
     assert isinstance(config, dict)
     log.info('Downloading s3-tests...')
     testdir = teuthology.get_testdir(ctx)
-    s3_branches = [ 'giant', 'firefly', 'firefly-original', 'hammer' ]
-    for (client, cconf) in config.items():
-        branch = cconf.get('force-branch', None)
-        if not branch:
-            ceph_branch = ctx.config.get('branch')
-            suite_branch = ctx.config.get('suite_branch', ceph_branch)
-            if suite_branch in s3_branches:
-                branch = cconf.get('branch', suite_branch)
-	    else:
-                branch = cconf.get('branch', 'ceph-' + suite_branch)
-        if not branch:
+    for (client, client_config) in config.items():
+        s3tests_branch = client_config.get('force-branch', None)
+        if not s3tests_branch:
             raise ValueError(
-                "Could not determine what branch to use for s3tests!")
-        else:
-            log.info("Using branch '%s' for s3tests", branch)
-        sha1 = cconf.get('sha1')
-        git_remote = cconf.get('git_remote', None) or teuth_config.ceph_git_base_url
+                "Could not determine what branch to use for s3-tests. Please add 'force-branch: {s3-tests branch name}' to the .yaml config for this s3tests task.")
+
+        log.info("Using branch '%s' for s3tests", s3tests_branch)
+        sha1 = client_config.get('sha1')
+        git_remote = client_config.get('git_remote', teuth_config.ceph_git_base_url)
         ctx.cluster.only(client).run(
             args=[
                 'git', 'clone',
-                '-b', branch,
+                '-b', s3tests_branch,
                 git_remote + 's3-tests.git',
                 '{tdir}/s3-tests'.format(tdir=testdir),
                 ],


### PR DESCRIPTION
- Ensure the download code for all tasks running
s3-tests is consistent.
- Cleanup of download code to ensure ceph-master
runs if a specific ceph branch isn't specified
as the suite_branch

Signed-off-by: Ali Maredia <amaredia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
