### PR TITLE
nautilus: core: mon: keep v1 address type when explicitly set

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -194,8 +194,10 @@ entity_addrvec_t make_mon_addrs(entity_addr_t a)
   } else if (a.get_port() == CEPH_MON_PORT_LEGACY) {
     a.set_type(entity_addr_t::TYPE_LEGACY);
     addrs.v.push_back(a);
-  } else {
+  } else if (a.get_type() == entity_addr_t::TYPE_ANY) {
     a.set_type(entity_addr_t::TYPE_MSGR2);
+    addrs.v.push_back(a);
+  } else {
     addrs.v.push_back(a);
   }
   return addrs;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43140

---

backport of https://github.com/ceph/ceph/pull/31765
parent tracker: https://tracker.ceph.com/issues/42906

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh