### PR TITLE
luminous: rpm: explicitly declare python-tox build dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -111,6 +111,7 @@ BuildRequires:	python-numpy-devel
 %endif
 BuildRequires:  python-coverage
 BuildRequires:	python-pecan
+BuildRequires:	python-tox
 BuildRequires:	socat
 %endif
 BuildRequires:	bc


### PR DESCRIPTION
"make check" needs python-tox to run, but until 71ac2163831ffd764bf3da6a3efa76ef02e5e884
("ceph.spec: added dashboard_v2 development and runtime dependencies")
this was not explicitly declared in the spec file. It does not make sense to
backport that commit to luminous, though, because the dashboard itself was never
backported to luminous.

Fixes: https://tracker.ceph.com/issues/43082
Signed-off-by: Nathan Cutler <ncutler@suse.com>
