### PR TITLE
rbd-mirror: peer_ping should send the local fsid to the remote

### DIFF
--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -132,7 +132,7 @@ public:
     EXPECT_EQ(0, m_local_ioctx.create(RBD_MIRRORING, false));
 
     m_local_status_updater = rbd::mirror::MirrorStatusUpdater<>::create(
-      m_local_ioctx, m_threads.get(), "");
+      m_local_ioctx, m_threads.get(), "", "");
     C_SaferCond status_updater_ctx;
     m_local_status_updater->init(&status_updater_ctx);
     EXPECT_EQ(0, status_updater_ctx.wait());

--- a/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
+++ b/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
@@ -247,7 +247,7 @@ public:
 
 TEST_F(TestMockMirrorStatusUpdater, InitShutDown) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -261,7 +261,7 @@ TEST_F(TestMockMirrorStatusUpdater, InitShutDown) {
 
 TEST_F(TestMockMirrorStatusUpdater, InitStatusWatcherError) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -278,7 +278,7 @@ TEST_F(TestMockMirrorStatusUpdater, InitStatusWatcherError) {
 
 TEST_F(TestMockMirrorStatusUpdater, ShutDownStatusWatcherError) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -297,7 +297,7 @@ TEST_F(TestMockMirrorStatusUpdater, ShutDownStatusWatcherError) {
 
 TEST_F(TestMockMirrorStatusUpdater, SmallBatch) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -328,7 +328,7 @@ TEST_F(TestMockMirrorStatusUpdater, SmallBatch) {
 
 TEST_F(TestMockMirrorStatusUpdater, LargeBatch) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -369,7 +369,7 @@ TEST_F(TestMockMirrorStatusUpdater, LargeBatch) {
 
 TEST_F(TestMockMirrorStatusUpdater, OverwriteStatus) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -399,7 +399,7 @@ TEST_F(TestMockMirrorStatusUpdater, OverwriteStatus) {
 
 TEST_F(TestMockMirrorStatusUpdater, OverwriteStatusInFlight) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -440,7 +440,7 @@ TEST_F(TestMockMirrorStatusUpdater, OverwriteStatusInFlight) {
 
 TEST_F(TestMockMirrorStatusUpdater, ImmediateUpdate) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -461,7 +461,7 @@ TEST_F(TestMockMirrorStatusUpdater, ImmediateUpdate) {
 
 TEST_F(TestMockMirrorStatusUpdater, RemoveIdleStatus) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -484,7 +484,7 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveIdleStatus) {
 
 TEST_F(TestMockMirrorStatusUpdater, RemoveInFlightStatus) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -518,7 +518,7 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveInFlightStatus) {
 
 TEST_F(TestMockMirrorStatusUpdater, ShutDownWhileUpdating) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "");
+                                                     m_mock_threads, "", "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 
@@ -557,7 +557,8 @@ TEST_F(TestMockMirrorStatusUpdater, MirrorPeerSitePing) {
   ASSERT_EQ(0, _rados->cluster_fsid(&fsid));
 
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
-                                                     m_mock_threads, "siteA");
+                                                     m_mock_threads, "siteA",
+                                                     fsid);
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
     new MockMirrorStatusWatcher();
 

--- a/src/test/rbd_mirror/test_mock_NamespaceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_NamespaceReplayer.cc
@@ -176,7 +176,8 @@ struct MirrorStatusUpdater<librbd::MockTestImageCtx> {
 
   static MirrorStatusUpdater *create(librados::IoCtx &io_ctx,
                                      Threads<librbd::MockTestImageCtx> *threads,
-                                     const std::string& site_name) {
+                                     const std::string& site_name,
+                                     const std::string& fsid) {
     ceph_assert(s_instance[site_name] != nullptr);
     return s_instance[site_name];
   }

--- a/src/tools/rbd_mirror/MirrorStatusUpdater.h
+++ b/src/tools/rbd_mirror/MirrorStatusUpdater.h
@@ -27,12 +27,13 @@ public:
 
   static MirrorStatusUpdater* create(librados::IoCtx& io_ctx,
                                      Threads<ImageCtxT> *threads,
-                                     const std::string& site_name) {
-    return new MirrorStatusUpdater(io_ctx, threads, site_name);
+                                     const std::string& site_name,
+                                     const std::string& fsid) {
+    return new MirrorStatusUpdater(io_ctx, threads, site_name, fsid);
   }
 
   MirrorStatusUpdater(librados::IoCtx& io_ctx, Threads<ImageCtxT> *threads,
-                      const std::string& site_name);
+                      const std::string& site_name, const std::string& fsid);
   ~MirrorStatusUpdater();
 
   void init(Context* on_finish);

--- a/src/tools/rbd_mirror/NamespaceReplayer.cc
+++ b/src/tools/rbd_mirror/NamespaceReplayer.cc
@@ -262,7 +262,7 @@ void NamespaceReplayer<I>::init_local_status_updater() {
   ceph_assert(!m_local_status_updater);
 
   m_local_status_updater.reset(MirrorStatusUpdater<I>::create(
-    m_local_io_ctx, m_threads, ""));
+    m_local_io_ctx, m_threads, "", ""));
   auto ctx = create_context_callback<
     NamespaceReplayer<I>,
     &NamespaceReplayer<I>::handle_init_local_status_updater>(this);
@@ -297,8 +297,18 @@ void NamespaceReplayer<I>::init_remote_status_updater() {
   ceph_assert(ceph_mutex_is_locked(m_lock));
   ceph_assert(!m_remote_status_updater);
 
+  librados::Rados rados(m_local_io_ctx);
+  std::string local_fsid;
+  int r = rados.cluster_fsid(&local_fsid);
+  if (r < 0) {
+    derr << "failed to retrieve local fsid: " << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    shut_down_local_status_updater();
+    return;
+  }
+
   m_remote_status_updater.reset(MirrorStatusUpdater<I>::create(
-    m_remote_io_ctx, m_threads, m_local_site_name));
+    m_remote_io_ctx, m_threads, m_local_site_name, local_fsid));
   auto ctx = create_context_callback<
     NamespaceReplayer<I>,
     &NamespaceReplayer<I>::handle_init_remote_status_updater>(this);


### PR DESCRIPTION
It was previously incorrectly sending the remote cluster's
fsid to the remote cluster.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
