### PR TITLE
mgr/orchestrator: Add simple scheduler

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 HostSpec = namedtuple('HostSpec', ['hostname', 'network', 'name'])
 
+
 def parse_host_specs(host, require_network=True):
     """
     Split host into host, network, and (optional) daemon name parts.  The network
@@ -899,8 +900,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def update_mgrs(self, num, hosts):
-        # type: (int, List[str]) -> Completion
+    def update_mgrs(self, spec):
+        # type: (StatefulServiceSpec) -> Completion
         """
         Update the number of cluster managers.
 
@@ -909,8 +910,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def update_mons(self, num, hosts):
-        # type: (int, List[HostSpec]) -> Completion
+    def update_mons(self, spec):
+        # type: (StatefulServiceSpec) -> Completion
         """
         Update the number of cluster monitors.
 
@@ -1042,12 +1043,16 @@ class PlacementSpec(object):
     For APIs that need to specify a node subset
     """
     def __init__(self, label=None, nodes=None, count=None):
+        # type: (Optional[str], Optional[List], Optional[int]) -> None
         self.label = label
         if nodes:
-            self.nodes = [parse_host_specs(x, require_network=False) for x in nodes if x]
+            if all([isinstance(node, HostSpec) for node in nodes]):
+                self.nodes = nodes
+            else:
+                self.nodes = [parse_host_specs(x, require_network=False) for x in nodes if x]
         else:
             self.nodes = []
-        self.count = count if count else 1
+        self.count = count  # type: Optional[int]
 
     def set_nodes(self, nodes):
         # To backpopulate the .nodes attribute when using labels or count
@@ -1055,14 +1060,16 @@ class PlacementSpec(object):
         self.nodes = nodes
 
     @classmethod
-    def from_yaml(cls, data):
-        return cls(**data)
+    def from_dict(cls, data):
+        _cls = cls(**data)
+        _cls.validate()
+        return _cls
 
     def validate(self):
         if self.nodes and self.label:
             # TODO: a less generic Exception
             raise Exception('Node and label are mutually exclusive')
-        if self.count <= 0:
+        if self.count is not None and self.count <= 0:
             raise Exception("num/count must be > 1")
 
 
@@ -1150,7 +1157,7 @@ class ServiceDescription(object):
 
     def __repr__(self):
         return "<ServiceDescription>({n_name}:{s_type})".format(n_name=self.nodename,
-                                                                  s_type=self.name())
+                                                                s_type=self.name())
 
     def to_json(self):
         out = {
@@ -1177,14 +1184,10 @@ class StatefulServiceSpec(object):
     """ Such as mgrs/mons
     """
     # TODO: create base class for Stateless/Stateful service specs and propertly inherit
-    def __init__(self,
-                 name=None,
-                 placement=None,
-                 count=None,
-                 scheduler=None):
+    def __init__(self, name=None, placement=None):
         self.placement = PlacementSpec() if placement is None else placement
         self.name = name
-        self.count = self.placement.count if self.placement else 1  # for backwards-compatibility
+        self.count = self.placement.count if self.placement is not None else 1  # for backwards-compatibility
 
 
 class StatelessServiceSpec(object):
@@ -1199,8 +1202,7 @@ class StatelessServiceSpec(object):
     # This structure is supposed to be enough information to
     # start the services.
 
-    def __init__(self, name,
-                 placement=None):
+    def __init__(self, name, placement=None):
         self.placement = PlacementSpec() if placement is None else placement
 
         #: Give this set of statelss services a name: typically it would
@@ -1209,7 +1211,7 @@ class StatelessServiceSpec(object):
         self.name = name
 
         #: Count of service instances
-        self.count = self.placement.count if self.placement else 1  # for backwards-compatibility
+        self.count = self.placement.count if self.placement is not None else 1  # for backwards-compatibility
 
     def validate_add(self):
         if not self.name:
@@ -1239,7 +1241,7 @@ class RGWSpec(StatelessServiceSpec):
 
     """
     def __init__(self,
-                 rgw_realm, # type: str
+                 rgw_realm,  # type: str
                  rgw_zone,  # type: str
                  placement=None,
                  hosts=None,  # type: Optional[List[str]]
@@ -1476,7 +1478,6 @@ class OrchestratorClientMixin(Orchestrator):
         mgr.log.debug("_oremote {} -> {}.{}(*{}, **{})".format(mgr.module_name, o, meth, args, kwargs))
         return mgr.remote(o, meth, *args, **kwargs)
 
-
     def _orchestrator_wait(self, completions):
         # type: (List[Completion]) -> None
         """
@@ -1536,7 +1537,6 @@ class OutdatableData(object):
         # drop the 'Z' timezone indication, it's always UTC
         timestr = timestr.rstrip('Z')
         return datetime.datetime.strptime(timestr, cls.DATEFMT)
-
 
     @classmethod
     def from_json(cls, data):

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -434,10 +434,10 @@ Usage:
         'orchestrator mds update',
         "name=fs_name,type=CephString "
         "name=num,type=CephInt,req=false "
-        "name=hosts,type=CephString,n=N,req=false "
         "name=label,type=CephString,req=false",
+        "name=hosts,type=CephString,n=N,req=false "
         'Update the number of MDS instances for the given fs_name')
