### PR TITLE
nautilus: tools/cephfs: make 'cephfs-data-scan scan_links' fix dentry's first

### DIFF
--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -174,7 +174,7 @@ class MetadataTool
    * Try and read a dentry from a dirfrag
    */
   int read_dentry(inodeno_t parent_ino, frag_t frag,
-                  const std::string &dname, InodeStore *inode);
+		  const std::string &dname, InodeStore *inode, snapid_t *dnfirst=nullptr);
 };
 
 /**
@@ -220,7 +220,7 @@ class MetadataDriver : public RecoveryDriver, public MetadataTool
 
     int inject_linkage(
         inodeno_t dir_ino, const std::string &dname,
-        const frag_t fragment, const InodeStore &inode);
+        const frag_t fragment, const InodeStore &inode, snapid_t dnfirst=CEPH_NOSNAP);
 
     int inject_with_backtrace(
         const inode_backtrace_t &bt,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43141

---

backport of https://github.com/ceph/ceph/pull/31680
parent tracker: https://tracker.ceph.com/issues/42829

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh