### PR TITLE
os/bluestore: default bluestore_block_size 1T -> 100G

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4061,7 +4061,7 @@ std::vector<Option> get_global_options() {
     .set_description("Path to block device/file"),
 
     Option("bluestore_block_size", Option::TYPE_SIZE, Option::LEVEL_DEV)
-    .set_default(1_T)
+    .set_default(100_G)
     .set_flag(Option::FLAG_CREATE)
     .set_description("Size of file to create for backing bluestore"),
 


### PR DESCRIPTION
This makes vstart *way* faster.  This option is only really relevant
for dev test environments.  We bumped it up back in dbdd1d9b6ec286982b5e86d4c51f831cc16afc12
from 10G just to make ENOSPC less common in dev/test.  Let's see if 100G
is a better balance.

Signed-off-by: Sage Weil <sage@redhat.com>
