### PR TITLE
librbd: fix rbd_open_by_id, rbd_open_by_id_read_only 

### DIFF
--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -4434,9 +4434,7 @@ extern "C" int rbd_open_by_id(rados_ioctx_t p, const char *id,
              ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
   int r = ictx->state->open(0);
-  if (r < 0) {
-    delete ictx;
-  } else {
+  if (r >= 0) {
     *image = (rbd_image_t)ictx;
   }
   tracepoint(librbd, open_image_exit, r);
@@ -4509,9 +4507,7 @@ extern "C" int rbd_open_by_id_read_only(rados_ioctx_t p, const char *id,
              ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
   int r = ictx->state->open(0);
-  if (r < 0) {
-    delete ictx;
-  } else {
+  if (r >= 0) {
     *image = (rbd_image_t)ictx;
   }
   tracepoint(librbd, open_image_exit, r);


### PR DESCRIPTION
Fixs: https://tracker.ceph.com/issues/43178
"ImageState::open" will free the "ImageCtx" memory upon failure, we dont need to add a delete in rbd_open_by_id(), rbd_open_by_id_read_only(),  so we need to remove the "delete  ictx" to avoid double-free problem.

@yangdongsheng @dillaman  Can you take a look at it for me sometime？ many thanks
