### PR TITLE
mgr/dashboard: Add a sheet to display the supplementary informationen to a datatable item

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
@@ -1,3 +1,11 @@
+<div *ngIf="selection.hasSingleSelection"
+     class="bar">
+  <span>Details of <strong>{{ selection.first().pool_name }}</strong></span>
+  <button type="button" class="close" aria-label="Close" (click)="closeSheet()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+
 <tabset #tabsetChild
         cdTableDetail
         *ngIf="selection.hasSingleSelection">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.ts
@@ -9,6 +9,7 @@ import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { RbdConfigurationEntry } from '../../../shared/models/configuration';
 import { Permissions } from '../../../shared/models/permissions';
+import { TableComponent } from "../../../shared/datatable/table/table.component";
 
 @Component({
   selector: 'cd-pool-details',
@@ -18,6 +19,8 @@ import { Permissions } from '../../../shared/models/permissions';
 export class PoolDetailsComponent implements OnChanges {
   cacheTierColumns: Array<CdTableColumn> = [];
 
+  @Input()
+  table: TableComponent;
   @Input()
   selection: CdTableSelection;
   @Input()
@@ -73,5 +76,10 @@ export class PoolDetailsComponent implements OnChanges {
 
   filterNonPoolData(pool: object): object {
     return _.omit(pool, ['cdExecuting', 'cdIsBinary']);
+  }
+
+  closeSheet() {
+    this.selection.clear(); // Clear local selection
+    this.table.selection.clear(); // Clear selection in table
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
@@ -19,6 +19,7 @@
       </cd-table-actions>
       <cd-pool-details cdTableDetail
                        id="pool-list-details"
+                       [table]="table"
                        [selection]="selection"
                        [permissions]="permissions"
                        [cacheTiers]="selectionCacheTiers">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
@@ -19,6 +19,8 @@
       </cd-table-actions>
       <cd-pool-details cdTableDetail
                        id="pool-list-details"
+                       class="sheets right"
+                       [ngClass]="{'active': selection.hasSingleSelection}"
                        [table]="table"
                        [selection]="selection"
                        [permissions]="permissions"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-selection.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-selection.ts
@@ -25,4 +25,12 @@ export class CdTableSelection {
   first() {
     return this.hasSelection ? this.selected[0] : null;
   }
+
+  /**
+   * Clear the selection of the object
+   */
+  clear() {
+    this.selected = [];
+    this.update();
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -1,5 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 @import 'defaults';
+@import 'sheets';
 
 // Fork-Awesome
 $fa-font-path: '~fork-awesome/fonts';

--- a/src/pybind/mgr/dashboard/frontend/src/styles/sheets.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/sheets.scss
@@ -1,0 +1,37 @@
+@mixin left-right {
+  top: 0;
+  width: 80%;
+  padding: 1em 3em;
+  overflow-y: scroll;
+  height: 100%;
+  max-height: 100%;
+}
+
+.ng-sidebar__content {
+  overflow-x: hidden !important;
+}
+
+.sheets {
+  position: absolute;
+  background: white;
+  z-index: 100;
+
+  &.right {
+    @include left-right;
+    border-left: 1px solid $color-light-gray;
+    left: 100%;
+    transition: 0.5s ease-in-out;
+
+    &.active {
+      left: 20%;
+      transition: 0.5s ease-in-out;
+    }
+  }
+
+  .bar {
+    width: 100%;
+    border-bottom: 1px solid $color-light-gray;
+    padding-bottom: 1em;
+    margin-bottom: 1em;
+  }
+}


### PR DESCRIPTION
As mentioned in the stand up, this will be a draft pull request.

The idea behind this pr was to move the supplementary information, of a datatable item, from below the datatable to a side sheet. This seemed very trivial for me and except one issue it was. The user should be able to close the dialog by clicking on a button. You can test the current implementation at the pools page. 

So selecting a pool will open the side sheet. In the top right corner the user will find the button to close the dialog and removing the selection. And here it becomes tricky. We don't have a single selection instance where we can clear the selection but we have at least three or more. Let me explain:

The pool list creates an instance of the [CdTableSelection](https://github.com/ceph/ceph/blob/master/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts#L52) and also the [CdTable](https://github.com/ceph/ceph/blob/master/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts#L146). This means we already have two independent object of the CdTableSelection and to make it even more complicated we also clone the object in the [CdTable](https://github.com/ceph/ceph/blob/master/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts#L484). The Problem with the clone is that it is just a shallow-copy, that means that the attribute `selected ` will always point to the same reference as the original object. I created a [code snippet](https://codepen.io/Exotelis/pen/JjoPopo) that demonstrates the problem. This can also cause strange behaviour.

In my first implementation I realised, that it is not enough to update the CdTableSelection in the PoolDetails component. And this make sense, because there is no event fired that informs the parent component (PoolList) that the selection changed. What I did was adding an event and it worked, well at least for 5 seconds because then the selection got updated from another component (CdTable) and the sheet was active again. 

In the current implementation I also bind the table to the cd-pool-list where I can also update the selection object of the table when the close button is clicked.

```javascript
closeSheet() {
    this.selection.clear(); // Clear local selection
    this.table.selection.clear(); // Clear selection in table
}
```

Now it's working. I guess I'd also have to add the event again to update the pool-list, because when closing the panel it takes a while until the footer of the datatable is updated where `1 selected / x total` is printed.

But I'm not a fan of my own implementation. I still don't like the fact to have multiple selection object. Using a service might be an idea but I'd like to ask you if you have any other and maybe better ideas.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
