### PR TITLE
mds: check if oldin is null before accessing its member

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7683,7 +7683,7 @@ void Server::handle_client_rename(MDRequestRef& mdr)
   if (srcdnl->is_remote() && !srci->is_auth())
     witnesses.insert(srci->authority().first);
   destdn->list_replicas(witnesses);
-  if (destdnl->is_remote() && !oldin->is_auth())
+  if (destdnl->is_remote() && oldin && !oldin->is_auth())
     witnesses.insert(oldin->authority().first);
   dout(10) << " witnesses " << witnesses << ", have " << mdr->more()->witnessed << dendl;
 
@@ -7733,7 +7733,7 @@ void Server::handle_client_rename(MDRequestRef& mdr)
     // is traversed.
     if (srcdnl->is_remote())
       lov.add_xlock(&srci->get_projected_parent_dn()->lock);
-    if (destdnl->is_remote())
+    if (destdnl->is_remote() && oldin)
       lov.add_xlock(&oldin->get_projected_parent_dn()->lock);
   }
 


### PR DESCRIPTION


Signed-off-by: Shen Hang <harryshen18@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
