### PR TITLE
mimic: qa/standalone/ceph-helpers.sh: fix mgr module path

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -18,8 +18,6 @@ function get_cmake_variable() {
 }
 
 function get_python_path() {
-    local ceph_lib=$1
-    shift
     local py_ver=$(get_cmake_variable MGR_PYTHON_VERSION | cut -d '.' -f1)
     if [ -z "${py_ver}" ]; then
         if [ $(get_cmake_variable WITH_PYTHON2) = ON ]; then
@@ -28,7 +26,7 @@ function get_python_path() {
             py_ver=3
         fi
     fi
-    echo $(realpath ../src/pybind):$ceph_lib/cython_modules/lib.$py_ver
+    echo $(realpath ../src/pybind):$(pwd)/lib/cython_modules/lib.$py_ver
 }
 
 if [ `uname` = FreeBSD ]; then

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -560,6 +560,7 @@ function run_mgr() {
         --admin-socket=$(get_asok_path) \
         --run-dir=$dir \
         --pid-file=$dir/\$name.pid \
+        --mgr-module-path=$(realpath ${CEPH_ROOT}/src/pybind/mgr) \
         "$@" || return 1
 }
 


### PR DESCRIPTION
callers of get_python_path were not passing in a $1 parameter, so
ceph_lib was an empty string resulting in an invalid path to the built
cython modules. assume this is called from the `lib` parent directory.

pass path to the manager modules when starting ceph-mgr.

Signed-off-by: Noah Watkins <nwatkins@redhat.com>
(cherry picked from commit 7d3fa9bda3b0160c872e388c9f75cd1cabf9d4b5)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
