### PR TITLE
mon,mds: map mds daemons to a particular fs

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -282,3 +282,6 @@
   would not allow a pool to ever have completely balanced PGs.  For example, if
   crush requires 1 replica on each of 3 racks, but there are fewer OSDs in 1 of
   the racks.  In those cases, the configuration value can be increased.
+
+* MDS daemons can now be assigned to manage a particular file system via the
+  new ``mds_join_fs`` option.

--- a/doc/cephfs/standby.rst
+++ b/doc/cephfs/standby.rst
@@ -26,6 +26,10 @@ A daemon has a *name* that is set statically by the administrator
 when the daemon is first configured.  Typical configurations
 use the hostname where the daemon runs as the daemon name.
 
+A ceph-mds daemons can be assigned to a particular file system by
+setting the `mds_join_fs` configuration option to the file system
+name.
+
 Each time a daemon starts up, it is also assigned a *GID*, which
 is unique to this particular process lifetime of the daemon.  The
 GID is an integer.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7552,6 +7552,11 @@ std::vector<Option> get_mds_options() {
     .set_flag(Option::FLAG_NO_MON_UPDATE)
     .set_description("path to MDS data and keyring"),
 
+    Option("mds_join_fs", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description("force mds daemon to join a specific fs")
+    .set_flag(Option::FLAG_RUNTIME),
+
     Option("mds_max_xattr_pairs_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(64_K)
     .set_description("maximum aggregate size of extended attributes on a file"),

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -204,9 +204,9 @@ bool Beacon::_send()
       want_state,
       last_seq,
       CEPH_FEATURES_SUPPORTED_DEFAULT);
-
   beacon->set_health(health);
   beacon->set_compat(compat);
+  beacon->set_fs(g_conf().get_val<std::string>("mds_join_fs"));
   // piggyback the sys info on beacon msg
   if (want_state == MDSMap::STATE_BOOT) {
     map<string, string> sys_info;

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -148,7 +148,7 @@ public:
    */
   std::map<mds_gid_t, MDSMap::mds_info_t> get_mds_info() const;
 
-  mds_gid_t get_available_standby() const;
+  mds_gid_t get_available_standby(fs_cluster_id_t fscid) const;
 
   /**
    * Resolve daemon name to GID

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -99,7 +99,8 @@ public:
       ever_enabled_multiple(rhs.ever_enabled_multiple),
       mds_roles(rhs.mds_roles),
       standby_daemons(rhs.standby_daemons),
-      standby_epochs(rhs.standby_epochs)
+      standby_epochs(rhs.standby_epochs),
+      standby_daemon_fscid(rhs.standby_daemon_fscid)
   {
     filesystems.clear();
     for (const auto &i : rhs.filesystems) {
@@ -181,6 +182,13 @@ public:
   void insert(const MDSMap::mds_info_t &new_info);
 
   /**
+   * Adjust an MDS daemon's fscid
+   */
+  void adjust_standby_fscid(mds_gid_t standby_gid,
+			    fs_cluster_id_t fscid);
+  void clear_standby_fscid(mds_gid_t standby_gid);
+
+  /**
    * Assign an MDS cluster standby replay rank to a standby daemon
    */
   void assign_standby_replay(
@@ -240,6 +248,11 @@ public:
   void erase_filesystem(fs_cluster_id_t fscid)
   {
     filesystems.erase(fscid);
+    for (auto& p : standby_daemon_fscid) {
+      if (p.second == fscid) {
+	p.second = FS_CLUSTER_ID_NONE;
+      }
+    }
   }
 
   /**
@@ -406,6 +419,9 @@ protected:
   // For MDS daemons not yet assigned to a Filesystem
   std::map<mds_gid_t, MDSMap::mds_info_t> standby_daemons;
   std::map<mds_gid_t, epoch_t> standby_epochs;
+
+  // Missing entry implies no preference for a fs; NONE means assign to no fs
+  std::map<mds_gid_t, fs_cluster_id_t> standby_daemon_fscid;
 };
 WRITE_CLASS_ENCODER_FEATURES(FSMap)
 

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -419,6 +419,32 @@ bool MDSMonitor::preprocess_beacon(MonOpRequestRef op)
     // ignore, already booted.
     goto ignore;
   }
+
+  // did the standby fs change
+  if (info.state == MDSMap::STATE_STANDBY &&
+      state == MDSMap::STATE_STANDBY) {
+    if (m->get_fs().size()) {
+      fs_cluster_id_t fscid = FS_CLUSTER_ID_NONE;
+      auto f = fsmap.get_filesystem(m->get_fs());
+      if (f) {
+	fscid = f->fscid;
+      }
+      auto p = fsmap.standby_daemon_fscid.find(gid);
+      if (p == fsmap.standby_daemon_fscid.end() ||
+	  p->second != fscid) {
+	dout(10) << __func__ << " standby mds_join_fs changed to " << fscid
+		 << " (" << m->get_fs() << ")" << dendl;
+	return false;
+      }
+    } else {
+      auto p = fsmap.standby_daemon_fscid.find(gid);
+      if (p != fsmap.standby_daemon_fscid.end()) {
+	dout(10) << __func__ << " standby mds_join_fs was cleared" << dendl;
+	return false;
+      }
+    }
+  }
+
   // is there a state change here?
   if (info.state != state) {
     // legal state change?
@@ -611,6 +637,14 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
       new_info.state = MDSMap::STATE_STANDBY;
       new_info.state_seq = seq;
       pending.insert(new_info);
+      if (m->get_fs().size()) {
+	fs_cluster_id_t fscid = FS_CLUSTER_ID_NONE;
+	auto f = pending.get_filesystem(m->get_fs());
+	if (f) {
+	  fscid = f->fscid;
+	}
+	pending.adjust_standby_fscid(gid, fscid);
+      }
     }
 
     // initialize the beacon timer
@@ -772,6 +806,20 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
         info.state = state;
         info.state_seq = seq;
       });
+
+      // Process standby mds_join_fs change
+      if (state == MDSMap::STATE_STANDBY) {
+	if (m->get_fs().size()) {
+	  fs_cluster_id_t fscid = FS_CLUSTER_ID_NONE;
+	  auto f = pending.get_filesystem(m->get_fs());
+	  if (f) {
+	    fscid = f->fscid;
+	  }
+	  pending.adjust_standby_fscid(gid, fscid);
+	} else {
+	  pending.clear_standby_fscid(gid);
+	}
+      }
     }
   }
 

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2020,7 +2020,7 @@ bool MDSMonitor::maybe_promote_standby(FSMap &fsmap, Filesystem& fs)
     // as standby-replay daemons. Don't do this when the cluster is degraded
     // as a standby-replay daemon may try to read a journal being migrated.
     for (;;) {
-      auto standby_gid = fsmap.get_available_standby();
+      auto standby_gid = fsmap.get_available_standby(fs.fscid);
       if (standby_gid == MDS_GID_NONE) break;
       dout(20) << "standby available mds." << standby_gid << dendl;
       bool changed = false;

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1289,6 +1289,13 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
     def add_mds(self, spec):
         if not spec.placement.hosts or len(spec.placement.hosts) < spec.placement.count:
             raise RuntimeError("must specify at least %d hosts" % spec.placement.count)
+        # ensure mds_join_fs is set for these daemons
+        ret, out, err = self.mon_command({
+            'prefix': 'config set',
+            'who': 'mds.' + spec.name,
+            'name': 'mds_join_fs',
+            'value': spec.name,
+        })
         return self._get_services('mds').then(lambda ds: self._add_mds(ds, spec))
 
     def _add_mds(self, daemons, spec):


### PR DESCRIPTION
- add ``mds_fs`` option to map an mds to a particular fs
- report it via the beacons
- update fsmap and mon logic to respect the setting
- update cephadm to set this for each set of mds daemons it deploys