### PR TITLE
nautilus: tests/multimds: ignore RECENT_CRASH for multimds snapshot testing

### DIFF
--- a/qa/suites/multimds/basic/tasks/cephfs_test_snapshots.yaml
+++ b/qa/suites/multimds/basic/tasks/cephfs_test_snapshots.yaml
@@ -4,6 +4,7 @@ overrides:
   ceph:
     log-whitelist:
       - evicting unresponsive client
+      - RECENT_CRASH
 
 tasks:
 - cephfs_test_runner:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43170

---

backport of https://github.com/ceph/ceph/pull/29911
parent tracker: https://tracker.ceph.com/issues/42922

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh