### PR TITLE
nautilus: mgr: Balancer fixes

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -132,9 +132,19 @@
 
     ceph config set global <option> <value>
 
-12.2.7
+14.2.7
 ------
 
 * The MGR now accepts 'profile rbd' and 'profile rbd-read-only' user caps.
   These caps can be used to provide users access to MGR-based RBD functionality
   such as 'rbd perf image iostat' an 'rbd perf image iotop'.
+
+* The configuration value ``osd_calc_pg_upmaps_max_stddev`` used for upmap
+  balancing has been removed. Instead use the mgr balancer config
+  ``upmap_max_deviation`` which now is an integer number of PGs of deviation
+  from the target PGs per OSD.  This can be set with a command like
+  ``ceph config set mgr mgr/balancer/upmap_max_deviation 2``.  The default
+  ``upmap_max_deviation`` is 1.  There are situations where crush rules
+  would not allow a pool to ever have completely balanced PGs.  For example, if
+  crush requires 1 replica on each of 3 racks, but there are fewer OSDs in 1 of
+  the racks.  In those cases, the configuration value can be increased.

--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -153,7 +153,7 @@ Options
 
 .. option:: --upmap-deviation <max-deviation>
 
-   max deviation from target [default: 1]
+   max deviation from target [default: 5]
 
 .. option:: --upmap-pool <poolname>
 

--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -17,7 +17,7 @@ Synopsis
 | **osdmaptool** *mapfilename* [--export-crush *crushmap*]
 | **osdmaptool** *mapfilename* [--upmap *file*] [--upmap-max *max-optimizations*]
   [--upmap-deviation *max-deviation*] [--upmap-pool *poolname*]
-  [--upmap-save *file*] [--upmap-save *newosdmap*]
+  [--upmap-save *file*] [--upmap-save *newosdmap*] [--upmap-active]
 | **osdmaptool** *mapfilename* [--upmap-cleanup] [--upmap-save *newosdmap*]
 
 
@@ -27,6 +27,8 @@ Description
 **osdmaptool** is a utility that lets you create, view, and manipulate
 OSD cluster maps from the Ceph distributed storage system. Notably, it
 lets you extract the embedded CRUSH map or import a new CRUSH map.
+It can also simulate the upmap balancer mode so you can get a sense of
+what is needed to balance your PGs.
 
 
 Options
@@ -161,6 +163,10 @@ Options
 
    write modified OSDMap with upmap changes
 
+.. option:: --upmap-active
+
+   Act like an active balancer, keep applying changes until balanced
+
 
 Example
 =======
@@ -243,6 +249,56 @@ placement group distribution, whose standard deviation is 1.41421::
         size 10
         size 20
         size 364
+
+   To simulate the active balancer in upmap mode::
+
+        osdmaptool --upmap upmaps.out --upmap-active --upmap-deviation 6 --upmap-max 11 osdmap
+
+   osdmaptool: osdmap file 'osdmap'
+   writing upmap command output to: upmaps.out
+   checking for upmap cleanups
+   upmap, max-count 11, max deviation 6
+   pools movies photos metadata data
+   prepared 11/11 changes
+   Time elapsed 0.00310404 secs
+   pools movies photos metadata data
+   prepared 11/11 changes
+   Time elapsed 0.00283402 secs
+   pools data metadata movies photos
+   prepared 11/11 changes
+   Time elapsed 0.003122 secs
+   pools photos metadata data movies
+   prepared 11/11 changes
+   Time elapsed 0.00324372 secs
+   pools movies metadata data photos
+   prepared 1/11 changes
+   Time elapsed 0.00222609 secs
+   pools data movies photos metadata
+   prepared 0/11 changes
+   Time elapsed 0.00209916 secs
+   Unable to find further optimization, or distribution is already perfect
+   osd.0 pgs 41
+   osd.1 pgs 42
+   osd.2 pgs 42
+   osd.3 pgs 41
+   osd.4 pgs 46
+   osd.5 pgs 39
+   osd.6 pgs 39
+   osd.7 pgs 43
+   osd.8 pgs 41
+   osd.9 pgs 46
+   osd.10 pgs 46
+   osd.11 pgs 46
+   osd.12 pgs 46
+   osd.13 pgs 41
+   osd.14 pgs 40
+   osd.15 pgs 40
+   osd.16 pgs 39
+   osd.17 pgs 46
+   osd.18 pgs 46
+   osd.19 pgs 39
+   osd.20 pgs 42
+   Total time elapsed 0.0167765 secs, 5 rounds
 
 
 Availability

--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -13,6 +13,8 @@ Synopsis
 
 | **osdmaptool** *mapfilename* [--print] [--createsimple *numosd*
   [--pgbits *bitsperosd* ] ] [--clobber]
+| **osdmaptool** *mapfilename* [--import-crush *crushmap*]
+| **osdmaptool** *mapfilename* [--export-crush *crushmap*]
 
 
 Description
@@ -111,6 +113,10 @@ Options
 
    mark osds up and in (but do not persist).
 
+.. option:: --mark-out
+
+   mark an osd as out (but do not persist)
+
 .. option:: --tree
 
    Displays a hierarchical tree of the map.
@@ -118,6 +124,15 @@ Options
 .. option:: --clear-temp
 
    clears pg_temp and primary_temp variables.
+
+.. option:: --health
+
+   dump health checks
+
+.. option:: --with-default-pool
+
+   include default pool when creating map
+
 
 Example
 =======
@@ -130,19 +145,19 @@ To view the result::
 
         osdmaptool --print osdmap
 
-To view the mappings of placement groups for pool 0::
+To view the mappings of placement groups for pool 1::
 
-        osdmaptool --test-map-pgs-dump rbd --pool 0
+        osdmaptool osdmap --test-map-pgs-dump --pool 1
 
         pool 0 pg_num 8
-        0.0     [0,2,1] 0
-        0.1     [2,0,1] 2
-        0.2     [0,1,2] 0
-        0.3     [2,0,1] 2
-        0.4     [0,2,1] 0
-        0.5     [0,2,1] 0
-        0.6     [0,1,2] 0
-        0.7     [1,0,2] 1
+        1.0     [0,2,1] 0
+        1.1     [2,0,1] 2
+        1.2     [0,1,2] 0
+        1.3     [2,0,1] 2
+        1.4     [0,2,1] 0
+        1.5     [0,2,1] 0
+        1.6     [0,1,2] 0
+        1.7     [1,0,2] 1
         #osd    count   first   primary c wt    wt
         osd.0   8       5       5       1       1
         osd.1   8       1       1       1       1
@@ -157,7 +172,7 @@ To view the mappings of placement groups for pool 0::
         size 3  8
 
 In which,
