### PR TITLE
nautilus: mgr/dashboard: grafana charts match time picker selection.

### DIFF
--- a/monitoring/grafana/dashboards/ceph-cluster.json
+++ b/monitoring/grafana/dashboards/ceph-cluster.json
@@ -116,7 +116,7 @@
         }
       ],
       "thresholds": "1,2",
-      "timeFrom": "1m",
+      "timeFrom": null,
       "title": "Health Status",
       "transparent": false,
       "type": "singlestat",

--- a/monitoring/grafana/dashboards/host-details.json
+++ b/monitoring/grafana/dashboards/host-details.json
@@ -527,7 +527,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "15m",
+      "timeFrom": null,
       "timeShift": null,
       "title": "Network drop rate",
       "tooltip": {
@@ -711,7 +711,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "15m",
+      "timeFrom": null,
       "timeShift": null,
       "title": "Network error rate",
       "tooltip": {

--- a/monitoring/grafana/dashboards/osds-overview.json
+++ b/monitoring/grafana/dashboards/osds-overview.json
@@ -503,7 +503,7 @@
           "step": 240
         }
       ],
-      "timeFrom": "2m",
+      "timeFrom": null,
       "timeShift": null,
       "title": "OSD Objectstore Types",
       "type": "grafana-piechart-panel",
@@ -620,7 +620,7 @@
           "step": 2
         }
       ],
-      "timeFrom": "2m",
+      "timeFrom": null,
       "timeShift": null,
       "title": "OSD Size Summary",
       "type": "grafana-piechart-panel",
@@ -781,7 +781,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "36h",
+      "timeFrom": null,
       "timeShift": null,
       "title": "Read/Write Profile",
       "tooltip": {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43115

---

backport of https://github.com/ceph/ceph/pull/31964
parent tracker: https://tracker.ceph.com/issues/43097

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh