### PR TITLE
mimic: osd: fix sending incremental map messages (more)

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6781,11 +6781,15 @@ void OSD::maybe_share_map(
   last_sent_epoch = session->last_sent_epoch;
   session->sent_epoch_lock.unlock();
 
+  // assume the peer has the newer of the op's sent_epoch and what
+  // we think we sent them.
+  epoch_t from = std::max(last_sent_epoch, op->sent_epoch);
+
   const Message *m = op->get_req();
   service.share_map(
     m->get_source(),
     m->get_connection().get(),
-    op->sent_epoch,
+    from,
     osdmap,
     session ? &last_sent_epoch : NULL);
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1323,11 +1323,17 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
   }
   // send something
   bufferlist bl;
-  if (!get_inc_map_bl(m->newest_map, bl)) {
+  if (get_inc_map_bl(m->newest_map, bl)) {
+    m->incremental_maps[m->newest_map].claim(bl);
+  } else {
     derr << __func__ << " unable to load latest map " << m->newest_map << dendl;
-    ceph_abort();
+    if (!get_map_bl(m->newest_map, bl)) {
+      derr << __func__ << " unable to load latest full map " << m->newest_map
+	   << dendl;
+      ceph_abort();
+    }
+    m->maps[m->newest_map].claim(bl);
   }
-  m->incremental_maps[m->newest_map].claim(bl);
   return m;
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1302,13 +1302,18 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
   }
   for (epoch_t e = since + 1; e <= to; ++e) {
     bufferlist bl;
-    if (!get_inc_map_bl(e, bl)) {
+    if (get_inc_map_bl(e, bl)) {
+      m->incremental_maps[e].claim(bl);
+    } else {
       derr << __func__ << " missing incremental map " << e << dendl;
-      goto panic;
+      if (!get_map_bl(e, bl)) {
+	derr << __func__ << " also missing full map " << e << dendl;
+	goto panic;
+      }
+      m->maps[e].claim(bl);
     }
     max--;
     max_bytes -= bl.length();
-    m->incremental_maps[e].claim(bl);
     if (max <= 0 || max_bytes <= 0) {
       break;
     }


### PR DESCRIPTION
Fixes an issue in 13.2.7 reported by @dvanders at https://tracker.ceph.com/issues/43106

backport tracker: https://tracker.ceph.com/issues/43119

---

backport of https://github.com/ceph/ceph/pull/26448
parent tracker: https://tracker.ceph.com/issues/38330

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh