### PR TITLE
rpm,deb: remove unwanted dashboard files

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -23,6 +23,7 @@
 %bcond_with make_check
 %bcond_with cmake_verbose_logging
 %bcond_without ceph_test_package
+%bcond_without dashboard_frontend
 %ifarch s390 s390x
 %bcond_with tcmalloc
 %else
@@ -1181,7 +1182,11 @@ ${CMAKE} .. \
     -DCMAKE_INSTALL_INCLUDEDIR=%{_includedir} \
     -DWITH_MANPAGE=ON \
     -DWITH_PYTHON3=%{python3_version} \
+%if 0%{with dashboard_frontend}
+    -DWITH_MGR_DASHBOARD_FRONTEND=ON \
+%else
     -DWITH_MGR_DASHBOARD_FRONTEND=OFF \
+%endif
 %if 0%{without ceph_test_package}
     -DWITH_TESTS=OFF \
 %endif

--- a/make-dist
+++ b/make-dist
@@ -145,7 +145,11 @@ download_boost $boost_version 59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa
                https://downloads.sourceforge.net/project/boost/boost/$boost_version \
                https://download.ceph.com/qa
 
-build_dashboard_frontend
+if [ ${WITH_MGR_DASHBOARD_FRONTEND:-OFF} == "OFF" ]; then
+    build_dashboard_frontend
+    tar --concatenate -f $outfile.all.tar dashboard_frontend.tar
+    rm -f dashboard_frontend.tar
+fi
 generate_rook_ceph_client
 tar --concatenate -f $outfile.all.tar $outfile.version.tar
 tar --concatenate -f $outfile.all.tar $outfile.boost.tar

--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -14,12 +14,16 @@ endif()
 install(DIRECTORY
   ${CMAKE_CURRENT_SOURCE_DIR}
   DESTINATION ${CEPH_INSTALL_DATADIR}
-  REGEX "CMakeLists.txt" EXCLUDE
-  REGEX "\\.gitignore" EXCLUDE
+  PATTERN "CMakeLists.txt" EXCLUDE
+  PATTERN ".gitignore" EXCLUDE
   REGEX ".*\\.pyi" EXCLUDE
   REGEX "hello/.*" EXCLUDE
   REGEX "tests/.*" EXCLUDE
   REGEX "rook/rook-client-python.*" EXCLUDE
   REGEX "osd_perf_query/.*" EXCLUDE
-  REGEX "tox.ini" EXCLUDE
-  REGEX "requirements.txt" EXCLUDE)
+  PATTERN "tox.ini" EXCLUDE
+  PATTERN "requirements*.txt" EXCLUDE
+  PATTERN "constraints*.txt" EXCLUDE
+  PATTERN "wheelhouse" EXCLUDE
+  REGEX "${CMAKE_CURRENT_SOURCE_DIR}/dashboard" EXCLUDE
+  )

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -1,126 +1,141 @@
-include(CMakeParseArguments)
-function(add_npm_command)
-  set(options NODEENV)
-  set(single_kw OUTPUT COMMENT WORKING_DIRECTORY)
-  set(multi_kw COMMAND DEPENDS)
-  cmake_parse_arguments(NC "${options}" "${single_kw}" "${multi_kw}" ${ARGN})
-  string(REPLACE ";" " " command "${NC_COMMAND}")
-  if(NC_NODEENV)
-    string(REGEX REPLACE "^(.*(npm|npx) .*)$" ". ${mgr-dashboard-nodeenv-dir}/bin/activate && \\1 && deactivate" command ${command})
+if(WITH_MGR_DASHBOARD_FRONTEND)
+  include(CMakeParseArguments)
+  function(add_npm_command)
+    set(options NODEENV)
+    set(single_kw OUTPUT COMMENT WORKING_DIRECTORY)
+    set(multi_kw COMMAND DEPENDS)
+    cmake_parse_arguments(NC "${options}" "${single_kw}" "${multi_kw}" ${ARGN})
+    string(REPLACE ";" " " command "${NC_COMMAND}")
+    if(NC_NODEENV)
+      string(REGEX REPLACE "^(.*(npm|npx) .*)$" ". ${mgr-dashboard-nodeenv-dir}/bin/activate && \\1 && deactivate" command ${command})
+    endif()
+    string(REPLACE " " ";" command "${command}")
+    add_custom_command(
+      OUTPUT "${NC_OUTPUT}"
+      COMMAND ${command}
+      DEPENDS ${NC_DEPENDS}
+      WORKING_DIRECTORY "${NC_WORKING_DIRECTORY}"
+      COMMENT ${NC_COMMENT})
+  endfunction(add_npm_command)
+
+  if(WITH_SYSTEM_NPM)
+    set(mgr-dashboard-nodeenv-dir )
+    set(nodeenv "")
+    add_custom_target(mgr-dashboard-frontend-deps
+      DEPENDS frontend/node_modules
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
+      )
+  else()
+    set(mgr-dashboard-nodeenv-dir ${CMAKE_CURRENT_BINARY_DIR}/node-env)
+    set(nodeenv NODEENV)
+
+    add_custom_command(
+      OUTPUT "${mgr-dashboard-nodeenv-dir}/bin/npm"
+      COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${MGR_PYTHON_EXECUTABLE} ${mgr-dashboard-nodeenv-dir}
+      COMMAND ${mgr-dashboard-nodeenv-dir}/bin/pip install nodeenv
+      COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv -p --node=10.18.1
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      COMMENT "dashboard nodeenv is being installed"
+      )
+    add_custom_target(mgr-dashboard-nodeenv
+      DEPENDS ${mgr-dashboard-nodeenv-dir}/bin/npm
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      )
+    add_custom_target(mgr-dashboard-frontend-deps
+      DEPENDS frontend/node_modules mgr-dashboard-nodeenv
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
+      )
   endif()
