### PR TITLE
ceph-daemon: fix bootstrap ownership of tmp monmap file

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -1066,7 +1066,7 @@ def command_bootstrap():
 
     # create initial monmap, tmp monmap file
     logger.info('Creating initial monmap...')
-    tmp_monmap = write_tmp('', uid, gid)
+    tmp_monmap = write_tmp('', 0, 0)
     out = CephContainer(
         image=args.image,
         entrypoint='/usr/bin/monmaptool',
@@ -1080,6 +1080,9 @@ def command_bootstrap():
             tmp_monmap.name: '/tmp/monmap:z',
         },
     ).run()
+
+    # pass monmap file to ceph user for use by ceph-mon --mkfs below
+    os.fchown(tmp_monmap.fileno(), uid, gid)
 
     # create mon
     logger.info('Creating mon...')


### PR DESCRIPTION
The file is created with mode 0644 by the ceph:ceph user, but root
cannot write to that.  Instead, create the tmp file owned by root, write
to it, then chown it to user ceph.

Fixes e92929d86dce2297d3e02ec88c6830224aefc061

Signed-off-by: Sage Weil <sage@redhat.com>