- #. pool 0 has 8 placement groups. And two tables follow:
+ #. pool 1 has 8 placement groups. And two tables follow:
  #. A table for placement groups. Each row presents a placement group. With columns of:
 
     * placement group id,

--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -15,6 +15,10 @@ Synopsis
   [--pgbits *bitsperosd* ] ] [--clobber]
 | **osdmaptool** *mapfilename* [--import-crush *crushmap*]
 | **osdmaptool** *mapfilename* [--export-crush *crushmap*]
+| **osdmaptool** *mapfilename* [--upmap *file*] [--upmap-max *max-optimizations*]
+  [--upmap-deviation *max-deviation*] [--upmap-pool *poolname*]
+  [--upmap-save *file*] [--upmap-save *newosdmap*]
+| **osdmaptool** *mapfilename* [--upmap-cleanup] [--upmap-save *newosdmap*]
 
 
 Description
@@ -132,6 +136,30 @@ Options
 .. option:: --with-default-pool
 
    include default pool when creating map
+
+.. option:: --upmap-cleanup <file>
+
+   clean up pg_upmap[_items] entries, writing commands to <file> [default: - for stdout]
+
+.. option:: --upmap <file>
+
+   calculate pg upmap entries to balance pg layout writing commands to <file> [default: - for stdout]
+
+.. option:: --upmap-max <max-optimizations>
+
+   set max upmap entries to calculate [default: 10]
+
+.. option:: --upmap-deviation <max-deviation>
+
+   max deviation from target [default: 1]
+
+.. option:: --upmap-pool <poolname>
+
+   restrict upmap balancing to 1 pool or the option can be repeated for multiple pools
+
+.. option:: --upmap-save
+
+   write modified OSDMap with upmap changes
 
 
 Example

--- a/doc/rados/operations/upmap.rst
+++ b/doc/rados/operations/upmap.rst
@@ -58,7 +58,7 @@ Upmap entries are updated with an offline optimizer built into ``osdmaptool``.
    If it cannot find any additional changes to make it will stop early
    (i.e., when the pool distribution is perfect).
 
-   The ``max-deviation`` value defaults to `1`.  If an OSD PG count
+   The ``max-deviation`` value defaults to `5`.  If an OSD PG count
    varies from the computed target number by less than or equal
    to this amount it will be considered perfect.
 

--- a/doc/rados/operations/upmap.rst
+++ b/doc/rados/operations/upmap.rst
@@ -43,6 +43,7 @@ Upmap entries are updated with an offline optimizer built into ``osdmaptool``.
 
      osdmaptool om --upmap out.txt [--upmap-pool <pool>]
               [--upmap-max <max-optimizations>] [--upmap-deviation <max-deviation>]
+              [--upmap-active]
 
    It is highly recommended that optimization be done for each pool
    individually, or for sets of similarly-utilized pools.  You can
@@ -60,6 +61,12 @@ Upmap entries are updated with an offline optimizer built into ``osdmaptool``.
    The ``max-deviation`` value defaults to `1`.  If an OSD PG count
    varies from the computed target number by less than or equal
    to this amount it will be considered perfect.
+
+   The ``--upmap-active`` option simulates the behavior of the active
+   balancer in upmap mode.  It keeps cycling until the OSDs are balanced
+   and reports how many rounds and how long each round is taking.  The
+   elapsed time for rounds indicates the CPU load ceph-mgr will be
+   consuming when it tries to compute the next optimization plan.
 
 #. Apply the changes::
 

--- a/doc/rados/operations/upmap.rst
+++ b/doc/rados/operations/upmap.rst
@@ -23,14 +23,12 @@ use with::
 
   ceph features
 
-A word of caution
+Balancer module
 -----------------
 
-This is a new feature and not very user friendly.  At the time of this
-writing we are working on a new `balancer` module for ceph-mgr that
-will eventually do all of this automatically.
+The new `balancer` module for ceph-mgr will automatically balance
+the number of PGs per OSD.  See ``Balancer``
 
-Until then,
 
 Offline optimization
 --------------------
@@ -43,7 +41,8 @@ Upmap entries are updated with an offline optimizer built into ``osdmaptool``.
 
 #. Run the optimizer::
 
-     osdmaptool om --upmap out.txt [--upmap-pool <pool>] [--upmap-max <max-count>] [--upmap-deviation <max-deviation>]
+     osdmaptool om --upmap out.txt [--upmap-pool <pool>]
+              [--upmap-max <max-optimizations>] [--upmap-deviation <max-deviation>]
 
    It is highly recommended that optimization be done for each pool
    individually, or for sets of similarly-utilized pools.  You can
@@ -52,24 +51,28 @@ Upmap entries are updated with an offline optimizer built into ``osdmaptool``.
    kind of data (e.g., RBD image pools, yes; RGW index pool and RGW
    data pool, no).
 
-   The ``max-count`` value is the maximum number of upmap entries to
-   identify in the run.  The default is 100, but you may want to make
-   this a smaller number so that the tool completes more quickly (but
-   does less work).  If it cannot find any additional changes to make
-   it will stop early (i.e., when the pool distribution is perfect).
+   The ``max-optimizations`` value is the maximum number of upmap entries to
+   identify in the run.  The default is `10` like the ceph-mgr balancer module,
+   but you should use a larger number if you are doing offline optimization.
+   If it cannot find any additional changes to make it will stop early
+   (i.e., when the pool distribution is perfect).
 
-   The ``max-deviation`` value defaults to `.01` (i.e., 1%).  If an OSD
-   utilization varies from the average by less than this amount it
-   will be considered perfect.
+   The ``max-deviation`` value defaults to `1`.  If an OSD PG count
+   varies from the computed target number by less than or equal
+   to this amount it will be considered perfect.
 
-#. The proposed changes are written to the output file ``out.txt`` in
-   the example above.  These are normal ceph CLI commands that can be
-   run to apply the changes to the cluster.  This can be done with::
+#. Apply the changes::
 
      source out.txt
+
+   The proposed changes are written to the output file ``out.txt`` in
+   the example above.  These are normal ceph CLI commands that can be
+   run to apply the changes to the cluster.
+
 
 The above steps can be repeated as many times as necessary to achieve
 a perfect distribution of PGs for each set of pools.
 
 You can see some (gory) details about what the tool is doing by
-passing ``--debug-osd 10`` to ``osdmaptool``.
+passing ``--debug-osd 10`` and even more with ``--debug-crush 10``
+to ``osdmaptool``.

