### PR TITLE
rgw: use STSEngine::authenticate when post upload with x_amz_security_token

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1648,6 +1648,7 @@ namespace rgw {
   namespace auth {
     namespace s3 {
       class AWSBrowserUploadAbstractor;
+      class STSEngine;
     }
     class Completer;
   }
@@ -2056,6 +2057,7 @@ struct req_state : DoutPrefixProvider {
       friend class RGWPostObj_ObjStore_S3;
       /* Reader. */
       friend class rgw::auth::s3::AWSBrowserUploadAbstractor;
+      friend class rgw::auth::s3::STSEngine;
 
       std::string access_key;
       std::string signature;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2308,7 +2308,12 @@ int RGWPostObj_ObjStore_S3::get_policy()
       }
     }
 
-    part_str(parts, "x-amz-security-token", &s->auth.s3_postobj_creds.x_amz_security_token);
+    if (part_str(parts, "x-amz-security-token", &s->auth.s3_postobj_creds.x_amz_security_token)) {
+      if (s->auth.s3_postobj_creds.x_amz_security_token.size() == 0) {
+        err_msg = "Invalid token";
+        return -EINVAL;
+      }
+    }
 
     /* FIXME: this is a makeshift solution. The browser upload authentication will be
      * handled by an instance of rgw::auth::Completer spawned in Handler's authorize()
@@ -5099,7 +5104,8 @@ rgw::auth::s3::STSEngine::authenticate(
   const req_state* const s) const
 {
   if (! s->info.args.exists("X-Amz-Security-Token") &&
-      ! s->info.env->exists("HTTP_X_AMZ_SECURITY_TOKEN")) {
+      ! s->info.env->exists("HTTP_X_AMZ_SECURITY_TOKEN") &&
+      s->auth.s3_postobj_creds.x_amz_security_token.empty()) {
     return result_t::deny();
   }
 


### PR DESCRIPTION
Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>

get sts token
```
import boto3
import botocore
botocore.session.Session().set_debug_logger()
access_key = 'yly'
secret_key = 'yly'
config_dict = { 'signature_version' : 's3', 'connect_timeout': 30000, 'read_timeout': 30000}
configuration = boto3.session.Config(**config_dict)
client = boto3.client('sts',
aws_access_key_id=access_key,
aws_secret_access_key=secret_key,
endpoint_url='http://192.168.122.122:7480',
region_name='',
use_ssl = False,
config = configuration,
)

response = client.get_session_token(DurationSeconds=7200)
print response['Credentials']['AccessKeyId']
print response['Credentials']['SecretAccessKey']
print response['Credentials']['SessionToken']
```

use token to post upload
```
# !/usr/bin/python
from boto3.session import Session
import boto3
import botocore
botocore.session.Session().set_debug_logger()
bucketname = 'test1'
objectname = 'prefix/keyv6'
access_key = "cEpiH53oCLdwL6rUkYl"
secret_key = "BB4KN1H0NRHXARHFHZZ4PAMLBXUDGIW2B73ZO1J"
# token = "TfSHR1kArYNceWvbWiTvJr/N02O8koXr28cbPEypvOc+VAt0ZzPnog8kJt8qE8Tej7ottfLnB8ittRHuy+dEzUI6izQMaCbBV2S/YdixODkK62/WoE7Sd3xT5M4r9vkEt1D1l8bTE+WfvYcZ3eQWipHPrcnelhiL+/t6bKjNDNzs3kqp11HnZcHA9x/WvPzDRTgysXc+QlOF6jAtg7E1/Q=="
token = '03+9a79FaIgsLn1oZXVEkDhmn2tOIVVV59Prd3RE6jYSd3m49oijh2T1zXQ974eCy20BMnoJiU2wV4u0AHIQtjTdHRrSPCfKkuuQYdFCFdEmttbN2F+uFThyEIHMcj5Zeu6P65urRnTSFc4zQF1dPKW0jfd0kHZg9PKwCk2nX4R/UqSCbQUWKcHujSx19QeJh+qr9gSPF5JnePMUUVsnLg=='
url = "http://192.168.122.122:7480"
session = boto3.session.Session()
credentials = {"access_key":access_key,
               "secret_key":secret_key,
               "endpoint_url": url,
               "token":token}

s3_client= session.client(service_name='s3',
                          endpoint_url=credentials['endpoint_url'],
                          aws_access_key_id=credentials['access_key'],
                          aws_secret_access_key=credentials['secret_key'],
                          aws_session_token=credentials['token'],
                          config=boto3.session.Config(signature_version='s3v4'))


conditions = [
    ["starts-with", "$Content-Type", "image/"],
    ["starts-with", "$key", "prefix/"],
    ["content-length-range", 0, 20000000],
]

form_data = s3_client.generate_presigned_post(
    Conditions=conditions,
    Bucket=bucketname,
    Key=objectname
)

form_data["fields"]['Content-Type'] = 'image/png'
form_data["fields"]['key'] = objectname
files = {"file": "this_is_file_content_!!!!!"}
import requests
import logging
from requests_toolbelt.utils import dump
logging.basicConfig(level=logging.DEBUG)
response = requests.post(form_data["url"], data=form_data["fields"], files=files)
data = dump.dump_all(response)
print(data.decode('utf-8'))
```

it will failed because in rgw::auth::s3::STSEngine::authenticate it only check `s->info.env->exists("HTTP_X_AMZ_SECURITY_TOKEN")` and `s->info.args.exists("X-Amz-Security-Token"`, we also need to check `s->auth.s3_postobj_creds.x_amz_security_token` too

