### PR TITLE
doc: obsolete entries for allow_standby_replay

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -2,17 +2,6 @@
  MDS Config Reference
 ======================
 
-``mon force standby active`` 
-
-:Description: If ``true`` monitors force standby-replay to be active. Set
-              under ``[mon]`` or ``[global]``.
-
-:Type: Boolean
-:Default: ``true``
-:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
-
-.. deprecated:: 14.2.0
-
 ``mds cache memory limit``
 
 :Description: The memory limit the MDS should enforce for its cache.
@@ -541,40 +530,6 @@
               
 :Type:  32-bit Integer
 :Default: ``0``
-
-
-``mds standby for name``
-
-:Description: An MDS daemon will standby for another MDS daemon of the name 
-              specified in this setting.
-
-:Type:  String
-:Default: N/A
-:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
-
-.. deprecated:: 14.2.0
-
-
-``mds standby for rank``
-
-:Description: An MDS daemon will standby for an MDS daemon of this rank. 
-:Type:  32-bit Integer
-:Default: ``-1``
-:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
-
-.. deprecated:: 14.2.0
-
-
-``mds standby replay``
-
-:Description: Determines whether a ``ceph-mds`` daemon should poll and replay 
-              the log of an active MDS (hot standby).
-              
-:Type:  Boolean
-:Default:  ``false``
-:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
-
-.. deprecated:: 14.2.0
 
 
 ``mds min caps per client``

--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -8,7 +8,10 @@
               under ``[mon]`` or ``[global]``.
 
 :Type: Boolean
-:Default: ``true`` 
+:Default: ``true``
+:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
+
+.. deprecated:: 14.2.0
 
 ``mds cache memory limit``
 
@@ -547,6 +550,9 @@
 
 :Type:  String
 :Default: N/A
+:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
+
+.. deprecated:: 14.2.0
 
 
 ``mds standby for rank``
@@ -554,6 +560,9 @@
 :Description: An MDS daemon will standby for an MDS daemon of this rank. 
 :Type:  32-bit Integer
 :Default: ``-1``
+:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
+
+.. deprecated:: 14.2.0
 
 
 ``mds standby replay``
@@ -563,6 +572,9 @@
               
 :Type:  Boolean
 :Default:  ``false``
+:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
+
+.. deprecated:: 14.2.0
 
 
 ``mds min caps per client``


### PR DESCRIPTION
Nautilus release presented the allow_standby_replay fs setting that obsoleted
several MDS config entries:  mds_standby_for_*, mon_force_standby_active, and
mds_standby_replay.

I didn't create a ticket on tracker.ceph.com because me user haven't been approved yet.

Signed-off-by: Rodrigo Severo <rodrigo@fabricadeideias.com>
