### PR TITLE
mon/PGMap: use NONE for 'pg ls[-*]' output too

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2279,8 +2279,8 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
     reported << st.reported_epoch << ":" << st.reported_seq;
 
     ostringstream upstr, actingstr;
-    upstr << st.up << 'p' << st.up_primary;
-    actingstr << st.acting << 'p' << st.acting_primary;
+    upstr << pg_vector_string(st.up) << 'p' << st.up_primary;
+    actingstr << pg_vector_string(st.acting) << 'p' << st.acting_primary;
     tab << *i
         << st.stats.sum.num_objects
         << st.stats.sum.num_objects_degraded


### PR DESCRIPTION
We already show CRUSH_ITEM_NONE as NONE in the 'pg dump' output as of
57bac8ea88e5cdcb3854852d439f7e6cbf9df900; do the same for 'pg ls' (which
is the friendlier of the two and what users should be using anyway!).

Signed-off-by: Sage Weil <sage@redhat.com>