### PR TITLE
crimson: stop osd before stopping messengers

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -174,9 +174,6 @@ int main(int argc, char* argv[])
           reference_wrapper<crimson::net::Messenger>(hb_front_msgr.local()),
           reference_wrapper<crimson::net::Messenger>(hb_back_msgr.local())).get();
         seastar::engine().at_exit([&] {
-          return osd.stop();
-        });
-        seastar::engine().at_exit([&] {
           return seastar::when_all_succeed(cluster_msgr.stop(),
                                            client_msgr.stop(),
                                            hb_front_msgr.stop(),
@@ -194,6 +191,9 @@ int main(int argc, char* argv[])
 	    local_conf().get_val<uuid_d>("osd_uuid"),
 	    local_conf().get_val<uuid_d>("fsid")).get();
         }
+        seastar::engine().at_exit([&] {
+          return osd.stop();
+        });
         if (config.count("mkkey") || config.count("mkfs")) {
           seastar::engine().exit(0);
         } else {


### PR DESCRIPTION
so we can drain all pending tasks referencing messenger before
destroying it, otherwise they will be using a already-stopped
messenger when they are still alive.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
