### PR TITLE
ceph-daemon: Allow env var for setting the used image

### DIFF
--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -76,7 +76,7 @@ function expect_false()
 }
 
 ## version + --image
-$SUDO $CEPH_DAEMON --image $IMAGE_NAUTILUS version \
+$SUDO CEPH_DAEMON_IMAGE=$IMAGE_NAUTILUS $CEPH_DAEMON version \
     | grep 'ceph version 14'
 $SUDO $CEPH_DAEMON --image $IMAGE_MIMIC version \
     | grep 'ceph version 13'

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1623,8 +1623,9 @@ def _get_parser():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         '--image',
-        default=DEFAULT_IMAGE,
-        help='container image')
+        default=os.environ.get('CEPH_DAEMON_IMAGE', DEFAULT_IMAGE),
+        help='container image. Can also be set via the "CEPH_DAEMON_IMAGE" '
+        'env var')
     parser.add_argument(
         '--docker',
         action='store_true',

--- a/src/ceph-daemon/tests/test_ceph_daemon.py
+++ b/src/ceph-daemon/tests/test_ceph_daemon.py
@@ -1,5 +1,7 @@
 import imp
 import unittest
+import mock
+import os
 
 
 cd = imp.load_source("ceph-daemon", "ceph-daemon")
@@ -8,3 +10,14 @@ cd = imp.load_source("ceph-daemon", "ceph-daemon")
 class TestCephDaemon(unittest.TestCase):
     def test_is_fsid(self):
         self.assertFalse(cd.is_fsid('no-uuid'))
+
+    def test__get_parser_image(self):
+        p = cd._get_parser()
+        args = p.parse_args(['--image', 'foo', 'version'])
+        assert args.image == 'foo'
+
+    @mock.patch.dict(os.environ,{'CEPH_DAEMON_IMAGE':'bar'})
+    def test__get_parser_image_with_envvar(self):
+        p = cd._get_parser()
+        args = p.parse_args(['version'])
+        assert args.image == 'bar'

--- a/src/ceph-daemon/tox.ini
+++ b/src/ceph-daemon/tox.ini
@@ -4,7 +4,9 @@ envlist = py27, py3, mypy
 [testenv]
 skipsdist=true
 skip_install=true
-deps = pytest
+deps =
+  pytest
+  mock
 commands=pytest {posargs}
 
 [testenv:mypy]


### PR DESCRIPTION
Instead of always adding "--image my-custom-image" when calling
ceph-daemon with a non-standard image, allow to set the environment
variable called CEPH_DAEMON_IMAGE which will adjust the --image
default.
That way, the command line arguments when using ceph-daemon with a
custom image are a bit shorter.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>