### PR TITLE
nautilus: tests/krbd: update krbd_blkroset.t and add krbd_get_features.t

### DIFF
--- a/qa/rbd/krbd_get_features.t
+++ b/qa/rbd/krbd_get_features.t
@@ -1,0 +1,31 @@
+
+journaling makes the image only unwritable, rather than both unreadable
+and unwritable:
+
+  $ rbd create --size 1 --image-feature layering,exclusive-lock,journaling img
+  $ rbd snap create img@snap
+  $ rbd snap protect img@snap
+  $ rbd clone --image-feature layering,exclusive-lock,journaling img@snap cloneimg
+
+  $ DEV=$(sudo rbd map img)
+  rbd: sysfs write failed
+  rbd: map failed: (6) No such device or address
+  [6]
+  $ DEV=$(sudo rbd map --read-only img)
+  $ blockdev --getro $DEV
+  1
+  $ sudo rbd unmap $DEV
+
+  $ DEV=$(sudo rbd map cloneimg)
+  rbd: sysfs write failed
+  rbd: map failed: (6) No such device or address
+  [6]
+  $ DEV=$(sudo rbd map --read-only cloneimg)
+  $ blockdev --getro $DEV
+  1
+  $ sudo rbd unmap $DEV
+
+  $ rbd rm --no-progress cloneimg
+  $ rbd snap unprotect img@snap
+  $ rbd snap rm --no-progress img@snap
+  $ rbd rm --no-progress img

--- a/qa/suites/krbd/basic/tasks/krbd_read_only.yaml
+++ b/qa/suites/krbd/basic/tasks/krbd_read_only.yaml
@@ -3,3 +3,4 @@ tasks:
     clients:
       client.0:
       - qa/rbd/krbd_blkroset.t
+      - qa/rbd/krbd_get_features.t


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42991

---

backport of https://github.com/ceph/ceph/pull/31771
parent tracker: https://tracker.ceph.com/issues/42915

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh