### PR TITLE
ceph-daemon: Enable "deploy" command  to create a prometheus server instance

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -859,8 +859,8 @@ def update_firewalld(daemon_type):
             logger.info('Enabling firewalld service %s in current zone...' % svc)
             out, err, ret = call([cmd, '--permanent', '--add-service', svc])
             if ret:
-                raise RuntimeError('unable to add service %s to current zone: %s' %
-                                   (svc, err))
+                raise RuntimeError(
+                    'unable to add service %s to current zone: %s' % (svc, err))
         else:
             logger.debug('firewalld service %s is enabled in current zone' % svc)
     for port in fw_ports:

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1932,6 +1932,31 @@ def command_rm_cluster():
 
 ##################################
 
+
+class CustomValidation(argparse.Action):
+
+    def _check_name(self, values):
+
+        try:
+            (daemon_type, daemon_id) = values.split('.', 1)
+        except ValueError:
+            raise argparse.ArgumentError(self,
+                                         "must be of the format <type>.<id>. For example, osd.1 or prometheus.myhost.com")
+        
+        daemons = Ceph.daemons.copy()
+        daemons.extend(Monitoring.components.keys())
+        
+        if daemon_type not in daemons:
+            raise argparse.ArgumentError(self, 
+                                         "name must declare the type of daemon e.g. "
+                                         "{}".format(', '.join(daemons)))
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if self.dest == "name":
+            self._check_name(values)
+            setattr(namespace, self.dest, values)
+
+
 def _get_parser():
     # type: () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser(
@@ -2014,6 +2039,7 @@ def _get_parser():
     parser_rm_daemon.add_argument(
         '--name', '-n',
         required=True,
+        action=CustomValidation,
         help='daemon name (type.id)')
     parser_rm_daemon.add_argument(
         '--fsid',
@@ -2202,6 +2228,7 @@ def _get_parser():
     parser_deploy.set_defaults(func=command_deploy)
     parser_deploy.add_argument(
         '--name',
+        action=CustomValidation,
         required=True,
         help='daemon name (type.id)')
     parser_deploy.add_argument(

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -53,6 +53,8 @@ import subprocess
 import sys
 import tempfile
 import time
+import yaml
+
 try:
     from typing import Dict, List, Tuple, Optional, Union
 except ImportError:
@@ -68,6 +70,47 @@ container_path = None
 
 class Error(Exception):
     pass
+
+
+class Ceph(object):
+    daemons = ['mon', 'mgr', 'mds', 'osd', 'rgw', 'rbd-mirror']
+
+
+class Monitoring(object):
+    # define the configs for the monitoring containers
+    components = {
+        "prometheus": {
+            "image": {
+                "cpus": '2',
+                "memory": '4GB',
+                "args": [
+                    "--config.file=/etc/prometheus/prometheus.yml",
+                    "--storage.tsdb.path=/prometheus",
+                    "--web.listen-address=:9095"
+                ]
+            },
+            "config": [
+                {
+                    "global": {
+                       "scrape_interval": "5s",
+                        "evaluation_interval": "10s"
+                    },
+                    "rule_files": [],
+                    "scrape_configs": [
+                        {
+                            "job_name": "prometheus",
+                            "static_configs": [
+                                { "targets": [
+                                    'localhost:9095'
+                                ]}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
 
 ##################################
 # Popen wrappers, lifted from ceph-volume
@@ -256,7 +299,10 @@ def makedirs(dir, uid, gid, mode):
 
 def get_data_dir(fsid, t, n):
     # type: (str, str, Union[int, str]) -> str
-    return os.path.join(args.data_dir, fsid, '%s.%s' % (t, n))
+    if n:
+        return os.path.join(args.data_dir, fsid, '%s.%s' % (t, n))
+    else:
+        return os.path.join(args.data_dir, fsid, '%s' % (t))
 
 def get_log_dir(fsid):
     # type: (str) -> str
@@ -411,19 +457,26 @@ def get_legacy_daemon_fsid(cluster, daemon_type, daemon_id, legacy_dir=None):
 
 def get_daemon_args(fsid, daemon_type, daemon_id):
     # type: (str, str, Union[int, str]) -> List[str]
-    r = [
-        '--default-log-to-file=false',
-        '--default-log-to-stderr=true',
+    r = []
+
+    if daemon_type in Ceph.daemons:
+        r += [
+            '--default-log-to-file=false',
+            '--default-log-to-stderr=true',
+            '--setuser', 'ceph',
+            '--setgroup', 'ceph'
         ]
-    r += ['--setuser', 'ceph']
-    r += ['--setgroup', 'ceph']
+
+    elif daemon_type in Monitoring.components:
+        metadata = Monitoring.components[daemon_type]['image']
+        r += metadata['args']
     return r
 
 def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
                        config=None, keyring=None):
     # type: (str, str, Union[int, str], int, int, str, str) ->  None
-    data_dir = make_data_dir(fsid, daemon_type, daemon_id)
-    make_log_dir(fsid)
+    data_dir = make_data_dir(fsid, daemon_type, daemon_id, uid, gid)
+    make_log_dir(fsid, uid, gid)
 
     if config:
         with open(data_dir + '/config', 'w') as f:
@@ -435,6 +488,32 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
             os.fchmod(f.fileno(), 0o600)
             os.fchown(f.fileno(), uid, gid)
             f.write(keyring)
+
+    if daemon_type == 'prometheus':
+        
+        # Set up directories
+        data_dir_root = get_data_dir(fsid, daemon_type, daemon_id)
+        makedirs(os.path.join(data_dir_root,'etc/prometheus'), uid, gid, 0o755)
+        makedirs(os.path.join(data_dir_root,'data'), uid, gid, 0o755)
+
+        # create configs
+        with open(os.path.join(data_dir_root,'etc/prometheus/prometheus.yml'), 'w') as f:
+            os.fchown(f.fileno(), uid, gid)
+            os.fchmod(f.fileno(), 0o600)
+            config = Monitoring.components['prometheus']['config'][0]
+            targets = []
+            for mgr in args.mgr_list.split(','):
+                targets.append('{}:9283'.format(mgr))
+            config['scrape_configs'].append({
+                "job_name": "ceph",
+                "static_configs": [
+                    { "targets": targets,
+                      "labels": {
+                          "instance": "ceph_cluster"
+                      } }
+                ],
+            })
+            f.write(yaml.safe_dump(config, explicit_start=True, indent=2))
 
 def get_config_and_keyring():
     # type: () -> Tuple[str, str]
@@ -494,15 +573,16 @@ def get_config_and_both_keyrings():
 def get_container_mounts(fsid, daemon_type, daemon_id):
     # type: (str, str, Union[int, str, None]) -> Dict[str, str]
     mounts = {}
-    if fsid:
-        run_path = os.path.join('/var/run/ceph', fsid);
-        if os.path.exists(run_path):
-            mounts[run_path] = '/var/run/ceph:z'
-        log_dir = get_log_dir(fsid)
-        mounts[log_dir] = '/var/log/ceph:z'
-        crash_dir = '/var/lib/ceph/%s/crash' % fsid
-        if os.path.exists(crash_dir):
-            mounts[crash_dir] = '/var/lib/ceph/crash:z'
+    if daemon_type in Ceph.daemons:
+        if fsid:
+            run_path = os.path.join('/var/run/ceph', fsid)
+            if os.path.exists(run_path):
+                mounts[run_path] = '/var/run/ceph:z'
+            log_dir = get_log_dir(fsid)
+            mounts[log_dir] = '/var/log/ceph:z'
+            crash_dir = '/var/lib/ceph/%s/crash' % fsid
+            if os.path.exists(crash_dir):
+                mounts[crash_dir] = '/var/lib/ceph/crash:z'
 
     if daemon_id:
         data_dir = get_data_dir(fsid, daemon_type, daemon_id)
@@ -523,6 +603,11 @@ def get_container_mounts(fsid, daemon_type, daemon_id):
         mounts['/sys'] = '/sys'  # for numa.cc, pick_address, cgroups, ...
         mounts['/run/lvm'] = '/run/lvm'
         mounts['/run/lock/lvm'] = '/run/lock/lvm'
+    if daemon_type in Monitoring.components:
+        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+        if daemon_type == 'prometheus':
+            mounts[os.path.join(data_dir, 'etc/prometheus')] = '/etc/prometheus:Z'
+            mounts[os.path.join(data_dir, 'data')] = '/prometheus:Z'
 
     return mounts
 
@@ -532,39 +617,52 @@ def get_container(fsid, daemon_type, daemon_id, privileged=False,
     if daemon_type in ['mon', 'osd'] or privileged:
         # mon and osd need privileged in order for libudev to query devices
         container_args += ['--privileged']
+
     if daemon_type == 'rgw':
         entrypoint = '/usr/bin/radosgw'
         name = 'client.rgw.%s' % daemon_id
     elif daemon_type == 'rbd-mirror':
         entrypoint = '/usr/bin/rbd-mirror'
         name = 'client.rbd-mirror.%s' % daemon_id
-    else:
+    elif daemon_type in ['mon', 'mgr', 'mds', 'osd']:
         entrypoint = '/usr/bin/ceph-' + daemon_type
         name = '%s.%s' % (daemon_type, daemon_id)
+    elif daemon_type in Monitoring.components:
+        entrypoint = None
+        name = daemon_type
+    
+    id_str = '.{}'.format(daemon_id)
+    name_args = ['-n', name, '-f']
+
+    if daemon_type in Monitoring.components:
+        id_str = ''
+        name_args = []
+
     return CephContainer(
         image=args.image,
         entrypoint=entrypoint,
-        args=[
-            '-n', name,
-            '-f', # foreground
-        ] + get_daemon_args(fsid, daemon_type, daemon_id),
+        args=name_args + get_daemon_args(fsid, daemon_type, daemon_id),
         container_args=container_args,
         volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
-        cname='ceph-%s-%s.%s' % (fsid, daemon_type, daemon_id),
+        cname='ceph-%s-%s%s' % (fsid, daemon_type, id_str),
     )
 
-def extract_uid_gid():
+def extract_uid_gid(img=None, file_path='/etc/ceph'):
     # type: () -> Tuple[int, int]
+
+    if not img:
+        img = args.image
+
     out = CephContainer(
-        image=args.image,
-        entrypoint='/usr/bin/grep',
-        args=['^ceph:', '/etc/passwd'],
+        image=img,
+        entrypoint='stat',
+        args=['-c', '%u %g', file_path]
     ).run()
-    (uid, gid) = out.split(':')[2:4]
+    (uid, gid) = out.split(' ')
     return (int(uid), int(gid))
 
 def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
-                  config, keyring):
+                  config=None, keyring=None):
     # type: (str, str, Union[int, str], CephContainer, int, int, Optional[str], Optional[str]) -> None
     if daemon_type == 'mon' and not os.path.exists(
             get_data_dir(fsid, 'mon', daemon_id)):
@@ -678,14 +776,21 @@ def update_firewalld(daemon_type):
 
     fw_services = []
     fw_ports = []
+
+    # handle services (defined in /usr/lib/firewalld/services)
     if daemon_type == 'mon':
         fw_services.append('ceph-mon')
     elif daemon_type in ['mgr', 'mds', 'osd']:
         fw_services.append('ceph')
+
+    # handle individual ports
     if daemon_type == 'mgr':
         fw_ports.append(8080)  # dashboard
         fw_ports.append(8443)  # dashboard
-        fw_ports.append(9283)  # prometheus
+        fw_ports.append(9283)  # mgr/prometheus exporter
+    elif daemon_type == 'prometheus':
+        fw_ports.append(9095)   # prometheus server
+
 
     for svc in fw_services:
         out, err, ret = call([cmd, '--permanent', '--query-service', svc])
@@ -693,7 +798,7 @@ def update_firewalld(daemon_type):
             logger.info('Enabling firewalld service %s in current zone...' % svc)
             out, err, ret = call([cmd, '--permanent', '--add-service', svc])
             if ret:
-                raise RuntimeError('unable to add service %s to current zone:' %
+                raise RuntimeError('unable to add service %s to current zone: %s' %
                                    (svc, err))
         else:
             logger.debug('firewalld service %s is enabled in current zone' % svc)
@@ -834,6 +939,9 @@ def deploy_crash(fsid, uid, gid, config, keyring):
 
 def get_unit_file(fsid, uid, gid):
     # type: (str, int, int) -> str
+    #
+    # FIXME - should monitoring containers be included in the ceph.target group?
+    #
     install_path = find_program('install')
     u = """[Unit]
 Description=Ceph daemon for {fsid}
@@ -876,6 +984,7 @@ WantedBy=ceph-{fsid}.target
 
 ##################################
 
+
 class CephContainer:
     def __init__(self,
                  image,
@@ -897,6 +1006,10 @@ class CephContainer:
         vols = [] # type: List[str]
         envs = [] # type: List[str]
         cname = [] # type: List[str]
+        entrypoint = []
+        if self.entrypoint:
+            entrypoint = ['--entrypoint', self.entrypoint]
+
         vols = sum(
             [['-v', '%s:%s' % (host_dir, container_dir)]
              for host_dir, container_dir in self.volume_mounts.items()], [])
@@ -912,9 +1025,8 @@ class CephContainer:
             '--net=host',
         ] + self.container_args + \
         cname + envs + \
-        vols + \
+        vols + entrypoint + \
         [
-            '--entrypoint', self.entrypoint,
             self.image
         ] + self.args # type: ignore
 
@@ -1265,13 +1377,18 @@ def command_bootstrap():
         logger.info('Enabling the dashboard module...')
         cli(['mgr', 'module', 'enable', 'dashboard'])
         logger.info('Waiting for the module to be available...')
-        # FIXME: potential for an endless loop?
+
+        limit = 20
         while True:
             c_out = cli(['-h'])
             if 'dashboard' in c_out:
                 break
-            logger.info('Dashboard not yet available, waiting...')
+            logger.info('Dashboard not yet available, waiting...({})'.format(limit))
             time.sleep(1)
+            limit -= 1
+            if limit == 0:
+                raise Error("Timeout waiting for dashboard to be available")
+
         logger.info('Generating a dashboard self-signed certificate...')
         cli(['dashboard', 'create-self-signed-cert'])
         logger.info('Creating initial admin user...')
@@ -1304,25 +1421,63 @@ def command_bootstrap():
 
 def command_deploy():
     # type: () -> None
-    (daemon_type, daemon_id) = args.name.split('.', 1)
-    if daemon_type not in ['mon', 'mgr', 'mds', 'osd', 'rgw', 'rbd-mirror']:
+    if '.' in args.name:
+        (daemon_type, daemon_id) = args.name.split('.', 1)
+    else:
+        daemon_type = args.name
+        daemon_id = None
+    
+    crash_keyring = None
+    
+    supported_daemons = Ceph.daemons.copy()
+    supported_daemons.extend(Monitoring.components)
+
+    if daemon_type not in supported_daemons:
         raise Error('daemon type %s not recognized' % daemon_type)
-    (config, keyring, crash_keyring) = get_config_and_both_keyrings()
-    if daemon_type == 'mon':
-        if args.mon_ip:
-            config += '[mon.%s]\n\tpublic_addr = %s\n' % (daemon_id, args.mon_ip)
-        elif args.mon_addrv:
-            config += '[mon.%s]\n\tpublic_addrv = %s\n' % (daemon_id,
-                                                           args.mon_addrv)
-        elif args.mon_network:
-            config += '[mon.%s]\n\tpublic_network = %s\n' % (daemon_id,
-                                                             args.mon_network)
+    
+    if daemon_type in Ceph.daemons:
+        (config, keyring, crash_keyring) = get_config_and_both_keyrings()
+        if daemon_type == 'mon':
+            if args.mon_ip:
+                config += '[mon.%s]\n\tpublic_addr = %s\n' % (daemon_id, args.mon_ip)
+            elif args.mon_addrv:
+                config += '[mon.%s]\n\tpublic_addrv = %s\n' % (daemon_id,
+                                                            args.mon_addrv)
+            elif args.mon_network:
+                config += '[mon.%s]\n\tpublic_network = %s\n' % (daemon_id,
+                                                                args.mon_network)
+            else:
+                raise Error('must specify --mon-ip or --mon-network')
+    
+    if daemon_type in Ceph.daemons:
+        (uid, gid) = extract_uid_gid()
+        c = get_container(args.fsid, daemon_type, daemon_id)
+        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
+                      config, keyring)
+    else:
+        # monitoring daemon - prometheus, grafana, alertmanager
+        monitoring_args = []
+        if daemon_type == 'prometheus':
+            if not args.mgr_list:
+                raise Error("mgr-list parameter is needed when deploying prometheus service")
+
+            uid, gid = extract_uid_gid(file_path='/etc/prometheus')
+            metadata = Monitoring.components['prometheus']['image']
+            monitoring_args = [
+                '--user', 
+                str(uid),
+                '--cpus',
+                metadata.get('cpus', '2'),
+                '--memory',
+                metadata.get('memory', '4GB')
+            ]
         else:
-            raise Error('must specify --mon-ip or --mon-network')
-    (uid, gid) = extract_uid_gid()
-    c = get_container(args.fsid, daemon_type, daemon_id)
-    deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
-                  config, keyring)
+            raise Error("{} not implemented in command_deploy function".format(daemon_type))
+
+        c = get_container(args.fsid, daemon_type, daemon_id, container_args=monitoring_args)
+        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid)
+
+
     if crash_keyring:
         deploy_crash(args.fsid, uid, gid, config, crash_keyring)
 
@@ -1644,7 +1799,12 @@ def command_adopt():
 
 def command_rm_daemon():
     # type: () -> None
-    (daemon_type, daemon_id) = args.name.split('.', 1)
+    if '.' in args.name:
+        (daemon_type, daemon_id) = args.name.split('.', 1)
+    else:
+        daemon_type = args.name
+        daemon_id = None
+
     if daemon_type in ['mon', 'osd'] and not args.force:
         raise Error('must pass --force to proceed: '
                       'this command may destroy precious data!')
@@ -1657,6 +1817,7 @@ def command_rm_daemon():
          verbose_on_failure=False)
     data_dir = get_data_dir(args.fsid, daemon_type, daemon_id)
     call_throws(['rm', '-rf', data_dir])
+    # TODO - remove the unit file
 
 ##################################
 
@@ -2007,6 +2168,10 @@ def _get_parser():
     parser_deploy.add_argument(
         '--config-and-keyrings',
         help='JSON file with config and keyrings for the daemon and crash agent')
+    parser_deploy.add_argument(
+        '--mgr-list',
+        help='Comma separated list of ceph mgr IP address or names e.g. mgr-1,mgr2'
+    )
     parser_deploy.add_argument(
         '--mon-ip',
         help='mon IP')

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1476,11 +1476,7 @@ def command_bootstrap():
 
 def command_deploy():
     # type: () -> None
-    if '.' in args.name:
-        (daemon_type, daemon_id) = args.name.split('.', 1)
-    else:
-        daemon_type = args.name
-        daemon_id = get_hostname()
+    (daemon_type, daemon_id) = args.name.split('.', 1)
     
     crash_keyring = None
     
@@ -1862,11 +1858,7 @@ def command_adopt():
 
 def command_rm_daemon():
     # type: () -> None
-    if '.' in args.name:
-        (daemon_type, daemon_id) = args.name.split('.', 1)
-    else:
-        daemon_type = args.name
-        daemon_id = get_hostname()
+    (daemon_type, daemon_id) = args.name.split('.', 1)
 
     if daemon_type in ['mon', 'osd'] and not args.force:
         raise Error('must pass --force to proceed: '

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -78,6 +78,10 @@ class Ceph(object):
 
 class Monitoring(object):
     # define the configs for the monitoring containers
+    port_map = {
+        "prometheus": 9095  # Avoid default 9090, due to conflict with cockpit UI
+    }
+
     components = {
         "prometheus": {
             "image": {
@@ -86,7 +90,7 @@ class Monitoring(object):
                 "args": [
                     "--config.file=/etc/prometheus/prometheus.yml",
                     "--storage.tsdb.path=/prometheus",
-                    "--web.listen-address=:9095"
+                    "--web.listen-address=:{}".format(port_map['prometheus'])
                 ]
             },
             "config": [
@@ -101,7 +105,7 @@ class Monitoring(object):
                             "job_name": "prometheus",
                             "static_configs": [
                                 { "targets": [
-                                    'localhost:9095'
+                                    'localhost:{}'.format(port_map['prometheus'])
                                 ]}
                             ]
                         }
@@ -111,6 +115,18 @@ class Monitoring(object):
         }
     }
 
+
+def port_in_use(port_num):
+    """Detect whether a port is in use on the local machine"""
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.connect(("127.0.0.1",port_num))
+    except ConnectionRefusedError:
+        return False
+    else:
+        s.close()
+        return True
 
 ##################################
 # Popen wrappers, lifted from ceph-volume
@@ -1109,7 +1125,7 @@ def command_bootstrap():
         raise Error('must specify --mon-ip or --mon-addrv')
     if not cp.has_section('global'):
         cp.add_section('global')
-    cp.set('global', 'fsid', fsid);
+    cp.set('global', 'fsid', fsid)
     cp.set('global', 'mon host', addr_arg)
     cp.set('global', 'container_image', args.image)
     cpf = StringIO()
@@ -1457,6 +1473,14 @@ def command_deploy():
     else:
         # monitoring daemon - prometheus, grafana, alertmanager
         monitoring_args = []
+
+        # Default Checks
+        daemon_port = Monitoring.port_map[daemon_type]
+        if port_in_use(daemon_port):
+            raise Error("TCP Port '{}' required for {} is already in use".format(daemon_port, daemon_type))
+        elif args.image == DEFAULT_IMAGE:
+            raise Error("--image parameter must be supplied for {}".format(daemon_type))
+
         if daemon_type == 'prometheus':
             if not args.mgr_list:
                 raise Error("mgr-list parameter is needed when deploying prometheus service")

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -805,7 +805,7 @@ def update_firewalld(daemon_type):
         fw_ports.append(8443)  # dashboard
         fw_ports.append(9283)  # mgr/prometheus exporter
     elif daemon_type == 'prometheus':
-        fw_ports.append(9095)   # prometheus server
+        fw_ports.append(Monitoring.port_map['prometheus'])   # prometheus server
 
 
     for svc in fw_services:

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -85,6 +85,7 @@ class Monitoring(object):
     components = {
         "prometheus": {
             "image": {
+                "image": "prom/prometheus:latest",
                 "cpus": '2',
                 "memory": '4GB',
                 "args": [
@@ -93,8 +94,8 @@ class Monitoring(object):
                     "--web.listen-address=:{}".format(port_map['prometheus'])
                 ]
             },
-            "config": [
-                {
+            "config": {
+                "prometheus.yml": {
                     "global": {
                        "scrape_interval": "5s",
                         "evaluation_interval": "10s"
@@ -111,7 +112,7 @@ class Monitoring(object):
                         }
                     ]
                 }
-            ]
+            }
         }
     }
 
@@ -315,10 +316,7 @@ def makedirs(dir, uid, gid, mode):
 
 def get_data_dir(fsid, t, n):
     # type: (str, str, Union[int, str]) -> str
-    if n:
-        return os.path.join(args.data_dir, fsid, '%s.%s' % (t, n))
-    else:
-        return os.path.join(args.data_dir, fsid, '%s' % (t))
+    return os.path.join(args.data_dir, fsid, '%s.%s' % (t, n))
 
 def get_log_dir(fsid):
     # type: (str) -> str
@@ -512,24 +510,73 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
         makedirs(os.path.join(data_dir_root,'etc/prometheus'), uid, gid, 0o755)
         makedirs(os.path.join(data_dir_root,'data'), uid, gid, 0o755)
 
+        config = get_parm(args.config_json)
+        if not config:
+            raise Error("Prometheus deployment requires config-json to be set")
+
+        prometheus_yml = dict()
+
+        if "prometheus.yml" in config:
+            # trust the provided version is appropriate
+            prometheus_yml = config.get('prometheus.yml')
+            logger.debug("Using supplied prometheus.yml definition")
+        else:
+            if "mgrs" in config:
+                prometheus_yml = Monitoring.components['prometheus']['config']['prometheus.yml']
+                if isinstance(config['mgrs'], list):
+                    targets=[]
+                    for mgr in config['mgrs']:
+                        targets.append('{}:9283'.format(mgr))
+                    prometheus_yml['scrape_configs'].append({
+                            "job_name": "ceph",
+                            "static_configs": [
+                                { "targets": targets,
+                                  "labels": {
+                                    "instance": "ceph_cluster"
+                                    }
+                                }
+                            ],
+                        })
+                    logger.debug("Using default prometheus settings with supplied list of ceph mgrs")
+                else:
+                    raise Error("config-json supplied with invalid mgrs setting - must be a list")
+            else:
+                raise Error("config-json must either specify a valid prometheus.yml, or a mgrs list")
+
         # create configs
         with open(os.path.join(data_dir_root,'etc/prometheus/prometheus.yml'), 'w') as f:
             os.fchown(f.fileno(), uid, gid)
             os.fchmod(f.fileno(), 0o600)
-            config = Monitoring.components['prometheus']['config'][0]
-            targets = []
-            for mgr in args.mgr_list.split(','):
-                targets.append('{}:9283'.format(mgr))
-            config['scrape_configs'].append({
-                "job_name": "ceph",
-                "static_configs": [
-                    { "targets": targets,
-                      "labels": {
-                          "instance": "ceph_cluster"
-                      } }
-                ],
-            })
-            f.write(yaml.safe_dump(config, explicit_start=True, indent=2))
+            f.write(yaml.safe_dump(prometheus_yml, explicit_start=True, indent=2))
+
+def get_parm(option):
+    """Read requested arg, and return as a dict"""
+
+    if not option:
+        return None
+
+    if option == '-':
+        try:
+            j = injected_stdin
+        except NameError:
+            j = sys.stdin.read()
+    else:
+        # inline json string
+        if option[0] == '{' and option[-1] == '}':
+            j = option
+        # json file
+        elif os.path.exists(option):
+            with open(option, 'r') as f:
+                j = f.read()
+        else:
+            raise Error("Config file {} not found".format(option))
+    
+    try:
+        js = json.loads(j)
+    except ValueError:
+        raise Error("Invalid JSON in {}".format(option))
+    else:
+        return js
 
 def get_config_and_keyring():
     # type: () -> Tuple[str, str]
@@ -600,7 +647,7 @@ def get_container_mounts(fsid, daemon_type, daemon_id):
             if os.path.exists(crash_dir):
                 mounts[crash_dir] = '/var/lib/ceph/crash:z'
 
-    if daemon_id:
+    if daemon_type in Ceph.daemons and daemon_id:
         data_dir = get_data_dir(fsid, daemon_type, daemon_id)
         if daemon_type == 'rgw':
             cdata_dir = '/var/lib/ceph/radosgw/ceph-rgw.%s' % (daemon_id)
@@ -647,20 +694,18 @@ def get_container(fsid, daemon_type, daemon_id, privileged=False,
         entrypoint = None
         name = daemon_type
     
-    id_str = '.{}'.format(daemon_id)
-    name_args = ['-n', name, '-f']
+    ceph_args = ['-n', name, '-f']
 
     if daemon_type in Monitoring.components:
-        id_str = ''
-        name_args = []
+        ceph_args = []
 
     return CephContainer(
         image=args.image,
         entrypoint=entrypoint,
-        args=name_args + get_daemon_args(fsid, daemon_type, daemon_id),
+        args=ceph_args + get_daemon_args(fsid, daemon_type, daemon_id),
         container_args=container_args,
         volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
-        cname='ceph-%s-%s%s' % (fsid, daemon_type, id_str),
+        cname='ceph-%s-%s.%s' % (fsid, daemon_type, daemon_id),
     )
 
 def extract_uid_gid(img=None, file_path='/etc/ceph'):
@@ -955,9 +1000,6 @@ def deploy_crash(fsid, uid, gid, config, keyring):
 
 def get_unit_file(fsid, uid, gid):
     # type: (str, int, int) -> str
-    #
-    # FIXME - should monitoring containers be included in the ceph.target group?
-    #
     install_path = find_program('install')
     u = """[Unit]
 Description=Ceph daemon for {fsid}
@@ -1393,17 +1435,14 @@ def command_bootstrap():
         logger.info('Enabling the dashboard module...')
         cli(['mgr', 'module', 'enable', 'dashboard'])
         logger.info('Waiting for the module to be available...')
+        # FIXME: potential for an endless loop?
 
-        limit = 20
         while True:
             c_out = cli(['-h'])
             if 'dashboard' in c_out:
                 break
-            logger.info('Dashboard not yet available, waiting...({})'.format(limit))
+            logger.info('Dashboard not yet available, waiting...')
             time.sleep(1)
-            limit -= 1
-            if limit == 0:
-                raise Error("Timeout waiting for dashboard to be available")
 
         logger.info('Generating a dashboard self-signed certificate...')
         cli(['dashboard', 'create-self-signed-cert'])
@@ -1441,7 +1480,7 @@ def command_deploy():
         (daemon_type, daemon_id) = args.name.split('.', 1)
     else:
         daemon_type = args.name
-        daemon_id = None
+        daemon_id = get_hostname()
     
     crash_keyring = None
     
@@ -1482,8 +1521,8 @@ def command_deploy():
             raise Error("--image parameter must be supplied for {}".format(daemon_type))
 
         if daemon_type == 'prometheus':
-            if not args.mgr_list:
-                raise Error("mgr-list parameter is needed when deploying prometheus service")
+            if not args.config_json:
+                raise Error("config-json parameter is needed when deploying prometheus service")
 
             uid, gid = extract_uid_gid(file_path='/etc/prometheus')
             metadata = Monitoring.components['prometheus']['image']
@@ -1827,7 +1866,7 @@ def command_rm_daemon():
         (daemon_type, daemon_id) = args.name.split('.', 1)
     else:
         daemon_type = args.name
-        daemon_id = None
+        daemon_id = get_hostname()
 
     if daemon_type in ['mon', 'osd'] and not args.force:
         raise Error('must pass --force to proceed: '
@@ -2181,6 +2220,9 @@ def _get_parser():
         '--config', '-c',
         help='config file for new daemon')
     parser_deploy.add_argument(
+        '--config-json',
+        help='Additional configuration information in JSON format')
+    parser_deploy.add_argument(
         '--keyring',
         help='keyring for new daemon')
     parser_deploy.add_argument(
@@ -2192,10 +2234,6 @@ def _get_parser():
     parser_deploy.add_argument(
         '--config-and-keyrings',
         help='JSON file with config and keyrings for the daemon and crash agent')
-    parser_deploy.add_argument(
-        '--mgr-list',
-        help='Comma separated list of ceph mgr IP address or names e.g. mgr-1,mgr2'
-    )
     parser_deploy.add_argument(
         '--mon-ip',
         help='mon IP')

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -493,8 +493,8 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
 def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
                        config=None, keyring=None):
     # type: (str, str, Union[int, str], int, int, str, str) ->  None
-    data_dir = make_data_dir(fsid, daemon_type, daemon_id, uid, gid)
-    make_log_dir(fsid, uid, gid)
+    data_dir = make_data_dir(fsid, daemon_type, daemon_id, uid=uid, gid=gid)
+    make_log_dir(fsid)
 
     if config:
         with open(data_dir + '/config', 'w') as f:
@@ -1934,9 +1934,6 @@ def command_rm_cluster():
     call_throws(['rm', '-f', args.logrotate_dir + '/ceph-%s' % args.fsid])
 
 
-##################################
-
-
 class CustomValidation(argparse.Action):
 
     def _check_name(self, values):
@@ -1960,6 +1957,38 @@ class CustomValidation(argparse.Action):
             self._check_name(values)
             setattr(namespace, self.dest, values)
 
+
+def check_time_sync():
+    units = ['chronyd.service', 'systemd-timesyncd.service', 'ntpd.service']
+    for u in units:
+        (enabled, state) = check_unit(u)
+        if enabled and state == 'running':
+            logger.info('Time sync unit %s is enabled and running' % u)
+            return True
+    logger.warning('No time sync service is running; checked for %s' % units)
+    return False
+
+def command_check_host():
+    # caller already checked for docker/podman
+    logger.info('podman|docker (%s) is present' % container_path)
+
+    if not find_program('systemctl'):
+        raise RuntimeError('unable to location systemctl')
+    logger.info('systemctl is present')
+
+    if not find_program('lvcreate'):
+        raise RuntimeError('LVM does not appear to be installed')
+    logger.info('LVM2 is present')
+
+    # check for configured+running chronyd or ntp
+    if not check_time_sync():
+        raise RuntimeError('No time synchronization is active (checked all of %s)' %
+                           units)
+
+    logger.info('Host looks OK')
+
+
+##################################
 
 def _get_parser():
     # type: () -> argparse.ArgumentParser

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -45,6 +45,7 @@ import json
 import logging
 import os
 import random
+import re
 import select
 import shutil
 import socket
@@ -53,8 +54,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import yaml
-
 try:
     from typing import Dict, List, Tuple, Optional, Union
 except ImportError:
@@ -63,7 +62,7 @@ import uuid
 
 from distutils.spawn import find_executable
 from functools import wraps
-from glob import iglob
+from glob import glob
 
 
 container_path = None
@@ -77,7 +76,8 @@ class Ceph(object):
 
 
 class Monitoring(object):
-    # define the configs for the monitoring containers
+    """Define the configs for the monitoring containers"""
+
     port_map = {
         "prometheus": 9095  # Avoid default 9090, due to conflict with cockpit UI
     }
@@ -94,38 +94,23 @@ class Monitoring(object):
                     "--web.listen-address=:{}".format(port_map['prometheus'])
                 ]
             },
-            "config": {
-                "prometheus.yml": {
-                    "global": {
-                       "scrape_interval": "5s",
-                        "evaluation_interval": "10s"
-                    },
-                    "rule_files": [],
-                    "scrape_configs": [
-                        {
-                            "job_name": "prometheus",
-                            "static_configs": [
-                                { "targets": [
-                                    'localhost:{}'.format(port_map['prometheus'])
-                                ]}
-                            ]
-                        }
-                    ]
-                }
-            }
+            "config-json": [
+                "prometheus.yml"
+            ]
         }
     }
 
 
 def port_in_use(port_num):
+    # type (int) -> bool
     """Detect whether a port is in use on the local machine - IPv4 and IPv6"""
 
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("127.0.0.1",port_num))
+        s.bind(("127.0.0.1", port_num))
         s.close()
         s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-        s.bind(("::1",port_num))
+        s.bind(("::1", port_num))
         s.close()
     except OSError:
         s.close()
@@ -244,6 +229,19 @@ def call_throws(command, **kwargs):
 
 ##################################
 
+def read_config(fn):
+    # type: (Optional[str]) -> ConfigParser
+    # bend over backwards here because py2's ConfigParser doesn't like
+    # whitespace before config option names (e.g., '\n foo = bar\n').
+    # Yeesh!
+    cp = ConfigParser()
+    if fn:
+        with open(fn, 'r') as f:
+            raw_conf = f.read()
+        nice_conf = re.sub('\n(\s)+', '\n', raw_conf)
+        cp.readfp(StringIO(nice_conf))
+    return cp
+
 def pathify(p):
     # type: (str) -> str
     if not p.startswith('/'):
@@ -309,6 +307,15 @@ def infer_fsid(func):
         return func()
     return _infer_fsid
 
+def write_tmp(s, uid, gid):
+    tmp_f = tempfile.NamedTemporaryFile(mode='w',
+                                        prefix='ceph-tmp')
+    os.fchown(tmp_f.fileno(), uid, gid)
+    tmp_f.write(s)
+    tmp_f.flush()
+
+    return tmp_f
+
 def makedirs(dir, uid, gid, mode):
     # type: (str, int, int, int) -> None
     if not os.path.exists(dir):
@@ -352,46 +359,49 @@ def make_log_dir(fsid, uid=None, gid=None):
     makedirs(log_dir, uid, gid, LOG_DIR_MODE)
     return log_dir
 
-def copy_file(src, dst, uid=None, gid=None):
-    # type: (str, str, int, int) -> str
+def copy_files(src, dst, uid=None, gid=None):
+    # type: (List[str], str, int, int) -> None
     """
-    Copy a file from src to dst
-    """
-    if not uid or not gid:
-        (uid, gid) = extract_uid_gid()
-
-    if os.path.isdir(dst):
-        dst = os.path.join(dst, os.path.basename(src))
-
-    logger.debug('Copy \'%s\' -> \'%s\'' % (src, dst))
-    shutil.copyfile(src, dst)
-    os.chown(dst, uid, gid)
-
-    return dst
-
-def move_file(src, dst, uid=None, gid=None):
-    # type: (str, str, int, int) -> str
-    """
-    Move a file from src to dst
+    Copy a files from src to dst
     """
     if not uid or not gid:
         (uid, gid) = extract_uid_gid()
 
-    if os.path.isdir(dst):
-        dst = os.path.join(dst, os.path.basename(src))
+    for src_file in src:
+        dst_file = dst
+        if os.path.isdir(dst):
+            dst_file = os.path.join(dst, os.path.basename(src_file))
 
-    if os.path.islink(src):
-        # shutil.move() in python2 does not handle symlinks correctly
-        src_rl = os.readlink(src)
-        logger.debug('symlink \'%s\' -> \'%s\'' % (dst, src_rl))
-        os.symlink(src_rl, dst)
-        os.unlink(src)
-    else:
-        logger.debug('Move \'%s\' -> \'%s\'' % (src, dst))
-        shutil.move(src, dst)
-    os.chown(dst, uid, gid)
+        logger.debug('copy file \'%s\' -> \'%s\'' % (src_file, dst_file))
+        shutil.copyfile(src_file, dst_file)
 
-    return dst
+        logger.debug('chown %s:%s \'%s\'' % (uid, gid, dst_file))
+        os.chown(dst_file, uid, gid)
+
+def move_files(src, dst, uid=None, gid=None):
+    # type: (List[str], str, int, int) -> None
+    """
+    Move files from src to dst
+    """
+    if not uid or not gid:
+        (uid, gid) = extract_uid_gid()
+
+    for src_file in src:
+        dst_file = dst
+        if os.path.isdir(dst):
+            dst_file = os.path.join(dst, os.path.basename(src_file))
+
+        if os.path.islink(src_file):
+            # shutil.move() in py2 does not handle symlinks correctly
+            src_rl = os.readlink(src_file)
+            logger.debug("symlink '%s' -> '%s'" % (dst_file, src_rl))
+            os.symlink(src_rl, dst_file)
+            os.unlink(src_file)
+        else:
+            logger.debug("move file '%s' -> '%s'" % (src_file, dst_file))
+            shutil.move(src_file, dst_file)
+            logger.debug('chown %s:%s \'%s\'' % (uid, gid, dst_file))
+            os.chown(dst_file, uid, gid)
 
 def find_program(filename):
     # type: (str) -> str
@@ -447,8 +457,7 @@ def get_legacy_config_fsid(cluster, legacy_dir=None):
     if legacy_dir is not None:
         config_file = os.path.abspath(legacy_dir + config_file)
 
-    config = ConfigParser()
-    config.read(config_file)
+    config = read_config(config_file)
 
     if config.has_section('global') and config.has_option('global', 'fsid'):
         return config.get('global', 'fsid')
@@ -475,7 +484,7 @@ def get_legacy_daemon_fsid(cluster, daemon_type, daemon_id, legacy_dir=None):
 
 def get_daemon_args(fsid, daemon_type, daemon_id):
     # type: (str, str, Union[int, str]) -> List[str]
-    r = []
+    r = list()  # type: List[str]
 
     if daemon_type in Ceph.daemons:
         r += [
@@ -486,15 +495,16 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
         ]
 
     elif daemon_type in Monitoring.components:
-        metadata = Monitoring.components[daemon_type]['image']
-        r += metadata['args']
+        component = Monitoring.components[daemon_type]  # type: ignore
+        metadata = component.get('image', list())  # type: ignore
+        r += metadata.get('args', list())  # type: ignore
     return r
 
 def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
                        config=None, keyring=None):
     # type: (str, str, Union[int, str], int, int, str, str) ->  None
     data_dir = make_data_dir(fsid, daemon_type, daemon_id, uid=uid, gid=gid)
-    make_log_dir(fsid)
+    make_log_dir(fsid, uid=uid, gid=gid)
 
     if config:
         with open(data_dir + '/config', 'w') as f:
@@ -507,61 +517,45 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
             os.fchown(f.fileno(), uid, gid)
             f.write(keyring)
 
-    if daemon_type == 'prometheus':
-        
-        # Set up directories
-        data_dir_root = get_data_dir(fsid, daemon_type, daemon_id)
-        makedirs(os.path.join(data_dir_root,'etc/prometheus'), uid, gid, 0o755)
-        makedirs(os.path.join(data_dir_root,'data'), uid, gid, 0o755)
+    if daemon_type in Monitoring.components.keys():
 
-        config = get_parm(args.config_json)
-        if not config:
-            raise Error("Prometheus deployment requires config-json to be set")
+        received_config = get_parm(args.config_json)
+        required_config = Monitoring.components[daemon_type].get('config-json', list())
+        if required_config:
+            if not received_config or not all(c in received_config.keys() for c in required_config):
+                raise Error("{} deployment requires config-json which must "
+                            "contain settings for {}".format(daemon_type.capitalize(), ', '.join(required_config)))
 
-        prometheus_yml = dict()
+        # Set up directories specific to the monitoring component
+        config_dir = ''
+        if daemon_type == 'prometheus':
+            data_dir_root = get_data_dir(fsid, daemon_type, daemon_id)
+            config_dir = 'etc/prometheus'
+            makedirs(os.path.join(data_dir_root, config_dir), uid, gid, 0o755)
+            makedirs(os.path.join(data_dir_root, config_dir, 'alerting'), uid, gid, 0o755)
+            makedirs(os.path.join(data_dir_root, 'data'), uid, gid, 0o755)
 
-        if "prometheus.yml" in config:
-            # trust the provided version is appropriate
-            prometheus_yml = config.get('prometheus.yml')
-            logger.debug("Using supplied prometheus.yml definition")
-        else:
-            if "mgrs" in config:
-                prometheus_yml = Monitoring.components['prometheus']['config']['prometheus.yml']
-                if isinstance(config['mgrs'], list):
-                    targets=[]
-                    for mgr in config['mgrs']:
-                        targets.append('{}:9283'.format(mgr))
-                    prometheus_yml['scrape_configs'].append({
-                            "job_name": "ceph",
-                            "static_configs": [
-                                { "targets": targets,
-                                  "labels": {
-                                    "instance": "ceph_cluster"
-                                    }
-                                }
-                            ],
-                        })
-                    logger.debug("Using default prometheus settings with supplied list of ceph mgrs")
-                else:
-                    raise Error("config-json supplied with invalid mgrs setting - must be a list")
+        # populate the config directory for the component from the config-json
+        for fname in required_config:
+            if isinstance(received_config[fname], list):
+                content = '\n'.join(received_config[fname])
             else:
-                raise Error("config-json must either specify a valid prometheus.yml, or a mgrs list")
+                content = received_config[fname]
 
-        # create configs
-        with open(os.path.join(data_dir_root,'etc/prometheus/prometheus.yml'), 'w') as f:
-            os.fchown(f.fileno(), uid, gid)
-            os.fchmod(f.fileno(), 0o600)
-            f.write(yaml.safe_dump(prometheus_yml, explicit_start=True, indent=2))
+            with open(os.path.join(data_dir_root, config_dir, fname), 'w') as f:
+                os.fchown(f.fileno(), uid, gid)
+                os.fchmod(f.fileno(), 0o600)
+                f.write(content)
 
 def get_parm(option):
-    """Read requested arg, and return as a dict"""
+    # type: (str) -> Dict[str, str]
 
     if not option:
-        return None
+        return dict()
 
     if option == '-':
         try:
-            j = injected_stdin
+            j = injected_stdin  # type: ignore
         except NameError:
             j = sys.stdin.read()
     else:
@@ -574,7 +568,7 @@ def get_parm(option):
                 j = f.read()
         else:
             raise Error("Config file {} not found".format(option))
-    
+
     try:
         js = json.loads(j)
     except ValueError:
@@ -639,10 +633,11 @@ def get_config_and_both_keyrings():
 
 def get_container_mounts(fsid, daemon_type, daemon_id):
     # type: (str, str, Union[int, str, None]) -> Dict[str, str]
-    mounts = {}
+    mounts = dict()
+
     if daemon_type in Ceph.daemons:
         if fsid:
-            run_path = os.path.join('/var/run/ceph', fsid)
+            run_path = os.path.join('/var/run/ceph', fsid);
             if os.path.exists(run_path):
                 mounts[run_path] = '/var/run/ceph:z'
             log_dir = get_log_dir(fsid)
@@ -670,7 +665,8 @@ def get_container_mounts(fsid, daemon_type, daemon_id):
         mounts['/sys'] = '/sys'  # for numa.cc, pick_address, cgroups, ...
         mounts['/run/lvm'] = '/run/lvm'
         mounts['/run/lock/lvm'] = '/run/lock/lvm'
-    if daemon_type in Monitoring.components:
+
+    if daemon_type in Monitoring.components and daemon_id:
         data_dir = get_data_dir(fsid, daemon_type, daemon_id)
         if daemon_type == 'prometheus':
             mounts[os.path.join(data_dir, 'etc/prometheus')] = '/etc/prometheus:Z'
@@ -684,7 +680,6 @@ def get_container(fsid, daemon_type, daemon_id, privileged=False,
     if daemon_type in ['mon', 'osd'] or privileged:
         # mon and osd need privileged in order for libudev to query devices
         container_args += ['--privileged']
-
     if daemon_type == 'rgw':
         entrypoint = '/usr/bin/radosgw'
         name = 'client.rgw.%s' % daemon_id
@@ -695,9 +690,9 @@ def get_container(fsid, daemon_type, daemon_id, privileged=False,
         entrypoint = '/usr/bin/ceph-' + daemon_type
         name = '%s.%s' % (daemon_type, daemon_id)
     elif daemon_type in Monitoring.components:
-        entrypoint = None
-        name = daemon_type
-    
+        entrypoint = ''
+        name = ''
+
     ceph_args = ['-n', name, '-f']
 
     if daemon_type in Monitoring.components:
@@ -712,8 +707,8 @@ def get_container(fsid, daemon_type, daemon_id, privileged=False,
         cname='ceph-%s-%s.%s' % (fsid, daemon_type, daemon_id),
     )
 
-def extract_uid_gid(img=None, file_path='/etc/ceph'):
-    # type: () -> Tuple[int, int]
+def extract_uid_gid(img='', file_path='/etc/ceph'):
+    # type: (str, str) -> Tuple[int, int]
 
     if not img:
         img = args.image
@@ -734,18 +729,10 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
         assert config
         assert keyring
         # tmp keyring file
-        tmp_keyring = tempfile.NamedTemporaryFile(mode='w')
-        os.fchmod(tmp_keyring.fileno(), 0o600)
-        os.fchown(tmp_keyring.fileno(), uid, gid)
-        tmp_keyring.write(keyring)
-        tmp_keyring.flush()
+        tmp_keyring = write_tmp(keyring, uid, gid)
 
         # tmp config file
-        tmp_config = tempfile.NamedTemporaryFile(mode='w')
-        os.fchmod(tmp_config.fileno(), 0o600)
-        os.fchown(tmp_config.fileno(), uid, gid)
-        tmp_config.write(config)
-        tmp_config.flush()
+        tmp_config = write_tmp(config, uid, gid)
 
         # --mkfs
         create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid)
@@ -841,21 +828,16 @@ def update_firewalld(daemon_type):
 
     fw_services = []
     fw_ports = []
-
-    # handle services (defined in /usr/lib/firewalld/services)
     if daemon_type == 'mon':
         fw_services.append('ceph-mon')
     elif daemon_type in ['mgr', 'mds', 'osd']:
         fw_services.append('ceph')
-
-    # handle individual ports
     if daemon_type == 'mgr':
         fw_ports.append(8080)  # dashboard
         fw_ports.append(8443)  # dashboard
         fw_ports.append(9283)  # mgr/prometheus exporter
     elif daemon_type == 'prometheus':
-        fw_ports.append(Monitoring.port_map['prometheus'])   # prometheus server
-
+        fw_ports.append(Monitoring.port_map['prometheus'])  # prometheus server
 
     for svc in fw_services:
         out, err, ret = call([cmd, '--permanent', '--query-service', svc])
@@ -985,7 +967,7 @@ def deploy_crash(fsid, uid, gid, config, keyring):
                 '[Service]\n'
                 'Type=simple\n'
                 'ExecStart={cmd}\n'
-                'ExecStop=-{container_path} stop ceph-{fsid}-crash\n'
+                'ExecStop=-{container_path} rm -f ceph-{fsid}-crash\n'
                 'Restart=always\n'
                 'RestartSec=10\n'
                 'StartLimitInterval=10min\n'
@@ -1025,7 +1007,7 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-{container_path} rm ceph-{fsid}-%i
 ExecStartPre=-{install_path} -d -m0770 -o {uid} -g {gid} /var/run/ceph/{fsid}
 ExecStart=/bin/bash {data_dir}/{fsid}/%i/cmd
-ExecStop=-{container_path} stop ceph-{fsid}-%i
+ExecStop=-{container_path} rm -f ceph-{fsid}-%i
 Restart=on-failure
 RestartSec=10s
 TimeoutStartSec=120
@@ -1045,7 +1027,6 @@ WantedBy=ceph-{fsid}.target
     return u
 
 ##################################
-
 
 class CephContainer:
     def __init__(self,
@@ -1068,7 +1049,7 @@ class CephContainer:
         vols = [] # type: List[str]
         envs = [] # type: List[str]
         cname = [] # type: List[str]
-        entrypoint = []
+        entrypoint = [] # type: List[str]
         if self.entrypoint:
             entrypoint = ['--entrypoint', self.entrypoint]
 
@@ -1140,6 +1121,18 @@ def command_version():
 
 ##################################
 
+def command_pull():
+    # type: () -> None
+    logger.info('Pulling latest %s...' % args.image)
+    call_throws([container_path, 'pull', args.image])
+    out, err, ret = call_throws([
+        container_path, 'inspect',
+        '--format', '{{.Id}}',
+        args.image])
+    print(out.strip())
+
+##################################
+
 def command_bootstrap():
     # type: () -> int
 
@@ -1158,9 +1151,7 @@ def command_bootstrap():
     logging.info('Cluster fsid: %s' % fsid)
 
     # config
-    cp = ConfigParser()
-    if args.config:
-        cp.read(args.config)
+    cp = read_config(args.config)
     if args.mon_ip:
         addr_arg = '[v2:%s:3300,v1:%s:6789]' % (args.mon_ip, args.mon_ip)
         mon_ip = args.mon_ip
@@ -1171,7 +1162,7 @@ def command_bootstrap():
         raise Error('must specify --mon-ip or --mon-addrv')
     if not cp.has_section('global'):
         cp.add_section('global')
-    cp.set('global', 'fsid', fsid)
+    cp.set('global', 'fsid', fsid);
     cp.set('global', 'mon host', addr_arg)
     cp.set('global', 'container_image', args.image)
     cpf = StringIO()
@@ -1235,16 +1226,11 @@ def command_bootstrap():
                % (mon_key, admin_key, mgr_id, mgr_key, hostname, crash_key))
 
     # tmp keyring file
-    tmp_bootstrap_keyring = tempfile.NamedTemporaryFile(mode='w')
-    os.fchmod(tmp_bootstrap_keyring.fileno(), 0o600)
-    os.fchown(tmp_bootstrap_keyring.fileno(), uid, gid)
-    tmp_bootstrap_keyring.write(keyring)
-    tmp_bootstrap_keyring.flush()
+    tmp_bootstrap_keyring = write_tmp(keyring, uid, gid)
 
     # create initial monmap, tmp monmap file
     logger.info('Creating initial monmap...')
-    tmp_monmap = tempfile.NamedTemporaryFile(mode='w')
-    os.fchmod(tmp_monmap.fileno(), 0o644)
+    tmp_monmap = write_tmp('', 0, 0)
     out = CephContainer(
         image=args.image,
         entrypoint='/usr/bin/monmaptool',
@@ -1258,6 +1244,9 @@ def command_bootstrap():
             tmp_monmap.name: '/tmp/monmap:z',
         },
     ).run()
+
+    # pass monmap file to ceph user for use by ceph-mon --mkfs below
+    os.fchown(tmp_monmap.fileno(), uid, gid)
 
     # create mon
     logger.info('Creating mon...')
@@ -1292,18 +1281,10 @@ def command_bootstrap():
                   config=None, keyring=None)
 
     # client.admin key + config to issue various CLI commands
-    tmp_admin_keyring = tempfile.NamedTemporaryFile(mode='w')
-    os.fchmod(tmp_admin_keyring.fileno(), 0o600)
-    os.fchown(tmp_admin_keyring.fileno(), uid, gid)
-    tmp_admin_keyring.write('[client.admin]\n'
-                      '\tkey = ' + admin_key + '\n')
-    tmp_admin_keyring.flush()
-
-    tmp_config = tempfile.NamedTemporaryFile(mode='w')
-    os.fchmod(tmp_config.fileno(), 0o600)
-    os.fchown(tmp_config.fileno(), uid, gid)
-    tmp_config.write(config)
-    tmp_config.flush()
+    tmp_admin_keyring = write_tmp('[client.admin]\n'
+                                  '\tkey = ' + admin_key + '\n',
+                                       uid, gid)
+    tmp_config = write_tmp(config, uid, gid)
 
     # a CLI helper to reduce our typing
     def cli(cmd, extra_mounts={}):
@@ -1440,14 +1421,12 @@ def command_bootstrap():
         cli(['mgr', 'module', 'enable', 'dashboard'])
         logger.info('Waiting for the module to be available...')
         # FIXME: potential for an endless loop?
-
         while True:
             c_out = cli(['-h'])
             if 'dashboard' in c_out:
                 break
             logger.info('Dashboard not yet available, waiting...')
             time.sleep(1)
-
         logger.info('Generating a dashboard self-signed certificate...')
         cli(['dashboard', 'create-self-signed-cert'])
         logger.info('Creating initial admin user...')
@@ -1481,15 +1460,13 @@ def command_bootstrap():
 def command_deploy():
     # type: () -> None
     (daemon_type, daemon_id) = args.name.split('.', 1)
-    
-    crash_keyring = None
-    
+
     supported_daemons = Ceph.daemons.copy()
     supported_daemons.extend(Monitoring.components)
 
     if daemon_type not in supported_daemons:
         raise Error('daemon type %s not recognized' % daemon_type)
-    
+
     if daemon_type in Ceph.daemons:
         (config, keyring, crash_keyring) = get_config_and_both_keyrings()
         if daemon_type == 'mon':
@@ -1503,15 +1480,18 @@ def command_deploy():
                                                                 args.mon_network)
             else:
                 raise Error('must specify --mon-ip or --mon-network')
-    
-    if daemon_type in Ceph.daemons:
+        
         (uid, gid) = extract_uid_gid()
         c = get_container(args.fsid, daemon_type, daemon_id)
         deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
                       config, keyring)
