### PR TITLE
mgr/dashboard: support removing OSDs in OSDs page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -14,6 +14,7 @@ import { TimepickerModule } from 'ngx-bootstrap/timepicker';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 
+import { OrchestratorDocModalComponent } from '../../shared/components/orchestrator-doc-modal/orchestrator-doc-modal.component';
 import { SharedModule } from '../../shared/shared.module';
 import { PerformanceCounterModule } from '../performance-counter/performance-counter.module';
 import { CephSharedModule } from '../shared/ceph-shared.module';
@@ -62,7 +63,8 @@ import { ServicesComponent } from './services/services.component';
     OsdReweightModalComponent,
     SilenceMatcherModalComponent,
     OsdDevicesSelectionModalComponent,
-    OsdCreationPreviewModalComponent
+    OsdCreationPreviewModalComponent,
+    OrchestratorDocModalComponent
   ],
   imports: [
     CommonModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.html
@@ -1,11 +1,5 @@
-<cd-alert-panel type="info"
-                *ngIf="!orchestratorExist && !checkingOrchestrator"
-                i18n>Please consult the
-  <a href="{{ docsUrl }}"
-     target="_blank">documentation</a> on how to
-  configure and enable the orchestrator functionality.</cd-alert-panel>
-
-<ng-container *ngIf="orchestratorExist">
+<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+<ng-container *ngIf="hasOrchestrator">
   <legend i18n>Devices</legend>
   <div class="row">
     <div class="col-md-12">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
@@ -2,8 +2,6 @@ import { Component, Input, OnChanges, OnInit } from '@angular/core';
 
 import { OrchestratorService } from '../../../shared/api/orchestrator.service';
 import { Icons } from '../../../shared/enum/icons.enum';
-import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
-import { SummaryService } from '../../../shared/services/summary.service';
 import { InventoryDevice } from './inventory-devices/inventory-device.model';
 
 @Component({
@@ -17,41 +15,24 @@ export class InventoryComponent implements OnChanges, OnInit {
 
   icons = Icons;
 
-  checkingOrchestrator = true;
-  orchestratorExist = false;
+  hasOrchestrator = false;
   docsUrl: string;
 
   devices: Array<InventoryDevice> = [];
 
-  constructor(
-    private cephReleaseNamePipe: CephReleaseNamePipe,
-    private orchService: OrchestratorService,
-    private summaryService: SummaryService
-  ) {}
+  constructor(private orchService: OrchestratorService) {}
 
   ngOnInit() {
-    // duplicated code with grafana
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
+    this.orchService.status().subscribe((status) => {
+      this.hasOrchestrator = status.available;
+      if (status.available) {
+        this.getInventory();
       }
-
-      const releaseName = this.cephReleaseNamePipe.transform(summary.version);
-      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/orchestrator/`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
-    });
-
-    this.orchService.status().subscribe((data: { available: boolean }) => {
-      this.orchestratorExist = data.available;
-      this.checkingOrchestrator = false;
     });
   }
 
   ngOnChanges() {
-    if (this.orchestratorExist) {
+    if (this.hasOrchestrator) {
       this.devices = [];
       this.getInventory();
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -1,13 +1,6 @@
-<cd-loading-panel *ngIf="loading"
-                  i18n>Loading...</cd-loading-panel>
-<cd-alert-panel type="info"
-                *ngIf="!orchestratorExist && !checkingOrchestrator"
-                i18n>Please consult the
-  <a href="{{ docsUrl }}"
-     target="_blank">documentation</a> on how to
-  configure and enable the orchestrator functionality.</cd-alert-panel>
+<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
 <div class="cd-col-form"
-     *ngIf="!loading && orchestratorExist">
+     *ngIf="!loading && hasOrchestrator">
   <form name="form"
         #formDir="ngForm"
         [formGroup]="form"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -12,9 +12,7 @@ import { ActionLabelsI18n } from '../../../../shared/constants/app.constants';
 import { Icons } from '../../../../shared/enum/icons.enum';
 import { CdFormGroup } from '../../../../shared/forms/cd-form-group';
 import { CdTableColumn } from '../../../../shared/models/cd-table-column';
-import { CephReleaseNamePipe } from '../../../../shared/pipes/ceph-release-name.pipe';
 import { AuthStorageService } from '../../../../shared/services/auth-storage.service';
-import { SummaryService } from '../../../../shared/services/summary.service';
 import { InventoryDevice } from '../../inventory/inventory-devices/inventory-device.model';
 import { OsdCreationPreviewModalComponent } from '../osd-creation-preview-modal/osd-creation-preview-modal.component';
 import { DevicesSelectionChangeEvent } from '../osd-devices-selection-groups/devices-selection-change-event.interface';
@@ -63,8 +61,7 @@ export class OsdFormComponent implements OnInit {
   features: { [key: string]: OsdFeature };
   featureList: OsdFeature[] = [];
 
-  checkingOrchestrator = true;
-  orchestratorExist = false;
+  hasOrchestrator = false;
   docsUrl: string;
 
   constructor(
@@ -73,9 +70,7 @@ export class OsdFormComponent implements OnInit {
     private i18n: I18n,
     private orchService: OrchestratorService,
     private router: Router,
-    private bsModalService: BsModalService,
-    private summaryService: SummaryService,
-    private cephReleaseNamePipe: CephReleaseNamePipe
+    private bsModalService: BsModalService
   ) {
     this.resource = this.i18n('OSDs');
     this.action = this.actionLabels.CREATE;
@@ -90,23 +85,9 @@ export class OsdFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
-
-      const releaseName = this.cephReleaseNamePipe.transform(summary.version);
-      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/orchestrator/`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
-    });
-
-    this.orchService.status().subscribe((data: { available: boolean }) => {
-      this.orchestratorExist = data.available;
-      this.checkingOrchestrator = false;
-      if (this.orchestratorExist) {
+    this.orchService.status().subscribe((status) => {
+      this.hasOrchestrator = status.available;
+      if (this.hasOrchestrator) {
         this.getDataDevices();
       }
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -55,12 +55,13 @@
 </ng-template>
 
 <ng-template #criticalConfirmationTpl
-             let-safeToDestroyResult="result"
+             let-safeToPerform="safeToPerform"
+             let-message="message"
              let-actionDescription="actionDescription">
-  <div *ngIf="!safeToDestroyResult['is_safe_to_destroy']"
+  <div *ngIf="!safeToPerform"
        class="danger">
     <cd-alert-panel type="warning"
-                    i18n>The {selection.hasSingleSelection, select, 1 {OSD is} 0 {OSDs are}} not safe to destroy!</cd-alert-panel>
+                    i18n>The {selection.hasSingleSelection, select, 1 {OSD is} 0 {OSDs are}} not safe to be {{ actionDescription }}! {{ message }}</cd-alert-panel>
   </div>
   <ng-container i18n><strong>OSD {{ getSelectedOsdIds() | join }}</strong> will be
 <strong>{{ actionDescription }}</strong> if you proceed.</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -16,6 +16,7 @@ import {
   PermissionHelper
 } from '../../../../../testing/unit-test-helper';
 import { CoreModule } from '../../../../core/core.module';
+import { OrchestratorService } from '../../../../shared/api/orchestrator.service';
 import { OsdService } from '../../../../shared/api/osd.service';
 import { ConfirmationModalComponent } from '../../../../shared/components/confirmation-modal/confirmation-modal.component';
 import { CriticalConfirmationModalComponent } from '../../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
@@ -80,6 +81,10 @@ describe('OsdListComponent', () => {
     spyOn(TestBed.get(OsdService), 'safeToDelete').and.callFake(() =>
       of({ is_safe_to_delete: true })
     );
+  };
+
+  const mockOrchestratorStatus = () => {
+    spyOn(TestBed.get(OrchestratorService), 'status').and.callFake(() => of({ available: true }));
   };
 
   configureTestBed({
@@ -395,6 +400,7 @@ describe('OsdListComponent', () => {
       expectOpensModal('Mark Lost', modalClass);
       expectOpensModal('Purge', modalClass);
       expectOpensModal('Destroy', modalClass);
+      mockOrchestratorStatus();
       mockSafeToDelete();
       expectOpensModal('Delete', modalClass);
     });
@@ -437,6 +443,7 @@ describe('OsdListComponent', () => {
       expectOsdServiceMethodCalled('Mark Lost', 'markLost');
       expectOsdServiceMethodCalled('Purge', 'purge');
       expectOsdServiceMethodCalled('Destroy', 'destroy');
+      mockOrchestratorStatus();
       mockSafeToDelete();
       expectOsdServiceMethodCalled('Delete', 'delete');
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -72,7 +72,13 @@ describe('OsdListComponent', () => {
    */
   const mockSafeToDestroy = () => {
     spyOn(TestBed.get(OsdService), 'safeToDestroy').and.callFake(() =>
-      of({ 'safe-to-destroy': true })
+      of({ is_safe_to_destroy: true })
+    );
+  };
+
+  const mockSafeToDelete = () => {
+    spyOn(TestBed.get(OsdService), 'safeToDelete').and.callFake(() =>
+      of({ is_safe_to_delete: true })
     );
   };
 
@@ -257,7 +263,8 @@ describe('OsdListComponent', () => {
           'Mark Down',
           'Mark Lost',
           'Purge',
-          'Destroy'
+          'Destroy',
+          'Delete'
         ],
         primary: { multiple: 'Scrub', executing: 'Edit', single: 'Edit', no: 'Create' }
       },
@@ -275,7 +282,7 @@ describe('OsdListComponent', () => {
         primary: { multiple: 'Scrub', executing: 'Edit', single: 'Edit', no: 'Create' }
       },
       'create,delete': {
-        actions: ['Create', 'Mark Lost', 'Purge', 'Destroy'],
+        actions: ['Create', 'Mark Lost', 'Purge', 'Destroy', 'Delete'],
         primary: {
           multiple: 'Create',
           executing: 'Mark Lost',
@@ -298,7 +305,8 @@ describe('OsdListComponent', () => {
           'Mark Down',
           'Mark Lost',
           'Purge',
-          'Destroy'
+          'Destroy',
+          'Delete'
         ],
         primary: { multiple: 'Scrub', executing: 'Edit', single: 'Edit', no: 'Edit' }
       },
@@ -307,7 +315,7 @@ describe('OsdListComponent', () => {
         primary: { multiple: 'Scrub', executing: 'Edit', single: 'Edit', no: 'Edit' }
       },
       delete: {
-        actions: ['Mark Lost', 'Purge', 'Destroy'],
+        actions: ['Mark Lost', 'Purge', 'Destroy', 'Delete'],
         primary: {
           multiple: 'Mark Lost',
           executing: 'Mark Lost',
@@ -387,13 +395,22 @@ describe('OsdListComponent', () => {
       expectOpensModal('Mark Lost', modalClass);
       expectOpensModal('Purge', modalClass);
       expectOpensModal('Destroy', modalClass);
+      mockSafeToDelete();
+      expectOpensModal('Delete', modalClass);
     });
   });
 
   describe('tests if the correct methods are called on confirmation', () => {
     const expectOsdServiceMethodCalled = (
       actionName: string,
-      osdServiceMethodName: 'markOut' | 'markIn' | 'markDown' | 'markLost' | 'purge' | 'destroy'
+      osdServiceMethodName:
+        | 'markOut'
+        | 'markIn'
+        | 'markDown'
+        | 'markLost'
+        | 'purge'
+        | 'destroy'
+        | 'delete'
     ): void => {
       const osdServiceSpy = spyOn(osdService, osdServiceMethodName).and.callFake(() => EMPTY);
       openActionModal(actionName);
@@ -420,6 +437,8 @@ describe('OsdListComponent', () => {
       expectOsdServiceMethodCalled('Mark Lost', 'markLost');
       expectOsdServiceMethodCalled('Purge', 'purge');
       expectOsdServiceMethodCalled('Destroy', 'destroy');
+      mockSafeToDelete();
+      expectOsdServiceMethodCalled('Delete', 'delete');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
@@ -1,11 +1,5 @@
-<cd-alert-panel type="info"
-                *ngIf="!orchestratorExist && !checkingOrchestrator"
-                i18n>Please consult the
-  <a href="{{ docsUrl }}"
-     target="_blank">documentation</a> on how to
-  configure and enable the orchestrator functionality.</cd-alert-panel>
-
-<ng-container *ngIf="orchestratorExist">
+<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+<ng-container *ngIf="hasOrchestrator">
   <cd-table [data]="services"
             [columns]="columns"
             identifier="service_name"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -9,9 +9,7 @@ import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-d
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permissions } from '../../../shared/models/permissions';
 import { CephService } from '../../../shared/models/service.interface';
-import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
-import { SummaryService } from '../../../shared/services/summary.service';
 
 @Component({
   selector: 'cd-services',
@@ -31,6 +29,7 @@ export class ServicesComponent implements OnChanges, OnInit {
 
   checkingOrchestrator = true;
   orchestratorExist = false;
+  hasOrchestrator = false;
   docsUrl: string;
 
   columns: Array<CdTableColumn> = [];
@@ -40,11 +39,9 @@ export class ServicesComponent implements OnChanges, OnInit {
 
   constructor(
     private authStorageService: AuthStorageService,
-    private cephReleaseNamePipe: CephReleaseNamePipe,
     private i18n: I18n,
     private orchService: OrchestratorService,
-    private cephServiceService: CephServiceService,
-    private summaryService: SummaryService
+    private cephServiceService: CephServiceService
   ) {
     this.permissions = this.authStorageService.getPermissions();
   }
@@ -87,23 +84,8 @@ export class ServicesComponent implements OnChanges, OnInit {
       return !this.hiddenColumns.includes(col.prop);
     });
 
-    // duplicated code with grafana
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
-
-      const releaseName = this.cephReleaseNamePipe.transform(summary.version);
-      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/orchestrator/`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
-    });
-
-    this.orchService.status().subscribe((data: { available: boolean }) => {
-      this.orchestratorExist = data.available;
-      this.checkingOrchestrator = false;
+    this.orchService.status().subscribe((status) => {
+      this.hasOrchestrator = status.available;
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
@@ -17,8 +17,8 @@ export class OrchestratorService {
 
   constructor(private http: HttpClient) {}
 
-  status() {
-    return this.http.get(`${this.url}/status`);
+  status(): Observable<{ available: boolean; description: string }> {
+    return this.http.get<{ available: boolean; description: string }>(`${this.url}/status`);
   }
 
   identifyDevice(hostname: string, device: string, duration: number) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
@@ -138,12 +138,26 @@ export class OsdService {
     return this.http.post(`${this.path}/${id}/destroy`, null);
   }
 
+  delete(id: number, force?: boolean) {
+    const options = force ? { params: new HttpParams().set('force', 'true') } : {};
+    options['observe'] = 'response';
+    return this.http.delete(`${this.path}/${id}`, options);
+  }
+
   safeToDestroy(ids: string) {
     interface SafeToDestroyResponse {
-      'safe-to-destroy': boolean;
+      is_safe_to_destroy: boolean;
       message?: string;
     }
     return this.http.get<SafeToDestroyResponse>(`${this.path}/safe_to_destroy?ids=${ids}`);
+  }
+
+  safeToDelete(ids: string) {
+    interface SafeToDeleteResponse {
+      is_safe_to_delete: boolean;
+      message?: string;
+    }
+    return this.http.get<SafeToDeleteResponse>(`${this.path}/safe_to_delete?svc_ids=${ids}`);
   }
 
   getDevices(osdId: number) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -28,6 +28,8 @@ import { LanguageSelectorComponent } from './language-selector/language-selector
 import { LoadingPanelComponent } from './loading-panel/loading-panel.component';
 import { ModalComponent } from './modal/modal.component';
 import { NotificationsSidebarComponent } from './notifications-sidebar/notifications-sidebar.component';
+import { OrchestratorDocModalComponent } from './orchestrator-doc-modal/orchestrator-doc-modal.component';
+import { OrchestratorDocPanelComponent } from './orchestrator-doc-panel/orchestrator-doc-panel.component';
 import { PwdExpirationNotificationComponent } from './pwd-expiration-notification/pwd-expiration-notification.component';
 import { RefreshSelectorComponent } from './refresh-selector/refresh-selector.component';
 import { SelectBadgesComponent } from './select-badges/select-badges.component';
@@ -77,7 +79,9 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     ConfigOptionComponent,
     AlertPanelComponent,
     FormModalComponent,
-    PwdExpirationNotificationComponent
+    PwdExpirationNotificationComponent,
+    OrchestratorDocPanelComponent,
+    OrchestratorDocModalComponent
   ],
   providers: [],
   exports: [
@@ -97,7 +101,8 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     RefreshSelectorComponent,
     ConfigOptionComponent,
     AlertPanelComponent,
-    PwdExpirationNotificationComponent
+    PwdExpirationNotificationComponent,
+    OrchestratorDocPanelComponent
   ],
   entryComponents: [
     ModalComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-modal/orchestrator-doc-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-modal/orchestrator-doc-modal.component.html
@@ -1,0 +1,16 @@
+<cd-modal [modalRef]="bsModalRef">
+  <ng-container class="modal-title"
+                i18n>{{ actionDescription }} {{ itemDescription }}</ng-container>
+
+  <ng-container class="modal-content">
+    <div class="modal-body">
+      <cd-orchestrator-doc-panel></cd-orchestrator-doc-panel>
+    </div>
+    <div class="modal-footer">
+      <cd-back-button [back]="bsModalRef.hide"
+                      name="Close"
+                      i18n-name>
+      </cd-back-button>
+    </div>
+  </ng-container>
+</cd-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-modal/orchestrator-doc-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-modal/orchestrator-doc-modal.component.spec.ts
@@ -1,0 +1,29 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { BsModalRef } from 'ngx-bootstrap/modal';
+
+import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { ComponentsModule } from '../components.module';
+import { OrchestratorDocModalComponent } from './orchestrator-doc-modal.component';
+
+describe('OrchestratorDocModalComponent', () => {
+  let component: OrchestratorDocModalComponent;
+  let fixture: ComponentFixture<OrchestratorDocModalComponent>;
+
+  configureTestBed({
+    imports: [ComponentsModule, HttpClientTestingModule, RouterTestingModule],
+    providers: [BsModalRef, i18nProviders]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OrchestratorDocModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-modal/orchestrator-doc-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-modal/orchestrator-doc-modal.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+
+import { BsModalRef } from 'ngx-bootstrap/modal';
+
+@Component({
+  selector: 'cd-orchestrator-doc-modal',
+  templateUrl: './orchestrator-doc-modal.component.html',
+  styleUrls: ['./orchestrator-doc-modal.component.scss']
+})
+export class OrchestratorDocModalComponent implements OnInit {
+  actionDescription: string;
+  itemDescription: string;
+
+  constructor(public bsModalRef: BsModalRef) {}
+
+  ngOnInit() {}
+
+  onSubmit() {
+    this.bsModalRef.hide();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.html
@@ -1,0 +1,5 @@
+<cd-alert-panel type="info"
+                i18n>Orchestrator is not available. Please consult the
+  <a href="{{ docsUrl }}"
+     target="_blank">documentation</a> on how to
+  configure and enable the functionality.</cd-alert-panel>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.spec.ts
@@ -1,0 +1,29 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { CephReleaseNamePipe } from '../../pipes/ceph-release-name.pipe';
+import { SummaryService } from '../../services/summary.service';
+import { ComponentsModule } from '../components.module';
+import { OrchestratorDocPanelComponent } from './orchestrator-doc-panel.component';
+
+describe('OrchestratorDocPanelComponent', () => {
+  let component: OrchestratorDocPanelComponent;
+  let fixture: ComponentFixture<OrchestratorDocPanelComponent>;
+
+  configureTestBed({
+    imports: [ComponentsModule, HttpClientTestingModule, RouterTestingModule],
+    providers: [CephReleaseNamePipe, SummaryService, i18nProviders]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OrchestratorDocPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+
+import { CephReleaseNamePipe } from '../../pipes/ceph-release-name.pipe';
+import { SummaryService } from '../../services/summary.service';
+
+@Component({
+  selector: 'cd-orchestrator-doc-panel',
+  templateUrl: './orchestrator-doc-panel.component.html',
+  styleUrls: ['./orchestrator-doc-panel.component.scss']
+})
+export class OrchestratorDocPanelComponent implements OnInit {
+  docsUrl: string;
+
+  constructor(
+    private cephReleaseNamePipe: CephReleaseNamePipe,
+    private summaryService: SummaryService
+  ) {}
+
+  ngOnInit() {
+    const subs = this.summaryService.subscribe((summary: any) => {
+      if (!summary) {
+        return;
+      }
+
+      const releaseName = this.cephReleaseNamePipe.transform(summary.version);
+      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/orchestrator_cli/`;
+
+      setTimeout(() => {
+        subs.unsubscribe();
+      }, 0);
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/dep-checker.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/dep-checker.service.spec.ts
@@ -1,0 +1,20 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { BsModalService, ModalModule } from 'ngx-bootstrap/modal';
+
+import { configureTestBed } from '../../../testing/unit-test-helper';
+import { OrchestratorService } from '../api/orchestrator.service';
+import { DepCheckerService } from './dep-checker.service';
+
+describe('DepCheckerService', () => {
+  configureTestBed({
+    providers: [BsModalService, DepCheckerService, OrchestratorService],
+    imports: [HttpClientTestingModule, ModalModule.forRoot()]
+  });
+
+  it('should be created', () => {
+    const service: DepCheckerService = TestBed.get(DepCheckerService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/dep-checker.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/dep-checker.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+
+import { BsModalService } from 'ngx-bootstrap/modal';
+
+import { OrchestratorService } from '../api/orchestrator.service';
+import { OrchestratorDocModalComponent } from '../components/orchestrator-doc-modal/orchestrator-doc-modal.component';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DepCheckerService {
+  constructor(private orchService: OrchestratorService, private modalService: BsModalService) {}
+
+  /**
+   * Check if orchestrator is available. Display an information modal if not.
+   * If orchestrator is available, then the provided function will be called.
+   * This helper function can be used with table actions.
+   * @param {string} actionDescription name of the action.
+   * @param {string} itemDescription the item's name that the action operates on.
+   * @param {Function} func the function to be called if orchestrator is available.
+   */
+  checkOrchestratorOrModal(actionDescription: string, itemDescription: string, func: Function) {
+    this.orchService.status().subscribe((status) => {
+      if (status.available) {
+        func();
+      } else {
+        this.modalService.show(OrchestratorDocModalComponent, {
+          initialState: {
+            actionDescription: actionDescription,
+            itemDescription: itemDescription
+          }
+        });
+      }
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -172,6 +172,9 @@ export class TaskMessageService {
         tracking_id: metadata.tracking_id
       })
     ),
+    'osd/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) =>
+      this.osd(metadata)
+    ),
     // Pool tasks
     'pool/create': this.newTaskMessage(
       this.commonOperations.create,
@@ -422,6 +425,12 @@ export class TaskMessageService {
   host(metadata: any) {
     return this.i18n(`host '{{hostname}}'`, {
       hostname: metadata.hostname
+    });
+  }
+
+  osd(metadata: any) {
+    return this.i18n(`OSD '{{svc_id}}'`, {
+      svc_id: metadata.svc_id
     });
   }
 

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -108,6 +108,14 @@ class OsdManager(ResourceManager):
     def create(self, drive_groups):
         return self.api.create_osds(drive_groups)
 
+    @wait_api_result
+    def remove(self, osd_ids):
+        return self.api.remove_osds(osd_ids)
+
+    @wait_api_result
+    def removing_status(self):
+        return self.api.remove_osds_status()
+
 
 class OrchClient(object):
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43062
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

## Screenshots
* A new action `Remove` is added to OSDs table
<img width="707" alt="action" src="https://user-images.githubusercontent.com/1691518/70127367-dbc16e00-16b5-11ea-92ac-8f66f74db5a9.png">

* A new backend call is added to check if it's safe to remove OSDs. Currently check if there are any `nearfull`, `full`, and `backfill-full` OSDs. Any suggestions?
<img width="977" alt="modal" src="https://user-images.githubusercontent.com/1691518/70127389-e7ad3000-16b5-11ea-8d23-8c129cd65ed5.png">

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

## How to test

Enable test orchestrator:

```
cd /ceph/build
bin/ceph mgr module enable test_orchestrator
bin/ceph orch set backend test_orchestrator
```

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
