### PR TITLE
rgw: pass stack variable to reference

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -180,7 +180,7 @@ int ManifestObjectProcessor::next(uint64_t offset, uint64_t *pstripe_size)
   if (r < 0) {
     return r;
   }
-  r = writer.set_stripe_obj(stripe_obj);
+  r = writer.set_stripe_obj(std::move(stripe_obj));
   if (r < 0) {
     return r;
   }
@@ -259,7 +259,7 @@ int AtomicObjectProcessor::prepare(optional_yield y)
 
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store->getRados());
 
-  r = writer.set_stripe_obj(stripe_obj);
+  r = writer.set_stripe_obj(std::move(stripe_obj));
   if (r < 0) {
     return r;
   }
@@ -388,7 +388,7 @@ int MultipartObjectProcessor::prepare_head()
   RGWSI_Tier_RADOS::raw_obj_to_obj(head_obj.bucket, stripe_obj, &head_obj);
   head_obj.index_hash_source = target_obj.key.name;
 
-  r = writer.set_stripe_obj(stripe_obj);
+  r = writer.set_stripe_obj(std::move(stripe_obj));
   if (r < 0) {
     return r;
   }


### PR DESCRIPTION
Signed-off-by: Chang Liu <channingliu@tencent.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
