### PR TITLE
nautilus: mon: remove the restriction of address type in init_with_hosts

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -491,7 +491,7 @@ int MonMap::init_with_hosts(const std::string& hostlist,
   vector<entity_addrvec_t> addrs;
   bool success = parse_ip_port_vec(
     hosts, addrs,
-    for_mkfs ? entity_addr_t::TYPE_MSGR2 : entity_addr_t::TYPE_ANY);
+    entity_addr_t::TYPE_ANY);
   free(hosts);
   if (!success)
     return -EINVAL;
@@ -504,8 +504,10 @@ int MonMap::init_with_hosts(const std::string& hostlist,
     string name = prefix;
     name += n;
     if (addrs[i].v.size() == 1) {
-      _add_ambiguous_addr(name, addrs[i].front(), 0);
+      _add_ambiguous_addr(name, addrs[i].front(), 0, for_mkfs);
     } else {
+      // they specified an addrvec, so let's assume they also specified
+      // the addr *type* and *port*.  (we could possibly improve this?)
       add(name, addrs[i], 0);
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42994

---

backport of https://github.com/ceph/ceph/pull/31691
parent tracker: https://tracker.ceph.com/issues/42844

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh