### PR TITLE
os/bluestore: don't round_up_to in apply_for_bitset_range.

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -837,8 +837,8 @@ int BlueFS::_replay(bool noop, bool to_stdout)
   if (cct->_conf->bluefs_log_replay_check_allocations) {
     for (size_t i = 0; i < MAX_BDEV; ++i) {
       if (alloc_size[i] != 0 && bdev[i] != nullptr) {
-        used_blocks[i].resize(bdev[i]->get_size() / alloc_size[i]);
-        owned_blocks[i].resize(bdev[i]->get_size() / alloc_size[i]);
+        used_blocks[i].resize(round_up_to(bdev[i]->get_size(), alloc_size[i]) / alloc_size[i]);
+        owned_blocks[i].resize(round_up_to(bdev[i]->get_size(), alloc_size[i]) / alloc_size[i]);
       }
     }
   }


### PR DESCRIPTION
I met the following error messages:
>sceph7: /home/Jianpeng/ceph/src/os/bluestore/bluestore_common.h: In function 'void apply_for_bitset_range(uint64_t, uint64_t, uint64_t, Bitset&, Func) [with Bitset = boost::dynamic_bitset<long unsigned int>; Func = BlueFS::_replay(bool, bool)::<lambda(uint64_t, boost::dynamic_bitset<long unsigned int>&)>; uint64_t = long unsigned int]' thread 7f7d55a3dd40 time 2019-11-27T23:26:05.949827+0800
>sceph7: /home/Jianpeng/ceph/src/os/bluestore/bluestore_common.h: 28: FAILED ceph_assert(end <= bitset.size())
>sceph7:  ceph version 15.0.0-7747-g22a9a28e28 (22a9a28e2859718c4168f5b3cf6e20a9186e18bc) octopus (dev)
>sceph7:  1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x14f) [0x56322c4440ef]
>sceph7:  2: (()+0x50d2d9) [0x56322c4442d9]
>sceph7:  3: (BlueFS::_replay(bool, bool)+0x5639) [0x56322cb51e49]
>sceph7:  4: (BlueFS::mount()+0x269) [0x56322cb53289]
>sceph7:  5: (BlueStore::_open_bluefs(bool)+0x29e) [0x56322ca6e38e]
>sceph7:  6: (BlueStore::_open_db(bool, bool, bool)+0x59b) [0x56322ca6e9cb]
>sceph7:  7: (BlueStore::mkfs()+0x749) [0x56322caaa259]
>sceph7:  8: (OSD::mkfs(CephContext*, ObjectStore*, uuid_d, int)+0x1c8) [0x56322c5099e8]
>sceph7:  9: (main()+0x1787) [0x56322c4ab117]
>sceph7:  10: (__libc_start_main()+0xeb) [0x7f7d55b5fb6b]
>sceph7:  11: (_start()+0x2a) [0x56322c4de71a]
>sceph7: *** Caught signal (Aborted) **
>sceph7:  in thread 7f7d55a3dd40 thread_name:ceph-osd

If bdev[i]->get_size() / alloc_size[i] != 0,
round_up_to(off+lengh,alloc_size[i])/alloc_size is larger than(one)
ownend_blocks[i].size().

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
