### PR TITLE
rgw: find oldest period and update RGWMetadataLogHistory()

### DIFF
--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -260,7 +260,7 @@ Cursor RGWSI_MDLog::find_oldest_period()
       RGWPeriod period;
       int r = period_puller->pull(predecessor, period);
       if (r < 0) {
-        return Cursor{r};
+        return cursor;
       }
       auto prev = period_history->insert(std::move(period));
       if (!prev) {
@@ -290,7 +290,6 @@ Cursor RGWSI_MDLog::init_oldest_log_period()
     if (!cursor) {
       return cursor;
     }
-
     // write the initial history
     state.oldest_realm_epoch = cursor.get_epoch();
     state.oldest_period_id = cursor.get_period().get_id();
@@ -313,7 +312,20 @@ Cursor RGWSI_MDLog::init_oldest_log_period()
   auto cursor = period_history->lookup(state.oldest_realm_epoch);
   if (cursor) {
     return cursor;
+  } else {
+    cursor = find_oldest_period();
+    state.oldest_realm_epoch = cursor.get_epoch();
+    state.oldest_period_id = cursor.get_period().get_id();
+    ldout(cct, 10) << "rewriting mdlog history" << dendl;
+    ret = write_history(state, &objv);
+    if (ret < 0 && ret != -ECANCELED) {
+    ldout(cct, 1) << "failed to write mdlog history: "
+          << cpp_strerror(ret) << dendl;
+    return Cursor{ret};
+    }
+    return cursor;
   }
+
   // pull the oldest period by id
   RGWPeriod period;
   ret = period_puller->pull(state.oldest_period_id, period);


### PR DESCRIPTION
when a period lookup for oldest_realm_epoch returns an ENOENT, 
find the oldest one and update RGWMetadataLogHistory. This is to avoid an
empty cursor being passed in to ceph_assert() in PurgePeriodLogsCR::operate()
in case of incomplete period history.

Signed-off-by: Shilpa Jagannath <smanjara@redhat.com>

Fixes: https://tracker.ceph.com/issues/40341

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: https://tracker.ceph.com/issues/40341
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
