### PR TITLE
common,crimson: supporting admin-socket commands

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -401,7 +401,7 @@ int AdminSocket::execute_command(const std::string& cmd, ceph::bufferlist& out)
   }
   string args;
   if (match != cmd) {
-    args = cmd.substr(match.length() + 1);
+    args = cmd.substr(match.length() + 1); /// RRR don't understand this line
   }
 
   // Drop lock to avoid cycles in cases where the hook takes

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -15,6 +15,10 @@
 #ifndef CEPH_COMMON_ADMIN_SOCKET_H
 #define CEPH_COMMON_ADMIN_SOCKET_H
 
+#ifdef WITH_SEASTAR
+#include "crimson/admin/admin_socket.h"
+#else
+
 #include <condition_variable>
 #include <mutex>
 #include <string>
@@ -141,4 +145,5 @@ private:
   friend class GetdescsHook;
 };
 
+#endif
 #endif

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -4,6 +4,9 @@ set_target_properties(crimson::cflags PROPERTIES
   INTERFACE_LINK_LIBRARIES Seastar::seastar)
 
 set(crimson_common_srcs
+  admin/admin_socket.cc
+  admin/context_admin.cc
+  admin/osd_admin.cc
   common/buffer_io.cc
   common/config_proxy.cc
   common/perf_counters_collection.cc
@@ -14,7 +17,6 @@ set(crimson_common_srcs
 #  - the logging is sent to Seastar backend
 #  - and the template parameter of lock_policy is SINGLE
 add_library(crimson-common STATIC
-  ${PROJECT_SOURCE_DIR}/src/common/admin_socket.cc
   ${PROJECT_SOURCE_DIR}/src/common/admin_socket_client.cc
   ${PROJECT_SOURCE_DIR}/src/common/bit_str.cc
   ${PROJECT_SOURCE_DIR}/src/common/bloom_filter.cc

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -1,0 +1,896 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2011 New Dream Network
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/version.h"
+#include "crimson/net/Socket.h"
+// activate for some inline unit-testing: #define UNIT_TEST_OSD_ASOK
+#include "crimson/admin/admin_socket.h"
+#include "crimson/common/log.h"
+//#include "seastar/testing/test_case.hh"
+#include "seastar/net/api.hh"
+#include "seastar/net/inet_address.hh"
+#include "seastar/core/reactor.hh"
+#include "seastar/core/thread.hh"
+//#include "seastar/util/log.hh"
+#include "seastar/util/std-compat.hh"
+#include <boost/algorithm/string.hpp>
+
+/*!
+  A Crimson-wise version of the admin socket - implementation file
+
+  \todo handle the unlinking of the admin socket. Note that 'cleanup_files' at-exit functionality is not yet
+        implemented in Crimson
+*/
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+#ifdef UNIT_TEST_OSD_ASOK
+namespace asok_unit_testing {
+  seastar::future<> utest_run_1(AdminSocket* asok);
+}
+#endif
+
+/*!
+  Hooks table - iterator support
+
+  Note: Each server-block is locked (via its gate member) before
+        iterating over its entries.
+ */
+
+AdminHooksIter AdminSocket::begin() {
+  AdminHooksIter it{*this};
+  it.m_miter->second.m_gate.enter();
+  it.m_in_gate = true;
+  return it;
+}
+
+AdminHooksIter AdminSocket::end() {
+  AdminHooksIter it{*this, true};
+  return it;
+}
+
+/*!
+  note that 'end-flag' is an optional parameter, and is only used internally (to
+  signal the end() state).
+ */
+AdminHooksIter::AdminHooksIter(AdminSocket& master, bool end_flag)
+    : m_master{master}
+{
+  if (end_flag) {
+    // create the equivalent of servers.end();
+    m_miter = m_master.servers.end();
+  } else {
+    m_miter = m_master.servers.begin();
+    m_siter = m_miter->second.m_hooks.begin();
+  }
+}
+
+AdminHooksIter& AdminHooksIter::operator++()
+{
+  ++m_siter;
+  if (m_siter == m_miter->second.m_hooks.end()) {
+    // move to the next server-block
+    m_miter->second.m_gate.leave();
+    m_in_gate = false;
+
+    while (true) {
+      m_miter++;
+      if (m_miter == m_master.servers.end())
+        return *this;
+
+      try {
+        m_miter->second.m_gate.enter(); // will throw if gate was already closed
+        m_siter = m_miter->second.m_hooks.begin();
+        m_in_gate = true;
+        return *this;
+      } catch (...) {
+        // this server-block is being torn-down, and cannot be used
+        continue;
+      }
+    }
+  }
+  return *this;
+}
+
+AdminHooksIter::~AdminHooksIter()
+{
+  if (m_in_gate) {
+    m_miter->second.m_gate.leave();
+  }
+}
+
+/*!
+  the defaut implementation of the hook API
+
+  Note that we never throw or return a failed future.
+ */
+seastar::future<bool> AdminSocketHook::call(std::string_view command, const cmdmap_t& cmdmap,
+                                            std::string_view format, ceph::bufferlist& out) const
+{
+  unique_ptr<Formatter> f{Formatter::create(format, "json-pretty"sv, "json-pretty"s)};
+
+  // customize the output section, as required by a couple of hook APIs:
+  std::string section{section_name(command)};
+  boost::replace_all(section, " ", "_");
+  if (format_as_array()) {
+    f->open_array_section(section.c_str());
+  } else {
+    f->open_object_section(section.c_str());
+  }
+
+  bool bres{false};
+
+  /*
+      call the command-specific hook.
+      A note re error handling:
+        - will be modified to use the new 'erroretor'. For now:
+        - exec_command() may throw or return an exceptional future. We return a message that starts
+          with "error" on both failure scenarios.
+   */
+  return seastar::do_with(std::move(f), std::move(bres), [this, &command, &cmdmap, &format, &out](unique_ptr<Formatter>& ftr, bool& br) {
+
+    return seastar::futurize_apply([this, &command, &cmdmap, &format, &out, f=ftr.get()] {
+      return exec_command(f, command, cmdmap, format, out);
+    }).
+      // get us to a resolved state:
+      then_wrapped([&ftr,&command,&br](seastar::future<> res) -> seastar::future<bool> {
+
+      //  we now have a ready future (or a failure)
+      if (!res.failed()) {
+        br = true;
+      }
+      res.ignore_ready_future();
+      return seastar::make_ready_future<bool>(br);
+    }).then([this, &ftr, &out](auto res) -> seastar::future<bool> {
+      ftr->close_section();
+      ftr->enable_line_break();
+      ftr->flush(out);
+      return seastar::make_ready_future<bool>(res);
+    });
+  });
+}
+
+
+AdminSocket::AdminSocket(CephContext *cct)
+  : m_cct(cct)
+{}
+
+AdminSocket::~AdminSocket()
+{}
+
+/*!
+  Note re context: running in the core running the asok.
+  And no futurization until required to support multiple cores.
+*/
+AsokRegistrationRes AdminSocket::server_registration(AdminSocket::hook_server_tag server_tag,
+                                 const std::vector<AsokServiceDef>& apis_served)
+{
+  auto ne = servers.try_emplace(
+                                server_tag,
+                                apis_served);
+
+  //  is this server tag already registered?
+  if (!ne.second) {
+    return std::nullopt;
+  }
+
+  logger().info("{}: {} server registration (tag: {})", __func__, (int)getpid(), (uint64_t)(server_tag));
+  return this->shared_from_this();
+}
+
+seastar::future<AsokRegistrationRes>
+AdminSocket::register_server(hook_server_tag  server_tag, const std::vector<AsokServiceDef>& apis_served)
+{
+  return seastar::with_lock(servers_tbl_rwlock, [this, server_tag, &apis_served]() {
+    return server_registration(server_tag, apis_served);
+  });
+}
+
+
+/*!
+  Called by the server implementing the hook. The gate will be closed, and the function
+  will block until all execution of commands within the gate are done.
+ */
+seastar::future<> AdminSocket::unregister_server(hook_server_tag server_tag)
+{
+  logger().debug("{}: {} server un-reg (tag: {}) ({} prev cnt: {})",
+                __func__, (int)getpid(), (uint64_t)(server_tag), (uint64_t)(this), servers.size());
+
+  //  locate the server registration
+  return seastar::with_shared(servers_tbl_rwlock, [this, server_tag]() {
+
+    auto srv_itr = servers.find(server_tag);
+    return srv_itr;
+
+  }).then([this, server_tag](auto srv_itr) {
+
+    if (srv_itr == servers.end()) {
+      logger().warn("{}: unregistering a non-existing registration (tag: {})", __func__, (uint64_t)(server_tag));
+      // list what servers *are* there (for debugging). Should be under the lock
+      //for (auto& [k, d] : servers) {
+      //  logger().debug("---> server: {} {}", (uint64_t)(k), d.m_hooks.front().command);
+      //}
+      return seastar::now();
+
+    } else {
+
+      // note: usually we would have liked to maintain the shared lock, and just upgrade it here
+      // to an exclusive one. But there is no chance of anyone else removing our specific server-block
+      // before we re-acquire the lock
+
+      return (srv_itr->second.m_gate.close()).then([this, srv_itr]() {
+        return with_lock(servers_tbl_rwlock, [this, srv_itr]() {
+          servers.erase(srv_itr);
+          return seastar::now();
+        });
+      });
+    }
+  }).finally([server_tag]() {
+    logger().info("{}: done removing server block {}", __func__, (uint64_t)(server_tag));
+  });
+}
+
+seastar::future<> AdminSocket::unregister_server(hook_server_tag server_tag, AdminSocketRef&& server_ref)
+{
+  // reducing the ref-count on us (the asok server) by discarding server_ref:
+  return seastar::do_with(std::move(server_ref), [this, server_tag](auto& srv) {
+    return unregister_server(server_tag).finally([this,server_tag,&srv]() {
+      logger().debug("{}: {} - {}", __func__, (uint64_t)(server_tag), srv->servers.size());
+    });
+  });
+}
+
+AdminSocket::GateAndHook AdminSocket::locate_command(std::string_view cmd)
+{
+  for (auto& [tag, srv] : servers) {
+    // "lock" the server's control block before searching for the command string
+    try {
+      srv.m_gate.enter();
+    } catch (...) {
+      // probable error: gate is already closed
+      continue;
+    }
+    for (auto& api : srv.m_hooks) {
+      if (api.command == cmd) {
+        logger().info("{}: located {} w/ server {}", __func__, cmd, tag);
+        // note that the gate was entered!
+        return AdminSocket::GateAndHook{&srv.m_gate, &api};
+      }
+    }
+    // not registered by this server. Close this server's gate.
+    srv.m_gate.leave();
+  }
+
+  return AdminSocket::GateAndHook{nullptr, nullptr};
+}
+
+seastar::future<AdminSocket::GateAndHook> AdminSocket::locate_subcmd(std::string match)
+{
+  return seastar::with_shared(servers_tbl_rwlock, [this, match]() mutable {
+
+    AdminSocket::GateAndHook gh;
+
+    while (match.size()) {
+      gh = locate_command(match);
+
+      if (gh.api) {
+        // found a match
+        break;
+      }
+
+      // drop right-most word
+      size_t pos = match.rfind(' ');
+      if (pos == std::string::npos) {
+        match.clear();  // we fail
+        break;
+      } else {
+        match.resize(pos);
+      }
+    }
+
+    return gh;
+  });
+}
+
+seastar::future<std::optional<AdminSocket::parsed_command_t>> AdminSocket::parse_cmd(const std::string command_text)
+{
+  /*
+    preliminaries:
+      - create the formatter specified by the command_text parameters
+      - locate the "op-code" string (the 'prefix' segment)
+      - prepare for command parameters extraction via cmdmap_t
+  */
+  cmdmap_t cmdmap;
+  vector<string> cmdvec;
+  stringstream errss;
+
+  //  note that cmdmap_from_json() may throw on syntax issues
+  cmdvec.push_back(command_text); // as cmdmap_from_json() likes the input in this format
+  try {
+    if (!cmdmap_from_json(cmdvec, &cmdmap, errss)) {
+      logger().error("{}: incoming command error: {}", __func__, errss.str()); // RRR verify errrss contents
+      return seastar::make_ready_future<Maybe_parsed>(Maybe_parsed{std::nullopt});
+    }
+  } catch ( ... ) {
+    logger().error("{}: incoming command syntax: {}", __func__, command_text);
+    return seastar::make_ready_future<Maybe_parsed>(Maybe_parsed{std::nullopt});
+  }
+
+  string format;
+  string match;
+  std::size_t full_command_seq;
+  try {
+    cmd_getval(m_cct, cmdmap, "format", format);
+    cmd_getval(m_cct, cmdmap, "prefix", match);
+    full_command_seq = match.length(); // the full sequence, before we start chipping away the end
+  } catch (const bad_cmd_get& e) {
+    return seastar::make_ready_future<Maybe_parsed>(Maybe_parsed{std::nullopt});
+  }
+
+  if (!match.length()) {
+    // no command identified
+    return seastar::make_ready_future<Maybe_parsed>(Maybe_parsed{std::nullopt});
+  }
+
+  if (format != "json"s && format != "json-pretty"s &&
+      format != "xml"s && format != "xml-pretty"s) {
+    format = "json-pretty"s;
+  }
+
+  /*
+      match the incoming op-code to one of the registered APIs (and lock the block containing that API from
+          de-registration)
+  */
+  return seastar::do_with(std::move(cmdmap), std::move(format), std::move(match),
+                         [this, full_command_seq](auto&& cmdmap, auto&& format, auto&& match) {
+    return locate_subcmd(match).then_wrapped([this, &match, &cmdmap, format, full_command_seq](auto&& fgh) {
+
+      if (fgh.failed()) {
+        return seastar::make_ready_future<Maybe_parsed>(Maybe_parsed{std::nullopt});
+      } else {
+        AdminSocket::GateAndHook gh = fgh.get0();
+        if (!gh.api)
+           return seastar::make_ready_future<Maybe_parsed>(Maybe_parsed{std::nullopt});
+        else
+          return seastar::make_ready_future<Maybe_parsed>(
+                  parsed_command_t{match, cmdmap, format, gh.api, gh.api->hook, gh.m_gate, full_command_seq});
+      }
+    });
+  });
+}
+
+bool AdminSocket::validate_command(const parsed_command_t& parsed,
+                                   const std::string& command_text,
+                                   ceph::buffer::list& out) const
+{
+  // did we receive any arguments apart from the command word(s)?
+  //logger().debug("ct:{} {} origl:{} pmc:{} pmcl:{}", command_text, command_text.length(), parsed.m_cmd_seq_len, parsed.m_cmd, parsed.m_cmd.length());
+  if (parsed.m_cmd_seq_len == parsed.m_cmd.length())
+    return true;
+
+  logger().debug("{}: validating {} against:{}", __func__, command_text, parsed.m_api->cmddesc);
+
+  stringstream os; // for possible validation error messages
+  try {
+    // validate_cmd throws on some syntax errors
+    if (validate_cmd(m_cct, parsed.m_api->cmddesc, parsed.m_parameters, os)) {
+      return true;
+    }
+  } catch( std::exception& e ) {
+    logger().error("{}: validation failure ({} : {}) {}", __func__, command_text, parsed.m_cmd, e.what());
+  }
+
+  logger().error("{}: validation failure (incoming:{}) {}", __func__, command_text, os.str());
+  out.append(os);
+  return false;
+}
+
+seastar::future<> AdminSocket::execute_line(std::string cmdline, seastar::output_stream<char>& out)
+{
+  return parse_cmd(cmdline).then([&out, cmdline, this](std::optional<AdminSocket::parsed_command_t> parsed) {
+
+    if (parsed.has_value()) {
+
+      return seastar::do_with(std::move(parsed), ::ceph::bufferlist(),
+                            [&out, cmdline, this, gatep = parsed->m_gate] (auto&& parsed, auto&& out_buf) {
+
+      return ((parsed->m_api && validate_command(*parsed, cmdline, out_buf)) ?
+
+              parsed->m_hook->call(parsed->m_cmd, parsed->m_parameters, (*parsed).m_format, out_buf) :
+              seastar::make_ready_future<bool>(false) /* failed args syntax validation */
+        ).
+        then_wrapped([&out, &out_buf, gatep](auto&& fut) -> seastar::future<bool> {
+
+          gatep->leave();
+
+          if (fut.failed()) {
+            // add 'failed' to the contents of out_buf? not what happens in the old code
+            return seastar::make_ready_future<bool>(false);
+          } else {
+            return std::move(fut);
+          }
+        }).then([&out, &out_buf, gatep](auto call_res) {
+
+          string outbuf_cont = out_buf.to_str();
+          uint32_t response_length = htonl(outbuf_cont.length());
+          logger().info("asok response length: {}", outbuf_cont.length());
+
+          return out.write((char*)&response_length, sizeof(uint32_t)).then([&out, outbuf_cont]() {
+
+            if (outbuf_cont.empty())
+              return out.write("    ");
+            else
+              return out.write(outbuf_cont.c_str());
+          });
+        });
+      });
+
+    } else {
+
+      // no command op-code identified
+      std::string no_opcode = "error: no command identified in incoming message ("s + cmdline + ")"s;
+      uint32_t response_length = htonl(no_opcode.length());
+      logger().info("asok f len: {}", no_opcode.length());
+
+      return out.write((char*)&response_length, sizeof(uint32_t)).
+        then([&out, no_opcode, response_length]() {
+          if (response_length)
+            return out.write(no_opcode.c_str());
+          else
+            return seastar::now();
+        });
+    }
+  });
+}
+
+seastar::future<> AdminSocket::handle_client(seastar::input_stream<char>& inp, seastar::output_stream<char>& out)
+{
+  //  RRR \todo safe read
+  //  RRR \todo handle old protocol (see original code) - is still needed?
+
+  return inp.read().
+    then( [&out, this](auto full_cmd) {
+
+      seastar::sstring cmd_line{full_cmd.begin(), full_cmd.end()};
+      logger().debug("{}: incoming asok string: {}\n", __func__, cmd_line);
+      return execute_line(cmd_line, out);
+
+    }).then([&out]() { return out.flush(); }).
+    finally([&out]() { return out.close(); }).
+    then([&inp,&out]() {
+      return inp.close();
+    }).handle_exception([](auto ep) {
+      logger().debug("exception on {}: {}", __func__, ep);
+      return seastar::make_ready_future<>();
+    }).discard_result();
+}
+
+seastar::future<> AdminSocket::init(const std::string& path)
+{
+#ifdef UNIT_TEST_OSD_ASOK
+  // in-line unit-testing:
+  std::ignore = seastar::async([this]() {
+     seastar::sleep(3s).wait();
+     asok_unit_testing::utest_run_1(this).wait();
+  });
+#endif
+
+  return seastar::async([this, path] {
+    auto serverfut = init_async(path);
+  });
+}
+
+
+seastar::future<> AdminSocket::init_async(const std::string& path)
+{
+  internal_hooks().get(); // we are executing in an async thread, thus OK to wait()
+
+  logger().debug("{}: asok socket path={}", __func__, path);
+  auto sock_path = seastar::socket_address{seastar::unix_domain_addr{path}};
+
+  return seastar::do_with(seastar::engine().listen(sock_path), [this](seastar::server_socket& lstn) {
+
+    return seastar::do_until([this](){ return do_die; }, [&lstn,this]() {
+      return lstn.accept().
+        then([this](seastar::accept_result from_accept) {
+
+          seastar::connected_socket cn = std::move(from_accept.connection);
+
+          return do_with(std::move(cn.input()), std::move(cn.output()), std::move(cn),
+                        [this](auto& inp, auto& out, auto& cn) {
+
+            return handle_client(inp, out).finally([this, &inp, &out] {
+              ; // left for debugging: std::cerr << "finally "  << std::endl;
+            });
+          });
+      });
+    });
+  });
+}
+
+// ///////////////////////////////////////
+// the internal hooks
+// ///////////////////////////////////////
+
+/*!
+    The response to the '0' command is not formatted, neither as JSON or otherwise.
+*/
+class The0Hook : public AdminSocketHook {
+public:
+  seastar::future<bool> call(std::string_view command, const cmdmap_t&,
+	    std::string_view format, bufferlist& out) const override {
+    out.append(CEPH_ADMIN_SOCK_VERSION);
+    return seastar::make_ready_future<bool>(true);
+  }
+};
+
+class VersionHook : public AdminSocketHook {
+  AdminSocket* m_as;
+public:
+  explicit VersionHook(AdminSocket* as) : m_as{as} {}
+
+  seastar::future<> exec_command(ceph::Formatter* f, [[maybe_unused]] std::string_view command,
+                                 [[maybe_unused]] const cmdmap_t& cmdmap,
+	                         [[maybe_unused]] std::string_view format, [[maybe_unused]] bufferlist& out) const final
+  {
+    f->dump_string("version", ceph_version_to_str());
+    f->dump_string("release", ceph_release_to_str());
+    f->dump_string("release_type", ceph_release_type());
+    return seastar::now();
+  }
+};
+
+/*!
+  Note that the git_version command is expected to return a 'version' JSON segment.
+*/
+class GitVersionHook : public AdminSocketHook {
+  AdminSocket* m_as;
+public:
+  explicit GitVersionHook(AdminSocket* as) : m_as{as} {}
+
+  std::string section_name(std::string_view command) const final {
+    return "version"s;
+  }
+
+  /*seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                                 std::string_view format, bufferlist& out) const final
+  {
+    f->dump_string("git_version", git_version_to_str());
+    return seastar::now();
+  }*/
+
+  // slowing the response down for debugging.
+  seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                                 std::string_view format, bufferlist& out) const final {
+    return seastar::sleep(1s).then([this, f]() {
+      f->dump_string("git_version", git_version_to_str());
+      return seastar::now();
+    });
+  }
+};
+
+class HelpHook : public AdminSocketHook {
+  AdminSocket* m_as;
+public:
+  explicit HelpHook(AdminSocket* as) : m_as{as} {}
+
+  seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                                 std::string_view format, bufferlist& out) const final {
+
+    return seastar::with_shared(m_as->servers_tbl_rwlock, [this,f]() {
+      for (const auto& hk_info : *m_as) {
+        if (hk_info->help.length())
+	  f->dump_string(hk_info->command.c_str(), hk_info->help);
+      }
+      return seastar::now();
+    });
+  }
+};
+
+class GetdescsHook : public AdminSocketHook {
+  AdminSocket *m_as;
+public:
+  explicit GetdescsHook(AdminSocket *as) : m_as{as}
+  {}
+
+  std::string section_name(std::string_view command) const final {
+    return "command_descriptions"s;
+  }
+
+  seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+                                 std::string_view format, bufferlist& out) const final
+  {
+    return seastar::with_shared(m_as->servers_tbl_rwlock, [this,f]() {
+      int cmdnum = 0;
+
+      for (const auto& hk_info : *m_as) {
+        ostringstream secname;
+        secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
+        dump_cmd_and_help_to_json(f,
+                                  CEPH_FEATURES_ALL,
+                                  secname.str().c_str(),
+                                  hk_info->cmddesc,
+                                  hk_info->help);
+        cmdnum++;
+      }
+      return seastar::now();
+    });
+  }
+};
+
+class TestThrowHook : public AdminSocketHook {
+  AdminSocket* m_as;
+public:
+  explicit TestThrowHook(AdminSocket* as) : m_as{as} {}
+
+  seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+                                 std::string_view format, bufferlist& out) const final {
+    if (command == "fthrowAs")
+      return seastar::make_exception_future<>(std::system_error{1, std::system_category()});
+
+    return seastar::sleep(3s).then([this]() {
+      throw(std::invalid_argument("As::TestThrowHook"));
+      return seastar::now();
+    });
+  }
+};
+
+/// the hooks that are served directly by the admin_socket server
+seastar::future<AsokRegistrationRes> AdminSocket::internal_hooks()
+{
+  version_hook = std::make_unique<VersionHook>(this);
+  git_ver_hook = std::make_unique<GitVersionHook>(this);
+  the0_hook = std::make_unique<The0Hook>();
+  help_hook = std::make_unique<HelpHook>(this);
+  getdescs_hook = std::make_unique<GetdescsHook>(this);
+  test_throw_hook = std::make_unique<TestThrowHook>(this);
+
+  static const std::vector<AsokServiceDef> internal_hooks_tbl{
+      AsokServiceDef{"0",            "0",                    the0_hook.get(),        ""}
+    , AsokServiceDef{"version",      "version",              version_hook.get(),     "get ceph version"}
+    , AsokServiceDef{"git_version",  "git_version",          git_ver_hook.get(),     "get git sha1"}
+    , AsokServiceDef{"help",         "help",                 help_hook.get(),        "list available commands"}
+    , AsokServiceDef{"get_command_descriptions", "get_command_descriptions",
+                                                             getdescs_hook.get(),    "list available commands"}
+    , AsokServiceDef{"throwAs",      "throwAs",              test_throw_hook.get(),  ""}   // dev
+    , AsokServiceDef{"fthrowAs",     "fthrowAs",             test_throw_hook.get(),  ""}   // dev
+  };
+
+  // server_registration() returns a shared pointer to the AdminSocket server, i.e. to us. As we
+  // already have shared ownership of this object, we do not need it. RRR verify
+  return register_server(AdminSocket::hook_server_tag{this}, internal_hooks_tbl);
+}
+
+#ifdef UNIT_TEST_OSD_ASOK
+// ///////////////////////////////////////////
+// unit-testing servers-block map manipulation
+// ///////////////////////////////////////////
+
+/*
+  run multiple seastar threads that register/remove/search server blocks, testing
+  the locks that protect them.
+*/
+
+#include <random>
+using namespace std::chrono;
+using namespace std::chrono_literals;
+using namespace seastar;
+
+namespace asok_unit_testing {
+
+class UTestHook : public AdminSocketHook {
+public:
+  explicit UTestHook() {}
+
+  seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                                 std::string_view format, bufferlist& out) const final
+  {
+    return seastar::now();
+  }
+};
+
+static const UTestHook test_hook;
+
+static const std::vector<AsokServiceDef> test_hooks{
+      AsokServiceDef{"3",            "3",                    &test_hook,        "3"}
+    , AsokServiceDef{"4",            "4",                    &test_hook,        "4"}
+    , AsokServiceDef{"5",            "5",                    &test_hook,        "5"}
+    , AsokServiceDef{"6",            "6",                    &test_hook,        "6"}
+    , AsokServiceDef{"7",            "7",                    &test_hook,        "7"}
+};
+
+
+static const std::vector<AsokServiceDef> test_hooks10{
+      AsokServiceDef{"13",            "13",                    &test_hook,        "13"}
+    , AsokServiceDef{"14",            "14",                    &test_hook,        "14"}
+    , AsokServiceDef{"15",            "15",                    &test_hook,        "15"}
+    , AsokServiceDef{"16",            "16",                    &test_hook,        "16"}
+    , AsokServiceDef{"17",            "17",                    &test_hook,        "17"}
+};
+
+
+struct test_reg_st {
+
+  AdminSocket*                       asok;
+  AdminSocket::hook_server_tag       tag;
+  milliseconds                       period;
+  gate&                              g;
+  const std::vector<AsokServiceDef>& hks;
+  std::random_device                 rd;
+  std::default_random_engine         generator{rd()};
+  AdminSocketRef                     current_reg; // holds the shared ownership
+
+  test_reg_st(AdminSocket* ask, AdminSocket::hook_server_tag tag, milliseconds period, gate& gt, const std::vector<AsokServiceDef>& hks) :
+    asok{ask},
+    tag{tag},
+    period{period},
+    g{gt},
+    hks{hks}
+  {
+    // start an async thread to reg/unreg
+    std::ignore = seastar::async([this, hks] {
+      auto loop_fut = loop(hks);
+    });
+  }
+
+  // sleep, register, or fail w/ exception
+  seastar::future<> delayed_reg(milliseconds dly) {
+    return seastar::sleep(dly).
+      then([this, dly]() {
+
+        return with_gate(g, [this, dly]() {
+          return asok->register_server(tag, hks);
+        }).then([this](AsokRegistrationRes r) {
+          current_reg = *r;
+          return seastar::now();
+        });
+      });
+  }
+
+  // sleep, un-register, or fail w/ exception
+  seastar::future<> delayed_unreg(milliseconds dly) {
+    return seastar::sleep(dly).
+      then([this]() {
+
+        // must not check gate here! return with_gate(g, [this]() {
+        return asok->unregister_server(tag, std::move(current_reg));
+        // });
+      });
+  }
+
+  seastar::future<> loop(const std::vector<AsokServiceDef>& hks) {
+    std::uniform_int_distribution<int> dist(80, 120);
+    auto act_period = milliseconds{period.count() * dist(generator) / 100};
+
+    ceph::get_logger(ceph_subsys_osd).warn("{} starting", (uint64_t)(tag));
+    return seastar::keep_doing([this, act_period, hks]() {
+
+      return delayed_reg(act_period).then([this, act_period]() {
+        return delayed_unreg(act_period);
+      });
+    }).handle_exception([this](std::exception_ptr eptr) {
+      return seastar::now();
+    }).finally([this]() {
+      ceph::get_logger(ceph_subsys_osd).warn("{} done", (uint64_t)(tag));
+      return seastar::now();
+    });
+  }
+};
+
+struct test_lookup_st {
+
+  AdminSocket*                       asok;
+  string                             cmd;
+  milliseconds                       period;
+  milliseconds                       delaying_inside;
+  gate&                              g;
+  std::random_device                 rd;
+  std::default_random_engine         generator{rd()};
+  std::uniform_int_distribution<int> dist{80, 120};
+
+
+  test_lookup_st(AdminSocket* ask, string cmd, milliseconds period, milliseconds delaying_inside, gate& gt) :
+    asok{ask},
+    cmd{cmd},
+    period{period},
+    delaying_inside{delaying_inside},
+    g{gt}
+  {
+    // start an async thread to reg/unreg
+    std::ignore = seastar::async([this] {
+      auto loop_fut = loop();
+    });
+  }
+
+  seastar::future<> loop() {
+    std::uniform_int_distribution<int> dist(80, 120);
+    ceph::get_logger(ceph_subsys_osd).warn("utest-lookup {} starting", cmd);
+
+    return seastar::keep_doing([this, dist]() mutable {
+      milliseconds act_period = milliseconds{period.count() * dist(generator) / 100};
+      milliseconds ins_period = milliseconds{delaying_inside.count() * dist(generator) / 100};
+
+      return seastar::futurize_apply( [this, act_period, ins_period]() {
+        return with_gate(g, [this, act_period, ins_period]()  {
+
+          //
+          //  look for the command, waste some time, then free the server-block
+          //
+          return seastar::async([this, act_period, ins_period]() mutable {
+
+            bool fnd{false};
+
+            for (const auto& hk : *asok) {
+
+              if (hk->command == cmd) {
+                fnd = true;
+                // wait here for a while, with the iterator still holding the gate
+                seastar::sleep(ins_period).get();
+                break;
+              }
+            }
+            if (!fnd) {
+              std::cerr << __func__ << "(): " << cmd << " not found\n";
+            }
+            seastar::sleep(act_period).get();
+          });
+        });
+      }).finally([this] {
+        return seastar::now();
+      });
+    }).handle_exception([this](auto e) {
+      // gate is closed
+      ceph::get_logger(ceph_subsys_osd).warn("utest-lookup {} done", cmd);
+      return seastar::now();
+    });
+  }
+};
+
+seastar::future<> utest_run_1(AdminSocket* asok)
+{
+  constexpr seconds run_time{3};
+  seastar::gate gt;
+
+  return seastar::do_with(std::move(gt), [run_time, asok](auto& gt) {
+
+    test_reg_st* ta1 = new test_reg_st{asok, AdminSocket::hook_server_tag{(void*)(0x17)}, 200ms, gt, test_hooks  };
+    test_reg_st ta2{asok, AdminSocket::hook_server_tag{(void*)(0x27)}, 150ms, gt, test_hooks10};
+
+    test_lookup_st* tlk1 = new test_lookup_st{asok, "0",  55ms, 95ms, gt};
+    test_lookup_st tlk2{asok, "help", 210ms, 90ms, gt};
+
+    return seastar::sleep(run_time).
+     then([&gt]() { return gt.close();}).
+     then([&gt](){ return seastar::sleep(2000ms); }).
+     then([ta1, &ta2, tlk1, &tlk2]() {
+       delete ta1;
+       delete tlk1;
+       return seastar::now();
+     });
+  }).then_wrapped([](auto&& x) {
+    try {
+      x.get();
+      return seastar::now();
+    } catch (... ) {
+      return seastar::now();
+    }
+  });
+}
+
+}
+#endif