-    def _mds_update(self, fs_name, num=None, hosts=[], label=None):
+    def _mds_update(self, fs_name, num=None, label=None, hosts=[]):
         placement = orchestrator.PlacementSpec(label=label, count=num, nodes=hosts)
         placement.validate()
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -384,8 +384,7 @@ Usage:
     def _rbd_mirror_add(self, num=None, hosts=None):
         spec = orchestrator.StatelessServiceSpec(
             None,
-            placement=orchestrator.PlacementSpec(nodes=hosts),
-            count=num or 1)
+            placement=orchestrator.PlacementSpec(nodes=hosts, count=num))
         completion = self.add_rbd_mirror(spec)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
@@ -393,14 +392,14 @@ Usage:
 
     @orchestrator._cli_write_command(
         'orchestrator rbd-mirror update',
-        "name=num,type=CephInt,req=true "
+        "name=num,type=CephInt,req=false "
+        "name=label,type=CephString,req=false "
         "name=hosts,type=CephString,n=N,req=false",
         'Update the number of rbd-mirror instances')
-    def _rbd_mirror_update(self, num, hosts=None):
+    def _rbd_mirror_update(self, num, label=None, hosts=[]):
         spec = orchestrator.StatelessServiceSpec(
             None,
-            placement=orchestrator.PlacementSpec(nodes=hosts),
-            count=num or 1)
+            placement=orchestrator.PlacementSpec(nodes=hosts, count=num, label=label))
         completion = self.update_rbd_mirror(spec)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
@@ -425,8 +424,7 @@ Usage:
     def _mds_add(self, fs_name, num=None, hosts=None):
         spec = orchestrator.StatelessServiceSpec(
             fs_name,
-            placement=orchestrator.PlacementSpec(nodes=hosts),
-            count=num or 1)
+            placement=orchestrator.PlacementSpec(nodes=hosts, count=num))
         completion = self.add_mds(spec)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
@@ -435,14 +433,18 @@ Usage:
     @orchestrator._cli_write_command(
         'orchestrator mds update',
         "name=fs_name,type=CephString "
-        "name=num,type=CephInt,req=true "
-        "name=hosts,type=CephString,n=N,req=false",
+        "name=num,type=CephInt,req=false "
+        "name=hosts,type=CephString,n=N,req=false "
+        "name=label,type=CephString,req=false",
         'Update the number of MDS instances for the given fs_name')
-    def _mds_update(self, fs_name, num, hosts=None):
+    def _mds_update(self, fs_name, num=None, hosts=[], label=None):
+        placement = orchestrator.PlacementSpec(label=label, count=num, nodes=hosts)
+        placement.validate()
+
         spec = orchestrator.StatelessServiceSpec(
             fs_name,
-            placement=orchestrator.PlacementSpec(nodes=hosts),
-            count=num or 1)
+            placement=placement)
+
         completion = self.update_mds(spec)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
@@ -481,8 +483,7 @@ Usage:
         rgw_spec = orchestrator.RGWSpec(
             rgw_realm=realm_name,
             rgw_zone=zone_name,
-            placement=orchestrator.PlacementSpec(nodes=hosts),
-            count=num or 1)
+            placement=orchestrator.PlacementSpec(nodes=hosts, count=num))
 
         completion = self.add_rgw(rgw_spec)
         self._orchestrator_wait([completion])
