### PR TITLE
python-common: move pytest integration from setup.py to tox.ini

### DIFF
--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -1,1 +1,6 @@
 six
+pytest >=2.1.3,<5; python_version < '3.5'
+mock; python_version < '3.3'
+mypy; python_version >= '3'
+pytest-mypy; python_version >= '3'
+pytest >= 2.1.3; python_version >= '3'

--- a/src/python-common/setup.cfg
+++ b/src/python-common/setup.cfg
@@ -1,5 +1,0 @@
-[tool:pytest]
-addopts = -vv --log-cli-level=DEBUG
-
-[aliases]
-test=pytest

--- a/src/python-common/setup.py
+++ b/src/python-common/setup.py
@@ -1,35 +1,8 @@
-import sys
-
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
-
-
-if sys.version_info >= (3,0):
-    mypy = ['mypy', 'pytest-mypy']
-    pytest = ['pytest >=2.1.3']
-else:
-    mypy = []
-    pytest = ['pytest >=2.1.3,<5', 'mock']
 
 
 with open("README.rst", "r") as fh:
     long_description = fh.read()
-
-
-class PyTest(TestCommand):
-    user_options = [('addopts=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.addopts = []
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        args = self.addopts.split() if isinstance(self.addopts, str) else self.addopts
-        errno = pytest.main(args)
-        sys.exit(errno)
 
 
 setup(
@@ -44,14 +17,9 @@ setup(
     keywords='ceph',
     url="https://github.com/ceph/ceph",
     zip_safe = False,
-    cmdclass={'pytest': PyTest},
     install_requires=(
         'six',
     ),
-    tests_require=[
-        'tox',
-        'pyyaml'
-    ] + mypy + pytest,
     classifiers = [
         'Intended Audience :: Developer',
         'Operating System :: POSIX :: Linux',

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -2,14 +2,15 @@
 envlist = py27, py3, lint
 skip_missing_interpreters = true
 
-[testenv]
-deps=-rrequirements.txt
-
 [testenv:py3]
-commands=python setup.py test --addopts="--mypy --mypy-ignore-missing-imports" {posargs}
+deps=
+    -rrequirements.txt
+commands=pytest --mypy --mypy-ignore-missing-imports --log-cli-level=DEBUG {posargs}
 
 [testenv:py27]
-commands=python setup.py test {posargs}
+deps=
+    -rrequirements.txt
+commands=pytest --log-cli-level=DEBUG {posargs}
 
 [tool:pytest]
 norecursedirs = .* _* virtualenv


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
