### PR TITLE
mgr/orchestrator: set node labels to empty list if none specified

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -1296,6 +1296,8 @@ class InventoryNode(object):
         # type: (str, inventory.Devices, List[str]) -> None
         if devices is None:
             devices = inventory.Devices([])
+        if labels is None:
+            labels = []
         assert isinstance(devices, inventory.Devices)
 
         self.name = name  # unique within cluster.  For example a hostname.


### PR DESCRIPTION
f06366836ff tries to ' '.join(node.labels), which raises an exception
if labels is None, so we need to default it to an empty list.

Signed-off-by: Tim Serong <tserong@suse.com>