+
+        if crash_keyring:
+            deploy_crash(args.fsid, uid, gid, config, crash_keyring)
+
     else:
         # monitoring daemon - prometheus, grafana, alertmanager
-        monitoring_args = []
+        monitoring_args = []  # type: List[str]
 
         # Default Checks
         daemon_port = Monitoring.port_map[daemon_type]
@@ -1525,24 +1505,22 @@ def command_deploy():
                 raise Error("config-json parameter is needed when deploying prometheus service")
 
             uid, gid = extract_uid_gid(file_path='/etc/prometheus')
-            metadata = Monitoring.components['prometheus']['image']
+            # Monitoring metadata is nested dicts, so asking mypy to ignore
+            p = Monitoring.components['prometheus']  # type: ignore
+            metadata = p.get('image', dict())  # type: ignore
             monitoring_args = [
                 '--user', 
                 str(uid),
                 '--cpus',
-                metadata.get('cpus', '2'),
+                metadata.get('cpus', '2'),  # type: ignore
                 '--memory',
-                metadata.get('memory', '4GB')
+                metadata.get('memory', '4GB')  # type: ignore
             ]
         else:
             raise Error("{} not implemented in command_deploy function".format(daemon_type))
 
         c = get_container(args.fsid, daemon_type, daemon_id, container_args=monitoring_args)
         deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid)