--- a/qa/standalone/mgr/balancer.sh
+++ b/qa/standalone/mgr/balancer.sh
@@ -195,17 +195,20 @@ function TEST_balancer2() {
     sleep 30
     ceph osd df
 
-    # FINAL_PER_OSD2 should distribute evenly
+    # We should be with plue or minus 1 of FINAL_PER_OSD2
+    # This is because here each pool is balanced independently
+    MIN=$(expr $FINAL_PER_OSD2 - 1)
+    MAX=$(expr $FINAL_PER_OSD2 + 1)
     PGS=$(ceph osd df --format=json-pretty | jq '.nodes[0].pgs')
-    test $PGS -eq $FINAL_PER_OSD2 || return 1
+    test $PGS -ge $MIN -a $PGS -le $MAX || return 1
     PGS=$(ceph osd df --format=json-pretty | jq '.nodes[1].pgs')
-    test $PGS -eq $FINAL_PER_OSD2 || return 1
+    test $PGS -ge $MIN -a $PGS -le $MAX || return 1
     PGS=$(ceph osd df --format=json-pretty | jq '.nodes[2].pgs')
-    test $PGS -eq $FINAL_PER_OSD2 || return 1
+    test $PGS -ge $MIN -a $PGS -le $MAX || return 1
     PGS=$(ceph osd df --format=json-pretty | jq '.nodes[3].pgs')
-    test $PGS -eq $FINAL_PER_OSD2 || return 1
+    test $PGS -ge $MIN -a $PGS -le $MAX || return 1
     PGS=$(ceph osd df --format=json-pretty | jq '.nodes[4].pgs')
-    test $PGS -eq $FINAL_PER_OSD2 || return 1
+    test $PGS -ge $MIN -a $PGS -le $MAX || return 1
 
     teardown $dir || return 1
 }

