### PR TITLE
osd/SnapMirror: no need to record purged_snaps every epoch

### DIFF
--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -25,7 +25,6 @@ const string SnapMapper::LEGACY_MAPPING_PREFIX = "MAP_";
 const string SnapMapper::MAPPING_PREFIX = "SNA_";
 const string SnapMapper::OBJECT_PREFIX = "OBJ_";
 
-const char *SnapMapper::PURGED_SNAP_EPOCH_PREFIX = "PSE_";
 const char *SnapMapper::PURGED_SNAP_PREFIX = "PSN_";
 
 /*
@@ -471,12 +470,6 @@ void SnapMapper::record_purged_snaps(
   map<string,bufferlist> m;
   set<string> rm;
   for (auto& [epoch, bypool] : purged_snaps) {
-    // store per-epoch key
-    char ek[80];
-    snprintf(ek, sizeof(ek), "%s_%08lx", PURGED_SNAP_EPOCH_PREFIX,
-	     (unsigned long)epoch);
-    ceph::encode(bypool, m[ek]);
-
     // index by (pool, snap)
     for (auto& [pool, snaps] : bypool) {
       for (auto i = snaps.begin();


### PR DESCRIPTION
These keys were a mirror of the mon's purged_epoch keys.  We were writing
them, but never looking at them.  We only need the per-pool keys that
are indexed by snapid for lookups, so we should stop storing the per-epoch
records.

Note that the OSDSuperblock has the purged_snaps_last that serves as our
position/cursor for ingesting the mon keys.

Fixes: https://tracker.ceph.com/issues/42012
Signed-off-by: Sage Weil <sage@redhat.com>