-
-
-    if crash_keyring:
-        deploy_crash(args.fsid, uid, gid, config, crash_keyring)
 
 ##################################
 
@@ -1627,6 +1605,7 @@ def command_ceph_volume():
     if args.fsid:
         make_log_dir(args.fsid)
 
+    (uid, gid) = (0, 0) # ceph-volume runs as root
     mounts = get_container_mounts(args.fsid, 'osd', None)
 
     tmp_config = None
@@ -1638,16 +1617,10 @@ def command_ceph_volume():
         (config, keyring) = get_config_and_keyring()
 
         # tmp keyring file
-        tmp_keyring = tempfile.NamedTemporaryFile(mode='w')
-        os.fchmod(tmp_keyring.fileno(), 0o600)
-        tmp_keyring.write(keyring)
-        tmp_keyring.flush()
+        tmp_keyring = write_tmp(keyring, uid, gid)
 
         # tmp config file
-        tmp_config = tempfile.NamedTemporaryFile(mode='w')
-        os.fchmod(tmp_config.fileno(), 0o600)
-        tmp_config.write(config)
-        tmp_config.flush()
+        tmp_config = write_tmp(config, uid, gid)
 
         mounts[tmp_config.name] = '/etc/ceph/ceph.conf:z'
         mounts[tmp_keyring.name] = '/var/lib/ceph/bootstrap-osd/ceph.keyring:z'
