### PR TITLE
mgr/dashboard: fix tests in order to match pg num conventions

### DIFF
--- a/qa/tasks/mgr/dashboard/test_ganesha.py
+++ b/qa/tasks/mgr/dashboard/test_ganesha.py
@@ -27,7 +27,7 @@ class GaneshaTest(DashboardTestCase):
     @classmethod
     def setUpClass(cls):
         super(GaneshaTest, cls).setUpClass()
-        cls.create_pool('ganesha', 3, 'replicated')
+        cls.create_pool('ganesha', 2**2, 'replicated')
         cls._rados_cmd(['-p', 'ganesha', '-N', 'ganesha1', 'create', 'conf-node1'])
         cls._rados_cmd(['-p', 'ganesha', '-N', 'ganesha1', 'create', 'conf-node2'])
         cls._rados_cmd(['-p', 'ganesha', '-N', 'ganesha1', 'create', 'conf-node3'])

--- a/qa/tasks/mgr/dashboard/test_rbd_mirroring.py
+++ b/qa/tasks/mgr/dashboard/test_rbd_mirroring.py
@@ -13,7 +13,7 @@ class RbdMirroringTest(DashboardTestCase):
     def create_pool(cls, name, application='rbd'):
         data = {
             'pool': name,
-            'pg_num': 10,
+            'pg_num': 2**3,
             'pool_type': 'replicated',
             'application_metadata': [application]
         }


### PR DESCRIPTION
Update the tests test_ganesha and test_rbd_mirroring in order to match the PG num conventions. It prevents the health warning 'POOL_PG_NUM_NOT_POWER_OF_TWO' from being shown.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