-  string(REPLACE " " ";" command "${command}")
-  add_custom_command(
-    OUTPUT "${NC_OUTPUT}"
-    COMMAND ${command}
-    DEPENDS ${NC_DEPENDS}
-    WORKING_DIRECTORY "${NC_WORKING_DIRECTORY}"
-    COMMENT ${NC_COMMENT})
-endfunction(add_npm_command)
 
-if(WITH_SYSTEM_NPM)
-  set(mgr-dashboard-nodeenv-dir )
-  set(nodeenv "")
-  add_custom_target(mgr-dashboard-frontend-deps
-    DEPENDS frontend/node_modules
+  add_npm_command(
+    OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/node_modules"
+    COMMAND NG_CLI_ANALYTICS=false npm ci
+    DEPENDS frontend/package.json
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
-  )
-else()
-  set(mgr-dashboard-nodeenv-dir ${CMAKE_CURRENT_BINARY_DIR}/node-env)
-  set(nodeenv NODEENV)
+    COMMENT "dashboard frontend dependencies are being installed"
+    ${nodeenv}
+    )
 
-  add_custom_command(
-    OUTPUT "${mgr-dashboard-nodeenv-dir}/bin/npm"
-    COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${MGR_PYTHON_EXECUTABLE} ${mgr-dashboard-nodeenv-dir}
-    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/pip install nodeenv
-    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv -p --node=10.18.1
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "dashboard nodeenv is being installed"
-  )
-  add_custom_target(mgr-dashboard-nodeenv
-    DEPENDS ${mgr-dashboard-nodeenv-dir}/bin/npm
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
-  add_custom_target(mgr-dashboard-frontend-deps
-    DEPENDS frontend/node_modules mgr-dashboard-nodeenv
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
-  )
-endif()
+  # Glob some frontend files. With CMake 3.6, this can be simplified
+  # to *.ts *.html. Just add:
+  # list(FILTER frontend_src INCLUDE REGEX "frontend/src")
+  file(
+    GLOB_RECURSE frontend_src
+    frontend/src/*.ts
+    frontend/src/*.html
+    frontend/src/*/*.ts
+    frontend/src/*/*.html
+    frontend/src/*/*/*.ts
+    frontend/src/*/*/*.html
+    frontend/src/*/*/*/*.ts
+    frontend/src/*/*/*/*.html
+    frontend/src/*/*/*/*/*.ts
+    frontend/src/*/*/*/*/*.html
+    frontend/src/*/*/*/*/*/*.ts
+    frontend/src/*/*/*/*/*/*.html)
 
-add_npm_command(
-  OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/node_modules"
-  COMMAND NG_CLI_ANALYTICS=false npm ci
-  DEPENDS frontend/package.json
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
-  COMMENT "dashboard frontend dependencies are being installed"
-  ${nodeenv}
-)
+  # these files are generated during build
+  list(REMOVE_ITEM frontend_src
+    ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/src/environments/environment.prod.ts
+    ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/src/environments/environment.ts)
 
-# Glob some frontend files. With CMake 3.6, this can be simplified
-# to *.ts *.html. Just add:
-# list(FILTER frontend_src INCLUDE REGEX "frontend/src")
-file(
-  GLOB_RECURSE frontend_src
-  frontend/src/*.ts
-  frontend/src/*.html
-  frontend/src/*/*.ts
-  frontend/src/*/*.html
-  frontend/src/*/*/*.ts
-  frontend/src/*/*/*.html
-  frontend/src/*/*/*/*.ts
-  frontend/src/*/*/*/*.html
-  frontend/src/*/*/*/*/*.ts
-  frontend/src/*/*/*/*/*.html
-  frontend/src/*/*/*/*/*/*.ts
-  frontend/src/*/*/*/*/*/*.html)
-
-# these files are generated during build
-list(REMOVE_ITEM frontend_src
-  ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/src/environments/environment.prod.ts
-  ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/src/environments/environment.ts)
-
-execute_process(
+  execute_process(
     COMMAND bash -c "jq -r .config.locale ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/package.json"
     OUTPUT_VARIABLE default_lang
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-if(DASHBOARD_FRONTEND_LANGS)
-  string(STRIP "${DASHBOARD_FRONTEND_LANGS}" DASHBOARD_FRONTEND_LANGS)
-  if(DASHBOARD_FRONTEND_LANGS STREQUAL "ALL")
-    set(build_target ":*")
-  else()
-    string(FIND "${DASHBOARD_FRONTEND_LANGS}" "${default_lang}" default_idx)
-    if (default_idx EQUAL -1)
-      # default language must be always built
-      string(CONCAT DASHBOARD_FRONTEND_LANGS "${DASHBOARD_FRONTEND_LANGS}" ",${default_lang}")
+  if(DASHBOARD_FRONTEND_LANGS)
+    string(STRIP "${DASHBOARD_FRONTEND_LANGS}" DASHBOARD_FRONTEND_LANGS)
+    if(DASHBOARD_FRONTEND_LANGS STREQUAL "ALL")
+      set(build_target ":*")
+    else()
+      string(FIND "${DASHBOARD_FRONTEND_LANGS}" "${default_lang}" default_idx)
+      if (default_idx EQUAL -1)
+        # default language must be always built
+        string(CONCAT DASHBOARD_FRONTEND_LANGS "${DASHBOARD_FRONTEND_LANGS}" ",${default_lang}")
+      endif()
+      set(build_target ":\{${DASHBOARD_FRONTEND_LANGS}\}")
     endif()
-    set(build_target ":\{${DASHBOARD_FRONTEND_LANGS}\}")
+  else(DASHBOARD_FRONTEND_LANGS)
+    set(build_target ":${default_lang}")
+  endif(DASHBOARD_FRONTEND_LANGS)
+
+  if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
+    set(npm_args "-- --prod --progress=false")
+  else()
+    set(npm_args "-- --progress=false")
   endif()
-else(DASHBOARD_FRONTEND_LANGS)
-  set(build_target ":${default_lang}")
-endif(DASHBOARD_FRONTEND_LANGS)
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(npm_args "-- --prod --progress=false")
-else()
-  set(npm_args "-- --progress=false")
+  add_npm_command(
+    OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/dist"
+    COMMAND npx npm-run-all --print-label --parallel --max-parallel 2 "\"build${build_target} -- ${npm_args}\""
+    DEPENDS ${frontend_src} frontend/node_modules
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
+    COMMENT "dashboard frontend is being created"
+    ${nodeenv}
+    )
+  add_custom_target(mgr-dashboard-frontend-build
+    ALL
+    DEPENDS frontend/dist mgr-dashboard-frontend-deps
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend)
+
+  add_dependencies(tests mgr-dashboard-frontend-build)
+
+  if(WITH_TESTS)
+    include(AddCephTest)
+    add_tox_test(mgr-dashboard TOX_ENVS lint check)
+  endif()
 endif()
 
-add_npm_command(
-  OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/dist"
-  COMMAND npx npm-run-all --print-label --parallel --max-parallel 2 "\"build${build_target} -- ${npm_args}\""
-  DEPENDS ${frontend_src} frontend/node_modules
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
-  COMMENT "dashboard frontend is being created"
-  ${nodeenv}
-)
-add_custom_target(mgr-dashboard-frontend-build
-  ALL
-  DEPENDS frontend/dist mgr-dashboard-frontend-deps
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend)
+install(CODE "execute_process(
+    COMMAND python3 setup.py install --skip-build --root ${CEPH_INSTALL_DATADIR}/mgr
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
 
-add_dependencies(tests mgr-dashboard-frontend-build)
-
-if(WITH_TESTS)
-  include(AddCephTest)
-  add_tox_test(mgr-dashboard TOX_ENVS lint check)
-endif()
+#install(DIRECTORY
+#  ${CMAKE_CURRENT_SOURCE_DIR}
+#  DESTINATION ${CEPH_INSTALL_DATADIR}/mgr
+#  FILES_MATCHING
+#  
+#  REGEX "/dashboard/(ci|tests|conftest.py)" INCLUDE
+##  REGEX "/dashboard/frontend/(coverage|e2e|node_modules|src)" EXCLUDE
+#)

--- a/src/pybind/mgr/dashboard/MANIFEST.in
+++ b/src/pybind/mgr/dashboard/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst
+include frontend/package.json
+recursive-include frontend/dist *

--- a/src/pybind/mgr/dashboard/setup.py
+++ b/src/pybind/mgr/dashboard/setup.py
@@ -1,0 +1,67 @@
+from setuptools import setup, find_packages
+from pkg_resources import normalize_path
+
+# https://packaging.python.org/guides/making-a-pypi-friendly-readme/
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name="Ceph-Dashboard",
+    version_format='{tag}.dev{commitcount}+{gitsha}',
+    url="https://ceph.io/",
+    description="ceph-mgr-dashboard is a manager module, providing a web-based application \
+        to monitor and manage many aspects of a Ceph cluster and related components. \
+        See the Dashboard documentation at http://docs.ceph.com/ for details and a \
+        detailed feature overview.",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author="Ceph-Dashboard Team",
+    author_email="dev@ceph.io",
+    project_urls={
+        "Bug Tracker": "https://tracker.ceph.com/projects/mgr/issues/",
+        "Documentation": "https://docs.ceph.com/docs/master/mgr/dashboard/",
+        "Source Code": "https://github.com/ceph/ceph/tree/master/src/pybind/mgr/dashboard",
+    },
+    platforms='any',
+    py_modules=[
+        '__init__',
+        'awsauth',
+        'cherrypy_backports',
+        'conftest',
+        'exceptions',
+        'grafana',
+        'module',
+        'rest_client',
+        'security',
+        'settings',
+        'setup',
+        'tools',
+    ],
+    packages=find_packages(exclude=['tests']),
+    #include_package_data=True,
+    package_data={
+        #'': ['*.pyc'],
+    },
+    data_files=[
+        #(),
+    ],
+    setup_requires=[
+        'setuptools-git-version',
+    ],
+    install_requires=[
+        "bcrypt",
+        "bcrypt",
+        "CherryPy",
+        "enum34; python_version<'3.4'",
+        "more-itertools",
+        "PyJWT",
+        "pyopenssl",
+        "python3-saml",
+        "requests",
+        "Routes",
+        "six",
+    ],
+    zip_safe=False
+)


### PR DESCRIPTION
Adds conditional building of the Dashboard Frontend in RPM specfile, and enables it in Ubuntu.

Fixes: https://tracker.ceph.com/issues/43005
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