@@ -491,17 +492,17 @@ Usage:
 
     @orchestrator._cli_write_command(
         'orchestrator rgw update',
-        'name=realm_name,type=CephString '
         'name=zone_name,type=CephString '
-        "name=num,type=CephInt,req=False "
+        'name=realm_name,type=CephString '
+        "name=num,type=CephInt,req=false "
+        "name=label,type=CephString,req=false "
         "name=hosts,type=CephString,n=N,req=false",
         'Update the number of RGW instances for the given zone')
-    def _rgw_update(self, realm_name, zone_name, num, hosts=None):
+    def _rgw_update(self, zone_name, realm_name, num=None, label=None, hosts=[]):
         spec = orchestrator.RGWSpec(
             rgw_realm=realm_name,
             rgw_zone=zone_name,
-            placement=orchestrator.PlacementSpec(nodes=hosts),
-            count=num or 1)
+            placement=orchestrator.PlacementSpec(nodes=hosts, label=label, count=num))
         completion = self.update_rgw(spec)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
@@ -580,50 +581,42 @@ Usage:
 
     @orchestrator._cli_write_command(
         'orchestrator mgr update',
-        "name=num,type=CephInt,req=true "
-        "name=hosts,type=CephString,n=N,req=false",
+        "name=num,type=CephInt,req=false "
+        "name=hosts,type=CephString,n=N,req=false "
+        "name=label,type=CephString,n=N,req=false",
         'Update the number of manager instances')
-    def _update_mgrs(self, num, hosts=None):
-        hosts = hosts if hosts is not None else []
+    def _update_mgrs(self, num=None, hosts=[], label=None):
 
-        if num <= 0:
-            return HandleCommandResult(-errno.EINVAL,
-                                       stderr="Invalid number of mgrs: require {} > 0".format(num))
+        placement = orchestrator.PlacementSpec(label=label, count=num, nodes=hosts)
+        placement.validate()
 
-        if hosts:
-            try:
-                hosts = [orchestrator.parse_host_specs(host_spec, require_network=False)
-                         for host_spec in hosts]
-            except Exception as e:
-                msg = "Failed to parse host list: '{}': {}".format(hosts, e)
-                return HandleCommandResult(-errno.EINVAL, stderr=msg)
+        spec = orchestrator.StatefulServiceSpec(placement=placement)
 
-        completion = self.update_mgrs(num, hosts)
+        completion = self.update_mgrs(spec)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
     @orchestrator._cli_write_command(
         'orchestrator mon update',
-        "name=num,type=CephInt,req=true "
-        "name=hosts,type=CephString,n=N,req=false",
+        "name=num,type=CephInt,req=false "
+        "name=hosts,type=CephString,n=N,req=false "
+        "name=label,type=CephString,n=N,req=false",
         'Update the number of monitor instances')
-    def _update_mons(self, num, hosts=None):
-        hosts = hosts if hosts is not None else []
+    def _update_mons(self, num=None, hosts=[], label=None):
 
-        if num <= 0:
-            return HandleCommandResult(-errno.EINVAL,
-                                       stderr="Invalid number of mons: require {} > 0".format(num))
+        placement = orchestrator.PlacementSpec(label=label, count=num, nodes=hosts)
+        if not hosts and not label:
+            # Improve Error message. Point to parse_host_spec examples
+            raise Exception("Mons need a host spec. (host, network, name(opt))")
+            # TODO: Scaling without a HostSpec doesn't work right now.
+            # we need network autodetection for that.
+            # placement = orchestrator.PlacementSpec(count=num)
+        placement.validate()
 
-        if hosts:
-            try:
-                hosts = [orchestrator.parse_host_specs(host_spec)
-                         for host_spec in hosts]
-            except Exception as e:
-                msg = "Failed to parse host list: '{}': {}".format(hosts, e)
-                return HandleCommandResult(-errno.EINVAL, stderr=msg)
+        spec = orchestrator.StatefulServiceSpec(placement=placement)
 
-        completion = self.update_mons(num, hosts)
+        completion = self.update_mons(spec)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -213,7 +213,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         'name=host,type=CephString '
         'name=label,type=CephString',
         'Add a host label')