--- a/src/crimson/admin/admin_socket.h
+++ b/src/crimson/admin/admin_socket.h
@@ -1,0 +1,320 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#pragma once
+
+/*!
+  A Crimson-wise version of the src/common/admin_socket.h
+
+  Running on a single core:
+  - the hooks database is only manipulated on that main core. The same applies to the hook-servers.
+
+  (was:
+    hook servers running on other cores dispatch the register/unregister requests to that main core).
+    Incoming requests arriving on the admin socket are only received on that specific core. The actual
+    operation is delegated to the relevant core if needed.
+  )
+ */
+#include <string>
+#include <string_view>
+#include <map>
+#include "seastar/core/future.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "seastar/core/shared_mutex.hh"
+#include "seastar/core/gate.hh"
+#include "seastar/core/iostream.hh"
+#include "common/cmdparse.h"
+
+class AdminSocket;
+class CephContext;
+
+using namespace std::literals;
+
+inline constexpr auto CEPH_ADMIN_SOCK_VERSION = "2"sv;
+
+/*!
+  A specific hook must implement exactly one of the two interfaces:
+  (1) call(command, cmdmap, format, out)
+  or
+  (2) exec_command(formatter, command, cmdmap, format, out)
+
+  The default implementation of (1) above calls exec_command() after handling most
+  of the boiler-plate choirs:
+  - setting up the formmater, with an appropiate 'section' already opened;
+  - handling possible failures (exceptions or future_exceptions) returned by (2)
+  - flushing the output to the outgoing bufferlist.
+*/
+class AdminSocketHook {
+public:
+  /*!
+      \retval 'false' for hook execution errors
+  */
+  virtual seastar::future<bool> call(std::string_view command, const cmdmap_t& cmdmap,
+		                     std::string_view format, ceph::buffer::list& out) const;
+
+  virtual ~AdminSocketHook() {}
+
+protected:
+  virtual seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                                 std::string_view format, bufferlist& out) const {
+    return seastar::now();
+  }
+
+  /*!
+    (customization point) the high-level section of the output is an array
+    (affects the JSON formatting)
+   */
+  virtual bool format_as_array() const {
+    return false;
+  }
+
+  /*!
+    customization point (as some commands expect non-standard response header)
+   */
+  virtual std::string section_name(std::string_view command) const {
+    return std::string{command};
+  }
+};
+
+/*!
+  The details of a single API in a server's hooks block
+*/
+struct AsokServiceDef {
+  const std::string command;   //!< the sequence of words that should be used
+  const std::string cmddesc;   //!< the command syntax
+  const AdminSocketHook* hook;
+  const std::string help;      //!< help message
+};
+
+class AdminHooksIter; // gates-controlled iterator over all server blocks
+
+// a ref-count owner of the AdminSocket, used to guarantee its existence until all server-blocks are unregistered
+using AdminSocketRef = seastar::lw_shared_ptr<AdminSocket>;
+
+using AsokRegistrationRes = std::optional<AdminSocketRef>;  // holding the server alive until after our unregistration
+
+class AdminSocket : public seastar::enable_lw_shared_from_this<AdminSocket> {
+public:
+  AdminSocket(CephContext* cct);
+  ~AdminSocket();
+
+  AdminSocket(const AdminSocket&) = delete;
+  AdminSocket& operator =(const AdminSocket&) = delete;
+  AdminSocket(AdminSocket&&) = delete;
+  AdminSocket& operator =(AdminSocket&&) = delete;
+
+  using hook_server_tag = const void*;
+
+  seastar::future<> init(const std::string& path);
+
+  /*!
+   * register an admin socket hooks server
+   *
+   * The server registers a set of APIs under a common hook_server_tag.
+   *
+   * The commands block registered by a specific server have a common
+   * seastar::gate, used when the server wishes to remove its block's
+   * registration.
+   *
+   * Commands (APIs) are registered under a command string. Incoming
+   * commands are split by spaces and matched against the longest
+   * registered command. For example, if 'foo' and 'foo bar' are
+   * registered, and an incoming command is 'foo bar baz', it is
+   * matched with 'foo bar', while 'foo fud' will match 'foo'.
+   *
+   * The entire incoming command string is passed to the registered
+   * hook.
+   *
+   * \param server_tag  a tag identifying the server registering the hook
+   * \param apis_served a vector of the commands served by this server. Each
+   *        command registration includes its identifying command string, the
+   *        expected call syntax, and some help text.
+   *        A note re the help text: if empty, command will not be included in 'help' output.
+   *
+   * \retval a shared ptr to the asok server itself, or nullopt if
+   *         a block with same tag is already registered.
+   */
+
+  seastar::future<AsokRegistrationRes>
+  register_server(hook_server_tag  server_tag, const std::vector<AsokServiceDef>& apis_served);
+
+
+  // no single-command unregistration, as en-bulk per server unregistration is the pref method.
+  // I will consider adding specific API for those cases where the client needs to disable
+  // one specific service. It will be clearly named, to mark the fact that it would not replace
+  // deregistration. Something like disable_command(). The point against adding it: will have to
+  // make the server-block objects mutable.
+
+  /*!
+     unregister all hooks registered by this hooks-server
+   */
+  seastar::future<> unregister_server(hook_server_tag server_tag);
+
+  seastar::future<> unregister_server(hook_server_tag server_tag, AdminSocketRef&& server_ref);
+
+private:
+
+  class parsed_command_t;
+  // and two shorthands:
+  using Maybe_parsed =  std::optional<AdminSocket::parsed_command_t>;
+  using Future_parsed = seastar::future<Maybe_parsed>;
+
+  /*!
+    server_registration() is called by register_server() after acquiring the
+    table lock.
+  */
+  AsokRegistrationRes server_registration(hook_server_tag  server_tag,
+                                          const std::vector<AsokServiceDef>& apis_served);
+
+  /*!
+    Registering the APIs that are served directly by the admin_socket server.
+  */
+  seastar::future<AsokRegistrationRes> internal_hooks();
+
+  seastar::future<> init_async(const std::string& path);
+
+  seastar::future<> handle_client(seastar::input_stream<char>& inp, seastar::output_stream<char>& out);
+
+  seastar::future<> execute_line(std::string cmdline, seastar::output_stream<char>& out);
+
+  bool validate_command(const parsed_command_t& parsed,
+                        const std::string& command_text,
+                        ceph::buffer::list& out) const;
+
+  CephContext* m_cct;
+  bool do_die{false};  // RRR when is the OSD expected to kill the asok interface?
+
+  // Note: seems like multiple Context objects are created when calling vstart, and that
+  // translates to multiple AdminSocket objects being created. But only the "real" one
+  // (the OSD's) is actually initialized by a call to 'init()'.
+  // Thus, we should try to discourage the "other" objects from registering hooks.
+
+  std::unique_ptr<AdminSocketHook> version_hook;
+  std::unique_ptr<AdminSocketHook> git_ver_hook;
+  std::unique_ptr<AdminSocketHook> the0_hook;
+  std::unique_ptr<AdminSocketHook> help_hook;
+  std::unique_ptr<AdminSocketHook> getdescs_hook;
+  std::unique_ptr<AdminSocketHook> test_throw_hook;  // for dev unit-tests
+
+  struct parsed_command_t {
+    std::string            m_cmd;
+    cmdmap_t               m_parameters;
+    std::string            m_format;
+    const AsokServiceDef*  m_api;
+    const AdminSocketHook* m_hook;
+    ::seastar::gate*       m_gate;      //!< the gate of the server-block where the command was located
+    /*!
+        the length of the whole command-sequence under the 'prefix' header
+     */
+    std::size_t            m_cmd_seq_len;
+  };
+
+  /*!
+    parse the incoming command line into the sequence of words that identifies the API,
+    and into its arguments.
+    Locate the command string in the registered blocks.
+  */
+  seastar::future<std::optional<AdminSocket::parsed_command_t>> parse_cmd(const std::string command_text);
+
+  struct server_block {
+    server_block(const std::vector<AsokServiceDef>& hooks)
+      : m_hooks{hooks}
+    {}
+    const std::vector<AsokServiceDef>& m_hooks;
+    mutable ::seastar::gate m_gate;
+  };
+
+  // \todo possible improvement: cache all available commands, from all servers, in one vector.
+  //  Recreate the list every register/unreg request.
+
+  /*!
+    The servers table is protected by a rw-lock, to be acquired exclusively only
+    when registering or removing a server.
+    Note that the lock is *not* held when executing a specific hook. As the map
+    keeps stable item addresses, we do not worry about a specific API block
+    disappearing from under our feet (each individual block is protected from removal
+    by a seastar::gate). Still, we must guarantee the ability to safely perform
+    map lookups.
+   */
+  seastar::shared_mutex servers_tbl_rwlock;
+  std::map<hook_server_tag, server_block> servers;
+
+  struct GateAndHook {
+    ::seastar::gate* m_gate;
+    const AsokServiceDef* api;
+  };
+
+  /*!
+    locate_command() will search all servers' control blocks. If found, the
+    relevant gate is entered. Returns the AsokServiceDef, and the "activated" gate.
+   */
+  AdminSocket::GateAndHook locate_command(std::string_view cmd);
+
+  /*!
+    Find the longest subset of words in 'match' that is a registered API (in any of the
+    servers' control blocks).
+    The search is conducted with the servers table RW-lock held.
+    If a matching API is found, the
+    relevant gate is entered. Returns the AsokServiceDef, and the "activated" gate.
+
+    Note: uses an async seastar::thread to wait for servers_tbl_rwlock. The returned
+    future is guaranteed to be available.
+   */
+  seastar::future<AdminSocket::GateAndHook> locate_subcmd(std::string match);
+
+public:
+  /*!
+    iterator support
+   */
+  AdminHooksIter begin();
+  AdminHooksIter end();
+
+  using ServersListIt = std::map<hook_server_tag, server_block>::iterator;
+  using ServerApiIt =  std::vector<AsokServiceDef>::const_iterator;
+
+  friend class AdminSocketTest;
+  friend class HelpHook;
+  friend class GetdescsHook;
+  friend class AdminHooksIter;
+};
+
+
+/*!
+  An iterator over all registered APIs. Each server-block is locked (via its own seastar::gate) before
+  iterating over its entries.
+*/
+struct AdminHooksIter : public std::iterator<std::output_iterator_tag, AsokServiceDef> {
+public:
+   explicit AdminHooksIter(AdminSocket& master, bool end_flag=false);
+
+  ~AdminHooksIter();
+
+  const AsokServiceDef* operator*() const {
+    return &(*m_siter);
+  }
+
+  /*!
+    The (in)equality test is only used to compare to 'end'.
+   */
+  bool operator!=(const AdminHooksIter & other) const { return m_in_gate != other.m_in_gate; }
+
+  AdminHooksIter& operator++();
+
+private:
+  AdminSocket&                 m_master;
+  bool                         m_in_gate{false};
+  AdminSocket::ServersListIt   m_miter;
+  AdminSocket::ServerApiIt     m_siter;
+
+  friend class AdminSocket;
+};

