### PR TITLE
nautilus: cephfs: client: add warning when cap != in->auth_cap.

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4025,7 +4025,9 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
      * don't remove caps.
      */
     if (ceph_seq_cmp(seq, cap.seq) <= 0) {
-      ceph_assert(&cap == in->auth_cap);
+      if (&cap != in->auth_cap)
+         ldout(cct, 0) << "WARNING: " <<  "inode " << *in << " caps on mds." << mds << " != auth_cap." << dendl;
+
       ceph_assert(cap.cap_id == cap_id);
       seq = cap.seq;
       mseq = cap.mseq;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42631

---

backport of https://github.com/ceph/ceph/pull/30402
parent tracker: https://tracker.ceph.com/issues/41799

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh