### PR TITLE
mgr/ssh: `test_mon_update` needs to set a mon name

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -33,6 +33,8 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+HostSpec = namedtuple('HostSpec', ['hostname', 'network', 'name'])
+
 
 def parse_host_specs(host, require_network=True):
     """
@@ -55,8 +57,6 @@ def parse_host_specs(host, require_network=True):
     # Matches from = to end of string
     name_re = r'=(.*?)$'
 
-    from collections import namedtuple
-    HostSpec = namedtuple('HostSpec', ['hostname', 'network', 'name'])
     # assign defaults
     host_spec = HostSpec('', '', '')
 
@@ -899,7 +899,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def update_mons(self, num, hosts):
-        # type: (int, List[Tuple[str,str,str]]) -> Completion
+        # type: (int, List[HostSpec]) -> Completion
         """
         Update the number of cluster monitors.
 

--- a/src/pybind/mgr/ssh/tests/test_ssh.py
+++ b/src/pybind/mgr/ssh/tests/test_ssh.py
@@ -85,8 +85,8 @@ class TestSSH(object):
     @mock.patch("ssh.module.SSHOrchestrator._get_connection")
     def test_mon_update(self, _send_command, _get_connection, ssh_module):
         with self._with_host(ssh_module, 'test'):
-            c = ssh_module.update_mons(1, [parse_host_specs('test:0.0.0.0')])
-            assert self._wait(ssh_module, c) == ["(Re)deployed mon.test on host 'test'"]
+            c = ssh_module.update_mons(1, [parse_host_specs('test:0.0.0.0=a')])
+            assert self._wait(ssh_module, c) == ["(Re)deployed mon.a on host 'test'"]
 
     @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
     @mock.patch("ssh.module.SSHOrchestrator.send_command")


### PR DESCRIPTION
... in order to exercise a code path to make use of `_get_services()`

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
