### PR TITLE
ceph-daemon: clean-up tempfiles on EXIT

### DIFF
--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -22,16 +22,12 @@ OSD_LV_NAME=${SCRIPT_NAME%.*}
 [ -z "$SUDO" ] && SUDO=sudo
 
 if [ -z "$CEPH_DAEMON" ]; then
-    [ -x src/ceph-daemon/ceph-daemon ] && CEPH_DAEMON=src/ceph-daemon/ceph-daemon
-    [ -x ../src/ceph-daemon/ceph-daemon ] && CEPH_DAEMON=../src/ceph-daemon/ceph-daemon
-    [ -x ./ceph-daemon/ceph-daemon ] && CEPH_DAEMON=./ceph-daemon/ceph-daemon
-    [ -x ./ceph-daemon ] && CEPH_DAEMON=.ceph-daemon
-    which ceph-daemon && CEPH_DAEMON=$(which ceph-daemon)
+    CEPH_DAEMON=${SCRIPT_DIR}/../../src/ceph-daemon/ceph-daemon
 fi
 
 # at this point, we need $CEPH_DAEMON set
-if [ -z "$CEPH_DAEMON" ]; then
-    echo "ceph-daemon not found.Please set \$CEPH_DAEMON"
+if ! [ -x "$CEPH_DAEMON" ]; then
+    echo "ceph-daemon not found. Please set \$CEPH_DAEMON"
     exit 1
 fi
 

--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -39,7 +39,7 @@ fi
 PYTHONS="python3 python2"  # which pythons we test
 if [ -z "$PYTHON_KLUDGE" ]; then
    TMPBINDIR=`mktemp -d $TMPDIR`
-   trap "rm -rf $TMPBINDIR" TERM HUP INT
+   trap "rm -rf $TMPBINDIR" EXIT
    ORIG_CEPH_DAEMON="$CEPH_DAEMON"
    CEPH_DAEMON="$TMPBINDIR/ceph-daemon"
    for p in $PYTHONS; do
@@ -67,7 +67,7 @@ if ! [ "$loopdev" = "" ]; then
 fi
 
 TMPDIR=`mktemp -d -p .`
-trap "rm -rf $TMPDIR" TERM HUP INT
+trap "rm -rf $TMPDIR" EXIT
 
 function expect_false()
 {


### PR DESCRIPTION
The standalone `ceph-daemon` tests are not removing tempfiles after a test failure.

Likewise, a stray `ceph-daemon` script in the CWD also causes a test failure due to logic guessing at the script location. 

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
