### PR TITLE
luminous: osd: refuse to start if we're > N+2 from recorded require_osd_release

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -27,6 +27,7 @@ using namespace std;
 #include "include/ceph_features.h"
 
 #include "common/config.h"
+#include "common/version.h"
 
 #include "mon/MonMap.h"
 
@@ -403,8 +404,10 @@ flushjournal_out:
   
   string magic;
   uuid_d cluster_fsid, osd_fsid;
+  int require_osd_release = 0;
   int w;
-  int r = OSD::peek_meta(store, magic, cluster_fsid, osd_fsid, w);
+  int r = OSD::peek_meta(store, &magic, &cluster_fsid, &osd_fsid, &w,
+			 &require_osd_release);
   if (r < 0) {
     derr << TEXT_RED << " ** ERROR: unable to open OSD superblock on "
 	 << g_conf->osd_data << ": " << cpp_strerror(-r)
@@ -432,6 +435,14 @@ flushjournal_out:
   if (get_osd_fsid) {
     cout << osd_fsid << std::endl;
     exit(0);
+  }
+
+  if (require_osd_release > 0 &&
+      require_osd_release + 2 < ceph_release()) {
+    derr << "OSD's recorded require_osd_release " << require_osd_release
+	 << " + 2 < this release " << ceph_release()
+	 << "; you can only upgrade 2 releases at a time" << dendl;
+    exit(1);
   }
 
   pick_addresses(g_ceph_context, CEPH_PICK_ADDRESS_PUBLIC

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1890,35 +1890,44 @@ int OSD::write_meta(CephContext *cct, ObjectStore *store, uuid_d& cluster_fsid, 
   return 0;
 }
 
-int OSD::peek_meta(ObjectStore *store, std::string& magic,
-		   uuid_d& cluster_fsid, uuid_d& osd_fsid, int& whoami)
+int OSD::peek_meta(ObjectStore *store,
+		   std::string *magic,
+		   uuid_d *cluster_fsid,
+		   uuid_d *osd_fsid,
+		   int *whoami,
+		   int *require_osd_release)
 {
   string val;
 
   int r = store->read_meta("magic", &val);
   if (r < 0)
     return r;
-  magic = val;
+  *magic = val;
 
   r = store->read_meta("whoami", &val);
   if (r < 0)
     return r;
-  whoami = atoi(val.c_str());
+  *whoami = atoi(val.c_str());
 
   r = store->read_meta("ceph_fsid", &val);
   if (r < 0)
     return r;
-  r = cluster_fsid.parse(val.c_str());
+  r = cluster_fsid->parse(val.c_str());
   if (!r)
     return -EINVAL;
 
   r = store->read_meta("fsid", &val);
   if (r < 0) {
-    osd_fsid = uuid_d();
+    *osd_fsid = uuid_d();
   } else {
-    r = osd_fsid.parse(val.c_str());
+    r = osd_fsid->parse(val.c_str());
     if (!r)
       return -EINVAL;
+  }
+
+  r = store->read_meta("require_osd_release", &val);
+  if (r >= 0) {
+    *require_osd_release = atoi(val.c_str());
   }
 
   return 0;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2582,6 +2582,12 @@ int OSD::init()
   service.recovery_request_timer.init();
   service.recovery_sleep_timer.init();
 
+  {
+    string val;
+    store->read_meta("require_osd_release", &val);
+    last_require_osd_release = atoi(val.c_str());
+  }
+
   // mount.
   dout(2) << "init " << dev_path
 	  << " (looks like " << (store_is_rotational ? "hdd" : "ssd") << ")"
@@ -8737,6 +8743,13 @@ void OSD::check_osdmap_features(ObjectStore *fs)
       int err = store->queue_transaction(service.meta_osr.get(), std::move(t), NULL);
       assert(err == 0);
     }
+  }
+
+  if (osdmap->require_osd_release != last_require_osd_release) {
+    dout(1) << __func__ << " require_osd_release " << last_require_osd_release
+	    << " -> " << osdmap->require_osd_release << dendl;
+    store->write_meta("require_osd_release", stringify(osdmap->require_osd_release));
+    last_require_osd_release = osdmap->require_osd_release;
   }
 }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1247,6 +1247,8 @@ protected:
   int whoami;
   std::string dev_path, journal_path;
 
+  int last_require_osd_release = 0;
+
   bool store_is_rotational = true;
   bool journal_is_rotational = true;
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2502,8 +2502,12 @@ private:
   float get_osd_recovery_sleep();
 
 public:
-  static int peek_meta(ObjectStore *store, string& magic,
-		       uuid_d& cluster_fsid, uuid_d& osd_fsid, int& whoami);
+  static int peek_meta(ObjectStore *store,
+		       string *magic,
+		       uuid_d *cluster_fsid,
+		       uuid_d *osd_fsid,
+		       int *whoami,
+		       int *min_osd_release);
   
 
   // startup/shutdown


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/38205

---

backport of https://github.com/ceph/ceph/pull/26177 (via #29241)
parent tracker: https://tracker.ceph.com/issues/38076

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh