### PR TITLE
rgw/pubsub: fix records/event json format to match documentation

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -318,3 +318,10 @@
   or manually without ceph-volume and LVM.  Going forward, the OSD
   will limit itself to only 'hdd' and 'ssd' (or whatever device class the user
   manually specifies).
+
+* RGW: a mismatch between the bucket notification documentation and the actual
+  message format was fixed. This means that any endpoints receiving bucket 
+  notification, will now receive the same notifications inside an JSON array
+  named 'Records'. Note that this does not affect pulling bucket notification
+  from a subscription in a 'pubsub' zone, as these are already wrapped inside
+  that array.

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -273,7 +273,7 @@ pushed or pulled using the pubsub sync module.
                    "eTag":"",
                    "versionId":"",
                    "sequencer": "",
-                   "metadata":""
+                   "metadata":[]
                }
            },
            "eventId":"",
@@ -298,7 +298,7 @@ pushed or pulled using the pubsub sync module.
 - s3.object.version: object version in case of versioned bucket
 - s3.object.sequencer: monotonically increasing identifier of the change per object (hexadecimal format)
 - s3.object.metadata: any metadata set on the object sent as: ``x-amz-meta-`` (an extension to the S3 notification API) 
-- s3.eventId: not supported (an extension to the S3 notification API)
+- s3.eventId: unique ID of the event, that could be used for acking (an extension to the S3 notification API)
 
 .. _PubSub Module : ../pubsub-module
 .. _S3 Notification Compatibility: ../s3-notification-compatibility

--- a/doc/radosgw/pubsub-module.rst
+++ b/doc/radosgw/pubsub-module.rst
@@ -474,7 +474,7 @@ the events will have an S3-compatible record format (JSON):
                    "eTag":"",
                    "versionId":"",
                    "sequencer":"",
-                   "metadata":""
+                   "metadata":[]
                }
            },
            "eventId":"",
@@ -488,7 +488,6 @@ the events will have an S3-compatible record format (JSON):
 - requestParameters: not supported
 - responseElements: not supported
 - s3.configurationId: notification ID that created the subscription for the event
-- s3.eventId: unique ID of the event, that could be used for acking (an extension to the S3 notification API)
 - s3.bucket.name: name of the bucket
 - s3.bucket.ownerIdentity.principalId: owner of the bucket
 - s3.bucket.arn: ARN of the bucket

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -15,6 +15,14 @@
 
 #define dout_subsys ceph_subsys_rgw
 
