### PR TITLE
nautilus: mgr/pg_autoscaler: implement shutdown method

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -164,6 +164,10 @@ class PgAutoscaler(MgrModule):
             self._maybe_adjust()
             self._shutdown.wait(timeout=int(self.sleep_interval))
 
+    def shutdown(self):
+        self.log.info('Stopping pg_autoscaler')
+        self._shutdown.set()
+
     def get_subtree_resource_status(self, osdmap, crush):
         """
         For each CRUSH subtree of interest (i.e. the roots under which


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42695

---

backport of https://github.com/ceph/ceph/pull/31398
parent tracker: https://tracker.ceph.com/issues/42640

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh