### PR TITLE
doc: add Python 2 to Ubuntu 18.04 installations

### DIFF
--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -62,6 +62,12 @@ configuration details, perform the following steps using ``ceph-deploy``.
    and a log file for the new cluster.  See `ceph-deploy new -h`_ for
    additional details.
 
+   Note for users of Ubuntu 18.04: Python 2 is a prerequisite of Ceph.
+   Install the ``python-minimal`` package on Ubuntu 18.04 to provide
+   Python 2::
+
+     [Ubuntu 18.04] $ sudo apt install python-minimal
+
 #. If you have more than one network interface, add the ``public network``
    setting under the ``[global]`` section of your Ceph configuration file.
    See the `Network Configuration Reference`_ for details. ::


### PR DESCRIPTION
This commit updates the "Create a Cluster" section of the
"Storage Cluster Quick Start" document. Ubuntu 18.04 does
not have Python 2 installed by default. This commit instructs
users of Python 18.04 to install the package "python-minimal"
to provide Python 2 prior to running "ceph-deploy".

This commit fixes Bug number 9 in the list here:
https://pad.ceph.com/p/Report_Documentation_Bugs

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
