### PR TITLE
DNM: nautilus: mgr/pg_autoscaler: default to pg_num[_min] = 16

### DIFF
--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -207,7 +207,7 @@ Ceph configuration file.
               value is the same as ``pg_num`` with ``mkpool``.
 
 :Type: 32-bit Integer
-:Default: ``8``
+:Default: ``16``
 
 
 ``osd pool default pgp num``

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2565,7 +2565,7 @@ std::vector<Option> get_global_options() {
     .add_service("mon"),
 
     Option("osd_pool_default_pg_num", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(8)
+    .set_default(16)
     .set_description("number of PGs for new pools")
     .set_flag(Option::FLAG_RUNTIME)
     .add_service("mon"),

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -25,7 +25,7 @@ Some terminology is made up for the purposes of this module:
 
 INTERVAL = 5
 
-PG_NUM_MIN = 4  # unless specified on a per-pool basis
+PG_NUM_MIN = 16  # unless specified on a per-pool basis
 
 def nearest_power_of_two(n):
     v = int(n)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42999

---

backport of https://github.com/ceph/ceph/pull/31636
parent tracker: https://tracker.ceph.com/issues/42509

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh