### PR TITLE
mgr/orchestrator: add optional "format" param for "orchestrator host ls"

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -144,8 +144,10 @@ class TestOrchestratorCli(MgrTestCase):
         self._orch_cmd("nfs", "rm", "service_name")
 
     def test_host_ls(self):
-        out = self._orch_cmd("host", "ls")
-        self.assertEqual(out, "localhost\n")
+        out = self._orch_cmd("host", "ls", "--format=json")
+        hosts = json.loads(out)
+        self.assertEqual(len(hosts), 1)
+        self.assertEqual(hosts[0]["host"], "localhost")
 
     def test_host_add(self):
         self._orch_cmd("host", "add", "hostname")

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -166,20 +166,27 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @orchestrator._cli_read_command(
         'orchestrator host ls',
-        desc='List hosts')
-    def _get_hosts(self):
+        'name=format,type=CephChoices,strings=json|plain,req=false',
+        'List hosts')
+    def _get_hosts(self, format='plain'):
         completion = self.get_hosts()
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
-        table = PrettyTable(
-            ['HOST', 'LABELS'],
-            border=False)
-        table.align = 'l'
-        table.left_padding_width = 0
-        table.right_padding_width = 1
-        for node in completion.result:
-            table.add_row((node.name, ' '.join(node.labels)))
-        return HandleCommandResult(stdout=table.get_string())
+        if format == 'json':
+            hosts = [dict(host=node.name, labels=node.labels)
+                     for node in completion.result]
+            output = json.dumps(hosts)
+        else:
+            table = PrettyTable(
+                ['HOST', 'LABELS'],
+                border=False)
+            table.align = 'l'
+            table.left_padding_width = 0
+            table.right_padding_width = 1
+            for node in completion.result:
+                table.add_row((node.name, ' '.join(node.labels)))
+            output = table.get_string()
+        return HandleCommandResult(stdout=output)
 
     @orchestrator._cli_write_command(
         'orchestrator host label add',


### PR DESCRIPTION
and update the test accordingly

Fixes: https://tracker.ceph.com/issues/43078
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
