### PR TITLE
mgr/dashboard: Add support for blinking enclosure LEDs

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -1,16 +1,23 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import cherrypy
-from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError
+import time
 
-from . import ApiController, Endpoint, ReadPermission
+import cherrypy
+
+try:
+    from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError
+except ImportError:
+    pass
+
+from . import ApiController, Endpoint, ReadPermission, UpdatePermission
 from . import RESTController, Task
 from .. import mgr
 from ..exceptions import DashboardException
 from ..security import Scope
+from ..services.exception import handle_orchestrator_error
 from ..services.orchestrator import OrchClient
-from ..tools import wraps
+from ..tools import TaskManager, wraps
 
 
 def get_device_osd_map():
@@ -68,6 +75,29 @@ class Orchestrator(RESTController):
     @ReadPermission
     def status(self):
         return OrchClient.instance().status()
+
+    @Endpoint(method='POST')
+    @UpdatePermission
+    @raise_if_no_orchestrator
+    @handle_orchestrator_error('osd')
+    @orchestrator_task('identify_device', ['{hostname}', '{device}'])
+    def identify_device(self, hostname, device, duration):
+        # type: (str, str, int) -> None
+        """
+        Identify a device by switching on the device light for N seconds.
+        :param hostname: The hostname of the device to process.
+        :param device: The device identifier to process, e.g. ``ABC1234DEF567-1R1234_ABC8DE0Q``.
+        :param duration: The duration in seconds how long the LED should flash.
+        """
+        orch = OrchClient.instance()
+        TaskManager.current_task().set_progress(0)
+        orch.blink_device_light(hostname, device, 'ident', True)
+        for i in range(int(duration)):
+            percentage = int(round(i / float(duration) * 100))
+            TaskManager.current_task().set_progress(percentage)
+            time.sleep(1)
+        orch.blink_device_light(hostname, device, 'ident', False)
+        TaskManager.current_task().set_progress(100)
 
 
 @ApiController('/orchestrator/inventory', Scope.HOSTS)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.spec.ts