@@ -1825,9 +1798,11 @@ def command_adopt():
         data_dir_src = ('/var/lib/ceph/%s/%s-%s' %
                         (daemon_type, args.cluster, daemon_id))
         data_dir_src = os.path.abspath(args.legacy_dir + data_dir_src)
-        data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id)
-        for data_file in iglob(os.path.join(data_dir_src, '*')):
-            move_file(data_file, data_dir_dst, uid=uid, gid=gid)
+        data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id,
+                                     uid=uid, gid=gid)
+        move_files(glob(os.path.join(data_dir_src, '*')),
+                   data_dir_dst,
+                   uid=uid, gid=gid)
         logger.debug('Remove dir \'%s\'' % (data_dir_src))
         if os.path.ismount(data_dir_src):
             call_throws(['umount', data_dir_src])
@@ -1837,7 +1812,7 @@ def command_adopt():
         config_src = '/etc/ceph/%s.conf' % (args.cluster)
         config_src = os.path.abspath(args.legacy_dir + config_src)
         config_dst = os.path.join(data_dir_dst, 'config')
-        copy_file(config_src, config_dst, uid=uid, gid=gid)
+        copy_files([config_src], config_dst, uid=uid, gid=gid)
 
         # logs
         logger.info('Moving logs...')
@@ -1845,8 +1820,9 @@ def command_adopt():
                         (args.cluster, daemon_type, daemon_id))
         log_dir_src = os.path.abspath(args.legacy_dir + log_dir_src)
         log_dir_dst = make_log_dir(fsid, uid=uid, gid=gid)