--- a/qa/standalone/mgr/balancer.sh
+++ b/qa/standalone/mgr/balancer.sh
@@ -141,6 +141,7 @@ function TEST_balancer2() {
     done
 
     ceph osd set-require-min-compat-client luminous
+    ceph config set mgr mgr/balancer/upmap_max_deviation 1
     ceph balancer mode upmap || return 1
     ceph balancer on || return 1
     ceph config set mgr mgr/balancer/sleep_interval 5

--- a/qa/standalone/mgr/balancer.sh
+++ b/qa/standalone/mgr/balancer.sh
@@ -67,9 +67,9 @@ function TEST_balancer() {
     ceph balancer pool add $TEST_POOL1 || return 1
     ceph balancer pool add $TEST_POOL2 || return 1
     ceph balancer pool ls || return 1
-    eval POOL=$(ceph balancer pool ls | jq '.[0]')
+    eval POOL=$(ceph balancer pool ls | jq 'sort | .[0]')
     test "$POOL" = "$TEST_POOL1" || return 1
-    eval POOL=$(ceph balancer pool ls | jq '.[1]')
+    eval POOL=$(ceph balancer pool ls | jq 'sort | .[1]')
     test "$POOL" = "$TEST_POOL2" || return 1
     ceph balancer pool rm $TEST_POOL1 || return 1
     ceph balancer pool rm $TEST_POOL2 || return 1

--- a/qa/standalone/mgr/balancer.sh
+++ b/qa/standalone/mgr/balancer.sh
@@ -104,7 +104,7 @@ function TEST_balancer() {
     ! ceph balancer optimize plan_upmap $TEST_POOL || return 1
     ceph balancer status || return 1
     eval RESULT=$(ceph balancer status | jq '.optimize_result')
-    test "$RESULT" = "Unable to find further optimization, or pool(s)' pg_num is decreasing, or distribution is already perfect" || return 1
+    test "$RESULT" = "Unable to find further optimization, or pool(s) pg_num is decreasing, or distribution is already perfect" || return 1
 
     ceph balancer on || return 1
     ACTIVE=$(ceph balancer status | jq '.active')

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2362,12 +2362,6 @@ std::vector<Option> get_global_options() {
                      "by doing a fairly exhaustive search of existing PGs "
                      "that can be unmapped or upmapped"),
 
-    Option("osd_calc_pg_upmaps_max_stddev", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(1.0)
-    .set_flag(Option::FLAG_RUNTIME)
-    .set_description("standard deviation below which there is no attempt made "
-                     "while trying to calculate PG upmaps"),
-
     Option("osd_calc_pg_upmaps_local_fallback_retries", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(100)
     .set_flag(Option::FLAG_RUNTIME)

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -3785,6 +3785,7 @@ int CrushWrapper::_choose_type_stack(
   const vector<pair<int,int>>& stack,
   const set<int>& overfull,
   const vector<int>& underfull,
+  const vector<int>& more_underfull,
   const vector<int>& orig,
   vector<int>::const_iterator& i,
   set<int>& used,
@@ -3897,6 +3898,33 @@ int CrushWrapper::_choose_type_stack(
 	      ++i;
 	      break;
 	    }
+	      if (!replaced) {
+	      for (auto item : more_underfull) {
+	        ldout(cct, 10) << __func__ << " more underfull pos " << pos
+			       << " was " << *i << " considering " << item
+			       << dendl;
+	        if (used.count(item)) {
+		  ldout(cct, 20) << __func__ << "   in used " << used << dendl;
+		  continue;
+	        }
+	        if (!subtree_contains(from, item)) {
+		  ldout(cct, 20) << __func__ << "   not in subtree " << from << dendl;
+		  continue;
+	        }
+	        if (std::find(orig.begin(), orig.end(), item) != orig.end()) {
+		  ldout(cct, 20) << __func__ << "   in orig " << orig << dendl;
+		  continue;
+	        }
+	        o.push_back(item);
+	        used.insert(item);
+	        ldout(cct, 10) << __func__ << " pos " << pos << " replace "
+			       << *i << " -> " << item << dendl;
+	        replaced = true;
+                assert(i != orig.end());
+	        ++i;
+	        break;
+	      }
+	    }
 	  }
 	  if (!replaced) {
 	    ldout(cct, 10) << __func__ << " pos " << pos << " keep " << *i
@@ -3974,6 +4002,7 @@ int CrushWrapper::try_remap_rule(
   int maxout,
   const set<int>& overfull,
   const vector<int>& underfull,
+  const vector<int>& more_underfull,
   const vector<int>& orig,
   vector<int> *out) const
 {
@@ -3983,7 +4012,9 @@ int CrushWrapper::try_remap_rule(
 
   ldout(cct, 10) << __func__ << " ruleno " << ruleno
 		<< " numrep " << maxout << " overfull " << overfull
-		<< " underfull " << underfull << " orig " << orig
+		<< " underfull " << underfull
+		<< " more_underfull " << more_underfull
+		<< " orig " << orig
 		<< dendl;
   vector<int> w; // working set
   out->clear();
@@ -4020,7 +4051,7 @@ int CrushWrapper::try_remap_rule(
 	type_stack.push_back(make_pair(type, numrep));
         if (type > 0)
 	  type_stack.push_back(make_pair(0, 1));
-	int r = _choose_type_stack(cct, type_stack, overfull, underfull, orig,
+	int r = _choose_type_stack(cct, type_stack, overfull, underfull, more_underfull, orig,
 				   i, used, &w, root_bucket, ruleno);
 	if (r < 0)
 	  return r;
@@ -4042,7 +4073,7 @@ int CrushWrapper::try_remap_rule(
     case CRUSH_RULE_EMIT:
       ldout(cct, 10) << " emit " << w << dendl;
       if (!type_stack.empty()) {
-	int r = _choose_type_stack(cct, type_stack, overfull, underfull, orig,
+	int r = _choose_type_stack(cct, type_stack, overfull, underfull, more_underfull, orig,
 				   i, used, &w, root_bucket, ruleno);
 	if (r < 0)
 	  return r;

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1580,6 +1580,7 @@ public:
     const vector<pair<int,int>>& stack,
     const set<int>& overfull,
     const vector<int>& underfull,
+    const vector<int>& more_underfull,
     const vector<int>& orig,
     vector<int>::const_iterator& i,
     set<int>& used,
@@ -1593,6 +1594,7 @@ public:
     int maxout,
     const set<int>& overfull,
     const vector<int>& underfull,
+    const vector<int>& more_underfull,
     const vector<int>& orig,
     vector<int> *out) const;
 

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1584,7 +1584,8 @@ public:
     vector<int>::const_iterator& i,
     set<int>& used,
     vector<int> *pw,
-    int root_bucket) const;
+    int root_bucket,
+    int rule) const;
 
   int try_remap_rule(
     CephContext *cct,

--- a/src/mgr/PyOSDMap.cc
+++ b/src/mgr/PyOSDMap.cc
@@ -114,9 +114,9 @@ static PyObject *osdmap_calc_pg_upmaps(BasePyOSDMap* self, PyObject *args)
 {
   PyObject *pool_list;
   BasePyOSDMapIncremental *incobj;
-  double max_deviation = 0;
+  int max_deviation = 0;
   int max_iterations = 0;
-  if (!PyArg_ParseTuple(args, "OdiO:calc_pg_upmaps",
+  if (!PyArg_ParseTuple(args, "OiiO:calc_pg_upmaps",
 			&incobj, &max_deviation,
 			&max_iterations, &pool_list)) {
     return nullptr;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4552,7 +4552,7 @@ int OSDMap::calc_pg_upmaps(
         overfull.insert(i->second);
       }
     if (overfull.empty()) {
-      lderr(cct) << __func__ << " failed to build overfull" << dendl;
+      ldout(cct, 20) << __func__ << " failed to build overfull" << dendl;
       break;
     }
 
@@ -4564,7 +4564,7 @@ int OSDMap::calc_pg_upmaps(
         underfull.push_back(i->second);
     }
     if (underfull.empty()) {
-      lderr(cct) << __func__ << " failed to build underfull" << dendl;
+      ldout(cct, 20) << __func__ << " failed to build underfull" << dendl;
       break;
     }
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4701,13 +4701,24 @@ int OSDMap::calc_pg_upmaps(
 	  continue;
 	}
 	ceph_assert(orig != out);
+	int pos = -1;
+	float max_dev = 0;
 	for (unsigned i = 0; i < out.size(); ++i) {
           if (orig[i] == out[i])
             continue; // skip invalid remappings
           if (existing.count(orig[i]) || existing.count(out[i]))
             continue; // we want new remappings only!
+	  if (osd_deviation[orig[i]] > max_dev) {
+	    max_dev = osd_deviation[orig[i]];
+	    pos = i;
+	    ldout(cct, 30) << "Max osd." << orig[i] << " pos " << i << " dev " << osd_deviation[orig[i]] << dendl;
+	  }
+	}
+	if (pos != -1) {
+	  int i = pos;
           ldout(cct, 10) << " will try adding new remapping pair "
                          << orig[i] << " -> " << out[i] << " for " << pg
+			 << (orig[i] != osd ? " NOT selected osd" : "")
                          << dendl;
           existing.insert(orig[i]);
           existing.insert(out[i]);

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1399,6 +1399,7 @@ public:
     pg_t pg,                       ///< pg to potentially remap
     const set<int>& overfull,      ///< osds we'd want to evacuate
     const vector<int>& underfull,  ///< osds to move to, in order of preference
+    const vector<int>& more_underfull,  ///< less full osds to move to, in order of preference
     vector<int> *orig,
     vector<int> *out);             ///< resulting alternative mapping
 

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1404,7 +1404,7 @@ public:
 
   int calc_pg_upmaps(
     CephContext *cct,
-    float max_deviation, ///< max deviation from target (value < 1.0)
+    uint32_t max_deviation, ///< max deviation from target (value >= 1)
     int max_iterations,  ///< max iterations to run
     const set<int64_t>& pools,        ///< [optional] restrict to pool
     Incremental *pending_inc

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -299,12 +299,11 @@ class Module(MgrModule):
         },
         {
             'name': 'upmap_max_deviation',
-            'type': 'float',
-            'default': .01,
-            'min': 0,
-            'max': 1,
+            'type': 'int',
+            'default': 1,
+            'min': 1,
             'desc': 'deviation below which no optimization is attempted',
-            'long_desc': 'If the ratio between the fullest and least-full OSD is below this value then we stop trying to optimize placement.',
+            'long_desc': 'If the number of PGs are within this count then no optimization is attempted',
             'runtime': True,
         },
         {

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -300,7 +300,7 @@ class Module(MgrModule):
         {
             'name': 'upmap_max_deviation',
             'type': 'int',
-            'default': 1,
+            'default': 5,
             'min': 1,
             'desc': 'deviation below which no optimization is attempted',
             'long_desc': 'If the number of PGs are within this count then no optimization is attempted',

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -980,7 +980,7 @@ class Module(MgrModule):
         self.log.info('prepared %d/%d changes' % (total_did, max_iterations))
         if total_did == 0:
             return -errno.EALREADY, 'Unable to find further optimization, ' \
-                                    'or pool(s)\' pg_num is decreasing, ' \
+                                    'or pool(s) pg_num is decreasing, ' \
                                     'or distribution is already perfect'
         return 0, ''
 

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -28,6 +28,7 @@
                              max deviation from target [default: 1]
      --upmap-pool <poolname> restrict upmap balancing to 1 or more pools
      --upmap-save            write modified OSDMap with upmap changes
+     --upmap-active          Act like an active balancer, keep applying changes until balanced
      --dump <format>         displays the map in plain text when <format> is 'plain', 'json' if specified format is not supported
      --tree                  displays a tree of the map
      --test-crush [--range-first <first> --range-last <last>] map pgs to acting osds

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -25,7 +25,7 @@
                              writing commands to <file> [default: - for stdout]
      --upmap-max <max-count> set max upmap entries to calculate [default: 10]
      --upmap-deviation <max-deviation>
-                             max deviation from target [default: 1]
+                             max deviation from target [default: 5]
      --upmap-pool <poolname> restrict upmap balancing to 1 or more pools
      --upmap-save            write modified OSDMap with upmap changes
      --upmap-active          Act like an active balancer, keep applying changes until balanced

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -25,7 +25,7 @@
                              writing commands to <file> [default: - for stdout]
      --upmap-max <max-count> set max upmap entries to calculate [default: 10]
      --upmap-deviation <max-deviation>
-                             max deviation from target [default: .01]
+                             max deviation from target [default: 1]
      --upmap-pool <poolname> restrict upmap balancing to 1 or more pools
      --upmap-save            write modified OSDMap with upmap changes
      --dump <format>         displays the map in plain text when <format> is 'plain', 'json' if specified format is not supported

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -23,7 +23,7 @@
                              commands to <file> [default: - for stdout]
      --upmap <file>          calculate pg upmap entries to balance pg layout
                              writing commands to <file> [default: - for stdout]
-     --upmap-max <max-count> set max upmap entries to calculate [default: 100]
+     --upmap-max <max-count> set max upmap entries to calculate [default: 10]
      --upmap-deviation <max-deviation>
                              max deviation from target [default: .01]
      --upmap-pool <poolname> restrict upmap balancing to 1 or more pools

--- a/src/test/cli/osdmaptool/upmap-out.t
+++ b/src/test/cli/osdmaptool/upmap-out.t
@@ -7,7 +7,7 @@
   marking OSD@147 as out
   writing upmap command output to: c
   checking for upmap cleanups
-  upmap, max-count 11, max deviation 1
+  upmap, max-count 11, max deviation 5
   pools rbd 
   prepared 11/11 changes
   $ cat c

--- a/src/test/cli/osdmaptool/upmap-out.t
+++ b/src/test/cli/osdmaptool/upmap-out.t
@@ -8,6 +8,8 @@
   writing upmap command output to: c
   checking for upmap cleanups
   upmap, max-count 11, max deviation 0.01
+  pools rbd 
+  prepared 11/11 changes
   $ cat c
   ceph osd pg-upmap-items 1.7 142 145
   ceph osd pg-upmap-items 1.8 219 223

--- a/src/test/cli/osdmaptool/upmap-out.t
+++ b/src/test/cli/osdmaptool/upmap-out.t
@@ -8,8 +8,8 @@
   writing upmap command output to: c
   checking for upmap cleanups
   upmap, max-count 11, max deviation 1
-  prepared 11 changes for pools(s) rbd 
-  prepared 11 changes in total
+  pools rbd 
+  prepared 11/11 changes
   $ cat c
   ceph osd pg-upmap-items 1.7 142 145
   ceph osd pg-upmap-items 1.8 219 223

--- a/src/test/cli/osdmaptool/upmap-out.t
+++ b/src/test/cli/osdmaptool/upmap-out.t
@@ -8,8 +8,8 @@
   writing upmap command output to: c
   checking for upmap cleanups
   upmap, max-count 11, max deviation 0.01
-  pools rbd 
-  prepared 11/11 changes
+  prepared 11 changes for pools(s) rbd 
+  prepared 11 changes in total
   $ cat c
   ceph osd pg-upmap-items 1.7 142 145
   ceph osd pg-upmap-items 1.8 219 223

--- a/src/test/cli/osdmaptool/upmap-out.t
+++ b/src/test/cli/osdmaptool/upmap-out.t
@@ -7,16 +7,18 @@
   marking OSD@147 as out
   writing upmap command output to: c
   checking for upmap cleanups
-  upmap, max-count 11, max deviation 0.01
+  upmap, max-count 11, max deviation 1
   prepared 11 changes for pools(s) rbd 
   prepared 11 changes in total
   $ cat c
   ceph osd pg-upmap-items 1.7 142 145
   ceph osd pg-upmap-items 1.8 219 223
-  ceph osd pg-upmap-items 1.17 171 173 201 202
+  ceph osd pg-upmap-items 1.17 201 202 171 173
   ceph osd pg-upmap-items 1.1a 201 202
-  ceph osd pg-upmap-items 1.1c 171 173 201 202
-  ceph osd pg-upmap-items 1.20 88 87 201 202
+  ceph osd pg-upmap-items 1.1c 201 202
+  ceph osd pg-upmap-items 1.20 201 202
+  ceph osd pg-upmap-items 1.51 201 202
   ceph osd pg-upmap-items 1.62 219 223
   ceph osd pg-upmap-items 1.6f 219 223
+  ceph osd pg-upmap-items 1.82 219 223
   $ rm -f om c

--- a/src/test/cli/osdmaptool/upmap.t
+++ b/src/test/cli/osdmaptool/upmap.t
@@ -7,8 +7,8 @@
   writing upmap command output to: c
   checking for upmap cleanups
   upmap, max-count 11, max deviation 1
-  prepared 11 changes for pools(s) rbd 
-  prepared 11 changes in total
+  pools rbd 
+  prepared 11/11 changes
   $ cat c
   ceph osd pg-upmap-items 1.7 142 147
   ceph osd pg-upmap-items 1.8 219 223

--- a/src/test/cli/osdmaptool/upmap.t
+++ b/src/test/cli/osdmaptool/upmap.t
@@ -6,7 +6,7 @@
   marking all OSDs up and in
   writing upmap command output to: c
   checking for upmap cleanups
-  upmap, max-count 11, max deviation 1
+  upmap, max-count 11, max deviation 5
   pools rbd 
   prepared 11/11 changes
   $ cat c

--- a/src/test/cli/osdmaptool/upmap.t
+++ b/src/test/cli/osdmaptool/upmap.t
@@ -7,6 +7,8 @@
   writing upmap command output to: c
   checking for upmap cleanups
   upmap, max-count 11, max deviation 0.01
+  pools rbd 
+  prepared 11/11 changes
   $ cat c
   ceph osd pg-upmap-items 1.7 142 147
   ceph osd pg-upmap-items 1.8 219 223

--- a/src/test/cli/osdmaptool/upmap.t
+++ b/src/test/cli/osdmaptool/upmap.t
@@ -7,8 +7,8 @@
   writing upmap command output to: c
   checking for upmap cleanups
   upmap, max-count 11, max deviation 0.01
-  pools rbd 
-  prepared 11/11 changes
+  prepared 11 changes for pools(s) rbd 
+  prepared 11 changes in total
   $ cat c
   ceph osd pg-upmap-items 1.7 142 147
   ceph osd pg-upmap-items 1.8 219 223

--- a/src/test/cli/osdmaptool/upmap.t
+++ b/src/test/cli/osdmaptool/upmap.t
@@ -6,16 +6,18 @@
   marking all OSDs up and in
   writing upmap command output to: c
   checking for upmap cleanups
-  upmap, max-count 11, max deviation 0.01
+  upmap, max-count 11, max deviation 1
   prepared 11 changes for pools(s) rbd 
   prepared 11 changes in total
   $ cat c
   ceph osd pg-upmap-items 1.7 142 147
   ceph osd pg-upmap-items 1.8 219 223
-  ceph osd pg-upmap-items 1.17 171 173 201 202
+  ceph osd pg-upmap-items 1.17 201 202 171 173
   ceph osd pg-upmap-items 1.1a 201 202
-  ceph osd pg-upmap-items 1.1c 171 173 201 202
-  ceph osd pg-upmap-items 1.20 88 87 201 202
+  ceph osd pg-upmap-items 1.1c 201 202
+  ceph osd pg-upmap-items 1.20 201 202
+  ceph osd pg-upmap-items 1.24 232 233
   ceph osd pg-upmap-items 1.51 201 202
   ceph osd pg-upmap-items 1.62 219 223
+  ceph osd pg-upmap-items 1.6f 219 223
   $ rm -f om c

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1329,9 +1329,10 @@ TEST(CrushWrapper, try_remap_rule) {
     vector<int> orig = { 0, 3, 9 };
     set<int> overfull = { 3 };
     vector<int> underfull = { 0, 2, 5, 8, 11 };
+    vector<int> more_underfull = {};
     vector<int> out;
     int r = c.try_remap_rule(g_ceph_context, rule, 3,
-			      overfull, underfull,
+			      overfull, underfull, more_underfull,
 			      orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
     ASSERT_EQ(r, 0);
@@ -1345,7 +1346,7 @@ TEST(CrushWrapper, try_remap_rule) {
     orig = {1, 3, 9};
 
     r = c.try_remap_rule(g_ceph_context, rule, 3,
-			 overfull, underfull,
+			 overfull, underfull, more_underfull,
 			 orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
     ASSERT_EQ(r, 0);
@@ -1353,6 +1354,21 @@ TEST(CrushWrapper, try_remap_rule) {
     ASSERT_EQ(1, out[0]);
     ASSERT_EQ(0, out[1]);
     ASSERT_EQ(9, out[2]);
+    //
+    // Check that more_underfull is used when underfull runs out
+    orig = { 0, 3, 9 };
+    overfull = { 3, 9 };
+    underfull = { 2 };
+    more_underfull = { 5, 8, 11 };
+    r = c.try_remap_rule(g_ceph_context, rule, 3,
+			      overfull, underfull, more_underfull,
+			      orig, &out);
+    cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(3u, out.size());
+    ASSERT_EQ(0, out[0]);
+    ASSERT_EQ(2, out[1]);
+    ASSERT_EQ(5, out[2]);
   }
 
   // chooseleaf
@@ -1366,9 +1382,10 @@ TEST(CrushWrapper, try_remap_rule) {
     vector<int> orig = { 0, 3, 9 };
     set<int> overfull = { 3 };
     vector<int> underfull = { 0, 2, 5, 8, 11 };
+    vector<int> more_underfull = { };
     vector<int> out;
     int r = c.try_remap_rule(g_ceph_context, rule, 3,
-			      overfull, underfull,
+			      overfull, underfull, more_underfull,
 			      orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
     ASSERT_EQ(r, 0);
@@ -1392,9 +1409,10 @@ TEST(CrushWrapper, try_remap_rule) {
     vector<int> orig = { 0, 3, 16, 12 };
     set<int> overfull = { 3, 12 };
     vector<int> underfull = { 6, 7, 9, 3, 0, 1, 15, 16, 13, 2, 5, 8, 11 };
+    vector<int> more_underfull = { };
     vector<int> out;
     int r = c.try_remap_rule(g_ceph_context, rule, 3,
-			      overfull, underfull,
+			      overfull, underfull, more_underfull,
 			      orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
     ASSERT_EQ(r, 0);
@@ -1407,7 +1425,7 @@ TEST(CrushWrapper, try_remap_rule) {
     orig.pop_back();
     out.clear();
     r = c.try_remap_rule(g_ceph_context, rule, 3,
-			 overfull, underfull,
+			 overfull, underfull, more_underfull,
 			 orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
     ASSERT_EQ(r, 0);

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -1323,15 +1323,11 @@ TEST_F(OSDMapTest, BUG_38897) {
 
   // ready to go
   {
-    // require perfect distribution!
-    auto ret = g_ceph_context->_conf.set_val(
-      "osd_calc_pg_upmaps_max_stddev", "0");
-    ASSERT_EQ(0, ret);
-    g_ceph_context->_conf.apply_changes(nullptr);
     set<int64_t> only_pools;
     ASSERT_TRUE(pool_1_id >= 0);
     only_pools.insert(pool_1_id);
     OSDMap::Incremental pending_inc(osdmap.get_epoch() + 1);
+    // require perfect distribution! (max deviation 0)
     osdmap.calc_pg_upmaps(g_ceph_context,
                           0, // so we can force optimizing
                           100,

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -54,7 +54,7 @@ void usage()
   cout << "                           writing commands to <file> [default: - for stdout]" << std::endl;
   cout << "   --upmap-max <max-count> set max upmap entries to calculate [default: 10]" << std::endl;
   cout << "   --upmap-deviation <max-deviation>" << std::endl;
-  cout << "                           max deviation from target [default: 1]" << std::endl;
+  cout << "                           max deviation from target [default: 5]" << std::endl;
   cout << "   --upmap-pool <poolname> restrict upmap balancing to 1 or more pools" << std::endl;
   cout << "   --upmap-save            write modified OSDMap with upmap changes" << std::endl;
   cout << "   --upmap-active          Act like an active balancer, keep applying changes until balanced" << std::endl;
@@ -145,7 +145,7 @@ int main(int argc, const char **argv)
   bool health = false;
   std::string upmap_file = "-";
   int upmap_max = 10;
-  int upmap_deviation = 1;
+  int upmap_deviation = 5;
   bool upmap_active = false;
   std::set<std::string> upmap_pools;
   int64_t pg_num = -1;

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -19,6 +19,7 @@
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "mon/health_check.h"
+#include <time.h>
 #include <algorithm>
 
 #include "global/global_init.h"
@@ -56,6 +57,7 @@ void usage()
   cout << "                           max deviation from target [default: 1]" << std::endl;
   cout << "   --upmap-pool <poolname> restrict upmap balancing to 1 or more pools" << std::endl;
   cout << "   --upmap-save            write modified OSDMap with upmap changes" << std::endl;
+  cout << "   --upmap-active          Act like an active balancer, keep applying changes until balanced" << std::endl;
   cout << "   --dump <format>         displays the map in plain text when <format> is 'plain', 'json' if specified format is not supported" << std::endl;
   cout << "   --tree                  displays a tree of the map" << std::endl;
   cout << "   --test-crush [--range-first <first> --range-last <last>] map pgs to acting osds" << std::endl;
@@ -144,6 +146,7 @@ int main(int argc, const char **argv)
   std::string upmap_file = "-";
   int upmap_max = 10;
   int upmap_deviation = 1;
+  bool upmap_active = false;
   std::set<std::string> upmap_pools;
   int64_t pg_num = -1;
   bool test_map_pgs_dump_all = false;
@@ -184,6 +187,8 @@ int main(int argc, const char **argv)
 	exit(EXIT_FAILURE);
       }
       createsimple = true;
+    } else if (ceph_argparse_flag(args, i, "--upmap-active", (char*)NULL)) {
+      upmap_active = true;
     } else if (ceph_argparse_flag(args, i, "--health", (char*)NULL)) {
       health = true;
     } else if (ceph_argparse_flag(args, i, "--with-default-pool", (char*)NULL)) {
@@ -379,9 +384,8 @@ int main(int argc, const char **argv)
     cout << "upmap, max-count " << upmap_max
 	 << ", max deviation " << upmap_deviation
 	 << std::endl;
-    OSDMap::Incremental pending_inc(osdmap.get_epoch()+1);
-    pending_inc.fsid = osdmap.get_fsid();
     vector<int64_t> pools;
+    set<int64_t> upmap_pool_nums;
     for (auto& s : upmap_pools) {
       int64_t p = osdmap.lookup_pg_pool_name(s);
       if (p < 0) {
@@ -389,6 +393,7 @@ int main(int argc, const char **argv)
 	exit(1);
       }
       pools.push_back(p);
+      upmap_pool_nums.insert(p);
     }
     if (!pools.empty()) {
       cout << " limiting to pools " << upmap_pools << " (" << pools << ")"
@@ -403,39 +408,79 @@ int main(int argc, const char **argv)
       cout << "No pools available" << std::endl;
       goto skip_upmap;
     }
-    std::random_device rd;
-    std::shuffle(pools.begin(), pools.end(), std::mt19937{rd()});
-    cout << "pools ";
-    for (auto& i: pools)
-      cout << osdmap.get_pool_name(i) << " ";
-    cout << std::endl;
-    int total_did = 0;
-    int left = upmap_max;
-    for (auto& i: pools) {
-      set<int64_t> one_pool;
-      one_pool.insert(i);
-      int did = osdmap.calc_pg_upmaps(
-        g_ceph_context, upmap_deviation,
-        left, one_pool,
-        &pending_inc);
-      total_did += did;
-      left -= did;
-      if (left <= 0)
-        break;
-    }
-    cout << "prepared " << total_did << "/" << upmap_max  << " changes" << std::endl;
-    if (total_did > 0) {
-      print_inc_upmaps(pending_inc, upmap_fd);
-      if (upmap_save) {
-	int r = osdmap.apply_incremental(pending_inc);
-	ceph_assert(r == 0);
-	modified = true;
+    int rounds = 0;
+    struct timespec round_start;
+    int r = clock_gettime(CLOCK_MONOTONIC, &round_start);
+    assert(r == 0);
+    do {
+      std::random_device rd;
+      std::shuffle(pools.begin(), pools.end(), std::mt19937{rd()});
+      cout << "pools ";
+      for (auto& i: pools)
+        cout << osdmap.get_pool_name(i) << " ";
+      cout << std::endl;
+      OSDMap::Incremental pending_inc(osdmap.get_epoch()+1);
+      pending_inc.fsid = osdmap.get_fsid();
+      int total_did = 0;
+      int left = upmap_max;
+      struct timespec begin, end;
+      r = clock_gettime(CLOCK_MONOTONIC, &begin);
+      assert(r == 0);
+      for (auto& i: pools) {
+        set<int64_t> one_pool;
+        one_pool.insert(i);
+        int did = osdmap.calc_pg_upmaps(
+          g_ceph_context, upmap_deviation,
+          left, one_pool,
+          &pending_inc);
+        total_did += did;
+        left -= did;
+        if (left <= 0)
+          break;
       }
-    } else {
-      cout << "Unable to find further optimization, "
-	   << "or distribution is already perfect"
-	   << std::endl;
-    }
+      r = clock_gettime(CLOCK_MONOTONIC, &end);
+      assert(r == 0);
+      cout << "prepared " << total_did << "/" << upmap_max  << " changes" << std::endl;
+      float elapsed_time = (end.tv_sec - begin.tv_sec) + 1.0e-9*(end.tv_nsec - begin.tv_nsec);
+      if (upmap_active)
+        cout << "Time elapsed " << elapsed_time << " secs" << std::endl;
+      if (total_did > 0) {
+        print_inc_upmaps(pending_inc, upmap_fd);
+        if (upmap_save || upmap_active) {
+	  int r = osdmap.apply_incremental(pending_inc);
+	  ceph_assert(r == 0);
+	  if (upmap_save)
+	    modified = true;
+        }
+      } else {
+        cout << "Unable to find further optimization, "
+	     << "or distribution is already perfect"
+	     << std::endl;
+        if (upmap_active) {
+          map<int,set<pg_t>> pgs_by_osd;
+          for (auto& i : osdmap.get_pools()) {
+            if (!upmap_pool_nums.empty() && !upmap_pool_nums.count(i.first))
+              continue;
+            for (unsigned ps = 0; ps < i.second.get_pg_num(); ++ps) {
+              pg_t pg(ps, i.first);
+              vector<int> up;
+              osdmap.pg_to_up_acting_osds(pg, &up, nullptr, nullptr, nullptr);
+              //ldout(cct, 20) << __func__ << " " << pg << " up " << up << dendl;
+              for (auto osd : up) {
+                if (osd != CRUSH_ITEM_NONE)
+                  pgs_by_osd[osd].insert(pg);
+              }
+            }
+          }
+          for (auto& i : pgs_by_osd)
+            cout << "osd." << i.first << " pgs " << i.second.size() << std::endl;
+          float elapsed_time = (end.tv_sec - round_start.tv_sec) + 1.0e-9*(end.tv_nsec - round_start.tv_nsec);
+          cout << "Total time elapsed " << elapsed_time << " secs, " << rounds << " rounds" << std::endl;
+        }
+        break;
+      }
+      ++rounds;
+    } while(upmap_active);
   }
 skip_upmap:
   if (upmap_file != "-") {

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -50,7 +50,7 @@ void usage()
   cout << "                           commands to <file> [default: - for stdout]" << std::endl;
   cout << "   --upmap <file>          calculate pg upmap entries to balance pg layout" << std::endl;
   cout << "                           writing commands to <file> [default: - for stdout]" << std::endl;
-  cout << "   --upmap-max <max-count> set max upmap entries to calculate [default: 100]" << std::endl;
+  cout << "   --upmap-max <max-count> set max upmap entries to calculate [default: 10]" << std::endl;
   cout << "   --upmap-deviation <max-deviation>" << std::endl;
   cout << "                           max deviation from target [default: .01]" << std::endl;
   cout << "   --upmap-pool <poolname> restrict upmap balancing to 1 or more pools" << std::endl;
@@ -141,7 +141,7 @@ int main(int argc, const char **argv)
   bool upmap_save = false;
   bool health = false;
   std::string upmap_file = "-";
-  int upmap_max = 100;
+  int upmap_max = 10;
   float upmap_deviation = .01;
   std::set<std::string> upmap_pools;
   int64_t pg_num = -1;

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -19,6 +19,7 @@
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "mon/health_check.h"
+#include <algorithm>
 
 #include "global/global_init.h"
 #include "osd/OSDMap.h"
@@ -376,23 +377,50 @@ int main(int argc, const char **argv)
 	 << std::endl;
     OSDMap::Incremental pending_inc(osdmap.get_epoch()+1);
     pending_inc.fsid = osdmap.get_fsid();
-    set<int64_t> pools;
+    vector<int64_t> pools;
     for (auto& s : upmap_pools) {
       int64_t p = osdmap.lookup_pg_pool_name(s);
       if (p < 0) {
-	cerr << " pool '" << s << "' does not exist" << std::endl;
+	cerr << " pool " << s << " does not exist" << std::endl;
 	exit(1);
       }
-      pools.insert(p);
+      pools.push_back(p);
     }
-    if (!pools.empty())
+    if (!pools.empty()) {
       cout << " limiting to pools " << upmap_pools << " (" << pools << ")"
 	   << std::endl;
-    int changed = osdmap.calc_pg_upmaps(
-      g_ceph_context, upmap_deviation,
-      upmap_max, pools,
-      &pending_inc);
-    if (changed) {
+    } else {
+      mempool::osdmap::map<int64_t,pg_pool_t> opools = osdmap.get_pools();
+      for (auto& i : opools) {
+         pools.push_back(i.first);
+      }
+    }
+    if (pools.empty()) {
+      cout << "No pools available" << std::endl;
+      goto skip_upmap;
+    }
+    srand(time(0));
+    random_shuffle (pools.begin(), pools.end());
+    cout << "pools ";
+    for (auto& i: pools)
+      cout << osdmap.get_pool_name(i) << " ";
+    cout << std::endl;
+    int total_did = 0;
+    int left = upmap_max;
+    for (auto& i: pools) {
+      set<int64_t> one_pool;
+      one_pool.insert(i);
+      int did = osdmap.calc_pg_upmaps(
+        g_ceph_context, upmap_deviation,
+        left, one_pool,
+        &pending_inc);
+      total_did += did;
+      left -= did;
+      if (left <= 0)
+        break;
+    }
+    cout << "prepared " << total_did << "/" << upmap_max  << " changes" << std::endl;
+    if (total_did > 0) {
       print_inc_upmaps(pending_inc, upmap_fd);
       if (upmap_save) {
 	int r = osdmap.apply_incremental(pending_inc);
@@ -400,9 +428,12 @@ int main(int argc, const char **argv)
 	modified = true;
       }
     } else {
-      cout << "no upmaps proposed" << std::endl;
+      cout << "Unable to find further optimization, "
+	   << "or distribution is already perfect"
+	   << std::endl;
     }
   }
+skip_upmap:
   if (upmap_file != "-") {
     ::close(upmap_fd);
   }

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -350,7 +350,7 @@ int main(int argc, const char **argv)
   int upmap_fd = STDOUT_FILENO;
   if (upmap || upmap_cleanup) {
     if (upmap_file != "-") {
-      upmap_fd = ::open(upmap_file.c_str(), O_CREAT|O_WRONLY, 0644);
+      upmap_fd = ::open(upmap_file.c_str(), O_CREAT|O_WRONLY|O_TRUNC, 0644);
       if (upmap_fd < 0) {
 	cerr << "error opening " << upmap_file << ": " << cpp_strerror(errno)
 	     << std::endl;

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -53,7 +53,7 @@ void usage()
   cout << "                           writing commands to <file> [default: - for stdout]" << std::endl;
   cout << "   --upmap-max <max-count> set max upmap entries to calculate [default: 10]" << std::endl;
   cout << "   --upmap-deviation <max-deviation>" << std::endl;
-  cout << "                           max deviation from target [default: .01]" << std::endl;
+  cout << "                           max deviation from target [default: 1]" << std::endl;
   cout << "   --upmap-pool <poolname> restrict upmap balancing to 1 or more pools" << std::endl;
   cout << "   --upmap-save            write modified OSDMap with upmap changes" << std::endl;
   cout << "   --dump <format>         displays the map in plain text when <format> is 'plain', 'json' if specified format is not supported" << std::endl;
@@ -143,7 +143,7 @@ int main(int argc, const char **argv)
   bool health = false;
   std::string upmap_file = "-";
   int upmap_max = 10;
-  float upmap_deviation = .01;
+  int upmap_deviation = 1;
   std::set<std::string> upmap_pools;
   int64_t pg_num = -1;
   bool test_map_pgs_dump_all = false;
@@ -253,6 +253,10 @@ int main(int argc, const char **argv)
   }
   else if (args.size() > 1) {
     cerr << me << ": too many arguments" << std::endl;
+    usage();
+  }
+  if (upmap_deviation < 1) {
+    cerr << me << ": upmap-deviation must be >= 1" << std::endl;
     usage();
   }
   fn = args[0];

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -433,8 +433,8 @@ int main(int argc, const char **argv)
     vector<int> rules;
     for (auto& r: pools_by_rule)
       rules.push_back(r.first);
-    srand(time(0));
-    random_shuffle (rules.begin(), rules.end());
+    std::random_device rd;
+    std::shuffle(rules.begin(), rules.end(), std::mt19937{rd()});
     if (debug) {
       for (auto& r: rules)
         cout << "rule: " << r << " " << pools_by_rule[r] << std::endl;


### PR DESCRIPTION
Backports:
#31542
#31774
#31990
#32247

Parent trackers
https://tracker.ceph.com/issues/42756
https://tracker.ceph.com/issues/42718
https://tracker.ceph.com/issues/43084 - no backport tracker
https://tracker.ceph.com/issues/43307
https://tracker.ceph.com/issues/43312

Backport trackers
https://tracker.ceph.com/issues/42797
https://tracker.ceph.com/issues/43092
https://tracker.ceph.com/issues/43529
https://tracker.ceph.com/issues/43530


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
