### PR TITLE
common/config: update values when they are removed via mon

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -318,6 +318,11 @@ int md_config_t::set_mon_vals(CephContext *cct,
 		  << " cleared (was " << Option::to_str(config->second) << ")"
 		  << dendl;
     values.rm_val(name, CONF_MON);
+    // if this is a debug option, it needs to propagate to teh subsys;
+    // this isn't covered by update_legacy_vals() below.  similarly,
+    // we want to trigger a config notification for these items.
+    const Option *o = find_option(name);
+    _refresh(values, *o);
   });
   values_bl.clear();
   update_legacy_vals(values);


### PR DESCRIPTION
If a value is set via the mon (ceph config set ...), and then later
removed, the removal doesn't propagate to the legacy values (or debug
options) because update_legacy_values() only iterates over legacy value
and not debug options.

Similarly, we want to trigger a config notification to any observers,
so we need to add the option to values.changed.

Fixes: https://tracker.ceph.com/issues/42964
Signed-off-by: Sage Weil <sage@redhat.com>