### PR TITLE
rgw: apply_olh_log ignores RGW_ATTR_OLH_VER decode error

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6815,10 +6815,6 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
     std::string str = olh_ver->second.to_str();
     std::string err;
     link_epoch = strict_strtoll(str.c_str(), 10, &err);
-    if (!err.empty()) {
-      ldout(cct, 0) << "apply_olh_log failed to decode olh ver '" << str << "'" << dendl;
-      return -EINVAL;
-    }
   }
   auto olh_info = state.attrset.find(RGW_ATTR_OLH_INFO);
   if (olh_info != state.attrset.end()) {


### PR DESCRIPTION
a followup to https://github.com/ceph/ceph/pull/31325 for https://tracker.ceph.com/issues/39142

this resolves test failures that return 400 Bad Request after:
```
  apply_olh_log failed to decode olh ver ''
```
because olh_init_modification_impl() is writing an empty attribute:
```c++
  bufferlist verbl;
  op.setxattr(RGW_ATTR_OLH_VER, verbl);
```
on such decode errors, link_epoch will be set to 0, and will correctly
be overwritten by real epochs from the olh log