### PR TITLE
mgr/diskprediction_local: import scipy early to fix self-test deadlock

### DIFF
--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -9,6 +9,14 @@ import time
 
 from mgr_module import MgrModule, CommandResult
 
+# Importing scipy early appears to avoid a future deadlock when
+# we try to do
+#
+#  from .predictor import get_diskfailurepredictor_path
+#
+# in a command thread.  See https://tracker.ceph.com/issues/42764
+import scipy
+
 
 TIME_FORMAT = '%Y%m%d-%H%M%S'
 TIME_DAYS = 24*60*60


### PR DESCRIPTION
We are seeing a hang on centos7 (but not ubuntu 18.04) from

        from .predictor import get_diskfailurepredictor_path

in _predict_life_expentancy.

Doing that same predictor import at the top of the file doesn't help--it
hangs right when the diskpredictor_local module is loaded.  Commenting
out the import scipy in predictor.py avoids the hang.

I'm not sure why, but doing the full scipy import here appears to work
around the problem.

Fixes: https://tracker.ceph.com/issues/42764
Signed-off-by: Sage Weil <sage@redhat.com>