### PR TITLE
crimson/common/errorator.h: simplify the compound safe_then() variant.

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -521,17 +521,15 @@ private:
     // taking ErrorFuncOne and ErrorFuncTwo separately from ErrorFuncTail
     // to avoid SFINAE
     template <class ValueFunc,
-              class ErrorFuncOne,
-              class ErrorFuncTwo,
+              class ErrorFuncHead,
               class... ErrorFuncTail>
     auto safe_then(ValueFunc&& value_func,
-                   ErrorFuncOne&& error_func_one,
-                   ErrorFuncTwo&& error_func_two,
+                   ErrorFuncHead&& error_func_head,
                    ErrorFuncTail&&... error_func_tail) {
+      static_assert(sizeof...(ErrorFuncTail) > 0);
       return safe_then(
         std::forward<ValueFunc>(value_func),
-        composer(std::forward<ErrorFuncOne>(error_func_one),
-                 std::forward<ErrorFuncTwo>(error_func_two),
+        composer(std::forward<ErrorFuncHead>(error_func_head),
                  std::forward<ErrorFuncTail>(error_func_tail)...));
     }
 


### PR DESCRIPTION

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