@@ -5,6 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsModule } from 'ngx-bootstrap/tabs';
+import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
@@ -31,7 +32,8 @@ describe('HostDetailsComponent', () => {
       CephModule,
       CoreModule,
       CephSharedModule,
-      SharedModule
+      SharedModule,
+      ToastrModule.forRoot()
     ],
     declarations: [],
     providers: [i18nProviders]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.html
@@ -5,7 +5,13 @@
           [selectionType]="selectionType"
           columnMode="flex"
           [autoReload]="false"
-          [searchField]="false">
+          [searchField]="false"
+          (updateSelection)="updateSelection($event)">
+  <cd-table-actions class="table-actions"
+                    [permission]="permission"
+                    [selection]="selection"
+                    [tableActions]="tableActions">
+  </cd-table-actions>
   <div class="table-filters form-inline"
        *ngIf="filters.length !== 0">
     <div class="form-group filter tc_filter"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.spec.ts
@@ -1,8 +1,10 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import { getterForProp } from '@swimlane/ngx-datatable/release/utils';
 import * as _ from 'lodash';
+import { ToastrModule } from 'ngx-toastr';
 
 import {
   configureTestBed,
@@ -89,7 +91,7 @@ describe('InventoryDevicesComponent', () => {
   ];
 
   configureTestBed({
-    imports: [FormsModule, SharedModule],
+    imports: [FormsModule, HttpClientTestingModule, SharedModule, ToastrModule.forRoot()],
     providers: [i18nProviders],
     declarations: [InventoryDevicesComponent]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
@@ -17,7 +18,13 @@ describe('InventoryComponent', () => {
   let orchService: OrchestratorService;
 
   configureTestBed({
-    imports: [FormsModule, SharedModule, HttpClientTestingModule, RouterTestingModule],
+    imports: [
+      FormsModule,
+      SharedModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+      ToastrModule.forRoot()
+    ],
     providers: [i18nProviders],
     declarations: [InventoryComponent, InventoryDevicesComponent]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.spec.ts
@@ -1,5 +1,8 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+
+import { ToastrModule } from 'ngx-toastr';
 
 import {
   configureTestBed,
@@ -46,7 +49,7 @@ describe('OsdDevicesSelectionGroupsComponent', () => {
   };
 
   configureTestBed({
-    imports: [FormsModule, SharedModule],
+    imports: [FormsModule, HttpClientTestingModule, SharedModule, ToastrModule.forRoot()],
     providers: [i18nProviders],
     declarations: [OsdDevicesSelectionGroupsComponent, InventoryDevicesComponent]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.spec.ts
@@ -1,8 +1,10 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
+import { ToastrModule } from 'ngx-toastr';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../../shared/shared.module';
@@ -41,7 +43,14 @@ describe('OsdDevicesSelectionModalComponent', () => {
   };
 
   configureTestBed({
-    imports: [FormsModule, SharedModule, ReactiveFormsModule, RouterTestingModule],
+    imports: [
+      FormsModule,
+      HttpClientTestingModule,
+      SharedModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      ToastrModule.forRoot()
+    ],
     providers: [BsModalRef, i18nProviders],
     declarations: [OsdDevicesSelectionModalComponent, InventoryDevicesComponent]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { ToastrModule } from 'ngx-toastr';
 import { BehaviorSubject, of } from 'rxjs';
 
 import {
@@ -98,7 +99,8 @@ describe('OsdFormComponent', () => {
       FormsModule,
       SharedModule,
       RouterTestingModule,
-      ReactiveFormsModule
+      ReactiveFormsModule,
+      ToastrModule.forRoot()
     ],
     providers: [i18nProviders],
     declarations: [OsdFormComponent, OsdDevicesSelectionGroupsComponent, InventoryDevicesComponent]

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.spec.ts
@@ -7,6 +7,7 @@ import { OrchestratorService } from './orchestrator.service';
 describe('OrchestratorService', () => {
   let service: OrchestratorService;
   let httpTesting: HttpTestingController;
+  const apiPath = 'api/orchestrator';
 
   configureTestBed({
     providers: [OrchestratorService, i18nProviders],
@@ -28,33 +29,33 @@ describe('OrchestratorService', () => {
 
   it('should call status', () => {
     service.status().subscribe();
-    const req = httpTesting.expectOne(service.statusURL);
+    const req = httpTesting.expectOne(`${apiPath}/status`);
     expect(req.request.method).toBe('GET');
   });
 
   it('should call inventoryList', () => {
     service.inventoryList().subscribe();
-    const req = httpTesting.expectOne(service.inventoryURL);
+    const req = httpTesting.expectOne(`${apiPath}/inventory`);
     expect(req.request.method).toBe('GET');
   });
 
   it('should call inventoryList with a host', () => {
     const host = 'host0';
     service.inventoryList(host).subscribe();
-    const req = httpTesting.expectOne(`${service.inventoryURL}?hostname=${host}`);
+    const req = httpTesting.expectOne(`${apiPath}/inventory?hostname=${host}`);
     expect(req.request.method).toBe('GET');
   });
 
   it('should call serviceList', () => {
     service.serviceList().subscribe();
-    const req = httpTesting.expectOne(service.serviceURL);
+    const req = httpTesting.expectOne(`${apiPath}/service`);
     expect(req.request.method).toBe('GET');
   });
 
   it('should call serviceList with a host', () => {
     const host = 'host0';
     service.serviceList(host).subscribe();
-    const req = httpTesting.expectOne(`${service.serviceURL}?hostname=${host}`);
+    const req = httpTesting.expectOne(`${apiPath}/service?hostname=${host}`);
     expect(req.request.method).toBe('GET');
   });
 
@@ -65,7 +66,7 @@ describe('OrchestratorService', () => {
       }
     };
     service.osdCreate(data['drive_group']).subscribe();
-    const req = httpTesting.expectOne(service.osdURL);
+    const req = httpTesting.expectOne(`${apiPath}/osd`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(data);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
@@ -13,20 +13,25 @@ import { ApiModule } from './api.module';
   providedIn: ApiModule
 })
 export class OrchestratorService {
-  statusURL = 'api/orchestrator/status';
-  inventoryURL = 'api/orchestrator/inventory';
-  serviceURL = 'api/orchestrator/service';
-  osdURL = 'api/orchestrator/osd';
+  private url = 'api/orchestrator';
 
   constructor(private http: HttpClient) {}
 
   status() {
-    return this.http.get(this.statusURL);
+    return this.http.get(`${this.url}/status`);
+  }
+
+  identifyDevice(hostname: string, device: string, duration: number) {
+    return this.http.post(`${this.url}/identify_device`, {
+      hostname,
+      device,
+      duration
+    });
   }
 
   inventoryList(hostname?: string): Observable<InventoryNode[]> {
     const options = hostname ? { params: new HttpParams().set('hostname', hostname) } : {};
-    return this.http.get<InventoryNode[]>(this.inventoryURL, options);
+    return this.http.get<InventoryNode[]>(`${this.url}/inventory`, options);
   }
 
   inventoryDeviceList(hostname?: string): Observable<InventoryDevice[]> {
@@ -46,13 +51,13 @@ export class OrchestratorService {
 
   serviceList(hostname?: string) {
     const options = hostname ? { params: new HttpParams().set('hostname', hostname) } : {};
-    return this.http.get(this.serviceURL, options);
+    return this.http.get(`${this.url}/service`, options);
   }
 
   osdCreate(driveGroup: {}) {
     const request = {
       drive_group: driveGroup
     };
-    return this.http.post(this.osdURL, request, { observe: 'response' });
+    return this.http.post(`${this.url}/osd`, request, { observe: 'response' });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
@@ -28,6 +28,30 @@
                         i18n>This field is required.</span>
                 </div>
               </ng-template>
+              <ng-template [ngSwitchCase]="'select'">
+                <label *ngIf="field.label"
+                       class="col-form-label col-sm-3"
+                       [for]="field.name">
+                  {{ field.label }}
+                </label>
+                <div [ngClass]="{'col-sm-9': field.label, 'col-sm-12': !field.label}">
+                  <select class="form-control custom-select"
+                          [id]="field.name"
+                          [formControlName]="field.name">
+                    <option *ngIf="field.placeholder"
+                            [ngValue]="null">
+                      {{ field.placeholder }}
+                    </option>
+                    <option *ngFor="let option of field.options"
+                            [value]="option.value">
+                      {{ option.text }}
+                    </option>
+                  </select>
+                  <span *ngIf="formGroup.hasError('required', field.name)"
+                        class="invalid-feedback"
+                        i18n>This field is required.</span>
+                </div>
+              </ng-template>
             </ng-container>
           </div>
         </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.ts
@@ -7,11 +7,17 @@ import { BsModalRef } from 'ngx-bootstrap/modal';
 import { CdFormBuilder } from '../../forms/cd-form-builder';
 
 interface CdFormFieldConfig {
-  type: 'textInput';
+  type: 'inputText' | 'select';
   name: string;
   label?: string;
   value?: any;
   required?: boolean;
+  // --- select ---
+  placeholder?: string;
+  options?: Array<{
+    text: string;
+    value: any;
+  }>;
 }
 
 @Component({

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -393,6 +393,15 @@ export class TaskMessageService {
       this.commonOperations.update,
       this.grafana.update_dashboards,
       () => ({})
+    ),
+    // Orchestrator tasks
+    'orchestrator/identify_device': this.newTaskMessage(
+      new TaskMessageOperation(
+        this.i18n('Identifying'),
+        this.i18n('identify'),
+        this.i18n('Identified')
+      ),
+      (metadata) => this.i18n(`device '{{device}}' on host '{{hostname}}'`, metadata)
     )
   };
 

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import logging
 
-from orchestrator import InventoryFilter
+from orchestrator import InventoryFilter, DeviceLightLoc, Completion
 from orchestrator import OrchestratorClientMixin, raise_if_exception, OrchestratorError
 from .. import mgr
 from ..tools import wraps
@@ -121,3 +121,8 @@ class OrchClient(object):
 
     def status(self):
         return self.api.status()
+
+    @wait_api_result
+    def blink_device_light(self, hostname, device, ident_fault, on):
+        # type: (str, str, str, bool) -> Completion
+        return self.api.blink_device_light(ident_fault, on, [DeviceLightLoc(hostname, device)])


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42609

![Peek 2019-11-25 14-30](https://user-images.githubusercontent.com/1897962/69544549-3f4dec00-0f90-11ea-9d82-5ca19810ca17.gif)

Signed-off-by: Volker Theile <vtheile@suse.com>

## Testing
You can easily test this PR by using the `test_orchestrator`. Check out https://github.com/ceph/ceph/pull/31757 how to use it.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