--- a/src/crimson/admin/context_admin.cc
+++ b/src/crimson/admin/context_admin.cc
@@ -1,0 +1,299 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+/*!
+  \brief implementation of the 'admin_socket' API of (Crimson) Ceph Context
+
+  Main functionality:
+  - manipulating Context-level configuraion
+  - process-wide commands ('abort', 'assert')
+  - ...
+ */
+#ifndef WITH_SEASTAR
+#error "this is a Crimson-specific implementation of some CephContext APIs"
+#endif
+
+#include <iostream>
+#include <atomic>
+#include <boost/algorithm/string.hpp>
+#include "seastar/core/sleep.hh"
+#include "seastar/core/thread.hh"
+#include "common/config.h"
+#include "common/errno.h"
+#include "common/Graylog.h"
+
+#include "crimson/common/log.h"
+#include "common/valgrind.h"
+
+// for CINIT_FLAGS
+#include "common/common_init.h"
+#include <iostream>
+
+#include "common/ceph_context.h"
+
+using ceph::bufferlist;
+using ceph::HeartbeatMap;
+using ceph::common::local_conf;
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+/*!
+  the hooks and states needed to handle configuration requests
+*/
+class ContextConfigAdminImp {
+  friend class ContextConfigAdmin;
+  //
+  //  ContextConfigAdminImp objects are held by CephContext objects. m_cct points back to our master.
+  //
+  CephContext* m_cct;
+  ceph::common::ConfigProxy& m_conf;
+
+  //  shared-ownership of the socket server itself, to guarantee its existence until we have
+  //  a chance to remove our registration:
+  AsokRegistrationRes m_socket_server;
+
+  friend class CephContextHookBase;
+  friend class ConfigGetHook;
+
+  /*!
+      Common code for all CephContext admin hooks.
+      Adds access to the configuration object and to the
+      parent Context.
+   */
+  class CephContextHookBase : public AdminSocketHook {
+  protected:
+    ContextConfigAdminImp& m_config_admin;
+
+    /// the specific command implementation
+    seastar::future<> exec_command(Formatter* formatter, std::string_view command, const cmdmap_t& cmdmap,
+	                      std::string_view format, bufferlist& out) const override = 0;
+
+    explicit CephContextHookBase(ContextConfigAdminImp& master) : m_config_admin{master} {}
+  };
+
+  /*!
+       A CephContext admin hook: listing the configuration values
+   */
+  class ConfigShowHook : public CephContextHookBase {
+  public:
+    explicit ConfigShowHook(ContextConfigAdminImp& master) : CephContextHookBase(master) {};
+    seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                      std::string_view format, bufferlist& out) const final {
+
+      return seastar::do_with(std::ostringstream{}, [this, f](std::ostringstream& os) {
+        return m_config_admin.m_conf.show_config(f).
+        then([f,&os]() {
+          //f->append(os.str());
+          return seastar::now();
+        });
+      });
+    }
+  };
+
+  /*!
+       A CephContext admin hook: fetching the value of a specific configuration item
+   */
+  class ConfigGetHook : public CephContextHookBase {
+  public:
+    explicit ConfigGetHook(ContextConfigAdminImp& master) : CephContextHookBase(master) {};
+    seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                      std::string_view format, bufferlist& out) const final {
+      std::string var;
+      if (!cmd_getval<std::string>(nullptr, cmdmap, "var", var)) {
+        // should have been caught by 'validate()'
+	f->dump_string("error", "syntax error: 'config get <var>'");
+
+      } else {
+
+        try {
+          std::string conf_val = m_config_admin.m_conf.get_val<std::string>(var.c_str());
+          f->dump_string(var.c_str(), conf_val.c_str());
+        } catch ( ... ) {
+          f->dump_string("error", "unrecognized configuration item " + var);
+        }
+      }
+      return seastar::now();
+    }
+  };
+
+  /*!
+       A CephContext admin hook: setting the value of a specific configuration item
+       (a real example: {"prefix": "config set", "var":"debug_osd", "val": ["30/20"]} )
+   */
+  class ConfigSetHook : public CephContextHookBase {
+  public:
+    explicit ConfigSetHook(ContextConfigAdminImp& master) : CephContextHookBase(master) {};
+
+    seastar::future<> exec_command(ceph::Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                      std::string_view format, bufferlist& out) const final {
+      std::string var;
+      std::vector<std::string> new_val;
+      if (!cmd_getval<std::string>(nullptr, cmdmap, "var", var) ||
+          !cmd_getval(nullptr, cmdmap, "val", new_val)) {
+
+	f->dump_string("error", "syntax error: 'config set <var> <value>'");
+        return seastar::now();
+
+      } else {
+        // val may be multiple words
+	string valstr = str_join(new_val, " ");
+
+        return m_config_admin.m_conf.set_val(var, valstr).then_wrapped([=](auto p) {
+          if (p.failed()) {
+            f->dump_string("error setting", var.c_str());
+          } else {
+            f->dump_string("success", command);
+          }
+          return seastar::now();
+        });
+      }
+    }
+  };
+
+  /*!
+       A CephContext admin hook: calling assert (if allowed by 'debug_asok_assert_abort')
+   */
+  class AssertAlwaysHook : public CephContextHookBase {
+  public:
+    explicit AssertAlwaysHook(ContextConfigAdminImp& master) : CephContextHookBase(master) {};
+    seastar::future<> exec_command(ceph::Formatter* f, [[maybe_unused]] std::string_view command,
+                                   [[maybe_unused]] const cmdmap_t& cmdmap,
+                                   std::string_view format, [[maybe_unused]] bufferlist& out) const final {
+      bool assert_conf = m_config_admin.m_conf.get_val<bool>("debug_asok_assert_abort");
+      if (!assert_conf) {
+	f->dump_string("error", "configuration set to disallow asok assert");
+	return seastar::now();
+      }
+      ceph_assert_always(0);
+      return seastar::now();
+     }
+  };
+
+  /*!
+       A test hook that throws or returns an exceptional future
+   */
+  class TestThrowHook : public CephContextHookBase {
+  public:
+    explicit TestThrowHook(ContextConfigAdminImp& master) : CephContextHookBase(master) {};
+    seastar::future<> exec_command([[maybe_unused]] Formatter* f, [[maybe_unused]] std::string_view command,
+                                   [[maybe_unused]] const cmdmap_t& cmdmap,
+                                   [[maybe_unused]] std::string_view format, [[maybe_unused]] bufferlist& out) const final {
+
+      if (command == "fthrowCtx")
+        return seastar::make_exception_future<>(std::system_error{1, std::system_category()});
+      throw(std::invalid_argument("TestThrowHook"));
+    }
+  };
+
+  ConfigShowHook   config_show_hook;
+  ConfigGetHook    config_get_hook;
+  ConfigSetHook    config_set_hook;
+  AssertAlwaysHook assert_hook;
+  TestThrowHook    ctx_test_throw_hook;  // for development testing
+
+  std::atomic_flag  m_no_registrations{false}; // 'double negative' as that matches 'atomic_flag' "direction"
+
+public:
+
+  ContextConfigAdminImp(CephContext* cct, ceph::common::ConfigProxy& conf)
+    : m_cct{cct}
+    , m_conf{conf}
+    , config_show_hook{*this}
+    , config_get_hook{*this}
+    , config_set_hook{*this}
+    , assert_hook{*this}
+    , ctx_test_throw_hook{*this}
+  {
+  }
+
+  ~ContextConfigAdminImp() {}
+
+  seastar::future<> register_admin_commands() {
+    logger().debug("{}: {} {} {}", __func__, "context-admin", (int)getpid(), (uint64_t)(this));
+
+    static const std::vector<AsokServiceDef> hooks_tbl{
+        AsokServiceDef{"config show",    "config show",  &config_show_hook,      "dump current config settings"}
+      , AsokServiceDef{"config get",     "onfig get name=var,type=CephString",
+                                                         &config_get_hook,       "config get <field>: get the config value"}
+      , AsokServiceDef{"config set",     "config set name=var,type=CephString name=val,type=CephString,n=N",
+                                                         &config_set_hook,       "config set <field> <val> [<val> ...]: set a config variable"}
+      , AsokServiceDef{"assert",         "assert",       &assert_hook,           "asserts"}
+      , AsokServiceDef{"throwCtx",       "throwCtx",     &ctx_test_throw_hook,   ""}    // dev throw
+      , AsokServiceDef{"fthrowCtx",      "fthrowCtx",    &ctx_test_throw_hook,   ""}    // dev throw
+    };
+
+    return m_cct->get_admin_socket()->register_server(AdminSocket::hook_server_tag{this}, hooks_tbl).
+           then([this](AsokRegistrationRes rr) {
+             m_socket_server = rr;
+           });
+  }
+
+  seastar::future<> unregister_admin_commands()
+  {
+    if (!m_socket_server.has_value()) {
+      logger().warn("{} no socket server", __func__);
+      return seastar::now();
+    }
+
+    auto admin_if = m_cct->get_admin_socket();
+    if (!admin_if) {
+      logger().warn("{}:no admin_if", __func__);
+      return seastar::now();
+    }
+
+    //  we are holding a shared-ownership of the admin socket server, just so that we
+    //  can keep it alive until after our de-registration.
+    AdminSocketRef srv{std::move(*m_socket_server)};
+    //AdminSocketRef srv = *m_socket_server;
+    //m_socket_server = std::nullopt; // should be redundant
+
+    // note that unregister_server() closes a seastar::gate (i.e. - it blocks)
+    return admin_if->unregister_server(AdminSocket::hook_server_tag{this}, std::move(srv));
+  }
+};
+
+//
+//  some Pimpl details:
+//
+ContextConfigAdmin::ContextConfigAdmin(CephContext* cct, ceph::common::ConfigProxy& conf)
+  : m_imp{ std::make_unique<ContextConfigAdminImp>(cct, conf) }
+  , m_cct{cct}
+{}
+
+seastar::future<>  ContextConfigAdmin::register_admin_commands()
+{
+  return m_imp->register_admin_commands();
+}
+
+seastar::future<>  ContextConfigAdmin::unregister_admin_commands()
+{
+  return m_imp->unregister_admin_commands();
+}
+
+ContextConfigAdmin::~ContextConfigAdmin()
+{
+  // relinquish control over the actual implementation object, as that one should only be
+  // destructed after the relevant seastar::gate closes
+
+  std::ignore = seastar::do_with(std::move(m_imp), [](auto&& imp) {
+    // test using sleep(). Change from 1ms to 1s:
+    return seastar::sleep(1ms).
+    then([imp_ptr = imp.get()]() {
+       return imp_ptr->unregister_admin_commands();
+    });
+  });
+}

