### PR TITLE
nautilus: doc: mention --namespace option in rados manpage

### DIFF
--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -32,6 +32,10 @@ Options
    PG id to which the command will be directed. With this option, certain
    commands like ``ls`` allow users to limit the scope of the command to the given PG.
 
+.. option:: -N namespace, --namespace namespace
+
+   Specify the rados namespace to use for the object.
+
 .. option:: -s snap, --snap snap
 
    Read from the given pool snapshot. Valid for all pool-specific read operations.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43030

---

backport of https://github.com/ceph/ceph/pull/31871
parent tracker: https://tracker.ceph.com/issues/43021

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh