### PR TITLE
ceph-daemon: configure firewalld for new daemons

### DIFF
--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -61,9 +61,9 @@ fi
 $SUDO $CEPH_DAEMON rm-cluster --fsid $FSID --force
 $SUDO $CEPH_DAEMON rm-cluster --fsid $FSID_LEGACY --force
 vgchange -an $OSD_VG_NAME || true
-loopdev=$(losetup -a | grep $(basename $OSD_IMAGE_NAME) | awk -F : '{print $1}')
+loopdev=$($SUDO losetup -a | grep $(basename $OSD_IMAGE_NAME) | awk -F : '{print $1}')
 if ! [ "$loopdev" = "" ]; then
-    losetup -d $loopdev
+    $SUDO losetup -d $loopdev
 fi
 
 TMPDIR=`mktemp -d -p .`
@@ -172,7 +172,7 @@ $SUDO $CEPH_DAEMON shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
 
 # add osd.{1,2,..}
 dd if=/dev/zero of=$TMPDIR/$OSD_IMAGE_NAME bs=1 count=0 seek=$OSD_IMAGE_SIZE
-loop_dev=$(losetup -f)
+loop_dev=$($SUDO losetup -f)
 $SUDO vgremove -f $OSD_VG_NAME || true
 $SUDO losetup $loop_dev $TMPDIR/$OSD_IMAGE_NAME
 $SUDO pvcreate $loop_dev && $SUDO vgcreate $OSD_VG_NAME $loop_dev

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -631,6 +631,7 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
         pc.run()
 
     deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c)
+    update_firewalld(daemon_type)
 
 def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                         enable=True, start=True):
@@ -660,6 +661,52 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
         call_throws(['systemctl', 'enable', unit_name])
     if start:
         call_throws(['systemctl', 'start', unit_name])
+
+def update_firewalld(daemon_type):
+    if args.skip_firewalld:
+        return
+    cmd = find_executable('firewall-cmd')
+    if not cmd:
+        logger.debug('firewalld does not appear to be present')
+        return
+    (enabled, state) = check_unit('firewalld.service')
+    if not enabled:
+        logger.debug('firewalld.service is not enabled')
+        return
+
+    fw_services = []
+    fw_ports = []
+    if daemon_type == 'mon':
+        fw_services.append('ceph-mon')
+    elif daemon_type in ['mgr', 'mds', 'osd']:
+        fw_services.append('ceph')
+    if daemon_type == 'mgr':
+        fw_ports.append(8080)  # dashboard
+        fw_ports.append(8443)  # dashboard
+        fw_ports.append(9283)  # prometheus
+
+    for svc in fw_services:
+        out, err, ret = call([cmd, '--permanent', '--query-service', svc])
+        if ret:
+            logger.info('Enabling firewalld service %s in current zone...' % svc)
+            out, err, ret = call([cmd, '--permanent', '--add-service', svc])
+            if ret:
+                raise RuntimeError('unable to add service %s to current zone:' %
+                                   (svc, err))
+        else:
+            logger.debug('firewalld service %s is enabled in current zone' % svc)
+    for port in fw_ports:
+        port = str(port) + '/tcp'
+        out, err, ret = call([cmd, '--permanent', '--query-port', port])
+        if ret:
+            logger.info('Enabling firewalld port %s in current zone...' % port)
+            out, err, ret = call([cmd, '--permanent', '--add-port', port])
+            if ret:
+                raise RuntimeError('unable to add port %s to current zone: %s' %
+                                   (port, err))
+        else:
+            logger.debug('firewalld port %s is enabled in current zone' % port)
+    call_throws([cmd, '--reload'])
 
 def install_base_units(fsid):
     # type: (str) -> None
@@ -1066,6 +1113,7 @@ def command_bootstrap():
 
     mon_c = get_container(fsid, 'mon', mon_id)
     deploy_daemon_units(fsid, uid, gid, 'mon', mon_id, mon_c)
