### PR TITLE
mgr/dashboard,grafana: remove shortcut menu

### DIFF
--- a/monitoring/grafana/dashboards/host-details.json
+++ b/monitoring/grafana/dashboards/host-details.json
@@ -38,17 +38,7 @@
   "graphTooltip": 0,
   "id": null,
   "iteration": 1557386759572,
-  "links": [
-    {
-      "asDropdown": true,
-      "icon": "external link",
-      "tags": [
-        "overview"
-      ],
-      "title": "Shortcuts",
-      "type": "dashboards"
-    }
-  ],
+  "links": [],
   "panels": [
     {
       "gridPos": {
@@ -1221,5 +1211,5 @@
   "timezone": "browser",
   "title": "Host Details",
   "uid": "rtOg0AiWz",
-  "version": 3
+  "version": 4
 }

--- a/src/pybind/mgr/dashboard/ci/check_grafana_uids.py
+++ b/src/pybind/mgr/dashboard/ci/check_grafana_uids.py
@@ -85,6 +85,13 @@ def get_grafana_dashboards(base_dir):
         with open(json_file) as f:
             dashboard_config = json.load(f)
             uid = dashboard_config.get('uid')
+
+            # Grafana dashboard checks
+            title = dashboard_config['title']
+            assert len(title) > 0, \
+                "Title not found in '{}'".format(json_file)
+            assert len(dashboard_config.get('links', [])) == 0, \
+                "Links found in '{}'".format(json_file)
             if not uid:
                 continue
             if uid in dashboards:
@@ -92,9 +99,10 @@ def get_grafana_dashboards(base_dir):
                 error_msg = 'Duplicated UID {} found, already defined in {}'.\
                     format(uid, dashboards[uid]['file'])
                 exit(error_msg)
+
             dashboards[uid] = {
                 'file': json_file,
-                'title': dashboard_config['title']
+                'title': title
             }
     return dashboards
 


### PR DESCRIPTION
Remove shortcut menu (links) and add check in grafana CI script.

![image](https://user-images.githubusercontent.com/37327689/69994783-ef05f980-154e-11ea-938a-6026cec4bce7.png)

Fixes: https://tracker.ceph.com/issues/43091
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
