### PR TITLE
mimic: doc, qa: remove invalid option mon_pg_warn_max_per_osd 

### DIFF
--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -60,15 +60,6 @@ Ceph configuration file.
 :Default: ``30``
 
 
-``mon pg warn max per osd``
-
-:Description: Issue a ``HEALTH_WARN`` in cluster log if the average number
-              of PGs per (in) OSD is above this number. (a non-positive number
-              disables this)
-:Type: Integer
-:Default: ``300``
-
-
 ``mon pg warn min objects``
 
 :Description: Do not warn if the total number of objects in cluster is below

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -13,7 +13,6 @@
 	ms die on old message = true
 
 	mon pg warn min per osd = 1
-	mon pg warn max per osd = 10000   # <= luminous
 	mon max pg per osd = 10000        # >= luminous
 	mon pg warn max object skew = 0
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42258

---

backport of https://github.com/ceph/ceph/pull/30787
parent tracker: https://tracker.ceph.com/issues/42221

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh