### PR TITLE
rbd: remove read only API of RBD open.

### DIFF
--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -224,13 +224,15 @@ public:
   void version(int *major, int *minor, int *extra);
 
   int open(IoCtx& io_ctx, Image& image, const char *name);
-  int open(IoCtx& io_ctx, Image& image, const char *name, const char *snapname);
+  int open(IoCtx& io_ctx, Image& image, const char *name, const char *snapname,
+           bool read_only =  false);
   int open_by_id(IoCtx& io_ctx, Image& image, const char *id);
-  int open_by_id(IoCtx& io_ctx, Image& image, const char *id, const char *snapname);
+  int open_by_id(IoCtx& io_ctx, Image& image, const char *id, const char *snapname,
+                 bool read_only =  false);
   int aio_open(IoCtx& io_ctx, Image& image, const char *name,
-	       const char *snapname, RBD::AioCompletion *c);
+	       const char *snapname, RBD::AioCompletion *c, bool read_only =  false);
   int aio_open_by_id(IoCtx& io_ctx, Image& image, const char *id,
-	             const char *snapname, RBD::AioCompletion *c);
+	             const char *snapname, RBD::AioCompletion *c, bool read_only =  false);
   // see librbd.h
   int open_read_only(IoCtx& io_ctx, Image& image, const char *name,
 		     const char *snapname);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -455,9 +455,9 @@ namespace librbd {
   }
 
   int RBD::open(IoCtx& io_ctx, Image& image, const char *name,
-		const char *snap_name)
+		const char *snap_name, bool read_only)
   {
-    ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, false);
+    ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, read_only);
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
@@ -478,9 +478,9 @@ namespace librbd {
   }
 
   int RBD::open_by_id(IoCtx& io_ctx, Image& image, const char *id,
-		      const char *snap_name)
+		      const char *snap_name, bool read_only)
   {
-    ImageCtx *ictx = new ImageCtx("", id, snap_name, io_ctx, false);
+    ImageCtx *ictx = new ImageCtx("", id, snap_name, io_ctx, read_only);
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, open_image_by_id_enter, ictx, ictx->id.c_str(),
                ictx->snap_name.c_str(), ictx->read_only);
@@ -502,9 +502,9 @@ namespace librbd {
   }
 
   int RBD::aio_open(IoCtx& io_ctx, Image& image, const char *name,
-		    const char *snap_name, RBD::AioCompletion *c)
+		    const char *snap_name, RBD::AioCompletion *c, bool read_only)
   {
-    ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, false);
+    ImageCtx *ictx = new ImageCtx(name, "", snap_name, io_ctx, read_only);
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only, c->pc);
 
@@ -520,9 +520,9 @@ namespace librbd {
   }
 
   int RBD::aio_open_by_id(IoCtx& io_ctx, Image& image, const char *id,
-		          const char *snap_name, RBD::AioCompletion *c)
+		          const char *snap_name, RBD::AioCompletion *c, bool read_only)
   {
-    ImageCtx *ictx = new ImageCtx("", id, snap_name, io_ctx, false);
+    ImageCtx *ictx = new ImageCtx("", id, snap_name, io_ctx, read_only);
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, aio_open_image_by_id_enter, ictx, ictx->id.c_str(),
                ictx->snap_name.c_str(), ictx->read_only, c->pc);


### PR DESCRIPTION
     there is no need to implement specific API for read only.
     just add an 'read_only' parameter to reuse the RBD open API.

Signed-off-by: Gangbiao Liu <liugangbiao@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
