### PR TITLE
ceph-daemon: consolidate NamedTemporaryFile logic

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1354,6 +1354,7 @@ def command_ceph_volume():
     if args.fsid:
         make_log_dir(args.fsid)
 
+    (uid, gid) = extract_uid_gid()
     mounts = get_container_mounts(args.fsid, 'osd', None)
 
     tmp_config = None
@@ -1367,12 +1368,14 @@ def command_ceph_volume():
         # tmp keyring file
         tmp_keyring = tempfile.NamedTemporaryFile(mode='w')
         os.fchmod(tmp_keyring.fileno(), 0o600)
+        os.fchown(tmp_keyring.fileno(), uid, gid)
         tmp_keyring.write(keyring)
         tmp_keyring.flush()
 
         # tmp config file
         tmp_config = tempfile.NamedTemporaryFile(mode='w')
         os.fchmod(tmp_config.fileno(), 0o600)
+        os.fchown(tmp_keyring.fileno(), uid, gid)
         tmp_config.write(config)
         tmp_config.flush()
 

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -240,6 +240,16 @@ def infer_fsid(func):
         return func()
     return _infer_fsid
 
+def write_tmp(s, uid, gid, mode=0o600):
+    tmp_f = tempfile.NamedTemporaryFile(mode='w',
+                                        prefix='ceph-tmp')
+    os.fchmod(tmp_f.fileno(), mode)
+    os.fchown(tmp_f.fileno(), uid, gid)
+    tmp_f.write(s)
+    tmp_f.flush()
+
+    return tmp_f
+
 def makedirs(dir, uid, gid, mode):
     # type: (str, int, int, int) -> None
     if not os.path.exists(dir):
@@ -564,18 +574,10 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
     if daemon_type == 'mon' and not os.path.exists(get_data_dir(fsid, 'mon',
                                                                 daemon_id)):
         # tmp keyring file
-        tmp_keyring = tempfile.NamedTemporaryFile(mode='w')
-        os.fchmod(tmp_keyring.fileno(), 0o600)
-        os.fchown(tmp_keyring.fileno(), uid, gid)
-        tmp_keyring.write(keyring)
-        tmp_keyring.flush()
+        tmp_keyring = write_tmp(keyring, uid, gid)
 
         # tmp config file
-        tmp_config = tempfile.NamedTemporaryFile(mode='w')
-        os.fchmod(tmp_config.fileno(), 0o600)
-        os.fchown(tmp_config.fileno(), uid, gid)
-        tmp_config.write(config)
-        tmp_config.flush()
+        tmp_config = write_tmp(config, uid, gid)
 
         # --mkfs
         create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid)
@@ -1007,16 +1009,11 @@ def command_bootstrap():
                % (mon_key, admin_key, mgr_id, mgr_key, hostname, crash_key))
 
     # tmp keyring file
-    tmp_bootstrap_keyring = tempfile.NamedTemporaryFile(mode='w')
-    os.fchmod(tmp_bootstrap_keyring.fileno(), 0o600)
-    os.fchown(tmp_bootstrap_keyring.fileno(), uid, gid)
-    tmp_bootstrap_keyring.write(keyring)
-    tmp_bootstrap_keyring.flush()
+    tmp_bootstrap_keyring = write_tmp(keyring, uid, gid)
 
     # create initial monmap, tmp monmap file
     logger.info('Creating initial monmap...')
-    tmp_monmap = tempfile.NamedTemporaryFile(mode='w')
-    os.fchmod(tmp_monmap.fileno(), 0o644)
+    tmp_monmap = write_tmp('', uid, gid, mode=0o644)
     out = CephContainer(
         image=args.image,
         entrypoint='/usr/bin/monmaptool',
@@ -1063,18 +1060,10 @@ def command_bootstrap():
     deploy_daemon_units(fsid, uid, gid, 'mon', mon_id, mon_c)
 
     # client.admin key + config to issue various CLI commands
-    tmp_admin_keyring = tempfile.NamedTemporaryFile(mode='w')
-    os.fchmod(tmp_admin_keyring.fileno(), 0o600)
-    os.fchown(tmp_admin_keyring.fileno(), uid, gid)
-    tmp_admin_keyring.write('[client.admin]\n'
-                      '\tkey = ' + admin_key + '\n')
-    tmp_admin_keyring.flush()
-
-    tmp_config = tempfile.NamedTemporaryFile(mode='w')
-    os.fchmod(tmp_config.fileno(), 0o600)
-    os.fchown(tmp_config.fileno(), uid, gid)
-    tmp_config.write(config)
-    tmp_config.flush()
+    tmp_admin_keyring = write_tmp('[client.admin]\n'
+                                  '\tkey = ' + admin_key + '\n',
+                                       uid, gid)
+    tmp_config = write_tmp(config, uid, gid)
 
     # a CLI helper to reduce our typing
     def cli(cmd, extra_mounts={}):
@@ -1366,18 +1355,10 @@ def command_ceph_volume():
         (config, keyring) = get_config_and_keyring()
 
         # tmp keyring file
-        tmp_keyring = tempfile.NamedTemporaryFile(mode='w')
-        os.fchmod(tmp_keyring.fileno(), 0o600)
-        os.fchown(tmp_keyring.fileno(), uid, gid)
-        tmp_keyring.write(keyring)
-        tmp_keyring.flush()
+        tmp_keyring = write_tmp(keyring, uid, gid)
 
         # tmp config file
-        tmp_config = tempfile.NamedTemporaryFile(mode='w')
-        os.fchmod(tmp_config.fileno(), 0o600)
-        os.fchown(tmp_keyring.fileno(), uid, gid)
-        tmp_config.write(config)
-        tmp_config.flush()
+        tmp_config = write_tmp(config, uid, gid)
 
         mounts[tmp_config.name] = '/etc/ceph/ceph.conf:z'
         mounts[tmp_keyring.name] = '/var/lib/ceph/bootstrap-osd/ceph.keyring:z'

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -240,10 +240,9 @@ def infer_fsid(func):
         return func()
     return _infer_fsid
 
-def write_tmp(s, uid, gid, mode=0o600):
+def write_tmp(s, uid, gid):
     tmp_f = tempfile.NamedTemporaryFile(mode='w',
                                         prefix='ceph-tmp')
-    os.fchmod(tmp_f.fileno(), mode)
     os.fchown(tmp_f.fileno(), uid, gid)
     tmp_f.write(s)
     tmp_f.flush()
@@ -1013,7 +1012,7 @@ def command_bootstrap():
 
     # create initial monmap, tmp monmap file
     logger.info('Creating initial monmap...')
-    tmp_monmap = write_tmp('', uid, gid, mode=0o644)
+    tmp_monmap = write_tmp('', uid, gid)
     out = CephContainer(
         image=args.image,
         entrypoint='/usr/bin/monmaptool',

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1342,7 +1342,7 @@ def command_ceph_volume():
     if args.fsid:
         make_log_dir(args.fsid)
 
-    (uid, gid) = extract_uid_gid()
+    (uid, gid) = (0, 0) # ceph-volume runs as root
     mounts = get_container_mounts(args.fsid, 'osd', None)
 
     tmp_config = None


### PR DESCRIPTION
Adds missing chown of the uid/gid for `ceph-volume` temp files as well as consolidates the logic for creating a `NamedTemporaryFile`.

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