-        for log_file in iglob(log_dir_src):
-            move_file(log_file, log_dir_dst, uid=uid, gid=gid)
+        move_files(glob(log_dir_src),
+                   log_dir_dst,
+                   uid=uid, gid=gid)
 
         logger.info('Creating new units...')
         c = get_container(fsid, daemon_type, daemon_id)
@@ -1863,7 +1839,6 @@ def command_adopt():
 def command_rm_daemon():
     # type: () -> None
     (daemon_type, daemon_id) = args.name.split('.', 1)
-
     if daemon_type in ['mon', 'osd'] and not args.force:
         raise Error('must pass --force to proceed: '
                       'this command may destroy precious data!')
@@ -1876,7 +1851,6 @@ def command_rm_daemon():
          verbose_on_failure=False)
     data_dir = get_data_dir(args.fsid, daemon_type, daemon_id)
     call_throws(['rm', '-rf', data_dir])
-    # TODO - remove the unit file
 
 ##################################
 
@@ -1934,29 +1908,7 @@ def command_rm_cluster():
     call_throws(['rm', '-f', args.logrotate_dir + '/ceph-%s' % args.fsid])
 
 
-class CustomValidation(argparse.Action):
-
-    def _check_name(self, values):
-
-        try:
-            (daemon_type, daemon_id) = values.split('.', 1)
-        except ValueError:
-            raise argparse.ArgumentError(self,
-                                         "must be of the format <type>.<id>. For example, osd.1 or prometheus.myhost.com")
-        
-        daemons = Ceph.daemons.copy()
-        daemons.extend(Monitoring.components.keys())
-        
-        if daemon_type not in daemons:
-            raise argparse.ArgumentError(self, 
-                                         "name must declare the type of daemon e.g. "
-                                         "{}".format(', '.join(daemons)))
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        if self.dest == "name":
-            self._check_name(values)
-            setattr(namespace, self.dest, values)
-
+##################################
 
 def check_time_sync():
     units = ['chronyd.service', 'systemd-timesyncd.service', 'ntpd.service']
@@ -1987,6 +1939,32 @@ def command_check_host():
 
     logger.info('Host looks OK')
 
+
+##################################
+
+
+class CustomValidation(argparse.Action):
+
+    def _check_name(self, values):
+
+        try:
+            (daemon_type, daemon_id) = values.split('.', 1)
+        except ValueError:
+            raise argparse.ArgumentError(self,
+                                         "must be of the format <type>.<id>. For example, osd.1 or prometheus.myhost.com")
+        
+        daemons = Ceph.daemons.copy()
+        daemons.extend(Monitoring.components.keys())
+        
+        if daemon_type not in daemons:
+            raise argparse.ArgumentError(self, 
+                                         "name must declare the type of daemon e.g. "
+                                         "{}".format(', '.join(daemons)))
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if self.dest == "name":
+            self._check_name(values)
+            setattr(namespace, self.dest, values)
 
 ##################################
 
@@ -2029,6 +2007,10 @@ def _get_parser():
     parser_version = subparsers.add_parser(
         'version', help='get ceph version from container')
     parser_version.set_defaults(func=command_version)
+
+    parser_pull = subparsers.add_parser(
+        'pull', help='pull latest image version')
+    parser_pull.set_defaults(func=command_pull)
 
     parser_ls = subparsers.add_parser(
         'ls', help='list daemon instances on this host')
@@ -2257,12 +2239,12 @@ def _get_parser():
         help='allow overwrite of existing --output-* config/keyring/ssh files')
 
     parser_deploy = subparsers.add_parser(
-    'deploy', help='deploy a daemon')
+        'deploy', help='deploy a daemon')
     parser_deploy.set_defaults(func=command_deploy)
     parser_deploy.add_argument(
         '--name',
-        action=CustomValidation,
         required=True,
+        action=CustomValidation,
         help='daemon name (type.id)')
     parser_deploy.add_argument(
         '--fsid',
@@ -2302,6 +2284,10 @@ def _get_parser():
         '--skip-firewalld',
         action='store_true',
         help='Do not configure firewalld')
+
+    parser_check_host = subparsers.add_parser(
+        'check-host', help='check host configuration')
+    parser_check_host.set_defaults(func=command_check_host)
 
     return parser
 

--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -118,16 +118,20 @@ class Monitoring(object):
 
 
 def port_in_use(port_num):
-    """Detect whether a port is in use on the local machine"""
+    """Detect whether a port is in use on the local machine - IPv4 and IPv6"""
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
-        s.connect(("127.0.0.1",port_num))
-    except ConnectionRefusedError:
-        return False
-    else:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1",port_num))
+        s.close()
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        s.bind(("::1",port_num))
+        s.close()
+    except OSError:
         s.close()
         return True
+    else:
+        return False
 
 ##################################
 # Popen wrappers, lifted from ceph-volume


### PR DESCRIPTION
Updates to allow the "ceph-deamon deploy" command to create a Prometheus server container on the local machine. Deploy requires a mgr-list parameter to be passed which is used to configure the initial scrape configuration of Ceph related metrics, from the mgr/prometheus exporter.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>
