### PR TITLE
test_cephfs_shell: set colors to Never for cephfs-shell

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -34,6 +34,15 @@ def humansize(nbytes):
 class TestCephFSShell(CephFSTestCase):
     CLIENTS_REQUIRED = 1
 
+    def setUp(self):
+        super(TestCephFSShell, self).setUp()
+
+        conf_contents = "[cephfs-shell]\ncolors = False\ndebug = True\n"
+        confpath = self.mount_a.run_shell(args=['mktemp']).stdout.\
+            getvalue().strip()
+        sudo_write_file(self.mount_a.client_remote, confpath, conf_contents)
+        self.default_shell_conf_path = confpath
+
     def run_cephfs_shell_cmd(self, cmd, mount_x=None, shell_conf_path=None,
                              opts=None, stdout=None, stderr=None, stdin=None,
                              check_status=True):
@@ -41,13 +50,12 @@ class TestCephFSShell(CephFSTestCase):
         stderr = stderr or StringIO()
         if mount_x is None:
             mount_x = self.mount_a
-
         if isinstance(cmd, list):
             cmd = " ".join(cmd)
+        if not shell_conf_path:
+            shell_conf_path = self.default_shell_conf_path
 
-        args = ["cephfs-shell"]
-        if shell_conf_path:
-            args += ["-c", shell_conf_path]
+        args = ["cephfs-shell", "-c", shell_conf_path]
         if opts:
             args += opts
         args.extend(("--", cmd))


### PR DESCRIPTION
* set colors to Never for cephfs-shell
    This should prevent color code from being captured in stdout of
    cepfs-shell commands which otherwise might lead to match failure with
    the expected output.

    Ideally, this commit should have been part of
    2f85a03b56e4c29f0eaa8ced2e5c0de08da1dd85.

    Fixes: https://tracker.ceph.com/issues/43191

* move options from cephfs-shell section to client section of ceph.conf

* set debug_shell to True if it wasn't set already (and reset it in teardown)

**DEPENDS ON https://github.com/ceph/ceph/pull/33286**



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>