### PR TITLE
crimson/common/errorator.h: add handle_error() method.

### DIFF
--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -25,11 +25,8 @@ static inline int execute_osd_op(cls_method_context_t hctx, OSDOp& op)
   // created for us by `seastar::async` in `::do_op_call()`.
   int ret = 0;
   using osd_op_errorator = crimson::osd::OpsExecuter::osd_op_errorator;
-  reinterpret_cast<crimson::osd::OpsExecuter*>(hctx)->execute_osd_op(op).safe_then(
-    [] {
-      // TODO: handle it nicer with `::handle_error()` in errorator
-      return seastar::now();
-    }, osd_op_errorator::all_same_way([&ret] (const std::error_code& err) {
+  reinterpret_cast<crimson::osd::OpsExecuter*>(hctx)->execute_osd_op(op).handle_error(
+    osd_op_errorator::all_same_way([&ret] (const std::error_code& err) {
       assert(err.value() > 0);
       ret = -err.value();
       return seastar::now();

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -24,12 +24,8 @@ seastar::future<bufferlist> OSDMeta::load_map(epoch_t e)
 {
   return store->read(coll,
                      osdmap_oid(e), 0, 0,
-                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).safe_then(
-    [] (auto&& bl) {
-      // TODO: introduce `::handle_error()` to errorated futures
-      // to avoid lambas like this one.
-      return bl;
-    }, crimson::ct_error::enoent::handle([e] {
+                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).handle_error(
+    crimson::ct_error::enoent::handle([e] {
       throw std::runtime_error(fmt::format("read gave enoent on {}",
                                            osdmap_oid(e)));
     }));


### PR DESCRIPTION
In contrast to `safe_then` it deals only with errors and, on return, leaves the value type `future<ValueT>` embodies unchanged.
While being basically a specialization of `safe_then`, it's also a convenience method to squeeze boilerplate.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
