### PR TITLE
mgr/orchestrator: Add mypy static type checking

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1,7 +1,7 @@
 import ceph_module  # noqa
 
 try:
-    from typing import Set, Tuple, Iterator, Any
+    from typing import Set, Tuple, Iterator, Any, Dict, Optional, Callable, List
 except ImportError:
     # just for type checking
     pass
@@ -251,7 +251,7 @@ class CRUSHMap(ceph_module.BasePyCRUSH):
         return osd_list
 
     def device_class_counts(self):
-        result = defaultdict(int)
+        result = defaultdict(int)  # type: Dict[str, int]
         # TODO don't abuse dump like this
         d = self.dump()
         for device in d['devices']:
@@ -262,7 +262,7 @@ class CRUSHMap(ceph_module.BasePyCRUSH):
 
 
 class CLICommand(object):
-    COMMANDS = {}
+    COMMANDS = {}  # type: Dict[str, CLICommand]
 
     def __init__(self, prefix, args="", desc="", perm="rw"):
         self.prefix = prefix
@@ -270,7 +270,7 @@ class CLICommand(object):
         self.args_dict = {}
         self.desc = desc
         self.perm = perm
-        self.func = None
+        self.func = None  # type: Optional[Callable]
         self._parse_args()
 
     def _parse_args(self):
@@ -300,6 +300,7 @@ class CLICommand(object):
             kwargs[a.replace("-", "_")] = cmd_dict[a]
         if inbuf:
             kwargs['inbuf'] = inbuf
+        assert self.func
         return self.func(mgr, **kwargs)
 
     @classmethod
@@ -528,8 +529,8 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
     from their active peer), and to configuration settings (read only).
     """
 
-    MODULE_OPTIONS = []
-    MODULE_OPTION_DEFAULTS = {}
+    MODULE_OPTIONS = []  # type: List[Dict[str, Any]]
+    MODULE_OPTION_DEFAULTS = {}  # type: Dict[str, Any]
 
     def __init__(self, module_name, capsule):
         super(MgrStandbyModule, self).__init__(capsule)
@@ -605,9 +606,9 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
 
 
 class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
-    COMMANDS = []
-    MODULE_OPTIONS = []
-    MODULE_OPTION_DEFAULTS = {}
+    COMMANDS = []  # type: List[Any]
+    MODULE_OPTIONS = []  # type: List[dict]
+    MODULE_OPTION_DEFAULTS = {}  # type: Dict[str, Any]
 
     # Priority definitions for perf counters
     PRIO_CRITICAL = 10
@@ -810,8 +811,9 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         return ''
 
     def _perfpath_to_path_labels(self, daemon, path):
-        label_names = ("ceph_daemon",)
-        labels = (daemon,)
+        # type: (str, str) -> Tuple[str, Tuple[str, ...], Tuple[str, ...]]
+        label_names = ("ceph_daemon",)  # type: Tuple[str, ...]
+        labels = (daemon,)  # type: Tuple[str, ...]
 
         if daemon.startswith('rbd-mirror.'):
             match = re.match(
@@ -1284,7 +1286,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         value.
         """
 
-        result = defaultdict(dict)
+        result = defaultdict(dict)  # type: Dict[str, dict]
 
         for server in self.list_servers():
             for service in server['services']:

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -108,10 +108,10 @@ def get_default_addr():
            return False
 
     try:
-        return get_default_addr.result
+        return get_default_addr.result  # type: ignore
     except AttributeError:
         result = '::' if is_ipv6_enabled() else '0.0.0.0'
-        get_default_addr.result = result
+        get_default_addr.result = result  # type: ignore
         return result
 
 

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -177,7 +177,7 @@ class _Promise(object):
                  on_complete=None,    # type: Optional[Callable]
                  name=None,  # type: Optional[str]
                  ):
-        self._on_complete = on_complete
+        self._on_complete_ = on_complete
         self._name = name
         self._next_promise = None  # type: Optional[_Promise]
 
@@ -190,6 +190,18 @@ class _Promise(object):
         # _Promise is not a continuation monad, as `_result` is of type
         # T instead of (T -> r) -> r. Therefore we need to store the first promise here.
         self._first_promise = _first_promise or self  # type: '_Promise'
+
+    @property
+    def _on_complete(self):
+        # type: () -> Optional[Callable]
+        # https://github.com/python/mypy/issues/4125
+        return self._on_complete_
+
+    @_on_complete.setter
+    def _on_complete(self, val):
+        # type: (Optional[Callable]) -> None
+        self._on_complete_ = val
+
 
     def __repr__(self):
         name = self._name or getattr(self._on_complete, '__name__', '??') if self._on_complete else 'None'

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -76,7 +76,7 @@ def parse_host_specs(host, require_network=True):
         return host_spec
 
     from ipaddress import ip_network, ip_address
-    networks = list()
+    networks = list()  # type: List[str]
     network = host_spec.network
     # in case we have [v2:1.2.3.4:3000,v1:1.2.3.4:6478]
     if ',' in network:
@@ -173,7 +173,7 @@ class _Promise(object):
 
     def __init__(self,
                  _first_promise=None,  # type: Optional["_Promise"]
-                 value=NO_RESULT,  # type: Optional
+                 value=NO_RESULT,  # type: Optional[Any]
                  on_complete=None,    # type: Optional[Callable]
                  name=None,  # type: Optional[str]
                  ):
@@ -189,7 +189,7 @@ class _Promise(object):
 
         # _Promise is not a continuation monad, as `_result` is of type
         # T instead of (T -> r) -> r. Therefore we need to store the first promise here.
-        self._first_promise = _first_promise or self  # type: 'Completion'
+        self._first_promise = _first_promise or self  # type: '_Promise'
 
     def __repr__(self):
         name = self._name or getattr(self._on_complete, '__name__', '??') if self._on_complete else 'None'
@@ -208,8 +208,6 @@ class _Promise(object):
         else:
             name = self._on_complete.__class__.__name__
         val = repr(self._value) if self._value not in (self.NO_RESULT, self.ASYNC_RESULT) else '...'
-        if hasattr(val, 'debug_str'):
-            val = val.debug_str()
         prefix = {
             self.INITIALIZED: '      ',
             self.RUNNING:     '   >>>',
@@ -278,6 +276,7 @@ class _Promise(object):
             assert self not in next_result
             next_result._append_promise(self._next_promise)
             self._set_next_promise(next_result)
+            assert self._next_promise
             if self._next_promise._value is self.NO_RESULT:
                 self._next_promise._value = self._value
             self.propagate_to_next()
@@ -453,7 +452,7 @@ class Completion(_Promise):
     def __init__(self,
                  _first_promise=None,  # type: Optional["Completion"]
                  value=_Promise.NO_RESULT,  # type: Any
-                 on_complete=None,  # type: Optional[Callable],
+                 on_complete=None,  # type: Optional[Callable]
                  name=None,  # type: Optional[str]
                  ):
         super(Completion, self).__init__(_first_promise, value, on_complete, name)
@@ -462,7 +461,7 @@ class Completion(_Promise):
     def _progress_reference(self):
         # type: () -> Optional[ProgressReference]
         if hasattr(self._on_complete, 'progress_id'):
-            return self._on_complete
+            return self._on_complete  # type: ignore
         return None
 
     @property
@@ -483,7 +482,7 @@ class Completion(_Promise):
     def with_progress(cls,  # type: Any
                       message,  # type: str
                       mgr,
-                      _first_promise=None,  # type: Optional["Completions"]
+                      _first_promise=None,  # type: Optional["Completion"]
                       value=_Promise.NO_RESULT,  # type: Any
                       on_complete=None,  # type: Optional[Callable]
                       calc_percent=None  # type: Optional[Callable[[], Any]]
@@ -788,21 +787,21 @@ class Orchestrator(object):
         return self.get_inventory()
 
     def add_host_label(self, host, label):
-        # type: (str) -> WriteCompletion
+        # type: (str, str) -> Completion
         """
         Add a host label
         """
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def remove_host_label(self, host, label):
-        # type: (str) -> WriteCompletion
+        # type: (str, str) -> Completion
         """
         Remove a host label
         """
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def get_inventory(self, node_filter=None, refresh=False):
-        # type: (InventoryFilter, bool) -> Completion
+        # type: (Optional[InventoryFilter], bool) -> Completion
         """
         Returns something that was created by `ceph-volume inventory`.
 
@@ -826,7 +825,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def service_action(self, action, service_type, service_name=None, service_id=None):
-        # type: (str, str, str, str) -> Completion
+        # type: (str, str, Optional[str], Optional[str]) -> Completion
         """
         Perform an action (start/stop/reload) on a service.
 
@@ -878,7 +877,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def blink_device_light(self, ident_fault, on, locations):
-        # type: (str, bool, List[DeviceLightLoc]) -> WriteCompletion
+        # type: (str, bool, List[DeviceLightLoc]) -> Completion
         """
         Instructs the orchestrator to enable or disable either the ident or the fault LED.
 
@@ -1237,13 +1236,13 @@ class RGWSpec(StatelessServiceSpec):
     @property
     def rgw_multisite_endpoint_addr(self):
         """Returns the first host. Not supported for Rook."""
-        return self.hosts[0]
+        return self.placement.hosts[0]
 
     @property
     def rgw_multisite_endpoints_list(self):
         return ",".join(["{}://{}:{}".format(self.rgw_multisite_proto,
                              host,
-                             self.rgw_frontend_port) for host in self.hosts])
+                             self.rgw_frontend_port) for host in self.placement.hosts])
 
     def genkey(self, nchars):
         """ Returns a random string of nchars
@@ -1282,11 +1281,13 @@ class InventoryFilter(object):
 
     """
     def __init__(self, labels=None, nodes=None):
-        # type: (List[str], List[str]) -> None
-        self.labels = labels  # Optional: get info about nodes matching labels
-        self.nodes = nodes  # Optional: get info about certain named nodes only
+        # type: (Optional[List[str]], Optional[List[str]]) -> None
 
+        #: Optional: get info about nodes matching labels
+        self.labels = labels
 
+        #: Optional: get info about certain named nodes only
+        self.nodes = nodes
 
 
 class InventoryNode(object):
@@ -1295,7 +1296,7 @@ class InventoryNode(object):
     InventoryNode.
     """
     def __init__(self, name, devices=None, labels=None):
-        # type: (str, inventory.Devices, List[str]) -> None
+        # type: (str, Optional[inventory.Devices], Optional[List[str]]) -> None
         if devices is None:
             devices = inventory.Devices([])
         if labels is None:
@@ -1459,13 +1460,13 @@ class OutdatableData(object):
         # type: (Optional[dict], Optional[datetime.datetime]) -> None
         self._data = data
         if data is not None and last_refresh is None:
-            self.last_refresh = datetime.datetime.utcnow()
+            self.last_refresh = datetime.datetime.utcnow()  # type: Optional[datetime.datetime]
         else:
             self.last_refresh = last_refresh
 
     def json(self):
         if self.last_refresh is not None:
-            timestr = self.last_refresh.strftime(self.DATEFMT)
+            timestr = self.last_refresh.strftime(self.DATEFMT)  # type: Optional[str]
         else:
             timestr = None
 
@@ -1515,16 +1516,16 @@ class OutdatableDictMixin(object):
 
     def __getitem__(self, item):
         # type: (str) -> OutdatableData
-        return OutdatableData.from_json(super(OutdatableDictMixin, self).__getitem__(item))
+        return OutdatableData.from_json(super(OutdatableDictMixin, self).__getitem__(item))  # type: ignore
 
     def __setitem__(self, key, value):
         # type: (str, OutdatableData) -> None
         val = None if value is None else value.json()
-        super(OutdatableDictMixin, self).__setitem__(key, val)
+        super(OutdatableDictMixin, self).__setitem__(key, val)  # type: ignore
 
     def items(self):
-        # type: () -> Iterator[Tuple[str, OutdatableData]]
-        for item in super(OutdatableDictMixin, self).items():
+        ## type: () -> Iterator[Tuple[str, OutdatableData]]
+        for item in super(OutdatableDictMixin, self).items():  # type: ignore
             k, v = item
             yield k, OutdatableData.from_json(v)
 
@@ -1543,7 +1544,7 @@ class OutdatableDictMixin(object):
     def remove_outdated(self):
         outdated = [item[0] for item in self.items() if item[1].outdated()]
         for o in outdated:
-            del self[o]
+            del self[o]  # type: ignore
 
     def invalidate(self, key):
         self[key] = OutdatableData(self[key].data,

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -72,10 +72,10 @@ except ImportError:
 
 class AsyncCompletion(orchestrator.Completion):
     def __init__(self,
-                 _first_promise=None,  # type: Optional["Completion"]
+                 _first_promise=None,  # type: Optional[orchestrator.Completion]
                  value=orchestrator._Promise.NO_RESULT,  # type: Any
-                 on_complete=None,  # type: Optional[Callable],
-                 name=None,  # type: Optional[str],
+                 on_complete=None,  # type: Optional[Callable]
+                 name=None,  # type: Optional[str]
                  many=False, # type: bool
                  ):
 
@@ -87,19 +87,20 @@ class AsyncCompletion(orchestrator.Completion):
 
     @property
     def _progress_reference(self):
-        if hasattr(self.__on_complete, 'progress_id'):
-            return self.__on_complete
+        # type: () -> Optional[orchestrator.ProgressReference]
+        if hasattr(self._on_complete_, 'progress_id'):  # type: ignore
+            return self._on_complete_  # type: ignore
         return None
 
     @property
     def _on_complete(self):
         # type: () -> Optional[Callable]
-        if self.__on_complete is None:
+        if self._on_complete_ is None:
             return None
 
         def callback(result):
             try:
-                self.__on_complete = None
+                self._on_complete_ = None
                 self._finalize(result)
             except Exception as e:
                 self.fail(e)
@@ -108,16 +109,17 @@ class AsyncCompletion(orchestrator.Completion):
             self.fail(e)
 
         if six.PY3:
-            _callback = self.__on_complete
+            _callback = self._on_complete_
         else:
             def _callback(*args, **kwargs):
                 # Py2 only: _worker_pool doesn't call error_callback
                 try:
-                    return self.__on_complete(*args, **kwargs)
+                    return self._on_complete_(*args, **kwargs)
                 except Exception as e:
                     self.fail(e)
 
         def run(value):
+            assert SSHOrchestrator.instance
             if self.many:
                 if not value:
                     logger.info('calling map_async without values')
@@ -143,7 +145,7 @@ class AsyncCompletion(orchestrator.Completion):
     @_on_complete.setter
     def _on_complete(self, inner):
         # type: (Callable) -> None
-        self.__on_complete = inner
+        self._on_complete_ = inner
 
 
 def ssh_completion(cls=AsyncCompletion, **c_kwargs):
@@ -224,7 +226,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
 
 
     instance = None
-    NATIVE_OPTIONS = []
+    NATIVE_OPTIONS = []  # type: List[Any]
     MODULE_OPTIONS = [
         {
             'name': 'ssh_config_file',
@@ -311,7 +313,6 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         self.log.error('ssh: shutdown')
         self._worker_pool.close()
         self._worker_pool.join()
-        self._worker_pool = None
 
     def config_notify(self):
         """
@@ -319,23 +320,23 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         """
         for opt in self.MODULE_OPTIONS:
             setattr(self,
-                    opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    opt['name'],  # type: ignore
+                    self.get_module_option(opt['name']) or opt['default'])  # type: ignore
             self.log.debug(' mgr option %s = %s',
-                           opt['name'], getattr(self, opt['name']))
+                           opt['name'], getattr(self, opt['name']))  # type: ignore
         for opt in self.NATIVE_OPTIONS:
             setattr(self,
-                    opt,
+                    opt,  # type: ignore
                     self.get_ceph_option(opt))
-            self.log.debug(' native option %s = %s', opt, getattr(self, opt))
+            self.log.debug(' native option %s = %s', opt, getattr(self, opt))  # type: ignore
 
     def get_unique_name(self, existing, prefix=None, forcename=None):
         """
         Generate a unique random service name
         """
         if forcename:
-            if len([d for d in existing if d.service_instance == name]):
-                raise RuntimeError('specified name %s already in use', name)
+            if len([d for d in existing if d.service_instance == forcename]):
+                raise RuntimeError('specified name %s already in use', forcename)
             return forcename
 
         while True:
@@ -354,8 +355,8 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         self.set_store('inventory', json.dumps(self.inventory))
 
     def _reconfig_ssh(self):
-        temp_files = []
-        ssh_options = []
+        temp_files = []  # type: list
+        ssh_options = []  # type: List[str]
 
         # ssh_config
         ssh_config_fname = self.ssh_config_file
@@ -394,7 +395,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         self._temp_files = temp_files
         if ssh_options:
-            self._ssh_options = ' '.join(ssh_options)
+            self._ssh_options = ' '.join(ssh_options)  # type: Optional[str]
         else:
             self._ssh_options = None
         self.log.info('ssh_options %s' % ssh_options)
@@ -944,9 +945,9 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
                 '--format', 'json',
             ])
         self.log.debug('code %s out %s' % (code, out))
-        j = json.loads('\n'.join(out))
+        osds_elems = json.loads('\n'.join(out))
         fsid = self._cluster_fsid
-        for osd_id, osds in j.items():
+        for osd_id, osds in osds_elems.items():
             for osd in osds:
                 if osd['tags']['ceph.cluster_fsid'] != fsid:
                     self.log.debug('mismatched fsid, skipping %s' % osd)

--- a/src/pybind/mgr/ssh/remotes.py
+++ b/src/pybind/mgr/ssh/remotes.py
@@ -77,5 +77,5 @@ def which(executable):
             return executable_path
 
 if __name__ == '__channelexec__':
-    for item in channel:
-        channel.send(eval(item))
+    for item in channel:  # type: ignore
+        channel.send(eval(item))  # type: ignore

--- a/src/pybind/mgr/ssh/tests/fixtures.py
+++ b/src/pybind/mgr/ssh/tests/fixtures.py
@@ -35,6 +35,7 @@ def ssh_module():
             mock.patch("ssh.module.SSHOrchestrator.get_store_prefix", get_store_prefix):
         SSHOrchestrator._register_commands('')
         m = SSHOrchestrator.__new__ (SSHOrchestrator)
+        m._root_logger = mock.MagicMock()
         m._store = {
             'ssh_config': '',
             'ssh_identity_key': '',

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -1,3 +1,4 @@
+# type: ignore
 from __future__ import absolute_import
 
 

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -12,4 +12,4 @@ basepython = python3
 deps =
     -r requirements.txt
     mypy
-commands = mypy --config-file=../../mypy.ini orchestrator.py
+commands = mypy --config-file=../../mypy.ini orchestrator.py ssh/module.py

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -1,8 +1,15 @@
 [tox]
-envlist = py3
+envlist = py3, mypy
 skipsdist = true
 
 [testenv]
 setenv = UNITTEST = true
-deps = -rrequirements.txt
+deps = -r requirements.txt
 commands = pytest -v --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ ssh/}
+
+[testenv:mypy]
+basepython = python3
+deps =
+    -r requirements.txt
+    mypy
+commands = mypy --config-file=../../mypy.ini orchestrator.py


### PR DESCRIPTION
static type checking is a good way to quickly increase the code coverage.
without creating lots of unit tests.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