+void set_event_id(std::string& id, const std::string& hash, const utime_t& ts) {
+  char buf[64];
+  const auto len = snprintf(buf, sizeof(buf), "%010ld.%06ld.%s", (long)ts.sec(), (long)ts.usec(), hash.c_str());
+  if (len > 0) {
+    id.assign(buf, len);
+  }
+}
+
 bool rgw_s3_key_filter::decode_xml(XMLObj* obj) {
   XMLObjIter iter = obj->find("FilterRule");
   XMLObj *o;

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -738,7 +738,7 @@ void RGWUserPubSub::SubWithEvents<EventType>::list_events_result::dump(Formatter
 
   Formatter::ArraySection s(*f, EventType::json_type_plural);
   for (auto& event : events) {
-    encode_json(EventType::json_type_single, event, f);
+    encode_json("", event, f);
   }
 }
 

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -108,7 +108,7 @@ class rgw_pubsub_topic_filter;
           <Name></Name>
           <Value></Value>
         </FilterRule>
-      </s3Metadata>
+      </S3Metadata>
     </Filter>
     <Id>notification1</Id>
     <Topic>arn:aws:sns:<region>:<account>:<topic></Topic>
@@ -195,17 +195,16 @@ struct rgw_pubsub_s3_notifications {
 
 struct rgw_pubsub_s3_record {
   constexpr static const char* const json_type_plural = "Records";
-  // 2.2
-  std::string eventVersion;
+  std::string eventVersion = "2.2";
   // aws:s3
-  std::string eventSource;
+  std::string eventSource = "ceph:s3";
   // zonegroup
   std::string awsRegion;
   // time of the request
   ceph::real_time eventTime;
   // type of the event
   std::string eventName;
-  // user that sent the requet (not implemented)
+  // user that sent the request
   std::string userIdentity;
   // IP address of source of the request (not implemented)
   std::string sourceIPAddress;
@@ -213,20 +212,19 @@ struct rgw_pubsub_s3_record {
   std::string x_amz_request_id;
   // radosgw that received the request
   std::string x_amz_id_2;
-  // 1.0
-  std::string s3SchemaVersion;
+  std::string s3SchemaVersion = "1.0";
   // ID received in the notification request
   std::string configurationId;
   // bucket name
   std::string bucket_name;
-  // bucket owner (not implemented)
+  // bucket owner
   std::string bucket_ownerIdentity;
   // bucket ARN
   std::string bucket_arn;
   // object key
   std::string object_key;
-  // object size (not implemented)
-  uint64_t object_size;
+  // object size
+  uint64_t object_size = 0;
   // object etag
   std::string object_etag;
   // object version id bucket is versioned
@@ -235,7 +233,7 @@ struct rgw_pubsub_s3_record {
   std::string object_sequencer;
   // this is an rgw extension (not S3 standard)
   // used to store a globally unique identifier of the event
-  // that could be used for acking
+  // that could be used for acking or any other identification of the event
   std::string id;
   // this is an rgw extension holding the internal bucket id
   std::string bucket_id;
@@ -333,6 +331,9 @@ struct rgw_pubsub_event {
   void dump(Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_pubsub_event)
+
+// settign a unique ID for an event/record based on object hash and timestamp
+void set_event_id(std::string& id, const std::string& hash, const utime_t& ts);
 
 struct rgw_pubsub_sub_dest {
   std::string bucket_name;

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -194,9 +194,8 @@ struct rgw_pubsub_s3_notifications {
 }*/
 
 struct rgw_pubsub_s3_record {
-  constexpr static const char* const json_type_single = "Record";
   constexpr static const char* const json_type_plural = "Records";
-  // 2.1
+  // 2.2
   std::string eventVersion;
   // aws:s3
   std::string eventSource;
@@ -304,7 +303,6 @@ struct rgw_pubsub_s3_record {
 WRITE_CLASS_ENCODER(rgw_pubsub_s3_record)
 
 struct rgw_pubsub_event {
-  constexpr static const char* const json_type_single = "event";
   constexpr static const char* const json_type_plural = "events";
   std::string id;
   std::string event_name;

--- a/src/rgw/rgw_pubsub_push.cc
+++ b/src/rgw/rgw_pubsub_push.cc
@@ -29,7 +29,13 @@ template<typename EventType>
 std::string json_format_pubsub_event(const EventType& event) {
   std::stringstream ss;
   JSONFormatter f(false);
-  encode_json(EventType::json_type_single, event, &f);
+  {
+    Formatter::ObjectSection s(f, EventType::json_type_plural);
+    {
+      Formatter::ArraySection s(f, EventType::json_type_plural);
+      encode_json("", event, &f);
+    }
+  }
   f.flush(ss);
   return ss.str();
 }

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -484,7 +484,7 @@ public:
   PSEvent(const EventRef<EventType>& _event) : event(_event) {}
 
   void format(bufferlist *bl) const {
-    bl->append(json_str(EventType::json_type_single, *event));
+    bl->append(json_str("", *event));
   }
 
   void encode_event(bufferlist& bl) const {

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -387,14 +387,6 @@ struct objstore_event {
   }
 };
 
-static void set_event_id(std::string& id, const std::string& hash, const utime_t& ts) {
-  char buf[64];
-  const auto len = snprintf(buf, sizeof(buf), "%010ld.%06ld.%s", (long)ts.sec(), (long)ts.usec(), hash.c_str());
-  if (len > 0) {
-    id.assign(buf, len);
-  }
-}
-
 static void make_event_ref(CephContext *cct, const rgw_bucket& bucket,
                        const rgw_obj_key& key,
                        const ceph::real_time& mtime,
@@ -426,22 +418,18 @@ static void make_s3_record_ref(CephContext *cct, const rgw_bucket& bucket,
   *record = std::make_shared<rgw_pubsub_s3_record>();
 
   EventRef<rgw_pubsub_s3_record>& r = *record;
-  r->eventVersion = "2.1";
-  r->eventSource = "aws:s3";
   r->eventTime = mtime;
   r->eventName = rgw::notify::to_string(event_type);
-  r->userIdentity = "";         // user that triggered the change: not supported in sync module
-  r->sourceIPAddress = "";      // IP address of client that triggered the change: not supported in sync module
-  r->x_amz_request_id = "";     // request ID of the original change: not supported in sync module
-  r->x_amz_id_2 = "";           // RGW on which the change was made: not supported in sync module
-  r->s3SchemaVersion = "1.0";
+  // userIdentity: not supported in sync module
+  // x_amz_request_id: not supported in sync module
+  // x_amz_id_2: not supported in sync module
   // configurationId is filled from subscription configuration
   r->bucket_name = bucket.name;
   r->bucket_ownerIdentity = owner.to_str();
   r->bucket_arn = to_string(rgw::ARN(bucket));
   r->bucket_id = bucket.bucket_id; // rgw extension
   r->object_key = key.name;
-  r->object_size = 0;           // not supported in sync module
+  // object_size not supported in sync module
   objstore_event oevent(bucket, key, mtime, attrs);
   r->object_etag = oevent.get_hash();
   r->object_versionId = key.instance;
@@ -451,8 +439,6 @@ static void make_s3_record_ref(CephContext *cct, const rgw_bucket& bucket,
   boost::algorithm::hex((const char*)&ts, (const char*)&ts + sizeof(utime_t), 
           std::back_inserter(r->object_sequencer));
  
-  // event ID is rgw extension (not in the S3 spec), used for acking the event
-  // same format is used in both S3 compliant and Ceph specific events
   set_event_id(r->id, r->object_etag, ts);
 }
 

--- a/src/test/rgw/rgw_multi/tests_ps.py
+++ b/src/test/rgw/rgw_multi/tests_ps.py
@@ -28,7 +28,7 @@ from nose.tools import assert_not_equal, assert_equal
 # configure logging for the tests module
 log = logging.getLogger(__name__)
 
-skip_push_tests = False
+skip_push_tests = True
 
 ####################################
 # utility functions for pubsub tests
@@ -247,15 +247,30 @@ def verify_events_by_elements(events, keys, exact_match=False, deletions=False):
     err = ''
     for key in keys:
         key_found = False
-        for event in events:
-            if event['info']['bucket']['name'] == key.bucket.name and \
-                event['info']['key']['name'] == key.name:
-                if deletions and event['event'] == 'OBJECT_DELETE':
-                    key_found = True
+        if type(events) is list:
+            for event_list in events: 
+                if key_found:
                     break
-                elif not deletions and event['event'] == 'OBJECT_CREATE':
-                    key_found = True
-                    break
+                for event in event_list['events']:
+                    if event['info']['bucket']['name'] == key.bucket.name and \
+                        event['info']['key']['name'] == key.name:
+                        if deletions and event['event'] == 'OBJECT_DELETE':
+                            key_found = True
+                            break
+                        elif not deletions and event['event'] == 'OBJECT_CREATE':
+                            key_found = True
+                            break
+        else:
+            for event in events['events']:
+                if event['info']['bucket']['name'] == key.bucket.name and \
+                    event['info']['key']['name'] == key.name:
+                    if deletions and event['event'] == 'OBJECT_DELETE':
+                        key_found = True
+                        break
+                    elif not deletions and event['event'] == 'OBJECT_CREATE':
+                        key_found = True
+                        break
+
         if not key_found:
             err = 'no ' + ('deletion' if deletions else 'creation') + ' event found for key: ' + str(key)
             log.error(events)
@@ -274,27 +289,44 @@ def verify_s3_records_by_elements(records, keys, exact_match=False, deletions=Fa
     err = ''
     for key in keys:
         key_found = False
-        for record in records:
-            if record['s3']['bucket']['name'] == key.bucket.name and \
-                record['s3']['object']['key'] == key.name:
-                if deletions and 'ObjectRemoved' in record['eventName']:
-                    key_found = True
+        if type(records) is list:
+            for record_list in records:
+                if key_found:
                     break
-                elif not deletions and 'ObjectCreated' in record['eventName']:
-                    key_found = True
-                    break
+                for record in record_list['Records']:
+                    if record['s3']['bucket']['name'] == key.bucket.name and \
+                        record['s3']['object']['key'] == key.name:
+                        if deletions and 'ObjectRemoved' in record['eventName']:
+                            key_found = True
+                            break
+                        elif not deletions and 'ObjectCreated' in record['eventName']:
+                            key_found = True
+                            break
+        else:
+            for record in records['Records']:
+                if record['s3']['bucket']['name'] == key.bucket.name and \
+                    record['s3']['object']['key'] == key.name:
+                    if deletions and 'ObjectRemoved' in record['eventName']:
+                        key_found = True
+                        break
+                    elif not deletions and 'ObjectCreated' in record['eventName']:
+                        key_found = True
+                        break
+
         if not key_found:
             err = 'no ' + ('deletion' if deletions else 'creation') + ' event found for key: ' + str(key)
-            for record in records:
-                log.error(str(record['s3']['bucket']['name']) + ',' + str(record['s3']['object']['key']))
+            for record_list in records:
+                for record in record_list['Records']:
+                    log.error(str(record['s3']['bucket']['name']) + ',' + str(record['s3']['object']['key']))
             assert False, err
 
     if not len(records) == len(keys):
         err = 'superfluous records are found'
         log.warning(err)
         if exact_match:
-            for record in records:
-                log.error(str(record['s3']['bucket']['name']) + ',' + str(record['s3']['object']['key']))
+            for record_list in records:
+                for record in record_list['Records']:
+                    log.error(str(record['s3']['bucket']['name']) + ',' + str(record['s3']['object']['key']))
             assert False, err
 
 
@@ -654,12 +686,12 @@ def test_ps_s3_notification_records():
 
     # get the events from the subscription
     result, _ = sub_conf.get_events()
-    parsed_result = json.loads(result)
-    for record in parsed_result['Records']:
+    records = json.loads(result)
+    for record in records['Records']:
         log.debug(record)
     keys = list(bucket.list())
     # TODO: use exact match
-    verify_s3_records_by_elements(parsed_result['Records'], keys, exact_match=False)
+    verify_s3_records_by_elements(records, keys, exact_match=False)
 
     # cleanup
     _, status = s3_notification_conf.del_config()
@@ -1021,8 +1053,8 @@ def ps_s3_notification_filter(on_master):
     found_in4 = []
 
     for event in receiver.get_and_reset_events():
-        notif_id = event['s3']['configurationId']
-        key_name = event['s3']['object']['key']
+        notif_id = event['Records'][0]['s3']['configurationId']
+        key_name = event['Records'][0]['s3']['object']['key']
         if notif_id == notification_name+'_1':
             found_in1.append(key_name)
         elif notif_id == notification_name+'_2':
@@ -1721,12 +1753,12 @@ def test_ps_subscription():
 
     # get the create events from the subscription
     result, _ = sub_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event: objname: "' + str(event['info']['key']['name']) + '" type: "' + str(event['event']) + '"')
     keys = list(bucket.list())
     # TODO: use exact match
-    verify_events_by_elements(parsed_result['events'], keys, exact_match=False)
+    verify_events_by_elements(events, keys, exact_match=False)
     # delete objects from the bucket
     for key in bucket.list():
         key.delete()
@@ -1736,11 +1768,11 @@ def test_ps_subscription():
 
     # get the delete events from the subscriptions
     result, _ = sub_conf.get_events()
-    for event in parsed_result['events']:
+    for event in events['events']:
         log.debug('Event: objname: "' + str(event['info']['key']['name']) + '" type: "' + str(event['event']) + '"')
     # TODO: check deletions
     # TODO: use exact match
-    # verify_events_by_elements(parsed_result['events'], keys, exact_match=False, deletions=True)
+    # verify_events_by_elements(events, keys, exact_match=False, deletions=True)
     # we should see the creations as well as the deletions
     # delete subscription
     _, status = sub_conf.del_config()
@@ -1819,28 +1851,28 @@ def test_ps_event_type_subscription():
 
     # get the events from the creation subscription
     result, _ = sub_create_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event (OBJECT_CREATE): objname: "' + str(event['info']['key']['name']) +
                   '" type: "' + str(event['event']) + '"')
     keys = list(bucket.list())
     # TODO: use exact match
-    verify_events_by_elements(parsed_result['events'], keys, exact_match=False)
+    verify_events_by_elements(events, keys, exact_match=False)
     # get the events from the deletions subscription
     result, _ = sub_delete_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event (OBJECT_DELETE): objname: "' + str(event['info']['key']['name']) +
                   '" type: "' + str(event['event']) + '"')
-    assert_equal(len(parsed_result['events']), 0)
+    assert_equal(len(events['events']), 0)
     # get the events from the all events subscription
     result, _ = sub_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event (OBJECT_CREATE,OBJECT_DELETE): objname: "' +
                   str(event['info']['key']['name']) + '" type: "' + str(event['event']) + '"')
     # TODO: use exact match
-    verify_events_by_elements(parsed_result['events'], keys, exact_match=False)
+    verify_events_by_elements(events, keys, exact_match=False)
     # delete objects from the bucket
     for key in bucket.list():
         key.delete()
@@ -1850,32 +1882,32 @@ def test_ps_event_type_subscription():
 
     # get the events from the creations subscription
     result, _ = sub_create_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event (OBJECT_CREATE): objname: "' + str(event['info']['key']['name']) +
                   '" type: "' + str(event['event']) + '"')
     # deletions should not change the creation events
     # TODO: use exact match
-    verify_events_by_elements(parsed_result['events'], keys, exact_match=False)
+    verify_events_by_elements(events, keys, exact_match=False)
     # get the events from the deletions subscription
     result, _ = sub_delete_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event (OBJECT_DELETE): objname: "' + str(event['info']['key']['name']) +
                   '" type: "' + str(event['event']) + '"')
     # only deletions should be listed here
     # TODO: use exact match
-    verify_events_by_elements(parsed_result['events'], keys, exact_match=False, deletions=True)
+    verify_events_by_elements(events, keys, exact_match=False, deletions=True)
     # get the events from the all events subscription
     result, _ = sub_create_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event (OBJECT_CREATE,OBJECT_DELETE): objname: "' + str(event['info']['key']['name']) +
                   '" type: "' + str(event['event']) + '"')
     # both deletions and creations should be here
     # TODO: use exact match
-    verify_events_by_elements(parsed_result['events'], keys, exact_match=False, deletions=False)
-    # verify_events_by_elements(parsed_result['events'], keys, exact_match=False, deletions=True)
+    verify_events_by_elements(events, keys, exact_match=False, deletions=False)
+    # verify_events_by_elements(events, keys, exact_match=False, deletions=True)
     # TODO: (1) test deletions (2) test overall number of events
 
     # test subscription deletion when topic is specified
@@ -1933,18 +1965,17 @@ def test_ps_event_fetching():
     while True:
         # get the events from the subscription
         result, _ = sub_conf.get_events(max_events, next_marker)
-        parsed_result = json.loads(result)
-        events = parsed_result['events']
-        total_events_count += len(events)
-        all_events.extend(events)
-        next_marker = parsed_result['next_marker']
-        for event in events:
+        events = json.loads(result)
+        total_events_count += len(events['events'])
+        all_events.extend(events['events'])
+        next_marker = events['next_marker']
+        for event in events['events']:
             log.debug('Event: objname: "' + str(event['info']['key']['name']) + '" type: "' + str(event['event']) + '"')
         if next_marker == '':
             break
     keys = list(bucket.list())
     # TODO: use exact match
-    verify_events_by_elements(all_events, keys, exact_match=False)
+    verify_events_by_elements({'events': all_events}, keys, exact_match=False)
 
     # cleanup
     sub_conf.del_config()
@@ -1988,17 +2019,16 @@ def test_ps_event_acking():
 
     # get the create events from the subscription
     result, _ = sub_conf.get_events()
-    parsed_result = json.loads(result)
-    events = parsed_result['events']
+    events = json.loads(result)
     original_number_of_events = len(events)
-    for event in events:
+    for event in events['events']:
         log.debug('Event (before ack)  id: "' + str(event['id']) + '"')
     keys = list(bucket.list())
     # TODO: use exact match
     verify_events_by_elements(events, keys, exact_match=False)
     # ack half of the  events
     events_to_ack = number_of_objects/2
-    for event in events:
+    for event in events['events']:
         if events_to_ack == 0:
             break
         _, status = sub_conf.ack_events(event['id'])
@@ -2007,10 +2037,10 @@ def test_ps_event_acking():
 
     # verify that acked events are gone
     result, _ = sub_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event (after ack) id: "' + str(event['id']) + '"')
-    assert len(parsed_result['events']) >= (original_number_of_events - number_of_objects/2)
+    assert len(events) >= (original_number_of_events - number_of_objects/2)
 
     # cleanup
     sub_conf.del_config()
@@ -2063,12 +2093,12 @@ def test_ps_creation_triggers():
 
     # get the create events from the subscription
     result, _ = sub_conf.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event key: "' + str(event['info']['key']['name']) + '" type: "' + str(event['event']) + '"')
 
     # TODO: verify the specific 3 keys: 'put', 'copy' and 'multipart'
-    assert len(parsed_result['events']) >= 3
+    assert len(events['events']) >= 3
     # cleanup
     sub_conf.del_config()
     notification_conf.del_config()
@@ -2219,13 +2249,13 @@ def test_ps_s3_multipart_on_master():
 
     events = receiver2.get_and_reset_events()
     assert_equal(len(events), 1)
-    assert_equal(events[0]['eventName'], 's3:ObjectCreated:Post')
-    assert_equal(events[0]['s3']['configurationId'], notification_name+'_2')
+    assert_equal(events[0]['Records'][0]['eventName'], 's3:ObjectCreated:Post')
+    assert_equal(events[0]['Records'][0]['s3']['configurationId'], notification_name+'_2')
 
     events = receiver3.get_and_reset_events()
     assert_equal(len(events), 1)
-    assert_equal(events[0]['eventName'], 's3:ObjectCreated:CompleteMultipartUpload')
-    assert_equal(events[0]['s3']['configurationId'], notification_name+'_3')
+    assert_equal(events[0]['Records'][0]['eventName'], 's3:ObjectCreated:CompleteMultipartUpload')
+    assert_equal(events[0]['Records'][0]['s3']['configurationId'], notification_name+'_3')
 
     # cleanup
     stop_amqp_receiver(receiver1, task1)
@@ -2310,14 +2340,14 @@ def test_ps_versioned_deletion():
 
     # get the delete events from the subscription
     result, _ = sub_conf1.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event key: "' + str(event['info']['key']['name']) + '" type: "' + str(event['event']) + '"')
         assert_equal(str(event['event']), event_type1)
 
     result, _ = sub_conf2.get_events()
-    parsed_result = json.loads(result)
-    for event in parsed_result['events']:
+    events = json.loads(result)
+    for event in events['events']:
         log.debug('Event key: "' + str(event['info']['key']['name']) + '" type: "' + str(event['event']) + '"')
         assert_equal(str(event['event']), event_type2)
 
@@ -2465,13 +2495,14 @@ def test_ps_s3_versioned_deletion_on_master():
     events = receiver.get_and_reset_events()
     delete_events = 0
     delete_marker_create_events = 0
-    for event in events:
-        if event['eventName'] == 's3:ObjectRemoved:Delete':
-            delete_events += 1
-            assert event['s3']['configurationId'] in [notification_name+'_1', notification_name+'_3']
-        if event['eventName'] == 's3:ObjectRemoved:DeleteMarkerCreated':
-            delete_marker_create_events += 1
-            assert event['s3']['configurationId'] in [notification_name+'_1', notification_name+'_2']
+    for event_list in events:
+        for event in event_list['Records']:
+            if event['eventName'] == 's3:ObjectRemoved:Delete':
+                delete_events += 1
+                assert event['s3']['configurationId'] in [notification_name+'_1', notification_name+'_3']
+            if event['eventName'] == 's3:ObjectRemoved:DeleteMarkerCreated':
+                delete_marker_create_events += 1
+                assert event['s3']['configurationId'] in [notification_name+'_1', notification_name+'_2']
    
     # 3 key versions were deleted (v1, v2 and the deletion marker)
     # notified over the same topic via 2 notifications (1,3)
@@ -2799,9 +2830,9 @@ def test_ps_delete_bucket():
     sub_conf = PSSubscription(ps_zones[0].conn, notification_name,
                               topic_name)
     result, _ = sub_conf.get_events()
-    parsed_result = json.loads(result)
+    records = json.loads(result)
     # TODO: use exact match
-    verify_s3_records_by_elements(parsed_result['Records'], keys, exact_match=False)
+    verify_s3_records_by_elements(records, keys, exact_match=False)
 
     # s3 notification is deleted with bucket
     _, status = s3_notification_conf.get_config(notification=notification_name)
@@ -3150,12 +3181,12 @@ def test_ps_s3_multiple_topics_notification():
 
     # get the events from both of the subscription
     result, _ = sub_conf1.get_events()
-    parsed_result = json.loads(result)
-    for record in parsed_result['Records']:
+    records = json.loads(result)
+    for record in records['Records']:
         log.debug(record)
     keys = list(bucket.list())
     # TODO: use exact match
-    verify_s3_records_by_elements(parsed_result['Records'], keys, exact_match=False)
+    verify_s3_records_by_elements(records, keys, exact_match=False)
     receiver.verify_s3_events(keys, exact_match=False)
 
     result, _ = sub_conf2.get_events()
@@ -3164,7 +3195,7 @@ def test_ps_s3_multiple_topics_notification():
         log.debug(record)
     keys = list(bucket.list())
     # TODO: use exact match
-    verify_s3_records_by_elements(parsed_result['Records'], keys, exact_match=False)
+    verify_s3_records_by_elements(records, keys, exact_match=False)
     http_server.verify_s3_events(keys, exact_match=False)
 
     # cleanup


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

Fixes: https://tracker.ceph.com/issues/43056

Currently events and records has a "wrapping JSON object" (e.g. "events" or "Records") when they are pulled from Ceph, but don't have it when they are pushed to an endpoint.
According to our own documentation as well as the AWS documentation for bucket notifications, the format should be the same.
More details are in the tracker issue.

This PR also add eventId support in push mode (separate commit). This may be needed in the receiving systems if they need to uniquely identify the event (even in the case of where acking is needed or possible). 
E.g. knative require an event ID as a mandatory input.