### PR TITLE
osd: add a missing '&' to OSDService DTOR

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -285,7 +285,7 @@ OSDService::~OSDService()
 {
   delete objecter;
 
-  for (auto f : objecter_finishers) {
+  for (auto& f : objecter_finishers) {
     delete f;
     f = NULL;
   }


### PR DESCRIPTION
as otherwise the f=nullptr line will be a do-nothing

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
