### PR TITLE
luminous: osd/ReplicatedBackend.cc: 1349: FAILED ceph_assert(peer_missing.count(fromshard))

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -762,7 +762,33 @@ void PG::MissingLoc::check_recovery_sources(const OSDMapRef& osdmap)
 
 void PG::MissingLoc::remove_stray_recovery_sources(pg_shard_t stray)
 {
-  set<pg_shard_t> now_stray;
+  ldout(pg->cct, 10) << __func__ << " remove osd " << stray << " from missing_loc" << dendl;
+  // filter missing_loc
+  map<hobject_t, set<pg_shard_t>>::iterator p = missing_loc.begin();
+  while (p != missing_loc.end()) {
+    set<pg_shard_t>::iterator q = p->second.begin();
+    bool changed = false;
+    while (q != p->second.end()) {
+      if (*q == stray) {
+        if (!changed) {
+          changed = true;
+          _dec_count(p->second);
+        }
+        p->second.erase(q++);
+      } else {
+        ++q;
+      }
+    }
+    if (p->second.empty()) {
+      missing_loc.erase(p++);
+    } else {
+      if (changed) {
+        _inc_count(p->second);
+      }
+      ++p;
+    }
+  }
+  // filter missing_loc_sources
   for (set<pg_shard_t>::iterator p = missing_loc_sources.begin();
        p != missing_loc_sources.end();
        ) {
@@ -770,42 +796,8 @@ void PG::MissingLoc::remove_stray_recovery_sources(pg_shard_t stray)
       ++p;
       continue;
     }
-    ldout(pg->cct, 10) << __func__ << " source osd." << *p << " now stray" << dendl;
-    now_stray.insert(*p);
+    ldout(pg->cct, 10) << __func__ << " remove osd" << stray << " from missing_loc_sources" << dendl;
     missing_loc_sources.erase(p++);
-  }
-
-  if (now_stray.empty()) {
-    ldout(pg->cct, 10) << __func__ << " no source osds (" << missing_loc_sources << ") became stray" << dendl;
-  } else {
-    ldout(pg->cct, 10) << __func__ << " sources osds " << now_stray << " now stray, remaining sources are "
-                       << missing_loc_sources << dendl;
-
-    // filter missing_loc
-    map<hobject_t, set<pg_shard_t>>::iterator p = missing_loc.begin();
-    while (p != missing_loc.end()) {
-      set<pg_shard_t>::iterator q = p->second.begin();
-      bool changed = false;
-      while (q != p->second.end()) {
-        if (now_stray.count(*q)) {
-          if (!changed) {
-            changed = true;
-            _dec_count(p->second);
-          }
-          p->second.erase(q++);
-        } else {
-          ++q;
-        }
-      }
-      if (p->second.empty()) {
-        missing_loc.erase(p++);
-      } else {
-        if (changed) {
-          _inc_count(p->second);
-        }
-        ++p;
-      }
-    }
   }
 }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2321,7 +2321,8 @@ void PG::finish_recovery(list<Context*>& tfin)
 void PG::_finish_recovery(Context *c)
 {
   lock();
-  if (deleting) {
+  if (deleting || !is_clean()) {
+    dout(10) << __func__ << " raced with delete or repair" << dendl;
     unlock();
     return;
   }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -759,7 +759,56 @@ void PG::MissingLoc::check_recovery_sources(const OSDMapRef& osdmap)
     }
   }
 }
-  
+
+void PG::MissingLoc::remove_stray_recovery_sources(pg_shard_t stray)
+{
+  set<pg_shard_t> now_stray;
+  for (set<pg_shard_t>::iterator p = missing_loc_sources.begin();
+       p != missing_loc_sources.end();
+       ) {
+    if (*p != stray) {
+      ++p;
+      continue;
+    }
+    ldout(pg->cct, 10) << __func__ << " source osd." << *p << " now stray" << dendl;
+    now_stray.insert(*p);
+    missing_loc_sources.erase(p++);
+  }
+
+  if (now_stray.empty()) {
+    ldout(pg->cct, 10) << __func__ << " no source osds (" << missing_loc_sources << ") became stray" << dendl;
+  } else {
+    ldout(pg->cct, 10) << __func__ << " sources osds " << now_stray << " now stray, remaining sources are "
+                       << missing_loc_sources << dendl;
+
+    // filter missing_loc
+    map<hobject_t, set<pg_shard_t>>::iterator p = missing_loc.begin();
+    while (p != missing_loc.end()) {
+      set<pg_shard_t>::iterator q = p->second.begin();
+      bool changed = false;
+      while (q != p->second.end()) {
+        if (now_stray.count(*q)) {
+          if (!changed) {
+            changed = true;
+            _dec_count(p->second);
+          }
+          p->second.erase(q++);
+        } else {
+          ++q;
+        }
+      }
+      if (p->second.empty()) {
+        missing_loc.erase(p++);
+      } else {
+        if (changed) {
+          _inc_count(p->second);
+        }
+        ++p;
+      }
+    }
+  }
+}
+
 void PG::discover_all_missing(map<int, map<spg_t,pg_query_t> > &query_map)
 {
   auto &missing = pg_log.get_missing();
@@ -2608,6 +2657,7 @@ void PG::purge_strays()
     }
     peer_missing.erase(*p);
     peer_info.erase(*p);
+    missing_loc.remove_stray_recovery_sources(*p);
     peer_purged.insert(*p);
     removed = true;
   }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -594,6 +594,9 @@ public:
     /// Uses osdmap to update structures for now down sources
     void check_recovery_sources(const OSDMapRef& osdmap);
 
+    /// Remove stray from recovery sources
+    void remove_stray_recovery_sources(pg_shard_t stray);
+
     /// Call when hoid is no longer missing in acting set
     void recovered(const hobject_t &hoid) {
       needs_recovery_map.erase(hoid);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41730

---

backport of:

- [x] https://github.com/ceph/ceph/pull/30119 (merged September 4, 2019)
- [x] https://github.com/ceph/ceph/pull/30059 (merged September 7, 2019)
- [x] https://github.com/ceph/ceph/pull/30226 (merged September 9, 2019)

parent tracker: https://tracker.ceph.com/issues/41385

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh