### PR TITLE
doc: missing virtualenv for build-doc

### DIFF
--- a/doc_deps.deb.txt
+++ b/doc_deps.deb.txt
@@ -3,6 +3,7 @@ gcc
 python3-dev
 python3-pip
 python3-virtualenv
+virtualenv
 doxygen
 ditaa
 libxml2-dev


### PR DESCRIPTION
The install deps command recommended by admin/build-doc doesn't install virtualenv which is required by admin/build-doc.

After manually installing virtualenv, admin/build-doc runned without issues.

Didn't create a issue in Ceph's tracker as my Tracker's user hasn't been approved yet.

Signed-off-by: Rodrigo Severo <rodrigo@fabricadeideias.com>
