### PR TITLE
luminous: ceph-detect-init: run tox tests on Python 2 only

### DIFF
--- a/src/ceph-detect-init/tox.ini
+++ b/src/ceph-detect-init/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = pep8,py27,py3
+envlist = pep8,py27
 skip_missing_interpreters = True
 
 [testenv]
 basepython =
     py27: python2.7
-    py3: python3
 setenv = VIRTUAL_ENV={envdir}
 usedevelop = true
 deps =


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43100
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

Note: in `src/ceph-disk/tox.ini`, py3 was dropped long ago by 28c545eff5f73e392b70ef4c0cf74f8a896b693b