### PR TITLE
tools/osdmaptool.cc: do not use deprecated std::random_shuffle()

### DIFF
--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -433,8 +433,8 @@ int main(int argc, const char **argv)
     vector<int> rules;
     for (auto& r: pools_by_rule)
       rules.push_back(r.first);
-    srand(time(0));
-    random_shuffle (rules.begin(), rules.end());
+    std::random_device rd;
+    std::shuffle(rules.begin(), rules.end(), std::mt19937{rd()});
     if (debug) {
       for (auto& r: rules)
         cout << "rule: " << r << " " << pools_by_rule[r] << std::endl;


### PR DESCRIPTION
the use of `std::random_shuffle()` was introduced by
b946308f03f1798915fafe7878f34b4a234c2ae4 .

in this change, it is replaced using `std::shuffle()`.

Fixes: https://tracker.ceph.com/issues/43084
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
