### PR TITLE
pybind/mgr: Make it easier to create a Module instance without the mgr

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -414,7 +414,7 @@ class CPlusPlusHandler(logging.Handler):
 
 class FileHandler(logging.FileHandler):
     def __init__(self, module_inst):
-        path = module_inst._ceph_get_option("log_file")
+        path = module_inst.get_ceph_option("log_file")
         idx = path.rfind(".log")
         if idx != -1:
             self.path = "{}.{}.log".format(path[:idx], module_inst.module_name)
@@ -535,7 +535,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
         super(MgrStandbyModule, self).__init__(capsule)
         self.module_name = module_name
 
-        mgr_level = self._ceph_get_option("debug_mgr")
+        mgr_level = self.get_ceph_option("debug_mgr")
         log_level = self.get_module_option("log_level")
         self._configure_logging(mgr_level, log_level, False)
 
@@ -641,7 +641,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         self.module_name = module_name
         super(MgrModule, self).__init__(py_modules_ptr, this_ptr)
 
-        mgr_level = self._ceph_get_option("debug_mgr")
+        mgr_level = self.get_ceph_option("debug_mgr")
         log_level = self.get_module_option("log_level")
         self._configure_logging(mgr_level, log_level,
                                 self.get_module_option("log_to_file", False))
@@ -733,7 +733,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
     def _config_notify(self):
         # check logging options for changes
-        mgr_level = self._ceph_get_option("debug_mgr")
+        mgr_level = self.get_ceph_option("debug_mgr")
         module_level = self.get_module_option("log_level")
         log_to_file = self.get_module_option("log_to_file", False)
 

--- a/src/pybind/mgr/ssh/tests/fixtures.py
+++ b/src/pybind/mgr/ssh/tests/fixtures.py
@@ -23,13 +23,17 @@ def get_store_prefix(self, prefix):
         if k.startswith(prefix)
     }
 
+def get_ceph_option(_, key):
+    return __file__
 
 @pytest.yield_fixture()
 def ssh_module():
-    with mock.patch("ssh.module.SSHOrchestrator.get_ceph_option", lambda _, key: __file__),\
+    with mock.patch("ssh.module.SSHOrchestrator.get_ceph_option", get_ceph_option),\
+            mock.patch("ssh.module.SSHOrchestrator._configure_logging", lambda *args: None),\
             mock.patch("ssh.module.SSHOrchestrator.set_store", set_store),\
             mock.patch("ssh.module.SSHOrchestrator.get_store", get_store),\
             mock.patch("ssh.module.SSHOrchestrator.get_store_prefix", get_store_prefix):
+        SSHOrchestrator._register_commands('')
         m = SSHOrchestrator.__new__ (SSHOrchestrator)
         m._store = {
             'ssh_config': '',


### PR DESCRIPTION
Caused by conflict between #30961 and #30262

This issue causes a `make check` error in the master branch

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Fixes https://jenkins.ceph.com/job/ceph-pull-requests/39747/console 

```
________________ ERROR at setup of TestCompletion.test_trivial _________________

    @pytest.yield_fixture()
    def ssh_module():
        with mock.patch("ssh.module.SSHOrchestrator.get_ceph_option", lambda _, key: __file__),\
                mock.patch("ssh.module.SSHOrchestrator.set_store", set_store),\
                mock.patch("ssh.module.SSHOrchestrator.get_store", get_store),\
                mock.patch("ssh.module.SSHOrchestrator.get_store_prefix", get_store_prefix):
            m = SSHOrchestrator.__new__ (SSHOrchestrator)
            m._store = {
                'ssh_config': '',
                'ssh_identity_key': '',
                'ssh_identity_pub': '',
                'inventory': {},
            }
>           m.__init__('ssh', 0, 0)

ssh/tests/fixtures.py:40: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
ssh/module.py:247: in __init__
    super(SSHOrchestrator, self).__init__(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ssh.module.SSHOrchestrator object at 0x7fe2c65c1410>
module_name = 'ssh', py_modules_ptr = 0, this_ptr = 0

    def __init__(self, module_name, py_modules_ptr, this_ptr):
        self.module_name = module_name
        super(MgrModule, self).__init__(py_modules_ptr, this_ptr)
    
>       mgr_level = self._ceph_get_option("debug_mgr")
E       AttributeError: 'SSHOrchestrator' object has no attribute '_ceph_get_option'

mgr_module.py:644: AttributeError
```



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
