### PR TITLE
rgw: Fix dynamic resharding not working for empty zonegroup in period

### DIFF
--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -1083,7 +1083,7 @@ public:
 
   bool is_single_zonegroup() const
   {
-      return (period_map.zonegroups.size() == 1);
+      return (period_map.zonegroups.size() <= 1);
   }
 
   /*


### PR DESCRIPTION
Sometimes when cluster has been upgraded from jewel, the period's zonegroup could be empty, so no dynamic resharding.
This fix should fix it and return true for less than 1 (0) zonegroup in period

Signed-off-by: Or Friedmann <ofriedma@redhat.com>