### PR TITLE
mgr/cephadm: extend support for drivegroups

### DIFF
--- a/src/pybind/mgr/cephadm/Vagrantfile
+++ b/src/pybind/mgr/cephadm/Vagrantfile
@@ -17,8 +17,8 @@ Vagrant.configure("2") do |config|
     config.vm.define "osd#{i}" do |osd|
       osd.vm.hostname = "osd#{i}"
       osd.vm.provider :libvirt do |libvirt|
-        libvirt.storage :file, :size => '5G'
-        libvirt.storage :file, :size => '5G'
+        libvirt.storage :file, :size => '20G'
+        libvirt.storage :file, :size => '20G'
       end
     end
   end

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -18,10 +18,11 @@ import multiprocessing.pool
 import shutil
 import subprocess
 
-from ceph.deployment import inventory
+from ceph.deployment import inventory, translate
+from ceph.deployment.drive_selection import selector
 from mgr_module import MgrModule
 import orchestrator
-from orchestrator import OrchestratorError
+from orchestrator import OrchestratorError, InventoryFilter
 
 from . import remotes
 
@@ -931,17 +932,51 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         return blink(locs)
 
-    @async_completion
-    def _create_osd(self, all_hosts_, drive_group):
-        all_hosts = orchestrator.InventoryNode.get_host_names(all_hosts_)
-        assert len(drive_group.hosts(all_hosts)) == 1
-        assert len(drive_group.data_devices.paths) > 0
-        assert all(map(lambda p: isinstance(p, six.string_types),
-            drive_group.data_devices.paths))
 
-        host = drive_group.hosts(all_hosts)[0]
+    def call_inventory(self, hosts, drive_groups):
+        def call_create(inventory):
+            return self._prepare_deployment(hosts, drive_groups, inventory)
+
+        return self.get_inventory().then(call_create)
+
+    def create_osds(self, drive_groups):
+        return self.get_hosts().then(lambda hosts: self.call_inventory(hosts, drive_groups))
+
+
+    def _prepare_deployment(self, all_hosts, drive_groups, inventory_list):
+        # type: (List[orchestrator.InventoryNode], List[orchestrator.DriveGroupSpecs], List[orchestrator.InventoryNode] -> orchestrator.Completion
+
+        for drive_group in drive_groups:
+            self.log.info("Processing DriveGroup {}".format(drive_group))
+            # 1) use fn_filter to determine matching_hosts
+            matching_hosts = drive_group.hosts([x.name for x in all_hosts])
+            # 2) Map the inventory to the InventoryNode object
+            # FIXME: lazy-load the inventory from a InventoryNode object;
+            #        this would save one call to the inventory(at least externally)
+
+            def _find_inv_for_host(hostname, inventory_list):
+                # This is stupid and needs to be loaded with the host
+                for _inventory in inventory_list:
+                    if _inventory.name == hostname:
+                        return _inventory
+
+            cmds = []
+            # 3) iterate over matching_host and call DriveSelection and to_ceph_volume
+            for host in matching_hosts:
+                inventory_for_host = _find_inv_for_host(host, inventory_list)
+                drive_selection = selector.DriveSelection(drive_group, inventory_for_host.devices)
+                cmd = translate.ToCephVolume(drive_group, drive_selection).run()
+                if not cmd:
+                    self.log.info("No data_devices, skipping DriveGroup: {}".format(drive_group.name))
+                    continue
+                cmds.append((host, cmd))
+
+        return self._create_osd(cmds)
+
+    @async_map_completion
+    def _create_osd(self, host, cmd):
+
         self._require_hosts(host)
-
 
         # get bootstrap key
         ret, keyring, err = self.mon_command({
@@ -959,20 +994,14 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
             'keyring': keyring,
         })
 
-        devices = drive_group.data_devices.paths
-        for device in devices:
-            out, err, code = self._run_cephadm(
-                host, 'osd', 'ceph-volume',
-                [
-                    '--config-and-keyring', '-',
-                    '--',
-                    'lvm', 'prepare',
-                    "--cluster-fsid", self._cluster_fsid,
-                    "--{}".format(drive_group.objectstore),
-                    "--data", device,
-                ],
-                stdin=j)
-            self.log.debug('ceph-volume prepare: %s' % out)
+        split_cmd = cmd.split(' ')
+        _cmd = ['--config-and-keyring', '-', '--']
+        _cmd.extend(split_cmd)
+        out, code = self._run_ceph_daemon(
+            host, 'osd', 'ceph-volume',
+            _cmd,
+            stdin=j)
+        self.log.debug('ceph-volume prepare: %s' % out)
 
         # check result
         out, err, code = self._run_cephadm(
@@ -990,10 +1019,6 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
                 if osd['tags']['ceph.cluster_fsid'] != fsid:
                     self.log.debug('mismatched fsid, skipping %s' % osd)
                     continue
-                if len(list(set(devices) & set(osd['devices']))) == 0 and osd.get('lv_path') not in devices:
-                    self.log.debug('mismatched devices, skipping %s' % osd)
-                    continue
-
                 # create
                 ret, keyring, err = self.mon_command({
                     'prefix': 'auth get',
@@ -1006,22 +1031,6 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
                     ])
 
         return "Created osd(s) on host '{}'".format(host)
-
-    def create_osds(self, drive_group):
-        """
-        Create a new osd.
-
-        The orchestrator CLI currently handles a narrow form of drive
-        specification defined by a single block device using bluestore.
-
-        :param drive_group: osd specification
-
-        TODO:
-          - support full drive_group specification
-          - support batch creation
-        """
-
-        return self.get_hosts().then(lambda hosts: self._create_osd(hosts, drive_group))
 
     def remove_osds(self, name):
         def _search(daemons):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -105,9 +105,9 @@ class TestSSH(object):
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     def test_create_osds(self, _send_command, _get_connection, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
-            dg = DriveGroupSpec('test', DeviceSelection(paths=['']))
-            c = cephadm_module.create_osds(dg)
-            assert self._wait(cephadm_module, c) == "Created osd(s) on host 'test'"
+            dg = DriveGroupSpec('test', data_devices=DeviceSelection(paths=['']))
+            c = cephadm_module.create_osds([dg])
+            assert self._wait(cephadm_module, c) == ["Created osd(s) on host 'test'"]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -336,10 +336,9 @@ Usage:
   ceph orchestrator osd create host:device1,device2,...
 """
 
-        # TODO: try if inbuf file is yaml of json
         if inbuf:
             try:
-                dgs = DriveGroupSpecs(json.loads(inbuf))
+                dgs = DriveGroupSpecs(yaml.load(inbuf))
                 drive_groups = dgs.drive_groups
             except ValueError as e:
                 msg = 'Failed to read JSON input: {}'.format(str(e)) + usage

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -1,5 +1,6 @@
 import errno
 import json
+import yaml
 from functools import wraps
 
 from ceph.deployment.inventory import Device
@@ -14,7 +15,7 @@ except ImportError:
 
 
 from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError, \
-    DeviceSelection
+    DeviceSelection, DriveGroupSpecs
 from mgr_module import MgrModule, CLICommand, HandleCommandResult
 
 import orchestrator
@@ -331,13 +332,15 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
         usage = """
 Usage:
-  ceph orchestrator osd create -i <json_file>
+  ceph orchestrator osd create -i <json_file/yaml_file>
   ceph orchestrator osd create host:device1,device2,...
 """
 
+        # TODO: try if inbuf file is yaml of json
         if inbuf:
             try:
-                drive_group = DriveGroupSpec.from_json(json.loads(inbuf))
+                dgs = DriveGroupSpecs(json.loads(inbuf))
+                drive_groups = dgs.drive_groups
             except ValueError as e:
                 msg = 'Failed to read JSON input: {}'.format(str(e)) + usage
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)
@@ -351,14 +354,13 @@ Usage:
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)
 
             devs = DeviceSelection(paths=block_devices)
-            drive_group = DriveGroupSpec(node_name, data_devices=devs)
+            drive_groups = [DriveGroupSpec(node_name, data_devices=devs)]
         else:
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
 
-        completion = self.create_osds(drive_group)
+        completion = self.create_osds(drive_groups)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
-        self.log.warning(str(completion.result))
         return HandleCommandResult(stdout=completion.result_str())
 
     @orchestrator._cli_write_command(

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -23,10 +23,16 @@ class DriveSelection(object):
         self.disks = disks.copy()
         self.spec = spec
 
-        self._data = self.assign_devices(self.spec.data_devices)
-        self._wal = self.assign_devices(self.spec.wal_devices)
-        self._db = self.assign_devices(self.spec.db_devices)
-        self._jornal = self.assign_devices(self.spec.journal_devices)
+        if self.spec.data_devices.paths:
+            self._data = self.spec.data_devices.paths
+            self._db = []
+            self._wal = []
+            self._journal = []
+        else:
+            self._data = self.assign_devices(self.spec.data_devices)
+            self._wal = self.assign_devices(self.spec.wal_devices)
+            self._db = self.assign_devices(self.spec.db_devices)
+            self._journal = self.assign_devices(self.spec.journal_devices)
 
     def data_devices(self):
         # type: () -> List[Device]
@@ -42,7 +48,7 @@ class DriveSelection(object):
 
     def journal_devices(self):
         # type: () -> List[Device]
-        return self._jornal
+        return self._journal
 
     @staticmethod
     def _limit_reached(device_filter, len_devices,
@@ -95,7 +101,7 @@ class DriveSelection(object):
 
         return a sorted(by path) list of devices
         """
-        if device_filter is None:
+        if not device_filter and not self.spec.data_devices.paths:
             logger.debug('device_filter is None')
             return []
         devices = list()  # type: List[Device]

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -23,11 +23,13 @@ class DriveSelection(object):
         self.disks = disks.copy()
         self.spec = spec
 
-        if self.spec.data_devices.paths:
-            self._data = self.spec.data_devices.paths
-            self._db = []
-            self._wal = []
-            self._journal = []
+        if self.spec.data_devices.paths:  # type: ignore
+            # re: type: ignore there is *always* a path attribute assigned to DeviceSelection
+            # it's just None if actual drivegroups are used
+            self._data = self.spec.data_devices.paths  # type: ignore
+            self._db = []  # type: List
+            self._wal = []  # type: List
+            self._journal = []  # type: List
         else:
             self._data = self.assign_devices(self.spec.data_devices)
             self._wal = self.assign_devices(self.spec.wal_devices)

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -5,7 +5,7 @@ from ceph.deployment.drive_selection.selector import DriveSelection
 logger = logging.getLogger(__name__)
 
 
-class ToCephVolume(object):
+class to_ceph_volume(object):
 
     def __init__(self,
                  spec,  # type: DriveGroupSpec

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -1,0 +1,70 @@
+import logging
+from ceph.deployment.drive_group import DriveGroupSpec
+from ceph.deployment.drive_selection.selector import DriveSelection
+
+logger = logging.getLogger(__name__)
+
+
+class ToCephVolume(object):
+
+    def __init__(self,
+                 spec,  # type: DriveGroupSpec
+                 selection  # type: DriveSelection
+                 ):
+
+        self.spec = spec
+        self.selection = selection
+
+    def run(self):
+        """ Generate ceph-volume commands based on the DriveGroup filters """
+        try:
+            data_devices = [x.path for x in self.selection.data_devices()]
+        except AttributeError:
+            data_devices = [x for x in self.selection.data_devices()]
+        db_devices = [x.path for x in self.selection.db_devices()]
+        wal_devices = [x.path for x in self.selection.wal_devices()]
+        journal_devices = [x.path for x in self.selection.journal_devices()]
+
+        if not data_devices:
+            return None
+
+        if self.spec.objectstore == 'filestore':
+            cmd = "lvm batch --no-auto"
+
+            cmd += " {}".format(" ".join(data_devices))
+
+            if self.spec.journal_size:
+                cmd += " --journal-size {}".format(self.spec.journal_size)
+
+            if journal_devices:
+                cmd += " --journal-devices {}".format(
+                    ' '.join(journal_devices))
+
+            cmd += " --filestore"
+
+        if self.spec.objectstore == 'bluestore':
+
+            cmd = "lvm batch --no-auto {}".format(" ".join(data_devices))
+
+            if db_devices:
+                cmd += " --db-devices {}".format(" ".join(db_devices))
+
+            if wal_devices:
+                cmd += " --wal-devices {}".format(" ".join(wal_devices))
+
+            if self.spec.block_wal_size:
+                cmd += " --block-wal-size {}".format(self.spec.block_wal_size)
+
+            if self.spec.block_db_size:
+                cmd += " --block-db-size {}".format(self.spec.block_db_size)
+
+        if self.spec.encrypted:
+            cmd += " --dmcrypt"
+
+        if self.spec.osds_per_device:
+            cmd += " --osds-per-device {}".format(self.spec.osds_per_device)
+
+        cmd += " --yes"
+        cmd += " --no-systemd"
+
+        return cmd

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -11,6 +11,7 @@ except ImportError:
 
 from ceph.deployment import drive_selection
 from ceph.tests.factories import InventoryFactory
+from ceph.tests.utils import _mk_inventory, _mk_device
 
 
 class TestMatcher(object):
@@ -672,39 +673,6 @@ class TestFilter(object):
         assert ret.is_matchable is False
 
 
-def _mk_device(rotational=True, locked=False):
-    return [Device(
-        path='??',
-        sys_api={
-            "rotational": '1' if rotational else '0',
-            "vendor": "Vendor",
-            "human_readable_size": "394.27 GB",
-            "partitions": {},
-            "locked": int(locked),
-            "sectorsize": "512",
-            "removable": "0",
-            "path": "??",
-            "support_discard": "",
-            "model": "Model",
-            "ro": "0",
-            "nr_requests": "128",
-            "size": 423347879936
-        },
-        available=not locked,
-        rejected_reasons=['locked'] if locked else [],
-        lvs=[],
-        device_id="Model-Vendor-foobar"
-    )]
-
-
-def _mk_inventory(devices):
-    devs = []
-    for dev_, name in zip(devices, map(chr, range(ord('a'), ord('z')))):
-        dev = Device.from_json(dev_.to_json())
-        dev.path = '/dev/sd' + name
-        dev.sys_api = dict(dev_.sys_api, path='/dev/sd' + name)
-        devs.append(dev)
-    return Devices(devices=devs)
 
 
 class TestDriveSelection(object):

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -673,8 +673,6 @@ class TestFilter(object):
         assert ret.is_matchable is False
 
 
-
-
 class TestDriveSelection(object):
 
     testdata = [

--- a/src/python-common/ceph/tests/utils.py
+++ b/src/python-common/ceph/tests/utils.py
@@ -1,0 +1,38 @@
+from ceph.deployment.inventory import Devices, Device
+
+
+def _mk_device(rotational=True,
+               locked=False,
+               size="394.27 GB"):
+    return [Device(
+        path='??',
+        sys_api={
+            "rotational": '1' if rotational else '0',
+            "vendor": "Vendor",
+            "human_readable_size": size,
+            "partitions": {},
+            "locked": int(locked),
+            "sectorsize": "512",
+            "removable": "0",
+            "path": "??",
+            "support_discard": "",
+            "model": "Model",
+            "ro": "0",
+            "nr_requests": "128",
+            "size": 423347879936  # ignore coversion from human_readable_size
+        },
+        available=not locked,
+        rejected_reasons=['locked'] if locked else [],
+        lvs=[],
+        device_id="Model-Vendor-foobar"
+    )]
+
+
+def _mk_inventory(devices):
+    devs = []
+    for dev_, name in zip(devices, map(chr, range(ord('a'), ord('z')))):
+        dev = Device.from_json(dev_.to_json())
+        dev.path = '/dev/sd' + name
+        dev.sys_api = dict(dev_.sys_api, path='/dev/sd' + name)
+        devs.append(dev)
+    return Devices(devices=devs)


### PR DESCRIPTION
The codepath in the ssh orchestrator will now actually pickup the drivegroup spec and applies it correctly onto the node(s).

* Added a new module that translates drivegroups to ceph-volume calls.
* This *is* handled via a single completion.

Since we also allow multiple DriveGroups in one definition I extended the spec to allow named drivegroups:

``` json

{
  "all_with_a": {
    "host_pattern": "a*",
    "data_devices": {
      "size": "10G"
    }
  },
  "all_with_b": {
    "host_pattern": "b*",
    "data_devices": {
      "size": "20G"
    }
  },
  "all_with_c": {
    "host_pattern": "c*",
    "data_devices": {
      "all": true
    }
  }
}
````
Note: This patch should be aligned with a change that incorporates 'named' drivegroups. @ceph/dashboard 



Signed-off-by: Joshua Schmid <jschmid@suse.de>