### PR TITLE
nautilus: mds: tolerate no snaprealm encoded in on-disk root inode

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2817,7 +2817,8 @@ void CInode::decode_snap_blob(const bufferlist& snapbl)
       }
     }
     dout(20) << __func__ << " " << *snaprealm << dendl;
-  } else if (snaprealm) {
+  } else if (snaprealm &&
+	     !is_root() && !is_mdsdir()) { // see https://tracker.ceph.com/issues/42675
     ceph_assert(mdcache->mds->is_any_replay());
     snaprealm->merge_to(NULL);
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43143

---

backport of https://github.com/ceph/ceph/pull/31455
parent tracker: https://tracker.ceph.com/issues/42675

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh