### PR TITLE
nautilus: rbd: journal: fix flush by age and in-flight byte tracking

### DIFF
--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -426,7 +426,7 @@ JournalRecorder::Lockers JournalRecorder::lock_object_recorders() {
   Lockers lockers;
   lockers.reserve(m_object_ptrs.size());
   for (auto& lock : m_object_locks) {
-    lockers.emplace_back(lock);
+    lockers.emplace_back({lock});
   }
   return lockers;
 }

--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -256,6 +256,7 @@ void JournalRecorder::open_object_set() {
   ldout(m_cct, 10) << "opening object set " << m_current_set << dendl;
 
   uint8_t splay_width = m_journal_metadata->get_splay_width();
+  bool overflowed = false;
 
   auto lockers{lock_object_recorders()};
   for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
@@ -266,8 +267,17 @@ void JournalRecorder::open_object_set() {
       ceph_assert(object_recorder->is_closed());
 
       // ready to close object and open object in active set
-      create_next_object_recorder(object_recorder);
+      if (create_next_object_recorder(object_recorder)) {
+        overflowed = true;
+      }
     }
+  }
+  lockers.clear();
+
+  if (overflowed) {
+    ldout(m_cct, 10) << "object set " << m_current_set << " now full" << dendl;
+    ldout(m_cct, 10) << "" << dendl;
+    close_and_advance_object_set(m_current_set);
   }
 }
 
@@ -288,6 +298,8 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
       // flush out all queued appends and hold future appends
       if (!object_recorder->close()) {
         ++m_in_flight_object_closes;
+        ldout(m_cct, 10) << "object " << object_recorder->get_oid() << " "
+                         << "close in-progress" << dendl;
       } else {
         ldout(m_cct, 10) << "object " << object_recorder->get_oid() << " closed"
                          << dendl;
@@ -310,7 +322,7 @@ ObjectRecorderPtr JournalRecorder::create_object_recorder(
   return object_recorder;
 }
 
-void JournalRecorder::create_next_object_recorder(
+bool JournalRecorder::create_next_object_recorder(
     ObjectRecorderPtr object_recorder) {
   ceph_assert(m_lock.is_locked());
 
@@ -336,8 +348,14 @@ void JournalRecorder::create_next_object_recorder(
       new_object_recorder->get_object_number());
   }
 
-  new_object_recorder->append(std::move(append_buffers));
+  bool object_full = new_object_recorder->append(std::move(append_buffers));
+  if (object_full) {
+    ldout(m_cct, 10) << "object " << new_object_recorder->get_oid() << " "
+                     << "now full" << dendl;
+  }
+
   m_object_ptrs[splay_offset] = new_object_recorder;
+  return object_full;
 }
 
 void JournalRecorder::handle_update() {

--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -257,7 +257,7 @@ void JournalRecorder::open_object_set() {
 
   uint8_t splay_width = m_journal_metadata->get_splay_width();
 
-  lock_object_recorders();
+  auto lockers{lock_object_recorders()};
   for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
        it != m_object_ptrs.end(); ++it) {
     ObjectRecorderPtr object_recorder = it->second;
@@ -269,7 +269,6 @@ void JournalRecorder::open_object_set() {
       create_next_object_recorder(object_recorder);
     }
   }
-  unlock_object_recorders();
 }
 
 bool JournalRecorder::close_object_set(uint64_t active_set) {
@@ -279,7 +278,7 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
   // object recorders will invoke overflow handler as they complete
   // closing the object to ensure correct order of future appends
   uint8_t splay_width = m_journal_metadata->get_splay_width();
-  lock_object_recorders();
+  auto lockers{lock_object_recorders()};
   for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
        it != m_object_ptrs.end(); ++it) {
     ObjectRecorderPtr object_recorder = it->second;
@@ -295,7 +294,6 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
       }
     }
   }
-  unlock_object_recorders();
   return (m_in_flight_object_closes == 0);
 }
 
@@ -404,6 +402,15 @@ void JournalRecorder::handle_overflow(ObjectRecorder *object_recorder) {
   ldout(m_cct, 10) << "object " << active_object_recorder->get_oid()
                    << " overflowed" << dendl;
   close_and_advance_object_set(object_number / splay_width);
+}
+
+JournalRecorder::Lockers JournalRecorder::lock_object_recorders() {
+  Lockers lockers;
+  lockers.reserve(m_object_ptrs.size());
+  for (auto& lock : m_object_locks) {
+    lockers.emplace_back(lock);
+  }
+  return lockers;
 }
 
 } // namespace journal

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -38,7 +38,7 @@ public:
 
 private:
   typedef std::map<uint8_t, ObjectRecorderPtr> ObjectRecorderPtrs;
-  typedef std::vector<std::unique_lock<ceph::mutex>> Lockers;
+  typedef std::vector<Mutex::Locker> Lockers;
 
   struct Listener : public JournalMetadataListener {
     JournalRecorder *journal_recorder;

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -113,7 +113,7 @@ private:
 
   ObjectRecorderPtr create_object_recorder(uint64_t object_number,
                                            std::shared_ptr<Mutex> lock);
-  void create_next_object_recorder(ObjectRecorderPtr object_recorder);
+  bool create_next_object_recorder(ObjectRecorderPtr object_recorder);
 
   void handle_update();
 

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -38,6 +38,7 @@ public:
 
 private:
   typedef std::map<uint8_t, ObjectRecorderPtr> ObjectRecorderPtrs;
+  typedef std::vector<std::unique_lock<ceph::mutex>> Lockers;
 
   struct Listener : public JournalMetadataListener {
     JournalRecorder *journal_recorder;
@@ -119,17 +120,7 @@ private:
   void handle_closed(ObjectRecorder *object_recorder);
   void handle_overflow(ObjectRecorder *object_recorder);
 
-  void lock_object_recorders() {
-    for (auto& lock : m_object_locks) {
-      lock->Lock();
-    }
-  }
-
-  void unlock_object_recorders() {
-    for (auto& lock : m_object_locks) {
-      lock->Unlock();
-    }
-  }
+  Lockers lock_object_recorders();
 };
 
 } // namespace journal


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42953

---

backport of https://github.com/ceph/ceph/pull/31392
parent tracker: https://tracker.ceph.com/issues/42598

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh