### PR TITLE
mgr/dashboard: adapt to create_osds parameters change

### DIFF
--- a/qa/tasks/mgr/dashboard/test_orchestrator.py
+++ b/qa/tasks/mgr/dashboard/test_orchestrator.py
@@ -52,11 +52,12 @@ test_data = {
 
 class OrchestratorControllerTest(DashboardTestCase):
 
-    AUTH_ROLES = ['read-only']
+    AUTH_ROLES = ['cluster-manager']
 
     URL_STATUS = '/api/orchestrator/status'
     URL_INVENTORY = '/api/orchestrator/inventory'
     URL_SERVICE = '/api/orchestrator/service'
+    URL_OSD = '/api/orchestrator/osd'
 
 
     @property
@@ -154,3 +155,33 @@ class OrchestratorControllerTest(DashboardTestCase):
         resp_services = sorted(data, key=sorting_key)
         for test, resp in zip(test_services, resp_services):
             self._validate_service(test, resp)
+
+    def test_create_osds(self):
+        data = {
+            'drive_group': {
+                'host_pattern': '*',
+                'data_devices': {
+                    'vendor': 'abc',
+                    'model': 'cba',
+                    'rotational': True,
+                    'size': '4 TB'
+                },
+                'wal_devices': {
+                    'vendor': 'def',
+                    'model': 'fed',
+                    'rotational': False,
+                    'size': '1 TB'
+                },
+                'db_devices': {
+                    'vendor': 'ghi',
+                    'model': 'ihg',
+                    'rotational': False,
+                    'size': '512 GB'
+                },
+                'wal_slots': 5,
+                'db_slots': 5,
+                'encrypted': True
+            }
+        }
+        self._post(self.URL_OSD, data)
+        self.assertStatus(201)

--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -102,9 +102,9 @@ class OrchestratorService(RESTController):
 class OrchestratorOsd(RESTController):
 
     @raise_if_no_orchestrator
-    def create(self, drive_group, all_hosts=None):
+    def create(self, drive_group):
         orch = OrchClient.instance()
         try:
-            orch.osds.create(DriveGroupSpec.from_json(drive_group), all_hosts)
+            orch.osds.create(DriveGroupSpec.from_json(drive_group))
         except (ValueError, TypeError, DriveGroupValidationError) as e:
             raise DashboardException(e, component='osd')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-creation-preview-modal/osd-creation-preview-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-creation-preview-modal/osd-creation-preview-modal.component.ts
@@ -17,9 +17,6 @@ export class OsdCreationPreviewModalComponent implements OnInit {
   @Input()
   driveGroup: DriveGroup;
 
-  @Input()
-  allHosts: string[];
-
   @Output()
   submitAction = new EventEmitter();
 
@@ -43,7 +40,7 @@ export class OsdCreationPreviewModalComponent implements OnInit {
   }
 
   onSubmit() {
-    this.orchService.osdCreate(this.driveGroup.spec, this.allHosts).subscribe(
+    this.orchService.osdCreate(this.driveGroup.spec).subscribe(
       undefined,
       () => {
         this.formGroup.setErrors({ cdSubmitButton: true });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -223,17 +223,9 @@ export class OsdFormComponent implements OnInit {
   }
 
   submit() {
-    let allHosts = [];
-    if (this.hostname === '') {
-      // wildcard * to match all hosts, provide hosts we can see
-      allHosts = _.sortedUniq(_.map(this.allDevices, 'hostname').sort());
-    } else {
-      allHosts = [this.hostname];
-    }
     const options: ModalOptions = {
       initialState: {
-        driveGroup: this.driveGroup,
-        allHosts: allHosts
+        driveGroup: this.driveGroup
       }
     };
     const modalRef = this.bsModalService.show(OsdCreationPreviewModalComponent, options);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.spec.ts
@@ -62,10 +62,9 @@ describe('OrchestratorService', () => {
     const data = {
       drive_group: {
         host_pattern: '*'
-      },
-      all_hosts: ['a', 'b']
+      }
     };
-    service.osdCreate(data['drive_group'], data['all_hosts']).subscribe();
+    service.osdCreate(data['drive_group']).subscribe();
     const req = httpTesting.expectOne(service.osdURL);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(data);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
@@ -49,13 +49,10 @@ export class OrchestratorService {
     return this.http.get(this.serviceURL, options);
   }
 
-  osdCreate(driveGroup: {}, all_hosts: string[]) {
+  osdCreate(driveGroup: {}) {
     const request = {
       drive_group: driveGroup
     };
-    if (!_.isEmpty(all_hosts)) {
-      request['all_hosts'] = all_hosts;
-    }
     return this.http.post(this.osdURL, request, { observe: 'response' });
   }
 }

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -89,8 +89,8 @@ class ServiceManager(ResourceManager):
 class OsdManager(ResourceManager):
 
     @wait_api_result
-    def create(self, drive_group, all_hosts=None):
-        return self.api.create_osds(drive_group, all_hosts)
+    def create(self, drive_group):
+        return self.api.create_osds(drive_group)
 
 
 class OrchClient(object):


### PR DESCRIPTION
Parameters of `create_osds` are changed after PR:
https://github.com/ceph/ceph/pull/30262.
Adapt dashboard backend to the change. Also a new test for creating OSDs
is added in backend QA.

Fixes: https://tracker.ceph.com/issues/43074
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
