### PR TITLE
nautilus: rgw: fix rgw crash when token is not base64 encode

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4922,7 +4922,13 @@ int
 rgw::auth::s3::STSEngine::get_session_token(const boost::string_view& session_token,
                                             STS::SessionToken& token) const
 {
-  string decodedSessionToken = rgw::from_base64(session_token);
+  string decodedSessionToken;
+  try {
+    decodedSessionToken = rgw::from_base64(session_token);
+  } catch (...) {
+    ldout(cct, 0) << "ERROR: Invalid session token, not base64 encoded." << dendl;
+    return -EINVAL;
+  }
 
   auto* cryptohandler = cct->get_crypto_handler(CEPH_CRYPTO_AES);
   if (! cryptohandler) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43158
possibly a backport of https://github.com/ceph/ceph/pull/31830
parent tracker: https://tracker.ceph.com/issues/43018

---

original PR body:

https://tracker.ceph.com/issues/43018

---

updated using ceph-backport.sh version 15.0.0.6950