--- a/src/crimson/admin/context_admin.h
+++ b/src/crimson/admin/context_admin.h
@@ -1,0 +1,43 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#pragma once
+
+#include <memory>
+
+class ContextConfigAdminImp;
+class CephContext;
+
+/*!
+  \brief implementation of the configuration-related 'admin_socket' API of
+         (Crimson) Ceph Context
+
+  Main functionality:
+  - manipulating Context-level configuraion
+  - process-wide commands ('abort', 'assert')
+  - ...
+ */
+class ContextConfigAdmin {
+  std::unique_ptr<ContextConfigAdminImp> m_imp;
+  CephContext* m_cct; //!< holding on to the owning CCT until our imp object is destructed
+public:
+  ContextConfigAdmin(CephContext* cct, ceph::common::ConfigProxy& conf);
+  ~ContextConfigAdmin();
+  /*!
+    Note: the only reason of having register_admin_commands() provided as a public interface (and not just called
+    from the ctor), is the (not just theoretical) race to register and unregister the same server block when creating
+    a Context and immediately removing it
+  */
+  seastar::future<> register_admin_commands();
+  seastar::future<> unregister_admin_commands();
+};

--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -1,0 +1,223 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include "common/ceph_context.h"
+
+#include <iostream>
+#include <atomic>
+#include <boost/algorithm/string.hpp>
+#include "seastar/core/future.hh"
+#include "seastar/core/thread.hh"
+#include "crimson/admin/admin_socket.h"
+#include "crimson/admin/osd_admin.h"
+#include "crimson/osd/osd.h"
+#include "crimson/osd/exceptions.h"
+#include "common/config.h"
+#include "crimson/common/log.h"
+
+// for CINIT_FLAGS
+//#include "common/common_init.h"
+
+#include <iostream>
+
+#ifndef WITH_SEASTAR
+#error "this is a Crimson-specific implementation of some OSD APIs"
+#endif
+
+using ceph::bufferlist;
+using ceph::common::local_conf;
+using ceph::osd::OSD;
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace ceph::osd {
+
+/*!
+  the hooks and states needed to handle OSD asok requests
+*/
+class OsdAdminImp {
+  friend class OsdAdmin;
+  friend class OsdAdminHookBase;
+
+  OSD* m_osd;
+  CephContext* m_cct;
+  ceph::common::ConfigProxy& m_conf;
+
+  //  shared-ownership of the socket server itself, to guarantee its existence until we have
+  //  a chance to remove our registration:
+  AsokRegistrationRes m_socket_server;
+
+  /*!
+       Common code for all OSD admin hooks.
+       Adds access to the owning OSD.
+  */
+  class OsdAdminHookBase : public AdminSocketHook {
+  protected:
+    OsdAdminImp& m_osd_admin;
+
+    /// the specific command implementation
+    virtual seastar::future<> exec_command(Formatter* formatter, std::string_view command, const cmdmap_t& cmdmap,
+	                      std::string_view format, bufferlist& out) const = 0;
+
+    explicit OsdAdminHookBase(OsdAdminImp& master) :
+      m_osd_admin{master}
+    {}
+  };
+
+  /*!
+       An OSD admin hook: OSD status
+   */
+  class OsdStatusHook : public OsdAdminHookBase {
+  public:
+    explicit OsdStatusHook(OsdAdminImp& master) : OsdAdminHookBase(master) {};
+    seastar::future<> exec_command(Formatter* f, std::string_view command, const cmdmap_t& cmdmap,
+	                      std::string_view format, bufferlist& out) const final {
+
+      f->dump_stream("cluster_fsid") << m_osd_admin.osd_superblock().cluster_fsid;
+      f->dump_stream("osd_fsid") << m_osd_admin.osd_superblock().osd_fsid;
+      f->dump_unsigned("whoami", m_osd_admin.osd_superblock().whoami);
+      // \todo f->dump_string("state", get_state_name(get_state()));       // RRR where should I look for the data?
+      f->dump_unsigned("oldest_map", m_osd_admin.osd_superblock().oldest_map);
+      f->dump_unsigned("newest_map", m_osd_admin.osd_superblock().newest_map);
+      // \todo f->dump_unsigned("num_pgs", num_pgs);  -> where to find the data?
+      return seastar::now();
+    }
+  };
+
+  /*!
+       An OSD admin hook: send beacon
+   */
+  class SendBeaconHook : public OsdAdminHookBase {
+  public:
+    explicit SendBeaconHook(OsdAdminImp& master) : OsdAdminHookBase(master) {};
+    seastar::future<> exec_command(Formatter* f, [[maybe_unused]] std::string_view command,
+                                   [[maybe_unused]] const cmdmap_t& cmdmap,
+	                           [[maybe_unused]] std::string_view format, [[maybe_unused]] bufferlist& out) const final
+    {
+      // \todo if (!is_active()) -> where to find the data?
+      // \todo   return seastar::now();
+
+      return m_osd_admin.m_osd->send_beacon();
+    }
+  };
+
+  /*!
+       A test hook that throws or returns an exceptional future
+   */
+  class TestThrowHook : public OsdAdminHookBase {
+  public:
+    explicit TestThrowHook(OsdAdminImp& master) : OsdAdminHookBase(master) {};
+    seastar::future<> exec_command(Formatter* f, std::string_view command,
+                                   [[maybe_unused]] const cmdmap_t& cmdmap,
+                                   [[maybe_unused]] std::string_view format, [[maybe_unused]] bufferlist& out) const final {
+
+      if (command == "fthrow")
+        return seastar::make_exception_future<>(ceph::osd::no_message_available{});
+      throw(std::invalid_argument("TestThrowHook"));
+    }
+  };
+
+  /*!
+       provide the hooks with access to OSD internals
+  */
+  const OSDSuperblock& osd_superblock() {
+    return m_osd->superblock;
+  }
+
+  OsdStatusHook   osd_status_hook;
+  SendBeaconHook  send_beacon_hook;
+  TestThrowHook   osd_test_throw_hook;
+
+public:
+
+  OsdAdminImp(OSD* osd, CephContext* cct, ceph::common::ConfigProxy& conf)
+    : m_osd{osd}
+    , m_cct{cct}
+    , m_conf{conf}
+    , osd_status_hook{*this}
+    , send_beacon_hook{*this}
+    , osd_test_throw_hook{*this}
+  {
+  }
+
+  ~OsdAdminImp() {
+    // our registration with the admin_socket server was already removed by
+    // 'OsdAdmin' - our 'pimpl' owner. Thus no need for:
+    //   unregister_admin_commands();
+  }
+
+  seastar::future<> register_admin_commands() {
+    static const std::vector<AsokServiceDef> hooks_tbl{
+        AsokServiceDef{"status",      "status",        &osd_status_hook,      "OSD status"}
+      , AsokServiceDef{"send_beacon", "send_beacon",   &send_beacon_hook,     "send OSD beacon to mon immediately"}
+      , AsokServiceDef{"throw",       "throw",         &osd_test_throw_hook,  ""}  // dev tool
+      , AsokServiceDef{"fthrow",      "fthrow",        &osd_test_throw_hook,  ""}  // dev tool
+    };
+
+    return m_cct->get_admin_socket()->register_server(AdminSocket::hook_server_tag{this}, hooks_tbl).
+      then([this](AsokRegistrationRes rr) {
+        m_socket_server = rr;
+      });
+  }
+
+  seastar::future<> unregister_admin_commands()
+  {
+    if (!m_socket_server.has_value()) {
+      logger().warn("{}: OSD asok APIs removed already", __func__);
+      return seastar::now();
+    }
+
+    AdminSocketRef srv{std::move(m_socket_server.value())};
+
+    // note that unregister_server() closes a seastar::gate (i.e. - it blocks)
+    auto admin_if = m_cct->get_admin_socket();
+    assert(admin_if);
+    return admin_if->unregister_server(AdminSocket::hook_server_tag{this}, std::move(srv));
+  }
+};
+
+//
+//  some Pimpl details:
+//
+OsdAdmin::OsdAdmin(OSD* osd, CephContext* cct, ceph::common::ConfigProxy& conf)
+  : m_imp{ std::make_unique<ceph::osd::OsdAdminImp>(osd, cct, conf) }
+{}
+
+seastar::future<>  OsdAdmin::register_admin_commands()
+{
+  return m_imp->register_admin_commands();
+}
+
+seastar::future<> OsdAdmin::unregister_admin_commands()
+{
+  return m_imp->unregister_admin_commands();
+}
+
+OsdAdmin::~OsdAdmin()
+{
+  // relinquish control over the actual implementation object, as that one should only be
+  // destructed after the relevant seastar::gate closes
+  std::ignore = seastar::do_with(std::move(m_imp), [](auto&& imp) {
+    // test using sleep(). Change from 1ms to 1s:
+    return seastar::sleep(1ms).
+    then([imp_ptr = imp.get()]() {
+       return imp_ptr->unregister_admin_commands();
+    });
+  });
+}
+
+} // namespace

