### PR TITLE
ceph-daemon: seek relative to the start of file

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1145,9 +1145,9 @@ def command_bootstrap():
         add_newline = False
         if os.path.exists(auth_keys_file):
             with open(auth_keys_file, 'r') as f:
-                f.seek(0, 2)
+                f.seek(0, os.SEEK_END)
                 if f.tell() > 0:
-                    f.seek(-1, 2)  # go to last character
+                    f.seek(f.tell()-1, os.SEEK_SET) # go to last char
                     if f.read() != '\n':
                         add_newline = True
         with open(auth_keys_file, 'a') as f:


### PR DESCRIPTION
python3 only allows seeks relative to the start of a text file

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
