### PR TITLE
doc: alphabetizes "Placement Group States" list

### DIFF
--- a/doc/rados/operations/pg-states.rst
+++ b/doc/rados/operations/pg-states.rst
@@ -7,72 +7,16 @@ Ceph will report on the status of the placement groups. A placement group has
 one or more states. The optimum state for placement groups in the placement group
 map is ``active + clean``. 
 
-*creating*
-  Ceph is still creating the placement group.
-
 *activating*
   The placement group is peered but not yet active.
 
 *active*
   Ceph will process requests to the placement group.
 
-*clean*
-  Ceph replicated all objects in the placement group the correct number of times.
-
-*down*
-  A replica with necessary data is down, so the placement group is offline.
-
-*laggy*
-  A replica is not acknowledging new leases from the primary in a timely fashion; IO is temporarily paused.
-
-*wait*
-  The set of OSDs for this PG has just changed and IO is temporarily paused until the previous interval's leases expire.
-
-*scrubbing*
-  Ceph is checking the placement group metadata for inconsistencies.
-
-*deep*
-  Ceph is checking the placement group data against stored checksums.
-
-*degraded*
-  Ceph has not replicated some objects in the placement group the correct number of times yet.
-
-*inconsistent*
-  Ceph detects inconsistencies in the one or more replicas of an object in the placement group
-  (e.g. objects are the wrong size, objects are missing from one replica *after* recovery finished, etc.).
-
-*peering*
-  The placement group is undergoing the peering process
-
-*repair*
-  Ceph is checking the placement group and repairing any inconsistencies it finds (if possible).
-
-*recovering*
-  Ceph is migrating/synchronizing objects and their replicas.
-
-*forced_recovery*
-  High recovery priority of that PG is enforced by user.
-
-*recovery_wait*
-  The placement group is waiting in line to start recover.
-
-*recovery_toofull*
-  A recovery operation is waiting because the destination OSD is over its
-  full ratio.
-
-*recovery_unfound*
-  Recovery stopped due to unfound objects.
-
 *backfilling*
   Ceph is scanning and synchronizing the entire contents of a placement group
   instead of inferring what contents need to be synchronized from the logs of
   recent operations. Backfill is a special case of recovery.
-
-*forced_backfill*
-  High backfill priority of that PG is enforced by user.
-
-*backfill_wait*
-  The placement group is waiting in line to start backfill.
 
 *backfill_toofull*
   A backfill operation is waiting because the destination OSD is over
@@ -80,6 +24,30 @@ map is ``active + clean``.
 
 *backfill_unfound*
   Backfill stopped due to unfound objects.
+ 
+*backfill_wait*
+  The placement group is waiting in line to start backfill.
+
+*clean*
+  Ceph replicated all objects in the placement group the correct number of times.
+
+*creating*
+  Ceph is still creating the placement group.
+
+*deep*
+  Ceph is checking the placement group data against stored checksums.
+
+*degraded*
+  Ceph has not replicated some objects in the placement group the correct number of times yet.
+
+*down*
+  A replica with necessary data is down, so the placement group is offline.
+
+*forced_backfill*
+  High backfill priority of that PG is enforced by user.
+  
+*forced_recovery*
+  High recovery priority of that PG is enforced by user.
 
 *incomplete*
   Ceph detects that a placement group is missing information about
@@ -88,21 +56,43 @@ map is ``active + clean``.
   contain the needed information. In the case of an erasure coded pool
   temporarily reducing min_size may allow recovery.
 
-*stale*
-  The placement group is in an unknown state - the monitors have not received
-  an update for it since the placement group mapping changed.
+*inconsistent*
+  Ceph detects inconsistencies in the one or more replicas of an object in the placement group
+  (e.g. objects are the wrong size, objects are missing from one replica *after* recovery finished, etc.).
 
-*remapped*
-  The placement group is temporarily mapped to a different set of OSDs from what
-  CRUSH specified.
-
-*undersized*
-  The placement group has fewer copies than the configured pool replication level.
+*laggy*
+  A replica is not acknowledging new leases from the primary in a timely fashion; IO is temporarily paused.
 
 *peered*
   The placement group has peered, but cannot serve client IO due to not having
   enough copies to reach the pool's configured min_size parameter.  Recovery
   may occur in this state, so the pg may heal up to min_size eventually.
+
+*peering*
+  The placement group is undergoing the peering process
+
+*recovering*
+  Ceph is migrating/synchronizing objects and their replicas.
+  
+*recovery_toofull*
+  A recovery operation is waiting because the destination OSD is over its
+  full ratio.
+
+*recovery_unfound*
+  Recovery stopped due to unfound objects.
+
+*recovery_wait*
+  The placement group is waiting in line to start recover.
+
+*remapped*
+  The placement group is temporarily mapped to a different set of OSDs from what
+  CRUSH specified.
+
+*repair*
+  Ceph is checking the placement group and repairing any inconsistencies it finds (if possible).
+
+*scrubbing*
+  Ceph is checking the placement group metadata for inconsistencies.
 
 *snaptrim*
   Trimming snaps.
@@ -113,6 +103,24 @@ map is ``active + clean``.
 *snaptrim_error*
   Error stopped trimming snaps.
 
+*stale*
+  The placement group is in an unknown state - the monitors have not received
+  an update for it since the placement group mapping changed.
+
+*undersized*
+  The placement group has fewer copies than the configured pool replication level.
+
 *unknown*
   The ceph-mgr hasn't yet received any information about the PG's state from an
   OSD since mgr started up.
+
+*wait*
+  The set of OSDs for this PG has just changed and IO is temporarily paused until the previous interval's leases expire.
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This commit alphabetizes the list of states in the
"Placement Group States" page. This is a commit made
in preparation for the addition of "inactive" as a
state in this list.

This commit supports a fix for Bug number 4 in the list here:
https://pad.ceph.com/p/Report_Documentation_Bugs

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