--- a/src/crimson/admin/osd_admin.h
+++ b/src/crimson/admin/osd_admin.h
@@ -1,0 +1,41 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#pragma once
+
+#include <memory>
+#include "common/ceph_context.h"
+
+class CephContext;
+
+namespace ceph::osd {
+class OSD;
+class OsdAdminImp;
+
+/*!
+  \brief implementation of the configuration-related 'admin_socket' API of
+         (Crimson) OSD
+
+  Main functionality:
+  - ... TBD
+ */
+class OsdAdmin {
+  std::unique_ptr<ceph::osd::OsdAdminImp> m_imp;
+public:
+  OsdAdmin(ceph::osd::OSD* osd, CephContext* cct, ceph::common::ConfigProxy& conf);
+  ~OsdAdmin();
+  seastar::future<> register_admin_commands();
+  seastar::future<> unregister_admin_commands();
+};
+
+} // namespace ceph::osd

--- a/src/crimson/common/config_proxy.cc
+++ b/src/crimson/common/config_proxy.cc
@@ -41,5 +41,11 @@ seastar::future<> ConfigProxy::start()
   });
 }
 
+seastar::future<>
+ConfigProxy::show_config(ceph::Formatter* f) {
+  get_config().show_config(*values, f);
+  return seastar::now();
+}
+
 ConfigProxy::ShardedConfig ConfigProxy::sharded_conf;
 }

--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -9,6 +9,10 @@
 #include "common/config_obs_mgr.h"
 #include "common/errno.h"
 
+namespace ceph {
+class Formatter;
+}
+
 namespace ceph::common {
 
 // a facade for managing config. each shard has its own copy of ConfigProxy.
@@ -28,10 +32,10 @@ class ConfigProxy : public seastar::peering_sharded_service<ConfigProxy>
   ObserverMgr<ConfigObserver> obs_mgr;
 
   const md_config_t& get_config() const {
-    return remote_config ? *remote_config : * local_config;
+    return remote_config ? *remote_config : *local_config;
   }
   md_config_t& get_config() {
-    return remote_config ? *remote_config : * local_config;
+    return remote_config ? *remote_config : *local_config;
   }
 
   // apply changes to all shards
@@ -147,6 +151,9 @@ public:
       get_config().set_mon_vals(nullptr, values, obs_mgr, kv, nullptr);
     });
   }
+
+  seastar::future<>
+  show_config(ceph::Formatter* f);
 
   seastar::future<> parse_argv(std::vector<const char*>& argv) {
     // we could pass whatever is unparsed to seastar, but seastar::app_template

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -15,6 +15,8 @@
 
 #include "crimson/common/type_helpers.h"
 #include "crimson/common/auth_handler.h"
+#include "crimson/admin/admin_socket.h"
+#include "crimson/admin/osd_admin.h"
 #include "crimson/common/simple_lru.h"
 #include "crimson/common/shared_lru.h"
 #include "crimson/mgr/client.h"
@@ -113,6 +115,8 @@ class OSD final : public ceph::net::Dispatcher,
   std::unique_ptr<Heartbeat> heartbeat;
   seastar::timer<seastar::lowres_clock> heartbeat_timer;
 
+  std::unique_ptr<OsdAdmin>    osd_admin;
+
 public:
   OSD(int id, uint32_t nonce,
       ceph::net::Messenger& cluster_msgr,
@@ -171,7 +175,8 @@ private:
 					Ref<MOSDRepOpReply> m);
   seastar::future<> handle_peering_op(ceph::net::Connection* conn,
 				      Ref<MOSDPeeringOp> m);
-
+  seastar::future<> handle_admin_cmd(ceph::net::Connection* conn,
+				     Ref<MCommand> m);
   seastar::future<> committed_osd_maps(version_t first,
                                        version_t last,
                                        Ref<MOSDMap> m);
@@ -206,6 +211,7 @@ public:
   seastar::future<> update_heartbeat_peers();
 
   friend class PGAdvanceMap;
+  friend class OsdAdminImp;
 };
 
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -285,9 +285,9 @@ OSDService::~OSDService()
 {
   delete objecter;
 
-  for (auto f : objecter_finishers) {
+  for (auto& f : objecter_finishers) {
     delete f;
-    f = NULL;
+    f = nullptr;
   }
 }
 


### PR DESCRIPTION
NOTE: for review. Has not been rebased yet to latest 'master'. ...But was heavily tested.

- basic infrastructure:
  - the seastar::thread that handles commands arriving over the UNIX_domain socket
  - command dispatching
- the implementation of some commands.

Test support:
- some inline unit-testing controlled by an #ifdef
- a python script to send sequences of commands. See:https://drive.google.com/file/d/1rOrl1B5tOKWBH6kWMEHgA_cYgzjiCC8G/view?usp=sharing
https://drive.google.com/file/d/1E819x-ejEypyDSnzqfc0GRBAXyQKr0sC/view?usp=sharing
https://drive.google.com/file/d/1-MQKnRcfNh3iciOgXKhWCtGE8UNgStKK/view?usp=sharing
https://drive.google.com/file/d/19c-Xi2TyBa4e7NinKjj4BgZ712nZCykD/view?usp=sharing


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
