### PR TITLE
nautilus: mds: no assert on frozen dir when scrub path

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -229,9 +229,10 @@ bool CDir::check_rstats(bool scrub)
 
   dout(25) << "check_rstats on " << this << dendl;
   if (!is_complete() || !is_auth() || is_frozen()) {
-    ceph_assert(!scrub);
-    dout(10) << "check_rstats bailing out -- incomplete or non-auth or frozen dir!" << dendl;
-    return true;
+    dout(3) << "check_rstats " << (scrub ? "(scrub) " : "")
+            << "bailing out -- incomplete or non-auth or frozen dir on " 
+            << *this << dendl;
+    return !scrub;
   }
 
   frag_info_t frag_info;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42650

---

backport of https://github.com/ceph/ceph/pull/30835
parent tracker: https://tracker.ceph.com/issues/42251

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh