### PR TITLE
ceph-volume: fix the integer overflow

### DIFF
--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -92,8 +92,8 @@ def main(args=None):
     logger.info('parsed sub-command: %s, extra data: %s', sub_command, extra_data)
     command = ['ceph-volume', sub_command, 'trigger', extra_data]
 
-    tries = os.environ.get('CEPH_VOLUME_SYSTEMD_TRIES', 30)
-    interval = os.environ.get('CEPH_VOLUME_SYSTEMD_INTERVAL', 5)
+    tries = int(os.environ.get('CEPH_VOLUME_SYSTEMD_TRIES', 30))
+    interval = int(os.environ.get('CEPH_VOLUME_SYSTEMD_INTERVAL', 5))
     while tries > 0:
         try:
             # don't log any output to the terminal, just rely on stderr/stdout


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43186

Signed-off-by: dongdong tao <dongdong.tao@canonical.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
