### PR TITLE
mgr/ssh: Port raising exceptions from completion handlers to Py2

### DIFF
--- a/src/pybind/mgr/ssh/tests/test_completion.py
+++ b/src/pybind/mgr/ssh/tests/test_completion.py
@@ -160,7 +160,6 @@ class TestCompletion(object):
         self._wait(ssh_module, c)
         assert c.result == "['2', '3']"
 
-    @pytest.mark.skipif(sys.version_info < (3,0), reason="requires python3")
     def test_raise(self, ssh_module):
         @async_completion
         def run(x):


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Mainly for finding a problem in `test_service_ls`. But still useful to have in general.

from https://jenkins.ceph.com/job/ceph-pull-requests/39516/console : 

```
___________________________ TestSSH.test_service_ls ____________________________

self = <ssh.tests.test_ssh.TestSSH object at 0x7fcdac47c650>
ssh_module = <ssh.module.SSHOrchestrator object at 0x7fcdac480650>

    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
    def test_service_ls(self, ssh_module):
        with self._with_host(ssh_module, 'test'):
            c = ssh_module.describe_service()
>           assert self._wait(ssh_module, c) == []

ssh/tests/test_ssh.py:74: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ssh.tests.test_ssh.TestSSH object at 0x7fcdac47c650>
m = <ssh.module.SSHOrchestrator object at 0x7fcdac480650>
c = <class 'ssh.module.AsyncCompletion'>(_s=1, val=NA, _on_c=<function run at 0x7fcdac392578>, id=140521334508624, name=_get_services_result, pr=NA, _next=None)

    def _wait(self, m, c):
        # type: (SSHOrchestrator, Completion) -> Any
        m.process([c])
        m.process([c])
    
        for _ in range(30):
            if c.is_finished:
                raise_if_exception(c)
                return c.result
            time.sleep(0.1)
>       assert False, "timeout" + str(c._state)
E       AssertionError: timeout1
E       assert False

ssh/tests/test_ssh.py:48: AssertionError
------------------------------ Captured log setup ------------------------------
DEBUG    ssh:module.py:311  mgr option ssh_config_file = <MagicMock name='mock()' id='140521334819344'>
DEBUG    ssh:module.py:311  mgr option inventory_cache_timeout = <MagicMock name='mock()' id='140521334819344'>
DEBUG    ssh:module.py:311  mgr option service_cache_timeout = <MagicMock name='mock()' id='140521334819344'>
DEBUG    ssh:module.py:311  mgr option mode = <MagicMock name='mock()' id='140521334819344'>
INFO     ssh:module.py:386 ssh_options ['-F', '/tmp/ceph-mgr-ssh-conf-Dm4XWA']
DEBUG    ssh:module.py:269 Loaded inventory {}
------------------------------ Captured log call -------------------------------
INFO     ssh:module.py:412 process: completions=<AsyncCompletion>[
       add_host((<ssh.module.SSHOrchestrator object at 0x7fcdac480650>, 'test')),
]
INFO     ssh:module.py:412 process: completions=<AsyncCompletion>[
   >>> add_host((<ssh.module.SSHOrchestrator object at 0x7fcdac480650>, 'test')),
]
INFO     ssh:module.py:708 refresing stale services for 'test'
INFO     ssh:module.py:412 process: completions=<AsyncCompletion>[
       _refresh_host_services([('test',)]),
       _get_services_result(...),
]
INFO     ssh:module.py:412 process: completions=<AsyncCompletion>[
   >>> _refresh_host_services([('test',)]),
       _get_services_result(...),
]
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
