### PR TITLE
test: run-standalone.sh: Only run execs in the subdirectories of qa/standalone

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -94,13 +94,9 @@ if ls $(dirname $(sysctl -n $KERNCORE)) | grep -q '^core\|core$' ; then
 fi
 
 ulimit -c unlimited
-for f in $(cd $location ; find . -perm $exec_mode -type f)
+for f in $(cd $location ; find . -mindepth 2 -perm $exec_mode -type f)
 do
     f=$(echo $f | sed 's/\.\///')
-    # This is tested with misc/test-ceph-helpers.sh
-    if [[ "$f" = "ceph-helpers.sh" ]]; then
-        continue
-    fi
     if [[ "$all" = "false" ]]; then
         found=false
         for c in "${!select[@]}"


### PR DESCRIPTION
This will ignore scripts placed at the qa/standalone level, though
I'm not sure if we should be putting any tests there.  It does
allow support scripts present like ceph-helper.sh without modifying
run-standalone.sh to ignore it.

Signed-off-by: David Zafman <dzafman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
