### PR TITLE
nautilus: mgr/pg_autoscaler: only generate target_* health warnings if targets set

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -418,7 +418,7 @@ class PgAutoscaler(MgrModule):
         too_much_target_ratio = []
         for root_id, total in iteritems(total_ratio):
             total_target = total_target_ratio[root_id]
-            if total > 1.0:
+            if total_target > 0 and total > 1.0:
                 too_much_target_ratio.append(
                     'Pools %s overcommit available storage by %.03fx due to '
                     'target_size_ratio %.03f on pools %s' % (
@@ -445,7 +445,7 @@ class PgAutoscaler(MgrModule):
         too_much_target_bytes = []
         for root_id, total in iteritems(total_bytes):
             total_target = total_target_bytes[root_id]
-            if total > root_map[root_id].capacity:
+            if total_target > 0 and total > root_map[root_id].capacity:
                 too_much_target_bytes.append(
                     'Pools %s overcommit available storage by %.03fx due to '
                     'target_size_bytes %s on pools %s' % (


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42899

---

backport of https://github.com/ceph/ceph/pull/31638
parent tracker: https://tracker.ceph.com/issues/42301

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh