### PR TITLE
ceph.spec.in: move distro-conditional deps to dedicated section

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -213,16 +213,6 @@ BuildRequires:	python%{_python_buildid}-nose
 BuildRequires:	python%{_python_buildid}-requests
 BuildRequires:	python%{_python_buildid}-six
 BuildRequires:	python%{_python_buildid}-virtualenv
-%if 0%{?rhel} < 8
-BuildRequires:	python%{_python_buildid}-coverage
-BuildRequires:	python%{_python_buildid}-pecan
-BuildRequires:	python%{_python_buildid}-tox
-%endif
-%if 0%{?rhel} == 7
-BuildRequires:  pyOpenSSL%{_python_buildid}
-%else
-BuildRequires:  python%{_python_buildid}-pyOpenSSL
-%endif
 BuildRequires:	socat
 %endif
 %if 0%{with seastar}
@@ -292,17 +282,27 @@ BuildRequires:	lz4-devel >= 1.7
 %endif
 # distro-conditional make check dependencies
 %if 0%{with make_check}
+%if 0%{?fedora} || 0%{?rhel}
 %if 0%{?fedora} || 0%{?rhel} == 7
 BuildRequires:	libtool-ltdl-devel
 BuildRequires:	python%{_python_buildid}-cherrypy
+BuildRequires:	python%{_python_buildid}-coverage
 BuildRequires:	python%{_python_buildid}-jwt
 BuildRequires:	python%{_python_buildid}-routes
+BuildRequires:	python%{_python_buildid}-pecan
+BuildRequires:	python%{_python_buildid}-tox
 BuildRequires:	python%{_python_buildid}-werkzeug
 BuildRequires:	xmlsec1
 BuildRequires:	xmlsec1-devel
 BuildRequires:	xmlsec1-nss
 BuildRequires:	xmlsec1-openssl
 BuildRequires:	xmlsec1-openssl-devel
+%if 0%{?rhel} == 7
+BuildRequires:  pyOpenSSL%{_python_buildid}
+%else
+BuildRequires:  python%{_python_buildid}-pyOpenSSL
+%endif
+%endif
 %endif
 %if 0%{?suse_version}
 BuildRequires:	libxmlsec1-1
@@ -312,7 +312,11 @@ BuildRequires:	python%{_python_buildid}-CherryPy
 BuildRequires:	python%{_python_buildid}-PyJWT
 BuildRequires:	python%{_python_buildid}-Routes
 BuildRequires:	python%{_python_buildid}-Werkzeug
+BuildRequires:	python%{_python_buildid}-coverage
 BuildRequires:	python%{_python_buildid}-numpy-devel
+BuildRequires:	python%{_python_buildid}-pecan
+BuildRequires:	python%{_python_buildid}-pyOpenSSL
+BuildRequires:	python%{_python_buildid}-tox
 BuildRequires:	rpm-build
 BuildRequires:	xmlsec1-devel
 BuildRequires:	xmlsec1-openssl-devel


### PR DESCRIPTION
Post e92cb7a0336406a2981e9241031497b1749b26aa cleanup. Restore previous
structure of "distro-conditional make check dependencies" section.

Fixes: https://tracker.ceph.com/issues/43171
Signed-off-by: Nathan Cutler <ncutler@suse.com>