### PR TITLE
mgr/dashboard: Use badges for counters in tabs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
@@ -5,9 +5,11 @@
     <cd-cephfs-detail [data]="details">
     </cd-cephfs-detail>
   </tab>
-  <tab i18n-heading
-       (selectTab)="softRefresh()"
-       heading="Clients: {{ clients.data.length }}">
+  <tab (selectTab)="softRefresh()">
+    <ng-template tabHeading>
+      <ng-container i18n>Clients</ng-container>
+      <span class="badge badge-pill badge-tab ml-1">{{ clients.data.length }}</span>
+    </ng-template>
     <cd-cephfs-clients [id]="id"
                        [clients]="clients"
                        (triggerApiUpdate)="refresh()">

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -442,3 +442,7 @@ bfv-messages {
   color: $color-solid-white;
   background-color: $color-blue;
 }
+.badge-tab {
+  color: $color-solid-gray;
+  background-color: $color-light-shade-gray;
+}


### PR DESCRIPTION
Improve the way we are displaying "counters" in tabs, by using badges.

Before
---
![Screenshot from 2019-12-02 12-42-39](https://user-images.githubusercontent.com/14297426/69963975-4da88480-1509-11ea-9732-24d15b4ebcf6.png)

After
---
![Screenshot from 2019-12-02 13-36-26](https://user-images.githubusercontent.com/14297426/69963968-4aad9400-1509-11ea-870b-3130eb8861ec.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
