### PR TITLE
nautilus: mgr/dashboard,grafana: remove shortcut menu

### DIFF
--- a/monitoring/grafana/dashboards/host-details.json
+++ b/monitoring/grafana/dashboards/host-details.json
@@ -38,17 +38,7 @@
   "graphTooltip": 0,
   "id": null,
   "iteration": 1557386759572,
-  "links": [
-    {
-      "asDropdown": true,
-      "icon": "external link",
-      "tags": [
-        "overview"
-      ],
-      "title": "Shortcuts",
-      "type": "dashboards"
-    }
-  ],
+  "links": [],
   "panels": [
     {
       "gridPos": {
@@ -1221,5 +1211,5 @@
   "timezone": "browser",
   "title": "Host Details",
   "uid": "rtOg0AiWz",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43103

---

backport of https://github.com/ceph/ceph/pull/31951
parent tracker: https://tracker.ceph.com/issues/43091

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh