### PR TITLE
mgr/volumes: check for string values in uid/gid

### DIFF
--- a/src/pybind/mgr/volumes/fs/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/subvolume.py
@@ -109,13 +109,23 @@ class SubVolume(object):
             groupstat = self.fs.stat(spec.group_path)
             if uid is None:
                 uid = int(groupstat.st_uid)
-            elif uid < 0:
-                raise VolumeException(-errno.EINVAL, "Provide a valid uid")
+            else:
+                try:
+                    uid = int(uid)
+                    if uid < 0:
+                        raise ValueError
+                except ValueError:
+                    raise VolumeException(-errno.EINVAL, "Invalid uid")
 
             if gid is None:
                 gid = int(groupstat.st_gid)
-            elif gid < 0:
-                raise VolumeException(-errno.EINVAL, "Provide a valid gid")
+            else:
+                try:
+                    gid = int(gid)
+                    if gid < 0:
+                        raise ValueError
+                except ValueError:
+                    raise VolumeException(-errno.EINVAL, "Invalid gid")
 
             try:
                 self.fs.chown(subvolpath, uid, gid)
@@ -302,13 +312,23 @@ class SubVolume(object):
 
             if uid is None:
                 uid = 0
-            elif uid < 0:
-                raise VolumeException(-errno.EINVAL, "Provide a valid uid")
+            else:
+                try:
+                    uid = int(uid)
+                    if uid < 0:
+                        raise ValueError
+                except ValueError:
+                    raise VolumeException(-errno.EINVAL, "Invalid uid")
 
             if gid is None:
                 gid = 0
-            elif gid < 0:
-                raise VolumeException(-errno.EINVAL, "Provide a valid gid")
+            else:
+                try:
+                    gid = int(gid)
+                    if gid < 0:
+                        raise ValueError
+                except ValueError:
+                    raise VolumeException(-errno.EINVAL, "Invalid gid")
 
             try:
                 self.fs.chown(path, uid, gid)


### PR DESCRIPTION
chown allows strings as per bbbfb44, which caused this error. Eventhough uid/gid are input as CephInt, the qa tests can pass in only string values to _fs_cmd. So try converting the incoming uid/gid to int in create_subvolume and create_group. It might be a valid string.

```
2019-11-27T12:56:17.408 INFO:tasks.ceph.mgr.y.smithi100.stderr:2019-11-27T12:56:17.414+0000 7f4d01f5e700 -1 mgr.server reply reply (22) Invalid argument Traceback (most recent call last):
2019-11-27T12:56:17.408 INFO:tasks.ceph.mgr.y.smithi100.stderr:  File "/usr/share/ceph/mgr/mgr_module.py", line 975, in _handle_command
2019-11-27T12:56:17.408 INFO:tasks.ceph.mgr.y.smithi100.stderr:    return self.handle_command(inbuf, cmd)
2019-11-27T12:56:17.408 INFO:tasks.ceph.mgr.y.smithi100.stderr:  File "/usr/share/ceph/mgr/volumes/module.py", line 201, in handle_command
2019-11-27T12:56:17.408 INFO:tasks.ceph.mgr.y.smithi100.stderr:    return handler(inbuf, cmd)
2019-11-27T12:56:17.408 INFO:tasks.ceph.mgr.y.smithi100.stderr:  File "/usr/share/ceph/mgr/volumes/module.py", line 248, in _cmd_fs_subvolume_create
2019-11-27T12:56:17.409 INFO:tasks.ceph.mgr.y.smithi100.stderr:    mode=cmd.get('mode', '755'))
2019-11-27T12:56:17.409 INFO:tasks.ceph.mgr.y.smithi100.stderr:  File "/usr/share/ceph/mgr/volumes/fs/volume.py", line 401, in conn_wrapper
2019-11-27T12:56:17.409 INFO:tasks.ceph.mgr.y.smithi100.stderr:    result = func(self, fs_h, **kwargs)
2019-11-27T12:56:17.409 INFO:tasks.ceph.mgr.y.smithi100.stderr:  File "/usr/share/ceph/mgr/volumes/fs/volume.py", line 440, in create_subvolume
2019-11-27T12:56:17.409 INFO:tasks.ceph.mgr.y.smithi100.stderr:    sv.create_subvolume(spec, size, pool=pool, uid=uid, gid=gid, mode=self.octal_str_to_decimal_int(mode))
2019-11-27T12:56:17.409 INFO:tasks.ceph.mgr.y.smithi100.stderr:  File "/usr/share/ceph/mgr/volumes/fs/subvolume.py", line 134, in create_subvolume
2019-11-27T12:56:17.409 INFO:tasks.ceph.mgr.y.smithi100.stderr:    raise e
2019-11-27T12:56:17.410 INFO:tasks.ceph.mgr.y.smithi100.stderr:TypeError: uid must be an int
```

Fixes: https://tracker.ceph.com/issues/43038