### PR TITLE
nautilus: monitoring: wait before firing osd full alert

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -59,8 +59,8 @@ groups:
           type: ceph_default
         annotations:
           description: >
-              OSD {{ $labels.ceph_daemon }} was marked down and back up at least once a
-              minute for 5 minutes.
+            OSD {{ $labels.ceph_daemon }} was marked down and back up at least once a
+            minute for 5 minutes.
       # alert on high deviation from average PG count
       - alert: high pg count deviation
         expr: abs(((ceph_osd_numpg > 0) - on (job) group_left avg(ceph_osd_numpg > 0) by (job)) / on (job) group_left avg(ceph_osd_numpg > 0) by (job)) > 0.35
@@ -70,8 +70,8 @@ groups:
           type: ceph_default
         annotations:
           description: >
-              OSD {{ $labels.ceph_daemon }} deviates by more than 30% from
-              average PG count.
+            OSD {{ $labels.ceph_daemon }} deviates by more than 30% from
+            average PG count.
       # alert on high commit latency...but how high is too high
   - name: mds
     rules:

--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -45,6 +45,7 @@ groups:
           description: One or more OSDs down for more than 15 minutes.
       - alert: OSDs near full
         expr: ((ceph_osd_stat_bytes_used / ceph_osd_stat_bytes) and on(ceph_daemon) ceph_osd_up == 1) > 0.8
+        for: 5m
         labels:
           severity: critical
           type: ceph_default


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42993

---

backport of https://github.com/ceph/ceph/pull/31711
parent tracker: https://tracker.ceph.com/issues/42862

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh