### PR TITLE
mgr: simply exit on SIGINT or SIGTERM

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -225,15 +225,14 @@ void Mgr::handle_signal(int signum)
   shutdown();
 }
 
-// A reference for use by the signal handler
-static Mgr *signal_mgr = nullptr;
-
 static void handle_mgr_signal(int signum)
 {
   derr << " *** Got signal " << sig_str(signum) << " ***" << dendl;
-  if (signal_mgr) {
-    signal_mgr->handle_signal(signum);
-  }
+
+  // The python modules don't reliably shut down, so don't even
+  // try. The mon will blacklist us (and all of our rados/cephfs
+  // clients) anyway. Just exit!
+
   _exit(0);  // exit with 0 result code, as if we had done an orderly shutdown
 }
 
@@ -244,7 +243,6 @@ void Mgr::init()
   ceph_assert(!initialized);
 
   // Enable signal handlers
-  signal_mgr = this;
   register_async_signal_handler_oneshot(SIGINT, handle_mgr_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_mgr_signal);
 


### PR DESCRIPTION
The python modules don't reliable shut down.  We've fixed a few shutdown
bugs chasing https://tracker.ceph.com/issues/42744.

This was compounded by https://tracker.ceph.com/issues/42981, which seems
to suggest something in the python module teardown is screwing with the
signal handlers.

Now that df507cde8d71063d5873a42f668156e4c32e86f9 is there, the mgr will
blacklist all rados clients the mgr instantiates, which means we can just
exit immediately and let the blacklisting clean things up.

Works-around: https://tracker.ceph.com/issues/42981
Fixes: https://tracker.ceph.com/issues/42744
Signed-off-by: Sage Weil <sage@redhat.com>