+    update_firewalld(daemon_type)
 
     # client.admin key + config to issue various CLI commands
     tmp_admin_keyring = tempfile.NamedTemporaryFile(mode='w')
@@ -1585,6 +1633,8 @@ def command_adopt():
         deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                             enable=True,  # unconditionally enable the new unit
                             start=(state == 'running'))
+        update_firewalld(daemon_type)
+
     else:
         raise Error('adoption of style %s not implemented' % args.style)
 
@@ -1734,6 +1784,10 @@ def _get_parser():
         '--legacy-dir',
         default='/',
         help='base directory for legacy daemon data')
+    parser_adopt.add_argument(
+        '--skip-firewalld',
+        action='store_true',
+        help='Do not configure firewalld')
 
     parser_rm_daemon = subparsers.add_parser(
         'rm-daemon', help='remove daemon instance')
@@ -1916,6 +1970,10 @@ def _get_parser():
         action='store_true',
         help='do not pull the latest image before bootstrapping')
     parser_bootstrap.add_argument(
+        '--skip-firewalld',
+        action='store_true',
+        help='Do not configure firewalld')
+    parser_bootstrap.add_argument(
         '--allow-overwrite',
         action='store_true',
         help='allow overwrite of existing --output-* config/keyring/ssh files')
@@ -1958,6 +2016,10 @@ def _get_parser():
     parser_deploy.add_argument(
         '--osd-fsid',
         help='OSD uuid, if creating an OSD container')
+    parser_deploy.add_argument(
+        '--skip-firewalld',
+        action='store_true',
+        help='Do not configure firewalld')
 
     return parser
 

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -565,9 +565,11 @@ def extract_uid_gid():
 
 def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
                   config, keyring):
-    # type: (str, str, Union[int, str], CephContainer, int, int, str, str) -> None
-    if daemon_type == 'mon' and not os.path.exists(get_data_dir(fsid, 'mon',
-                                                                daemon_id)):
+    # type: (str, str, Union[int, str], CephContainer, int, int, Optional[str], Optional[str]) -> None
+    if daemon_type == 'mon' and not os.path.exists(
+            get_data_dir(fsid, 'mon', daemon_id)):
+        assert config
+        assert keyring
         # tmp keyring file
         tmp_keyring = tempfile.NamedTemporaryFile(mode='w')
         os.fchmod(tmp_keyring.fileno(), 0o600)
@@ -1112,8 +1114,8 @@ def command_bootstrap():
         f.write(config)
 
     mon_c = get_container(fsid, 'mon', mon_id)
-    deploy_daemon_units(fsid, uid, gid, 'mon', mon_id, mon_c)
-    update_firewalld(daemon_type)
+    deploy_daemon(fsid, 'mon', mon_id, mon_c, uid, gid,
+                  config=None, keyring=None)
 
     # client.admin key + config to issue various CLI commands
     tmp_admin_keyring = tempfile.NamedTemporaryFile(mode='w')

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -194,6 +194,11 @@ def get_fqdn():
     # type: () -> str
     return socket.getfqdn() or socket.gethostname()
 
+def generate_service_id():
+    # type: () -> str
+    return ''.join(random.choice(string.ascii_lowercase)
+                   for _ in range(6))
+
 def generate_password():
     # type: () -> str
     return ''.join(random.choice(string.ascii_lowercase + string.digits)
@@ -926,7 +931,7 @@ def command_bootstrap():
     fsid = args.fsid or make_fsid()
     hostname = get_hostname()
     mon_id = args.mon_id or hostname
-    mgr_id = args.mgr_id or hostname
+    mgr_id = args.mgr_id or generate_service_id()
     logging.info('Cluster fsid: %s' % fsid)
 
     # config


### PR DESCRIPTION
This captures both bootstrapped mon+mgr and other daemons deployed later.

Right now the ports are hard-coded into ceph-daemon.  We can extend this to take additional ports if we like?