-    def _host_label_add(self, host, label):
+    def _host_label_rm(self, host, label):
         completion = self.remove_host_label(host, label)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
@@ -494,9 +494,9 @@ Usage:
         'orchestrator rgw update',
         'name=zone_name,type=CephString '
         'name=realm_name,type=CephString '
-        "name=num,type=CephInt,req=false "
-        "name=label,type=CephString,req=false "
-        "name=hosts,type=CephString,n=N,req=false",
+        'name=num,type=CephInt,req=false '
+        'name=label,type=CephString,req=false '
+        'name=hosts,type=CephString,n=N,req=false',
         'Update the number of RGW instances for the given zone')
     def _rgw_update(self, zone_name, realm_name, num=None, label=None, hosts=[]):
         spec = orchestrator.RGWSpec(
@@ -608,7 +608,7 @@ Usage:
         placement = orchestrator.PlacementSpec(label=label, count=num, nodes=hosts)
         if not hosts and not label:
             # Improve Error message. Point to parse_host_spec examples
-            raise Exception("Mons need a host spec. (host, network, name(opt))")
+            raise orchestrator.OrchestratorValidationError("Mons need a host spec. (host, network, name(opt))")
             # TODO: Scaling without a HostSpec doesn't work right now.
             # we need network autodetection for that.
             # placement = orchestrator.PlacementSpec(count=num)

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -337,13 +337,13 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             'NFS', name, lambda: self.rook_cluster.rm_service('cephnfses', name)
         )
 
-    def update_mons(self, num, hosts):
-        if hosts:
+    def update_mons(self, spec):
+        if spec.placement.nodes:
             raise RuntimeError("Host list is not supported by rook.")
 
         return write_completion(
-            lambda: self.rook_cluster.update_mon_count(num),
-            "Updating mon count to {0}".format(num),
+            lambda: self.rook_cluster.update_mon_count(spec.placement.count),
+            "Updating mon count to {0}".format(spec.placement.count),
             mgr=self
         )
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -260,12 +260,12 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         assert isinstance(host, six.string_types)
 
     @deferred_write("update_mgrs")
-    def update_mgrs(self, num, hosts):
-        assert not hosts or len(hosts) == num
-        assert all([isinstance(h, str) for h in hosts])
+    def update_mgrs(self, spec):
+        assert not spec.nodes or len(spec.placement.nodes) == spec.placement.count
+        assert all([isinstance(h, str) for h in spec.nodes])
 
     @deferred_write("update_mons")
-    def update_mons(self, num, hosts):
-        assert not hosts or len(hosts) == num
-        assert all([isinstance(h[0], str) for h in hosts])
-        assert all([isinstance(h[1], str) or h[1] is None for h in hosts])
+    def update_mons(self, spec):
+        assert not spec.nodes or len(spec.placement.nodes) == spec.placement.count
+        assert all([isinstance(h[0], str) for h in spec.nodes])
+        assert all([isinstance(h[1], str) or h[1] is None for h in spec.nodes])


### PR DESCRIPTION
* `count` is now in `PlacementSpec` and not in $ServiceSpec anymore.
   - kept a reference to count in the `$ServiceSpec` for backwards compatibility
* Added `StatefulService` to streamline the arg passing in the `update_mon` and `update_mgr` functions. Before this patch, they passed `num, host_spec` which is wrapped in `spec.placement` now. All `update_$service` now have the same signature.
* Adding `label` param to all `update_$service` functions.
* Extend support of `PlacementSpec` for labels
* No hard requirement for `count/num` anymore. (removed the req=true) as this isn't the only declarative option anymore (labels are also declarative)
* [ssh] added NodeAssignment that back-populates the `.nodes` when any non-imperative method is used (count&label) using a Scheduler
* [ssh] Implemented a SimpleScheduler that takes a host_pool, shuffles it and picks from that pool.

This now allow rook-like scaling (up and down) with `num/count` and labels.

Caveats/Known issues:

* Querying for labels doesn't work correctly. Fixing in follow-up PR.
* Like the existing implementation, there are problems in detecting which nodes are used for what when `count/num` is used. Potential duplication of services on a given node.



Signed-off-by: Joshua Schmid <jschmid@suse.de>

